### PR TITLE
GEODE-6347: Setting tolerance to 1 for Cache XML tests

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/cache30/CacheXmlTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/CacheXmlTestCase.java
@@ -51,6 +51,7 @@ public class CacheXmlTestCase extends JUnit4CacheTestCase {
 
   /** set this to false if a test needs a non-loner distributed system */
   static boolean lonerDistributedSystem = true;
+  private static String previousMemoryEventTolerance;
 
   @Rule
   public DistributedRestoreSystemProperties restoreSystemProperties =
@@ -64,7 +65,8 @@ public class CacheXmlTestCase extends JUnit4CacheTestCase {
 
   @Override
   public final void postSetUp() throws Exception {
-    System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "memoryEventTolerance", "1");
+    previousMemoryEventTolerance =
+        System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "memoryEventTolerance", "1");
     disconnectAllFromDS();
   }
 
@@ -75,6 +77,11 @@ public class CacheXmlTestCase extends JUnit4CacheTestCase {
 
     waitForNoRebalancing();
     Invoke.invokeInEveryVM(CacheXmlTestCase::waitForNoRebalancing);
+
+    if (previousMemoryEventTolerance != null) {
+      System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "memoryEventTolerance",
+          previousMemoryEventTolerance);
+    }
 
     super.preTearDownCacheTestCase();
   }

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/CacheXmlTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/CacheXmlTestCase.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 
 import org.apache.geode.cache.Cache;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.cache.xmlcache.CacheXml;
@@ -63,6 +64,7 @@ public class CacheXmlTestCase extends JUnit4CacheTestCase {
 
   @Override
   public final void postSetUp() throws Exception {
+    System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "memoryEventTolerance", "1");
     disconnectAllFromDS();
   }
 


### PR DESCRIPTION
The default tolerance of 1 was masking an issue with high heap in these cache XML tests.  Setting the default back to 1 for these tests, which is what it was prior to the changes from https://github.com/apache/geode/commit/546abdd173afe13c01e148900c2b9114dc5bc4cc.  Going to continue investigating the source of the high heap after this is merged.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [N/A] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
