### PR TITLE
GEODE-6330: Return a TransactionException Instead of a Generic ReplyMessage

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
@@ -496,7 +496,7 @@ public abstract class DistributionMessage implements DataSerializableFixedID, Cl
       if (pid != 0) {
         procId = " processorId=" + pid;
       }
-      if (Thread.currentThread().getName().startsWith("P2P Message Reader")) {
+      if (Thread.currentThread().getName().startsWith("P2P message reader")) {
         sender = procId;
       } else {
         sender = "sender=" + getSender() + procId;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
@@ -27,6 +27,7 @@ import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.cache.TransactionException;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DirectReplyProcessor;
@@ -200,12 +201,19 @@ public abstract class RemoteOperationMessage extends DistributionMessage
           } else if (tx.isInProgress()) {
             sendReply = operateOnRegion(dm, r, startTime);
             tx.updateProxyServer(this.getSender());
+          } else {
+            /*
+             * This can occur when processing an in-flight message after the transaction has
+             * been failed over and committed.
+             */
+            throw new TransactionException("transactional operation elided because transaction {"
+                + tx.getTxId() + "} is closed");
           }
         } finally {
           txMgr.unmasquerade(tx);
         }
       }
-    } catch (RegionDestroyedException | RemoteOperationException ex) {
+    } catch (RegionDestroyedException | RemoteOperationException | TransactionException ex) {
       thr = ex;
     } catch (DistributedSystemDisconnectedException se) {
       // bug 37026: this is too noisy...


### PR DESCRIPTION
When a `FunctionStreamingResultCollector` is processing (reply) messages for a transactional operation, it sometimes encounters a message that is a generic `ReplyMessage`, not a `FunctionStreamingReplyMessage`. This happens when the (remote) message processor (`PartitionMessage.process()`) attempts to perform the operation, but finds that the transaction is already closed. `process()` replies with a generic `ReplyMessage` in that case, resulting in a `ClassCastException` over in the `FunctionStreamingResultCollector`.

The solution, here, is to reply with a `TransactionException` from `process()` in this case.

This PR consists of two commits: one for the bug just described, and another (tiny one) that got the breadcrumbs facility working again. The latter was helpful in debugging the IPC.
### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
