### PR TITLE
GEODE-6313: Make ControllableProcess fail if status is only whitespace

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/process/ControllableProcess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/ControllableProcess.java
@@ -181,7 +181,7 @@ public class ControllableProcess {
         false);
   }
 
-  private static String fetchStatusWithValidation(final ControlNotificationHandler handler) {
+  static String fetchStatusWithValidation(final ControlNotificationHandler handler) {
     ServiceState<?> state = handler.handleStatus();
     if (state == null) {
       throw new IllegalStateException("Null ServiceState is invalid");
@@ -190,7 +190,7 @@ public class ControllableProcess {
     String jsonContent = state.toJson();
     if (jsonContent == null) {
       throw new IllegalStateException("Null JSON for status is invalid");
-    } else if (jsonContent.isEmpty()) {
+    } else if (jsonContent.trim().isEmpty()) {
       throw new IllegalStateException("Empty JSON for status is invalid");
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/process/ControllableProcessTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/ControllableProcessTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.process;
+
+import static java.lang.System.lineSeparator;
+import static org.apache.geode.internal.process.ControllableProcess.fetchStatusWithValidation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.apache.geode.distributed.AbstractLauncher.ServiceState;
+
+/**
+ * Unit tests for {@link ControllableProcess}.
+ */
+public class ControllableProcessTest {
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonIsNull() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn(null);
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Null JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonIsEmpty() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn("");
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonOnlyContainsSpaces() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn("  ");
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonOnlyContainsTabs() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn("\t\t");
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationThrowsIfJsonOnlyContainsLineFeeds() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    when(state.toJson()).thenReturn(lineSeparator() + lineSeparator());
+
+    Throwable thrown = catchThrowable(() -> fetchStatusWithValidation(handler));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Empty JSON for status is invalid");
+  }
+
+  @Test
+  public void fetchStatusWithValidationReturnsJsonIfItHasContent() {
+    ControlNotificationHandler handler = mock(ControlNotificationHandler.class);
+    ServiceState state = mock(ServiceState.class);
+    when(handler.handleStatus()).thenReturn(state);
+    String jsonContent = "json content";
+    when(state.toJson()).thenReturn(jsonContent);
+
+    String result = fetchStatusWithValidation(handler);
+
+    assertThat(result).isEqualTo(jsonContent);
+  }
+}


### PR DESCRIPTION
This fixes a potential cause of GEODE-6297 by preventing locator/server status from writing to status file if the status contains only whitespace.