### PR TITLE
GEODE-6301: Add lock details to ExecutorServiceRule dumpThreads

### DIFF
--- a/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleIntegrationTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleIntegrationTest.java
@@ -32,6 +32,10 @@ import org.mockito.InOrder;
 
 import org.apache.geode.test.junit.runners.TestRunner;
 
+/**
+ * Integration tests for {@link ExecutorServiceRule}. These are tests that pause a little than we'd
+ * like for a unit test.
+ */
 public class ExecutorServiceRuleIntegrationTest {
 
   private static volatile CountDownLatch hangLatch;
@@ -69,8 +73,7 @@ public class ExecutorServiceRuleIntegrationTest {
     assertThat(result.wasSuccessful()).isTrue();
 
     assertThat(isTestHung()).isTrue();
-    await()
-        .untilAsserted(() -> assertThat(executorService.isTerminated()).isTrue());
+    await().untilAsserted(() -> assertThat(executorService.isTerminated()).isTrue());
     invocations.afterRule();
 
     InOrder invocationOrder = inOrder(invocations);
@@ -117,6 +120,7 @@ public class ExecutorServiceRuleIntegrationTest {
     }
 
     interface Invocations {
+
       void afterHangLatch();
 
       void afterTerminateLatch();

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleGetThreadsTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ExecutorServiceRuleGetThreadsTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.test.junit.rules;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.commons.lang3.StringUtils.countMatches;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +25,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.junit.After;
 import org.junit.Rule;
@@ -89,12 +93,222 @@ public class ExecutorServiceRuleGetThreadsTest {
     executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
 
     long[] threadIds = executorServiceRule.getThreadIds();
-
     assertThat(threadIds).hasSize(2);
 
     Set<Thread> threads = executorServiceRule.getThreads();
     for (Thread thread : threads) {
       assertThat(threadIds).contains(thread.getId());
     }
+  }
+
+  @Test
+  public void dumpThreadsAwaitingLatch() {
+    executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+    executorServiceRule.submit(() -> terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS));
+
+    String dump = executorServiceRule.dumpThreads();
+    System.out.println(dump);
+
+    Set<Thread> threads = executorServiceRule.getThreads();
+    for (Thread thread : threads) {
+      assertThat(dump).contains(thread.getName());
+    }
+  }
+
+  @Test
+  public void dumpThreadsContainsExecutorServiceThread() throws InterruptedException {
+    CountDownLatch threadRunning = new CountDownLatch(1);
+    AtomicReference<Thread> threadRef = new AtomicReference<>();
+
+    executorServiceRule.submit(() -> {
+      threadRef.set(Thread.currentThread());
+      threadRunning.countDown();
+      terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
+      return null;
+    });
+
+    threadRunning.await(TIMEOUT_MILLIS, MILLISECONDS);
+
+    String dump = executorServiceRule.dumpThreads();
+    System.out.println(dump);
+
+    Thread thread = threadRef.get();
+    assertThat(dump).contains(thread.getName()).contains(String.format("0x%1$x", thread.getId()));
+  }
+
+  @Test
+  public void dumpThreadsIncludesLockedMonitors() throws InterruptedException {
+    Object lock1 = new Object();
+    Object lock2 = new Object();
+    CountDownLatch lockedMonitors = new CountDownLatch(1);
+
+    executorServiceRule.submit(() -> {
+      synchronized (lock1) {
+        synchronized (lock2) {
+          lockedMonitors.countDown();
+          terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
+        }
+      }
+      return null;
+    });
+
+    lockedMonitors.await(TIMEOUT_MILLIS, MILLISECONDS);
+
+    String dump = executorServiceRule.dumpThreads();
+    System.out.println(dump);
+
+    assertThat(dump)
+        .contains("- locked <" + formatToHexString(lock1.hashCode()) + "> (a " +
+            Object.class.getName() + ")")
+        .contains("- locked <" + formatToHexString(lock2.hashCode()) + "> (a " +
+            Object.class.getName() + ")");
+  }
+
+  @Test
+  public void dumpThreadsIncludesLockedSynchronizers() throws InterruptedException {
+    Lock sync = new ReentrantLock();
+    CountDownLatch lockedSynchronizer = new CountDownLatch(1);
+
+    executorServiceRule.submit(() -> {
+      sync.lockInterruptibly();
+      lockedSynchronizer.countDown();
+      terminateLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
+      return null;
+    });
+
+    lockedSynchronizer.await(TIMEOUT_MILLIS, MILLISECONDS);
+
+    String dump = executorServiceRule.dumpThreads();
+    System.out.println(dump);
+
+    assertThat(dump)
+        .contains("- locked synchronizer <")
+        .contains("> (a " + ReentrantLock.class.getName() + "$NonfairSync)");
+  }
+
+  @Test
+  public void dumpThreadsShowsDeadlockedOnMonitor() throws InterruptedException {
+    Object lock1 = new Object();
+    Object lock2 = new Object();
+    CountDownLatch deadlockLatch = new CountDownLatch(1);
+    CountDownLatch acquiredLock1Latch = new CountDownLatch(1);
+    CountDownLatch acquiredLock2Latch = new CountDownLatch(1);
+
+    executorServiceRule.submit(() -> {
+      synchronized (lock1) {
+        acquiredLock1Latch.countDown();
+        deadlockLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
+        synchronized (lock2) {
+          System.out.println(Thread.currentThread().getName() + " acquired lock1 and lock2");
+        }
+      }
+      return null;
+    });
+    executorServiceRule.submit(() -> {
+      synchronized (lock2) {
+        acquiredLock2Latch.countDown();
+        deadlockLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
+        synchronized (lock1) {
+          System.out.println(Thread.currentThread().getName() + " acquired lock2 and lock1");
+        }
+      }
+      return null;
+    });
+
+    acquiredLock1Latch.await(TIMEOUT_MILLIS, MILLISECONDS);
+    acquiredLock2Latch.await(TIMEOUT_MILLIS, MILLISECONDS);
+
+    deadlockLatch.countDown();
+
+    String dump = executorServiceRule.dumpThreads();
+    System.out.println(dump);
+
+    Set<Thread> threads = executorServiceRule.getThreads();
+    assertThat(threads).hasSize(2);
+
+    for (Thread thread : threads) {
+      assertThat(dump).contains(thread.getName());
+    }
+
+    assertThat(dump)
+        .contains("- locked <" + formatToHexString(lock1.hashCode()) + "> (a " +
+            Object.class.getName() + ")")
+        .contains("- locked <" + formatToHexString(lock2.hashCode()) + "> (a " +
+            Object.class.getName() + ")")
+        .contains("- waiting to lock <" + formatToHexString(lock1.hashCode()) + "> (a " +
+            Object.class.getName() + ")")
+        .contains("- waiting to lock <" + formatToHexString(lock2.hashCode()) + "> (a " +
+            Object.class.getName() + ")");
+  }
+
+  @Test
+  public void dumpThreadsShowsDeadlockedOnSynchronizer() throws InterruptedException {
+    Lock sync1 = new ReentrantLock();
+    Lock sync2 = new ReentrantLock();
+    CountDownLatch deadlockLatch = new CountDownLatch(1);
+    CountDownLatch acquiredSync1Latch = new CountDownLatch(1);
+    CountDownLatch acquiredSync2Latch = new CountDownLatch(1);
+
+    executorServiceRule.submit(() -> {
+      sync1.lockInterruptibly();
+      try {
+        acquiredSync1Latch.countDown();
+        deadlockLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
+        sync2.lockInterruptibly();
+        try {
+          // nothing
+        } finally {
+          sync2.unlock();
+        }
+      } finally {
+        sync1.unlock();
+      }
+      return null;
+    });
+    executorServiceRule.submit(() -> {
+      sync2.lockInterruptibly();
+      try {
+        acquiredSync2Latch.countDown();
+        deadlockLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
+        sync1.lockInterruptibly();
+        try {
+          // nothing
+        } finally {
+          sync1.unlock();
+        }
+      } finally {
+        sync2.unlock();
+      }
+      return null;
+    });
+
+    acquiredSync1Latch.await(TIMEOUT_MILLIS, MILLISECONDS);
+    acquiredSync2Latch.await(TIMEOUT_MILLIS, MILLISECONDS);
+
+    deadlockLatch.countDown();
+
+    String dump = executorServiceRule.dumpThreads();
+    System.out.println(dump);
+
+    Set<Thread> threads = executorServiceRule.getThreads();
+    assertThat(threads).hasSize(2);
+
+    for (Thread thread : threads) {
+      assertThat(dump).contains(thread.getName());
+    }
+
+    String syncType = "> (a " + ReentrantLock.class.getName() + "$NonfairSync)";
+
+    assertThat(dump)
+        .contains("- locked synchronizer <")
+        .contains(syncType);
+
+    assertThat(countMatches(dump, syncType))
+        .as("Count matches of " + syncType + " in " + dump)
+        .isEqualTo(4);
+  }
+
+  private String formatToHexString(int value) {
+    return String.format("0x%1$x", value);
   }
 }


### PR DESCRIPTION
Add details about lock monitors and synchronizers that the threads are holding or waiting for.

I suppose we could refactor the code in `OSProcess` and `ExecutorServiceRule` that's similar, but I didn't want to go quite that far yet. For `ExecutorServiceRule`, I grouped the locked synchronizers at the top of the dump for each thread and didn't include the `Number of locked synchronizers` header.

If you run `ExecutorServiceRuleGetThreadsTest`, you can see what the dump actually looks like for various scenarios. Interesting to note that these `ThreadPoolExecutor` threads are always holding a synchronizer for its own `Worker` thread so that's why all of these show an extra `locked synchronizer`. 

I really wish there was a way to determine which stack frame a `Synchronizer` was locked in but it seems to be impossible in the current JDK version.

`dumpThreadsContainsExecutorServiceThread` shows a thread parked on a `CountDownLatch`:
```
"pool-2-thread-1" tid=0xd
   - locked synchronizer <0x6fadae5d> (a java.util.concurrent.ThreadPoolExecutor$Worker)
   java.lang.Thread.State: TIMED_WAITING
	at sun.misc.Unsafe.park(Native Method)
	- parking to timed-wait for <0x2d6e8792> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1037)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1328)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:277)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest.lambda$dumpThreadsContainsExecutorServiceThread$10(ExecutorServiceRuleGetThreadsTest.java:126)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest$$Lambda$3/1504109395.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
`dumpThreadsIncludesLockedMonitors` shows a thread with two monitors locked:
```
"pool-6-thread-1" tid=0x12
   - locked synchronizer <0x36f6e879> (a java.util.concurrent.ThreadPoolExecutor$Worker)
   java.lang.Thread.State: TIMED_WAITING
	at sun.misc.Unsafe.park(Native Method)
	- parking to timed-wait for <0x52af6cff> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1037)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1328)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:277)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest.lambda$dumpThreadsIncludesLockedMonitors$11(ExecutorServiceRuleGetThreadsTest.java:149)
	- locked <0x3551a94> (a java.lang.Object)
	- locked <0x531be3c5> (a java.lang.Object)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest$$Lambda$13/1915058446.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
`dumpThreadsIncludesLockedSynchronizers` shows a thread with a `ReentrantLock` synchronizer locked:
```
"pool-10-thread-1" tid=0x1b
   - locked synchronizer <0x14acaea5> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
   - locked synchronizer <0x4c70fda8> (a java.util.concurrent.ThreadPoolExecutor$Worker)
   java.lang.Thread.State: TIMED_WAITING
	at sun.misc.Unsafe.park(Native Method)
	- parking to timed-wait for <0x46d56d67> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1037)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1328)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:277)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest.lambda$dumpThreadsIncludesLockedSynchronizers$12(ExecutorServiceRuleGetThreadsTest.java:175)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest$$Lambda$21/486898233.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
`dumpThreadsShowsDeadlockedOnMonitor` shows two threads deadlocked by locking monitors in the wrong order:
```
"pool-8-thread-2" tid=0x16 owned by "pool-8-thread-1" tid=0x15
   - locked synchronizer <0x153f5a29> (a java.util.concurrent.ThreadPoolExecutor$Worker)
   java.lang.Thread.State: BLOCKED
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest.lambda$dumpThreadsShowsDeadlockedOnMonitor$14(ExecutorServiceRuleGetThreadsTest.java:212)
	- waiting to lock <0x7ca48474> (a java.lang.Object)
	- locked <0x13a57a3b> (a java.lang.Object)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest$$Lambda$17/159259014.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

"pool-8-thread-1" tid=0x15 owned by "pool-8-thread-2" tid=0x16
   - locked synchronizer <0x3dd3bcd> (a java.util.concurrent.ThreadPoolExecutor$Worker)
   java.lang.Thread.State: BLOCKED
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest.lambda$dumpThreadsShowsDeadlockedOnMonitor$13(ExecutorServiceRuleGetThreadsTest.java:202)
	- waiting to lock <0x13a57a3b> (a java.lang.Object)
	- locked <0x7ca48474> (a java.lang.Object)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest$$Lambda$16/331844619.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
`dumpThreadsShowsDeadlockedOnSynchronizer` shows two threads deadlocked by acquiring `ReentrantLock` synchronizers in the wrong order:
```
"pool-5-thread-1" tid=0x10 owned by "pool-5-thread-2" tid=0x11
   - locked synchronizer <0x90f6bfd> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
   - locked synchronizer <0x2d554825> (a java.util.concurrent.ThreadPoolExecutor$Worker)
   java.lang.Thread.State: WAITING
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for <0x47f6473> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireInterruptibly(AbstractQueuedSynchronizer.java:897)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireInterruptibly(AbstractQueuedSynchronizer.java:1222)
	at java.util.concurrent.locks.ReentrantLock.lockInterruptibly(ReentrantLock.java:335)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest.lambda$dumpThreadsShowsDeadlockedOnSynchronizer$15(ExecutorServiceRuleGetThreadsTest.java:257)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest$$Lambda$11/1874154700.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

"pool-5-thread-2" tid=0x11 owned by "pool-5-thread-1" tid=0x10
   - locked synchronizer <0x47f6473> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
   - locked synchronizer <0x3567135c> (a java.util.concurrent.ThreadPoolExecutor$Worker)
   java.lang.Thread.State: WAITING
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for <0x90f6bfd> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireInterruptibly(AbstractQueuedSynchronizer.java:897)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireInterruptibly(AbstractQueuedSynchronizer.java:1222)
	at java.util.concurrent.locks.ReentrantLock.lockInterruptibly(ReentrantLock.java:335)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest.lambda$dumpThreadsShowsDeadlockedOnSynchronizer$16(ExecutorServiceRuleGetThreadsTest.java:273)
	at org.apache.geode.test.junit.rules.ExecutorServiceRuleGetThreadsTest$$Lambda$12/1753447031.call(Unknown Source)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```