### PR TITLE
GEODE-6307: Attempt to normalize file paths for correct comparison

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesJUnitTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesJUnitTestBase.java
@@ -435,7 +435,7 @@ public abstract class AnalyzeSerializablesJUnitTestBase {
             Collectors.toList());
     String gradleBuildDirName =
         Paths.get(getModuleName(), "build", "classes", "java", "main").toString();
-    System.out.println("gradleBuildDirName is " + classpath);
+    System.out.println("gradleBuildDirName is " + gradleBuildDirName);
     String ideaBuildDirName = Paths.get(getModuleName(), "out", "production", "classes").toString();
     String buildDir = null;
 

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesJUnitTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesJUnitTestBase.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,6 +46,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
@@ -428,16 +430,20 @@ public abstract class AnalyzeSerializablesJUnitTestBase {
     String classpath = System.getProperty("java.class.path");
     System.out.println("java classpath is " + classpath);
 
-    String[] entries = classpath.split(File.pathSeparator);
+    List<File> entries =
+        Arrays.stream(classpath.split(File.pathSeparator)).map(x -> new File(x)).collect(
+            Collectors.toList());
     String gradleBuildDirName =
         Paths.get(getModuleName(), "build", "classes", "java", "main").toString();
+    System.out.println("gradleBuildDirName is " + classpath);
     String ideaBuildDirName = Paths.get(getModuleName(), "out", "production", "classes").toString();
     String buildDir = null;
 
-    for (String entry : entries) {
+    for (File entry : entries) {
       System.out.println("examining '" + entry + "'");
-      if (entry.endsWith(gradleBuildDirName) || entry.endsWith(ideaBuildDirName)) {
-        buildDir = entry;
+      if (entry.toString().endsWith(gradleBuildDirName)
+          || entry.toString().endsWith(ideaBuildDirName)) {
+        buildDir = entry.toString();
         break;
       }
     }


### PR DESCRIPTION
- Trying to fix an issue with AnalyzeSerializablesJUnitTest on Windows and
  JDK 11.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
