### PR TITLE
GEODE-6268: Reduce the number of iterations for unique port ranges in AvailablePortHelperIntegrationTest

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -266,7 +266,7 @@ public class AvailablePortHelperIntegrationTest {
   @Parameters({"true", "false"})
   public void initializeUniquePortRange_willReturnSamePortsForSameRange(
       final boolean useMembershipPortRange) {
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 100; ++i) {
       initializeUniquePortRange(i);
       int[] testPorts = getRandomAvailableTCPPorts(3, useMembershipPortRange);
       initializeUniquePortRange(i);
@@ -280,7 +280,7 @@ public class AvailablePortHelperIntegrationTest {
       final boolean useMembershipPortRange) {
     Set<Integer> ports = new HashSet<>();
 
-    for (int i = 0; i < 1000; ++i) {
+    for (int i = 0; i < 100; ++i) {
       initializeUniquePortRange(i);
       int[] testPorts = getRandomAvailableTCPPorts(5, useMembershipPortRange);
       for (int testPort : testPorts) {


### PR DESCRIPTION
- This test was failing fairly consistently on Windows. An initial assumption
  was that the given port range would be completely free. This is typically
  true in a Linux/Docker environment but is not the case on Windows.
- The logic of these modified tests is somewhat extreme as in actual use, there
  would never be a need for 1000 ranges.

Signed-off-by: Aditya Anchuri <aanchuri@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
