### PR TITLE
GEODE-6294: Add disable-jmx config property

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/DisableJmxIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/DisableJmxIntegrationTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management;
+
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_JMX;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.ResourceEventsListener;
+import org.apache.geode.internal.cache.InternalCache;
+
+/**
+ * Integration test to ensure that Geode does not create MBeans when
+ * {@link ConfigurationProperties#DISABLE_JMX} is set to true.
+ */
+public class DisableJmxIntegrationTest {
+
+  private InternalCache cache;
+
+  @Before
+  public void setUp() {
+    Properties config = new Properties();
+    config.setProperty(DISABLE_JMX, "true");
+    config.setProperty(LOCATORS, "");
+
+    cache = (InternalCache) new CacheFactory(config).create();
+  }
+
+  @After
+  public void tearDown() {
+    cache.close();
+  }
+
+  @Test
+  public void disableJmxPreventsRegistrationOfManagementListener() {
+    InternalDistributedSystem system = cache.getInternalDistributedSystem();
+
+    List<ResourceEventsListener> result = system.getResourceListeners();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void disableJmxPreventsCreationOfMemberMXBean() {
+    ManagementService managementService = ManagementService.getManagementService(cache);
+
+    MemberMXBean result = managementService.getMemberMXBean();
+
+    assertThat(result).isNull();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemConfig.java
@@ -197,6 +197,9 @@ public interface DistributedSystemConfig extends Cloneable {
   /** The default disable-tcp value (<code>false</code>) */
   boolean DEFAULT_DISABLE_TCP = DistributionConfig.DEFAULT_DISABLE_TCP;
 
+  /** The default disable-jmx value (<code>false</code>) */
+  boolean DEFAULT_DISABLE_JMX = DistributionConfig.DEFAULT_DISABLE_JMX;
+
   /** The default enable-network-partition-detection setting (<code>false</code>) */
   boolean DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION =
       DistributionConfig.DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION;
@@ -367,6 +370,17 @@ public interface DistributedSystemConfig extends Cloneable {
    */
   boolean getDisableTcp();
 
+  /**
+   * Sets the disable-jmx property for the system. When JMX is disabled, Geode will not create
+   * MBeans.
+   */
+  void setDisableJmx(boolean flag);
+
+  /**
+   * Returns the disable-jmx property for the process. When JMX is disabled, Geode will not create
+   * MBeans.
+   */
+  boolean getDisableJmx();
 
   /**
    * Turns on network partition detection

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
@@ -20,6 +20,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.CLUSTER_SSL_E
 import static org.apache.geode.distributed.ConfigurationProperties.CLUSTER_SSL_PROTOCOLS;
 import static org.apache.geode.distributed.ConfigurationProperties.CLUSTER_SSL_REQUIRE_AUTHENTICATION;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_JMX;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_TCP;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_ADDRESS;
@@ -79,6 +80,7 @@ public class DistributedSystemConfigImpl implements DistributedSystemConfig {
   private String serverBindAddress = DEFAULT_BIND_ADDRESS;
   private String remoteCommand = DEFAULT_REMOTE_COMMAND;
   private boolean disableTcp = DEFAULT_DISABLE_TCP;
+  private boolean disableJmx = DEFAULT_DISABLE_JMX;
   private boolean enableNetworkPartitionDetection = DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION;
   private boolean disableAutoReconnect = DEFAULT_DISABLE_AUTO_RECONNECT;
   private int memberTimeout = DEFAULT_MEMBER_TIMEOUT;
@@ -631,6 +633,18 @@ public class DistributedSystemConfigImpl implements DistributedSystemConfig {
   public void setDisableTcp(boolean flag) {
     checkReadOnly();
     disableTcp = flag;
+    configChanged();
+  }
+
+  @Override
+  public boolean getDisableJmx() {
+    return disableJmx;
+  }
+
+  @Override
+  public void setDisableJmx(boolean flag) {
+    checkReadOnly();
+    disableJmx = flag;
     configChanged();
   }
 
@@ -1197,6 +1211,9 @@ public class DistributedSystemConfigImpl implements DistributedSystemConfig {
     buf.append(lf);
     buf.append("  " + DISABLE_TCP + "=");
     buf.append(String.valueOf(this.disableTcp));
+    buf.append(lf);
+    buf.append("  " + DISABLE_JMX + "=");
+    buf.append(disableJmx);
     buf.append(lf);
     buf.append("  " + DISABLE_AUTO_RECONNECT + "=");
     buf.append(String.valueOf(this.disableAutoReconnect));

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AdminDistributedSystemJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AdminDistributedSystemJmxImpl.java
@@ -1118,6 +1118,11 @@ public class AdminDistributedSystemJmxImpl extends AdminDistributedSystemImpl
   }
 
   @Override
+  public boolean getDisableJmx() {
+    return getConfig().getDisableJmx();
+  }
+
+  @Override
   public void setEnableNetworkPartitionDetection(boolean newValue) {
     getConfig().setEnableNetworkPartitionDetection(newValue);
   }
@@ -1325,6 +1330,11 @@ public class AdminDistributedSystemJmxImpl extends AdminDistributedSystemImpl
   @Override
   public void setDisableTcp(boolean flag) {
     this.getConfig().setDisableTcp(flag);
+  }
+
+  @Override
+  public void setDisableJmx(boolean flag) {
+    getConfig().setDisableJmx(flag);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -392,6 +392,18 @@ public interface ConfigurationProperties {
    */
   String DISABLE_TCP = "disable-tcp";
   /**
+   * The static String definition of the <i>"disable-jmx"</i> property <a name="disable-tcp"/a>
+   * <p>
+   * <U>Description</U>: Turns off use of JMX, preventing the process from creating Geode MBeans.
+   * <p>
+   * <U>Default</U>: "false"
+   * <p>
+   * <U>Allowed values</U>: true or false
+   * <p>
+   * <U>Since</U>: Geode 1.9
+   */
+  String DISABLE_JMX = "disable-jmx";
+  /**
    * The static String definition of the <i>"distributed-system-id"</i> property
    * <p>
    * <a name="distributed-system-id"/a> <U>Decription:</U>A number that uniquely identifies this

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -38,6 +38,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.CONSERVE_SOCK
 import static org.apache.geode.distributed.ConfigurationProperties.DELTA_PROPAGATION;
 import static org.apache.geode.distributed.ConfigurationProperties.DEPLOY_WORKING_DIR;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_JMX;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_TCP;
 import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
 import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_TRANSACTIONS;
@@ -925,6 +926,10 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
 
     m.put(DISABLE_TCP, String.format(
         "Determines whether TCP/IP communications will be disabled, forcing use of datagrams between members of the distributed system. Defaults to %s",
+        Boolean.FALSE));
+
+    m.put(DISABLE_JMX, String.format(
+        "Determines whether JMX will be disabled which prevents Geode from creating MBeans. Defaults to %s",
         Boolean.FALSE));
 
     m.put(ENABLE_TIME_STATISTICS,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -38,6 +38,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.CONSERVE_SOCK
 import static org.apache.geode.distributed.ConfigurationProperties.DELTA_PROPAGATION;
 import static org.apache.geode.distributed.ConfigurationProperties.DEPLOY_WORKING_DIR;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_JMX;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_TCP;
 import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
 import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_TRANSACTIONS;
@@ -1627,6 +1628,29 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * The default value of the {@link ConfigurationProperties#DISABLE_TCP} property
    */
   boolean DEFAULT_DISABLE_TCP = false;
+
+  /**
+   * Returns the value of the {@link ConfigurationProperties#DISABLE_JMX} property
+   */
+  @ConfigAttributeGetter(name = DISABLE_JMX)
+  boolean getDisableJmx();
+
+  /**
+   * Sets the value of the {@link ConfigurationProperties#DISABLE_JMX} property.
+   */
+  @ConfigAttributeSetter(name = DISABLE_JMX)
+  void setDisableJmx(boolean newValue);
+
+  /**
+   * The name of the {@link ConfigurationProperties#DISABLE_JMX} property
+   */
+  @ConfigAttribute(type = Boolean.class)
+  String DISABLE_JMX_NAME = DISABLE_JMX;
+
+  /**
+   * The default value of the {@link ConfigurationProperties#DISABLE_JMX} property
+   */
+  boolean DEFAULT_DISABLE_JMX = false;
 
   /**
    * Turns on timing statistics for the distributed system

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -276,6 +276,11 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   protected boolean disableTcp = DEFAULT_DISABLE_TCP;
 
   /**
+   * whether JMX should be disabled
+   */
+  protected boolean disableJmx = DEFAULT_DISABLE_JMX;
+
+  /**
    * whether time statistics should be enabled for the distributed system
    */
   protected boolean enableTimeStatistics = DEFAULT_ENABLE_TIME_STATISTICS;
@@ -711,6 +716,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     udpRecvBufferSize = other.getUdpRecvBufferSize();
     udpFragmentSize = other.getUdpFragmentSize();
     disableTcp = other.getDisableTcp();
+    disableJmx = other.getDisableJmx();
     enableTimeStatistics = other.getEnableTimeStatistics();
     memberTimeout = other.getMemberTimeout();
     membershipPortRange = other.getMembershipPortRange();
@@ -2284,6 +2290,16 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
+  public boolean getDisableJmx() {
+    return disableJmx;
+  }
+
+  @Override
+  public void setDisableJmx(boolean newValue) {
+    disableJmx = newValue;
+  }
+
+  @Override
   public boolean getEnableTimeStatistics() {
     return enableTimeStatistics;
   }
@@ -3121,6 +3137,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(udpSendBufferSize, that.udpSendBufferSize)
         .append(udpRecvBufferSize, that.udpRecvBufferSize)
         .append(udpFragmentSize, that.udpFragmentSize).append(disableTcp, that.disableTcp)
+        .append(disableJmx, that.disableJmx)
         .append(enableTimeStatistics, that.enableTimeStatistics)
         .append(memberTimeout, that.memberTimeout)
         .append(maxWaitTimeForReconnect, that.maxWaitTimeForReconnect)
@@ -3269,7 +3286,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(clusterSSLKeyStorePassword).append(clusterSSLTrustStore)
         .append(clusterSSLTrustStorePassword).append(clusterSSLAlias).append(mcastSendBufferSize)
         .append(mcastRecvBufferSize).append(mcastFlowControl).append(udpSendBufferSize)
-        .append(udpRecvBufferSize).append(udpFragmentSize).append(disableTcp)
+        .append(udpRecvBufferSize).append(udpFragmentSize).append(disableTcp).append(disableJmx)
         .append(enableTimeStatistics).append(memberTimeout).append(membershipPortRange)
         .append(maxWaitTimeForReconnect).append(maxNumReconnectTries)
         .append(asyncDistributionTimeout).append(asyncQueueTimeout).append(asyncMaxQueueSize)

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -875,11 +875,16 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         // We only support management on members of a distributed system
         // Should do this: if (!getSystem().isLoner()) {
         // but it causes quickstart.CqClientTest to hang
-        this.resourceEventsListener = new ManagementListener(this.system);
-        this.system.addResourceListener(this.resourceEventsListener);
-        if (this.system.isLoner()) {
-          this.system.getInternalLogWriter()
-              .info("Running in local mode since no locators were specified.");
+        boolean disableJmx = system.getConfig().getDisableJmx();
+        if (disableJmx) {
+          logger.info("Running with JMX disabled.");
+        } else {
+          this.resourceEventsListener = new ManagementListener(this.system);
+          this.system.addResourceListener(this.resourceEventsListener);
+          if (this.system.isLoner()) {
+            this.system.getInternalLogWriter()
+                .info("Running in local mode since no locators were specified.");
+          }
         }
       } else {
         logger.info("Running in client mode");

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -101,7 +101,7 @@ public class DistributionConfigJUnitTest {
   @Test
   public void testGetAttributeNames() {
     String[] attNames = AbstractDistributionConfig._getAttNames();
-    assertThat(attNames.length).isEqualTo(164);
+    assertThat(attNames.length).isEqualTo(165);
 
     List boolList = new ArrayList();
     List intList = new ArrayList();
@@ -135,7 +135,7 @@ public class DistributionConfigJUnitTest {
 
     // TODO - This makes no sense. One has no idea what the correct expected number of attributes
     // are.
-    assertEquals(33, boolList.size());
+    assertEquals(34, boolList.size());
     assertEquals(35, intList.size());
     assertEquals(87, stringList.size());
     assertEquals(5, fileList.size());


### PR DESCRIPTION
This is needed in order to disable JMX in PersistentPartitionedRegionRegressionTest which will then prevent that test from deadlocking in the JMX ManagementListener.

I did not add this property to GFSH commands because I didn't think it was useful enough for most Users to worry about having it on the start server or start locator commands.