### PR TITLE
GEODE-6242 Consume tgz release artifact for geode-old-versions

### DIFF
--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -28,15 +28,16 @@ task createGeodeClasspathsFile {
 
   // Add sourceSets for backwards compatibility, rolling upgrade, and
   // pdx testing.
-  addOldVersion('test100', '1.0.0-incubating', false)
-  addOldVersion('test110', '1.1.0', false)
-  addOldVersion('test111', '1.1.1', false)
-  addOldVersion('test120', '1.2.0', true)
-  addOldVersion('test130', '1.3.0', true)
-  addOldVersion('test140', '1.4.0', true)
-  addOldVersion('test150', '1.5.0', true)
-  addOldVersion('test160', '1.6.0', true)
-  addOldVersion('test170', '1.7.0', true)
+  addOldVersion('test100', '1.0.0-incubating', false, false)
+  addOldVersion('test110', '1.1.0', false, false)
+  addOldVersion('test111', '1.1.1', false, false)
+  addOldVersion('test120', '1.2.0', true, false)
+  addOldVersion('test130', '1.3.0', true, false)
+  addOldVersion('test140', '1.4.0', true, false)
+  addOldVersion('test150', '1.5.0', true, false)
+  addOldVersion('test160', '1.6.0', true, false)
+  addOldVersion('test170', '1.7.0', true, false)
+  addOldVersion('test180', '1.8.0', true)
 
   doLast {
     Properties versions = new Properties()
@@ -59,7 +60,7 @@ task createGeodeClasspathsFile {
 }
 createGeodeClasspathsFile.mustRunAfter(clean)
 
-def addOldVersion(def source, def geodeVersion, def downloadInstall) {
+def addOldVersion(def source, def geodeVersion, def downloadInstall, def useTgz = true) {
   sourceSets.create("${source}", {})
 
   configurations {
@@ -77,8 +78,15 @@ def addOldVersion(def source, def geodeVersion, def downloadInstall) {
   if (downloadInstall) {
     configurations.create("${source}OldInstall")
 
+    def archiveType = "tgz"
+    def extractMethod = "tarTree"
+    if (!useTgz) {
+      archiveType = "zip"
+      extractMethod = "zipTree"
+    }
+
     dependencies {
-      "${source}OldInstall"  "org.apache.geode:apache-geode:${geodeVersion}"
+      "${source}OldInstall"  "org.apache.geode:apache-geode:${geodeVersion}@${archiveType}"
     }
 
     project.ext.installs.setProperty(source, "${buildDir}/apache-geode-${geodeVersion}")
@@ -91,7 +99,7 @@ def addOldVersion(def source, def geodeVersion, def downloadInstall) {
       outputs.dir("${buildDir}/apache-geode-${geodeVersion}")
       doLast {
         copy {
-          from zipTree(configurations."${source}OldInstall".singleFile)
+          from "${extractMethod}"(configurations."${source}OldInstall".singleFile)
           into project.buildDir
         }
       }


### PR DESCRIPTION
From 1.8.0 onward we are only releasing tgz, so we need to consume those
instead of zip archives.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Dick Cavender <dcavender@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
