### PR TITLE
GEODE-6351: Use AvailablePortHelper to retrieve ports

### DIFF
--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailoverWithOldClient.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailoverWithOldClient.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.AvailablePort;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.NetworkUtils;
@@ -45,15 +45,17 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMembe
     VM site2Server1 = host.getVM(VersionManager.CURRENT_VERSION, 5);
     VM site2Server2 = host.getVM(VersionManager.CURRENT_VERSION, 6);
 
+    int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
+
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
-    final int site1LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
+    final int site1LocatorPort = locatorPorts[0];
     DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get current site locator properties
-    final int site2LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
+    final int site2LocatorPort = locatorPorts[1];
     DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;


### PR DESCRIPTION
- This should avoid `AvailablePort.getRandomAvailablePort` returning the same port twice in a row.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
