### PR TITLE
GEODE-3967: fix the offheap memory leak in serial gateway sender's un…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
@@ -471,7 +471,7 @@ public class DistributedAckRegionCCEDUnitTest extends DistributedAckRegionDUnitT
           // ARM.updateEntry will be called one more time, so there will be 2 conflicted events
           assertThat(CCRegion.getCachePerfStats().getConflatedEventsCount())
               .describedAs("conflated event count")
-              .isEqualTo(1);
+              .isEqualTo(2);
         }
       });
     } finally {

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1988,9 +1988,11 @@ org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackArgument,2
 fromData,63
 toData,87
 
-org/apache/geode/internal/cache/wan/GatewaySenderEventImpl,2
-fromData,183
-toData,133
+org/apache/geode/internal/cache/wan/GatewaySenderEventImpl,4
+fromData,30
+fromDataPre_GEODE_1_9_0_0,183
+toData,17
+toDataPre_GEODE_1_9_0_0,134
 
 org/apache/geode/internal/cache/wan/GatewaySenderQueueEntrySynchronizationOperation$GatewaySenderQueueEntrySynchronizationEntry,2
 fromData,20

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5708,6 +5708,8 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         logger.debug("caught concurrent modification attempt when applying {}", event);
       }
       notifyBridgeClients(event);
+      notifyGatewaySender(event.getOperation().isUpdate() ? EnumListenerEvent.AFTER_UPDATE
+          : EnumListenerEvent.AFTER_CREATE, event);
       return false;
     }
 
@@ -6204,8 +6206,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   }
 
   protected void notifyGatewaySender(EnumListenerEvent operation, EntryEventImpl event) {
-    if (isPdxTypesRegion() || event.isConcurrencyConflict()) {
-      // isConcurrencyConflict is usually a concurrent cache modification problem
+    if (isPdxTypesRegion()) {
       return;
     }
 
@@ -6600,6 +6601,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       // Notify clients only if its NOT a gateway event.
       if (event.getVersionTag() != null && !event.getVersionTag().isGatewayTag()) {
         notifyBridgeClients(event);
+        notifyGatewaySender(EnumListenerEvent.AFTER_DESTROY, event);
       }
       return true; // event was elided
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -559,6 +559,20 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
                 }
               }
             }
+
+            // filter out the events with CME
+            Iterator<GatewaySenderEventImpl> cmeItr = filteredList.iterator();
+            while (cmeItr.hasNext()) {
+              GatewaySenderEventImpl event = cmeItr.next();
+              if (event.isConcurrencyConflict()) {
+                cmeItr.remove();
+                logger.debug("The CME event: {} is removed from Gateway Sender queue: {}", event,
+                    sender);
+                statistics.incEventsNotQueued();
+                continue;
+              }
+            }
+
             /*
              * if (filteredList.isEmpty()) { eventQueueRemove(events.size()); continue; }
              */

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.RegionAttributes;
+
+public class UpdateOperationJUnitTest {
+  EntryEventImpl event;
+  UpdateOperation.UpdateMessage message;
+  DistributedRegion region;
+
+  @Before
+  public void setup() {
+    event = mock(EntryEventImpl.class);
+    region = mock(DistributedRegion.class);
+    RegionAttributes attr = mock(RegionAttributes.class);
+    CachePerfStats stats = mock(CachePerfStats.class);
+    when(event.isOriginRemote()).thenReturn(false);
+    when(stats.endPut(anyLong(), eq(false))).thenReturn(0L);
+
+    message = new UpdateOperation.UpdateMessage();
+    message.event = event;
+    when(region.isAllEvents()).thenReturn(true);
+    when(region.getAttributes()).thenReturn(attr);
+    when(region.isUsedForPartitionedRegionBucket()).thenReturn(false);
+    when(region.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
+    when(region.getConcurrencyChecksEnabled()).thenReturn(true);
+    when(region.getCachePerfStats()).thenReturn(stats);
+    when(attr.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
+    when(event.getOperation()).thenReturn(Operation.CREATE);
+  }
+
+  /**
+   * AUO's doPutOrCreate will try with create first. If it succeed, it will not try update
+   * retry update
+   */
+  @Test
+  public void createSucceedShouldNotRetryAnymore() {
+    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
+        .thenReturn(true);
+    message.basicOperateOnRegion(event, region);
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+  }
+
+  /**
+   * AUO's doPutOrCreate will try with create first. If it failed with ConcurrencyConflict, should
+   * not
+   * retry update
+   */
+  @Test
+  public void createFailWithConcurrencyConflictShouldNotRetry() {
+    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
+        .thenReturn(false);
+    when(event.isConcurrencyConflict()).thenReturn(true);
+    message.basicOperateOnRegion(event, region);
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+  }
+
+  /**
+   * AUO's doPutOrCreate will try with create first. If it failed, it will try update.
+   * If update succeed, no more retry
+   */
+  @Test
+  public void updateSucceedShouldNotRetryAnymore() {
+    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
+        .thenReturn(false);
+    when(region.basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true)))
+        .thenReturn(true);
+    message.basicOperateOnRegion(event, region);
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+  }
+
+  /**
+   * AUO's doPutOrCreate() will try with create, then update.
+   * If retry again, it should be an update with ifNew==false and ifOld==false
+   * It should not retry with create again
+   */
+  @Test
+  public void doPutOrCreate3rdRetryShouldBeUpdate() {
+    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
+        .thenReturn(false);
+    when(region.basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true)))
+        .thenReturn(false);
+    message.basicOperateOnRegion(event, region);
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+  }
+
+}

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Rule;
@@ -51,6 +52,7 @@ import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.cache.ForceReattemptException;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.parallel.BatchRemovalThreadHelper;
 import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySenderQueue;
@@ -58,6 +60,7 @@ import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderQueue;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.DUnitLauncher;
@@ -198,8 +201,8 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     client.invoke(() -> doPuts(regionName, numPuts));
 
     // Wait for local site queues to be empty
-    localServer1.invoke(() -> waitForEmptyQueueRegion(senderId, primaryOnly));
-    localServer2.invoke(() -> waitForEmptyQueueRegion(senderId, primaryOnly));
+    localServer1.invoke(() -> waitForQueueRegionToCertainSize(senderId, 0, primaryOnly));
+    localServer2.invoke(() -> waitForQueueRegionToCertainSize(senderId, 0, primaryOnly));
 
     // Verify remote site received events
     int remoteServer1EventsReceived = remoteServer1.invoke(() -> getEventsReceived(regionName));
@@ -224,7 +227,7 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     localServer1.invoke(() -> closeCache());
 
     // Wait for the other sender's queue to be empty
-    localServer2.invoke(() -> waitForEmptyQueueRegion(senderId, false));
+    localServer2.invoke(() -> waitForQueueRegionToCertainSize(senderId, 0, false));
 
     // Verify remote site did not receive any events. The events received were previously cleared on
     // all members, so there should be 0 events received on the remote site.
@@ -263,7 +266,7 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     server.start();
   }
 
-  private void startClient(String hostName, int locatorPort, String regionName) {
+  protected void startClient(String hostName, int locatorPort, String regionName) {
     ClientCacheFactory ccf = new ClientCacheFactory().addPoolLocator(hostName, locatorPort);
     ClientCache cache = getClientCache(ccf);
     cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create(regionName);
@@ -306,19 +309,62 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
         .setPartitionAttributes(paf.create()).create(regionName);
   }
 
-  private void doPuts(String regionName, int numPuts) {
+  protected void doPuts(String regionName, int numPuts) {
     Region region = getCache().getRegion(regionName);
     for (int i = 0; i < numPuts; i++) {
       region.put(i, i);
     }
   }
 
-  private void waitForEmptyQueueRegion(String gatewaySenderId, boolean primaryOnly) {
-    await()
-        .until(() -> getQueueRegionSize(gatewaySenderId, primaryOnly) == 0);
+  protected void pauseSender(String senderId) {
+    final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
+    IgnoredException exp =
+        IgnoredException.addIgnoredException(ForceReattemptException.class.getName());
+    try {
+      Set<GatewaySender> senders = cache.getGatewaySenders();
+      GatewaySender sender = null;
+      for (GatewaySender s : senders) {
+        if (s.getId().equals(senderId)) {
+          sender = s;
+          break;
+        }
+      }
+      sender.pause();
+      ((AbstractGatewaySender) sender).getEventProcessor().waitForDispatcherToPause();
+
+    } finally {
+      exp.remove();
+      exln.remove();
+    }
   }
 
-  private int getQueueRegionSize(String gatewaySenderId, boolean primaryOnly) {
+  protected void resumeSender(String senderId) {
+    final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
+    IgnoredException exp =
+        IgnoredException.addIgnoredException(ForceReattemptException.class.getName());
+    try {
+      Set<GatewaySender> senders = cache.getGatewaySenders();
+      GatewaySender sender = null;
+      for (GatewaySender s : senders) {
+        if (s.getId().equals(senderId)) {
+          sender = s;
+          break;
+        }
+      }
+      sender.resume();
+    } finally {
+      exp.remove();
+      exln.remove();
+    }
+  }
+
+  protected void waitForQueueRegionToCertainSize(String gatewaySenderId, int expectedSize,
+      boolean primaryOnly) {
+    await()
+        .until(() -> getQueueRegionSize(gatewaySenderId, primaryOnly) == expectedSize);
+  }
+
+  protected int getQueueRegionSize(String gatewaySenderId, boolean primaryOnly) {
     // This method currently only supports parallel senders. It gets the size of the local data set
     // from the
     // underlying co-located region. Depending on the value of primaryOnly, it gets either the local
@@ -334,14 +380,14 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     return localDataSet.size();
   }
 
-  private Integer getEventsReceived(String regionName) {
+  protected Integer getEventsReceived(String regionName) {
     Region region = getCache().getRegion(regionName);
     EventCountCacheListener cl =
         (EventCountCacheListener) region.getAttributes().getCacheListener();
     return cl.getEventsReceived();
   }
 
-  private void clearEventsReceived(String regionName) {
+  protected void clearEventsReceived(String regionName) {
     Region region = getCache().getRegion(regionName);
     EventCountCacheListener cl =
         (EventCountCacheListener) region.getAttributes().getCacheListener();

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeNewSenderProcessOldEvent.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeNewSenderProcessOldEvent.java
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.wan;
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderQueue;
+import org.apache.geode.test.dunit.DistributedTestUtils;
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.NetworkUtils;
+import org.apache.geode.test.dunit.VM;
+
+public class WANRollingUpgradeNewSenderProcessOldEvent
+    extends WANRollingUpgradeDUnitTest {
+  final Host host = Host.getHost(0);
+
+  private VM site1Locator;
+  private VM site1Server1;
+  private VM site1Server2;
+  private VM site1Client;
+
+  private VM site2Locator;
+  private VM site2Server1;
+  private VM site2Server2;
+
+  private String site1Locators;
+  private String site2Locators;
+  private String site1SenderId;
+  private String site2SenderId;
+  private String regionName;
+
+  final int numPuts = 100;
+  final int site1DistributedSystemId = 0;
+  final int site2DistributedSystemId = 1;
+  int site1LocatorPort;
+  int site2LocatorPort;
+
+  @Before
+  public void prepare() {
+    // Get mixed site members
+    site1Locator = host.getVM(oldVersion, 0);
+    site1Server1 = host.getVM(oldVersion, 1);
+    site1Server2 = host.getVM(oldVersion, 2);
+    site1Client = host.getVM(oldVersion, 3);
+
+    // Get old site members
+    site2Locator = host.getVM(oldVersion, 4);
+    site2Server1 = host.getVM(oldVersion, 5);
+    site2Server2 = host.getVM(oldVersion, 6);
+
+    // Get mixed site locator properties
+    String hostName = NetworkUtils.getServerHostName(host);
+    final int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
+    site1LocatorPort = availablePorts[0];
+    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locators = hostName + "[" + site1LocatorPort + "]";
+
+    // Get old site locator properties
+    site2LocatorPort = availablePorts[1];
+    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locators = hostName + "[" + site2LocatorPort + "]";
+
+    // Start mixed site locator
+    site1Locator.invoke(() -> startLocator(site1LocatorPort, site1DistributedSystemId,
+        site1Locators, site2Locators));
+
+    // Start old site locator
+    site2Locator.invoke(() -> startLocator(site2LocatorPort, site2DistributedSystemId,
+        site2Locators, site1Locators));
+
+    // Locators before 1.4 handled configuration asynchronously.
+    // We must wait for configuration configuration to be ready, or confirm that it is disabled.
+    site1Locator.invoke(
+        () -> await()
+            .untilAsserted(() -> assertTrue(
+                !InternalLocator.getLocator().getConfig().getEnableClusterConfiguration()
+                    || InternalLocator.getLocator().isSharedConfigurationRunning())));
+    site2Locator.invoke(
+        () -> await()
+            .untilAsserted(() -> assertTrue(
+                !InternalLocator.getLocator().getConfig().getEnableClusterConfiguration()
+                    || InternalLocator.getLocator().isSharedConfigurationRunning())));
+
+    // Start and configure mixed site servers
+    regionName = getName() + "_region";
+    site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+    startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
+        regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+
+    site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+
+    // pause the senders at mixed site
+    site1Server1.invoke(() -> pauseSender(site1SenderId));
+    site1Server2.invoke(() -> pauseSender(site1SenderId));
+
+    // start client
+    site1Client.invoke(() -> startClient(hostName, site1LocatorPort, regionName));
+
+    // Do puts from client
+    site1Client.invoke(() -> doPuts(regionName, numPuts));
+
+    // check queue size should be numPuts
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+    site1Server2.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+  }
+
+  /**
+   * 1.create a sender, pause
+   * 2.do puts, build up the queue.
+   * 3.roll one server to current and stop another old server
+   * 4.start sender on current
+   * Current sender should handle old events, the remove site should receive all of them
+   */
+  @Test
+  public void oldEventShouldBeProcessedAtNewSender() {
+    // Roll mixed site locator to current
+    rollLocatorToCurrent(site1Locator, site1LocatorPort, site1DistributedSystemId, site1Locators,
+        site2Locators);
+
+    // Roll mixed site servers to current
+    rollStartAndConfigureServerToCurrent(site1Server1, site1Locators, site2DistributedSystemId,
+        regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+    site1Server1.invoke(() -> pauseSender(site1SenderId));
+
+    // double check queue size should be numPuts
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+    site1Server2.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+
+    // Start and configure old site servers
+    startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
+        regionName, site2SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+
+    // stop one of the sender to force all the old events are processed by the new sender
+    site1Server2.invoke(() -> closeCache());
+
+    // double check queue size should be numPuts since all primary buckets are in this server
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, true));
+
+    // resume the senders at mixed site
+    site1Server1.invoke(() -> resumeSender(site1SenderId));
+
+    // Wait for mixed site queues to be empty
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, 0, false));
+
+    // Verify remote site received events
+    int remoteServer1EventsReceived = site2Server1.invoke(() -> getEventsReceived(regionName));
+    int remoteServer2EventsReceived = site2Server2.invoke(() -> getEventsReceived(regionName));
+    assertEquals(numPuts, remoteServer1EventsReceived + remoteServer2EventsReceived);
+
+    // Clear events received in both sites
+    site1Server1.invoke(() -> clearEventsReceived(regionName));
+    site2Server1.invoke(() -> clearEventsReceived(regionName));
+    site2Server2.invoke(() -> clearEventsReceived(regionName));
+  }
+
+  /**
+   * 1.create a sender, pause
+   * 2.do puts, build up the queue.
+   * 3.roll all old server to current
+   * 4.start senders on current
+   * Current sender should handle old events, the remove site should receive all of them
+   */
+  @Test
+  public void oldEventShouldBeProcessedAtTwoNewSender() {
+    // Roll mixed site locator to current
+    rollLocatorToCurrent(site1Locator, site1LocatorPort, site1DistributedSystemId, site1Locators,
+        site2Locators);
+
+    // Roll mixed site servers to current
+    rollStartAndConfigureServerToCurrent(site1Server1, site1Locators, site2DistributedSystemId,
+        regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+    site1Server1.invoke(() -> pauseSender(site1SenderId));
+
+    // wait until site1Server finished rolling
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+
+    rollStartAndConfigureServerToCurrent(site1Server2, site1Locators, site2DistributedSystemId,
+        regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+    site1Server2.invoke(() -> pauseSender(site1SenderId));
+
+    // double check queue size should be numPuts
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+    site1Server2.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+
+    // Start and configure old site servers
+    startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
+        regionName, site2SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+
+    // resume the senders at mixed site
+    site1Server1.invoke(() -> resumeSender(site1SenderId));
+    site1Server2.invoke(() -> resumeSender(site1SenderId));
+
+    // Wait for mixed site queues to be empty
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, 0, false));
+    site1Server2.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, 0, false));
+
+    // Verify remote site received events
+    int remoteServer1EventsReceived = site2Server1.invoke(() -> getEventsReceived(regionName));
+    int remoteServer2EventsReceived = site2Server2.invoke(() -> getEventsReceived(regionName));
+    assertEquals(numPuts, remoteServer1EventsReceived + remoteServer2EventsReceived);
+
+    // Clear events received in both sites
+    site1Server1.invoke(() -> clearEventsReceived(regionName));
+    site1Server2.invoke(() -> clearEventsReceived(regionName));
+    site2Server1.invoke(() -> clearEventsReceived(regionName));
+    site2Server2.invoke(() -> clearEventsReceived(regionName));
+  }
+
+  /**
+   * get new events to flow back to the old member and have the old member try to deserialize
+   * the new event
+   * 1.create 2 old senders, pause
+   * 2.do puts, build up the queue.
+   * 3.roll one sender to current
+   * 4.do additional puts that get queued in the new member with a redundant copy on the old member
+   * 5.remove the new member
+   * 6.start sender on old member
+   *
+   * The old sender should handle both old and new events, the remove site should receive all of
+   * them
+   */
+  @Test
+  public void bothOldAndNewEventsShouldBeProcessedByOldSender() {
+    // Roll mixed site locator to current
+    rollLocatorToCurrent(site1Locator, site1LocatorPort, site1DistributedSystemId, site1Locators,
+        site2Locators);
+
+    // Roll one mixed site server to current
+    rollStartAndConfigureServerToCurrent(site1Server1, site1Locators, site2DistributedSystemId,
+        regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+    site1Server1.invoke(() -> pauseSender(site1SenderId));
+
+    // double check queue size should be numPuts
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+    site1Server2.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts, false));
+
+    // do additional puts, at least half of them will be put into new sender, then distributed to
+    // the old sender
+    site1Client.invoke(() -> {
+      Region region = getCache().getRegion(regionName);
+      for (int i = numPuts; i < numPuts * 2; i++) {
+        region.put(i, i);
+      }
+    });
+
+    // check queue size should be numPuts*2
+    site1Server1.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts * 2, false));
+    site1Server2.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, numPuts * 2, false));
+
+    // Start and configure old site servers
+    startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
+        regionName, site2SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
+
+    // stop the new sender to force all the old+new events are processed by the remained old sender
+    site1Server1.invoke(() -> closeCache());
+
+    // resume the senders at mixed site
+    site1Server2.invoke(() -> resumeSender(site1SenderId));
+
+    // Wait for mixed site queues to be empty
+    site1Server2.invoke(() -> waitForQueueRegionToCertainSize(site1SenderId, 0, false));
+
+    // Verify remote site received events
+    int remoteServer1EventsReceived = site2Server1.invoke(() -> getEventsReceived(regionName));
+    int remoteServer2EventsReceived = site2Server2.invoke(() -> getEventsReceived(regionName));
+    assertEquals(numPuts * 2, remoteServer1EventsReceived + remoteServer2EventsReceived);
+
+    // Clear events received in both sites
+    site1Server2.invoke(() -> clearEventsReceived(regionName));
+    site2Server1.invoke(() -> clearEventsReceived(regionName));
+    site2Server2.invoke(() -> clearEventsReceived(regionName));
+  }
+}


### PR DESCRIPTION
…processedEvents.

@jhuynh1 @boglesby 

When ConcurrentCacheModificationException happened, GatewaySenderEventImpl
should save the status and notify gatewaysender if it hold primary queue,
because other member might have put the event into the secondary queue

Let event with CME only enqueue to primary, but not to dispatch. The old
logic does not allow CME event to  enqueue. This is wrong, because an event
without CME might have been added into the secondary queue.

We should not dispatch the CME event, otherwise it will cause remote site
data inconsistency since these CME events are misordered.

So we should enqueue it, but not to dispatch.

Also add rollingUpgradeTests

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
