### PR TITLE
Feature/geode 6244 sick member kicks out healthy member

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingPoolDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingPoolDUnitTest.java
@@ -105,6 +105,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
     disconnectAllFromDS();
     IgnoredException.addIgnoredException("Connection reset");
     IgnoredException.addIgnoredException("Socket input is shutdown");
+    IgnoredException.addIgnoredException("Connection refused");
   }
 
   @Override

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -615,6 +615,40 @@ public class GMSHealthMonitorJUnitTest {
     assertTrue(gmsHealthMonitor.isSuspectMember(memberToCheck));
   }
 
+  /**
+   * a failed availablility check should initiate suspect processing
+   */
+  @Test
+  public void testFailedCheckIfAvailableDoesNotRemoveMember() {
+    NetView v = installAView();
+
+    setFailureDetectionPorts(v);
+
+    InternalDistributedMember memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    boolean available = gmsHealthMonitor.checkIfAvailable(memberToCheck, "Not responding", false);
+    assertFalse(available);
+    verify(joinLeave, never()).remove(isA(InternalDistributedMember.class), isA(String.class));
+    assertTrue(gmsHealthMonitor.isSuspectMember(memberToCheck));
+    verify(messenger).send(isA(SuspectMembersMessage.class));
+  }
+
+
+  /**
+   * Same test as above but with request to initiate removal
+   */
+  @Test
+  public void testFailedCheckIfAvailableRemovesMember() {
+    NetView v = installAView();
+
+    setFailureDetectionPorts(v);
+
+    InternalDistributedMember memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    boolean available = gmsHealthMonitor.checkIfAvailable(memberToCheck, "Not responding", true);
+    assertFalse(available);
+    verify(joinLeave).remove(isA(InternalDistributedMember.class), isA(String.class));
+  }
+
+
 
   @Test
   public void testShutdown() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -150,7 +150,7 @@ public class GMSHealthMonitorJUnitTest {
     when(stopper.isCancelInProgress()).thenReturn(false);
 
     if (mockMembers == null) {
-      mockMembers = new ArrayList<InternalDistributedMember>();
+      mockMembers = new ArrayList<>();
       for (int i = 0; i < 7; i++) {
         InternalDistributedMember mbr = new InternalDistributedMember("localhost", 8888 + i);
 
@@ -628,7 +628,7 @@ public class GMSHealthMonitorJUnitTest {
     boolean available = gmsHealthMonitor.checkIfAvailable(memberToCheck, "Not responding", false);
     assertFalse(available);
     verify(joinLeave, never()).remove(isA(InternalDistributedMember.class), isA(String.class));
-    assertTrue(gmsHealthMonitor.isSuspectMember(memberToCheck));
+    assertFalse(gmsHealthMonitor.isSuspectMember(memberToCheck));
     verify(messenger).send(isA(SuspectMembersMessage.class));
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -629,7 +629,6 @@ public class GMSHealthMonitorJUnitTest {
     assertFalse(available);
     verify(joinLeave, never()).remove(isA(InternalDistributedMember.class), isA(String.class));
     assertFalse(gmsHealthMonitor.isSuspectMember(memberToCheck));
-    verify(messenger).send(isA(SuspectMembersMessage.class));
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -436,10 +436,7 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
     if (services.getJoinLeave().isMemberLeaving(mbr)) {
       return;
     }
-    SuspectRequest sr = new SuspectRequest(mbr, reason);
-    List<SuspectRequest> sl = new ArrayList<>();
-    sl.add(sr);
-    sendSuspectRequest(sl);
+    sendSuspectRequest(Collections.singletonList(new SuspectRequest(mbr, reason)));
   }
 
   /**
@@ -1278,6 +1275,8 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
           if (initiateRemoval) {
             logger.info("Requesting removal of suspect member {}", mbr);
             services.getJoinLeave().remove(mbr, reason);
+          } else {
+            initiateSuspicion(mbr, reason);
           }
           // make sure it is still suspected
           memberSuspected(localAddress, mbr, reason);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
@@ -1649,7 +1649,7 @@ public class GMSMembershipManager implements MembershipManager, Manager {
    */
   public boolean verifyMember(DistributedMember mbr, String reason) {
     return mbr != null && memberExists(mbr)
-        && this.services.getHealthMonitor().checkIfAvailable(mbr, reason, true);
+        && this.services.getHealthMonitor().checkIfAvailable(mbr, reason, false);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
@@ -1645,6 +1645,8 @@ public class GMSMembershipManager implements MembershipManager, Manager {
    *
    * @param reason why the check is being done (must not be blank/null)
    *
+   * @param initiateRemoval whether to immediately remove the suspect if verification fails
+   *
    * @return true if the member checks out
    */
   public boolean verifyMember(DistributedMember mbr, String reason) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction66.java
@@ -164,7 +164,7 @@ public class ExecuteFunction66 extends BaseCommand {
         functionObject = internalFunctionExecutionService.getFunction((String) function);
         if (functionObject == null) {
           String message = String
-              .format("Function named %s is not registered to FunctionService for %s", function);
+              .format("Function named %s is not registered to FunctionService", function);
           logger.warn("{}: {}", serverConnection.getName(), message);
           sendError(hasResult, clientMessage, message, serverConnection);
           return;


### PR DESCRIPTION
MembershipManager.verifyMember() was directly initiating member removal if an initial tcp/ip connection check failed.  This PR changes that behavior to perform a self-check and then initiate suspect processing.  This is more in line with how GemFire 8.x behaved - perform a connection test and then initiate suspect verification.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
