### PR TITLE
GEODE-6264: Remove TODO comments from logging classes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/Log4jAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/Log4jAgent.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.lookup.StrLookup;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 
+import org.apache.geode.annotations.TestingOnly;
 import org.apache.geode.internal.logging.LogConfig;
 import org.apache.geode.internal.logging.LogLevelUpdateOccurs;
 import org.apache.geode.internal.logging.LogLevelUpdateScope;
@@ -70,10 +71,8 @@ public class Log4jAgent implements ProviderAgent {
     return ((Logger) logger).get();
   }
 
-  /**
-   * TODO:KIRK: delete getConfigurationInfoString
-   */
-  public static String getConfigurationInfoString() {
+  @TestingOnly
+  static String getConfigurationInfoString() {
     return getConfiguration().getConfigurationSource().toString();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/LogWriterAppender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/LogWriterAppender.java
@@ -350,7 +350,6 @@ public class LogWriterAppender extends AbstractAppender
   private void doAppendToLogWriter(final ManagerLogWriter logWriter, final LogEvent event) {
     byte[] bytes = getLayout().toByteArray(event);
     if (bytes != null && bytes.length > 0) {
-      // TODO:KIRK:PERF: creating new String - change to event.getMessage().getFormattedMessage()?
       logWriter.writeFormattedMessage(new String(bytes, Charset.defaultCharset()));
     }
     if (debug) {


### PR DESCRIPTION
Mark Log4jAgent.getConfigurationInfoString() with @TestingOnly
