### PR TITLE
GEODE-5955 CacheClientUpdater statistics are created and never closed…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/ClientSideHandshake.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/ClientSideHandshake.java
@@ -30,6 +30,10 @@ public interface ClientSideHandshake {
 
   ClientProxyMembershipID getMembershipId();
 
+  default boolean isDurable() {
+    return getMembershipId().isDurable();
+  }
+
   ServerQueueStatus handshakeWithSubscriptionFeed(Socket socket, boolean isPrimary)
       throws IOException, AuthenticationRequiredException, AuthenticationFailedException,
       ServerRefusedConnectionException, ClassNotFoundException;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdaterJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdaterJUnitTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.SocketException;
+
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.client.internal.Endpoint;
+import org.apache.geode.cache.client.internal.EndpointManager;
+import org.apache.geode.cache.client.internal.QueueManager;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.ServerLocation;
+import org.apache.geode.internal.cache.tier.ClientSideHandshake;
+import org.apache.geode.internal.net.SocketCreator;
+
+public class CacheClientUpdaterJUnitTest {
+
+  @Test
+  public void failureToConnectClosesStatistics() throws Exception {
+    // CacheClientUpdater's constructor takes a lot of parameters that we need to mock
+    ServerLocation location = new ServerLocation("localhost", 1234);
+    ClientSideHandshake handshake = mock(ClientSideHandshake.class);
+    when(handshake.isDurable()).thenReturn(Boolean.FALSE);
+    QueueManager queueManager = null;
+    mock(QueueManager.class);
+    EndpointManager endpointManager = mock(EndpointManager.class);
+    Endpoint endpoint = mock(Endpoint.class);
+
+    // shutdown checks
+    DistributedSystem distributedSystem = mock(DistributedSystem.class);
+    CancelCriterion cancelCriterion = mock(CancelCriterion.class);
+    when(distributedSystem.getCancelCriterion()).thenReturn(cancelCriterion);
+    when(cancelCriterion.isCancelInProgress()).thenReturn(Boolean.FALSE);
+
+    // engineer a failure to connect via SocketCreator
+    SocketCreator socketCreator = mock(SocketCreator.class);
+    when(socketCreator.connectForClient(any(String.class), any(Integer.class),
+        any(Integer.class), any(Integer.class))).thenThrow(new SocketException("ouch"));
+
+    // mock some stats that we can then use to ensure that they're closed when the problem occurs
+    CacheClientUpdater.StatisticsProvider statisticsProvider = mock(
+        CacheClientUpdater.StatisticsProvider.class);
+    CacheClientUpdater.CCUStats ccuStats = mock(CacheClientUpdater.CCUStats.class);
+    when(statisticsProvider
+        .createStatistics(distributedSystem, location))
+            .thenReturn(ccuStats);
+
+    // CCU's constructor fails to connect
+    CacheClientUpdater clientUpdater =
+        new CacheClientUpdater("testUpdater", location, false, distributedSystem, handshake,
+            queueManager, endpointManager, endpoint, 10000, socketCreator, statisticsProvider);
+
+    // now introspect to make sure the right actions were taken
+    // The updater should not be in a connected state
+    assertThat(clientUpdater.isConnected()).isFalse();
+    // The statistics should be closed
+    verify(ccuStats).close();
+    // The endpoint should be reported as having crashed
+    verify(endpointManager).serverCrashed(endpoint);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdaterJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdaterJUnitTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import java.net.SocketException;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.client.internal.Endpoint;
@@ -32,7 +33,9 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.internal.cache.tier.ClientSideHandshake;
 import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
+@Category({ClientSubscriptionTest.class})
 public class CacheClientUpdaterJUnitTest {
 
   @Test

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.test.dunit.tests;
 
-import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.hamcrest.Matchers.instanceOf;
@@ -62,14 +61,6 @@ public class BasicDistributedTest extends DistributedTestCase {
     bindings = null;
     invokeInEveryVM(() -> bindings = null);
   }
-
-  @Override
-  public Properties getDistributedSystemProperties() {
-    Properties config = super.getDistributedSystemProperties();
-    config.setProperty(LOG_LEVEL, "fine");
-    return config;
-  }
-
 
   @Test
   public void testPreconditions() {

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.test.dunit.tests;
 
+import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.hamcrest.Matchers.instanceOf;
@@ -61,6 +62,14 @@ public class BasicDistributedTest extends DistributedTestCase {
     bindings = null;
     invokeInEveryVM(() -> bindings = null);
   }
+
+  @Override
+  public Properties getDistributedSystemProperties() {
+    Properties config = super.getDistributedSystemProperties();
+    config.setProperty(LOG_LEVEL, "fine");
+    return config;
+  }
+
 
   @Test
   public void testPreconditions() {
@@ -154,8 +163,11 @@ public class BasicDistributedTest extends DistributedTestCase {
     String name = getUniqueName();
     String value = "Hello";
 
-    vm0.invokeAsync(() -> remoteBind(name, value)).join().checkException();
-    vm0.invokeAsync(() -> remoteValidateBind(name, value)).join().checkException();
+    AsyncInvocation async1 = vm0.invokeAsync(() -> remoteBind(name, value)).join().checkException();
+    AsyncInvocation async2 =
+        vm0.invokeAsync(() -> remoteValidateBind(name, value)).join().checkException();
+    async1.join();
+    async2.join();
   }
 
   @Test


### PR DESCRIPTION
… on failed initialization

Close statistics if construction of a CacheClientUpdater fails.

I had to introduce a StatisticsProvider in order to inject a mock
statistics object into the CacheClientUpdater.  I also reworked the
"finally" block in the constructor to use the updater's close()
method.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
