### PR TITLE
GEODE-6334: Create CachePerfStatsTest and cleanup CachePerfStats

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache;
 
 import org.apache.geode.StatisticDescriptor;
@@ -27,133 +26,133 @@ import org.apache.geode.internal.NanoTimer;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 /**
- * CachePerfStats tracks statistics about GemFire cache performance.
+ * CachePerfStats tracks statistics about Geode cache performance and usage.
  */
 public class CachePerfStats {
   public static boolean enableClockStats;
 
   private static final StatisticsType type;
 
-  protected static final int loadsInProgressId;
-  protected static final int loadsCompletedId;
-  protected static final int loadTimeId;
-  protected static final int netloadsInProgressId;
-  protected static final int netloadsCompletedId;
-  protected static final int netloadTimeId;
-  protected static final int netsearchesInProgressId;
-  protected static final int netsearchesCompletedId;
-  protected static final int netsearchTimeId;
-  protected static final int cacheWriterCallsInProgressId;
-  protected static final int cacheWriterCallsCompletedId;
-  protected static final int cacheWriterCallTimeId;
-  protected static final int cacheListenerCallsInProgressId;
-  protected static final int cacheListenerCallsCompletedId;
-  protected static final int cacheListenerCallTimeId;
-  protected static final int getInitialImagesInProgressId;
-  protected static final int getInitialImagesCompletedId;
-  protected static final int deltaGetInitialImagesCompletedId;
-  protected static final int getInitialImageTimeId;
-  protected static final int getInitialImageKeysReceivedId;
-  protected static final int regionsId;
-  protected static final int partitionedRegionsId;
+  static final int loadsInProgressId;
+  static final int loadsCompletedId;
+  static final int loadTimeId;
+  static final int netloadsInProgressId;
+  static final int netloadsCompletedId;
+  static final int netloadTimeId;
+  static final int netsearchesInProgressId;
+  static final int netsearchesCompletedId;
+  static final int netsearchTimeId;
+  static final int cacheWriterCallsInProgressId;
+  static final int cacheWriterCallsCompletedId;
+  static final int cacheWriterCallTimeId;
+  static final int cacheListenerCallsInProgressId;
+  static final int cacheListenerCallsCompletedId;
+  static final int cacheListenerCallTimeId;
+  static final int getInitialImagesInProgressId;
+  static final int getInitialImagesCompletedId;
+  static final int deltaGetInitialImagesCompletedId;
+  static final int getInitialImageTimeId;
+  static final int getInitialImageKeysReceivedId;
+  static final int regionsId;
+  static final int partitionedRegionsId;
   protected static final int destroysId;
-  protected static final int createsId;
-  protected static final int putsId;
+  static final int createsId;
+  static final int putsId;
   protected static final int putTimeId;
-  protected static final int putallsId;
-  protected static final int putallTimeId;
-  protected static final int removeAllsId;
-  protected static final int removeAllTimeId;
+  static final int putallsId;
+  static final int putallTimeId;
+  static final int removeAllsId;
+  private static final int removeAllTimeId;
   protected static final int updatesId;
-  protected static final int updateTimeId;
-  protected static final int invalidatesId;
-  protected static final int getsId;
+  static final int updateTimeId;
+  static final int invalidatesId;
+  static final int getsId;
   protected static final int getTimeId;
   protected static final int eventQueueSizeId;
-  protected static final int eventQueueThrottleTimeId;
-  protected static final int eventQueueThrottleCountId;
-  protected static final int eventThreadsId;
-  protected static final int missesId;
+  static final int eventQueueThrottleTimeId;
+  static final int eventQueueThrottleCountId;
+  static final int eventThreadsId;
+  static final int missesId;
   protected static final int queryExecutionsId;
-  protected static final int queryExecutionTimeId;
-  protected static final int queryResultsHashCollisionsId;
-  protected static final int queryResultsHashCollisionProbeTimeId;
-  protected static final int partitionedRegionQueryRetriesId;
+  static final int queryExecutionTimeId;
+  static final int queryResultsHashCollisionsId;
+  static final int queryResultsHashCollisionProbeTimeId;
+  static final int partitionedRegionQueryRetriesId;
 
-  protected static final int txSuccessLifeTimeId;
-  protected static final int txFailedLifeTimeId;
-  protected static final int txRollbackLifeTimeId;
-  protected static final int txCommitsId;
-  protected static final int txFailuresId;
-  protected static final int txRollbacksId;
-  protected static final int txCommitTimeId;
-  protected static final int txFailureTimeId;
-  protected static final int txRollbackTimeId;
-  protected static final int txCommitChangesId;
-  protected static final int txFailureChangesId;
-  protected static final int txRollbackChangesId;
-  protected static final int txConflictCheckTimeId;
+  static final int txSuccessLifeTimeId;
+  static final int txFailedLifeTimeId;
+  static final int txRollbackLifeTimeId;
+  static final int txCommitsId;
+  static final int txFailuresId;
+  static final int txRollbacksId;
+  static final int txCommitTimeId;
+  static final int txFailureTimeId;
+  static final int txRollbackTimeId;
+  static final int txCommitChangesId;
+  static final int txFailureChangesId;
+  static final int txRollbackChangesId;
+  static final int txConflictCheckTimeId;
 
-  protected static final int reliableQueuedOpsId;
-  protected static final int reliableQueueSizeId;
-  protected static final int reliableQueueMaxId;
-  protected static final int reliableRegionsId;
-  protected static final int reliableRegionsMissingId;
-  protected static final int reliableRegionsQueuingId;
-  protected static final int reliableRegionsMissingFullAccessId;
-  protected static final int reliableRegionsMissingLimitedAccessId;
-  protected static final int reliableRegionsMissingNoAccessId;
-  protected static final int entryCountId;
+  static final int reliableQueuedOpsId;
+  static final int reliableQueueSizeId;
+  static final int reliableQueueMaxId;
+  static final int reliableRegionsId;
+  static final int reliableRegionsMissingId;
+  static final int reliableRegionsQueuingId;
+  static final int reliableRegionsMissingFullAccessId;
+  static final int reliableRegionsMissingLimitedAccessId;
+  static final int reliableRegionsMissingNoAccessId;
+  static final int entryCountId;
   protected static final int eventsQueuedId;
-  protected static final int retriesId;
+  static final int retriesId;
 
-  protected static final int diskTasksWaitingId;
-  protected static final int evictorJobsStartedId;
-  protected static final int evictorJobsCompletedId;
-  protected static final int evictorQueueSizeId;
+  static final int diskTasksWaitingId;
+  static final int evictorJobsStartedId;
+  static final int evictorJobsCompletedId;
+  static final int evictorQueueSizeId;
 
-  protected static final int evictWorkTimeId;
+  static final int evictWorkTimeId;
 
-  protected static final int indexUpdateInProgressId;
-  protected static final int indexUpdateCompletedId;
-  protected static final int indexUpdateTimeId;
-  protected static final int clearsId;
-  protected static final int indexInitializationInProgressId;
-  protected static final int indexInitializationCompletedId;
-  protected static final int indexInitializationTimeId;
+  static final int indexUpdateInProgressId;
+  static final int indexUpdateCompletedId;
+  static final int indexUpdateTimeId;
+  static final int clearsId;
+  private static final int indexInitializationInProgressId;
+  private static final int indexInitializationCompletedId;
+  private static final int indexInitializationTimeId;
 
   /** Id of the meta data refresh statistic */
-  protected static final int metaDataRefreshCountId;
+  static final int metaDataRefreshCountId;
 
-  protected static final int conflatedEventsId;
-  protected static final int tombstoneCountId;
-  protected static final int tombstoneGCCountId;
-  protected static final int tombstoneOverhead1Id;
-  protected static final int tombstoneOverhead2Id;
-  protected static final int clearTimeoutsId;
+  static final int conflatedEventsId;
+  static final int tombstoneCountId;
+  static final int tombstoneGCCountId;
+  private static final int tombstoneOverhead1Id;
+  private static final int tombstoneOverhead2Id;
+  static final int clearTimeoutsId;
 
-  protected static final int deltaUpdatesId;
-  protected static final int deltaUpdatesTimeId;
-  protected static final int deltaFailedUpdatesId;
+  static final int deltaUpdatesId;
+  private static final int deltaUpdatesTimeId;
+  static final int deltaFailedUpdatesId;
 
-  protected static final int deltasPreparedId;
-  protected static final int deltasPreparedTimeId;
-  protected static final int deltasSentId;
+  static final int deltasPreparedId;
+  private static final int deltasPreparedTimeId;
+  static final int deltasSentId;
 
-  protected static final int deltaFullValuesSentId;
-  protected static final int deltaFullValuesRequestedId;
+  static final int deltaFullValuesSentId;
+  static final int deltaFullValuesRequestedId;
 
-  protected static final int importedEntriesCountId;
-  protected static final int importTimeId;
-  protected static final int exportedEntriesCountId;
-  protected static final int exportTimeId;
+  static final int importedEntriesCountId;
+  static final int importTimeId;
+  static final int exportedEntriesCountId;
+  static final int exportTimeId;
 
-  protected static final int compressionCompressTimeId;
-  protected static final int compressionDecompressTimeId;
-  protected static final int compressionCompressionsId;
-  protected static final int compressionDecompressionsId;
-  protected static final int compressionPreCompressedBytesId;
-  protected static final int compressionPostCompressedBytesId;
+  static final int compressionCompressTimeId;
+  static final int compressionDecompressTimeId;
+  static final int compressionCompressionsId;
+  static final int compressionDecompressionsId;
+  static final int compressionPreCompressedBytesId;
+  static final int compressionPostCompressedBytesId;
 
   static {
     StatisticsTypeFactory f = StatisticsTypeFactoryImpl.singleton();
@@ -653,7 +652,7 @@ public class CachePerfStats {
    * Returns the current NanoTime or, if clock stats are disabled, zero.
    *
    * @since GemFire 5.0
-   * @deprecated Please use instance method cachePerfStats.getClockTime() instead.
+   * @deprecated Please use instance method {@link #getClockTime()} instead.
    */
   @Deprecated
   public static long getStatTime() {
@@ -664,12 +663,8 @@ public class CachePerfStats {
     return type;
   }
 
-  public long getClockTime() {
+  private long getClockTime() {
     return clock.getTime();
-  }
-
-  public int getLoadsInProgress() {
-    return stats.getInt(loadsInProgressId);
   }
 
   public int getLoadsCompleted() {
@@ -680,20 +675,8 @@ public class CachePerfStats {
     return stats.getLong(loadTimeId);
   }
 
-  public int getNetloadsInProgress() {
-    return stats.getInt(netloadsInProgressId);
-  }
-
   public int getNetloadsCompleted() {
     return stats.getInt(netloadsCompletedId);
-  }
-
-  public long getNetloadTime() {
-    return stats.getLong(netloadTimeId);
-  }
-
-  public int getNetsearchesInProgress() {
-    return stats.getInt(netsearchesInProgressId);
   }
 
   public int getNetsearchesCompleted() {
@@ -704,20 +687,12 @@ public class CachePerfStats {
     return stats.getLong(netsearchTimeId);
   }
 
-  public int getGetInitialImagesInProgress() {
-    return stats.getInt(getInitialImagesInProgressId);
-  }
-
   public int getGetInitialImagesCompleted() {
     return stats.getInt(getInitialImagesCompletedId);
   }
 
-  public int getDeltaGetInitialImagesCompleted() {
+  int getDeltaGetInitialImagesCompleted() {
     return stats.getInt(deltaGetInitialImagesCompletedId);
-  }
-
-  public long getGetInitialImageTime() {
-    return stats.getLong(getInitialImageTimeId);
   }
 
   public int getGetInitialImageKeysReceived() {
@@ -726,10 +701,6 @@ public class CachePerfStats {
 
   public int getRegions() {
     return stats.getInt(regionsId);
-  }
-
-  public int getPartitionedRegions() {
-    return stats.getInt(partitionedRegionsId);
   }
 
   public int getDestroys() {
@@ -752,7 +723,7 @@ public class CachePerfStats {
     return stats.getInt(putallsId);
   }
 
-  public int getRemoveAlls() {
+  int getRemoveAlls() {
     return stats.getInt(removeAllsId);
   }
 
@@ -784,24 +755,12 @@ public class CachePerfStats {
     stats.incInt(reliableQueuedOpsId, inc);
   }
 
-  public int getReliableQueueSize() {
-    return stats.getInt(reliableQueueSizeId);
-  }
-
   public void incReliableQueueSize(int inc) {
     stats.incInt(reliableQueueSizeId, inc);
   }
 
-  public int getReliableQueueMax() {
-    return stats.getInt(reliableQueueMaxId);
-  }
-
   public void incReliableQueueMax(int inc) {
     stats.incInt(reliableQueueMaxId, inc);
-  }
-
-  public int getReliableRegions() {
-    return stats.getInt(reliableRegionsId);
   }
 
   public void incReliableRegions(int inc) {
@@ -814,10 +773,6 @@ public class CachePerfStats {
 
   public void incReliableRegionsMissing(int inc) {
     stats.incInt(reliableRegionsMissingId, inc);
-  }
-
-  public int getReliableRegionsQueuing() {
-    return stats.getInt(reliableRegionsQueuingId);
   }
 
   public void incReliableRegionsQueuing(int inc) {
@@ -852,15 +807,11 @@ public class CachePerfStats {
     stats.incLong(eventsQueuedId, inc);
   }
 
-  public long getQueuedEvents() {
-    return stats.getInt(eventsQueuedId);
-  }
-
-  public int getDeltaUpdates() {
+  int getDeltaUpdates() {
     return stats.getInt(deltaUpdatesId);
   }
 
-  public long getDeltaUpdatesTime() {
+  long getDeltaUpdatesTime() {
     return stats.getLong(deltaUpdatesTimeId);
   }
 
@@ -868,11 +819,11 @@ public class CachePerfStats {
     return stats.getInt(deltaFailedUpdatesId);
   }
 
-  public int getDeltasPrepared() {
+  int getDeltasPrepared() {
     return stats.getInt(deltasPreparedId);
   }
 
-  public long getDeltasPreparedTime() {
+  long getDeltasPreparedTime() {
     return stats.getLong(deltasPreparedTimeId);
   }
 
@@ -884,7 +835,7 @@ public class CachePerfStats {
     return stats.getInt(deltaFullValuesSentId);
   }
 
-  public int getDeltaFullValuesRequested() {
+  int getDeltaFullValuesRequested() {
     return stats.getInt(deltaFullValuesRequestedId);
   }
 
@@ -1014,7 +965,7 @@ public class CachePerfStats {
     stats.incInt(cacheWriterCallsCompletedId, 1);
   }
 
-  public int getCacheWriterCallsCompleted() {
+  int getCacheWriterCallsCompleted() {
     return stats.getInt(cacheWriterCallsCompletedId);
   }
 
@@ -1039,7 +990,7 @@ public class CachePerfStats {
     stats.incInt(cacheListenerCallsCompletedId, 1);
   }
 
-  public int getCacheListenerCallsCompleted() {
+  int getCacheListenerCallsCompleted() {
     return stats.getInt(cacheListenerCallsCompletedId);
   }
 
@@ -1072,7 +1023,7 @@ public class CachePerfStats {
     stats.incInt(getInitialImagesInProgressId, -1);
   }
 
-  public void incDeltaGIICompleted() {
+  void incDeltaGIICompleted() {
     stats.incInt(deltaGetInitialImagesCompletedId, 1);
   }
 
@@ -1092,16 +1043,16 @@ public class CachePerfStats {
     stats.incInt(indexUpdateCompletedId, 1);
   }
 
-  public int getIndexUpdateCompleted() {
+  int getIndexUpdateCompleted() {
     return stats.getInt(indexUpdateCompletedId);
   }
 
-  public long startIndexInitialization() {
+  long startIndexInitialization() {
     stats.incInt(indexInitializationInProgressId, 1);
     return getClockTime();
   }
 
-  public void endIndexInitialization(long start) {
+  void endIndexInitialization(long start) {
     long ts = getClockTime();
     stats.incLong(indexInitializationTimeId, ts - start);
     stats.incInt(indexInitializationInProgressId, -1);
@@ -1281,7 +1232,7 @@ public class CachePerfStats {
     stats.incLong(txRollbackLifeTimeId, txLifeTime);
   }
 
-  public void endDeltaUpdate(long start) {
+  void endDeltaUpdate(long start) {
     stats.incInt(deltaUpdatesId, 1);
     if (enableClockStats) {
       stats.incLong(deltaUpdatesTimeId, getClockTime() - start);
@@ -1374,7 +1325,7 @@ public class CachePerfStats {
     stats.incInt(diskTasksWaitingId, -1);
   }
 
-  public int getDiskTasksWaiting() {
+  int getDiskTasksWaiting() {
     return stats.getInt(diskTasksWaitingId);
   }
 
@@ -1386,7 +1337,7 @@ public class CachePerfStats {
     stats.incInt(evictorJobsStartedId, 1);
   }
 
-  public int getEvictorJobsStarted() {
+  int getEvictorJobsStarted() {
     return stats.getInt(evictorJobsStartedId);
   }
 
@@ -1394,7 +1345,7 @@ public class CachePerfStats {
     stats.incInt(evictorJobsCompletedId, 1);
   }
 
-  public int getEvictorJobsCompleted() {
+  int getEvictorJobsCompleted() {
     return stats.getInt(evictorJobsCompletedId);
   }
 
@@ -1467,20 +1418,12 @@ public class CachePerfStats {
     stats.incInt(tombstoneGCCountId, 1);
   }
 
-  public void setReplicatedTombstonesSize(long size) {
+  void setReplicatedTombstonesSize(long size) {
     stats.setLong(tombstoneOverhead1Id, size);
   }
 
-  public long getReplicatedTombstonesSize() {
-    return stats.getLong(tombstoneOverhead1Id);
-  }
-
-  public void setNonReplicatedTombstonesSize(long size) {
+  void setNonReplicatedTombstonesSize(long size) {
     stats.setLong(tombstoneOverhead2Id, size);
-  }
-
-  public long getNonReplicatedTombstonesSize() {
-    return stats.getLong(tombstoneOverhead2Id);
   }
 
   public int getClearTimeouts() {
@@ -1495,7 +1438,7 @@ public class CachePerfStats {
     stats.incLong(partitionedRegionQueryRetriesId, 1);
   }
 
-  public long getPRQueryRetries() {
+  long getPRQueryRetries() {
     return stats.getLong(partitionedRegionQueryRetriesId);
   }
 
@@ -1522,16 +1465,8 @@ public class CachePerfStats {
     stats.incLong(metaDataRefreshCountId, 1);
   }
 
-  public long getMetaDataRefreshCount() {
+  long getMetaDataRefreshCount() {
     return stats.getLong(metaDataRefreshCountId);
-  }
-
-  public long getImportedEntriesCount() {
-    return stats.getLong(importedEntriesCountId);
-  }
-
-  public long getImportTime() {
-    return stats.getLong(importTimeId);
   }
 
   public void endImport(long entryCount, long start) {
@@ -1539,14 +1474,6 @@ public class CachePerfStats {
     if (enableClockStats) {
       stats.incLong(importTimeId, getClockTime() - start);
     }
-  }
-
-  public long getExportedEntriesCount() {
-    return stats.getLong(exportedEntriesCountId);
-  }
-
-  public long getExportTime() {
-    return stats.getLong(exportTimeId);
   }
 
   public void endExport(long entryCount, long start) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -20,6 +20,7 @@ import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.QueueStatHelper;
 import org.apache.geode.internal.NanoTimer;
@@ -29,9 +30,7 @@ import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
  * CachePerfStats tracks statistics about GemFire cache performance.
  */
 public class CachePerfStats {
-  public static boolean enableClockStats = false;
-
-  ////////////////// Static fields ///////////////////////////
+  public static boolean enableClockStats;
 
   private static final StatisticsType type;
 
@@ -115,7 +114,6 @@ public class CachePerfStats {
 
   protected static final int evictWorkTimeId;
 
-
   protected static final int indexUpdateInProgressId;
   protected static final int indexUpdateCompletedId;
   protected static final int indexUpdateTimeId;
@@ -156,11 +154,6 @@ public class CachePerfStats {
   protected static final int compressionDecompressionsId;
   protected static final int compressionPreCompressedBytesId;
   protected static final int compressionPostCompressedBytesId;
-
-  /** The Statistics object that we delegate most behavior to */
-  protected final Statistics stats;
-
-  //////////////////////// Static methods ////////////////////////
 
   static {
     StatisticsTypeFactory f = StatisticsTypeFactoryImpl.singleton();
@@ -324,25 +317,20 @@ public class CachePerfStats {
         "The total number of bytes before compressing.";
     final String compressionPostCompressedBytesDesc =
         "The total number of bytes after compressing.";
-    final String evictByCriteria_evictionsDesc = "The total number of entries evicted";// total
-                                                                                       // actual
-                                                                                       // evictions
-                                                                                       // (entries
-                                                                                       // evicted)
-    final String evictByCriteria_evictionTimeDesc = "Time taken for eviction process";// total
-                                                                                      // eviction
-                                                                                      // time
-                                                                                      // including
-                                                                                      // product +
-                                                                                      // user expr.
+
+    // total actual evictions (entries evicted)
+    final String evictByCriteria_evictionsDesc = "The total number of entries evicted";
+
+    // total eviction time including product + user expr.
+    final String evictByCriteria_evictionTimeDesc = "Time taken for eviction process";
     final String evictByCriteria_evictionsInProgressDesc = "Total number of evictions in progress";
-    final String evictByCriteria_evaluationsDesc = "Total number of evaluations for eviction";// total
-                                                                                              // eviction
-                                                                                              // attempts
+
+    // total eviction attempts
+    final String evictByCriteria_evaluationsDesc = "Total number of evaluations for eviction";
+
+    // time taken to evaluate user expression.
     final String evictByCriteria_evaluationTimeDesc =
-        "Total time taken for evaluation of user expression during eviction";// time taken to
-                                                                             // evaluate user
-                                                                             // expression.
+        "Total time taken for evaluation of user expression during eviction";
 
     type = f.createType("CachePerfStats", "Statistics about GemFire cache performance",
         new StatisticDescriptor[] {
@@ -505,7 +493,6 @@ public class CachePerfStats {
             f.createLongCounter("evictByCriteria_evaluationTime",
                 evictByCriteria_evaluationTimeDesc, "nanoseconds")});
 
-    // Initialize id fields
     loadsInProgressId = type.nameToId("loadsInProgress");
     loadsCompletedId = type.nameToId("loadsCompleted");
     loadTimeId = type.nameToId("loadTime");
@@ -627,13 +614,17 @@ public class CachePerfStats {
     compressionPostCompressedBytesId = type.nameToId("postCompressedBytes");
   }
 
-  //////////////////////// Constructors ////////////////////////
+  /** The Statistics object that we delegate most behavior to */
+  protected final Statistics stats;
+
+  private final Clock clock;
 
   /**
    * Created specially for bug 39348. Should not be invoked in any other case.
    */
   public CachePerfStats() {
     stats = null;
+    clock = () -> enableClockStats ? NanoTimer.getTime() : 0;
   }
 
   /**
@@ -641,27 +632,41 @@ public class CachePerfStats {
    * factory.
    */
   public CachePerfStats(StatisticsFactory factory) {
-    stats = factory.createAtomicStatistics(type, "cachePerfStats");
+    this(factory, "cachePerfStats", () -> enableClockStats ? NanoTimer.getTime() : 0);
   }
 
   /**
    * Creates a new <code>CachePerfStats</code> and registers itself with the given statistics
    * factory.
    */
-  public CachePerfStats(StatisticsFactory factory, String name) {
-    stats = factory.createAtomicStatistics(type, "RegionStats-" + name);
+  public CachePerfStats(StatisticsFactory factory, String regionName) {
+    this(factory, "RegionStats-" + regionName, () -> enableClockStats ? NanoTimer.getTime() : 0);
+  }
+
+  @VisibleForTesting
+  CachePerfStats(StatisticsFactory factory, String textId, Clock clock) {
+    stats = factory.createAtomicStatistics(type, textId);
+    this.clock = clock;
   }
 
   /**
    * Returns the current NanoTime or, if clock stats are disabled, zero.
    *
    * @since GemFire 5.0
+   * @deprecated Please use instance method cachePerfStats.getClockTime() instead.
    */
+  @Deprecated
   public static long getStatTime() {
     return enableClockStats ? NanoTimer.getTime() : 0;
   }
 
-  ////////////////////// Accessing Stats //////////////////////
+  public static StatisticsType getStatisticsType() {
+    return type;
+  }
+
+  public long getClockTime() {
+    return clock.getTime();
+  }
 
   public int getLoadsInProgress() {
     return stats.getInt(loadsInProgressId);
@@ -739,6 +744,10 @@ public class CachePerfStats {
     return stats.getInt(putsId);
   }
 
+  public long getPutTime() {
+    return stats.getLong(putTimeId);
+  }
+
   public int getPutAlls() {
     return stats.getInt(putallsId);
   }
@@ -757,6 +766,10 @@ public class CachePerfStats {
 
   public int getGets() {
     return stats.getInt(getsId);
+  }
+
+  public long getGetTime() {
+    return stats.getLong(getTimeId);
   }
 
   public int getMisses() {
@@ -836,11 +849,11 @@ public class CachePerfStats {
   }
 
   public void incQueuedEvents(int inc) {
-    this.stats.incLong(eventsQueuedId, inc);
+    stats.incLong(eventsQueuedId, inc);
   }
 
   public long getQueuedEvents() {
-    return this.stats.getInt(eventsQueuedId);
+    return stats.getInt(eventsQueuedId);
   }
 
   public int getDeltaUpdates() {
@@ -899,16 +912,14 @@ public class CachePerfStats {
     return stats.getLong(compressionPostCompressedBytesId);
   }
 
-  ////////////////////// Updating Stats //////////////////////
-
   public long startCompression() {
     stats.incLong(compressionCompressionsId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   public void endCompression(long startTime, long startSize, long endSize) {
     if (enableClockStats) {
-      stats.incLong(compressionCompressTimeId, getStatTime() - startTime);
+      stats.incLong(compressionCompressTimeId, getClockTime() - startTime);
     }
     stats.incLong(compressionPreCompressedBytesId, startSize);
     stats.incLong(compressionPostCompressedBytesId, endSize);
@@ -916,12 +927,12 @@ public class CachePerfStats {
 
   public long startDecompression() {
     stats.incLong(compressionDecompressionsId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   public void endDecompression(long startTime) {
     if (enableClockStats) {
-      stats.incLong(compressionDecompressTimeId, getStatTime() - startTime);
+      stats.incLong(compressionDecompressTimeId, getClockTime() - startTime);
     }
   }
 
@@ -950,7 +961,7 @@ public class CachePerfStats {
    */
   public long startNetload() {
     stats.incInt(netloadsInProgressId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   /**
@@ -958,7 +969,7 @@ public class CachePerfStats {
    */
   public void endNetload(long start) {
     if (enableClockStats) {
-      stats.incLong(netloadTimeId, getStatTime() - start);
+      stats.incLong(netloadTimeId, getClockTime() - start);
     }
     stats.incInt(netloadsInProgressId, -1);
     stats.incInt(netloadsCompletedId, 1);
@@ -989,7 +1000,7 @@ public class CachePerfStats {
    */
   public long startCacheWriterCall() {
     stats.incInt(cacheWriterCallsInProgressId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   /**
@@ -997,10 +1008,14 @@ public class CachePerfStats {
    */
   public void endCacheWriterCall(long start) {
     if (enableClockStats) {
-      stats.incLong(cacheWriterCallTimeId, getStatTime() - start);
+      stats.incLong(cacheWriterCallTimeId, getClockTime() - start);
     }
     stats.incInt(cacheWriterCallsInProgressId, -1);
     stats.incInt(cacheWriterCallsCompletedId, 1);
+  }
+
+  public int getCacheWriterCallsCompleted() {
+    return stats.getInt(cacheWriterCallsCompletedId);
   }
 
   /**
@@ -1009,7 +1024,7 @@ public class CachePerfStats {
    */
   public long startCacheListenerCall() {
     stats.incInt(cacheListenerCallsInProgressId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   /**
@@ -1018,10 +1033,14 @@ public class CachePerfStats {
    */
   public void endCacheListenerCall(long start) {
     if (enableClockStats) {
-      stats.incLong(cacheListenerCallTimeId, getStatTime() - start);
+      stats.incLong(cacheListenerCallTimeId, getClockTime() - start);
     }
     stats.incInt(cacheListenerCallsInProgressId, -1);
     stats.incInt(cacheListenerCallsCompletedId, 1);
+  }
+
+  public int getCacheListenerCallsCompleted() {
+    return stats.getInt(cacheListenerCallsCompletedId);
   }
 
   /**
@@ -1029,7 +1048,7 @@ public class CachePerfStats {
    */
   public long startGetInitialImage() {
     stats.incInt(getInitialImagesInProgressId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   /**
@@ -1037,7 +1056,7 @@ public class CachePerfStats {
    */
   public void endGetInitialImage(long start) {
     if (enableClockStats) {
-      stats.incLong(getInitialImageTimeId, getStatTime() - start);
+      stats.incLong(getInitialImageTimeId, getClockTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
     stats.incInt(getInitialImagesCompletedId, 1);
@@ -1048,7 +1067,7 @@ public class CachePerfStats {
    */
   public void endNoGIIDone(long start) {
     if (enableClockStats) {
-      stats.incLong(getInitialImageTimeId, getStatTime() - start);
+      stats.incLong(getInitialImageTimeId, getClockTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
   }
@@ -1063,23 +1082,27 @@ public class CachePerfStats {
 
   public long startIndexUpdate() {
     stats.incInt(indexUpdateInProgressId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   public void endIndexUpdate(long start) {
-    long ts = getStatTime();
+    long ts = getClockTime();
     stats.incLong(indexUpdateTimeId, ts - start);
     stats.incInt(indexUpdateInProgressId, -1);
     stats.incInt(indexUpdateCompletedId, 1);
   }
 
+  public int getIndexUpdateCompleted() {
+    return stats.getInt(indexUpdateCompletedId);
+  }
+
   public long startIndexInitialization() {
     stats.incInt(indexInitializationInProgressId, 1);
-    return getStatTime();
+    return getClockTime();
   }
 
   public void endIndexInitialization(long start) {
-    long ts = getStatTime();
+    long ts = getClockTime();
     stats.incLong(indexInitializationTimeId, ts - start);
     stats.incInt(indexInitializationInProgressId, -1);
     stats.incInt(indexInitializationCompletedId, 1);
@@ -1113,7 +1136,7 @@ public class CachePerfStats {
    * @return the timestamp that marks the start of the operation
    */
   public long startGet() {
-    return getStatTime();
+    return getClockTime();
   }
 
   /**
@@ -1121,7 +1144,8 @@ public class CachePerfStats {
    */
   public void endGet(long start, boolean miss) {
     if (enableClockStats) {
-      stats.incLong(getTimeId, getStatTime() - start);
+      long delta = getClockTime() - start;
+      stats.incLong(getTimeId, delta);
     }
     stats.incInt(getsId, 1);
     if (miss) {
@@ -1138,13 +1162,13 @@ public class CachePerfStats {
     if (isUpdate) {
       stats.incInt(updatesId, 1);
       if (enableClockStats) {
-        total = getStatTime() - start;
+        total = getClockTime() - start;
         stats.incLong(updateTimeId, total);
       }
     } else {
       stats.incInt(putsId, 1);
       if (enableClockStats) {
-        total = getStatTime() - start;
+        total = getClockTime() - start;
         stats.incLong(putTimeId, total);
       }
     }
@@ -1154,13 +1178,13 @@ public class CachePerfStats {
   public void endPutAll(long start) {
     stats.incInt(putallsId, 1);
     if (enableClockStats)
-      stats.incLong(putallTimeId, getStatTime() - start);
+      stats.incLong(putallTimeId, getClockTime() - start);
   }
 
   public void endRemoveAll(long start) {
     stats.incInt(removeAllsId, 1);
     if (enableClockStats)
-      stats.incLong(removeAllTimeId, getStatTime() - start);
+      stats.incLong(removeAllTimeId, getClockTime() - start);
   }
 
   public void endQueryExecution(long executionTime) {
@@ -1170,9 +1194,13 @@ public class CachePerfStats {
     }
   }
 
+  public int getQueryExecutions() {
+    return stats.getInt(queryExecutionsId);
+  }
+
   public void endQueryResultsHashCollisionProbe(long start) {
     if (enableClockStats) {
-      stats.incLong(queryResultsHashCollisionProbeTimeId, getStatTime() - start);
+      stats.incLong(queryResultsHashCollisionProbeTimeId, getClockTime() - start);
     }
   }
 
@@ -1256,7 +1284,7 @@ public class CachePerfStats {
   public void endDeltaUpdate(long start) {
     stats.incInt(deltaUpdatesId, 1);
     if (enableClockStats) {
-      stats.incLong(deltaUpdatesTimeId, getStatTime() - start);
+      stats.incLong(deltaUpdatesTimeId, getClockTime() - start);
     }
   }
 
@@ -1267,7 +1295,7 @@ public class CachePerfStats {
   public void endDeltaPrepared(long start) {
     stats.incInt(deltasPreparedId, 1);
     if (enableClockStats) {
-      stats.incLong(deltasPreparedTimeId, getStatTime() - start);
+      stats.incLong(deltasPreparedTimeId, getClockTime() - start);
     }
   }
 
@@ -1290,7 +1318,7 @@ public class CachePerfStats {
    * @since GemFire 3.5
    */
   void close() {
-    this.stats.close();
+    stats.close();
   }
 
   /**
@@ -1299,71 +1327,83 @@ public class CachePerfStats {
    * @since GemFire 3.5
    */
   public boolean isClosed() {
-    return this.stats.isClosed();
+    return stats.isClosed();
   }
 
   public int getEventQueueSize() {
-    return this.stats.getInt(eventQueueSizeId);
+    return stats.getInt(eventQueueSizeId);
   }
 
   public void incEventQueueSize(int items) {
-    this.stats.incInt(eventQueueSizeId, items);
+    stats.incInt(eventQueueSizeId, items);
   }
 
   public void incEventQueueThrottleCount(int items) {
-    this.stats.incInt(eventQueueThrottleCountId, items);
+    stats.incInt(eventQueueThrottleCountId, items);
   }
 
   protected void incEventQueueThrottleTime(long nanos) {
-    this.stats.incLong(eventQueueThrottleTimeId, nanos);
+    stats.incLong(eventQueueThrottleTimeId, nanos);
   }
 
   protected void incEventThreads(int items) {
-    this.stats.incInt(eventThreadsId, items);
+    stats.incInt(eventThreadsId, items);
   }
 
   public void incEntryCount(int delta) {
-    this.stats.incLong(entryCountId, delta);
+    stats.incLong(entryCountId, delta);
   }
 
   public long getEntries() {
-    return this.stats.getLong(entryCountId);
+    return stats.getLong(entryCountId);
   }
 
   public void incRetries() {
-    this.stats.incInt(retriesId, 1);
+    stats.incInt(retriesId, 1);
+  }
+
+  public int getRetries() {
+    return stats.getInt(retriesId);
   }
 
   public void incDiskTasksWaiting() {
-    this.stats.incInt(diskTasksWaitingId, 1);
+    stats.incInt(diskTasksWaitingId, 1);
   }
 
   public void decDiskTasksWaiting() {
-    this.stats.incInt(diskTasksWaitingId, -1);
+    stats.incInt(diskTasksWaitingId, -1);
   }
 
   public int getDiskTasksWaiting() {
-    return this.stats.getInt(diskTasksWaitingId);
+    return stats.getInt(diskTasksWaitingId);
   }
 
   public void decDiskTasksWaiting(int count) {
-    this.stats.incInt(diskTasksWaitingId, -count);
+    stats.incInt(diskTasksWaitingId, -count);
   }
 
   public void incEvictorJobsStarted() {
-    this.stats.incInt(evictorJobsStartedId, 1);
+    stats.incInt(evictorJobsStartedId, 1);
+  }
+
+  public int getEvictorJobsStarted() {
+    return stats.getInt(evictorJobsStartedId);
   }
 
   public void incEvictorJobsCompleted() {
-    this.stats.incInt(evictorJobsCompletedId, 1);
+    stats.incInt(evictorJobsCompletedId, 1);
+  }
+
+  public int getEvictorJobsCompleted() {
+    return stats.getInt(evictorJobsCompletedId);
   }
 
   public void incEvictorQueueSize(int delta) {
-    this.stats.incInt(evictorQueueSizeId, delta);
+    stats.incInt(evictorQueueSizeId, delta);
   }
 
   public void incEvictWorkTime(long delta) {
-    this.stats.incLong(evictWorkTimeId, delta);
+    stats.incLong(evictWorkTimeId, delta);
   }
 
   /**
@@ -1372,33 +1412,9 @@ public class CachePerfStats {
    * @since GemFire 3.5
    */
   public Statistics getStats() {
-    return this.stats;
+    return stats;
   }
 
-  // /**
-  // * Returns a helper object so that the event queue can record its
-  // * stats to the proper cache perf stats.
-  // * @since GemFire 3.5
-  // */
-  // public ThrottledQueueStatHelper getEventQueueHelper() {
-  // return new ThrottledQueueStatHelper() {
-  // public void incThrottleCount() {
-  // incEventQueueThrottleCount(1);
-  // }
-  // public void throttleTime(long nanos) {
-  // incEventQueueThrottleTime(nanos);
-  // }
-  // public void add() {
-  // incEventQueueSize(1);
-  // }
-  // public void remove() {
-  // incEventQueueSize(-1);
-  // }
-  // public void remove(int count) {
-  // incEventQueueSize(-count);
-  // }
-  // };
-  // }
   /**
    * Returns a helper object so that the event pool can record its stats to the proper cache perf
    * stats.
@@ -1424,7 +1440,7 @@ public class CachePerfStats {
   }
 
   public void incClearCount() {
-    this.stats.incInt(clearsId, 1);
+    stats.incInt(clearsId, 1);
   }
 
   public long getConflatedEventsCount() {
@@ -1432,55 +1448,55 @@ public class CachePerfStats {
   }
 
   public void incConflatedEventsCount() {
-    this.stats.incLong(conflatedEventsId, 1);
+    stats.incLong(conflatedEventsId, 1);
   }
 
   public int getTombstoneCount() {
-    return this.stats.getInt(tombstoneCountId);
+    return stats.getInt(tombstoneCountId);
   }
 
   public void incTombstoneCount(int amount) {
-    this.stats.incInt(tombstoneCountId, amount);
+    stats.incInt(tombstoneCountId, amount);
   }
 
   public int getTombstoneGCCount() {
-    return this.stats.getInt(tombstoneGCCountId);
+    return stats.getInt(tombstoneGCCountId);
   }
 
   public void incTombstoneGCCount() {
-    this.stats.incInt(tombstoneGCCountId, 1);
+    stats.incInt(tombstoneGCCountId, 1);
   }
 
   public void setReplicatedTombstonesSize(long size) {
-    this.stats.setLong(tombstoneOverhead1Id, size);
+    stats.setLong(tombstoneOverhead1Id, size);
   }
 
   public long getReplicatedTombstonesSize() {
-    return this.stats.getLong(tombstoneOverhead1Id);
+    return stats.getLong(tombstoneOverhead1Id);
   }
 
   public void setNonReplicatedTombstonesSize(long size) {
-    this.stats.setLong(tombstoneOverhead2Id, size);
+    stats.setLong(tombstoneOverhead2Id, size);
   }
 
   public long getNonReplicatedTombstonesSize() {
-    return this.stats.getLong(tombstoneOverhead2Id);
+    return stats.getLong(tombstoneOverhead2Id);
   }
 
   public int getClearTimeouts() {
-    return this.stats.getInt(clearTimeoutsId);
+    return stats.getInt(clearTimeoutsId);
   }
 
   public void incClearTimeouts() {
-    this.stats.incInt(clearTimeoutsId, 1);
+    stats.incInt(clearTimeoutsId, 1);
   }
 
   public void incPRQueryRetries() {
-    this.stats.incLong(partitionedRegionQueryRetriesId, 1);
+    stats.incLong(partitionedRegionQueryRetriesId, 1);
   }
 
   public long getPRQueryRetries() {
-    return this.stats.getLong(partitionedRegionQueryRetriesId);
+    return stats.getLong(partitionedRegionQueryRetriesId);
   }
 
   public QueueStatHelper getEvictionQueueStatHelper() {
@@ -1503,11 +1519,11 @@ public class CachePerfStats {
   }
 
   public void incMetaDataRefreshCount() {
-    this.stats.incLong(metaDataRefreshCountId, 1);
+    stats.incLong(metaDataRefreshCountId, 1);
   }
 
   public long getMetaDataRefreshCount() {
-    return this.stats.getLong(metaDataRefreshCountId);
+    return stats.getLong(metaDataRefreshCountId);
   }
 
   public long getImportedEntriesCount() {
@@ -1521,7 +1537,7 @@ public class CachePerfStats {
   public void endImport(long entryCount, long start) {
     stats.incLong(importedEntriesCountId, entryCount);
     if (enableClockStats) {
-      stats.incLong(importTimeId, getStatTime() - start);
+      stats.incLong(importTimeId, getClockTime() - start);
     }
   }
 
@@ -1536,7 +1552,11 @@ public class CachePerfStats {
   public void endExport(long entryCount, long start) {
     stats.incLong(exportedEntriesCountId, entryCount);
     if (enableClockStats) {
-      stats.incLong(exportTimeId, getStatTime() - start);
+      stats.incLong(exportTimeId, getClockTime() - start);
     }
+  }
+
+  interface Clock {
+    long getTime();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -32,11 +32,6 @@ public class DummyCachePerfStats extends CachePerfStats {
   // //////////////////// Accessing Stats //////////////////////
 
   @Override
-  public int getLoadsInProgress() {
-    return 0;
-  }
-
-  @Override
   public int getLoadsCompleted() {
     return 0;
   }
@@ -47,22 +42,7 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getNetloadsInProgress() {
-    return 0;
-  }
-
-  @Override
   public int getNetloadsCompleted() {
-    return 0;
-  }
-
-  @Override
-  public long getNetloadTime() {
-    return 0;
-  }
-
-  @Override
-  public int getNetsearchesInProgress() {
     return 0;
   }
 
@@ -77,17 +57,7 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getGetInitialImagesInProgress() {
-    return 0;
-  }
-
-  @Override
   public int getGetInitialImagesCompleted() {
-    return 0;
-  }
-
-  @Override
-  public long getGetInitialImageTime() {
     return 0;
   }
 
@@ -98,11 +68,6 @@ public class DummyCachePerfStats extends CachePerfStats {
 
   @Override
   public int getRegions() {
-    return 0;
-  }
-
-  @Override
-  public int getPartitionedRegions() {
     return 0;
   }
 
@@ -155,25 +120,10 @@ public class DummyCachePerfStats extends CachePerfStats {
   public void incReliableQueuedOps(int inc) {}
 
   @Override
-  public int getReliableQueueSize() {
-    return 0;
-  }
-
-  @Override
   public void incReliableQueueSize(int inc) {}
 
   @Override
-  public int getReliableQueueMax() {
-    return 0;
-  }
-
-  @Override
   public void incReliableQueueMax(int inc) {}
-
-  @Override
-  public int getReliableRegions() {
-    return 0;
-  }
 
   @Override
   public void incReliableRegions(int inc) {}
@@ -185,11 +135,6 @@ public class DummyCachePerfStats extends CachePerfStats {
 
   @Override
   public void incReliableRegionsMissing(int inc) {}
-
-  @Override
-  public int getReliableRegionsQueuing() {
-    return 0;
-  }
 
   @Override
   public void incReliableRegionsQueuing(int inc) {}
@@ -220,11 +165,6 @@ public class DummyCachePerfStats extends CachePerfStats {
 
   @Override
   public void incQueuedEvents(int inc) {}
-
-  @Override
-  public long getQueuedEvents() {
-    return 0;
-  }
 
   // //////////////////// Updating Stats //////////////////////
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -103,6 +103,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getPuts()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code puts} is to invoke
+   * {@code endPut}.
+   */
   @Test
   public void endPutIncrementsPuts() {
     cachePerfStats.endPut(0, false);
@@ -110,6 +114,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(putsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code puts} currently wraps to negative from max integer value.
+   */
   @Test
   public void putsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(putsId, Integer.MAX_VALUE);
@@ -126,6 +133,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getGets()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code gets} is to invoke
+   * {@code endGet}.
+   */
   @Test
   public void endGetIncrementsGets() {
     cachePerfStats.endGet(0, false);
@@ -133,6 +144,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(getsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code gets} currently wraps to negative from max integer value.
+   */
   @Test
   public void getsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(getsId, Integer.MAX_VALUE);
@@ -150,6 +164,10 @@ public class CachePerfStatsTest {
 
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code putTime} is to invoke
+   * {@code endPut}.
+   */
   @Test
   public void endPutIncrementsPutTime() {
     cachePerfStats.endPut(0, false);
@@ -165,6 +183,10 @@ public class CachePerfStatsTest {
 
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code getTime} is to invoke
+   * {@code endGet}.
+   */
   @Test
   public void endGetIncrementsGetTime() {
     cachePerfStats.endGet(0, false);
@@ -186,6 +208,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(destroysId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code destroys} currently wraps to negative from max integer value.
+   */
   @Test
   public void destroysWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(destroysId, Integer.MAX_VALUE);
@@ -209,6 +234,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(createsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code creates} currently wraps to negative from max integer value.
+   */
   @Test
   public void createsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(createsId, Integer.MAX_VALUE);
@@ -225,6 +253,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getPutAlls()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code putalls} is to invoke
+   * {@code endPutAll}.
+   */
   @Test
   public void endPutAllIncrementsDestroys() {
     cachePerfStats.endPutAll(0);
@@ -232,6 +264,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(putallsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code putAlls} currently wraps to negative from max integer value.
+   */
   @Test
   public void putAllsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(putallsId, Integer.MAX_VALUE);
@@ -248,6 +283,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getRemoveAlls()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code removeAlls} is to invoke
+   * {@code endRemoveAll}.
+   */
   @Test
   public void endRemoveAllIncrementsDestroys() {
     cachePerfStats.endRemoveAll(0);
@@ -255,6 +294,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(removeAllsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code removeAlls} currently wraps to negative from max integer value.
+   */
   @Test
   public void removeAllsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(removeAllsId, Integer.MAX_VALUE);
@@ -271,6 +313,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getUpdates()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code updates} is to invoke
+   * {@code endPut}.
+   */
   @Test
   public void endPutIncrementsUpdates() {
     cachePerfStats.endPut(0, true);
@@ -278,6 +324,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(updatesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code updates} currently wraps to negative from max integer value.
+   */
   @Test
   public void updatesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(updatesId, Integer.MAX_VALUE);
@@ -301,6 +350,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(invalidatesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code invalidates} currently wraps to negative from max integer value.
+   */
   @Test
   public void invalidatesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(invalidatesId, Integer.MAX_VALUE);
@@ -317,6 +369,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getMisses()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code misses} is to invoke
+   * {@code endGet}.
+   */
   @Test
   public void endGetIncrementsMisses() {
     cachePerfStats.endGet(0, true);
@@ -324,6 +380,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(missesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code misses} currently wraps to negative from max integer value.
+   */
   @Test
   public void missesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(missesId, Integer.MAX_VALUE);
@@ -347,6 +406,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(retriesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code retries} currently wraps to negative from max integer value.
+   */
   @Test
   public void retriesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(retriesId, Integer.MAX_VALUE);
@@ -370,6 +432,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(clearsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code clears} currently wraps to negative from max integer value.
+   */
   @Test
   public void clearsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(clearsId, Integer.MAX_VALUE);
@@ -386,6 +451,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getLoadsCompleted()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code loadsCompleted} is to invoke
+   * {@code endLoad}.
+   */
   @Test
   public void endLoadIncrementsMisses() {
     cachePerfStats.endLoad(0);
@@ -393,6 +462,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(loadsCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code loads} currently wraps to negative from max integer value.
+   */
   @Test
   public void loadsCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(loadsCompletedId, Integer.MAX_VALUE);
@@ -409,6 +481,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getNetloadsCompleted()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code netloadsCompleted} is to
+   * invoke {@code endNetload}.
+   */
   @Test
   public void endNetloadIncrementsNetloadsCompleted() {
     cachePerfStats.endNetload(0);
@@ -416,6 +492,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(netloadsCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code netloadsComplete} currently wraps to negative from max integer
+   * value.
+   */
   @Test
   public void netloadsCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(netloadsCompletedId, Integer.MAX_VALUE);
@@ -432,6 +512,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getNetsearchesCompleted()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code netsearchesCompleted} is to
+   * invoke {@code endNetsearch}.
+   */
   @Test
   public void endLoadIncrementsNetsearchesCompleted() {
     cachePerfStats.endNetsearch(0);
@@ -439,6 +523,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(netsearchesCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code netsearchesCompleted} currently wraps to negative from max
+   * integer value.
+   */
   @Test
   public void netsearchesCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(netsearchesCompletedId, Integer.MAX_VALUE);
@@ -455,6 +543,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getCacheWriterCallsCompleted()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code cacheWriterCallsCompleted} is
+   * to invoke {@code endCacheWriterCall}.
+   */
   @Test
   public void endCacheWriterCallIncrementsCacheWriterCallsCompleted() {
     cachePerfStats.endCacheWriterCall(0);
@@ -462,8 +554,12 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(cacheWriterCallsCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code cacheWriterCallsCompleted} currently wraps to negative from max
+   * integer value.
+   */
   @Test
-  public void cacheWriterCallsCompletedCompletedWrapsFromMaxIntegerToNegativeValue() {
+  public void cacheWriterCallsCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(cacheWriterCallsCompletedId, Integer.MAX_VALUE);
 
     cachePerfStats.endCacheWriterCall(0);
@@ -478,6 +574,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getCacheListenerCallsCompleted()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code cacheListenerCallsCompleted}
+   * is to invoke {@code endCacheListenerCall}.
+   */
   @Test
   public void endCacheWriterCallIncrementsCacheListenerCallsCompleted() {
     cachePerfStats.endCacheListenerCall(0);
@@ -485,6 +585,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(cacheListenerCallsCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code cacheListenerCallsCompleted} currently wraps to negative from max
+   * integer value.
+   */
   @Test
   public void cacheListenerCallsCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(cacheListenerCallsCompletedId, Integer.MAX_VALUE);
@@ -501,6 +605,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getGetInitialImagesCompleted()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code getInitialImagesCompleted}
+   * is to invoke {@code endGetInitialImage}.
+   */
   @Test
   public void endCacheWriterCallIncrementsGetInitialImagesCompleted() {
     cachePerfStats.endGetInitialImage(0);
@@ -508,6 +616,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(getInitialImagesCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code getInitialImagesCompleted} currently wraps to negative from max
+   * integer value.
+   */
   @Test
   public void getInitialImagesCompletedCallsCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(getInitialImagesCompletedId, Integer.MAX_VALUE);
@@ -531,6 +643,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(deltaGetInitialImagesCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code deltaGetInitialImagesCompleted} currently wraps to negative from
+   * max integer value.
+   */
   @Test
   public void deltaGetInitialImagesCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(deltaGetInitialImagesCompletedId, Integer.MAX_VALUE);
@@ -547,6 +663,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getQueryExecutions()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code queryExecutions} is to invoke
+   * {@code endQueryExecution}.
+   */
   @Test
   public void endQueryExecutionIncrementsQueryExecutions() {
     cachePerfStats.endQueryExecution(1);
@@ -554,6 +674,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(queryExecutionsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code queryExecutions} currently wraps to negative from max integer
+   * value.
+   */
   @Test
   public void queryExecutionsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(queryExecutionsId, Integer.MAX_VALUE);
@@ -570,6 +694,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getTxCommits()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code txCommits} is to invoke
+   * {@code txSuccess}.
+   */
   @Test
   public void txSuccessIncrementsTxCommits() {
     cachePerfStats.txSuccess(1, 1, 1);
@@ -577,6 +705,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(txCommitsId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code txCommits} currently wraps to negative from max integer value.
+   */
   @Test
   public void txCommitsWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(txCommitsId, Integer.MAX_VALUE);
@@ -593,6 +724,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getTxFailures()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code txFailures} is to invoke
+   * {@code txFailure}.
+   */
   @Test
   public void txFailureIncrementsTxFailures() {
     cachePerfStats.txFailure(1, 1, 1);
@@ -600,6 +735,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(txFailuresId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code txFailures} currently wraps to negative from max integer value.
+   */
   @Test
   public void txFailuresWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(txFailuresId, Integer.MAX_VALUE);
@@ -616,6 +754,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getTxRollbacks()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code txRollbacks} is to invoke
+   * {@code txRollback}.
+   */
   @Test
   public void txRollbackIncrementsTxRollbacks() {
     cachePerfStats.txRollback(1, 1, 1);
@@ -623,6 +765,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(txRollbacksId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code txRollbacks} currently wraps to negative from max integer value.
+   */
   @Test
   public void txRollbacksWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(txRollbacksId, Integer.MAX_VALUE);
@@ -639,6 +784,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getTxCommitChanges()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code txCommitChanges} is to invoke
+   * {@code txSuccess}.
+   */
   @Test
   public void txSuccessIncrementsTxCommitChanges() {
     cachePerfStats.txSuccess(1, 1, 1);
@@ -646,6 +795,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(txCommitChangesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code txCommitChanges} currently wraps to negative from max integer
+   * value.
+   */
   @Test
   public void txCommitChangesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(txCommitChangesId, Integer.MAX_VALUE);
@@ -662,6 +815,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getTxFailureChanges()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code txFailureChanges} is to
+   * invoke {@code txFailure}.
+   */
   @Test
   public void txFailureIncrementsTxFailureChanges() {
     cachePerfStats.txFailure(1, 1, 1);
@@ -669,6 +826,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(txFailureChangesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code txFailureChanges} currently wraps to negative from max integer
+   * value.
+   */
   @Test
   public void txFailureChangesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(txFailureChangesId, Integer.MAX_VALUE);
@@ -685,6 +846,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getTxRollbackChanges()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code txRollbackChanges} is to
+   * invoke {@code txRollback}.
+   */
   @Test
   public void txRollbackIncrementsTxRollbackChanges() {
     cachePerfStats.txRollback(1, 1, 1);
@@ -692,6 +857,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(txRollbackChangesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code txRollbackChanges} currently wraps to negative from max integer
+   * value.
+   */
   @Test
   public void txRollbackChangesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(txRollbackChangesId, Integer.MAX_VALUE);
@@ -715,6 +884,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(evictorJobsStartedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code evictorJobsStarted} currently wraps to negative from max integer
+   * value.
+   */
   @Test
   public void evictorJobsStartedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(evictorJobsStartedId, Integer.MAX_VALUE);
@@ -738,6 +911,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(evictorJobsCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code evictorJobsCompleted} currently wraps to negative from max
+   * integer value.
+   */
   @Test
   public void evictorJobsCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(evictorJobsCompletedId, Integer.MAX_VALUE);
@@ -754,6 +931,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getIndexUpdateCompleted()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code indexUpdateCompleted} is to
+   * invoke {@code endIndexUpdate}.
+   */
   @Test
   public void endIndexUpdateIncrementsEvictorJobsCompleted() {
     cachePerfStats.endIndexUpdate(1);
@@ -761,6 +942,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(indexUpdateCompletedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code indexUpdateCompleted} currently wraps to negative from max
+   * integer value.
+   */
   @Test
   public void indexUpdateCompletedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(indexUpdateCompletedId, Integer.MAX_VALUE);
@@ -777,6 +962,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getDeltaUpdates()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code deltaUpdates} is to
+   * invoke {@code endDeltaUpdate}.
+   */
   @Test
   public void endDeltaUpdateIncrementsDeltaUpdates() {
     cachePerfStats.endDeltaUpdate(1);
@@ -784,6 +973,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(deltaUpdatesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code deltaUpdatesId} currently wraps to negative from max integer
+   * value.
+   */
   @Test
   public void deltaUpdatesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(deltaUpdatesId, Integer.MAX_VALUE);
@@ -807,6 +1000,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(deltaFailedUpdatesId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code deltaFailedUpdates} currently wraps to negative from max
+   * integer value.
+   */
   @Test
   public void deltaFailedUpdatesWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(deltaFailedUpdatesId, Integer.MAX_VALUE);
@@ -823,6 +1020,10 @@ public class CachePerfStatsTest {
     assertThat(cachePerfStats.getDeltasPrepared()).isEqualTo(Integer.MAX_VALUE);
   }
 
+  /**
+   * Characterization test: Note that the only way to increment {@code deltasPrepared} is to
+   * invoke {@code endDeltaPrepared}.
+   */
   @Test
   public void endDeltaPreparedIncrementsDeltasPrepared() {
     cachePerfStats.endDeltaPrepared(1);
@@ -830,6 +1031,10 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(deltasPreparedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code deltasPrepared} currently wraps to negative from max
+   * integer value.
+   */
   @Test
   public void deltasPreparedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(deltasPreparedId, Integer.MAX_VALUE);
@@ -853,6 +1058,9 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(deltasSentId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code deltasSent} currently wraps to negative from max integer value.
+   */
   @Test
   public void deltasSentWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(deltasSentId, Integer.MAX_VALUE);
@@ -876,8 +1084,12 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(deltaFullValuesSentId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code deltaFullValuesSent} currently wraps to negative from max integer
+   * value.
+   */
   @Test
-  public void deltaFullValuesSentFromMaxIntegerToNegativeValue() {
+  public void deltaFullValuesSentWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(deltaFullValuesSentId, Integer.MAX_VALUE);
 
     cachePerfStats.incDeltaFullValuesSent();
@@ -899,8 +1111,12 @@ public class CachePerfStatsTest {
     assertThat(statistics.getInt(deltaFullValuesRequestedId)).isEqualTo(1);
   }
 
+  /**
+   * Characterization test: {@code deltaFullValuesRequested} currently wraps to negative from max
+   * integer value.
+   */
   @Test
-  public void deltaFullValuesRequestedFromMaxIntegerToNegativeValue() {
+  public void deltaFullValuesRequestedWrapsFromMaxIntegerToNegativeValue() {
     statistics.incInt(deltaFullValuesRequestedId, Integer.MAX_VALUE);
 
     cachePerfStats.incDeltaFullValuesRequested();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -1,0 +1,910 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.internal.cache.CachePerfStats.cacheListenerCallsCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.cacheWriterCallsCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.clearsId;
+import static org.apache.geode.internal.cache.CachePerfStats.createsId;
+import static org.apache.geode.internal.cache.CachePerfStats.deltaFailedUpdatesId;
+import static org.apache.geode.internal.cache.CachePerfStats.deltaFullValuesRequestedId;
+import static org.apache.geode.internal.cache.CachePerfStats.deltaFullValuesSentId;
+import static org.apache.geode.internal.cache.CachePerfStats.deltaGetInitialImagesCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.deltaUpdatesId;
+import static org.apache.geode.internal.cache.CachePerfStats.deltasPreparedId;
+import static org.apache.geode.internal.cache.CachePerfStats.deltasSentId;
+import static org.apache.geode.internal.cache.CachePerfStats.destroysId;
+import static org.apache.geode.internal.cache.CachePerfStats.evictorJobsCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.evictorJobsStartedId;
+import static org.apache.geode.internal.cache.CachePerfStats.getInitialImagesCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.getTimeId;
+import static org.apache.geode.internal.cache.CachePerfStats.getsId;
+import static org.apache.geode.internal.cache.CachePerfStats.indexUpdateCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.invalidatesId;
+import static org.apache.geode.internal.cache.CachePerfStats.loadsCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.missesId;
+import static org.apache.geode.internal.cache.CachePerfStats.netloadsCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.netsearchesCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.putTimeId;
+import static org.apache.geode.internal.cache.CachePerfStats.putallsId;
+import static org.apache.geode.internal.cache.CachePerfStats.putsId;
+import static org.apache.geode.internal.cache.CachePerfStats.queryExecutionsId;
+import static org.apache.geode.internal.cache.CachePerfStats.removeAllsId;
+import static org.apache.geode.internal.cache.CachePerfStats.retriesId;
+import static org.apache.geode.internal.cache.CachePerfStats.txCommitChangesId;
+import static org.apache.geode.internal.cache.CachePerfStats.txCommitsId;
+import static org.apache.geode.internal.cache.CachePerfStats.txFailureChangesId;
+import static org.apache.geode.internal.cache.CachePerfStats.txFailuresId;
+import static org.apache.geode.internal.cache.CachePerfStats.txRollbackChangesId;
+import static org.apache.geode.internal.cache.CachePerfStats.txRollbacksId;
+import static org.apache.geode.internal.cache.CachePerfStats.updatesId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.StatisticsType;
+import org.apache.geode.internal.cache.CachePerfStats.Clock;
+import org.apache.geode.internal.statistics.StatisticsManager;
+import org.apache.geode.internal.stats50.Atomic50StatisticsImpl;
+
+/**
+ * Unit tests for {@link CachePerfStats}.
+ */
+public class CachePerfStatsTest {
+
+  private static final String TEXT_ID = "cachePerfStats";
+  private static final long CLOCK_TIME = 10;
+
+  private Statistics statistics;
+  private CachePerfStats cachePerfStats;
+
+  @Before
+  public void setUp() {
+    StatisticsType statisticsType = CachePerfStats.getStatisticsType();
+
+    StatisticsManager statisticsManager = mock(StatisticsManager.class);
+    StatisticsFactory statisticsFactory = mock(StatisticsFactory.class);
+    Clock clock = mock(Clock.class);
+
+    statistics = spy(new Atomic50StatisticsImpl(statisticsType, TEXT_ID, 1, 1,
+        statisticsManager));
+
+    when(clock.getTime()).thenReturn(CLOCK_TIME);
+    when(statisticsFactory.createAtomicStatistics(eq(statisticsType), eq(TEXT_ID)))
+        .thenReturn(statistics);
+
+    CachePerfStats.enableClockStats = true;
+    cachePerfStats = new CachePerfStats(statisticsFactory, TEXT_ID, clock);
+  }
+
+  @Test
+  public void getPutsDelegatesToStatistics() {
+    statistics.incInt(putsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getPuts()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endPutIncrementsPuts() {
+    cachePerfStats.endPut(0, false);
+
+    assertThat(statistics.getInt(putsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void putsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(putsId, Integer.MAX_VALUE);
+
+    cachePerfStats.endPut(0, false);
+
+    assertThat(cachePerfStats.getPuts()).isNegative();
+  }
+
+  @Test
+  public void getGetsDelegatesToStatistics() {
+    statistics.incInt(getsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getGets()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endGetIncrementsGets() {
+    cachePerfStats.endGet(0, false);
+
+    assertThat(statistics.getInt(getsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void getsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(getsId, Integer.MAX_VALUE);
+
+    cachePerfStats.endGet(0, false);
+
+    assertThat(cachePerfStats.getGets()).isNegative();
+  }
+
+  @Test
+  public void getPutTimeDelegatesToStatistics() {
+    statistics.incLong(putTimeId, Long.MAX_VALUE);
+
+    assertThat(cachePerfStats.getPutTime()).isEqualTo(Long.MAX_VALUE);
+
+  }
+
+  @Test
+  public void endPutIncrementsPutTime() {
+    cachePerfStats.endPut(0, false);
+
+    assertThat(statistics.getLong(putTimeId)).isEqualTo(CLOCK_TIME);
+  }
+
+  @Test
+  public void getGetTimeDelegatesToStatistics() {
+    statistics.incLong(getTimeId, Long.MAX_VALUE);
+
+    assertThat(cachePerfStats.getGetTime()).isEqualTo(Long.MAX_VALUE);
+
+  }
+
+  @Test
+  public void endGetIncrementsGetTime() {
+    cachePerfStats.endGet(0, false);
+
+    assertThat(statistics.getLong(getTimeId)).isEqualTo(CLOCK_TIME);
+  }
+
+  @Test
+  public void getDestroysDelegatesToStatistics() {
+    statistics.incInt(destroysId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDestroys()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incDestroysIncrementsDestroys() {
+    cachePerfStats.incDestroys();
+
+    assertThat(statistics.getInt(destroysId)).isEqualTo(1);
+  }
+
+  @Test
+  public void destroysWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(destroysId, Integer.MAX_VALUE);
+
+    cachePerfStats.incDestroys();
+
+    assertThat(cachePerfStats.getDestroys()).isNegative();
+  }
+
+  @Test
+  public void getCreatesDelegatesToStatistics() {
+    statistics.incInt(createsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getCreates()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incCreatesIncrementsDestroys() {
+    cachePerfStats.incCreates();
+
+    assertThat(statistics.getInt(createsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void createsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(createsId, Integer.MAX_VALUE);
+
+    cachePerfStats.incCreates();
+
+    assertThat(cachePerfStats.getCreates()).isNegative();
+  }
+
+  @Test
+  public void getPutAllsDelegatesToStatistics() {
+    statistics.incInt(putallsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getPutAlls()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endPutAllIncrementsDestroys() {
+    cachePerfStats.endPutAll(0);
+
+    assertThat(statistics.getInt(putallsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void putAllsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(putallsId, Integer.MAX_VALUE);
+
+    cachePerfStats.endPutAll(0);
+
+    assertThat(cachePerfStats.getPutAlls()).isNegative();
+  }
+
+  @Test
+  public void getRemoveAllsDelegatesToStatistics() {
+    statistics.incInt(removeAllsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getRemoveAlls()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endRemoveAllIncrementsDestroys() {
+    cachePerfStats.endRemoveAll(0);
+
+    assertThat(statistics.getInt(removeAllsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void removeAllsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(removeAllsId, Integer.MAX_VALUE);
+
+    cachePerfStats.endRemoveAll(0);
+
+    assertThat(cachePerfStats.getRemoveAlls()).isNegative();
+  }
+
+  @Test
+  public void getUpdatesDelegatesToStatistics() {
+    statistics.incInt(updatesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getUpdates()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endPutIncrementsUpdates() {
+    cachePerfStats.endPut(0, true);
+
+    assertThat(statistics.getInt(updatesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void updatesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(updatesId, Integer.MAX_VALUE);
+
+    cachePerfStats.endPut(0, true);
+
+    assertThat(cachePerfStats.getUpdates()).isNegative();
+  }
+
+  @Test
+  public void getInvalidatesDelegatesToStatistics() {
+    statistics.incInt(invalidatesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getInvalidates()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incInvalidatesIncrementsInvalidates() {
+    cachePerfStats.incInvalidates();
+
+    assertThat(statistics.getInt(invalidatesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void invalidatesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(invalidatesId, Integer.MAX_VALUE);
+
+    cachePerfStats.incInvalidates();
+
+    assertThat(cachePerfStats.getInvalidates()).isNegative();
+  }
+
+  @Test
+  public void getMissesDelegatesToStatistics() {
+    statistics.incInt(missesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getMisses()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endGetIncrementsMisses() {
+    cachePerfStats.endGet(0, true);
+
+    assertThat(statistics.getInt(missesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void missesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(missesId, Integer.MAX_VALUE);
+
+    cachePerfStats.endGet(0, true);
+
+    assertThat(cachePerfStats.getMisses()).isNegative();
+  }
+
+  @Test
+  public void getRetriesDelegatesToStatistics() {
+    statistics.incInt(retriesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getRetries()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incRetriesIncrementsRetries() {
+    cachePerfStats.incRetries();
+
+    assertThat(statistics.getInt(retriesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void retriesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(retriesId, Integer.MAX_VALUE);
+
+    cachePerfStats.incRetries();
+
+    assertThat(cachePerfStats.getRetries()).isNegative();
+  }
+
+  @Test
+  public void getClearsDelegatesToStatistics() {
+    statistics.incInt(clearsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getClearCount()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incClearCountIncrementsClears() {
+    cachePerfStats.incClearCount();
+
+    assertThat(statistics.getInt(clearsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void clearsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(clearsId, Integer.MAX_VALUE);
+
+    cachePerfStats.incClearCount();
+
+    assertThat(cachePerfStats.getClearCount()).isNegative();
+  }
+
+  @Test
+  public void getLoadsCompletedDelegatesToStatistics() {
+    statistics.incInt(loadsCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getLoadsCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endLoadIncrementsMisses() {
+    cachePerfStats.endLoad(0);
+
+    assertThat(statistics.getInt(loadsCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void loadsCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(loadsCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endLoad(0);
+
+    assertThat(cachePerfStats.getLoadsCompleted()).isNegative();
+  }
+
+  @Test
+  public void getNetloadsCompletedDelegatesToStatistics() {
+    statistics.incInt(netloadsCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getNetloadsCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endNetloadIncrementsNetloadsCompleted() {
+    cachePerfStats.endNetload(0);
+
+    assertThat(statistics.getInt(netloadsCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void netloadsCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(netloadsCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endNetload(0);
+
+    assertThat(cachePerfStats.getNetloadsCompleted()).isNegative();
+  }
+
+  @Test
+  public void getNetsearchesCompletedDelegatesToStatistics() {
+    statistics.incInt(netsearchesCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getNetsearchesCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endLoadIncrementsNetsearchesCompleted() {
+    cachePerfStats.endNetsearch(0);
+
+    assertThat(statistics.getInt(netsearchesCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void netsearchesCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(netsearchesCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endNetsearch(0);
+
+    assertThat(cachePerfStats.getNetsearchesCompleted()).isNegative();
+  }
+
+  @Test
+  public void getCacheWriterCallsCompletedDelegatesToStatistics() {
+    statistics.incInt(cacheWriterCallsCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getCacheWriterCallsCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endCacheWriterCallIncrementsCacheWriterCallsCompleted() {
+    cachePerfStats.endCacheWriterCall(0);
+
+    assertThat(statistics.getInt(cacheWriterCallsCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void cacheWriterCallsCompletedCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(cacheWriterCallsCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endCacheWriterCall(0);
+
+    assertThat(cachePerfStats.getCacheWriterCallsCompleted()).isNegative();
+  }
+
+  @Test
+  public void getCacheListenerCallsCompletedDelegatesToStatistics() {
+    statistics.incInt(cacheListenerCallsCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getCacheListenerCallsCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endCacheWriterCallIncrementsCacheListenerCallsCompleted() {
+    cachePerfStats.endCacheListenerCall(0);
+
+    assertThat(statistics.getInt(cacheListenerCallsCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void cacheListenerCallsCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(cacheListenerCallsCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endCacheListenerCall(0);
+
+    assertThat(cachePerfStats.getCacheListenerCallsCompleted()).isNegative();
+  }
+
+  @Test
+  public void getGetInitialImagesCompletedDelegatesToStatistics() {
+    statistics.incInt(getInitialImagesCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getGetInitialImagesCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endCacheWriterCallIncrementsGetInitialImagesCompleted() {
+    cachePerfStats.endGetInitialImage(0);
+
+    assertThat(statistics.getInt(getInitialImagesCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void getInitialImagesCompletedCallsCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(getInitialImagesCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endGetInitialImage(0);
+
+    assertThat(cachePerfStats.getGetInitialImagesCompleted()).isNegative();
+  }
+
+  @Test
+  public void getDeltaGetInitialImagesCompletedDelegatesToStatistics() {
+    statistics.incInt(deltaGetInitialImagesCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDeltaGetInitialImagesCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incDeltaGIICompletedIncrementsDeltaGetInitialImagesCompleted() {
+    cachePerfStats.incDeltaGIICompleted();
+
+    assertThat(statistics.getInt(deltaGetInitialImagesCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void deltaGetInitialImagesCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(deltaGetInitialImagesCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.incDeltaGIICompleted();
+
+    assertThat(cachePerfStats.getDeltaGetInitialImagesCompleted()).isNegative();
+  }
+
+  @Test
+  public void getQueryExecutionsDelegatesToStatistics() {
+    statistics.incInt(queryExecutionsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getQueryExecutions()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endQueryExecutionIncrementsQueryExecutions() {
+    cachePerfStats.endQueryExecution(1);
+
+    assertThat(statistics.getInt(queryExecutionsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void queryExecutionsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(queryExecutionsId, Integer.MAX_VALUE);
+
+    cachePerfStats.endQueryExecution(1);
+
+    assertThat(cachePerfStats.getQueryExecutions()).isNegative();
+  }
+
+  @Test
+  public void getTxCommitsDelegatesToStatistics() {
+    statistics.incInt(txCommitsId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getTxCommits()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void txSuccessIncrementsTxCommits() {
+    cachePerfStats.txSuccess(1, 1, 1);
+
+    assertThat(statistics.getInt(txCommitsId)).isEqualTo(1);
+  }
+
+  @Test
+  public void txCommitsWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(txCommitsId, Integer.MAX_VALUE);
+
+    cachePerfStats.txSuccess(1, 1, 1);
+
+    assertThat(cachePerfStats.getTxCommits()).isNegative();
+  }
+
+  @Test
+  public void getTxFailuresDelegatesToStatistics() {
+    statistics.incInt(txFailuresId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getTxFailures()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void txFailureIncrementsTxFailures() {
+    cachePerfStats.txFailure(1, 1, 1);
+
+    assertThat(statistics.getInt(txFailuresId)).isEqualTo(1);
+  }
+
+  @Test
+  public void txFailuresWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(txFailuresId, Integer.MAX_VALUE);
+
+    cachePerfStats.txFailure(1, 1, 1);
+
+    assertThat(cachePerfStats.getTxFailures()).isNegative();
+  }
+
+  @Test
+  public void getTxRollbacksDelegatesToStatistics() {
+    statistics.incInt(txRollbacksId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getTxRollbacks()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void txRollbackIncrementsTxRollbacks() {
+    cachePerfStats.txRollback(1, 1, 1);
+
+    assertThat(statistics.getInt(txRollbacksId)).isEqualTo(1);
+  }
+
+  @Test
+  public void txRollbacksWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(txRollbacksId, Integer.MAX_VALUE);
+
+    cachePerfStats.txRollback(1, 1, 1);
+
+    assertThat(cachePerfStats.getTxRollbacks()).isNegative();
+  }
+
+  @Test
+  public void getTxCommitChangesDelegatesToStatistics() {
+    statistics.incInt(txCommitChangesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getTxCommitChanges()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void txSuccessIncrementsTxCommitChanges() {
+    cachePerfStats.txSuccess(1, 1, 1);
+
+    assertThat(statistics.getInt(txCommitChangesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void txCommitChangesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(txCommitChangesId, Integer.MAX_VALUE);
+
+    cachePerfStats.txSuccess(1, 1, 1);
+
+    assertThat(cachePerfStats.getTxCommitChanges()).isNegative();
+  }
+
+  @Test
+  public void getTxFailureChangesDelegatesToStatistics() {
+    statistics.incInt(txFailureChangesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getTxFailureChanges()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void txFailureIncrementsTxFailureChanges() {
+    cachePerfStats.txFailure(1, 1, 1);
+
+    assertThat(statistics.getInt(txFailureChangesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void txFailureChangesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(txFailureChangesId, Integer.MAX_VALUE);
+
+    cachePerfStats.txFailure(1, 1, 1);
+
+    assertThat(cachePerfStats.getTxFailureChanges()).isNegative();
+  }
+
+  @Test
+  public void getTxRollbackChangesDelegatesToStatistics() {
+    statistics.incInt(txRollbackChangesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getTxRollbackChanges()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void txRollbackIncrementsTxRollbackChanges() {
+    cachePerfStats.txRollback(1, 1, 1);
+
+    assertThat(statistics.getInt(txRollbackChangesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void txRollbackChangesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(txRollbackChangesId, Integer.MAX_VALUE);
+
+    cachePerfStats.txRollback(1, 1, 1);
+
+    assertThat(cachePerfStats.getTxRollbackChanges()).isNegative();
+  }
+
+  @Test
+  public void getEvictorJobsStartedChangesDelegatesToStatistics() {
+    statistics.incInt(evictorJobsStartedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getEvictorJobsStarted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incEvictorJobsStartedIncrementsEvictorJobsStarted() {
+    cachePerfStats.incEvictorJobsStarted();
+
+    assertThat(statistics.getInt(evictorJobsStartedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void evictorJobsStartedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(evictorJobsStartedId, Integer.MAX_VALUE);
+
+    cachePerfStats.incEvictorJobsStarted();
+
+    assertThat(cachePerfStats.getEvictorJobsStarted()).isNegative();
+  }
+
+  @Test
+  public void getEvictorJobsCompletedChangesDelegatesToStatistics() {
+    statistics.incInt(evictorJobsCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getEvictorJobsCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incEvictorJobsCompletedIncrementsEvictorJobsCompleted() {
+    cachePerfStats.incEvictorJobsCompleted();
+
+    assertThat(statistics.getInt(evictorJobsCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void evictorJobsCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(evictorJobsCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.incEvictorJobsCompleted();
+
+    assertThat(cachePerfStats.getEvictorJobsCompleted()).isNegative();
+  }
+
+  @Test
+  public void getIndexUpdateCompletedChangesDelegatesToStatistics() {
+    statistics.incInt(indexUpdateCompletedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getIndexUpdateCompleted()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endIndexUpdateIncrementsEvictorJobsCompleted() {
+    cachePerfStats.endIndexUpdate(1);
+
+    assertThat(statistics.getInt(indexUpdateCompletedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void indexUpdateCompletedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(indexUpdateCompletedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endIndexUpdate(1);
+
+    assertThat(cachePerfStats.getIndexUpdateCompleted()).isNegative();
+  }
+
+  @Test
+  public void getDeltaUpdatesDelegatesToStatistics() {
+    statistics.incInt(deltaUpdatesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDeltaUpdates()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endDeltaUpdateIncrementsDeltaUpdates() {
+    cachePerfStats.endDeltaUpdate(1);
+
+    assertThat(statistics.getInt(deltaUpdatesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void deltaUpdatesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(deltaUpdatesId, Integer.MAX_VALUE);
+
+    cachePerfStats.endDeltaUpdate(1);
+
+    assertThat(cachePerfStats.getDeltaUpdates()).isNegative();
+  }
+
+  @Test
+  public void getDeltaFailedUpdatesDelegatesToStatistics() {
+    statistics.incInt(deltaFailedUpdatesId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDeltaFailedUpdates()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incDeltaFailedUpdatesIncrementsDeltaFailedUpdates() {
+    cachePerfStats.incDeltaFailedUpdates();
+
+    assertThat(statistics.getInt(deltaFailedUpdatesId)).isEqualTo(1);
+  }
+
+  @Test
+  public void deltaFailedUpdatesWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(deltaFailedUpdatesId, Integer.MAX_VALUE);
+
+    cachePerfStats.incDeltaFailedUpdates();
+
+    assertThat(cachePerfStats.getDeltaFailedUpdates()).isNegative();
+  }
+
+  @Test
+  public void getDeltasPreparedUpdatesDelegatesToStatistics() {
+    statistics.incInt(deltasPreparedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDeltasPrepared()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void endDeltaPreparedIncrementsDeltasPrepared() {
+    cachePerfStats.endDeltaPrepared(1);
+
+    assertThat(statistics.getInt(deltasPreparedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void deltasPreparedWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(deltasPreparedId, Integer.MAX_VALUE);
+
+    cachePerfStats.endDeltaPrepared(1);
+
+    assertThat(cachePerfStats.getDeltasPrepared()).isNegative();
+  }
+
+  @Test
+  public void getDeltasSentDelegatesToStatistics() {
+    statistics.incInt(deltasSentId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDeltasSent()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incDeltasSentPreparedIncrementsDeltasSent() {
+    cachePerfStats.incDeltasSent();
+
+    assertThat(statistics.getInt(deltasSentId)).isEqualTo(1);
+  }
+
+  @Test
+  public void deltasSentWrapsFromMaxIntegerToNegativeValue() {
+    statistics.incInt(deltasSentId, Integer.MAX_VALUE);
+
+    cachePerfStats.incDeltasSent();
+
+    assertThat(cachePerfStats.getDeltasSent()).isNegative();
+  }
+
+  @Test
+  public void getDeltaFullValuesSentDelegatesToStatistics() {
+    statistics.incInt(deltaFullValuesSentId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDeltaFullValuesSent()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incDeltaFullValuesSentIncrementsDeltaFullValuesSent() {
+    cachePerfStats.incDeltaFullValuesSent();
+
+    assertThat(statistics.getInt(deltaFullValuesSentId)).isEqualTo(1);
+  }
+
+  @Test
+  public void deltaFullValuesSentFromMaxIntegerToNegativeValue() {
+    statistics.incInt(deltaFullValuesSentId, Integer.MAX_VALUE);
+
+    cachePerfStats.incDeltaFullValuesSent();
+
+    assertThat(cachePerfStats.getDeltaFullValuesSent()).isNegative();
+  }
+
+  @Test
+  public void getDeltaFullValuesRequestedDelegatesToStatistics() {
+    statistics.incInt(deltaFullValuesRequestedId, Integer.MAX_VALUE);
+
+    assertThat(cachePerfStats.getDeltaFullValuesRequested()).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void incDeltaFullValuesRequestedIncrementsDeltaFullValuesRequested() {
+    cachePerfStats.incDeltaFullValuesRequested();
+
+    assertThat(statistics.getInt(deltaFullValuesRequestedId)).isEqualTo(1);
+  }
+
+  @Test
+  public void deltaFullValuesRequestedFromMaxIntegerToNegativeValue() {
+    statistics.incInt(deltaFullValuesRequestedId, Integer.MAX_VALUE);
+
+    cachePerfStats.incDeltaFullValuesRequested();
+
+    assertThat(cachePerfStats.getDeltaFullValuesRequested()).isNegative();
+  }
+}


### PR DESCRIPTION
Cleaned up some minor warnings in CachePerfStats and introduced an inner-interface with constructor changes to facilitate unit testing. Unit tests were written for all CachePerfStats operation count stats that are currently implemented as IntCounters which can wrap from max integer to negative values.

Please review @mhansonp @demery-pivotal 