### PR TITLE
GEODE-6309 ClusterConfigLocatorRestartDUnitTest fails to spin up a new server

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
@@ -115,12 +115,17 @@ public class ClusterConfigLocatorRestartDUnitTest {
   private void waitForLocatorToReconnect(MemberVM locator) {
     // Ensure that disconnect/reconnect sequence starts otherwise in the next await we might end up
     // with the initial locator instead of a newly created one.
-    await()
-        .until(() -> locator.invoke(() -> TestDisconnectListener.disconnectCount > 0));
+    locator.invoke(() -> await()
+        .until(() -> TestDisconnectListener.disconnectCount > 0));
 
-    await().until(() -> locator.invoke(() -> {
-      InternalLocator intLocator = InternalLocator.getLocator();
-      return intLocator != null && intLocator.isSharedConfigurationRunning();
-    }));
+    locator.invoke(() -> {
+      await().until(() -> {
+        InternalLocator intLocator = InternalLocator.getLocator();
+        return intLocator != null
+            && intLocator.getDistributedSystem() != null
+            && intLocator.getDistributedSystem().isConnected()
+            && intLocator.isSharedConfigurationRunning();
+      });
+    });
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
@@ -34,6 +34,8 @@ public class ServiceConfig {
   private final long joinTimeout;
   private final int[] membershipPortRange;
   private final long memberTimeout;
+
+  private final boolean isReconnecting;
   private Integer lossThreshold;
   private final Integer memberWeight;
   private boolean networkPartitionDetectionEnabled;
@@ -45,6 +47,10 @@ public class ServiceConfig {
   /** the transport config from the distribution manager */
   private final RemoteTransportConfig transport;
 
+
+  public boolean isReconnecting() {
+    return isReconnecting;
+  }
 
   public int getLocatorWaitTime() {
     return locatorWaitTime;
@@ -74,7 +80,6 @@ public class ServiceConfig {
   public int getMemberWeight() {
     return memberWeight;
   }
-
 
   public boolean isNetworkPartitionDetectionEnabled() {
     return networkPartitionDetectionEnabled;
@@ -110,9 +115,10 @@ public class ServiceConfig {
   public ServiceConfig(RemoteTransportConfig transport, DistributionConfig theConfig) {
     this.dconfig = theConfig;
     this.transport = transport;
+    this.isReconnecting = (transport.getOldDSMembershipInfo() != null);
 
     long defaultJoinTimeout = 24000;
-    if (theConfig.getLocators().length() > 0 && !Locator.hasLocator()) {
+    if (isReconnecting || theConfig.getLocators().length() > 0 && !Locator.hasLocator()) {
       defaultJoinTimeout = 60000;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1135,7 +1135,8 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
                   + "so I will not become membership coordinator on this attempt to join");
               state.hasContactedAJoinedLocator = true;
             }
-            if (response.getCoordinator() != null) {
+            InternalDistributedMember responseCoordinator = response.getCoordinator();
+            if (responseCoordinator != null) {
               anyResponses = true;
               NetView v = response.getView();
               int viewId = v == null ? -1 : v.getViewId();
@@ -1145,10 +1146,16 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
                 state.registrants.clear();
               }
               if (viewId > -1) {
-                coordinatorsWithView.add(response.getCoordinator());
+                coordinatorsWithView.add(responseCoordinator);
               }
-
-              possibleCoordinators.add(response.getCoordinator());
+              // if this node is restarting it should never create its own cluster because
+              // the QuorumChecker would have contacted a quorum of live nodes and one of
+              // them should already be the coordinator, or should become the coordinator soon
+              boolean isMyOldAddress =
+                  services.getConfig().isReconnecting() && localAddress.equals(responseCoordinator);
+              if (!isMyOldAddress) {
+                possibleCoordinators.add(response.getCoordinator());
+              }
             }
           }
         } catch (IOException | ClassNotFoundException problem) {
@@ -1286,7 +1293,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
     for (FindCoordinatorResponse resp : result) {
       logger.info("findCoordinatorFromView processing {}", resp);
       InternalDistributedMember mbr = resp.getCoordinator();
-      if (!state.alreadyTried.contains(mbr)) {
+      if (!localAddress.equals(mbr) && !state.alreadyTried.contains(mbr)) {
         boolean mbrIsNoob = (mbr.getVmViewId() < 0);
         if (mbrIsNoob) {
           // member has not yet joined


### PR DESCRIPTION
This modifies auto-reconnect to lengthen the time a Locator will attempt
to join from 24 seconds to 60 seconds and prevents the Locator from
creating its own cluster (which would form a split-brain).  In an
auto-reconnect attempt the location service will not start up until a
quorum of the old cluster can be contacted, meaning that some process
that's still in the cluster exists and should have taken over the role
of membership coordinator.  The locator needs to join using that
coordinator and not create its own cluster.

This also corrects the handling of the old membership view in
GMSLocator.  The restarted location service was incorrectly using this
old view as an authority on who had the role of coordinator but it
should only be used as a hint.  This is done by putting the view into
the recoveredView variable and assigning it an invalid viewID.

In real applications this bug isn't likely to be encountered because the
first auto-reconnect attempt doesn't take place for a minute.  The
ClusterStartupRule modifies this default to start reconnecting in 5
seconds, which wasn't giving the cluster enough time to react to the
loss of the old Locator and assign a new membership coordinator.
With these changes the test passes even if the default is reduced to 1
second.

Finally, the test was incorrectly using internal APIs to detect whether
the Locator had successfully reconnected. I fixed some of that but
opened GEODE-6312 to track the problem that stopping the old Locator did
not actually stop its cluster configuration service.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
