### PR TITLE
GEODE-6261: Do not break repeatable read by cleaning up TXEntries

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -1553,7 +1553,6 @@ public class TXState implements TXStateInterface {
       if (expectedOldValue != null) {
         Object val = result.getNearSidePendingValue();
         if (!AbstractRegionEntry.checkExpectedOldValue(expectedOldValue, val, internalRegion)) {
-          txr.cleanupNonDirtyEntries(internalRegion);
           throw new EntryNotFoundException(
               "The current value was not equal to expected value.");
         }


### PR DESCRIPTION
 * Do not cleanup existing TXEntries if finding an entry does not have expected value.

