### PR TITLE
GEODE-6364: Deploy of invalid jar file does not write file contents to config on locator

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
@@ -37,6 +37,7 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.internal.DeployedJar;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.Result;
@@ -83,6 +84,8 @@ public class DeployCommand extends InternalGfshCommand {
     TabularResultData tabularData = ResultBuilder.createTabularResultData();
 
     List<String> jarFullPaths = CommandExecutionContext.getFilePathFromShell();
+
+    verifyJarContent(jarFullPaths);
 
     Set<DistributedMember> targetMembers;
     targetMembers = findMembers(groups, null);
@@ -146,6 +149,16 @@ public class DeployCommand extends InternalGfshCommand {
     }
 
     return result;
+  }
+
+  private void verifyJarContent(List<String> jarNames) {
+    for (String jarName : jarNames) {
+      File jar = new File(jarName);
+      if (!DeployedJar.hasValidJarContent(jar)) {
+        throw new IllegalArgumentException(
+            "File does not contain valid JAR content: " + jar.getName());
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
