### PR TITLE
GEODE-6259: Correct issues with publish targets

### DIFF
--- a/ci/pipelines/meta/jinja.template.yml
+++ b/ci/pipelines/meta/jinja.template.yml
@@ -44,6 +44,7 @@ resources:
     - ci/pipelines/geode-build/*
     - ci/pipelines/shared/*
     - ci/pipelines/render.py
+    - ci/pipelines/meta/meta.properties
 - name: geode-images-pipeline
   type: git
   source:
@@ -81,6 +82,7 @@ resources:
     - ci/pipelines/examples/*
     - ci/pipelines/shared/*
     - ci/pipelines/render.py
+    - ci/pipelines/meta/meta.properties
 - name: geode-pr-pipeline
   type: git
   source:
@@ -90,6 +92,7 @@ resources:
     - ci/pipelines/pull-request/*
     - ci/pipelines/shared/*
     - ci/pipelines/render.py
+    - ci/pipelines/meta/meta.properties
 {% endif %}
 - name: geode-metrics-pipeline
   type: git

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,8 +31,8 @@
 version = 1.9.0-SNAPSHOT
 
 # Default Maven targets
-mavenSnapshotUrl = "gcs://maven.apachegeode-ci.info/snapshots"
-mavenReleaseUrl = "https://repository.apache.org/service/local/staging/deploy/maven2"
+mavenSnapshotUrl = gcs://maven.apachegeode-ci.info/snapshots
+mavenReleaseUrl = https://repository.apache.org/service/local/staging/deploy/maven2
 
 # Maven also uses the project group as a prefix.
 group = org.apache.geode

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -107,11 +107,15 @@ publishing {
   repositories {
     maven {
       // Use specified mavenRepository if provided, else use release or snapshot defaults.
-      url = project.findProperty("mavenRepository") ||
+      url = project.findProperty("mavenRepository") ?:
           project.isReleaseVersion ? project.mavenReleaseUrl : project.mavenSnapshotUrl
-      credentials {
-        username project.findProperty("mavenUsername")
-        password project.findProperty("mavenPassword")
+      if (url.toString().startsWith("http") || url.toString().startsWith("sftp")) {
+        // Username / password credentials are only supported for http, https, and sftp repos.
+        // See the Gradle documentation on Repository Types for more information.
+        credentials {
+          username project.findProperty("mavenUsername")
+          password project.findProperty("mavenPassword")
+        }
       }
     }
   }


### PR DESCRIPTION
* Default values in gradle.properties should not be quote-wrapped
* Short-circuit-when-exists operator is ?: in Groovy, not || like in Python.
* Username/Password credentials are only valid for maven targets of HTTP, HTTPS, and SFTP.
* The meta pipeline should be updated when meta.properties changes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
