### PR TITLE
GEODE-6308: Use line separators in launcher status

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -465,6 +465,14 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
     protected static final String JSON_UPTIME = "uptime";
     protected static final String JSON_WORKINGDIRECTORY = "workingDirectory";
 
+    static final String TO_STRING_PROCESS_ID = "Process ID: ";
+    static final String TO_STRING_JAVA_VERSION = "Java Version: ";
+    static final String TO_STRING_LOG_FILE = "Log File: ";
+    static final String TO_STRING_JVM_ARGUMENTS = "JVM Arguments: ";
+    static final String TO_STRING_CLASS_PATH = "Class-Path: ";
+    static final String TO_STRING_UPTIME = "Uptime: ";
+    static final String TO_STRING_GEODE_VERSION = "Geode Version: ";
+
     private static final String DATE_TIME_FORMAT_PATTERN = "MM/dd/yyyy hh:mm a";
 
     private final Integer pid;
@@ -764,26 +772,44 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
      */
     @Override
     public String toString() {
+      StringBuilder sb = new StringBuilder();
       switch (getStatus()) {
         case STARTING:
-          return String.format(
-              "Starting %s in %s on %s as %s at %sProcess ID: %sGeode Version: %sJava Version: %sLog File: %sJVM Arguments: %sClass-Path: %s",
+          sb.append("Starting %s in %s on %s as %s at %s").append(System.lineSeparator());
+          sb.append(TO_STRING_PROCESS_ID).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_JAVA_VERSION).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_LOG_FILE).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_JVM_ARGUMENTS).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_CLASS_PATH).append("%s");
+          return String.format(sb.toString(),
               getServiceName(), getWorkingDirectory(), getServiceLocation(), getMemberName(),
               toString(getTimestamp()), toString(getPid()), toString(getGemFireVersion()),
               toString(getJavaVersion()), getLogFile(), ArgumentRedactor.redact(getJvmArguments()),
               toString(getClasspath()));
+
         case ONLINE:
-          return String.format(
-              "%s in %s on %s as %s is currently %s.Process ID: %sUptime: %sGeode Version: %sJava Version: %sLog File: %sJVM Arguments: %sClass-Path: %s",
+          sb.append("%s in %s on %s as %s is currently %s.").append(System.lineSeparator());
+          sb.append(TO_STRING_PROCESS_ID).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_UPTIME).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_GEODE_VERSION).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_JAVA_VERSION).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_LOG_FILE).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_JVM_ARGUMENTS).append("%s").append(System.lineSeparator());
+          sb.append(TO_STRING_CLASS_PATH).append("%s");
+          return String.format(sb.toString(),
               getServiceName(), getWorkingDirectory(), getServiceLocation(), getMemberName(),
               getStatus(), toString(getPid()), toDaysHoursMinutesSeconds(getUptime()),
               toString(getGemFireVersion()), toString(getJavaVersion()), getLogFile(),
               ArgumentRedactor.redact(getJvmArguments()), toString(getClasspath()));
+
         case STOPPED:
-          return String.format("%s in %s on %s has been requested to stop.",
+          sb.append("%s in %s on %s has been requested to stop.");
+          return String.format(sb.toString(),
               getServiceName(), getWorkingDirectory(), getServiceLocation());
+
         default: // NOT_RESPONDING
-          return String.format("%s in %s on %s is currently %s.", getServiceName(),
+          sb.append("%s in %s on %s is currently %s.");
+          return String.format(sb.toString(), getServiceName(),
               getWorkingDirectory(), getServiceLocation(), getStatus());
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/process/ControllableProcess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/ControllableProcess.java
@@ -181,7 +181,7 @@ public class ControllableProcess {
         false);
   }
 
-  private static String fetchStatusWithValidation(final ControlNotificationHandler handler) {
+  static String fetchStatusWithValidation(final ControlNotificationHandler handler) {
     ServiceState<?> state = handler.handleStatus();
     if (state == null) {
       throw new IllegalStateException("Null ServiceState is invalid");
@@ -190,7 +190,7 @@ public class ControllableProcess {
     String jsonContent = state.toJson();
     if (jsonContent == null) {
       throw new IllegalStateException("Null JSON for status is invalid");
-    } else if (jsonContent.isEmpty()) {
+    } else if (jsonContent.trim().isEmpty()) {
       throw new IllegalStateException("Empty JSON for status is invalid");
     }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/AbstractLauncherServiceStateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/AbstractLauncherServiceStateTest.java
@@ -14,6 +14,18 @@
  */
 package org.apache.geode.distributed;
 
+import static org.apache.geode.distributed.AbstractLauncher.ServiceState.TO_STRING_CLASS_PATH;
+import static org.apache.geode.distributed.AbstractLauncher.ServiceState.TO_STRING_GEODE_VERSION;
+import static org.apache.geode.distributed.AbstractLauncher.ServiceState.TO_STRING_JAVA_VERSION;
+import static org.apache.geode.distributed.AbstractLauncher.ServiceState.TO_STRING_JVM_ARGUMENTS;
+import static org.apache.geode.distributed.AbstractLauncher.ServiceState.TO_STRING_LOG_FILE;
+import static org.apache.geode.distributed.AbstractLauncher.ServiceState.TO_STRING_PROCESS_ID;
+import static org.apache.geode.distributed.AbstractLauncher.ServiceState.TO_STRING_UPTIME;
+import static org.apache.geode.distributed.AbstractLauncher.Status.NOT_RESPONDING;
+import static org.apache.geode.distributed.AbstractLauncher.Status.ONLINE;
+import static org.apache.geode.distributed.AbstractLauncher.Status.STARTING;
+import static org.apache.geode.distributed.AbstractLauncher.Status.STOPPED;
+import static org.apache.geode.distributed.AbstractLauncher.Status.valueOfDescription;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -23,6 +35,7 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,6 +82,7 @@ public class AbstractLauncherServiceStateTest {
     InetAddress host = InetAddress.getLocalHost();
 
     launcher = new TestLauncher(host, port, name);
+    launcher.setStatus(STARTING);
   }
 
   @After
@@ -83,11 +97,609 @@ public class AbstractLauncherServiceStateTest {
   }
 
   @Test
-  public void serviceStateCanBeMarshalledToAndFromJson() throws Exception {
+  public void serviceStateMarshalsToAndFromJsonWhenStarting() {
     TestLauncher.TestState status = launcher.status();
     String json = status.toJson();
     validateJson(status, json);
     validateStatus(status, TestLauncher.TestState.fromJson(json));
+  }
+
+  @Test
+  public void serviceStateMarshalsToAndFromJsonWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+    String json = status.toJson();
+    validateJson(status, json);
+    validateStatus(status, TestLauncher.TestState.fromJson(json));
+  }
+
+  @Test
+  public void serviceStateMarshalsToAndFromJsonWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+    String json = status.toJson();
+    validateJson(status, json);
+    validateStatus(status, TestLauncher.TestState.fromJson(json));
+  }
+
+  @Test
+  public void serviceStateMarshalsToAndFromJsonWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+    String json = status.toJson();
+    validateJson(status, json);
+    validateStatus(status, TestLauncher.TestState.fromJson(json));
+  }
+
+  @Test
+  public void toStringContainsLineSeparatorsWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(System.lineSeparator());
+  }
+
+  @Test
+  public void toStringDoesNotContainLineSeparatorsWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(System.lineSeparator());
+  }
+
+  @Test
+  public void toStringContainsLineSeparatorsWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(System.lineSeparator());
+  }
+
+  @Test
+  public void toStringDoesNotContainLineSeparatorsWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(System.lineSeparator());
+  }
+
+  @Test
+  public void toStringContainsProcessIdWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_PROCESS_ID + pid);
+  }
+
+  @Test
+  public void toStringDoesNotContainProcessIdWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringContainsProcessIdWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_PROCESS_ID + pid);
+  }
+
+  @Test
+  public void toStringDoesNotContainProcessIdWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringContainsJavaVersionWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringDoesNotContainJavaVersionWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringContainsJavaVersionWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringDoesNotContainJavaVersionWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringContainsLogFileWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringDoesNotContainLogFileWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringContainsLogFileWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringDoesNotContainLogFileWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void toStringContainsJvmArgumentsWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_JVM_ARGUMENTS);
+  }
+
+  @Test
+  public void toStringDoesNotContainJvmArgumentsWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_JVM_ARGUMENTS);
+  }
+
+  @Test
+  public void toStringContainsJvmArgumentsWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_JVM_ARGUMENTS);
+  }
+
+  @Test
+  public void toStringDoesNotContainJvmArgumentsWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_JVM_ARGUMENTS);
+  }
+
+  @Test
+  public void toStringContainsClassPathWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_CLASS_PATH);
+  }
+
+  @Test
+  public void toStringDoesNotContainClassPathWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_CLASS_PATH);
+  }
+
+  @Test
+  public void toStringContainsClassPathWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_CLASS_PATH);
+  }
+
+  @Test
+  public void toStringDoesNotContainClassPathWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_CLASS_PATH);
+  }
+
+  @Test
+  public void toStringDoesNotContainUptimeWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_UPTIME);
+  }
+
+  @Test
+  public void toStringDoesNotContainUptimeWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_UPTIME);
+  }
+
+  @Test
+  public void toStringContainsUptimeWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_UPTIME);
+  }
+
+  @Test
+  public void toStringDoesNotContainUptimeWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_UPTIME);
+  }
+
+  @Test
+  public void toStringDoesNotContainGeodeVersionWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_GEODE_VERSION);
+  }
+
+  @Test
+  public void toStringDoesNotContainGeodeVersionWhenNotResponding() {
+    launcher.setStatus(NOT_RESPONDING);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_GEODE_VERSION);
+  }
+
+  @Test
+  public void toStringContainsGeodeVersionWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).contains(TO_STRING_GEODE_VERSION);
+  }
+
+  @Test
+  public void toStringDoesNotContainGeodeVersionWhenStopped() {
+    launcher.setStatus(STOPPED);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+
+    assertThat(result).doesNotContain(TO_STRING_GEODE_VERSION);
+  }
+
+  @Test
+  public void processIdStartsOnNewLineInToStringWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String processId = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_PROCESS_ID)) {
+        processId = line;
+        break;
+      }
+    }
+
+    assertThat(processId)
+        .as(TO_STRING_PROCESS_ID + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void processIdStartsOnNewLineInToStringWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String processId = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_PROCESS_ID)) {
+        processId = line;
+        break;
+      }
+    }
+
+    assertThat(processId)
+        .as(TO_STRING_PROCESS_ID + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_PROCESS_ID);
+  }
+
+  @Test
+  public void uptimeStartsOnNewLineInToStringWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String uptime = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_UPTIME)) {
+        uptime = line;
+        break;
+      }
+    }
+
+    assertThat(uptime)
+        .as(TO_STRING_UPTIME + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_UPTIME);
+  }
+
+  @Test
+  public void geodeVersionStartsOnNewLineInToStringWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String geodeVersion = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_GEODE_VERSION)) {
+        geodeVersion = line;
+        break;
+      }
+    }
+
+    assertThat(geodeVersion)
+        .as(TO_STRING_GEODE_VERSION + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_GEODE_VERSION);
+  }
+
+  @Test
+  public void javaVersionStartsOnNewLineInToStringWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String javaVersion = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_JAVA_VERSION)) {
+        javaVersion = line;
+        break;
+      }
+    }
+
+    assertThat(javaVersion)
+        .as(TO_STRING_JAVA_VERSION + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_JAVA_VERSION);
+  }
+
+  @Test
+  public void javaVersionStartsOnNewLineInToStringWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String javaVersion = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_JAVA_VERSION)) {
+        javaVersion = line;
+        break;
+      }
+    }
+
+    assertThat(javaVersion)
+        .as(TO_STRING_JAVA_VERSION + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_JAVA_VERSION);
+  }
+
+  @Test
+  public void logFileStartsOnNewLineInToStringWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String logFile = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_LOG_FILE)) {
+        logFile = line;
+        break;
+      }
+    }
+
+    assertThat(logFile)
+        .as(TO_STRING_LOG_FILE + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_LOG_FILE);
+  }
+
+  @Test
+  public void logFileStartsOnNewLineInToStringWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String logFile = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_LOG_FILE)) {
+        logFile = line;
+        break;
+      }
+    }
+
+    assertThat(logFile)
+        .as(TO_STRING_LOG_FILE + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_LOG_FILE);
+  }
+
+  @Test
+  public void jvmArgumentsStartsOnNewLineInToStringWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String jvmArguments = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_JVM_ARGUMENTS)) {
+        jvmArguments = line;
+        break;
+      }
+    }
+
+    assertThat(jvmArguments)
+        .as(TO_STRING_JVM_ARGUMENTS + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_JVM_ARGUMENTS);
+  }
+
+  @Test
+  public void jvmArgumentsStartsOnNewLineInToStringWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String jvmArguments = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_JVM_ARGUMENTS)) {
+        jvmArguments = line;
+        break;
+      }
+    }
+
+    assertThat(jvmArguments)
+        .as(TO_STRING_JVM_ARGUMENTS + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_JVM_ARGUMENTS);
+  }
+
+  @Test
+  public void classPathStartsOnNewLineInToStringWhenStarting() {
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String classPath = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_CLASS_PATH)) {
+        classPath = line;
+        break;
+      }
+    }
+
+    assertThat(classPath)
+        .as(TO_STRING_CLASS_PATH + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_CLASS_PATH);
+  }
+
+  @Test
+  public void classPathStartsOnNewLineInToStringWhenOnline() {
+    launcher.setStatus(ONLINE);
+    TestLauncher.TestState status = launcher.status();
+
+    String result = status.toString();
+    List<String> lines = Arrays.asList(StringUtils.split(result, System.lineSeparator()));
+
+    String classPath = null;
+    for (String line : lines) {
+      if (line.contains(TO_STRING_CLASS_PATH)) {
+        classPath = line;
+        break;
+      }
+    }
+
+    assertThat(classPath)
+        .as(TO_STRING_CLASS_PATH + " line in " + lines)
+        .isNotNull()
+        .startsWith(TO_STRING_CLASS_PATH);
   }
 
   private void validateStatus(final TestLauncher.TestState expected,
@@ -118,15 +730,17 @@ public class AbstractLauncherServiceStateTest {
     private final String memberName;
     private final File logFile;
 
+    private Status status;
+
     TestLauncher(final InetAddress bindAddress, final int port, final String memberName) {
       this.bindAddress = bindAddress;
       this.port = port;
       this.memberName = memberName;
-      this.logFile = new File(memberName + ".log");
+      logFile = new File(memberName + ".log");
     }
 
     public TestState status() {
-      return new TestState(Status.ONLINE, null, System.currentTimeMillis(), getId(), pid, uptime,
+      return new TestState(status, null, System.currentTimeMillis(), getId(), pid, uptime,
           workingDirectory, jvmArguments, classpath, gemfireVersion, javaVersion, getLogFileName(),
           getBindAddressAsString(), getPortAsString(), name);
     }
@@ -180,13 +794,17 @@ public class AbstractLauncherServiceStateTest {
       return String.valueOf(getPort());
     }
 
+    void setStatus(Status status) {
+      this.status = status;
+    }
+
     private static class TestState extends ServiceState<String> {
 
       protected static TestState fromJson(final String json) {
         try {
           GfJsonObject gfJsonObject = new GfJsonObject(json);
 
-          Status status = Status.valueOfDescription(gfJsonObject.getString(JSON_STATUS));
+          Status status = valueOfDescription(gfJsonObject.getString(JSON_STATUS));
           List<String> jvmArguments = Arrays
               .asList(GfJsonArray.toStringArray(gfJsonObject.getJSONArray(JSON_JVMARGUMENTS)));
 

--- a/geode-core/src/test/java/org/apache/geode/internal/process/ControllableProcessTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/ControllableProcessTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.process;
+
+import static java.lang.System.lineSeparator;
+import static org.apache.geode.internal.process.ControllableProcess.fetchStatusWithValidation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.apache.geode.distributed.AbstractLauncher.ServiceState;
+
+/**
+ * Unit tests for {@link ControllableProcess}.
+ */
+public class ControllableProcessTest {
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonIsNull() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn(null);
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Null JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonIsEmpty() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn("");
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonOnlyContainsSpaces() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn("  ");
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonOnlyContainsTabs() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn("\t\t");
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonOnlyContainsLineFeeds() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn(lineSeparator() + lineSeparator());
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationReturnsJsonIfItHasContent() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    String jsonContent = "json content";
+    when(state.toJson()).thenReturn(jsonContent);
+
+    String result = fetchStatusWithValidation(handler);
+
+    assertThat(result).isEqualTo(jsonContent);
+  }
+}


### PR DESCRIPTION
The launcher status used to contain line separators. Looks like this was lost when LocalizedStrings were removed.

This PR restores line separators to the status output of the launchers and adds new unit tests for it.