### PR TITLE
GEODE-6285: Make MBean names immutable in loner

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClientMembershipDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClientMembershipDUnitTest.java
@@ -1582,6 +1582,11 @@ public class ClientMembershipDUnitTest extends ClientServerTestCase {
     }
 
     @Override
+    public String getUniqueId() {
+      return host;
+    }
+
+    @Override
     public int compareTo(DistributedMember o) {
       if ((o == null) || !(o instanceof TestDistributedMember)) {
         throw new InternalGemFireException("Invalidly comparing TestDistributedMember to " + o);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/DistributedSystemMXBeanWithNotificationsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/DistributedSystemMXBeanWithNotificationsDistributedTest.java
@@ -22,7 +22,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_S
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.management.JMXNotificationType.REGION_CREATED;
 import static org.apache.geode.management.internal.MBeanJMXAdapter.getMemberMBeanName;
-import static org.apache.geode.management.internal.MBeanJMXAdapter.getMemberNameOrId;
+import static org.apache.geode.management.internal.MBeanJMXAdapter.getMemberNameOrUniqueId;
 import static org.apache.geode.management.internal.ManagementConstants.REGION_CREATED_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
@@ -175,7 +175,7 @@ public class DistributedSystemMXBeanWithNotificationsDistributedTest implements 
     for (VM memberVM : toArray(memberVM1, memberVM2, memberVM3)) {
       memberVM.invoke(() -> {
         Notification notification =
-            new Notification(REGION_CREATED, getMemberNameOrId(distributedMember),
+            new Notification(REGION_CREATED, getMemberNameOrUniqueId(distributedMember),
                 SequenceNumber.next(), System.currentTimeMillis(), REGION_CREATED_PREFIX + "/test");
         NotificationBroadcasterSupport notifier = (MemberMBean) managementService.getMemberMXBean();
         notifier.sendNotification(notification);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/RegionManagementDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/RegionManagementDUnitTest.java
@@ -804,7 +804,8 @@ public class RegionManagementDUnitTest implements Serializable {
     Cache cache = getCache();
 
     String memberId =
-        MBeanJMXAdapter.getMemberNameOrId(cache.getDistributedSystem().getDistributedMember());
+        MBeanJMXAdapter
+            .getMemberNameOrUniqueId(cache.getDistributedSystem().getDistributedMember());
     ObjectName objectName = ObjectName.getInstance("GemFire:type=Member,member=" + memberId);
 
     // List<Notification> notifications = new ArrayList<>();

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/UniversalMembershipListenerAdapterDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/UniversalMembershipListenerAdapterDUnitTest.java
@@ -1706,6 +1706,11 @@ public class UniversalMembershipListenerAdapterDUnitTest extends ClientServerTes
     }
 
     @Override
+    public String getUniqueId() {
+      return host;
+    }
+
+    @Override
     public int compareTo(DistributedMember o) {
       if ((o == null) || !(o instanceof FakeDistributedMember)) {
         throw new InternalGemFireException("Invalidly comparing TestDistributedMember to " + o);

--- a/geode-core/src/main/java/org/apache/geode/distributed/DistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/DistributedMember.java
@@ -62,9 +62,15 @@ public interface DistributedMember extends Comparable<DistributedMember> {
   int getProcessId();
 
   /**
-   * Returns a unique identifier for this member.
+   * Returns a unique identifier for this member. Note that this value may change during the life
+   * of the member.
    */
   String getId();
+
+  /**
+   * Returns an immutable unique identifier for this member.
+   */
+  String getUniqueId();
 
   /**
    * Returns the durable attributes for this client.

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -1191,6 +1191,24 @@ public class InternalDistributedMember implements DistributedMember, Externaliza
     return toString();
   }
 
+  @Override
+  public String getUniqueId() {
+    StringBuilder sb = new StringBuilder();
+    addFixedToString(sb);
+
+    // add version if not current
+    short version = netMbr.getVersionOrdinal();
+    if (version != Version.CURRENT.ordinal()) {
+      sb.append("(version:").append(Version.toString(version)).append(')');
+    }
+
+    if (SHOW_NETMEMBER) {
+      sb.append("[[").append(netMbr.getUniqueId()).append("]]");
+    }
+
+    return sb.toString();
+  }
+
   public void setVersionObjectForTest(Version v) {
     this.versionObj = v;
     netMbr.setVersion(v);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/NetMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/NetMember.java
@@ -110,4 +110,9 @@ public interface NetMember extends Comparable<NetMember> {
   /** compare data that is not known to DistributedMember instances */
   int compareAdditionalData(NetMember other);
 
+  /**
+   * Return a unique string id for this member which is immutable and will not change during the
+   * life of this member.
+   */
+  String getUniqueId();
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMember.java
@@ -330,8 +330,7 @@ public class GMSMember implements NetMember, DataSerializableFixedID {
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder(100);
-    String uuid = SHOW_UUIDS ? (";uuid=" + getUUID().toStringLong())
-        : ((this.uuidLSBs == 0 && this.uuidMSBs == 0) ? "; no uuid" : "; uuid set");
+    String uuid = formatUUID();
 
     sb.append("GMSMember[addr=").append(inetAddr).append(";port=").append(udpPort)
         .append(";processId=").append(processId).append(";name=").append(name).append(uuid)
@@ -339,6 +338,15 @@ public class GMSMember implements NetMember, DataSerializableFixedID {
     return sb.toString();
   }
 
+  @Override
+  public String getUniqueId() {
+    StringBuilder sb = new StringBuilder(100);
+    sb.append("GMSMember[addr=").append(inetAddr);
+    sb.append(";processId=").append(processId);
+    sb.append(";name=").append(name);
+    sb.append(formatUUID()).append("]");
+    return sb.toString();
+  }
 
   public int getUdpPort() {
     return udpPort;
@@ -565,5 +573,10 @@ public class GMSMember implements NetMember, DataSerializableFixedID {
     } catch (EOFException e) {
       // some IDs do not have UUID or membership weight information
     }
+  }
+
+  private String formatUUID() {
+    return SHOW_UUIDS ? ";uuid=" + getUUID().toStringLong()
+        : uuidLSBs == 0 && uuidMSBs == 0 ? "; no uuid" : "; uuid set";
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/MBeanJMXAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/MBeanJMXAdapter.java
@@ -94,7 +94,7 @@ public class MBeanJMXAdapter implements ManagementConstants {
     ObjectName newObjectName = objectName;
     try {
       if (!isGemFireMBean) {
-        String member = getMemberNameOrId(distMember);
+        String member = getMemberNameOrUniqueId(distMember);
         String objectKeyProperty = objectName.getKeyPropertyListString();
 
         newObjectName = ObjectName.getInstance(
@@ -258,11 +258,11 @@ public class MBeanJMXAdapter implements ManagementConstants {
    * @param member Member to find the name for
    * @return The name used to register this member as a JMX bean.
    */
-  public static String getMemberNameOrId(DistributedMember member) {
+  public static String getMemberNameOrUniqueId(DistributedMember member) {
     if (member.getName() != null && !member.getName().equals("")) {
       return makeCompliantName(member.getName());
     }
-    return makeCompliantName(member.getId());
+    return makeCompliantName(member.getUniqueId());
   }
 
   /**
@@ -403,7 +403,7 @@ public class MBeanJMXAdapter implements ManagementConstants {
 
   public static ObjectName getMemberMBeanName(DistributedMember member) {
     return getObjectName(
-        (MessageFormat.format(OBJECTNAME__MEMBER_MXBEAN, getMemberNameOrId(member))));
+        (MessageFormat.format(OBJECTNAME__MEMBER_MXBEAN, getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getMemberMBeanName(String member) {
@@ -414,7 +414,7 @@ public class MBeanJMXAdapter implements ManagementConstants {
   public static ObjectName getRegionMBeanName(DistributedMember member, String regionPath) {
 
     return getObjectName((MessageFormat.format(OBJECTNAME__REGION_MXBEAN,
-        makeCompliantRegionPath(regionPath), getMemberNameOrId(member))));
+        makeCompliantRegionPath(regionPath), getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getRegionMBeanName(String member, String regionPath) {
@@ -430,7 +430,8 @@ public class MBeanJMXAdapter implements ManagementConstants {
 
   public static ObjectName getDiskStoreMBeanName(DistributedMember member, String diskName) {
     return getObjectName(
-        (MessageFormat.format(OBJECTNAME__DISKSTORE_MXBEAN, diskName, getMemberNameOrId(member))));
+        (MessageFormat.format(OBJECTNAME__DISKSTORE_MXBEAN, diskName,
+            getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getDiskStoreMBeanName(String member, String diskName) {
@@ -440,7 +441,7 @@ public class MBeanJMXAdapter implements ManagementConstants {
 
   public static ObjectName getClientServiceMBeanName(int serverPort, DistributedMember member) {
     return getObjectName((MessageFormat.format(OBJECTNAME__CLIENTSERVICE_MXBEAN,
-        String.valueOf(serverPort), getMemberNameOrId(member))));
+        String.valueOf(serverPort), getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getClientServiceMBeanName(int serverPort, String member) {
@@ -451,7 +452,7 @@ public class MBeanJMXAdapter implements ManagementConstants {
   public static ObjectName getLockServiceMBeanName(DistributedMember member,
       String lockServiceName) {
     return getObjectName((MessageFormat.format(OBJECTNAME__LOCKSERVICE_MXBEAN, lockServiceName,
-        getMemberNameOrId(member))));
+        getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getLockServiceMBeanName(String member, String lockServiceName) {
@@ -461,7 +462,8 @@ public class MBeanJMXAdapter implements ManagementConstants {
 
   public static ObjectName getGatewayReceiverMBeanName(DistributedMember member) {
     return getObjectName(
-        (MessageFormat.format(OBJECTNAME__GATEWAYRECEIVER_MXBEAN, getMemberNameOrId(member))));
+        (MessageFormat.format(OBJECTNAME__GATEWAYRECEIVER_MXBEAN,
+            getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getGatewayReceiverMBeanName(String member) {
@@ -471,7 +473,8 @@ public class MBeanJMXAdapter implements ManagementConstants {
 
   public static ObjectName getGatewaySenderMBeanName(DistributedMember member, String id) {
     return getObjectName(
-        (MessageFormat.format(OBJECTNAME__GATEWAYSENDER_MXBEAN, id, getMemberNameOrId(member))));
+        (MessageFormat.format(OBJECTNAME__GATEWAYSENDER_MXBEAN, id,
+            getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getGatewaySenderMBeanName(String member, String id) {
@@ -481,7 +484,7 @@ public class MBeanJMXAdapter implements ManagementConstants {
 
   public static ObjectName getAsyncEventQueueMBeanName(DistributedMember member, String queueId) {
     return getObjectName((MessageFormat.format(OBJECTNAME__ASYNCEVENTQUEUE_MXBEAN, queueId,
-        getMemberNameOrId(member))));
+        getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getDistributedRegionMbeanName(String regionPath) {
@@ -510,13 +513,14 @@ public class MBeanJMXAdapter implements ManagementConstants {
 
   public static ObjectName getManagerName() {
     String member =
-        getMemberNameOrId(InternalDistributedSystem.getConnectedInstance().getDistributedMember());
+        getMemberNameOrUniqueId(
+            InternalDistributedSystem.getConnectedInstance().getDistributedMember());
     return getObjectName((MessageFormat.format(OBJECTNAME__MANAGER_MXBEAN, member)));
   }
 
   public static ObjectName getLocatorMBeanName(DistributedMember member) {
     return getObjectName(
-        (MessageFormat.format(OBJECTNAME__LOCATOR_MXBEAN, getMemberNameOrId(member))));
+        (MessageFormat.format(OBJECTNAME__LOCATOR_MXBEAN, getMemberNameOrUniqueId(member))));
   }
 
   public static ObjectName getLocatorMBeanName(String member) {
@@ -527,7 +531,7 @@ public class MBeanJMXAdapter implements ManagementConstants {
   public static ObjectName getCacheServiceMBeanName(DistributedMember member,
       String cacheServiceId) {
     return getObjectName((MessageFormat.format(OBJECTNAME__CACHESERVICE_MXBEAN, cacheServiceId,
-        getMemberNameOrId(member))));
+        getMemberNameOrUniqueId(member))));
   }
 
   public Map<ObjectName, Object> getLocalGemFireMBean() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/NotificationHub.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/NotificationHub.java
@@ -67,7 +67,8 @@ public class NotificationHub {
     logger = InternalDistributedSystem.getLogger();
     this.listenerObjectMap = new HashMap<ObjectName, NotificationHubListener>();
     memberSource = MBeanJMXAdapter
-        .getMemberNameOrId(InternalDistributedSystem.getConnectedInstance().getDistributedMember());
+        .getMemberNameOrUniqueId(
+            InternalDistributedSystem.getConnectedInstance().getDistributedMember());
 
 
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
@@ -1585,23 +1585,29 @@ public class DistributedSystemBridge {
 
   public void memberDeparted(InternalDistributedMember id, boolean crashed) {
     Notification notification = new Notification(JMXNotificationType.CACHE_MEMBER_DEPARTED,
-        MBeanJMXAdapter.getMemberNameOrId(id), SequenceNumber.next(), System.currentTimeMillis(),
-        ManagementConstants.CACHE_MEMBER_DEPARTED_PREFIX + MBeanJMXAdapter.getMemberNameOrId(id)
+        MBeanJMXAdapter.getMemberNameOrUniqueId(id), SequenceNumber.next(),
+        System.currentTimeMillis(),
+        ManagementConstants.CACHE_MEMBER_DEPARTED_PREFIX
+            + MBeanJMXAdapter.getMemberNameOrUniqueId(id)
             + " has crashed = " + crashed);
     systemLevelNotifEmitter.sendNotification(notification);
   }
 
   public void memberJoined(InternalDistributedMember id) {
     Notification notification = new Notification(JMXNotificationType.CACHE_MEMBER_JOINED,
-        MBeanJMXAdapter.getMemberNameOrId(id), SequenceNumber.next(), System.currentTimeMillis(),
-        ManagementConstants.CACHE_MEMBER_JOINED_PREFIX + MBeanJMXAdapter.getMemberNameOrId(id));
+        MBeanJMXAdapter.getMemberNameOrUniqueId(id), SequenceNumber.next(),
+        System.currentTimeMillis(),
+        ManagementConstants.CACHE_MEMBER_JOINED_PREFIX
+            + MBeanJMXAdapter.getMemberNameOrUniqueId(id));
     systemLevelNotifEmitter.sendNotification(notification);
   }
 
   public void memberSuspect(InternalDistributedMember id, InternalDistributedMember whoSuspected) {
     Notification notification = new Notification(JMXNotificationType.CACHE_MEMBER_SUSPECT,
-        MBeanJMXAdapter.getMemberNameOrId(id), SequenceNumber.next(), System.currentTimeMillis(),
-        ManagementConstants.CACHE_MEMBER_SUSPECT_PREFIX + MBeanJMXAdapter.getMemberNameOrId(id)
+        MBeanJMXAdapter.getMemberNameOrUniqueId(id), SequenceNumber.next(),
+        System.currentTimeMillis(),
+        ManagementConstants.CACHE_MEMBER_SUSPECT_PREFIX
+            + MBeanJMXAdapter.getMemberNameOrUniqueId(id)
             + " By : " + whoSuspected.getName());
     systemLevelNotifEmitter.sendNotification(notification);
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/ManagementAdapter.java
@@ -149,7 +149,7 @@ public class ManagementAdapter {
           InternalDistributedSystem.getConnectedInstance().getDistributedMember());
 
       memberSource = MBeanJMXAdapter
-          .getMemberNameOrId(internalCache.getDistributedSystem().getDistributedMember());
+          .getMemberNameOrUniqueId(internalCache.getDistributedSystem().getDistributedMember());
 
       // Type casting to MemberMXBean to expose only those methods described in
       // the interface;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
@@ -134,7 +134,7 @@ public class CliUtil {
 
     for (DistributedMember member : allClusterMembers) {
       for (String regionAssociatedMemberName : regionAssociatedMemberNames) {
-        String name = MBeanJMXAdapter.getMemberNameOrId(member);
+        String name = MBeanJMXAdapter.getMemberNameOrUniqueId(member);
         if (name.equals(regionAssociatedMemberName)) {
           matchedMembers.add(member);
           if (!returnAll) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
@@ -384,7 +384,7 @@ public class RebalanceCommand extends InternalGfshCommand {
       while (it.hasNext() && !matchFound) {
         DistributedMember dsmember = (DistributedMember) it.next();
         for (String memberName : membersName) {
-          if (MBeanJMXAdapter.getMemberNameOrId(dsmember).equals(memberName)) {
+          if (MBeanJMXAdapter.getMemberNameOrUniqueId(dsmember).equals(memberName)) {
             member = dsmember;
             matchFound = true;
             break;
@@ -663,7 +663,7 @@ public class RebalanceCommand extends InternalGfshCommand {
           String[] memberNames = bean.getMembers();
           for (DistributedMember dsmember : dsMembers) {
             for (String memberName : memberNames) {
-              if (MBeanJMXAdapter.getMemberNameOrId(dsmember).equals(memberName)) {
+              if (MBeanJMXAdapter.getMemberNameOrUniqueId(dsmember).equals(memberName)) {
                 MemberPRInfo memberAndItsPRRegions = new MemberPRInfo();
                 memberAndItsPRRegions.region = regionName;
                 memberAndItsPRRegions.dsMemberList.add(dsmember);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
@@ -184,7 +184,7 @@ public class ShowMetricsCommand extends GfshCommand {
 
     if (memberMxBean == null) {
       String errorMessage = CliStrings.format(CliStrings.SHOW_METRICS__ERROR, "Member MBean for "
-          + MBeanJMXAdapter.getMemberNameOrId(distributedMember) + " not found");
+          + MBeanJMXAdapter.getMemberNameOrUniqueId(distributedMember) + " not found");
       return ResultModel.createError(errorMessage);
     }
 
@@ -195,7 +195,7 @@ public class ShowMetricsCommand extends GfshCommand {
       if (csMxBean == null) {
         return ResultModel.createError(
             CliStrings.format(CliStrings.SHOW_METRICS__CACHE__SERVER__NOT__FOUND,
-                cacheServerPort, MBeanJMXAdapter.getMemberNameOrId(distributedMember)));
+                cacheServerPort, MBeanJMXAdapter.getMemberNameOrUniqueId(distributedMember)));
       }
     }
 
@@ -279,14 +279,14 @@ public class ShowMetricsCommand extends GfshCommand {
     if (regionMxBean == null) {
       String errorMessage = CliStrings.format(CliStrings.SHOW_METRICS__ERROR,
           "Region MBean for " + regionName + " on member "
-              + MBeanJMXAdapter.getMemberNameOrId(distributedMember) + " not found");
+              + MBeanJMXAdapter.getMemberNameOrUniqueId(distributedMember) + " not found");
       return ResultModel.createError(errorMessage);
     }
 
     ResultModel result = new ResultModel();
     TabularResultModel metricsTable = result.addTable("metrics");
     metricsTable.setHeader("Metrics for region:" + regionName + " On Member "
-        + MBeanJMXAdapter.getMemberNameOrId(distributedMember));
+        + MBeanJMXAdapter.getMemberNameOrUniqueId(distributedMember));
 
     Set<Category> categoriesToDisplay = ArrayUtils.isNotEmpty(categoriesArr)
         ? getCategorySet(categoriesArr) : new HashSet<>(REGION_METRIC_CATEGORIES);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/MBeanJMXAdapterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/MBeanJMXAdapterTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -34,7 +35,13 @@ import org.junit.Test;
 
 import org.apache.geode.distributed.DistributedMember;
 
+/**
+ * Unique tests for {@link MBeanJMXAdapter}.
+ */
 public class MBeanJMXAdapterTest {
+
+  private static final String UNIQUE_ID = "unique-id";
+
   private ObjectName objectName;
   private MBeanServer mockMBeanServer;
   private DistributedMember distMember;
@@ -44,6 +51,7 @@ public class MBeanJMXAdapterTest {
     mockMBeanServer = mock(MBeanServer.class);
     objectName = new ObjectName("d:type=Foo,name=Bar");
     distMember = mock(DistributedMember.class);
+    when(distMember.getUniqueId()).thenReturn(UNIQUE_ID);
   }
 
   @Test
@@ -85,5 +93,24 @@ public class MBeanJMXAdapterTest {
     // InstanceNotFoundException should just log a debug message as it is essentially a no-op
     // during registration
     verify(mBeanJMXAdapter, times(1)).logRegistrationWarning(any(ObjectName.class), eq(true));
+  }
+
+  @Test
+  public void getMemberNameOrUniqueIdReturnsNameIfProvided() {
+    String memberName = "member-name";
+    when(distMember.getName()).thenReturn(memberName);
+
+    String result = MBeanJMXAdapter.getMemberNameOrUniqueId(distMember);
+
+    assertThat(result).isEqualTo(memberName);
+  }
+
+  @Test
+  public void getMemberNameOrUniqueIdReturnsUniqueIdIfNameIsNotProvided() {
+    when(distMember.getName()).thenReturn("");
+
+    String result = MBeanJMXAdapter.getMemberNameOrUniqueId(distMember);
+
+    assertThat(result).isEqualTo(UNIQUE_ID);
   }
 }


### PR DESCRIPTION
Introduce new DistributedMember.getUniqueId which is immutable.

Change MBeanJMXAdapter to use getUniqueId for MBean names
instead of getId when a member name has not been specified.

Notes: 

I went ahead and added getUniqueId to both DistributedMember and NetMember because the returned value should be the same as getId but without the membership port that was being changed in NetMember. If there is a better name for getUniqueId, please make suggestions!

I also renamed MBeanJMXAdapter.getMemberNameOrId to MBeanJMXAdapter.getMemberNameOrUniqueId and added new tests to MBeanJMXAdapterTest for my changes.

PR #3071 has failing tests caused by the MBean names changing in Loners because of getId mutating at runtime. I think that will be enough test coverage for GEODE-6285.