### PR TITLE
GEODE-6236 fix inconsistent handling of versionNumber

### DIFF
--- a/ci/scripts/archive_results.sh
+++ b/ci/scripts/archive_results.sh
@@ -48,7 +48,7 @@ fi
 SANITIZED_GRADLE_TASK=${GRADLE_TASK##*:}
 TMPDIR=${DEST_DIR}/tmp
 GEODE_BUILD=${DEST_DIR}/geode
-GEODE_BUILD_VERSION_NUMBER=$(grep "versionNumber *=" ${GEODE_BUILD}/gradle.properties | awk -F "=" '{print $2}' | tr -d ' ')
+GEODE_BUILD_VERSION_NUMBER=$(echo "${GRADLE_GLOBAL_ARGS}"|tr ' ' '\n' | grep "versionNumber *=" - ${GEODE_BUILD}/gradle.properties | awk -F "=" '{print $2; exit}' | tr -d ' ')
 BUILD_TIMESTAMP=$(date +%s)
 
 GEODE_PULL_REQUEST_ID_FILE=${BUILDROOT}/geode/.git/resource/version.json

--- a/ci/scripts/execute_build.sh
+++ b/ci/scripts/execute_build.sh
@@ -41,7 +41,7 @@ BUILD_DATE=$(date +%s)
 if [ -e "${ROOT_DIR}/geode-build-version" ] ; then
   GEODE_BUILD_VERSION_FILE=${ROOT_DIR}/geode-build-version/number
   GEODE_RESULTS_VERSION_FILE=${ROOT_DIR}/results/number
-  GEODE_BUILD_VERSION_NUMBER=$(grep "versionNumber *=" geode/gradle.properties | awk -F "=" '{print $2}' | tr -d ' ')
+  GEODE_BUILD_VERSION_NUMBER=$(echo "${GRADLE_GLOBAL_ARGS}"|tr ' ' '\n' | grep "versionNumber *=" - geode/gradle.properties | awk -F "=" '{print $2; exit}' | tr -d ' ')
   GEODE_BUILD_DIR=/tmp/geode-build
   GEODE_PULL_REQUEST_ID_FILE=${ROOT_DIR}/geode/.git/id
 
@@ -99,6 +99,7 @@ GRADLE_ARGS="\
     ${DEFAULT_GRADLE_TASK_OPTIONS} \
     ${GRADLE_SKIP_TASK_OPTIONS} \
     ${GRADLE_GLOBAL_ARGS} \
+    -PbuildId=${BUILD_ID} \
     build install javadoc spotlessCheck rat checkPom resolveDependencies -x test"
 
 EXEC_COMMAND="mkdir -p tmp && cd geode && ${SET_JAVA_HOME} && ./gradlew ${GRADLE_ARGS}"

--- a/ci/scripts/execute_publish.sh
+++ b/ci/scripts/execute_publish.sh
@@ -37,7 +37,7 @@ EMAIL_BODY="results/body"
 
 GEODE_BUILD_VERSION_FILE=${ROOT_DIR}/geode-build-version/number
 GEODE_RESULTS_VERSION_FILE=${ROOT_DIR}/results/number
-GEODE_BUILD_VERSION_NUMBER=$(grep "versionNumber *=" geode/gradle.properties | awk -F "=" '{print $2}' | tr -d ' ')
+GEODE_BUILD_VERSION_NUMBER=$(echo "${GRADLE_GLOBAL_ARGS}"|tr ' ' '\n' | grep "versionNumber *=" - geode/gradle.properties | awk -F "=" '{print $2; exit}' | tr -d ' ')
 GEODE_BUILD_DIR=/tmp/geode-build
 GEODE_PULL_REQUEST_ID_FILE=${ROOT_DIR}/geode/.git/id
 


### PR DESCRIPTION
In a few build scripts versionNumber was obtained by parsing gradle.properties directly. This approach gave incorrect value if that property had been overridden with a -P on the gradle command line.

Now the overrides are considered before the properties file, mimicking the value gradle would choose in all cases.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [n/a] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
