### PR TITLE
GEODE-6270: Correctly set up user-provided client cache regions for session modules

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -102,7 +102,7 @@ configurations {
   }
   gfshDependencies
 
-  //Configurations used to download and cache web application servers for session module testing
+  // Configurations used to download and cache web application servers for session module testing
   webServerTomcat6
   webServerTomcat7
   webServerTomcat8
@@ -119,6 +119,9 @@ def webServersDir = "$buildDir/generated-resources/webservers"
 
 sourceSets {
   distributedTest {
+    resources {
+      srcDirs webServersDir
+    }
     output.dir(webServersDir, builtBy: 'downloadWebServers')
   }
 }

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ServerContainer.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ServerContainer.java
@@ -429,7 +429,7 @@ public abstract class ServerContainer {
       attributes.put("host", locatorAddress);
       attributes.put("port", Integer.toString(locatorPort));
 
-      ContainerInstall.editXMLFile(getSystemProperty("cache-xml-file"), "locator", "pool",
+      ContainerInstall.editXMLFile(cacheXMLFile.getAbsolutePath(), "locator", "pool",
           attributes, true);
     } else {
       setSystemProperty("locators", locatorAddress + "[" + locatorPort + "]");

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/CargoTestBase.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/CargoTestBase.java
@@ -87,7 +87,11 @@ public abstract class CargoTestBase {
     install.setDefaultLocatorPort(locatorVM.getPort());
 
     manager.addContainers(2, install);
+
+    customizeContainers();
   }
+
+  public void customizeContainers() throws Exception {}
 
   /**
    * Stops all containers that were previously started and cleans up their configurations
@@ -187,8 +191,7 @@ public abstract class CargoTestBase {
    * Test that invalidating a session in one container invalidates the session in all containers.
    */
   @Test
-  public void invalidationShouldRemoveValueAccessForAllContainers()
-      throws IOException, URISyntaxException {
+  public void invalidationShouldRemoveValueAccessForAllContainers() throws Exception {
     manager.startAllInactiveContainers();
 
     String key = "value_testInvalidate";
@@ -335,7 +338,7 @@ public abstract class CargoTestBase {
    * data.
    */
   @Test
-  public void newContainersShouldShareDataAccess() throws IOException, URISyntaxException {
+  public void newContainersShouldShareDataAccess() throws Exception {
     manager.startAllInactiveContainers();
 
     String key = "value_testSessionAdd";
@@ -349,6 +352,8 @@ public abstract class CargoTestBase {
     int numContainers = manager.numContainers();
     // Add and start new container
     manager.addContainer(install);
+    customizeContainers();
+
     manager.startAllInactiveContainers();
     // Check that a container was added
     assertEquals(numContainers + 1, manager.numContainers());

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat8ClientServerCustomCacheXmlTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat8ClientServerCustomCacheXmlTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.session.tests;
+
+import java.util.HashMap;
+
+public class Tomcat8ClientServerCustomCacheXmlTest extends Tomcat8ClientServerTest {
+
+  @Override
+  public void customizeContainers() throws Exception {
+    for (int i = 0; i < manager.numContainers(); i++) {
+      ServerContainer container = manager.getContainer(i);
+
+      HashMap<String, String> regionAttributes = new HashMap<>();
+      regionAttributes.put("refid", "PROXY");
+      regionAttributes.put("name", "gemfire_modules_sessions");
+
+      ContainerInstall.editXMLFile(
+          container.cacheXMLFile.getAbsolutePath(),
+          null,
+          "region",
+          "client-cache",
+          regionAttributes);
+    }
+  }
+
+  @Override
+  public void afterStartServers() throws Exception {
+    gfsh.connect(locatorVM);
+    gfsh.executeAndAssertThat("create region --name=gemfire_modules_sessions --type=PARTITION")
+        .statusIsSuccess();
+  }
+
+}

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/TomcatClientServerTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/TomcatClientServerTest.java
@@ -49,7 +49,11 @@ public abstract class TomcatClientServerTest extends CargoTestBase {
   public void startServer() throws Exception {
     serverName1 = startAServer(1);
     serverName2 = startAServer(2);
+
+    afterStartServers();
   }
+
+  public void afterStartServers() throws Exception {}
 
   private String startAServer(int serverNumber) {
     // List of all the jars for tomcat to put on the server classpath


### PR DESCRIPTION

- If a user provides their own client cache xml, we need to ensure that the
  SessionExpirationCacheListener, as well as any necessary interest
  registration, has been set up.
- Update build.xml so that these tests can be run from IntelliJ

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
