### PR TITLE
GEODE-6317: Fix intermittent CacheConnectionJUnitTest failures

### DIFF
--- a/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheConnectionJUnitTest.java
+++ b/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheConnectionJUnitTest.java
@@ -205,6 +205,8 @@ public class CacheConnectionJUnitTest {
     ClientProtocol.Message getMessage =
         MessageUtil.makeGetRequestMessage(serializationService, TEST_KEY, TEST_REGION);
     protobufProtocolSerializer.serialize(getMessage, outputStream);
+    // Make sure we're done processing the message server side.
+    socket.getInputStream().read();
 
     // make sure socket is still open
     assertFalse(socket.isClosed());


### PR DESCRIPTION
- This test would fail intermittently on Windows with JDK11. It seems like the
  protobuf message is still being processed on the server, when the sending
  socket is closed by the test. Just wait to start reading something back on
  the socket before continuing.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
