### PR TITLE
GEODE-6219: Disable one more test that uses lsof

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -88,7 +88,7 @@ tests:
   CALL_STACK_TIMEOUT: "7200"
   DUNIT_PARALLEL_FORKS: "24"
   GRADLE_TASK: distributedTest
-  execute_test_timeout: 3h30m
+  execute_test_timeout: 2h15m
   PARALLEL_DUNIT: "true"
 - name: "Integration"
   CPUS: "96"
@@ -115,7 +115,7 @@ tests:
   CALL_STACK_TIMEOUT: "7200"
   DUNIT_PARALLEL_FORKS: "24"
   GRADLE_TASK: repeatTest
-  execute_test_timeout: 3h30m
+  execute_test_timeout: 2h15m
   PARALLEL_DUNIT: "true"
 - name: "WindowsAcceptance"
   CPUS: "16"

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -161,7 +161,7 @@ public class NetstatDUnitTest {
     assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactly("server-1");
   }
 
-  // This test runs OK on JDK8 but takes a very long time on JDK8
+  // This test runs OK on JDK11 but takes a very long time on JDK8
   @Ignore("GEODE-6228")
   @Test
   public void testOutputWithLsofToFile() throws Exception {

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -161,6 +161,8 @@ public class NetstatDUnitTest {
     assertThat(lines.get(4).trim().split("[,\\s]+")).containsExactly("server-1");
   }
 
+  // This test runs OK on JDK8 but takes a very long time on JDK8
+  @Ignore("GEODE-6228")
   @Test
   public void testOutputWithLsofToFile() throws Exception {
     File outputFile = new File(temp.newFolder(), "command.log.txt");

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/NetstatDUnitTest.java
@@ -15,7 +15,9 @@
 
 package org.apache.geode.management.internal.cli;
 
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Scanner;
 
+import org.apache.commons.lang3.JavaVersion;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -162,9 +165,12 @@ public class NetstatDUnitTest {
   }
 
   // This test runs OK on JDK11 but takes a very long time on JDK8
-  @Ignore("GEODE-6228")
   @Test
   public void testOutputWithLsofToFile() throws Exception {
+    // Skipping test on JDK8. Running lsof command takes an excessive amount of time on Java 8
+    assumeThat(isJavaVersionAtLeast(JavaVersion.JAVA_11))
+        .as("Skipping test due to excessive run time when running lsof on JDK 8").isTrue();
+
     File outputFile = new File(temp.newFolder(), "command.log.txt");
 
     CommandResult result =


### PR DESCRIPTION
Running gfsh command "netstat --with-lsof" to a file takes a very long time (> 30min)
when running on JDK8. However it takes only a few seconds with JDK11.

Test is therefore being @Ignore'd until we can figure out the problem.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
