### PR TITLE
GEODE-6363 LocatorUDPSecurityDUnitTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -38,6 +38,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTOR
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
@@ -90,7 +91,6 @@ import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.tcp.Connection;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DUnitBlackboard;
 import org.apache.geode.test.dunit.DistributedTestUtils;
@@ -253,7 +253,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       DistributedLockService serviceNamed =
           DistributedLockService.getServiceNamed("test service");
       serviceNamed.lock("foo3", 0, 0);
-      GeodeAwaitility.await()
+      await()
           .until(serviceNamed::isLockGrantor);
       assertThat(serviceNamed.isLockGrantor()).isTrue();
     });
@@ -682,7 +682,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       logger.info("waiting for my distributed system to disconnect due to partition detection");
 
-      GeodeAwaitility.await().until(() -> !system.isConnected());
+      await().until(() -> !system.isConnected());
 
       if (system.isConnected()) {
         fail(
@@ -780,7 +780,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       // stop the locator normally. This should also be okay
       locator.stop();
 
-      GeodeAwaitility.await()
+      await()
           .until(() -> {
             assertThat(Locator.getLocator()).describedAs("locator is not stopped").isNull();
             return true;
@@ -1027,37 +1027,37 @@ public class LocatorDUnitTest implements java.io.Serializable {
         loc.stop();
       });
 
-      GeodeAwaitility.await().until(testRunnerLocatorDS::isConnected);
+      await().until(testRunnerLocatorDS::isConnected);
 
       waitUntilTheSystemIsConnected(memberThatWillBeShutdownVM, memberVM);
 
       // disconnect the first vm and demonstrate that the non-lead vm and the
       // locator notice the failure and continue to run
       memberThatWillBeShutdownVM.invoke(LocatorDUnitTest::disconnectDistributedSystem);
-      GeodeAwaitility.await().until(
+      await().until(
           () -> memberThatWillBeShutdownVM.invoke(() -> !LocatorDUnitTest.isSystemConnected()));
-      GeodeAwaitility.await().until(() -> memberVM.invoke(LocatorDUnitTest::isSystemConnected));
+      await().until(() -> memberVM.invoke(LocatorDUnitTest::isSystemConnected));
 
       assertThat(memberVM.invoke(LocatorDUnitTest::isSystemConnected))
           .describedAs("Distributed system should not have disconnected").isTrue();
 
-      GeodeAwaitility.await("waiting for the old coordinator to drop out").until(
+      await("waiting for the old coordinator to drop out").until(
           () -> MembershipManagerHelper.getCoordinator(testRunnerLocatorDS) != oldCoordinator);
 
-      GeodeAwaitility.await().until(() -> {
+      await().until(() -> {
         DistributedMember survivingDistributedMember = testRunnerLocatorDS.getDistributedMember();
         DistributedMember coordinator = MembershipManagerHelper.getCoordinator(testRunnerLocatorDS);
         assertThat(survivingDistributedMember).isEqualTo(coordinator);
         return true;
       });
 
-      GeodeAwaitility.await("Waiting for the old leader to drop out")
+      await("Waiting for the old leader to drop out")
           .pollInterval(1, TimeUnit.SECONDS).until(() -> {
             DistributedMember leader = MembershipManagerHelper.getLeadMember(testRunnerLocatorDS);
             return leader != oldLeader;
           });
 
-      GeodeAwaitility.await().until(() -> {
+      await().until(() -> {
         assertThat(distributedMember)
             .isEqualTo(MembershipManagerHelper.getLeadMember(testRunnerLocatorDS));
         return true;
@@ -1164,7 +1164,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       // now ensure that one of the remaining members became the coordinator
 
-      GeodeAwaitility.await()
+      await()
           .until(() -> !coord.equals(MembershipManagerHelper.getCoordinator(system)));
 
       DistributedMember newCoord = MembershipManagerHelper.getCoordinator(system);
@@ -1231,7 +1231,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       vm0.invoke(LocatorDUnitTest::stopLocator);
 
       // now ensure that one of the remaining members became the coordinator
-      GeodeAwaitility.await()
+      await()
           .until(() -> !coord.equals(MembershipManagerHelper.getCoordinator(system)));
 
       DistributedMember newCoord = MembershipManagerHelper.getCoordinator(system);
@@ -1248,7 +1248,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       final DistributedMember tempCoord = newCoord;
 
-      GeodeAwaitility.await()
+      await()
           .until(() -> !tempCoord.equals(MembershipManagerHelper.getCoordinator(system)));
 
       system.disconnect();
@@ -1306,7 +1306,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
         addDSProps(props);
         system = getConnectedDistributedSystem(props);
 
-        GeodeAwaitility.await().until(() -> system.getDM().getViewMembers().size() >= 3);
+        await().until(() -> system.getDM().getViewMembers().size() >= 3);
 
         // three applications plus
         assertThat(system.getDM().getViewMembers().size()).isEqualTo(5);
@@ -1326,7 +1326,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
 
   private void waitUntilLocatorBecomesCoordinator() {
-    GeodeAwaitility.await().until(() -> system != null && system.isConnected() &&
+    await().until(() -> system != null && system.isConnected() &&
         getCoordinator()
             .getVmKind() == ClusterDistributionManager.LOCATOR_DM_TYPE);
   }
@@ -1385,7 +1385,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
       system = getConnectedDistributedSystem(dsProps);
 
-      GeodeAwaitility.await().until(() -> system.getDM().getViewMembers().size() == 6);
+      await().until(() -> system.getDM().getViewMembers().size() == 6);
 
       // three applications plus
       assertThat(system.getDM().getViewMembers().size()).isEqualTo(6);
@@ -1394,7 +1394,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       vm1.invoke(LocatorDUnitTest::stopLocator);
       vm2.invoke(LocatorDUnitTest::stopLocator);
 
-      GeodeAwaitility.await()
+      await()
           .until(() -> system.getDM().getMembershipManager().getView().size() <= 3);
 
       final String newLocators = host0 + "[" + port2 + "]," + host0 + "[" + port3 + "]";
@@ -1411,7 +1411,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       startLocator(vm1, dsProps, port2);
       startLocator(vm2, dsProps, port3);
 
-      GeodeAwaitility.await()
+      await()
           .until(() -> !getCoordinator().equals(currentCoordinator)
               && system.getDM().getAllHostedLocators().size() == 2);
 
@@ -1458,6 +1458,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
   public void testMultipleLocatorsRestartingAtSameTimeWithMissingServers() throws Exception {
     IgnoredException.addIgnoredException("ForcedDisconnectException");
     IgnoredException.addIgnoredException("Possible loss of quorum");
+    IgnoredException.addIgnoredException("java.lang.Exception: Message id is");
 
     VM vm0 = VM.getVM(0);
     VM vm1 = VM.getVM(1);
@@ -1477,6 +1478,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
     final Properties dsProps = getBasicProperties(locators);
     dsProps.setProperty(LOG_LEVEL, logger.getLevel().name());
     dsProps.setProperty(DISABLE_AUTO_RECONNECT, "true");
+    dsProps.setProperty(MEMBER_TIMEOUT, "2000");
 
     addDSProps(dsProps);
     startLocator(vm0, dsProps, port1);
@@ -1491,7 +1493,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       vm4.invoke(() -> {
         getConnectedDistributedSystem(dsProps);
 
-        GeodeAwaitility.await()
+        await()
             .until(() -> system.getDM().getViewMembers()
                 .size() == 5);
         return true;
@@ -1504,7 +1506,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
       SerializableRunnable waitForDisconnect = new SerializableRunnable("waitForDisconnect") {
         @Override
         public void run() {
-          GeodeAwaitility.await()
+          await()
               .until(() -> system == null);
         }
       };
@@ -1745,6 +1747,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
   protected static InternalDistributedSystem getConnectedDistributedSystem(Properties properties) {
     if (system == null || !system.isConnected()) {
+      properties.put(NAME, "vm" + VM.getCurrentVMNum());
       system = (InternalDistributedSystem) DistributedSystem.connect(properties);
     }
     return system;
@@ -1805,7 +1808,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
   private void waitForMemberToBecomeLeadMemberOfDistributedSystem(final DistributedMember member,
       final DistributedSystem sys) {
-    GeodeAwaitility.await().until(() -> {
+    await().until(() -> {
       DistributedMember lead = MembershipManagerHelper.getLeadMember(sys);
       if (member != null) {
         return member.equals(lead);
@@ -1904,7 +1907,7 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
   private void waitUntilTheSystemIsConnected(VM vm2, VM locatorVM) {
 
-    GeodeAwaitility.await().until(() -> {
+    await().until(() -> {
       assertThat(isSystemConnected())
           .describedAs("Distributed system should not have disconnected")
           .isTrue();

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
@@ -33,6 +33,13 @@ import org.apache.geode.test.junit.categories.MembershipTest;
 
 @Category({MembershipTest.class})
 public class LocatorUDPSecurityDUnitTest extends LocatorDUnitTest {
+
+  @Override
+  @Test
+  public void testMultipleLocatorsRestartingAtSameTimeWithMissingServers() throws Exception {
+    super.testMultipleLocatorsRestartingAtSameTimeWithMissingServers();
+  }
+
   @Override
   protected void addDSProps(Properties p) {
     super.addDSProps(p);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -599,7 +599,7 @@ public class ClusterDistributionManager implements DistributionManager {
         Object[] logArgs = new Object[] {distributionManager.getDistributionManagerId(), transport,
             Integer.valueOf(distributionManager.getOtherDistributionManagerIds().size()),
             distributionManager.getOtherDistributionManagerIds(),
-            (logger.isInfoEnabled(LogMarker.DM_MARKER) ? " (VERBOSE, took " + delta + " ms)" : ""),
+            (logger.isInfoEnabled(LogMarker.DM_MARKER) ? " (took " + delta + " ms)" : ""),
             ((distributionManager.getDMType() == ADMIN_ONLY_DM_TYPE) ? " (admin only)"
                 : (distributionManager.getDMType() == LOCATOR_DM_TYPE) ? " (locator)" : "")};
         logger.info(LogMarker.DM_MARKER,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorResponse.java
@@ -126,7 +126,7 @@ public class FindCoordinatorResponse extends HighPriorityDistributionMessage
   @Override
   public String toString() {
     if (this.isShortForm) {
-      return "FindCoordinatorResponse(coordinator=" + coordinator + ")";
+      return "FindCoordinatorResponse(coordinator=" + coordinator + "; senderId=" + senderId + ")";
     } else {
       return "FindCoordinatorResponse(coordinator=" + coordinator + ", fromView=" + fromView
           + ", viewId=" + (view == null ? "null" : view.getViewId()) + ", registrants="

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -256,6 +256,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
   NetView quorumLostView;
 
   static class SearchState {
+    public int joinedMembersContacted;
     Set<InternalDistributedMember> alreadyTried = new HashSet<>();
     Set<InternalDistributedMember> registrants = new HashSet<>();
     InternalDistributedMember possibleCoordinator;
@@ -264,6 +265,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
     boolean hasContactedAJoinedLocator;
     NetView view;
     final Set<FindCoordinatorResponse> responses = new HashSet<>();
+    public int responsesExpected;
 
     void cleanup() {
       alreadyTried.clear();
@@ -277,6 +279,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
     public String toString() {
       StringBuffer sb = new StringBuffer(200);
       sb.append("SearchState(locatorsContacted=").append(locatorsContacted)
+          .append("; findInViewResponses=").append(joinedMembersContacted)
           .append("; alreadyTried=").append(alreadyTried).append("; registrants=")
           .append(registrants).append("; possibleCoordinator=").append(possibleCoordinator)
           .append("; viewId=").append(viewId).append("; hasContactedAJoinedLocator=")
@@ -329,7 +332,8 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
           logger.info("found possible coordinator {}", state.possibleCoordinator);
           if (localAddress.getNetMember().preferredForCoordinator()
               && state.possibleCoordinator.equals(this.localAddress)) {
-            if (tries > 2 || System.currentTimeMillis() < giveupTime) {
+            if (state.joinedMembersContacted <= 0 &&
+                (tries > 2 || System.currentTimeMillis() < giveupTime)) {
               synchronized (viewInstallationLock) {
                 becomeCoordinator();
               }
@@ -1249,6 +1253,8 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
     }
     recipients.remove(localAddress);
 
+    logger.info("sending FindCoordinatorRequests to {}", recipients);
+
     boolean testing = unitTesting.contains("findCoordinatorFromView");
     synchronized (state.responses) {
       if (!testing) {
@@ -1280,6 +1286,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
       }
       try {
         if (!testing) {
+          state.responsesExpected = recipients.size();
           state.responses.wait(DISCOVERY_TIMEOUT);
         }
       } catch (InterruptedException e) {
@@ -1290,36 +1297,43 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
       state.responses.clear();
     }
 
-    InternalDistributedMember coord = null;
+    InternalDistributedMember bestGuessCoordinator = null;
     if (localAddress.getNetMember().preferredForCoordinator()) {
       // it's possible that all other potential coordinators are gone
       // and this new member must become the coordinator
-      coord = localAddress;
+      bestGuessCoordinator = localAddress;
     }
-    boolean coordIsNoob = true;
+    state.joinedMembersContacted = 0;
+    boolean bestGuessIsNotMember = true;
     for (FindCoordinatorResponse resp : result) {
       logger.info("findCoordinatorFromView processing {}", resp);
-      InternalDistributedMember mbr = resp.getCoordinator();
-      if (!localAddress.equals(mbr) && !state.alreadyTried.contains(mbr)) {
-        boolean mbrIsNoob = (mbr.getVmViewId() < 0);
-        if (mbrIsNoob) {
+      InternalDistributedMember suggestedCoordinator = resp.getCoordinator();
+      if (resp.getSenderId().getVmViewId() >= 0) {
+        state.joinedMembersContacted++;
+      }
+      if (!localAddress.equals(suggestedCoordinator)
+          && !state.alreadyTried.contains(suggestedCoordinator)) {
+        boolean suggestedIsNotMember = (suggestedCoordinator.getVmViewId() < 0);
+        if (suggestedIsNotMember) {
           // member has not yet joined
-          if (coordIsNoob && (coord == null || coord.compareTo(mbr, false) > 0)) {
-            coord = mbr;
+          if (bestGuessIsNotMember && (bestGuessCoordinator == null
+              || bestGuessCoordinator.compareTo(suggestedCoordinator, false) > 0)) {
+            bestGuessCoordinator = suggestedCoordinator;
           }
         } else {
           // member has already joined
-          if (coordIsNoob || mbr.getVmViewId() > coord.getVmViewId()) {
-            coord = mbr;
-            coordIsNoob = false;
+          if (bestGuessIsNotMember
+              || suggestedCoordinator.getVmViewId() > bestGuessCoordinator.getVmViewId()) {
+            bestGuessCoordinator = suggestedCoordinator;
+            bestGuessIsNotMember = false;
           }
         }
+        logger.info("findCoordinatorFromView's best guess is now {}", bestGuessCoordinator);
       }
-      logger.info("findCoordinatorFromView is selecting {}", coord);
     }
 
-    state.possibleCoordinator = coord;
-    return coord != null;
+    state.possibleCoordinator = bestGuessCoordinator;
+    return bestGuessCoordinator != null;
   }
 
   /**
@@ -1378,7 +1392,9 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
   private void processFindCoordinatorResponse(FindCoordinatorResponse resp) {
     synchronized (searchState.responses) {
       searchState.responses.add(resp);
-      searchState.responses.notifyAll();
+      if (searchState.responsesExpected <= searchState.responses.size()) {
+        searchState.responses.notifyAll();
+      }
     }
     setCoordinatorPublicKey(resp);
   }


### PR DESCRIPTION
This test appeared to be flaky and recently started failing more consistently because I messed with its settings.  The failures were real and showed that locators were starting up in a split-brain configuration in testMultipleLocatorsRestartingAtSameTimeWithMissingServers.

Changes in GMSJoinLeave prevent a restarting locator from becoming
membership coordinator if its findCoordinatorFromView method indicates
that it received responses from processes that are members of a
distributed system.  It now also waits for more than one response to its
requests to find the coordinator from other members so that it gets a
better picture of who's out there that might be the current coordinator.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
