### PR TITLE
GEODE-6292 hot loop in GMSJoinLeave.findCoordinator

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -1678,7 +1678,6 @@ public class LocatorDUnitTest extends JUnit4DistributedTestCase {
     final Properties properties =
         getBasicProperties(Host.getHost(0).getHostName() + "[" + port1 + "]");
     properties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
-    properties.setProperty(LOG_LEVEL, "finest");
     addDSProps(properties);
     if (stateFile.exists()) {
       assertThat(stateFile.delete()).isTrue();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -208,6 +208,8 @@ public class GMSJoinLeaveJUnitTest {
     assertThatThrownBy(() -> gmsJoinLeave.findCoordinator())
         .isInstanceOf(SystemConnectException.class)
         .hasMessageContaining("Interrupted while trying to contact locators");
+    verify(tcpClientWrapper, times(1)).sendCoordinatorFindRequest(any(InetSocketAddress.class),
+        any(FindCoordinatorRequest.class), any(Integer.class));
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -14,7 +14,9 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.membership;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -49,6 +51,7 @@ import org.junit.experimental.categories.Category;
 import org.mockito.internal.verification.Times;
 import org.mockito.verification.Timeout;
 
+import org.apache.geode.SystemConnectException;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionConfig;
@@ -186,6 +189,24 @@ public class GMSJoinLeaveJUnitTest {
       return isCoordinator;
     }
 
+  }
+
+  @Test
+  public void testFindCoordinatorPausesWhenLocatorWaitTimeIsSet() throws Exception {
+    initMocks(false);
+    when(mockConfig.getLocatorWaitTime()).thenReturn(15000);
+
+    TcpClientWrapper tcpClientWrapper = mock(TcpClientWrapper.class);
+    gmsJoinLeave.setTcpClientWrapper(tcpClientWrapper);
+
+    when(tcpClientWrapper.sendCoordinatorFindRequest(isA(InetSocketAddress.class),
+        isA(FindCoordinatorRequest.class), isA(Integer.class))).thenThrow(new IOException("Connection refused"));
+
+    // interrupt this thread so that findCoordinator() won't keep looping
+    // and will throw an exception when going to pause
+    Thread.currentThread().interrupt();
+    assertThatThrownBy(() -> gmsJoinLeave.findCoordinator()).isInstanceOf(SystemConnectException.class)
+        .hasMessageContaining("Interrupted while trying to contact locators");
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.distributed.internal.membership.gms.membership;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -208,6 +209,7 @@ public class GMSJoinLeaveJUnitTest {
     assertThatThrownBy(() -> gmsJoinLeave.findCoordinator())
         .isInstanceOf(SystemConnectException.class)
         .hasMessageContaining("Interrupted while trying to contact locators");
+    assertThat(Thread.currentThread().interrupted()).isTrue();
     verify(tcpClientWrapper, times(1)).sendCoordinatorFindRequest(any(InetSocketAddress.class),
         any(FindCoordinatorRequest.class), any(Integer.class));
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.membership;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -200,12 +199,14 @@ public class GMSJoinLeaveJUnitTest {
     gmsJoinLeave.setTcpClientWrapper(tcpClientWrapper);
 
     when(tcpClientWrapper.sendCoordinatorFindRequest(isA(InetSocketAddress.class),
-        isA(FindCoordinatorRequest.class), isA(Integer.class))).thenThrow(new IOException("Connection refused"));
+        isA(FindCoordinatorRequest.class), isA(Integer.class)))
+            .thenThrow(new IOException("Connection refused"));
 
     // interrupt this thread so that findCoordinator() won't keep looping
     // and will throw an exception when going to pause
     Thread.currentThread().interrupt();
-    assertThatThrownBy(() -> gmsJoinLeave.findCoordinator()).isInstanceOf(SystemConnectException.class)
+    assertThatThrownBy(() -> gmsJoinLeave.findCoordinator())
+        .isInstanceOf(SystemConnectException.class)
         .hasMessageContaining("Interrupted while trying to contact locators");
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1152,7 +1152,14 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
             }
           }
         } catch (IOException | ClassNotFoundException problem) {
-          logger.debug("EOFException IOException ", problem);
+          logger.debug("Exception thrown when contacting a locator", problem);
+          if (state.locatorsContacted == 0 && System.currentTimeMillis() < giveUpTime) {
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              throw new SystemConnectException("Interrupted while trying to contact locators");
+            }
+          }
         }
       }
     } while (!anyResponses && System.currentTimeMillis() < giveUpTime);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1157,6 +1157,8 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
             try {
               Thread.sleep(1000);
             } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              services.getCancelCriterion().checkCancelInProgress(e);
               throw new SystemConnectException("Interrupted while trying to contact locators");
             }
           }


### PR DESCRIPTION
Added a 1 second pause before retrying if no locators could
be contacted and locator-wait-time has been set.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
