### PR TITLE
GEODE-6276: Use named cli option in benchmark

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -344,6 +344,7 @@ jobs:
         AWS_REGION: us-west-2
         ARTIFACT_BUCKET: ((artifact-bucket))
         BASELINE_BRANCH: {{benchmarks.baseline_branch}}
+        BASELINE_VERSION: {{benchmarks.baseline_version}}
       run:
         path: geode-ci/ci/scripts/run_benchmarks.sh
       inputs:
@@ -365,6 +366,7 @@ jobs:
             AWS_REGION: us-west-2
             ARTIFACT_BUCKET: ((artifact-bucket))
             BASELINE_BRANCH: {{benchmarks.baseline_branch}}
+            BASELINE_VERSION: {{benchmarks.baseline_version}}
           run:
             path: geode-ci/ci/scripts/cleanup_benchmarks.sh
           inputs:

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -57,7 +57,7 @@ java_test_versions:
   version: 11
 
 benchmarks:
-  baseline_branch: "rel/v1.8.0"
+  baseline_version: "1.8.0"
 
 java_build_version:
   name: OpenJDK8

--- a/ci/scripts/cleanup_benchmarks.sh
+++ b/ci/scripts/cleanup_benchmarks.sh
@@ -62,7 +62,7 @@ pushd ${RESULTS_BASE_DIR}
     gsutil cp ${BENCHMARKS_ARCHIVE_FILE} gs://${BENCHMARKS_ARTIFACTS_DESTINATION}/${BENCHMARKS_ARCHIVE_FILENAME}
     printf "\n"
     printf "\033[92m=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\033[0m\n"
-    printf "\033[92mThis benchmark run is the result of comparing ${GEODE_SHA} with baseline ${BASELINE_BRANCH}\033[0m\n"
+    printf "\033[92mThis benchmark run is the result of comparing ${GEODE_SHA} with baseline ${BASELINE_BRANCH:-${BASELINE_VERSION}}\033[0m\n"
     printf "\033[92m=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=- Commit Message =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\033[0m\n"
     echo "${GEODE_SHA_COMMIT_MESSAGE}"
     printf "\033[92m=-=-=-=-=-=-=-=-=-=-=-=-=-=-= Benchmark Results URI =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\033[0m\n"

--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -42,6 +42,13 @@ popd
 
 pushd geode-benchmarks/infrastructure/scripts/aws/
 ./launch_cluster.sh ${CLUSTER_TAG} ${CLUSTER_COUNT}
-./run_against_baseline.sh ${CLUSTER_TAG} ${GEODE_SHA} ${BASELINE_BRANCH} ${BENCHMARKS_BRANCH} ${RESULTS_DIR}
+
+if [ -z "${BASELINE_VERSION}" ]; then
+  ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} -B ${BASELINE_BRANCH} -m ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR}
+else
+  ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} -V ${BASELINE_VERSION} -m ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR}
+fi
+
+
 
 popd


### PR DESCRIPTION
The Benchmark scripts now take named cli options instead of positional
ones. Use the named options in CI to call the benchmark, and pass the
branch and version number through to the scripts, even though only one
will be used at a time.

Signed-off-by: Helena A. Bales <hbales@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
