### PR TITLE
GEODE-6342 ThreadsMonitor prints many warnings in gateway sender logs

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -695,6 +695,9 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
                       break;
                     }
                     try {
+                      if (threadMonitoring != null) {
+                        threadMonitoring.updateThreadStatus();
+                      }
                       Thread.sleep(100);
                     } catch (InterruptedException ie) {
                       Thread.currentThread().interrupt();

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoring.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoring.java
@@ -49,4 +49,10 @@ public interface ThreadsMonitoring {
    * Ending the monitoring of an executor object.
    */
   public void endMonitor();
+
+  /**
+   * A long-running thread that may appear stuck should periodically update its "alive"
+   * status by invoking this method
+   */
+  public void updateThreadStatus();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringImpl.java
@@ -87,6 +87,14 @@ public class ThreadsMonitoringImpl implements ThreadsMonitoring {
   }
 
   @Override
+  public void updateThreadStatus() {
+    AbstractExecutor executor = monitorMap.get(Thread.currentThread().getId());
+    if (executor != null) {
+      executor.setStartTime(System.currentTimeMillis());
+    }
+  }
+
+  @Override
   public boolean startMonitor(Mode mode) {
     AbstractExecutor absExtgroup;
     switch (mode) {

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringImplDummy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringImplDummy.java
@@ -33,6 +33,9 @@ public class ThreadsMonitoringImplDummy implements ThreadsMonitoring {
   public void endMonitor() {}
 
   @Override
+  public void updateThreadStatus() {}
+
+  @Override
   public ConcurrentMap<Long, AbstractExecutor> getMonitorMap() {
     return null;
   }


### PR DESCRIPTION
Modified the gateways to update the ThreadsMonitor before sleeping.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
