### PR TITLE
GEODE-6235 Publish sources and javadoc to maven

### DIFF
--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -20,6 +20,16 @@ subprojects {
   apply plugin: 'maven-publish'
   apply plugin: 'signing'
 
+  task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier = 'sources'
+  }
+
+  task javadocJar(type: Jar) {
+    from javadoc
+    classifier = 'javadoc'
+  }
+
   publishing {
     publications {
       maven(MavenPublication) {


### PR DESCRIPTION
When we switched to the Nexus plugin we stopped publishing
sources and javadoc artifacts.  These are useful for IDE integration.
Add tasks to ensure these get generated during publishing.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
