### PR TITLE
GEODE-92: Fix deadlock issue from previous commit

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
@@ -22,6 +22,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,10 +42,25 @@ import org.apache.geode.test.junit.categories.EvictionTest;
 
 @Category({EvictionTest.class})
 public class RegionEntryEvictionIntegrationTest {
+
+  private Cache cache;
+
   private Region<String, String> region;
 
   @Rule
   public TestName testName = new TestName();
+
+  @Before
+  public void setup() {
+    cache = new CacheFactory().set("locators", "").set("mcast-port", "0").create();
+  }
+
+  @After
+  public void cleaup() {
+    if (cache != null && !cache.isClosed()) {
+      cache.close();
+    }
+  }
 
   @Test
   public void verifyMostRecentEntryIsNotEvicted() {
@@ -88,14 +107,12 @@ public class RegionEntryEvictionIntegrationTest {
 
 
   private Region<String, String> createRegion() {
-    Cache cache = new CacheFactory().set("locators", "").set("mcast-port", "0").create();
     return cache.<String, String>createRegionFactory(RegionShortcut.REPLICATE)
         .setEvictionAttributes(EvictionAttributes.createLRUEntryAttributes(2))
         .create(testName.getMethodName());
   }
 
   private Region<String, String> createRegionWithCustomExpiration(int evictionCount) {
-    Cache cache = new CacheFactory().set("locators", "").set("mcast-port", "0").create();
     return cache.<String, String>createRegionFactory(RegionShortcut.REPLICATE)
         .setCustomEntryIdleTimeout(new CustomExpiry<String, String>() {
           @Override

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/eviction/RegionEntryEvictionIntegrationTest.java
@@ -23,9 +23,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/AbstractRegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/AbstractRegionMapPut.java
@@ -156,8 +156,10 @@ public abstract class AbstractRegionMapPut {
    * Always called, even if the put failed.
    * Note that the RegionEntry that was modified by the put
    * is no longer synchronized when this is called.
+   *
+   * @param disabledEviction true if caller previously disabled eviction
    */
-  protected abstract void doAfterCompletionActions();
+  protected abstract void doAfterCompletionActions(boolean disabledEviction);
 
   /**
    * @return regionEntry if put completed, otherwise null.
@@ -173,13 +175,14 @@ public abstract class AbstractRegionMapPut {
   }
 
   private void doPut() {
+    final boolean disabledEviction = getRegionMap().disableLruUpdateCallback();
     try {
       doWithIndexInUpdateMode(this::doPutRetryingIfNeeded);
     } catch (DiskAccessException dae) {
       getOwner().handleDiskAccessException(dae);
       throw dae;
     } finally {
-      doAfterCompletionActions();
+      doAfterCompletionActions(disabledEviction);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/FocusedRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/FocusedRegionMap.java
@@ -22,8 +22,9 @@ import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.internal.cache.RegionEntryFactory;
 import org.apache.geode.internal.cache.TXEntryState;
+import org.apache.geode.internal.cache.eviction.EvictableMap;
 
-public interface FocusedRegionMap {
+public interface FocusedRegionMap extends EvictableMap {
 
   RegionEntry getEntry(EntryEventImpl event);
 
@@ -51,10 +52,6 @@ public interface FocusedRegionMap {
   void incEntryCount(int delta);
 
   void runWhileEvictionDisabled(Runnable runnable);
-
-  void lruUpdateCallback();
-
-  void resetThreadLocals();
 
   void txRemoveOldIndexEntry(Operation putOp, RegionEntry regionEntry);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapCommitPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapCommitPut.java
@@ -270,7 +270,7 @@ public class RegionMapCommitPut extends AbstractRegionMapPut {
   }
 
   @Override
-  protected void doAfterCompletionActions() {
+  protected void doAfterCompletionActions(boolean disabledEviction) {
     if (isOnlyExisting() && !isCompleted()) {
       if (didDestroy) {
         getOwner().txApplyPutHandleDidDestroy(getEvent().getKey());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/AbstractRegionMapPutTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/AbstractRegionMapPutTest.java
@@ -19,6 +19,7 @@ package org.apache.geode.internal.cache.map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -114,7 +115,27 @@ public class AbstractRegionMapPutTest {
     verify(instance, never()).createOrUpdateEntry();
     verify(instance, times(1)).shouldCreatedEntryBeRemoved();
     verify(instance, never()).doBeforeCompletionActions();
-    verify(instance, times(1)).doAfterCompletionActions();
+    verify(instance, times(1)).doAfterCompletionActions(anyBoolean());
+  }
+
+  @Test
+  public void putWithDisableLruUpdateCallbackTrueCallsDoAfterCompletionActionsWithTrue() {
+    instance.checkPreconditions = false;
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(true);
+
+    instance.put();
+
+    verify(instance, times(1)).doAfterCompletionActions(true);
+  }
+
+  @Test
+  public void putWithDisableLruUpdateCallbackFalseCallsDoAfterCompletionActionsWithFalse() {
+    instance.checkPreconditions = false;
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(false);
+
+    instance.put();
+
+    verify(instance, times(1)).doAfterCompletionActions(false);
   }
 
   @Test
@@ -283,7 +304,7 @@ public class AbstractRegionMapPutTest {
       verify(instance, never()).doBeforeCompletionActions();
       verify(instance, never()).shouldCreatedEntryBeRemoved();
     }
-    verify(instance, times(1)).doAfterCompletionActions();
+    verify(instance, times(1)).doAfterCompletionActions(anyBoolean());
   }
 
   private class TestableRegionMapPut extends AbstractRegionMapPut {
@@ -343,7 +364,7 @@ public class AbstractRegionMapPutTest {
     }
 
     @Override
-    protected void doAfterCompletionActions() {}
+    protected void doAfterCompletionActions(boolean disabledEviction) {}
 
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
@@ -683,8 +683,9 @@ public class RegionMapPutTest {
   }
 
   @Test
-  public void lruUpdateCallbackCalled_ifPutDoneWithoutAClear() throws Exception {
+  public void lruUpdateCallbackCalled_ifPutDoneWithoutAClear() {
     ifNew = true;
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(true);
     when(event.getOperation()).thenReturn(Operation.CREATE);
 
     doPut();
@@ -693,9 +694,43 @@ public class RegionMapPutTest {
   }
 
   @Test
+  public void lruUpdateCallbackNotCalled_ifCallbacksNotDisabled() {
+    ifNew = true;
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(false);
+    when(event.getOperation()).thenReturn(Operation.CREATE);
+
+    doPut();
+
+    verify(focusedRegionMap, never()).lruUpdateCallback();
+  }
+
+  @Test
+  public void enableLruUpdateCallbackCalled_ifCallbacksDisabled() {
+    ifNew = true;
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(true);
+    when(event.getOperation()).thenReturn(Operation.CREATE);
+
+    doPut();
+
+    verify(focusedRegionMap, times(1)).enableLruUpdateCallback();
+  }
+
+  @Test
+  public void enableLruUpdateCallbackNotCalled_ifCallbacksNotDisabled() {
+    ifNew = true;
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(false);
+    when(event.getOperation()).thenReturn(Operation.CREATE);
+
+    doPut();
+
+    verify(focusedRegionMap, never()).enableLruUpdateCallback();
+  }
+
+  @Test
   public void lruUpdateCallbackNotCalled_ifPutDoneWithAClear() throws Exception {
     ifNew = true;
     when(event.getOperation()).thenReturn(Operation.CREATE);
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(true);
     doThrow(RegionClearedException.class).when(event).putNewEntry(any(), any());
 
     doPut();
@@ -778,6 +813,7 @@ public class RegionMapPutTest {
   public void putThrows_ifLruUpdateCallbackThrowsDiskAccessException() throws Exception {
     ifNew = true;
     when(event.getOperation()).thenReturn(Operation.CREATE);
+    when(focusedRegionMap.disableLruUpdateCallback()).thenReturn(true);
     doThrow(DiskAccessException.class).when(focusedRegionMap).lruUpdateCallback();
 
     assertThatThrownBy(() -> doPut()).isInstanceOf(DiskAccessException.class);


### PR DESCRIPTION
The commit f4b0643829b00d0ba9b0852fdd3a679812395545 introduced deadlock between concurrent updates with custom expiry which invoked getValue() from the region entry.

In this case the basicPut() was taking the regionEntry lock and calling customExpiry() which gets the regionEntry from the LRU list which could have been locked by another thread, calling getValue() on this regionEntry invokes lruUpdateCallback() which tries to acquire a lock, resulting in dead lock. 

The issue was fixed by making sure lruUpdateCallback is deferred/called at the higher/caller level (before synchronizing region entry).

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [Y ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [Y ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [Y ] Is your initial contribution a single, squashed commit?

- [Y ] Does `gradlew build` run cleanly?

- [Y] Have you written or updated unit tests to verify your changes?

- [NA ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

