### PR TITLE
GEODE-6301: Add call stack support to ExecutorServiceRule

### DIFF
--- a/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleIntegrationTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleIntegrationTest.java
@@ -40,14 +40,14 @@ public class ExecutorServiceRuleIntegrationTest {
   private static Awaits.Invocations invocations;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     hangLatch = new CountDownLatch(1);
     terminateLatch = new CountDownLatch(1);
     invocations = mock(Awaits.Invocations.class);
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     invocations = null;
 
     while (hangLatch != null && hangLatch.getCount() > 0) {
@@ -92,17 +92,17 @@ public class ExecutorServiceRuleIntegrationTest {
         ExecutorServiceRule.builder().awaitTermination(2, SECONDS).build();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
       executorService = executorServiceRule.getExecutorService();
     }
 
     @After
-    public void after() throws Exception {
+    public void after() {
       invocations.afterTest();
     }
 
     @Test
-    public void doTest() throws Exception {
+    public void doTest() {
       executorServiceRule.runAsync(() -> {
         try {
           hangLatch.await(1, SECONDS);

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleGetThreadsTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleGetThreadsTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.rules;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link ExecutorServiceRule#getThreads()}.
+ */
+public class ExecutorServiceRuleGetThreadsTest {
+
+  private static final long TIMEOUT_MILLIS = getTimeout().getValueInMS();
+
+  private final CountDownLatch terminateLatch = new CountDownLatch(1);
+  private final AtomicBoolean submittedChildren = new AtomicBoolean();
+
+  private volatile ExecutorService executorService;
+
+  @Rule
+  public ExecutorServiceRule executorServiceRule = new ExecutorServiceRule();
+
+  @After
+  public void tearDown() {
+    terminateLatch.countDown();
+  }
+
+  @Test
+  public void noThreads() {
+    assertThat(executorServiceRule.getThreads()).isEmpty();
+  }
+
+  @Test
+  public void oneThread() {
+    executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+
+    assertThat(executorServiceRule.getThreads()).hasSize(1);
+  }
+
+  @Test
+  public void twoThreads() {
+    executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+    executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+
+    assertThat(executorServiceRule.getThreads()).hasSize(2);
+  }
+
+  @Test
+  public void childExecutorService() {
+    executorServiceRule.submit(() -> {
+      executorService = Executors.newCachedThreadPool();
+      executorService.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+      executorService.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+      submittedChildren.set(true);
+    });
+
+    await().untilTrue(submittedChildren);
+
+    assertThat(executorServiceRule.getThreads().size()).isLessThanOrEqualTo(1);
+  }
+
+  @Test
+  public void getThreadIds() {
+    executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+    executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+
+    long[] threadIds = executorServiceRule.getThreadIds();
+
+    assertThat(threadIds).hasSize(2);
+
+    Set<Thread> threads = executorServiceRule.getThreads();
+    for (Thread thread : threads) {
+      assertThat(threadIds).contains(thread.getId());
+    }
+  }
+}


### PR DESCRIPTION
This change is required for the RegressionTest that I attached to [GEODE-6255: ManagementListener may deadlock with Cache close](https://issues.apache.org/jira/browse/GEODE-6255).