### PR TITLE
GEODE-6143: Remove PowerMock from ExecuteFunction tests

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionService.java
@@ -148,7 +148,10 @@ public class InternalFunctionService extends FunctionService {
     getInternalFunctionExecutionService().unregisterAllFunctions();
   }
 
-  private static InternalFunctionExecutionService getInternalFunctionExecutionService() {
+  /**
+   * Returns non-static reference to {@code InternalFunctionExecutionService} singleton instance.
+   */
+  public static InternalFunctionExecutionService getInternalFunctionExecutionService() {
     return INSTANCE.internalFunctionExecutionService;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction.java
@@ -16,17 +16,20 @@ package org.apache.geode.internal.cache.tier.sockets.command;
 
 import java.io.IOException;
 
+import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
-import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.cache.operations.ExecuteFunctionOperationContext;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.FunctionContextImpl;
 import org.apache.geode.internal.cache.execute.FunctionStats;
+import org.apache.geode.internal.cache.execute.InternalFunctionExecutionService;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
+import org.apache.geode.internal.cache.execute.InternalFunctionService;
 import org.apache.geode.internal.cache.execute.MemberMappedArgument;
 import org.apache.geode.internal.cache.execute.ServerToClientFunctionResultSender;
 import org.apache.geode.internal.cache.tier.Command;
@@ -53,6 +56,25 @@ public class ExecuteFunction extends BaseCommand {
 
   public static Command getCommand() {
     return singleton;
+  }
+
+  private final InternalFunctionExecutionService internalFunctionExecutionService;
+  private final ServerToClientFunctionResultSenderFactory serverToClientFunctionResultSenderFactory;
+  private final FunctionContextImplFactory functionContextImplFactory;
+
+  private ExecuteFunction() {
+    this(InternalFunctionService.getInternalFunctionExecutionService(),
+        new DefaultServerToClientFunctionResultSenderFactory(),
+        new DefaultFunctionContextImplFactory());
+  }
+
+  @TestingOnly
+  ExecuteFunction(InternalFunctionExecutionService internalFunctionExecutionService,
+      ServerToClientFunctionResultSenderFactory serverToClientFunctionResultSenderFactory,
+      FunctionContextImplFactory functionContextImplFactory) {
+    this.internalFunctionExecutionService = internalFunctionExecutionService;
+    this.serverToClientFunctionResultSenderFactory = serverToClientFunctionResultSenderFactory;
+    this.functionContextImplFactory = functionContextImplFactory;
   }
 
   @Override
@@ -97,7 +119,7 @@ public class ExecuteFunction extends BaseCommand {
     try {
       Function<?> functionObject = null;
       if (function instanceof String) {
-        functionObject = FunctionService.getFunction((String) function);
+        functionObject = internalFunctionExecutionService.getFunction((String) function);
         if (functionObject == null) {
           final String message =
               String.format("Function named %s is not registered to FunctionService",
@@ -124,7 +146,7 @@ public class ExecuteFunction extends BaseCommand {
 
       ChunkedMessage m = serverConnection.getFunctionResponseMessage();
       m.setTransactionId(clientMessage.getTransactionId());
-      ResultSender resultSender = new ServerToClientFunctionResultSender(m,
+      ResultSender resultSender = serverToClientFunctionResultSenderFactory.create(m,
           MessageType.EXECUTE_FUNCTION_RESULT, serverConnection, functionObject, executeContext);
 
       FunctionContext context = null;
@@ -133,10 +155,11 @@ public class ExecuteFunction extends BaseCommand {
           (InternalDistributedMember) cache.getDistributedSystem().getDistributedMember();
 
       if (memberMappedArg != null) {
-        context = new FunctionContextImpl(cache, functionObject.getId(),
+        context = functionContextImplFactory.create(cache, functionObject.getId(),
             memberMappedArg.getArgumentsForMember(localVM.getId()), resultSender);
       } else {
-        context = new FunctionContextImpl(cache, functionObject.getId(), args, resultSender);
+        context =
+            functionContextImplFactory.create(cache, functionObject.getId(), args, resultSender);
       }
 
       ServerSideHandshake handshake = serverConnection.getHandshake();
@@ -177,21 +200,18 @@ public class ExecuteFunction extends BaseCommand {
       // information to user to take any corrective action hence logging
       // this at fine level logging
       // 1> When bucket is moved
-      // 2> Incase of HA FucntionInvocationTargetException thrown. Since
-      // it is HA, fucntion will be reexecuted on right node
+      // 2> In case of HA FunctionInvocationTargetException thrown. Since
+      // it is HA, function will be re-executed on right node
       // 3> Multiple target nodes found for single hop operation
       // 4> in case of HA member departed
       if (logger.isDebugEnabled()) {
-        logger.debug(String.format("Exception on server while executing function: %s",
-            new Object[] {function}),
+        logger.debug(String.format("Exception on server while executing function: %s", function),
             internalfunctionException);
       }
       final String message = internalfunctionException.getMessage();
       sendException(hasResult, clientMessage, message, serverConnection, internalfunctionException);
     } catch (Exception e) {
-      logger.warn(String.format("Exception on server while executing function: %s",
-          function),
-          e);
+      logger.warn(String.format("Exception on server while executing function: %s", function), e);
       final String message = e.getMessage();
       sendException(hasResult, clientMessage, message, serverConnection, e);
     }
@@ -214,4 +234,30 @@ public class ExecuteFunction extends BaseCommand {
     }
   }
 
+  interface ServerToClientFunctionResultSenderFactory {
+    ServerToClientFunctionResultSender create(ChunkedMessage msg, int messageType,
+        ServerConnection sc, Function function, ExecuteFunctionOperationContext authzContext);
+  }
+
+  interface FunctionContextImplFactory {
+    FunctionContextImpl create(Cache cache, String functionId, Object args,
+        ResultSender resultSender);
+  }
+
+  private static class DefaultServerToClientFunctionResultSenderFactory
+      implements ServerToClientFunctionResultSenderFactory {
+    @Override
+    public ServerToClientFunctionResultSender create(ChunkedMessage msg, int messageType,
+        ServerConnection sc, Function function, ExecuteFunctionOperationContext authzContext) {
+      return new ServerToClientFunctionResultSender(msg, messageType, sc, function, authzContext);
+    }
+  }
+
+  private static class DefaultFunctionContextImplFactory implements FunctionContextImplFactory {
+    @Override
+    public FunctionContextImpl create(Cache cache, String functionId, Object args,
+        ResultSender resultSender) {
+      return new FunctionContextImpl(cache, functionId, args, resultSender);
+    }
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70.java
@@ -28,6 +28,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
+import org.apache.geode.internal.cache.execute.InternalFunctionExecutionService;
 import org.apache.geode.internal.cache.execute.InternalFunctionExecutionServiceImpl;
 import org.apache.geode.internal.cache.execute.MemberFunctionExecutor;
 import org.apache.geode.internal.cache.execute.ServerToClientFunctionResultSender;
@@ -45,7 +46,16 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
     return singleton;
   }
 
-  private ExecuteFunction70() {}
+  private ExecuteFunction70() {
+    // nothing
+  }
+
+  ExecuteFunction70(InternalFunctionExecutionService internalFunctionExecutionService,
+      ServerToClientFunctionResultSender65Factory serverToClientFunctionResultSender65Factory,
+      FunctionContextImplFactory functionContextImplFactory) {
+    super(internalFunctionExecutionService, serverToClientFunctionResultSender65Factory,
+        functionContextImplFactory);
+  }
 
   @Override
   public void cmdExecute(final Message clientMessage, final ServerConnection serverConnection,
@@ -75,7 +85,7 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
 
   private boolean isFlagSet(Message msg, int index) {
     boolean isSet = false;
-    byte[] flags = null;
+    byte[] flags;
     Part p = msg.getPart(5);
     if (p != null) {
       flags = p.getSerializedForm();
@@ -98,13 +108,12 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
       throw new IllegalStateException(
           "DistributedSystem is either not created or not ready");
     }
-    Set<DistributedMember> members = new HashSet<DistributedMember>();
+    Set<DistributedMember> members = new HashSet<>();
     for (String group : groups) {
       if (allMembers) {
         members.addAll(ds.getGroupMembers(group));
       } else {
-        ArrayList<DistributedMember> memberList =
-            new ArrayList<DistributedMember>(ds.getGroupMembers(group));
+        ArrayList<DistributedMember> memberList = new ArrayList<>(ds.getGroupMembers(group));
         if (!memberList.isEmpty()) {
           if (!InternalFunctionExecutionServiceImpl.RANDOM_onMember
               && memberList.contains(ds.getDistributedMember())) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.apache.geode.cache.client.internal.ExecuteFunctionOp;
@@ -65,12 +66,12 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
 
   @Override
   protected String[] getGroups(Message msg) throws IOException, ClassNotFoundException {
-    String[] grp = null;
-    Part p = msg.getPart(4);
-    if (p != null) {
-      grp = (String[]) p.getObject();
+    String[] groups = null;
+    Part messagePart = msg.getPart(4);
+    if (messagePart != null) {
+      groups = (String[]) messagePart.getObject();
     }
-    return grp;
+    return groups;
   }
 
   @Override
@@ -85,10 +86,9 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
 
   private boolean isFlagSet(Message msg, int index) {
     boolean isSet = false;
-    byte[] flags;
-    Part p = msg.getPart(5);
-    if (p != null) {
-      flags = p.getSerializedForm();
+    Part messagePart = msg.getPart(5);
+    if (messagePart != null) {
+      byte[] flags = messagePart.getSerializedForm();
       if (flags != null && flags.length > index) {
         if (flags[index] == 1) {
           isSet = true;
@@ -102,18 +102,17 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
   protected void executeFunctionOnGroups(Object function, Object args, String[] groups,
       boolean allMembers, Function functionObject, ServerToClientFunctionResultSender resultSender,
       boolean ignoreFailedMembers) {
-
     DistributedSystem ds = InternalDistributedSystem.getConnectedInstance();
     if (ds == null) {
-      throw new IllegalStateException(
-          "DistributedSystem is either not created or not ready");
+      throw new IllegalStateException("DistributedSystem is either not created or not ready");
     }
+
     Set<DistributedMember> members = new HashSet<>();
     for (String group : groups) {
       if (allMembers) {
         members.addAll(ds.getGroupMembers(group));
       } else {
-        ArrayList<DistributedMember> memberList = new ArrayList<>(ds.getGroupMembers(group));
+        List<DistributedMember> memberList = new ArrayList<>(ds.getGroupMembers(group));
         if (!memberList.isEmpty()) {
           if (!InternalFunctionExecutionServiceImpl.RANDOM_onMember
               && memberList.contains(ds.getDistributedMember())) {
@@ -125,23 +124,28 @@ public class ExecuteFunction70 extends ExecuteFunction66 {
         }
       }
     }
+
     if (logger.isDebugEnabled()) {
       logger.debug("Executing Function on Groups: {} all members: {} members are: {}",
           Arrays.toString(groups), allMembers, members);
     }
+
     Execution execution = new MemberFunctionExecutor(ds, members, resultSender);
     if (args != null) {
       execution = execution.setArguments(args);
     }
+
     if (ignoreFailedMembers) {
       if (logger.isDebugEnabled()) {
         logger.debug("Function will ignore failed members");
       }
       ((AbstractExecution) execution).setIgnoreDepartedMembers(true);
     }
+
     if (!functionObject.isHA()) {
       ((AbstractExecution) execution).setWaitOnExceptionFlag(true);
     }
+
     if (function instanceof String) {
       execution.execute(functionObject.getId()).getResult();
     } else {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction65Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction65Test.java
@@ -15,11 +15,13 @@
 package org.apache.geode.internal.cache.tier.sockets.command;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
@@ -27,25 +29,20 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.LowMemoryException;
 import org.apache.geode.cache.execute.Function;
-import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.operations.ExecuteFunctionOperationContext;
+import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.control.HeapMemoryMonitor;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.execute.InternalFunctionExecutionService;
+import org.apache.geode.internal.cache.execute.ServerToClientFunctionResultSender65;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.cache.tier.sockets.ChunkedMessage;
@@ -53,6 +50,8 @@ import org.apache.geode.internal.cache.tier.sockets.Message;
 import org.apache.geode.internal.cache.tier.sockets.Part;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
 import org.apache.geode.internal.cache.tier.sockets.ServerSideHandshakeImpl;
+import org.apache.geode.internal.cache.tier.sockets.command.ExecuteFunction65.FunctionContextImplFactory;
+import org.apache.geode.internal.cache.tier.sockets.command.ExecuteFunction65.ServerToClientFunctionResultSender65Factory;
 import org.apache.geode.internal.security.AuthorizeRequest;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.internal.security.ResourcePermissions;
@@ -61,53 +60,23 @@ import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
-@Category({ClientServerTest.class})
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("*.UnitTest")
-@PrepareForTest({FunctionService.class})
+@Category(ClientServerTest.class)
 public class ExecuteFunction65Test {
+
   private static final String FUNCTION = "function";
   private static final String FUNCTION_ID = "function_id";
   private static final boolean OPTIMIZE_FOR_WRITE = false;
   private static final Object CALLBACK_ARG = "arg";
   private static final byte[] RESULT = new byte[] {Integer.valueOf(0).byteValue()};
 
-  @Mock
-  private SecurityService securityService;
-  @Mock
-  private Message message;
-  @Mock
-  private ServerConnection serverConnection;
-  @Mock
-  private AuthorizeRequest authzRequest;
-  @Mock
-  private LocalRegion region;
-  @Mock
-  private GemFireCacheImpl cache;
-  @Mock
-  private ChunkedMessage functionResponseMessage;
-  @Mock
+  private AuthorizeRequest authorizeRequest;
   private ChunkedMessage chunkedResponseMessage;
-  @Mock
-  private Part functionPart;
-  @Mock
-  private Part functionStatePart;
-  @Mock
-  private Part argsPart;
-  @Mock
-  private Part partPart;
-  @Mock
-  private Part callbackArgPart;
-  @Mock
-  private Function functionObject;
-  @Mock
-  private InternalResourceManager internalResourceManager;
-  @Mock
-  private AcceptorImpl acceptor;
-  @Mock
-  private ExecuteFunctionOperationContext executeFunctionOperationContext;
+  private ChunkedMessage functionResponseMessage;
+  private Message message;
+  private SecurityService securityService;
+  private ServerConnection serverConnection;
+  private ServerToClientFunctionResultSender65Factory serverToClientFunctionResultSender65Factory;
 
-  @InjectMocks
   private ExecuteFunction65 executeFunction65;
 
   @Rule
@@ -117,105 +86,140 @@ public class ExecuteFunction65Test {
   public void setUp() throws Exception {
     System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "statsDisabled", "true");
 
-    this.executeFunction65 = new ExecuteFunction65();
-    MockitoAnnotations.initMocks(this);
+    authorizeRequest = mock(AuthorizeRequest.class);
+    chunkedResponseMessage = mock(ChunkedMessage.class);
+    functionResponseMessage = mock(ChunkedMessage.class);
+    message = mock(Message.class);
+    securityService = mock(SecurityService.class);
+    serverConnection = mock(ServerConnection.class);
+    serverToClientFunctionResultSender65Factory =
+        mock(ServerToClientFunctionResultSender65Factory.class);
 
-    when(this.authzRequest.executeFunctionAuthorize(eq(FUNCTION_ID), eq(null), eq(null), eq(null),
-        eq(OPTIMIZE_FOR_WRITE))).thenReturn(this.executeFunctionOperationContext);
+    AcceptorImpl acceptor = mock(AcceptorImpl.class);
+    InternalCache cache = mock(InternalCache.class);
+    ExecuteFunctionOperationContext executeFunctionOperationContext =
+        mock(ExecuteFunctionOperationContext.class);
+    Function functionObject = mock(Function.class);
+    FunctionContextImplFactory functionContextImplFactory = mock(FunctionContextImplFactory.class);
+    HeapMemoryMonitor heapMemoryMonitor = mock(HeapMemoryMonitor.class);
+    InternalFunctionExecutionService internalFunctionExecutionService =
+        mock(InternalFunctionExecutionService.class);
+    InternalResourceManager internalResourceManager = mock(InternalResourceManager.class);
+    ServerToClientFunctionResultSender65 serverToClientFunctionResultSender65 =
+        mock(ServerToClientFunctionResultSender65.class);
 
-    when(this.cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
-    when(this.cache.getDistributedSystem()).thenReturn(mock(InternalDistributedSystem.class));
-    when(this.cache.getResourceManager()).thenReturn(this.internalResourceManager);
+    Part argsPart = mock(Part.class);
+    Part callbackArgPart = mock(Part.class);
+    Part functionPart = mock(Part.class);
+    Part functionStatePart = mock(Part.class);
+    Part partPart = mock(Part.class);
 
-    when(this.callbackArgPart.getObject()).thenReturn(CALLBACK_ARG);
+    when(authorizeRequest.executeFunctionAuthorize(eq(FUNCTION_ID), eq(null), eq(null), eq(null),
+        eq(OPTIMIZE_FOR_WRITE))).thenReturn(executeFunctionOperationContext);
 
-    when(this.functionObject.getId()).thenReturn(FUNCTION_ID);
-    doCallRealMethod().when(this.functionObject).getRequiredPermissions(any());
-    doCallRealMethod().when(this.functionObject).getRequiredPermissions(any(), any());
+    when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    when(cache.getDistributedSystem()).thenReturn(mock(InternalDistributedSystem.class));
+    when(cache.getInternalResourceManager()).thenReturn(internalResourceManager);
+    when(cache.getMyId()).thenReturn(mock(InternalDistributedMember.class));
 
-    when(this.functionPart.getStringOrObject()).thenReturn(FUNCTION);
+    when(callbackArgPart.getObject()).thenReturn(CALLBACK_ARG);
 
-    when(this.functionStatePart.getSerializedForm()).thenReturn(RESULT);
+    when(functionObject.getId()).thenReturn(FUNCTION_ID);
+    doCallRealMethod().when(functionObject).getRequiredPermissions(any());
+    doCallRealMethod().when(functionObject).getRequiredPermissions(any(), any());
 
-    when(this.internalResourceManager.getHeapMonitor()).thenReturn(mock(HeapMemoryMonitor.class));
+    when(functionPart.getStringOrObject()).thenReturn(FUNCTION);
+    when(functionStatePart.getSerializedForm()).thenReturn(RESULT);
+    when(heapMemoryMonitor.createLowMemoryIfNeeded(any(), any(DistributedMember.class)))
+        .thenReturn(mock(LowMemoryException.class));
+    when(internalFunctionExecutionService.getFunction(eq(FUNCTION))).thenReturn(functionObject);
+    when(internalResourceManager.getHeapMonitor()).thenReturn(heapMemoryMonitor);
 
-    when(this.message.getNumberOfParts()).thenReturn(4);
-    when(this.message.getPart(eq(0))).thenReturn(this.functionStatePart);
-    when(this.message.getPart(eq(1))).thenReturn(this.functionPart);
-    when(this.message.getPart(eq(2))).thenReturn(this.argsPart);
-    when(this.message.getPart(eq(3))).thenReturn(this.partPart);
+    when(message.getNumberOfParts()).thenReturn(4);
+    when(message.getPart(eq(0))).thenReturn(functionStatePart);
+    when(message.getPart(eq(1))).thenReturn(functionPart);
+    when(message.getPart(eq(2))).thenReturn(argsPart);
+    when(message.getPart(eq(3))).thenReturn(partPart);
 
-    when(this.serverConnection.getCache()).thenReturn(this.cache);
-    when(this.serverConnection.getAuthzRequest()).thenReturn(this.authzRequest);
-    when(this.serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
-    when(this.serverConnection.getFunctionResponseMessage())
-        .thenReturn(this.functionResponseMessage);
-    when(this.serverConnection.getChunkedResponseMessage()).thenReturn(this.chunkedResponseMessage);
-    when(this.serverConnection.getAcceptor()).thenReturn(this.acceptor);
-    when(this.serverConnection.getHandshake()).thenReturn(mock(ServerSideHandshakeImpl.class));
+    when(internalResourceManager.getHeapMonitor()).thenReturn(heapMemoryMonitor);
 
-    PowerMockito.mockStatic(FunctionService.class);
-    PowerMockito.when(FunctionService.getFunction(eq(FUNCTION))).thenReturn(functionObject);
+    when(serverConnection.getAcceptor()).thenReturn(acceptor);
+    when(serverConnection.getAuthzRequest()).thenReturn(authorizeRequest);
+    when(serverConnection.getCache()).thenReturn(cache);
+    when(serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
+    when(serverConnection.getChunkedResponseMessage()).thenReturn(chunkedResponseMessage);
+    when(serverConnection.getFunctionResponseMessage()).thenReturn(functionResponseMessage);
+    when(serverConnection.getHandshake()).thenReturn(mock(ServerSideHandshakeImpl.class));
+
+    when(serverToClientFunctionResultSender65Factory.create(any(), anyInt(), any(), any(), any()))
+        .thenReturn(
+            serverToClientFunctionResultSender65);
+
+    executeFunction65 = new ExecuteFunction65(internalFunctionExecutionService,
+        serverToClientFunctionResultSender65Factory, functionContextImplFactory);
   }
 
   @Test
   public void nonSecureShouldSucceed() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(false);
+    when(securityService.isClientSecurityRequired()).thenReturn(false);
 
-    this.executeFunction65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction65.cmdExecute(message, serverConnection, securityService, 0);
 
-    // verify(this.functionResponseMessage).sendChunk(this.serverConnection); // TODO: why do none
-    // of the reply message types get sent?
+    verify(serverToClientFunctionResultSender65Factory).create(eq(functionResponseMessage),
+        anyInt(), any(), any(), any());
   }
 
   @Test
   public void withIntegratedSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
 
-    this.executeFunction65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction65.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
-    // verify(this.replyMessage).send(this.serverConnection); TODO: why do none of the reply message
-    // types get sent?
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(serverToClientFunctionResultSender65Factory).create(eq(functionResponseMessage),
+        anyInt(), any(), any(), any());
   }
 
   @Test
   public void withIntegratedSecurityShouldThrowIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
-    doThrow(new NotAuthorizedException("")).when(this.securityService).authorize(Resource.DATA,
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
+    doThrow(new NotAuthorizedException("")).when(securityService).authorize(Resource.DATA,
         Operation.WRITE);
 
-    this.executeFunction65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction65.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
-    // verify(this.chunkedResponseMessage).sendChunk(this.serverConnection);
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(serverToClientFunctionResultSender65Factory).create(eq(functionResponseMessage),
+        anyInt(), any(), any(), any());
   }
 
   @Test
   public void withOldSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
 
-    this.executeFunction65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction65.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.authzRequest).executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(),
+    verify(authorizeRequest).executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(),
         eq(false));
 
-    // function will be called, but no op.
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(serverToClientFunctionResultSender65Factory).create(eq(functionResponseMessage),
+        anyInt(), any(), any(), any());
   }
 
   @Test
   public void withOldSecurityShouldThrowIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
-    doThrow(new NotAuthorizedException("")).when(this.authzRequest)
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
+    doThrow(new NotAuthorizedException("")).when(authorizeRequest)
         .executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(), eq(false));
 
-    this.executeFunction65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
-  }
+    executeFunction65.cmdExecute(message, serverConnection, securityService, 0);
 
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verifyZeroInteractions(serverToClientFunctionResultSender65Factory);
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66Test.java
@@ -16,98 +16,72 @@ package org.apache.geode.internal.cache.tier.sockets.command;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+
+import java.util.concurrent.Executor;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.execute.Function;
-import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.operations.ExecuteFunctionOperationContext;
+import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.control.HeapMemoryMonitor;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.execute.InternalFunctionExecutionService;
+import org.apache.geode.internal.cache.execute.ServerToClientFunctionResultSender65;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.ServerSideHandshake;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.cache.tier.sockets.ChunkedMessage;
 import org.apache.geode.internal.cache.tier.sockets.Message;
+import org.apache.geode.internal.cache.tier.sockets.OldClientSupportService;
 import org.apache.geode.internal.cache.tier.sockets.Part;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
+import org.apache.geode.internal.cache.tier.sockets.command.ExecuteFunction66.FunctionContextImplFactory;
+import org.apache.geode.internal.cache.tier.sockets.command.ExecuteFunction66.ServerToClientFunctionResultSender65Factory;
 import org.apache.geode.internal.security.AuthorizeRequest;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.internal.security.ResourcePermissions;
 import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
-@Category({ClientServerTest.class})
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("*.UnitTest")
-@PrepareForTest({FunctionService.class})
+@Category(ClientServerTest.class)
 public class ExecuteFunction66Test {
+
   private static final String FUNCTION = "function";
   private static final String FUNCTION_ID = "function_id";
   private static final boolean OPTIMIZE_FOR_WRITE = false;
   private static final Object CALLBACK_ARG = "arg";
   private static final byte[] RESULT = new byte[] {Integer.valueOf(0).byteValue()};
 
-  @Mock
-  private SecurityService securityService;
-  @Mock
-  private Message message;
-  @Mock
-  private ServerConnection serverConnection;
-  @Mock
   private AuthorizeRequest authzRequest;
-  @Mock
-  private LocalRegion region;
-  @Mock
-  private GemFireCacheImpl cache;
-  @Mock
   private ChunkedMessage functionResponseMessage;
-  @Mock
-  private Message replyMessage;
-  @Mock
-  private Part functionPart;
-  @Mock
-  private Part functionStatePart;
-  @Mock
-  private Part argsPart;
-  @Mock
-  private Part partPart;
-  @Mock
-  private Part callbackArgPart;
-  @Mock
-  private Function functionObject;
-  @Mock
-  private AcceptorImpl acceptor;
-  @Mock
-  private InternalResourceManager internalResourceManager;
-  @Mock
-  private ExecuteFunctionOperationContext executeFunctionOperationContext;
+  private Message message;
+  private OldClientSupportService oldClientSupportService;
+  private SecurityService securityService;
+  private ServerConnection serverConnection;
 
-  @InjectMocks
-  private ExecuteFunction66 executeFunction66;
+  // the following fields are all accessed in sub-class
+  InternalFunctionExecutionService internalFunctionExecutionService;
+  ServerToClientFunctionResultSender65Factory serverToClientFunctionResultSender65Factory;
+  FunctionContextImplFactory functionContextImplFactory;
+
+  ExecuteFunction66 executeFunction;
 
   @Rule
   public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
@@ -116,106 +90,153 @@ public class ExecuteFunction66Test {
   public void setUp() throws Exception {
     System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "statsDisabled", "true");
 
-    this.executeFunction66 = new ExecuteFunction66();
-    MockitoAnnotations.initMocks(this);
+    authzRequest = mock(AuthorizeRequest.class);
+    functionResponseMessage = mock(ChunkedMessage.class);
+    internalFunctionExecutionService = mock(InternalFunctionExecutionService.class);
+    message = mock(Message.class);
+    oldClientSupportService = mock(OldClientSupportService.class);
+    securityService = mock(SecurityService.class);
+    serverConnection = mock(ServerConnection.class);
 
-    when(this.authzRequest.executeFunctionAuthorize(eq(FUNCTION_ID), eq(null), eq(null), eq(null),
-        eq(OPTIMIZE_FOR_WRITE))).thenReturn(this.executeFunctionOperationContext);
+    serverToClientFunctionResultSender65Factory =
+        mock(ServerToClientFunctionResultSender65Factory.class);
+    functionContextImplFactory = mock(FunctionContextImplFactory.class);
 
-    when(this.cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
-    when(this.cache.getDistributedSystem()).thenReturn(mock(InternalDistributedSystem.class));
-    when(this.cache.getResourceManager()).thenReturn(this.internalResourceManager);
-    when(this.cache.getInternalResourceManager()).thenReturn(this.internalResourceManager);
+    AcceptorImpl acceptor = mock(AcceptorImpl.class);
+    InternalCache cache = mock(InternalCache.class);
+    ClusterDistributionManager clusterDistributionManager = mock(ClusterDistributionManager.class);
+    Message errorResponseMessage = mock(Message.class);
+    ExecuteFunctionOperationContext executeFunctionOperationContext =
+        mock(ExecuteFunctionOperationContext.class);
+    Function functionObject = mock(Function.class);
+    Executor functionExecutor = mock(Executor.class);
+    InternalResourceManager internalResourceManager = mock(InternalResourceManager.class);
+    Message replyMessage = mock(Message.class);
+    ServerToClientFunctionResultSender65 serverToClientFunctionResultSender65 =
+        mock(ServerToClientFunctionResultSender65.class);
 
-    when(this.callbackArgPart.getObject()).thenReturn(CALLBACK_ARG);
+    Part argsPart = mock(Part.class);
+    Part callbackArgPart = mock(Part.class);
+    Part functionPart = mock(Part.class);
+    Part functionStatePart = mock(Part.class);
+    Part partPart = mock(Part.class);
 
-    when(this.functionObject.getId()).thenReturn(FUNCTION_ID);
-    doCallRealMethod().when(this.functionObject).getRequiredPermissions(any());
-    doCallRealMethod().when(this.functionObject).getRequiredPermissions(any(), any());
+    when(authzRequest.executeFunctionAuthorize(eq(FUNCTION_ID), eq(null), eq(null), eq(null),
+        eq(OPTIMIZE_FOR_WRITE))).thenReturn(executeFunctionOperationContext);
 
-    when(this.functionPart.getStringOrObject()).thenReturn(FUNCTION);
+    when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    when(cache.getDistributionManager()).thenReturn(clusterDistributionManager);
+    when(cache.getDistributedSystem()).thenReturn(mock(InternalDistributedSystem.class));
+    when(cache.getInternalResourceManager()).thenReturn(internalResourceManager);
+    when(cache.getResourceManager()).thenReturn(internalResourceManager);
+    when(cache.getService(eq(OldClientSupportService.class))).thenReturn(oldClientSupportService);
 
-    when(this.functionStatePart.getSerializedForm()).thenReturn(RESULT);
+    when(callbackArgPart.getObject()).thenReturn(CALLBACK_ARG);
 
-    when(this.message.getNumberOfParts()).thenReturn(4);
-    when(this.message.getPart(eq(0))).thenReturn(this.functionStatePart);
-    when(this.message.getPart(eq(1))).thenReturn(this.functionPart);
-    when(this.message.getPart(eq(2))).thenReturn(this.argsPart);
-    when(this.message.getPart(eq(3))).thenReturn(this.partPart);
+    when(clusterDistributionManager.getFunctionExecutor()).thenReturn(functionExecutor);
 
-    when(this.serverConnection.getCache()).thenReturn(this.cache);
-    when(this.serverConnection.getAuthzRequest()).thenReturn(this.authzRequest);
-    when(this.serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
-    when(this.serverConnection.getFunctionResponseMessage())
-        .thenReturn(this.functionResponseMessage);
-    when(this.serverConnection.getReplyMessage()).thenReturn(this.replyMessage);
-    when(this.serverConnection.getAcceptor()).thenReturn(this.acceptor);
-    when(this.serverConnection.getHandshake()).thenReturn(mock(ServerSideHandshake.class));
+    when(functionObject.getId()).thenReturn(FUNCTION_ID);
+    doCallRealMethod().when(functionObject).getRequiredPermissions(any());
+    doCallRealMethod().when(functionObject).getRequiredPermissions(any(), any());
 
-    when(this.internalResourceManager.getHeapMonitor()).thenReturn(mock(HeapMemoryMonitor.class));
+    when(functionPart.getStringOrObject()).thenReturn(FUNCTION);
+    when(functionStatePart.getSerializedForm()).thenReturn(RESULT);
+    when(internalFunctionExecutionService.getFunction(eq(FUNCTION))).thenReturn(functionObject);
+    when(internalResourceManager.getHeapMonitor()).thenReturn(mock(HeapMemoryMonitor.class));
 
-    PowerMockito.mockStatic(FunctionService.class);
-    PowerMockito.when(FunctionService.getFunction(eq(FUNCTION))).thenReturn(this.functionObject);
+    when(message.getNumberOfParts()).thenReturn(4);
+    when(message.getPart(eq(0))).thenReturn(functionStatePart);
+    when(message.getPart(eq(1))).thenReturn(functionPart);
+    when(message.getPart(eq(2))).thenReturn(argsPart);
+    when(message.getPart(eq(3))).thenReturn(partPart);
+
+    when(serverConnection.getAcceptor()).thenReturn(acceptor);
+    when(serverConnection.getAuthzRequest()).thenReturn(authzRequest);
+    when(serverConnection.getCache()).thenReturn(cache);
+    when(serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
+    when(serverConnection.getErrorResponseMessage()).thenReturn(errorResponseMessage);
+    when(serverConnection.getFunctionResponseMessage()).thenReturn(functionResponseMessage);
+    when(serverConnection.getHandshake()).thenReturn(mock(ServerSideHandshake.class));
+    when(serverConnection.getReplyMessage()).thenReturn(replyMessage);
+
+    when(serverToClientFunctionResultSender65Factory.create(any(), anyInt(), any(), any(), any()))
+        .thenReturn(
+            serverToClientFunctionResultSender65);
+
+    executeFunction = new ExecuteFunction66(internalFunctionExecutionService,
+        serverToClientFunctionResultSender65Factory, functionContextImplFactory);
+
+    postSetUp();
+  }
+
+  void postSetUp() {
+    // override in sub-class
   }
 
   @Test
   public void nonSecureShouldSucceed() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(false);
+    when(oldClientSupportService.getThrowable(any(), any())).thenReturn(mock(Throwable.class));
+    when(securityService.isClientSecurityRequired()).thenReturn(false);
 
-    this.executeFunction66.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
 
-    // verify(this.functionResponseMessage).sendChunk(this.serverConnection); // TODO: why do none
-    // of the reply message types get sent?
+    verify(serverToClientFunctionResultSender65Factory).create(eq(functionResponseMessage),
+        anyInt(), any(), any(), any());
   }
 
   @Test
   public void withIntegratedSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
+    when(oldClientSupportService.getThrowable(any(), any())).thenReturn(mock(Throwable.class));
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
 
-    this.executeFunction66.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
-    // verify(this.replyMessage).send(this.serverConnection); TODO: why do none of the reply message
-    // types get sent?
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(serverToClientFunctionResultSender65Factory).create(eq(functionResponseMessage),
+        anyInt(), any(), any(), any());
   }
 
   @Test
-  public void withIntegratedSecurityShouldThrowIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
-    doThrow(new NotAuthorizedException("")).when(this.securityService)
+  public void withIntegratedSecurityShouldThrowIfNotAuthorized() {
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
+    doThrow(new NotAuthorizedException("")).when(securityService)
         .authorize(ResourcePermissions.DATA_WRITE);
 
-    assertThatThrownBy(() -> this.executeFunction66.cmdExecute(this.message, this.serverConnection,
-        this.securityService, 0)).isExactlyInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> executeFunction.cmdExecute(message, serverConnection,
+        securityService, 0)).isExactlyInstanceOf(NullPointerException.class);
 
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
     // verify(this.chunkedResponseMessage).sendChunk(this.serverConnection);
+    verifyZeroInteractions(serverToClientFunctionResultSender65Factory);
   }
 
   @Test
   public void withOldSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
+    when(oldClientSupportService.getThrowable(any(), any())).thenReturn(mock(Throwable.class));
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
 
-    this.executeFunction66.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.authzRequest).executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(),
+    verify(authzRequest).executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(),
         eq(false));
+    verify(serverToClientFunctionResultSender65Factory).create(eq(functionResponseMessage),
+        anyInt(), any(), any(), any());
   }
 
   @Test
-  public void withOldSecurityShouldThrowIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
-    doThrow(new NotAuthorizedException("")).when(this.authzRequest)
+  public void withOldSecurityShouldThrowIfNotAuthorized() {
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
+    doThrow(new NotAuthorizedException("")).when(authzRequest)
         .executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(), eq(false));
 
-    assertThatThrownBy(() -> this.executeFunction66.cmdExecute(this.message, this.serverConnection,
-        this.securityService, 0)).isExactlyInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> executeFunction.cmdExecute(message, serverConnection,
+        securityService, 0)).isExactlyInstanceOf(NullPointerException.class);
 
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verifyZeroInteractions(serverToClientFunctionResultSender65Factory);
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70Test.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets.command;
+
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.ClientServerTest;
+
+@Category(ClientServerTest.class)
+public class ExecuteFunction70Test extends ExecuteFunction66Test {
+
+  @Override
+  public void postSetUp() {
+    executeFunction = new ExecuteFunction70(internalFunctionExecutionService,
+        serverToClientFunctionResultSender65Factory, functionContextImplFactory);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunctionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunctionTest.java
@@ -15,11 +15,14 @@
 package org.apache.geode.internal.cache.tier.sockets.command;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
@@ -27,42 +30,35 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.execute.Function;
-import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.operations.ExecuteFunctionOperationContext;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.control.HeapMemoryMonitor;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.execute.FunctionContextImpl;
+import org.apache.geode.internal.cache.execute.InternalFunctionExecutionService;
+import org.apache.geode.internal.cache.execute.ServerToClientFunctionResultSender;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.ServerSideHandshake;
 import org.apache.geode.internal.cache.tier.sockets.AcceptorImpl;
 import org.apache.geode.internal.cache.tier.sockets.ChunkedMessage;
 import org.apache.geode.internal.cache.tier.sockets.Message;
+import org.apache.geode.internal.cache.tier.sockets.OldClientSupportService;
 import org.apache.geode.internal.cache.tier.sockets.Part;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
+import org.apache.geode.internal.cache.tier.sockets.command.ExecuteFunction.FunctionContextImplFactory;
+import org.apache.geode.internal.cache.tier.sockets.command.ExecuteFunction.ServerToClientFunctionResultSenderFactory;
 import org.apache.geode.internal.security.AuthorizeRequest;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.internal.security.ResourcePermissions;
 import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
-@Category({ClientServerTest.class})
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("*.UnitTest")
-@PrepareForTest({FunctionService.class})
+@Category(ClientServerTest.class)
 public class ExecuteFunctionTest {
   private static final String FUNCTION = "function";
   private static final String FUNCTION_ID = "function_id";
@@ -70,44 +66,14 @@ public class ExecuteFunctionTest {
   private static final Object CALLBACK_ARG = "arg";
   private static final byte[] RESULT = new byte[] {Integer.valueOf(1).byteValue()};
 
-  @Mock
-  private SecurityService securityService;
-  @Mock
-  private Message message;
-  @Mock
-  private ServerConnection serverConnection;
-  @Mock
-  private AuthorizeRequest authzRequest;
-  @Mock
-  private LocalRegion region;
-  @Mock
-  private GemFireCacheImpl cache;
-  @Mock
-  private ChunkedMessage functionResponseMessage;
-  @Mock
+  private AuthorizeRequest authorizeRequest;
   private ChunkedMessage chunkedResponseMessage;
-  @Mock
-  private Part hasResultPart;
-  @Mock
-  private Part functionPart;
-  @Mock
-  private Part argsPart;
-  @Mock
-  private Part partPart;
-  @Mock
-  private Part callbackArgPart;
-  @Mock
-  private Function functionObject;
-  @Mock
-  private AcceptorImpl acceptor;
-  @Mock
-  private ServerSideHandshake handshake;
-  @Mock
-  private InternalResourceManager internalResourceManager;
-  @Mock
-  private ExecuteFunctionOperationContext executeFunctionOperationContext;
+  private ChunkedMessage functionResponseMessage;
+  private Message message;
+  private SecurityService securityService;
+  private ServerConnection serverConnection;
+  private ServerToClientFunctionResultSenderFactory serverToClientFunctionResultSenderFactory;
 
-  @InjectMocks
   private ExecuteFunction executeFunction;
 
   @Rule
@@ -117,104 +83,143 @@ public class ExecuteFunctionTest {
   public void setUp() throws Exception {
     System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "statsDisabled", "true");
 
-    this.executeFunction = new ExecuteFunction();
-    MockitoAnnotations.initMocks(this);
+    authorizeRequest = mock(AuthorizeRequest.class);
+    chunkedResponseMessage = mock(ChunkedMessage.class);
+    functionResponseMessage = mock(ChunkedMessage.class);
+    message = mock(Message.class);
+    securityService = mock(SecurityService.class);
+    serverConnection = mock(ServerConnection.class);
+    serverToClientFunctionResultSenderFactory =
+        mock(ServerToClientFunctionResultSenderFactory.class);
 
-    when(this.authzRequest.executeFunctionAuthorize(eq(FUNCTION_ID), eq(null), eq(null), eq(null),
-        eq(OPTIMIZE_FOR_WRITE))).thenReturn(this.executeFunctionOperationContext);
+    InternalCache cache = mock(InternalCache.class, RETURNS_DEEP_STUBS);
+    AcceptorImpl acceptor = mock(AcceptorImpl.class);
+    FunctionContextImplFactory functionContextImplFactory = mock(FunctionContextImplFactory.class);
+    ExecuteFunctionOperationContext executeFunctionOperationContext =
+        mock(ExecuteFunctionOperationContext.class);
+    Function functionObject = mock(Function.class);
+    FunctionContextImpl functionContextImpl = mock(FunctionContextImpl.class);
+    InternalFunctionExecutionService internalFunctionExecutionService =
+        mock(InternalFunctionExecutionService.class);
+    InternalResourceManager internalResourceManager =
+        mock(InternalResourceManager.class, RETURNS_DEEP_STUBS);
+    OldClientSupportService oldClientSupportService = mock(OldClientSupportService.class);
+    ServerSideHandshake handshake = mock(ServerSideHandshake.class);
+    ServerToClientFunctionResultSender serverToClientFunctionResultSender =
+        mock(ServerToClientFunctionResultSender.class);
 
-    when(this.cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
-    when(this.cache.getDistributedSystem()).thenReturn(mock(InternalDistributedSystem.class));
-    when(this.cache.getResourceManager()).thenReturn(this.internalResourceManager);
+    Part argsPart = mock(Part.class);
+    Part callbackArgPart = mock(Part.class);
+    Part functionPart = mock(Part.class);
+    Part hasResultPart = mock(Part.class);
+    Part partPart = mock(Part.class);
 
-    when(this.callbackArgPart.getObject()).thenReturn(CALLBACK_ARG);
+    when(authorizeRequest.executeFunctionAuthorize(eq(FUNCTION_ID), eq(null), eq(null), eq(null),
+        eq(OPTIMIZE_FOR_WRITE))).thenReturn(executeFunctionOperationContext);
 
-    when(this.functionObject.getId()).thenReturn(FUNCTION_ID);
-    doCallRealMethod().when(this.functionObject).getRequiredPermissions(any());
-    doCallRealMethod().when(this.functionObject).getRequiredPermissions(any(), any());
+    when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    when(cache.getDistributedSystem()).thenReturn(mock(InternalDistributedSystem.class));
+    when(cache.getResourceManager()).thenReturn(internalResourceManager);
+    when(cache.getService(eq(OldClientSupportService.class))).thenReturn(oldClientSupportService);
 
-    when(this.functionPart.getStringOrObject()).thenReturn(FUNCTION);
+    when(callbackArgPart.getObject()).thenReturn(CALLBACK_ARG);
 
-    when(this.hasResultPart.getSerializedForm()).thenReturn(RESULT);
+    when(functionContextImplFactory.create(any(), any(), any(), any())).thenReturn(
+        functionContextImpl);
 
-    when(this.internalResourceManager.getHeapMonitor()).thenReturn(mock(HeapMemoryMonitor.class));
+    when(functionObject.getId()).thenReturn(FUNCTION_ID);
+    doCallRealMethod().when(functionObject).getRequiredPermissions(any());
+    doCallRealMethod().when(functionObject).getRequiredPermissions(any(), any());
 
-    when(this.message.getNumberOfParts()).thenReturn(4);
-    when(this.message.getPart(eq(0))).thenReturn(this.hasResultPart);
-    when(this.message.getPart(eq(1))).thenReturn(this.functionPart);
-    when(this.message.getPart(eq(2))).thenReturn(this.argsPart);
-    when(this.message.getPart(eq(3))).thenReturn(this.partPart);
+    when(functionPart.getStringOrObject()).thenReturn(FUNCTION);
+    when(hasResultPart.getSerializedForm()).thenReturn(RESULT);
+    when(internalFunctionExecutionService.getFunction(eq(FUNCTION))).thenReturn(functionObject);
+    when(internalResourceManager.getHeapMonitor()).thenReturn(mock(HeapMemoryMonitor.class));
 
-    when(this.serverConnection.getCache()).thenReturn(this.cache);
-    when(this.serverConnection.getAuthzRequest()).thenReturn(this.authzRequest);
-    when(this.serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
-    when(this.serverConnection.getFunctionResponseMessage())
-        .thenReturn(this.functionResponseMessage);
-    when(this.serverConnection.getChunkedResponseMessage()).thenReturn(this.chunkedResponseMessage);
-    when(this.serverConnection.getAcceptor()).thenReturn(this.acceptor);
-    when(this.serverConnection.getHandshake()).thenReturn(this.handshake);
+    when(message.getNumberOfParts()).thenReturn(4);
+    when(message.getPart(eq(0))).thenReturn(hasResultPart);
+    when(message.getPart(eq(1))).thenReturn(functionPart);
+    when(message.getPart(eq(2))).thenReturn(argsPart);
+    when(message.getPart(eq(3))).thenReturn(partPart);
 
-    PowerMockito.mockStatic(FunctionService.class);
-    PowerMockito.when(FunctionService.getFunction(eq(FUNCTION))).thenReturn(functionObject);
+    when(oldClientSupportService.getThrowable(any(), any())).thenReturn(mock(Throwable.class));
+
+    when(serverConnection.getAcceptor()).thenReturn(acceptor);
+    when(serverConnection.getAuthzRequest()).thenReturn(authorizeRequest);
+    when(serverConnection.getCache()).thenReturn(cache);
+    when(serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
+    when(serverConnection.getChunkedResponseMessage()).thenReturn(chunkedResponseMessage);
+    when(serverConnection.getFunctionResponseMessage()).thenReturn(functionResponseMessage);
+    when(serverConnection.getHandshake()).thenReturn(handshake);
+
+    when(serverToClientFunctionResultSenderFactory.create(any(), anyInt(), any(), any(), any()))
+        .thenReturn(
+            serverToClientFunctionResultSender);
+
+    executeFunction = new ExecuteFunction(internalFunctionExecutionService,
+        serverToClientFunctionResultSenderFactory,
+        functionContextImplFactory);
   }
 
   @Test
   public void nonSecureShouldSucceed() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(false);
+    when(securityService.isClientSecurityRequired()).thenReturn(false);
 
-    this.executeFunction.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
 
-    // verify(this.functionResponseMessage).sendChunk(this.serverConnection); // TODO: why do none
-    // of the reply message types get sent?
+    verify(serverToClientFunctionResultSenderFactory).create(eq(functionResponseMessage), anyInt(),
+        any(), any(), any());
   }
 
   @Test
   public void withIntegratedSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
-    this.executeFunction.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
 
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
-    // verify(this.replyMessage).send(this.serverConnection); TODO: why do none of the reply message
-    // types get sent?
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(serverToClientFunctionResultSenderFactory).create(eq(functionResponseMessage), anyInt(),
+        any(), any(), any());
   }
 
   @Test
   public void withIntegratedSecurityShouldThrowIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
-    doThrow(new NotAuthorizedException("")).when(this.securityService)
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
+    doThrow(new NotAuthorizedException("")).when(securityService)
         .authorize(ResourcePermissions.DATA_WRITE);
 
-    this.executeFunction.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.securityService).authorize(ResourcePermissions.DATA_WRITE);
-    verify(this.chunkedResponseMessage).sendChunk(this.serverConnection);
+    verify(securityService).authorize(ResourcePermissions.DATA_WRITE);
+    verify(chunkedResponseMessage).sendChunk(serverConnection);
+    verifyZeroInteractions(serverToClientFunctionResultSenderFactory);
   }
 
   @Test
   public void withOldSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
 
-    this.executeFunction.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.authzRequest).executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(),
+    verify(authorizeRequest).executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(),
         eq(false));
-    // verify(this.replyMessage).send(this.serverConnection); TODO: why do none of the reply message
-    // types get sent?
+    verify(serverToClientFunctionResultSenderFactory).create(eq(functionResponseMessage), anyInt(),
+        any(), any(), any());
   }
 
   @Test
   public void withOldSecurityShouldThrowIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
-    doThrow(new NotAuthorizedException("")).when(this.authzRequest)
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
+    doThrow(new NotAuthorizedException("")).when(authorizeRequest)
         .executeFunctionAuthorize(eq(FUNCTION_ID), any(), any(), any(), eq(false));
 
-    this.executeFunction.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    executeFunction.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.chunkedResponseMessage).sendChunk(this.serverConnection);
+    verify(chunkedResponseMessage).sendChunk(serverConnection);
+    verifyZeroInteractions(serverToClientFunctionResultSenderFactory);
   }
-
 }


### PR DESCRIPTION
Remove PowerMock from:
* ExecuteFunctionTest
* ExecuteFunction65Test
* ExecuteFunction66Test

Add test for ExecuteFunction70Test by subclasses ExecuteFunction66Test.

There are two commits. 1st commit is the main one to review. 2nd and 3rd commits fix some log statements, reduce IDE warnings, etc.