### PR TITLE
GEODE-6303 Membership gets confused by multiple locators being specified by gfsh

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,6 +59,7 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.NetView;
 import org.apache.geode.distributed.internal.membership.gms.GMSMember;
+import org.apache.geode.distributed.internal.membership.gms.GMSUtil;
 import org.apache.geode.distributed.internal.membership.gms.ServiceConfig;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.Services.Stopper;
@@ -429,6 +431,13 @@ public class GMSJoinLeaveJUnitTest {
     await()
         .until(() -> gmsJoinLeave.getView().getViewId() > newView.getViewId());
     assertFalse(gmsJoinLeave.getView().getCrashedMembers().contains(mockMembers[1]));
+  }
+
+  @Test
+  public void multipleLocatorsWithSameAddressAreCanonicalized() throws Exception {
+    List<HostAddress> locators = GMSUtil.parseLocators(
+        "localhost[1234],localhost[1234],localhost[1234]", (InetAddress) null);
+    assertThat(locators.size()).isEqualTo(1);
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
@@ -18,7 +18,9 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.StringTokenizer;
 
 import org.apache.geode.GemFireConfigException;
@@ -58,6 +60,7 @@ public class GMSUtil {
    */
   public static List<HostAddress> parseLocators(String locatorsString, InetAddress bindAddress) {
     List<HostAddress> result = new ArrayList<>(2);
+    Set<InetSocketAddress> inetAddresses = new HashSet<>();
     String host;
     int port;
     boolean checkLoopback = (bindAddress != null);
@@ -94,7 +97,10 @@ public class GMSUtil {
           }
         }
         HostAddress la = new HostAddress(isa, host);
-        result.add(la);
+        if (!inetAddresses.contains(isa)) {
+          inetAddresses.add(isa);
+          result.add(la);
+        }
       } catch (NumberFormatException e) {
         // this shouldn't happen because the config has already been parsed and
         // validated

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -323,7 +323,8 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
       for (int tries = 0; !this.isJoined && !this.isStopping; tries++) {
         logger.debug("searching for the membership coordinator");
         boolean found = findCoordinator();
-        logger.info("state after looking for membership coordinator is {}", state);
+        logger.info("Discovery state after looking for membership coordinator is {}",
+            state);
         if (found) {
           logger.info("found possible coordinator {}", state.possibleCoordinator);
           if (localAddress.getNetMember().preferredForCoordinator()
@@ -1791,6 +1792,9 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
     DistributionConfig dconfig = services.getConfig().getDistributionConfig();
     String bindAddr = dconfig.getBindAddress();
     locators = GMSUtil.parseLocators(dconfig.getLocators(), bindAddr);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Parsed locators are {}", locators);
+    }
   }
 
   @Override


### PR DESCRIPTION
Added canonicalization of locator addresses so that duplicate
entries in the "locators" setting are ignored.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
