### PR TITLE
GEODE-6232: Ignore disconnect in PersistentPartitionedRegionRegressionTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionRegressionTest.java
@@ -44,6 +44,7 @@ import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.persistence.PartitionOfflineException;
+import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
@@ -342,6 +343,8 @@ public class PersistentPartitionedRegionRegressionTest implements Serializable {
    */
   @Test
   public void doesNotWaitForPreviousInstanceOfOnlineServer() {
+    addIgnoredException(DistributedSystemDisconnectedException.class);
+
     // Add a hook to disconnect from the distributed system when the initial image message shows up.
     vm0.invoke(() -> {
       DistributionMessageObserver.setInstance(new DistributionMessageObserver() {


### PR DESCRIPTION
Add IgnoredException to doesNotWaitForPreviousInstanceOfOnlineServer.

While testing for GEODE-6232, the only reproducible problem appears to
be a DistributedSystemDisconnectedException in a background thread due
to doesNotWaitForPreviousInstanceOfOnlineServer disconnecting during
the handling of a GII request.

@mhansonp Please review!