### PR TITLE
GEODE-6349: Fix potential race in DistributedRegionBridge.listAllRegions

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
@@ -820,18 +820,18 @@ public class DistributedSystemBridge {
    * @return a list of region names hosted on the system
    */
   public String[] listAllRegions() {
-    Iterator<DistributedRegionBridge> it = distrRegionMap.values().iterator();
     if (distrRegionMap.values().size() == 0) {
       return ManagementConstants.NO_DATA_STRING;
     }
-    String[] listOfRegions = new String[distrRegionMap.values().size()];
-    int j = 0;
+
+    List<String> listOfRegions = new ArrayList<>();
+    Iterator<DistributedRegionBridge> it = distrRegionMap.values().iterator();
     while (it.hasNext()) {
       DistributedRegionBridge bridge = it.next();
-      listOfRegions[j] = bridge.getName();
-      j++;
+      listOfRegions.add(bridge.getName());
     }
-    return listOfRegions;
+
+    return listOfRegions.toArray(new String[listOfRegions.size()]);
   }
 
   /**


### PR DESCRIPTION
- There is a small window where the iterator has been created 
  but the underlying structure (a ConcurrentHashMap) has changed,
  resulting in an ArrayIndexOutOfBoundsException during iteration.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
