### PR TITLE
GEODE-6267: Logged out subject

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerConnectDisconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerConnectDisconnectDistributedTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.shiro.subject.Subject;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.examples.SimpleSecurityManager;
+import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.SecurityTest;
+
+@Category({SecurityTest.class})
+public class ClientServerConnectDisconnectDistributedTest implements Serializable {
+
+  @ClassRule
+  public static ClusterStartupRule cluster = new ClusterStartupRule();
+
+  private static MemberVM locator;
+  private static MemberVM server;
+  private static ClientVM client;
+
+  private static List<Subject> serverConnectionSubjects;
+
+  private static Subject proxySubject;
+
+  private static List<ClientUserAuths> authorizations;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Properties locatorProps = new Properties();
+    locatorProps.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getCanonicalName());
+    locator = cluster.startLocatorVM(0, locatorProps);
+
+    Properties serverProps = new Properties();
+    serverProps.setProperty("security-username", "cluster");
+    serverProps.setProperty("security-password", "cluster");
+    server = cluster.startServerVM(1, serverProps, locator.getPort());
+
+    server.invoke(() -> {
+      Cache cache = ClusterStartupRule.getCache();
+      cache.createRegionFactory(RegionShortcut.PARTITION).create("region");
+    });
+  }
+
+  @Test
+  public void testClientConnectDisconnect() throws Exception {
+    // Connect client
+    int locatorPort = locator.getPort();
+    client = cluster.startClientVM(3, c -> c.withCredential("data", "data")
+        .withPoolSubscription(true)
+        .withLocatorConnection(locatorPort));
+
+    // Do some puts
+    client.invoke(() -> {
+      ClientCache cache = ClusterStartupRule.getClientCache();
+      Region region = cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
+      for (int i = 0; i < 10; i++) {
+        Object key = String.valueOf(i);
+        region.put(key, key);
+      }
+    });
+
+    // Verify client sessions are logged in on the server
+    server.invoke(() -> verifySubjectsAreLoggedIn());
+
+    // Close client
+    client.invoke(() -> {
+      ClusterStartupRule.getClientCache().close();
+    });
+
+    // Verify client sessions are logged out on the server
+    server.invoke(() -> verifySubjectsAreLoggedOut());
+  }
+
+  private void verifySubjectsAreLoggedIn() {
+    Cache cache = ClusterStartupRule.getCache();
+    List<CacheServer> cacheServers = cache.getCacheServers();
+    CacheServer cacheServer = cacheServers.get(0);
+    AcceptorImpl acceptor = ((CacheServerImpl) cacheServer).getAcceptor();
+
+    // Verify ServerConnection subjects are logged in
+    verifyServerConnectionSubjectsAreLoggedIn(acceptor);
+
+    // Verify CacheClientProxy subject is logged out
+    verifyCacheClientProxySubjectIsLoggedIn(acceptor);
+  }
+
+  private void verifyServerConnectionSubjectsAreLoggedIn(AcceptorImpl acceptor) {
+    serverConnectionSubjects = new ArrayList<>();
+    authorizations = new ArrayList<>();
+    for (ServerConnection sc : acceptor.getAllServerConnections()) {
+      ClientUserAuths auth = sc.getClientUserAuths();
+      assertThat(auth.getSubjects().size()).isNotEqualTo(0);
+      authorizations.add(auth);
+      for (Subject subject : auth.getSubjects()) {
+        assertThat(subject.getPrincipal()).isNotNull();
+        assertThat(subject.getPrincipals()).isNotNull();
+        assertThat(subject.isAuthenticated()).isTrue();
+        serverConnectionSubjects.add(subject);
+      }
+    }
+  }
+
+  private void verifyCacheClientProxySubjectIsLoggedIn(AcceptorImpl acceptor) {
+    // Ensure the CacheClientProxy is created since its asynchronous
+    await().until(() -> acceptor.getCacheClientNotifier().getClientProxies().size() == 1);
+    CacheClientProxy proxy = acceptor.getCacheClientNotifier().getClientProxies().iterator().next();
+
+    // Check CacheClientProxy subject
+    proxySubject = proxy.getSubject();
+    assertThat(proxySubject).isNotNull();
+    assertThat(proxySubject.getPrincipal()).isNotNull();
+    assertThat(proxySubject.getPrincipals()).isNotNull();
+    assertThat(proxySubject.isAuthenticated()).isTrue();
+  }
+
+  private void verifySubjectsAreLoggedOut() {
+    // Verify ServerConnection subjects are logged out
+    verifyServerConnectionSubjectsAreLoggedOut();
+
+    // Verify the CacheClientProxy subject is logged out
+    verifyCacheClientProxyIsLoggedOut();
+  }
+
+  private void verifyServerConnectionSubjectsAreLoggedOut() {
+    for (Subject subject : serverConnectionSubjects) {
+      assertThat(subject.getPrincipal()).isNull();
+      assertThat(subject.getPrincipals()).isNull();
+      assertThat(subject.isAuthenticated()).isFalse();
+    }
+
+    for (ClientUserAuths auth : authorizations) {
+      assertThat(auth.getSubjects().size()).isEqualTo(0);
+    }
+  }
+
+  private void verifyCacheClientProxyIsLoggedOut() {
+    assertThat(proxySubject.getPrincipal()).isNull();
+    assertThat(proxySubject.getPrincipals()).isNull();
+    assertThat(proxySubject.isAuthenticated()).isFalse();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -865,6 +865,7 @@ public class CacheClientProxy implements ClientSession {
       return;
     }
 
+    boolean closedSocket = false;
     try {
       if (logger.isDebugEnabled()) {
         logger.debug("{}: Terminating processing", this);
@@ -912,7 +913,7 @@ public class CacheClientProxy implements ClientSession {
         // to fix bug 37684
         // 1. check to see if dispatcher is still alive
         if (this._messageDispatcher.isAlive()) {
-          closeSocket();
+          closedSocket = closeSocket();
           destroyRQ();
           alreadyDestroyed = true;
           this._messageDispatcher.interrupt();
@@ -941,7 +942,11 @@ public class CacheClientProxy implements ClientSession {
     } finally {
       // Close the statistics
       this._statistics.close(); // fix for bug 40105
-      closeTransientFields(); // make sure this happens
+      if (closedSocket) {
+        closeOtherTransientFields();
+      } else {
+        closeTransientFields(); // make sure this happens
+      }
     }
   }
 
@@ -963,6 +968,10 @@ public class CacheClientProxy implements ClientSession {
       return;
     }
 
+    closeOtherTransientFields();
+  }
+
+  private void closeOtherTransientFields() {
     // Null out comm buffer, host address, ports and proxy id. All will be
     // replaced when the client reconnects.
     releaseCommBuffer();
@@ -981,6 +990,11 @@ public class CacheClientProxy implements ClientSession {
     // Commented to fix bug 40259
     // this.clientVersion = null;
     closeNonDurableCqs();
+
+    // Logout the subject
+    if (this.subject != null) {
+      this.subject.logout();
+    }
   }
 
   private void releaseCommBuffer() {
@@ -1932,6 +1946,10 @@ public class CacheClientProxy implements ClientSession {
 
   public Version getVersion() {
     return this.clientVersion;
+  }
+
+  protected Subject getSubject() {
+    return this.subject;
   }
 
   protected void scheduleDurableExpirationTask() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -45,6 +45,7 @@ import org.apache.shiro.util.ThreadState;
 import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.StatisticsFactory;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.ClientSession;
@@ -1948,6 +1949,7 @@ public class CacheClientProxy implements ClientSession {
     return this.clientVersion;
   }
 
+  @VisibleForTesting
   protected Subject getSubject() {
     return this.subject;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Random;
@@ -76,6 +78,10 @@ public class ClientUserAuths {
 
   public UserAuthAttributes getUserAuthAttributes(long userId) {
     return uniqueIdVsUserAuth.get(userId);
+  }
+
+  protected Collection<Subject> getSubjects() {
+    return Collections.unmodifiableCollection(this.uniqueIdVsSubject.values());
   }
 
   public Subject getSubject(long userId) {
@@ -188,6 +194,11 @@ public class ClientUserAuths {
       } else if (fromCacheClientProxy && userAuth.isDurable()) {// from cacheclientProxy class
         cleanUserAuth(userAuth);
       }
+    }
+
+    // Logout the subjects
+    for (Long subjectId : uniqueIdVsSubject.keySet()) {
+      removeSubject(subjectId);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.logging.log4j.Logger;
 import org.apache.shiro.subject.Subject;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.security.AuthorizeRequest;
 import org.apache.geode.internal.security.AuthorizeRequestPP;
@@ -80,6 +81,7 @@ public class ClientUserAuths {
     return uniqueIdVsUserAuth.get(userId);
   }
 
+  @VisibleForTesting
   protected Collection<Subject> getSubjects() {
     return Collections.unmodifiableCollection(this.uniqueIdVsSubject.values());
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -45,6 +45,7 @@ import org.apache.shiro.util.ThreadState;
 import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.SystemFailure;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.UnsupportedVersionException;
 import org.apache.geode.cache.client.internal.AbstractOp;
 import org.apache.geode.cache.client.internal.Connection;
@@ -1102,6 +1103,7 @@ public abstract class ServerConnection implements Runnable {
     }
   }
 
+  @VisibleForTesting
   protected ClientUserAuths getClientUserAuths() {
     return this.clientUserAuths;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -1102,6 +1102,10 @@ public abstract class ServerConnection implements Runnable {
     }
   }
 
+  protected ClientUserAuths getClientUserAuths() {
+    return this.clientUserAuths;
+  }
+
   private void setSecurityPart() {
     try {
       this.connectionId = randomConnectionIdGen.nextLong();


### PR DESCRIPTION
The changes to CacheClientProxy  closeTransientFields and closeOtherTransientFields are to address the bug I found while debugging this leak.

The main changes to address the leak are to invoke removeSubject in ClientUserAuths. cleanup and logout in CacheClientProxy.closeOtherTransientFields.