### PR TITLE
GEODE-6174: more error handling in LocatorClusterConfigurationService

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
@@ -79,6 +79,7 @@ public class RegionManagementDunitTest {
 
   @Test
   public void createsAPartitionedRegionByDefault() throws Exception {
+    IgnoredException.addIgnoredException("cache element orders already exists.");
     String json = "{\"name\": \"orders\"}";
 
     ClusterManagementResult result = restClient.doPostAndAssert("/regions", json)
@@ -94,6 +95,13 @@ public class RegionManagementDunitTest {
 
     // make sure region is persisted
     locator.invoke(() -> verifyRegionPersisted("orders", "PARTITION"));
+
+    // create the same region 2nd time
+    result = restClient.doPostAndAssert("/regions", json)
+        .hasStatusCode(409)
+        .getClusterManagementResult();
+    assertThat(result.isSuccessfullyAppliedOnMembers()).isFalse();
+    assertThat(result.isSuccessfullyPersisted()).isFalse();
   }
 
   @Test

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
@@ -79,7 +79,6 @@ public class RegionManagementDunitTest {
 
   @Test
   public void createsAPartitionedRegionByDefault() throws Exception {
-    IgnoredException.addIgnoredException("cache element orders already exists.");
     String json = "{\"name\": \"orders\"}";
 
     ClusterManagementResult result = restClient.doPostAndAssert("/regions", json)

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.management.internal.api.ClusterManagementResult;
+import org.apache.geode.test.junit.rules.GeodeDevRestClient;
+import org.apache.geode.test.junit.rules.LocatorStarterRule;
+import org.apache.geode.test.junit.rules.RequiresGeodeHome;
+
+public class DisabledClusterConfigTest {
+  @Rule
+  public LocatorStarterRule locator = new LocatorStarterRule();
+
+  @ClassRule
+  public static RequiresGeodeHome requiresGeodeHome = new RequiresGeodeHome();
+
+  public static GeodeDevRestClient restClient;
+
+  @Test
+  public void disabledClusterConfig() throws Exception {
+    locator.withProperty(ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION, "false")
+        .withHttpService().startLocator();
+    restClient =
+        new GeodeDevRestClient("/geode-management/v2", "localhost", locator.getHttpPort(), false);
+
+    ClusterManagementResult result =
+        restClient.doPostAndAssert("/regions", "{\"name\":\"test\"}")
+            .hasStatusCode(500)
+            .getClusterManagementResult();
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.isSuccessfullyPersisted()).isFalse();
+    assertThat(result.isSuccessfullyAppliedOnMembers()).isFalse();
+    assertThat(result.getPersistenceStatus().getMessage())
+        .isEqualTo("Cluster configuration service needs to be enabled");
+  }
+}

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/api/RegionAPIDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/api/RegionAPIDUnitTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.management.internal.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -97,18 +96,6 @@ public class RegionAPIDUnitTest {
     server.invoke(() -> verifyRegionCreated(regionName, "REPLICATE"));
 
     locator.invoke(() -> verifyRegionPersisted(regionName, "REPLICATE"));
-  }
-
-  @Test
-  public void noName() {
-    locator.invoke(() -> {
-      RegionConfig config = new RegionConfig();
-      ClusterManagementService clusterManagementService =
-          ClusterStartupRule.getLocator().getClusterManagementService();
-      assertThatThrownBy(() -> clusterManagementService.create(config, "cluster"))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining("Name of the region has to be specified");
-    });
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -43,7 +43,6 @@ import org.apache.geode.management.internal.configuration.mutators.RegionConfigM
 import org.apache.geode.management.internal.configuration.validators.ConfigurationValidator;
 import org.apache.geode.management.internal.configuration.validators.RegionConfigValidator;
 import org.apache.geode.management.internal.exceptions.EntityExistsException;
-import org.apache.geode.management.internal.exceptions.NoMembersException;
 
 public class LocatorClusterManagementService implements ClusterManagementService {
   private static Logger logger = LogService.getLogger();
@@ -77,6 +76,11 @@ public class LocatorClusterManagementService implements ClusterManagementService
       group = "cluster";
     }
 
+    if (persistenceService == null) {
+      return new ClusterManagementResult(false,
+          "Cluster configuration service needs to be enabled");
+    }
+
     ClusterManagementResult result = new ClusterManagementResult();
     ConfigurationMutator configurationMutator = mutators.get(config.getClass());
 
@@ -84,20 +88,17 @@ public class LocatorClusterManagementService implements ClusterManagementService
     if (validator != null) {
       validator.validate(config);
     }
-    final boolean configurationPersistenceEnabled = persistenceService != null;
 
     // exit early if config element already exists in cache config
-    if (configurationPersistenceEnabled) {
-      CacheConfig currentPersistedConfig = persistenceService.getCacheConfig(group, true);
-      if (configurationMutator.exists(config, currentPersistedConfig)) {
-        throw new EntityExistsException("cache element " + config.getId() + " already exists.");
-      }
+    CacheConfig currentPersistedConfig = persistenceService.getCacheConfig(group, true);
+    if (configurationMutator.exists(config, currentPersistedConfig)) {
+      throw new EntityExistsException("cache element " + config.getId() + " already exists.");
     }
 
     // execute function on all members
     Set<DistributedMember> targetedMembers = findMembers(null, null);
     if (targetedMembers.size() == 0) {
-      throw new NoMembersException("no members found to create cache element");
+      return new ClusterManagementResult(false, "no members found to create cache element");
     }
 
     List<CliFunctionResult> functionResults = executeAndGetFunctionResult(
@@ -109,25 +110,26 @@ public class LocatorClusterManagementService implements ClusterManagementService
             functionResult.isSuccessful(),
             functionResult.getStatusMessage()));
 
-    // persist configuration in cache config
-    if (configurationPersistenceEnabled) {
-      String finalGroup = group;
-      persistenceService.updateCacheConfig(finalGroup, cacheConfigForGroup -> {
-        try {
-          configurationMutator.add(config, cacheConfigForGroup);
-          result.setClusterConfigPersisted(true,
-              "successfully persisted config for " + finalGroup);
-        } catch (Exception e) {
-          String message = "failed to update cluster config for " + finalGroup;
-          logger.error(message, e);
-          result.setClusterConfigPersisted(false, message);
-          return null;
-        }
-
-        return cacheConfigForGroup;
-      });
+    if (!result.isSuccessfullyAppliedOnMembers()) {
+      result.setClusterConfigPersisted(false, "Failed to apply the update on all members.");
+      return result;
     }
 
+    // persist configuration in cache config
+    String finalGroup = group;
+    persistenceService.updateCacheConfig(finalGroup, cacheConfigForGroup -> {
+      try {
+        configurationMutator.add(config, cacheConfigForGroup);
+        result.setClusterConfigPersisted(true,
+            "successfully persisted config for " + finalGroup);
+      } catch (Exception e) {
+        String message = "failed to update cluster config for " + finalGroup;
+        logger.error(message, e);
+        result.setClusterConfigPersisted(false, message);
+        return null;
+      }
+      return cacheConfigForGroup;
+    });
     return result;
   }
 
@@ -141,11 +143,13 @@ public class LocatorClusterManagementService implements ClusterManagementService
     throw new NotImplementedException();
   }
 
-  private Set<DistributedMember> findMembers(String[] groups, String[] members) {
+  @VisibleForTesting
+  Set<DistributedMember> findMembers(String[] groups, String[] members) {
     return CliUtil.findMembers(groups, members, distributionManager);
   }
 
-  private List<CliFunctionResult> executeAndGetFunctionResult(Function function, Object args,
+  @VisibleForTesting
+  List<CliFunctionResult> executeAndGetFunctionResult(Function function, Object args,
       Set<DistributedMember> targetMembers) {
     ResultCollector rc = CliUtil.executeFunction(function, args, targetMembers);
     return CliFunctionResult.cleanResults((List<?>) rc.getResult());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -86,7 +86,11 @@ public class LocatorClusterManagementService implements ClusterManagementService
 
     ConfigurationValidator validator = validators.get(config.getClass());
     if (validator != null) {
-      validator.validate(config);
+      try {
+        validator.validate(config);
+      } catch (IllegalArgumentException e) {
+        return new ClusterManagementResult(false, e.getMessage());
+      }
     }
 
     // exit early if config element already exists in cache config

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CliFunctionResult.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CliFunctionResult.java
@@ -82,10 +82,6 @@ public class CliFunctionResult implements Comparable<CliFunctionResult>, DataSer
     this.state = StatusState.OK;
   }
 
-  /**
-   * @deprecated Use {@code CliFunctionResult(String, StatusState, String)} instead
-   */
-  @Deprecated
   public CliFunctionResult(final String memberIdOrName, final boolean successful,
       final String message) {
     this(memberIdOrName, successful ? StatusState.OK : StatusState.ERROR, message);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigMutator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigMutator.java
@@ -18,6 +18,7 @@
 package org.apache.geode.management.internal.configuration.mutators;
 
 import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.cache.configuration.RegionConfig;
 
 public class RegionConfigMutator implements ConfigurationMutator<RegionConfig> {
@@ -31,7 +32,7 @@ public class RegionConfigMutator implements ConfigurationMutator<RegionConfig> {
 
   @Override
   public boolean exists(RegionConfig config, CacheConfig existing) {
-    return false;
+    return CacheElement.exists(existing.getRegions(), config.getId());
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.distributed.ConfigurationPersistenceService;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
+import org.apache.geode.management.internal.exceptions.EntityExistsException;
+
+public class LocatorClusterManagementServiceTest {
+
+  private LocatorClusterManagementService service;
+  private DistributionManager distributionManager;
+  private ConfigurationPersistenceService persistenceService;
+  private RegionConfig regionConfig;
+  private ClusterManagementResult result;
+
+  @Before
+  public void before() throws Exception {
+    distributionManager = mock(DistributionManager.class);
+    persistenceService = mock(ConfigurationPersistenceService.class);
+    service = spy(new LocatorClusterManagementService(distributionManager, persistenceService));
+    regionConfig = new RegionConfig();
+  }
+
+  @Test
+  public void persistenceIsNull() throws Exception {
+    service = new LocatorClusterManagementService(distributionManager, null);
+    result = service.create(regionConfig, "cluster");
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getPersistenceStatus().getMessage())
+        .contains("Cluster configuration service needs to be enabled");
+  }
+
+  @Test
+  public void elementAlreadyExist() throws Exception {
+    regionConfig.setName("test");
+    CacheConfig cacheConfig = new CacheConfig();
+    cacheConfig.getRegions().add(regionConfig);
+    when(persistenceService.getCacheConfig("cluster", true)).thenReturn(cacheConfig);
+
+    assertThatThrownBy(() -> service.create(regionConfig, "cluster"))
+        .isInstanceOf(EntityExistsException.class)
+        .hasMessageContaining("cache element test already exists");
+  }
+
+  @Test
+  public void validationFailed() throws Exception {
+    assertThatThrownBy(() -> service.create(regionConfig, "cluster"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Name of the region has to be specified");
+  }
+
+  @Test
+  public void noMemberFound() throws Exception {
+    regionConfig.setName("test");
+    when(persistenceService.getCacheConfig("cluster", true)).thenReturn(new CacheConfig());
+    doReturn(Collections.emptySet()).when(service).findMembers(any(), any());
+    result = service.create(regionConfig, "cluster");
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.isSuccessfullyAppliedOnMembers()).isFalse();
+    assertThat(result.getPersistenceStatus().getMessage())
+        .contains("no members found to create cache element");
+  }
+
+  @Test
+  public void partialFailureOnMembers() throws Exception {
+    List<CliFunctionResult> functionResults = new ArrayList<>();
+    functionResults.add(new CliFunctionResult("member1", true, "success"));
+    functionResults.add(new CliFunctionResult("member2", false, "failed"));
+    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any(), any());
+
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(service).findMembers(any(),
+        any());
+
+    when(persistenceService.getCacheConfig("cluster", true)).thenReturn(new CacheConfig());
+    regionConfig.setName("test");
+    result = service.create(regionConfig, "cluster");
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.isSuccessfullyAppliedOnMembers()).isFalse();
+    assertThat(result.isSuccessfullyPersisted()).isFalse();
+    assertThat(result.getPersistenceStatus().getMessage())
+        .contains("Failed to apply the update on all members");
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -77,9 +77,10 @@ public class LocatorClusterManagementServiceTest {
 
   @Test
   public void validationFailed() throws Exception {
-    assertThatThrownBy(() -> service.create(regionConfig, "cluster"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Name of the region has to be specified");
+    result = service.create(regionConfig, "cluster");
+    assertThat(result.isSuccessful()).isFalse();
+    assertThat(result.getPersistenceStatus().getMessage())
+        .contains("Name of the region has to be specified");
   }
 
   @Test

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -240,7 +240,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   public T withHttpService(boolean useDefaultPort) {
     properties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
     if (!useDefaultPort) {
-      properties.putIfAbsent(HTTP_SERVICE_PORT,
+      properties.put(HTTP_SERVICE_PORT,
           portSupplier.getAvailablePort() + "");
       this.httpPort = Integer.parseInt(properties.getProperty(HTTP_SERVICE_PORT));
     } else {

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
@@ -44,7 +44,7 @@ public class ManagementControllerAdvice {
 
   @ExceptionHandler(EntityExistsException.class)
   public ResponseEntity<ClusterManagementResult> entityExists(final Exception e) {
-    logger.error(e.getMessage(), e);
+    // no need to log the error stack. User only needs to know the message.
     return new ResponseEntity<>(new ClusterManagementResult(false, e.getMessage()),
         HttpStatus.CONFLICT);
   }
@@ -57,21 +57,18 @@ public class ManagementControllerAdvice {
 
   @ExceptionHandler({NotAuthorizedException.class, SecurityException.class})
   public ResponseEntity<ClusterManagementResult> forbidden(Exception e) {
-    logger.info(e.getMessage());
     return new ResponseEntity<>(new ClusterManagementResult(false, e.getMessage()),
         HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler(MalformedObjectNameException.class)
   public ResponseEntity<ClusterManagementResult> badRequest(final MalformedObjectNameException e) {
-    logger.info(e.getMessage(), e);
     return new ResponseEntity<>(new ClusterManagementResult(false, e.getMessage()),
         HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(InstanceNotFoundException.class)
   public ResponseEntity<ClusterManagementResult> notFound(final InstanceNotFoundException e) {
-    logger.info(e.getMessage(), e);
     return new ResponseEntity<>(new ClusterManagementResult(false, e.getMessage()),
         HttpStatus.NOT_FOUND);
   }
@@ -87,7 +84,6 @@ public class ManagementControllerAdvice {
   @ExceptionHandler(AccessDeniedException.class)
   public ResponseEntity<ClusterManagementResult> handleException(
       final AccessDeniedException cause) {
-    logger.info(cause.getMessage(), cause);
     return new ResponseEntity<>(new ClusterManagementResult(false, cause.getMessage()),
         HttpStatus.FORBIDDEN);
   }

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.internal.api.ClusterManagementResult;
+import org.apache.geode.management.internal.exceptions.EntityExistsException;
 import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.NotAuthorizedException;
 
@@ -39,6 +40,13 @@ public class ManagementControllerAdvice {
     logger.error(e.getMessage(), e);
     return new ResponseEntity<>(new ClusterManagementResult(false, e.getMessage()),
         HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(EntityExistsException.class)
+  public ResponseEntity<ClusterManagementResult> entityExists(final Exception e) {
+    logger.error(e.getMessage(), e);
+    return new ResponseEntity<>(new ClusterManagementResult(false, e.getMessage()),
+        HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler({AuthenticationFailedException.class, AuthenticationException.class})


### PR DESCRIPTION
* fail early if cluster persistence serivce is not enabled
* creating the region twice will result in status code 409
* if region creation is partially failed on members, do not update cluster configuration.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
