### PR TITLE
GEODE-6124 Sign distributions

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -40,6 +40,13 @@ publishing {
   }
 }
 
+signing {
+  afterEvaluate {
+    sign distTar
+    sign srcDistTar
+  }
+}
+
 logger.info("Gradle doesn't automatically remove the jar artifact even though we disabled it")
 logger.info("this causes publishing to fail.  So we nuke all the disabled artifacts from all configurations.")
 configurations.all {


### PR DESCRIPTION
The distribution archives need to be signed on release branches.
When we changed away from the nexus plugin the source archive was
no longer signed because it doesn't get published to maven.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
