### PR TITLE
GEODE-6259: Refine version specification and consumption

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,8 +54,11 @@ dependencyVersions.load(new FileInputStream("${project.projectDir}/gradle/depend
 dependencyVersions.keys().each{ k -> project.ext[k] = dependencyVersions[k]}
 
 allprojects {
-  version = versionNumber + releaseQualifier + releaseType
-  ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
+  ext.isReleaseVersion = true
+  if(version.contains("SNAPSHOT")) {
+    ext.isReleaseVersion = false
+    version = (version as String).replaceFirst(/SNAPSHOT.*/, 'SNAPSHOT')
+  }
 
   repositories {
     mavenLocal()

--- a/ci/pipelines/geode-build/deploy_pipeline.sh
+++ b/ci/pipelines/geode-build/deploy_pipeline.sh
@@ -73,6 +73,7 @@ version-bucket: ${VERSION_BUCKET}
 artifact-bucket: ${ARTIFACT_BUCKET}
 gradle-global-args: ${GRADLE_GLOBAL_ARGS}
 maven-snapshot-bucket: ${MAVEN_SNAPSHOT_BUCKET}
+semver-prerelease-token: ${SEMVER_PRERELEASE_TOKEN}
 YML
 
 

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -190,7 +190,7 @@ jobs:
       trigger: true
     - get: geode-build-version
       params:
-        pre: build
+        pre: {{semver-prerelease-token}}
     - do:
       - put: concourse-metadata-resource
       - task: create_instance
@@ -326,7 +326,7 @@ jobs:
       trigger: true
     - get: geode-build-version
       params:
-        pre: build
+        pre: {{semver-prerelease-token}}
     - do:
       - put: concourse-metadata-resource
       - task: create_instance

--- a/ci/pipelines/meta/meta.properties
+++ b/ci/pipelines/meta/meta.properties
@@ -23,4 +23,5 @@ ARTIFACT_BUCKET=files.apachegeode-ci.info
 PUBLIC=true
 REPOSITORY_PUBLIC=true
 GRADLE_GLOBAL_ARGS=""
-MAVEN_SNAPSHOT_BUCKET=maven.apachegeode-ci.info
+MAVEN_SNAPSHOT_BUCKET=gcs://maven.apachegeode-ci.info/snapshot/
+SEMVER_PRERELEASE_TOKEN=SNAPSHOT

--- a/ci/scripts/execute_build.sh
+++ b/ci/scripts/execute_build.sh
@@ -41,7 +41,6 @@ BUILD_DATE=$(date +%s)
 if [ -e "${ROOT_DIR}/geode-build-version" ] ; then
   GEODE_BUILD_VERSION_FILE=${ROOT_DIR}/geode-build-version/number
   GEODE_RESULTS_VERSION_FILE=${ROOT_DIR}/results/number
-  GEODE_BUILD_VERSION_NUMBER=$(echo "${GRADLE_GLOBAL_ARGS}"|tr ' ' '\n' | grep "versionNumber *=" - geode/gradle.properties | awk -F "=" '{print $2; exit}' | tr -d ' ')
   GEODE_BUILD_DIR=/tmp/geode-build
   GEODE_PULL_REQUEST_ID_FILE=${ROOT_DIR}/geode/.git/id
 
@@ -49,14 +48,23 @@ if [ -e "${ROOT_DIR}/geode-build-version" ] ; then
     GEODE_PULL_REQUEST_ID=$(cat ${GEODE_PULL_REQUEST_ID_FILE})
     FULL_PRODUCT_VERSION="geode-pr-${GEODE_PULL_REQUEST_ID}"
   else
+    # semver resource, e.g., "1.9.0-SNAPSHOT.325"
     CONCOURSE_VERSION=$(cat ${GEODE_BUILD_VERSION_FILE})
-    CONCOURSE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
-    GEODE_PRODUCT_VERSION=${GEODE_BUILD_VERSION_NUMBER}
+    # Prune all after '-', yielding e.g., "1.9.0"
+    GEODE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
+    # Prune all before '-', yielding e.g., "SNAPSHOT.325"
     CONCOURSE_BUILD_SLUG=${CONCOURSE_VERSION##*-}
-    BUILD_ID=${CONCOURSE_VERSION##*.}
-    FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${CONCOURSE_BUILD_SLUG}
+    # Prune all before '.', yielding e.g., "SNAPSHOT"
+    SNAPSHOT_SLUG=${CONCOURSE_BUILD_SLUG##*.}
+    # Prune all before '.', yielding e.g., "325"
+    BUILD_ID=$(printf "%04d" ${CONCOURSE_VERSION##*.})
+
+    # Rebuild version, zero-padded
+    FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${SNAPSHOT_SLUG}.${BUILD_ID}
+
     echo "Concourse VERSION is ${CONCOURSE_VERSION}"
     echo "Geode product VERSION is ${GEODE_PRODUCT_VERSION}"
+    echo "Full product VERSION is ${FULL_PRODUCT_VERSION}"
     echo "Build ID is ${BUILD_ID}"
   fi
 
@@ -99,6 +107,7 @@ GRADLE_ARGS="\
     ${DEFAULT_GRADLE_TASK_OPTIONS} \
     ${GRADLE_SKIP_TASK_OPTIONS} \
     ${GRADLE_GLOBAL_ARGS} \
+    -Pversion=${FULL_PRODUCT_VERSION} \
     -PbuildId=${BUILD_ID} \
     build install javadoc spotlessCheck rat checkPom resolveDependencies -x test"
 

--- a/ci/scripts/execute_publish.sh
+++ b/ci/scripts/execute_publish.sh
@@ -44,18 +44,23 @@ if [ -e "${GEODE_PULL_REQUEST_ID_FILE}" ]; then
   GEODE_PULL_REQUEST_ID=$(cat ${GEODE_PULL_REQUEST_ID_FILE})
   FULL_PRODUCT_VERSION="geode-pr-${GEODE_PULL_REQUEST_ID}"
 else
-  # semver resource, e.g., "1.9.0-build.325"
+  # semver resource, e.g., "1.9.0-SNAPSHOT.325"
   CONCOURSE_VERSION=$(cat ${GEODE_BUILD_VERSION_FILE})
   # Prune all after '-', yielding e.g., "1.9.0"
   GEODE_PRODUCT_VERSION=${CONCOURSE_VERSION%%-*}
-  # Prune all before '-', yielding e.g., "build.325"
+  # Prune all before '-', yielding e.g., "SNAPSHOT.325"
   CONCOURSE_BUILD_SLUG=${CONCOURSE_VERSION##*-}
+  # Prune all before '.', yielding e.g., "SNAPSHOT"
+  SNAPSHOT_SLUG=${CONCOURSE_BUILD_SLUG##*.}
   # Prune all before '.', yielding e.g., "325"
-  BUILD_ID=${CONCOURSE_VERSION##*.}
+  BUILD_ID=$(printf "%04d" ${CONCOURSE_VERSION##*.})
 
-  FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${CONCOURSE_BUILD_SLUG}
+  # Rebuild version, zero-padded
+  FULL_PRODUCT_VERSION=${GEODE_PRODUCT_VERSION}-${SNAPSHOT_SLUG}.${BUILD_ID}
+
   echo "Concourse VERSION is ${CONCOURSE_VERSION}"
   echo "Geode product VERSION is ${GEODE_PRODUCT_VERSION}"
+  echo "Full product VERSION is ${FULL_PRODUCT_VERSION}"
   echo "Build ID is ${BUILD_ID}"
 fi
 
@@ -71,9 +76,10 @@ SET_JAVA_HOME="export JAVA_HOME=/usr/lib/jvm/java-${JAVA_BUILD_VERSION}-openjdk-
 GRADLE_COMMAND="./gradlew \
     ${DEFAULT_GRADLE_TASK_OPTIONS} \
     ${GRADLE_GLOBAL_ARGS} \
-    -PversionNumber=${GEODE_PRODUCT_VERSION} \
-    -PreleaseType=-${CONCOURSE_BUILD_SLUG} \
-    -PbuildId=${BUILD_ID} -PmavenRepository=\"gcs://${MAVEN_SNAPSHOT_BUCKET}/pre-release\" publish"
+    -Pversion=${FULL_PRODUCT_VERSION} \
+    -PbuildId=${BUILD_ID} \
+    -PmavenRepository=\"${MAVEN_SNAPSHOT_BUCKET}\" \
+    publish"
 
 echo "${GRADLE_COMMAND}"
 ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "mkdir -p tmp && cd geode && ${SET_JAVA_HOME} && ${GRADLE_COMMAND}"

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -15,6 +15,7 @@
  */
 package org.apache.geode.test.dunit.rules;
 
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Host.getHost;
@@ -31,6 +32,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.JavaVersion;
 import org.junit.rules.ExternalResource;
 
 import org.apache.geode.cache.client.ClientCache;
@@ -41,6 +43,7 @@ import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.dunit.DUnitEnv;
 import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.RMIException;
 import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.VM;
@@ -135,6 +138,10 @@ public class ClusterStartupRule extends ExternalResource implements Serializable
 
   @Override
   protected void before() throws Throwable {
+    if (isJavaVersionAtLeast(JavaVersion.JAVA_11)) {
+      // GEODE-6247: JDK 11 has an issue where native code is reporting committed is 2MB > max.
+      IgnoredException.addIgnoredException("committed = 538968064 should be < max = 536870912");
+    }
     DUnitLauncher.launchIfNeeded();
     for (int i = 0; i < vmCount; i++) {
       Host.getHost(0).getVM(i);

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,10 @@ releaseQualifier =
 #   <blank>   - release
 releaseType = -SNAPSHOT
 
+# Default Maven targets
+mavenSnapshotUrl = "gcs://maven.apachegeode-ci.info/snapshots"
+mavenReleaseUrl = "https://repository.apache.org/service/local/staging/deploy/maven2"
+
 # Maven also uses the project group as a prefix.
 group = org.apache.geode
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,20 +16,19 @@
 
 
 # Version information for use by Maven artifacts
-# The full version string consists of 'versionNumber + releaseQualifier + releaseType'
 #
 # The versionNumber follows semantic versioning conventions.
-versionNumber = 1.9.0
-
+#   X.Y.Z     - major.minor.patch
 # The releaseQualifier uses the following conventions:
 #   .M?       - milestone release
 #   -beta.?   - beta release
 #   <blank>   - release
-releaseQualifier =
 # The releaseType uses the following conventions:
 #   -SNAPSHOT - development version
 #   <blank>   - release
-releaseType = -SNAPSHOT
+#
+# The full version string consists of 'versionNumber + releaseQualifier + releaseType'
+version = 1.9.0-SNAPSHOT
 
 # Default Maven targets
 mavenSnapshotUrl = "gcs://maven.apachegeode-ci.info/snapshots"

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,10 +34,6 @@ version = 1.9.0-SNAPSHOT
 mavenSnapshotUrl = "gcs://maven.apachegeode-ci.info/snapshots"
 mavenReleaseUrl = "https://repository.apache.org/service/local/staging/deploy/maven2"
 
-# Default Maven targets
-mavenSnapshotUrl = "gcs://maven.apachegeode-ci.info/snapshots"
-mavenReleaseUrl = "https://repository.apache.org/service/local/staging/deploy/maven2"
-
 # Maven also uses the project group as a prefix.
 group = org.apache.geode
 

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -34,58 +34,56 @@ publishing {
     maven(MavenPublication) {
       from components.java
 
-      afterEvaluate {
-        // uses the tasks created by nexus for sources and javadoc
-        if (!getTasksByName('sourcesJar', false).isEmpty()) {
-          artifact sourcesJar
-        }
-        if (!getTasksByName('javadocJar', false).isEmpty()) {
-          artifact javadocJar
+      // use the (possibly empty) Jar tasks above for sources and javadoc
+      artifact sourcesJar
+      artifact javadocJar
+
+      pom {
+        name = 'Apache Geode'
+        description = 'Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing'
+        url = 'http://geode.apache.org'
+
+        scm {
+          url = 'https://github.com/apache/geode'
+          connection = 'scm:git:https://github.com:apache/geode.git'
+          developerConnection = 'scm:git:https://github.com:apache/geode.git'
         }
 
-        pom {
-          name = 'Apache Geode'
-          description = 'Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing'
-          url = 'http://geode.apache.org'
-
-          scm {
-            url = 'https://github.com/apache/geode'
-            connection = 'scm:git:https://github.com:apache/geode.git'
-            developerConnection = 'scm:git:https://github.com:apache/geode.git'
+        licenses {
+          license {
+            name = 'The Apache Software License, Version 2.0'
+            url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
           }
+        }
 
-          licenses {
-            license {
-              name = 'The Apache Software License, Version 2.0'
-              url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+        withXml {
+          // This black magic checks to see if a dependency has the flag ext.optional=true
+          // set on it, and if so marks the dependency as optional in the maven pom
+          def depMap = project.configurations.compile.dependencies.collectEntries { [it.name, it] }
+          def runtimeDeps = project.configurations.runtime.dependencies.collectEntries {
+            [it.name, it]
+          }
+          def runtimeOnlyDeps = project.configurations.runtimeOnly.dependencies.collectEntries {
+            [it.name, it]
+          }
+          depMap.putAll(runtimeDeps)
+          depMap.putAll(runtimeOnlyDeps)
+          asNode().dependencies.dependency.findAll {
+            def dep = depMap.get(it.artifactId.text())
+            return dep?.hasProperty('optional') && dep.optional
+          }.each {
+            if (it.optional) {
+              it.optional.value = 'true'
+            } else {
+              it.appendNode('optional', 'true')
             }
           }
-
-          withXml {
-            //This black magic checks to see if a dependency has the flag ext.optional=true
-            //set on it, and if so marks the dependency as optional in the maven pom
-            def depMap = project.configurations.compile.dependencies.collectEntries { [it.name, it] }
-            def runtimeDeps = project.configurations.runtime.dependencies.collectEntries { [it.name, it] }
-            def runtimeOnlyDeps = project.configurations.runtimeOnly.dependencies.collectEntries { [it.name, it] }
-            depMap.putAll(runtimeDeps)
-            depMap.putAll(runtimeOnlyDeps)
-            asNode().dependencies.dependency.findAll {
-              def dep = depMap.get(it.artifactId.text())
-              return dep?.hasProperty('optional') && dep.optional
-            }.each {
-              if (it.optional) {
-                it.optional.value = 'true'
-              } else {
-                it.appendNode('optional', 'true')
-              }
-            }
-          }
         }
-        pom {
-          withXml {
-            def elem = asElement()
-            def hdr = elem.ownerDocument().createComment(
-                '''
+
+        withXml {
+          def elem = asElement()
+          def hdr = elem.ownerDocument().createComment(
+              '''
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
   this work for additional information regarding copyright ownership.
@@ -101,34 +99,19 @@ publishing {
   See the License for the specific language governing permissions and
   limitations under the License.
   ''')
-            elem.insertBefore(hdr, elem.firstChild)
-          }
+          elem.insertBefore(hdr, elem.firstChild)
         }
       }
     }
   }
   repositories {
     maven {
-      if (project.hasProperty("mavenRepository")) {
-        url = project.mavenRepository
-      } else if (project.isReleaseVersion) {
-        url = "https://repository.apache.org/service/local/staging/deploy/maven2"
-      } else if (project.hasProperty("mavenSnapshotBucket")) {
-        // If testing from a non-GCE instance, then the shell needs service-account creds
-        // following the instructions at https://cloud.google.com/docs/authentication/production
-        url = "gcs://$project.mavenSnapshotBucket/snapshots"
-      } else {
-        url = "gcs://maven.apachegeode-ci.info/snapshots"
-      }
-      if (!url.toString().startsWith("gcs:")) {
-        credentials {
-          if (project.hasProperty("mavenUsername")) {
-            username = project.mavenUsername
-          }
-          if (project.hasProperty("mavenPassword")) {
-            password = project.mavenPassword
-          }
-        }
+      // Use specified mavenRepository if provided, else use release or snapshot defaults.
+      url = project.findProperty("mavenRepository") ||
+          project.isReleaseVersion ? project.mavenReleaseUrl : project.mavenSnapshotUrl
+      credentials {
+        username project.findProperty("mavenUsername")
+        password project.findProperty("mavenPassword")
       }
     }
   }


### PR DESCRIPTION
* Do not delay publication logic evaluation to accommodate a plugin we no longer use.
* Streamline version specification -- set version directly rather than through three separate properties.
* Remove scripted references to removed versionNumber property.
* Streamline publication target logic -- specify mavenRepository directly rather than via an interpolated mavenSnapshotBucket
* Concourse environment variable MAVEN_SNAPSNOT_BUCKET is now a complete bucket path.
* Concourse uses a semver object as the source-of-truth for binary
  build-id and version.  Zero-pad build-id for lexicographical sorting of artifacts.
* Use semver content to help determine release or snapshot in concourse
* Concourse uses 'SNAPSHOT' as the semver pre-release token for develop (from "build")

-----

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
