### PR TITLE
GEODE-6369 Cache-creation failure after a successful auto-reconnect causes subsequent NPE

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -38,7 +38,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTOR
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
-import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -91,6 +90,7 @@ import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.tcp.Connection;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DUnitBlackboard;
 import org.apache.geode.test.dunit.DistributedTestUtils;
@@ -253,7 +253,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       DistributedLockService serviceNamed =
           DistributedLockService.getServiceNamed("test service");
       serviceNamed.lock("foo3", 0, 0);
-      await()
+      GeodeAwaitility.await()
           .until(serviceNamed::isLockGrantor);
       assertThat(serviceNamed.isLockGrantor()).isTrue();
     });
@@ -682,7 +682,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       logger.info("waiting for my distributed system to disconnect due to partition detection");
 
-      await().until(() -> !system.isConnected());
+      GeodeAwaitility.await().until(() -> !system.isConnected());
 
       if (system.isConnected()) {
         fail(
@@ -780,7 +780,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       // stop the locator normally. This should also be okay
       locator.stop();
 
-      await()
+      GeodeAwaitility.await()
           .until(() -> {
             assertThat(Locator.getLocator()).describedAs("locator is not stopped").isNull();
             return true;
@@ -1027,37 +1027,37 @@ public class LocatorDUnitTest implements java.io.Serializable {
         loc.stop();
       });
 
-      await().until(testRunnerLocatorDS::isConnected);
+      GeodeAwaitility.await().until(testRunnerLocatorDS::isConnected);
 
       waitUntilTheSystemIsConnected(memberThatWillBeShutdownVM, memberVM);
 
       // disconnect the first vm and demonstrate that the non-lead vm and the
       // locator notice the failure and continue to run
       memberThatWillBeShutdownVM.invoke(LocatorDUnitTest::disconnectDistributedSystem);
-      await().until(
+      GeodeAwaitility.await().until(
           () -> memberThatWillBeShutdownVM.invoke(() -> !LocatorDUnitTest.isSystemConnected()));
-      await().until(() -> memberVM.invoke(LocatorDUnitTest::isSystemConnected));
+      GeodeAwaitility.await().until(() -> memberVM.invoke(LocatorDUnitTest::isSystemConnected));
 
       assertThat(memberVM.invoke(LocatorDUnitTest::isSystemConnected))
           .describedAs("Distributed system should not have disconnected").isTrue();
 
-      await("waiting for the old coordinator to drop out").until(
+      GeodeAwaitility.await("waiting for the old coordinator to drop out").until(
           () -> MembershipManagerHelper.getCoordinator(testRunnerLocatorDS) != oldCoordinator);
 
-      await().until(() -> {
+      GeodeAwaitility.await().until(() -> {
         DistributedMember survivingDistributedMember = testRunnerLocatorDS.getDistributedMember();
         DistributedMember coordinator = MembershipManagerHelper.getCoordinator(testRunnerLocatorDS);
         assertThat(survivingDistributedMember).isEqualTo(coordinator);
         return true;
       });
 
-      await("Waiting for the old leader to drop out")
+      GeodeAwaitility.await("Waiting for the old leader to drop out")
           .pollInterval(1, TimeUnit.SECONDS).until(() -> {
             DistributedMember leader = MembershipManagerHelper.getLeadMember(testRunnerLocatorDS);
             return leader != oldLeader;
           });
 
-      await().until(() -> {
+      GeodeAwaitility.await().until(() -> {
         assertThat(distributedMember)
             .isEqualTo(MembershipManagerHelper.getLeadMember(testRunnerLocatorDS));
         return true;
@@ -1164,7 +1164,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       // now ensure that one of the remaining members became the coordinator
 
-      await()
+      GeodeAwaitility.await()
           .until(() -> !coord.equals(MembershipManagerHelper.getCoordinator(system)));
 
       DistributedMember newCoord = MembershipManagerHelper.getCoordinator(system);
@@ -1231,7 +1231,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       vm0.invoke(LocatorDUnitTest::stopLocator);
 
       // now ensure that one of the remaining members became the coordinator
-      await()
+      GeodeAwaitility.await()
           .until(() -> !coord.equals(MembershipManagerHelper.getCoordinator(system)));
 
       DistributedMember newCoord = MembershipManagerHelper.getCoordinator(system);
@@ -1248,7 +1248,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       final DistributedMember tempCoord = newCoord;
 
-      await()
+      GeodeAwaitility.await()
           .until(() -> !tempCoord.equals(MembershipManagerHelper.getCoordinator(system)));
 
       system.disconnect();
@@ -1306,7 +1306,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
         addDSProps(props);
         system = getConnectedDistributedSystem(props);
 
-        await().until(() -> system.getDM().getViewMembers().size() >= 3);
+        GeodeAwaitility.await().until(() -> system.getDM().getViewMembers().size() >= 3);
 
         // three applications plus
         assertThat(system.getDM().getViewMembers().size()).isEqualTo(5);
@@ -1326,7 +1326,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
 
   private void waitUntilLocatorBecomesCoordinator() {
-    await().until(() -> system != null && system.isConnected() &&
+    GeodeAwaitility.await().until(() -> system != null && system.isConnected() &&
         getCoordinator()
             .getVmKind() == ClusterDistributionManager.LOCATOR_DM_TYPE);
   }
@@ -1385,7 +1385,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       system = getConnectedDistributedSystem(dsProps);
 
-      await().until(() -> system.getDM().getViewMembers().size() == 6);
+      GeodeAwaitility.await().until(() -> system.getDM().getViewMembers().size() == 6);
 
       // three applications plus
       assertThat(system.getDM().getViewMembers().size()).isEqualTo(6);
@@ -1394,7 +1394,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       vm1.invoke(LocatorDUnitTest::stopLocator);
       vm2.invoke(LocatorDUnitTest::stopLocator);
 
-      await()
+      GeodeAwaitility.await()
           .until(() -> system.getDM().getMembershipManager().getView().size() <= 3);
 
       final String newLocators = host0 + "[" + port2 + "]," + host0 + "[" + port3 + "]";
@@ -1411,7 +1411,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       startLocator(vm1, dsProps, port2);
       startLocator(vm2, dsProps, port3);
 
-      await()
+      GeodeAwaitility.await()
           .until(() -> !getCoordinator().equals(currentCoordinator)
               && system.getDM().getAllHostedLocators().size() == 2);
 
@@ -1458,7 +1458,6 @@ public class LocatorDUnitTest implements java.io.Serializable {
   public void testMultipleLocatorsRestartingAtSameTimeWithMissingServers() throws Exception {
     IgnoredException.addIgnoredException("ForcedDisconnectException");
     IgnoredException.addIgnoredException("Possible loss of quorum");
-    IgnoredException.addIgnoredException("java.lang.Exception: Message id is");
 
     VM vm0 = VM.getVM(0);
     VM vm1 = VM.getVM(1);
@@ -1478,7 +1477,6 @@ public class LocatorDUnitTest implements java.io.Serializable {
     final Properties dsProps = getBasicProperties(locators);
     dsProps.setProperty(LOG_LEVEL, logger.getLevel().name());
     dsProps.setProperty(DISABLE_AUTO_RECONNECT, "true");
-    dsProps.setProperty(MEMBER_TIMEOUT, "2000");
 
     addDSProps(dsProps);
     startLocator(vm0, dsProps, port1);
@@ -1493,7 +1491,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       vm4.invoke(() -> {
         getConnectedDistributedSystem(dsProps);
 
-        await()
+        GeodeAwaitility.await()
             .until(() -> system.getDM().getViewMembers()
                 .size() == 5);
         return true;
@@ -1506,19 +1504,13 @@ public class LocatorDUnitTest implements java.io.Serializable {
       SerializableRunnable waitForDisconnect = new SerializableRunnable("waitForDisconnect") {
         @Override
         public void run() {
-          await()
+          GeodeAwaitility.await()
               .until(() -> system == null);
         }
       };
       vm0.invoke(() -> waitForDisconnect);
       vm1.invoke(() -> waitForDisconnect);
       vm2.invoke(() -> waitForDisconnect);
-
-      // wait for suspect processing to finish
-      vm3.invoke(() -> {
-        await().until(() -> system.getDistributionManager().getAllOtherMembers().size() == 1);
-      });
-
 
       final String newLocators = host0 + "[" + port2 + "]," + host0 + "[" + port3 + "]";
       dsProps.setProperty(LOCATORS, newLocators);
@@ -1813,7 +1805,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
   private void waitForMemberToBecomeLeadMemberOfDistributedSystem(final DistributedMember member,
       final DistributedSystem sys) {
-    await().until(() -> {
+    GeodeAwaitility.await().until(() -> {
       DistributedMember lead = MembershipManagerHelper.getLeadMember(sys);
       if (member != null) {
         return member.equals(lead);
@@ -1912,7 +1904,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
   private void waitUntilTheSystemIsConnected(VM vm2, VM locatorVM) {
 
-    await().until(() -> {
+    GeodeAwaitility.await().until(() -> {
       assertThat(isSystemConnected())
           .describedAs("Distributed system should not have disconnected")
           .isTrue();

--- a/geode-core/src/main/java/org/apache/geode/cache/Cache.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/Cache.java
@@ -413,6 +413,8 @@ public interface Cache extends GemFireCache {
 
   /**
    * Wait for the Cache to finish reconnecting to the distributed system and recreate a new Cache.
+   * This may throw a CacheClosedException if reconnect attempts fail due to an exception. The
+   * exception will detail what went wrong.
    *
    * @see #getReconnectedCache
    * @param time amount of time to wait, or -1 to wait forever

--- a/geode-core/src/main/java/org/apache/geode/distributed/DistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/DistributedSystem.java
@@ -648,6 +648,8 @@ public abstract class DistributedSystem implements StatisticsFactory {
 
   /**
    * Wait for the DistributedSystem to finish reconnecting to the system and recreate the cache.
+   * This may throw a DistributedSystemDisconnectedException if reconnect fails. The exception
+   * will detail what went wrong.
    *
    * @param time amount of time to wait, or -1 to wait forever
    * @return true if the system was reconnected

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -950,7 +950,11 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
           Thread.sleep(5000);
         }
         logger.info("waiting for distributed system to reconnect...");
-        restarted = ds.waitUntilReconnected(-1, TimeUnit.SECONDS);
+        try {
+          restarted = ds.waitUntilReconnected(-1, TimeUnit.SECONDS);
+        } catch (CancelException e) {
+          // reconnect attempt failed
+        }
         if (restarted) {
           logger.info("system restarted");
         } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerLauncher.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.geode.CancelException;
 import org.apache.geode.LogWriter;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.Cache;
@@ -728,7 +729,11 @@ public class CacheServerLauncher {
         // system.isReconnecting());
         boolean reconnected = false;
         if (system.isReconnecting()) {
-          reconnected = system.waitUntilReconnected(-1, TimeUnit.SECONDS);
+          try {
+            reconnected = system.waitUntilReconnected(-1, TimeUnit.SECONDS);
+          } catch (CancelException e) {
+            // reconnect failed
+          }
           if (reconnected) {
             system = (InternalDistributedSystem) system.getReconnectedSystem();
             cache = system.getCache();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -2462,12 +2462,16 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   @Override
   public boolean waitUntilReconnected(long time, TimeUnit units) throws InterruptedException {
-    boolean systemReconnected = this.system.waitUntilReconnected(time, units);
-    if (!systemReconnected) {
-      return false;
+    try {
+      boolean systemReconnected = this.system.waitUntilReconnected(time, units);
+      if (!systemReconnected) {
+        return false;
+      }
+      GemFireCacheImpl cache = getInstance();
+      return cache != null && cache.isInitialized();
+    } catch (CancelException e) {
+      throw new CacheClosedException("Cache could not be recreated", e);
     }
-    GemFireCacheImpl cache = getInstance();
-    return cache != null && cache.isInitialized();
   }
 
   @Override


### PR DESCRIPTION


If an error occurs while rebuilding the cache on auto-reconnect we can't
continue and should throw an exception to any thread waiting for the
reconnect to complete.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
