### PR TITLE
GEODE-6265: Rename TestingOnly to VisibleForTesting

### DIFF
--- a/geode-common/src/main/java/org/apache/geode/annotations/VisibleForTesting.java
+++ b/geode-common/src/main/java/org/apache/geode/annotations/VisibleForTesting.java
@@ -19,9 +19,17 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+/**
+ * Annotates a program element that exists, or is more widely visible than otherwise necessary, only
+ * for use in test code.
+ *
+ * <p>
+ * Introduced while mobbing with Michael Feathers. Name and javadoc borrowed from Guava and AssertJ
+ * (both are Apache License 2.0).
+ */
 @Documented
 @Target({ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.FIELD})
-public @interface TestingOnly {
+public @interface VisibleForTesting {
 
   /** Optional description */
   String value() default "";

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
@@ -64,7 +64,7 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import org.apache.geode.CancelException;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheLoaderException;
 import org.apache.geode.cache.DataPolicy;
@@ -139,7 +139,7 @@ public class InternalConfigurationPersistenceService implements ConfigurationPer
   private DistributedLockService sharedConfigLockingService;
   private JAXBService jaxbService;
 
-  @TestingOnly
+  @VisibleForTesting
   InternalConfigurationPersistenceService(Class<?>... xsdClasses) {
     configDirPath = null;
     configDiskDirPath = null;
@@ -148,7 +148,7 @@ public class InternalConfigurationPersistenceService implements ConfigurationPer
     jaxbService.validateWithLocalCacheXSD();
   }
 
-  @TestingOnly
+  @VisibleForTesting
   InternalConfigurationPersistenceService() {
     configDirPath = null;
     configDiskDirPath = null;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -36,7 +36,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.InternalGemFireException;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
@@ -133,7 +133,7 @@ public class GMSLocator implements Locator, NetLocator {
     return false;
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public File setViewFile(File file) {
     this.viewFile = file.getAbsoluteFile();
     return this.viewFile;

--- a/geode-core/src/main/java/org/apache/geode/internal/JarDeployer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/JarDeployer.java
@@ -43,7 +43,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.logging.LogService;
 
 public class JarDeployer implements Serializable {
@@ -442,7 +442,7 @@ public class JarDeployer implements Serializable {
     return this.deployedJars.get(jarName);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public DeployedJar deploy(final String jarName, final File stagedJarFile)
       throws IOException, ClassNotFoundException {
     lock.lock();

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AlertListenerMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AlertListenerMessage.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.admin.AlertLevel;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.AdminMessageType;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
@@ -156,22 +156,22 @@ public class AlertListenerMessage extends PooledDistributionMessage implements A
     return "Alert \"" + message + "\" level " + AlertLevel.forSeverity(alertLevel);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public static void addListener(Listener listener) {
     listenerRef.compareAndSet(null, listener);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public static void removeListener(Listener listener) {
     listenerRef.compareAndSet(listener, null);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public static Listener getListener() {
     return listenerRef.get();
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public interface Listener {
 
     void received(AlertListenerMessage message);

--- a/geode-core/src/main/java/org/apache/geode/internal/alerting/AlertingProviderRegistry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/alerting/AlertingProviderRegistry.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal.alerting;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 
 /**
  * Provides publication of {@code AlertingProvider} that may be initiated by a third party logging
@@ -36,7 +36,7 @@ public class AlertingProviderRegistry {
     return INSTANCE;
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public static AlertingProvider getNullAlertingProvider() {
     return NULL_ALERTING_PROVIDER;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/alerting/AlertingService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/alerting/AlertingService.java
@@ -15,7 +15,7 @@
 package org.apache.geode.internal.alerting;
 
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.DistributedMember;
 
 /**
@@ -50,7 +50,7 @@ public class AlertingService {
     return providerRegistry.getAlertingProvider().hasAlertListener(member, alertLevel);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   AlertingProviderRegistry getAlertingProviderRegistry() {
     return providerRegistry;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/alerting/AlertingSession.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/alerting/AlertingSession.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.alerting;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 
 /**
  * The {@code DistributedSystem} connection uses {@code AlertingSession} to control the lifecycle
@@ -42,7 +42,7 @@ public class AlertingSession {
     return create(AlertingSessionListeners.get());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   static AlertingSession create(final AlertingSessionListeners alertingSessionListeners) {
     return new AlertingSession(alertingSessionListeners);
   }
@@ -70,7 +70,7 @@ public class AlertingSession {
     // nothing?
   }
 
-  @TestingOnly
+  @VisibleForTesting
   AlertingSessionListeners getAlertingSessionListeners() {
     return alertingSessionListeners;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.StatisticsFactory;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.AttributesMutator;
 import org.apache.geode.cache.CacheCallback;
 import org.apache.geode.cache.CacheListener;
@@ -375,7 +375,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
     }
   }
 
-  @TestingOnly
+  @VisibleForTesting
   AbstractRegion() {
     this.cache = null;
     this.serialNumber = 0;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.GemFireException;
 import org.apache.geode.InternalGemFireError;
 import org.apache.geode.SystemFailure;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.CacheTransactionManager;
 import org.apache.geode.cache.CommitConflictException;
 import org.apache.geode.cache.TransactionDataRebalancedException;
@@ -1199,7 +1199,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     }
   }
 
-  @TestingOnly
+  @VisibleForTesting
   /** remove the given TXStates for test */
   public void removeTransactions(Set<TXId> txIds, boolean distribute) {
     synchronized (this.hostedTXStates) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXRegionLockRequestImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXRegionLockRequestImpl.java
@@ -23,7 +23,7 @@ import java.util.Set;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.locks.TXRegionLockRequest;
@@ -62,7 +62,7 @@ public class TXRegionLockRequestImpl implements TXRegionLockRequest {
   /**
    * Used by unit tests
    */
-  @TestingOnly
+  @VisibleForTesting
   public TXRegionLockRequestImpl(String regionPath, Set<Object> entryKeys) {
     this.cache = null;
     this.regionPath = regionPath;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupOperation.java
@@ -20,7 +20,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.geode.admin.internal.AdminDistributedSystemImpl;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.persistence.PersistentID;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionManager;
@@ -50,7 +50,7 @@ public class BackupOperation {
         new DefaultMissingPersistentMembersProvider());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   BackupOperation(FlushToDiskFactory flushToDiskFactory, PrepareBackupFactory prepareBackupFactory,
       AbortBackupFactory abortBackupFactory, FinishBackupFactory finishBackupFactory,
       DistributionManager dm, InternalCache cache, BackupLockService backupLockService,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.DiskAccessException;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.persistence.ConflictingPersistentDataException;
@@ -93,7 +93,7 @@ public class PersistenceAdvisorImpl implements InternalPersistenceAdvisor {
         diskRegionStats, persistentMemberManager, new PersistentStateQueryMessageSenderFactory());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   PersistenceAdvisorImpl(CacheDistributionAdvisor cacheDistributionAdvisor,
       DistributedLockService distributedLockService, PersistentMemberView persistentMemberView,
       String regionPath, DiskRegionStats diskRegionStats,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal.cache.tier.sockets.command;
 
 import java.io.IOException;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
@@ -68,7 +68,7 @@ public class ExecuteFunction extends BaseCommand {
         new DefaultFunctionContextImplFactory());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   ExecuteFunction(InternalFunctionExecutionService internalFunctionExecutionService,
       ServerToClientFunctionResultSenderFactory serverToClientFunctionResultSenderFactory,
       FunctionContextImplFactory functionContextImplFactory) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction65.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal.cache.tier.sockets.command;
 
 import java.io.IOException;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.LowMemoryException;
 import org.apache.geode.cache.execute.Function;
@@ -67,7 +67,7 @@ public class ExecuteFunction65 extends BaseCommand {
         new DefaultFunctionContextImplFactory());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   ExecuteFunction65(InternalFunctionExecutionService internalFunctionExecutionService,
       ServerToClientFunctionResultSender65Factory serverToClientFunctionResultSender65Factory,
       FunctionContextImplFactory functionContextImplFactory) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionVector.java
@@ -34,7 +34,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelCriterion;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionManager;
@@ -189,7 +189,7 @@ public abstract class RegionVersionVector<T extends VersionSource<?>>
     this(ownerId, owner, 0);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   RegionVersionVector(T ownerId, LocalRegion owner, long version) {
     this.myId = ownerId;
     this.isLiveVector = true;

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/Configuration.java
@@ -18,7 +18,7 @@ import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.apache.geode.internal.logging.LogLevelUpdateOccurs.ONLY_WHEN_USING_DEFAULT_CONFIG;
 import static org.apache.geode.internal.logging.LogLevelUpdateScope.GEODE_LOGGERS;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Cache;
 
 /**
@@ -29,7 +29,7 @@ public class Configuration implements LogConfigListener {
   /**
    * The default {@link LogWriterLevel} is {@link LogWriterLevel#CONFIG}.
    */
-  @TestingOnly
+  @VisibleForTesting
   public static final int DEFAULT_LOGWRITER_LEVEL = LogWriterLevel.CONFIG.intLevel();
 
   /**
@@ -84,19 +84,19 @@ public class Configuration implements LogConfigListener {
         .findProviderAgent());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public static Configuration create(final ProviderAgent providerAgent) {
     return create(getLogLevelUpdateOccurs(), getLogLevelUpdateScope(), providerAgent);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public static Configuration create(final LogLevelUpdateOccurs logLevelUpdateOccurs,
       final LogLevelUpdateScope logLevelUpdateScope) {
     return create(logLevelUpdateOccurs, logLevelUpdateScope,
         new ProviderAgentLoader().findProviderAgent());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public static Configuration create(final LogLevelUpdateOccurs logLevelUpdateOccurs,
       final LogLevelUpdateScope logLevelUpdateScope, final ProviderAgent providerAgent) {
     return new Configuration(logLevelUpdateOccurs, logLevelUpdateScope, providerAgent);
@@ -183,7 +183,7 @@ public class Configuration implements LogConfigListener {
     }
   }
 
-  @TestingOnly
+  @VisibleForTesting
   synchronized LogConfigSupplier getLogConfigSupplier() {
     return logConfigSupplier;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingSession.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingSession.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 
 /**
  * Configures the logging {@code Configuration} and provides lifecycle to Geode logging.
@@ -44,7 +44,7 @@ public class LoggingSession implements SessionContext {
     return create(Configuration.create(), LoggingSessionListeners.get());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   static LoggingSession create(final Configuration configuration,
       final LoggingSessionListeners loggingSessionListeners) {
     return new LoggingSession(configuration, loggingSessionListeners);
@@ -111,7 +111,7 @@ public class LoggingSession implements SessionContext {
     return configuration.getLogConfigSupplier();
   }
 
-  @TestingOnly
+  @VisibleForTesting
   LoggingSessionListeners getLoggingSessionListeners() {
     return loggingSessionListeners;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingSessionListeners.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/LoggingSessionListeners.java
@@ -18,7 +18,7 @@ import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 
 /**
  * Manages registration of {@link LoggingSessionListener}s and provides notifications to them.
@@ -33,7 +33,7 @@ public class LoggingSessionListeners {
 
   private final Set<LoggingSessionListener> listeners;
 
-  @TestingOnly
+  @VisibleForTesting
   LoggingSessionListeners() {
     listeners = new LinkedHashSet<>();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/ManagerLogWriterFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/ManagerLogWriterFactory.java
@@ -26,7 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
 import org.apache.geode.GemFireIOException;
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.process.ProcessLauncherContext;
 import org.apache.geode.internal.statistics.StatisticsConfig;
@@ -95,7 +95,7 @@ public class ManagerLogWriterFactory {
     return logWriter;
   }
 
-  @TestingOnly
+  @VisibleForTesting
   File getLogFile(final LogConfig config) {
     if (security) {
       return config.getSecurityLogFile();
@@ -104,7 +104,7 @@ public class ManagerLogWriterFactory {
     }
   }
 
-  @TestingOnly
+  @VisibleForTesting
   int getLogLevel(final LogConfig config) {
     if (security) {
       return config.getSecurityLogLevel();

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/ProviderAgentLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/ProviderAgentLoader.java
@@ -22,7 +22,7 @@ import java.util.ServiceLoader;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.status.StatusLogger;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.ClassPathLoader;
 
 /**
@@ -54,7 +54,7 @@ public class ProviderAgentLoader {
     this(new DefaultProvider());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   ProviderAgentLoader(final AvailabilityChecker availabilityChecker) {
     this.availabilityChecker = availabilityChecker;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/GeodeConsoleAppender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/GeodeConsoleAppender.java
@@ -39,7 +39,7 @@ import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 import org.apache.logging.log4j.core.util.NullOutputStream;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 
 /**
  * Wraps {@link ConsoleAppender} with additions defined in {@link PausableAppender} and
@@ -245,7 +245,7 @@ public class GeodeConsoleAppender extends AbstractOutputStreamAppender<OutputStr
         + " {paused=" + paused + ", debug=" + debug + ", delegate=" + delegate + "}";
   }
 
-  @TestingOnly
+  @VisibleForTesting
   ConsoleAppender getDelegate() {
     return delegate;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/Log4jAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/Log4jAgent.java
@@ -34,7 +34,7 @@ import org.apache.logging.log4j.core.filter.AbstractFilterable;
 import org.apache.logging.log4j.core.lookup.StrLookup;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.logging.LogConfig;
 import org.apache.geode.internal.logging.LogLevelUpdateOccurs;
 import org.apache.geode.internal.logging.LogLevelUpdateScope;
@@ -71,7 +71,7 @@ public class Log4jAgent implements ProviderAgent {
     return ((Logger) logger).get();
   }
 
-  @TestingOnly
+  @VisibleForTesting
   static String getConfigurationInfoString() {
     return getConfiguration().getConfigurationSource().toString();
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -31,7 +31,7 @@ import javax.management.ObjectName;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.EvictionAction;
@@ -92,7 +92,7 @@ public class FederatingManager extends Manager {
     messenger = new MemberMessenger(jmxAdapter, system);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   void setProxyFactory(MBeanProxyFactory newProxyFactory) {
     proxyFactory = newProxyFactory;
   }
@@ -542,12 +542,12 @@ public class FederatingManager extends Manager {
     return messenger;
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public void setMessenger(MemberMessenger messenger) {
     this.messenger = messenger;
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public synchronized Exception getAndResetLatestException() {
     return latestException.getAndSet(null);
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementListener.java
@@ -17,7 +17,7 @@ package org.apache.geode.management.internal.beans;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
@@ -55,7 +55,7 @@ public class ManagementListener implements ResourceEventsListener {
     this(system, new ManagementAdapter(), new ReentrantReadWriteLock());
   }
 
-  @TestingOnly
+  @VisibleForTesting
   ManagementListener(InternalDistributedSystem system, ManagementAdapter adapter,
       ReadWriteLock readWriteLock) {
     this.system = system;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CommandRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CommandRequest.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.management.cli.CliMetaData;
 
 /**
@@ -38,7 +38,7 @@ public class CommandRequest {
   private final boolean downloadFile;
 
 
-  @TestingOnly
+  @VisibleForTesting
   public CommandRequest(final Map<String, String> env) {
     this.env = env;
     this.fileList = null;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/OnlineCommandProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/OnlineCommandProcessor.java
@@ -24,7 +24,7 @@ import org.springframework.shell.core.Parser;
 import org.springframework.shell.event.ParseResult;
 import org.springframework.util.StringUtils;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.cli.CliMetaData;
@@ -54,7 +54,7 @@ public class OnlineCommandProcessor {
     this(cacheProperties, securityService, new CommandExecutor(), cache);
   }
 
-  @TestingOnly
+  @VisibleForTesting
   public OnlineCommandProcessor(Properties cacheProperties, SecurityService securityService,
       CommandExecutor commandExecutor, InternalCache cache) {
     this.gfshParser = new GfshParser(new CommandManager(cacheProperties, cache));

--- a/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptor.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 
-import org.apache.geode.annotations.TestingOnly;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.security.SecurityService;
@@ -68,7 +68,7 @@ public class LoginHandlerInterceptor extends HandlerInterceptorAdapter
 
   public LoginHandlerInterceptor() {}
 
-  @TestingOnly
+  @VisibleForTesting
   LoginHandlerInterceptor(SecurityService securityService) {
     this.securityService = securityService;
   }


### PR DESCRIPTION
VisibleForTesting is an annotation which identifies a program
element that exists, or is more widely visible than otherwise
necessary, only for use in test code.

TestingOnly has been renamed to VisibleForTesting without
adding Guava as a dependency for src/main. Currently, Guava
is only a dependency for src/test.
