### PR TITLE
GEODE-6244 Healthy member kicked out by Sick member when final-check fails

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -733,6 +733,26 @@ public class GMSJoinLeaveJUnitTest {
     assertTrue("Expected becomeCoordinator to be invoked", gmsJoinLeave.isCoordinator());
   }
 
+  /**
+   * Given a view with [A, B, C, D, E] where C is coordinator, A failed availability checks and
+   * C shuts down we should see B become the coordinator.
+   */
+  @Test
+  public void testBecomeCoordinatorThroughShutdownWhenOlderMemberCrashed() throws Exception {
+    initMocks();
+    InternalDistributedMember A = mockMembers[0],
+        B = gmsJoinLeaveMemberId,
+        C = mockMembers[1],
+        D = mockMembers[2],
+        E = mockMembers[3];
+    prepareAndInstallView(C, createMemberList(A, B, C, D, E));
+    when(healthMonitor.getMembersFailingAvailabilityCheck()).thenReturn(Collections.singleton(A));
+    LeaveRequestMessage msg = new LeaveRequestMessage(B, C, "leaving for test");
+    msg.setSender(C);
+    gmsJoinLeave.processMessage(msg);
+    assertTrue("Expected becomeCoordinator to be invoked", gmsJoinLeave.isCoordinator());
+  }
+
   @Test
   public void testBecomeCoordinatorThroughViewChange() throws Exception {
     initMocks();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -842,12 +842,17 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
       }
       InternalDistributedMember oldNeighbor = nextNeighbor;
       if (oldNeighbor != newNeighbor) {
-        logger.info("Failure detection is now watching {}", newNeighbor);
+        logger.info("Failure detection is now watching " + newNeighbor
+            + "; suspects are " + suspectedMemberIds);
         nextNeighbor = newNeighbor;
       }
     }
 
     if (nextNeighbor != null && nextNeighbor.equals(localAddress)) {
+      if (logger.isDebugEnabled()) {
+        logger.debug("Health monitor is unable to find a neighbor to watch.  "
+            + "Current suspects are {}", suspectedMemberIds);
+      }
       nextNeighbor = null;
     }
 
@@ -1353,6 +1358,11 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
   @Override
   public int getFailureDetectionPort() {
     return this.socketPort;
+  }
+
+  @Override
+  public Collection<InternalDistributedMember> getMembersFailingAvailabilityCheck() {
+    return Collections.unmodifiableCollection(this.suspectedMemberIds.keySet());
   }
 
   private void sendSuspectRequest(final List<SuspectRequest> requests) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.interfaces;
 
+import java.util.Collection;
+
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
@@ -50,5 +52,10 @@ public interface HealthMonitor extends Service {
    * Returns the failure detection port for this member, or -1 if there is no such port
    */
   int getFailureDetectionPort();
+
+  /**
+   * Returns the set of members declared dead by the health monitor
+   */
+  Collection<InternalDistributedMember> getMembersFailingAvailabilityCheck();
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -610,7 +610,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
       }
       Collection<InternalDistributedMember> suspectMembers =
           services.getHealthMonitor().getMembersFailingAvailabilityCheck();
-      // check.removeAll(suspectMembers);
+      check.removeAll(suspectMembers);
       logger.info(
           "View with removed and left members removed is {}\nremoved members: {}\nleft members: {}\nsuspect members: {}",
           check, removedMembers, leftMembers, suspectMembers);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -608,6 +608,12 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
         leftMembers.add(mbr);
         check.removeAll(leftMembers);
       }
+      Collection<InternalDistributedMember> suspectMembers =
+          services.getHealthMonitor().getMembersFailingAvailabilityCheck();
+      // check.removeAll(suspectMembers);
+      logger.info(
+          "View with removed and left members removed is {}\nremoved members: {}\nleft members: {}\nsuspect members: {}",
+          check, removedMembers, leftMembers, suspectMembers);
       if (check.getCoordinator().equals(localAddress)) {
         synchronized (viewInstallationLock) {
           becomeCoordinator(mbr);


### PR DESCRIPTION
The initial fix caused a problem that prevented election of a new
membership coordinator in a certain case.  The case was a view
with nodes [A, B, C, D, E] where C was the coordinator.  Node A had
crashed and the crash had been detected by B.  Node C then left the
cluster, sending a Leave message to B.  B's JoinLeave did not know about
the HealthMonitor's decision that A was crashed and did not become the
new coordinator.

This commit makes B's JoinLeave pay attention to the crashed-member set
in the HealthMonitor when deciding whether to become the membership
coordinator for the cluster.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
