### PR TITLE
GEODE-6295: Add Micrometer-based metrics system 

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -538,6 +538,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -861,7 +861,9 @@ javadoc/package-list
 javadoc/script.js
 javadoc/serialized-form.html
 javadoc/stylesheet.css
+lib/HdrHistogram-2.1.9.jar
 lib/HikariCP-3.2.0.jar
+lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
 lib/classgraph-4.0.6.jar
 lib/commons-beanutils-1.9.3.jar
@@ -929,6 +931,7 @@ lib/lucene-analyzers-phonetic-6.6.2.jar
 lib/lucene-core-6.6.2.jar
 lib/lucene-queries-6.6.2.jar
 lib/lucene-queryparser-6.6.2.jar
+lib/micrometer-core-1.1.2.jar
 lib/mx4j-3.0.2.jar
 lib/mx4j-remote-3.0.2.jar
 lib/mx4j-tools-3.0.1.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -1,4 +1,6 @@
+HdrHistogram-2.1.9.jar
 HikariCP-3.2.0.jar
+LatencyUtils-2.0.3.jar
 antlr-2.7.7.jar
 classgraph-4.0.6.jar
 commons-beanutils-1.9.3.jar
@@ -58,6 +60,7 @@ lucene-analyzers-phonetic-6.6.2.jar
 lucene-core-6.6.2.jar
 lucene-queries-6.6.2.jar
 lucene-queryparser-6.6.2.jar
+micrometer-core-1.1.2.jar
 netty-all-4.1.31.Final.jar
 protobuf-java-3.6.1.jar
 rmiio-2.1.2.jar

--- a/geode-assembly/src/integrationTest/resources/expected_jars.txt
+++ b/geode-assembly/src/integrationTest/resources/expected_jars.txt
@@ -1,4 +1,6 @@
+HdrHistogram
 HikariCP
+LatencyUtils
 animal-sniffer-annotations
 antlr
 aopalliance
@@ -66,6 +68,7 @@ lucene-core
 lucene-queries
 lucene-queryparser
 mapstruct
+micrometer-core
 mx4j
 mx4j-remote
 mx4j-tools

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -725,4 +725,6 @@ domain:
   - AOP Alliance v1.0 (http://aopalliance.sourceforge.net)
   - CompactConcurrentHashSet2, derived from JSR-166 ConcurrentHashMap v1.43
     (http://gee.cs.oswego.edu/dl/concurrency-interest).
+  - HdrHistogram (https://github.com/HdrHistogram/HdrHistogram)
+  - LatencyUtils (https://github.com/LatencyUtils/LatencyUtils)
   - tooltip.js v1.2.6 (https://github.com/jquerytools/jquerytools)

--- a/geode-assembly/src/test/resources/expected-pom.xml
+++ b/geode-assembly/src/test/resources/expected-pom.xml
@@ -538,6 +538,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-common/src/test/resources/expected-pom.xml
+++ b/geode-common/src/test/resources/expected-pom.xml
@@ -537,6 +537,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-concurrency-test/src/test/resources/expected-pom.xml
+++ b/geode-concurrency-test/src/test/resources/expected-pom.xml
@@ -549,6 +549,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-connectors/src/test/resources/expected-pom.xml
+++ b/geode-connectors/src/test/resources/expected-pom.xml
@@ -611,6 +611,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -186,6 +186,8 @@ dependencies {
     exclude module: 'xml-apis'
     ext.optional = true
   }
+  compile('io.micrometer:micrometer-core')
+
   compile('io.netty:netty-all') {
     ext.optional = true
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/metrics/MetricsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/metrics/MetricsIntegrationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import static org.apache.geode.cache.RegionShortcut.LOCAL;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.InternalCache;
+
+public class MetricsIntegrationTest {
+
+  private InternalCache cache;
+  private Region<String, String> region;
+
+  @Rule
+  public TestName testName = new TestName();
+  private InternalDistributedSystem internalDistributedSystem;
+
+
+  @Before
+  public void setUp() {
+    cache = (InternalCache) new CacheFactory().create();
+    internalDistributedSystem = cache.getInternalDistributedSystem();
+
+    String regionName = getClass().getSimpleName() + "_" + testName.getMethodName();
+    region = cache.<String, String>createRegionFactory(LOCAL).create(regionName);
+  }
+
+  @After
+  public void tearDown() {
+    cache.close();
+  }
+
+  @Test
+  public void memberMeterRegistry_registerMeter_forwardsTheMeterToDownstreamRegistries() {
+    MeterRegistry memberMeterRegistry = internalDistributedSystem.getMeterRegistry();
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+
+    internalDistributedSystem.getMetricsSession().connectDownstreamRegistry(downstreamRegistry);
+
+    String gaugeName = "test.region.size";
+
+    Gauge.builder(gaugeName, region, Region::size)
+        .tag("region.name", region.getName())
+        .register(memberMeterRegistry);
+
+    Gauge downstreamGauge = downstreamRegistry.find(gaugeName).gauge();
+    assertThat(downstreamGauge)
+        .as("downstream gauge")
+        .isNotNull();
+
+    assertThat(downstreamGauge.value())
+        .as("value of downstream gauge before putting entries")
+        .isEqualTo(region.size());
+
+    int numberOfEntries = 100;
+    for (int i = 1; i <= numberOfEntries; i++) {
+      region.put("key-" + i, "value-" + i);
+    }
+
+    assertThat(downstreamGauge.value())
+        .as("value of downstream gauge after putting entries")
+        .isEqualTo(region.size());
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import org.apache.geode.distributed.internal.membership.QuorumChecker;
+
+/**
+ * Contains the distribution config and internal properties for connecting.
+ */
+public interface ConnectionConfig {
+  /**
+   * Indicates whether this config is reconnecting.
+   */
+  boolean isReconnecting();
+
+  /**
+   * Returns the quorum checker to use while reconnecting.
+   */
+  QuorumChecker quorumChecker();
+
+  /**
+   * Returns the distribution config.
+   */
+  DistributionConfig distributionConfig();
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfigImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_CONFIG_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_QUORUM_CHECKER_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_RECONNECTING_NAME;
+
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import org.apache.geode.distributed.internal.membership.QuorumChecker;
+
+public class ConnectionConfigImpl implements ConnectionConfig {
+  private final boolean isReconnecting;
+  private final QuorumChecker quorumChecker;
+  private final DistributionConfigImpl distributionConfig;
+
+  ConnectionConfigImpl(Properties properties) {
+    isReconnecting = convert(properties.get(DS_RECONNECTING_NAME), Boolean.class,
+        () -> Boolean.FALSE);
+    quorumChecker = convert(properties.get(DS_QUORUM_CHECKER_NAME), QuorumChecker.class,
+        () -> null);
+    distributionConfig = convert(properties.get(DS_CONFIG_NAME), DistributionConfigImpl.class,
+        () -> new DistributionConfigImpl(removeNonUserProperties(properties)));
+  }
+
+  @Override
+  public boolean isReconnecting() {
+    return isReconnecting;
+  }
+
+  @Override
+  public QuorumChecker quorumChecker() {
+    return quorumChecker;
+  }
+
+  @Override
+  public DistributionConfig distributionConfig() {
+    return distributionConfig;
+  }
+
+  /**
+   * Remove the non distribution config properties so that they are not passed to the {@code
+   * DistributionConfigImpl} constructor
+   */
+  private static Properties removeNonUserProperties(Properties properties) {
+    Properties cleanedProperties = new Properties();
+    properties.forEach(cleanedProperties::put);
+    cleanedProperties.remove(DS_QUORUM_CHECKER_NAME);
+    cleanedProperties.remove(DS_RECONNECTING_NAME);
+    cleanedProperties.remove(DS_CONFIG_NAME);
+    return cleanedProperties;
+  }
+
+  /**
+   * Casts the object to the specified type, or returns the default value if the object cannot be
+   * cast.
+   */
+  private static <T> T convert(Object object, Class<T> type, Supplier<T> defaultValueSupplier) {
+    return type.isInstance(object) ? type.cast(object) : defaultValueSupplier.get();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/MemberMetricsSession.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/MemberMetricsSession.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.distributed.internal.DistributionConfig;
+
+/**
+ * Creates, configures, and manages the meter registry for a member of a distributed system.
+ */
+public class MemberMetricsSession implements MetricsSession {
+  private final CompositeMeterRegistry composite;
+
+  /**
+   * Constructs a metrics session to maintain the meter registry for a member of a distributed
+   * system. The registry is configured to give each meter a set of common tags that identify the
+   * member.
+   *
+   * @param memberConfig the configuration that describes this member
+   */
+  public MemberMetricsSession(DistributionConfig memberConfig) {
+    this(new CompositeMeterRegistry(), memberConfig);
+  }
+
+  /**
+   * Constructs a metrics session that maintains its meters using the given registry.
+   *
+   * @param registry the registry to use as the member's meter registry
+   * @param memberConfig the configuration that describes this member
+   */
+  @VisibleForTesting
+  public MemberMetricsSession(CompositeMeterRegistry registry, DistributionConfig memberConfig) {
+    MeterRegistry.Config registryConfig = registry.config();
+
+    int systemId = memberConfig.getDistributedSystemId();
+    registryConfig.commonTags("DistributedSystemID", String.valueOf(systemId));
+
+    String memberName = memberConfig.getName();
+    registryConfig.commonTags("MemberName", memberName == null ? "" : memberName);
+
+    composite = registry;
+  }
+
+  /**
+   * Returns the member's meter registry.
+   */
+  public MeterRegistry meterRegistry() {
+    return composite;
+  }
+
+  @Override
+  public void connectDownstreamRegistry(MeterRegistry downstream) {
+    composite.add(downstream);
+  }
+
+  @Override
+  public void disconnectDownstreamRegistry(MeterRegistry downstream) {
+    composite.remove(downstream);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/MetricsSession.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/MetricsSession.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Manages the lifecycle of a meter registry and allows connecting "downstream" meter registries to
+ * publish the managed registry's meters to external monitoring systems.
+ */
+public interface MetricsSession {
+  /**
+   * Connects the given "downstream" registry to the managed registry. For each meter in the
+   * managed registry, a corresponding meter is created or discovered in the downstream registry.
+   * Subsequent operations on the managed registry's meters are forwarded to the corresponding
+   * meters in the downstream registry. When meters are subsequently added or removed in the
+   * managed registry, corresponding meters are added or removed in the downstream registry.
+   *
+   * @param downstream the registry to connect to the managed registry
+   */
+  void connectDownstreamRegistry(MeterRegistry downstream);
+
+  /**
+   * Disconnects the given registry from the managed registry. For each meter in the managed
+   * registry, the corresponding meter in the downstream registry is removed. Subsequent additions
+   * and removals of meters in the managed registry have no effect on disconnected registries.
+   *
+   * @param downstream the registry to disconnect from the managed registry
+   */
+  void disconnectDownstreamRegistry(MeterRegistry downstream);
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/ConnectionConfigImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/ConnectionConfigImplTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_CONFIG_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_QUORUM_CHECKER_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_RECONNECTING_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.apache.geode.distributed.internal.membership.QuorumChecker;
+
+public class ConnectionConfigImplTest {
+  @Test
+  public void distributionConfigDoesNotContainDsQuorumCheckerProperty() {
+    QuorumChecker quorumChecker = mock(QuorumChecker.class);
+    Properties properties = new Properties();
+    properties.put(DS_QUORUM_CHECKER_NAME, quorumChecker);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    DistributionConfigImpl result = (DistributionConfigImpl) config.distributionConfig();
+    assertThat(result.getProps()).doesNotContainKey(DS_QUORUM_CHECKER_NAME);
+  }
+
+  @Test
+  public void distributionConfigDoesNotContainDsReconnectingProperty() {
+    Properties properties = new Properties();
+    properties.put(DS_RECONNECTING_NAME, Boolean.TRUE);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    DistributionConfigImpl result = (DistributionConfigImpl) config.distributionConfig();
+    assertThat(result.getProps()).doesNotContainKey(DS_RECONNECTING_NAME);
+  }
+
+  @Test
+  public void distributionConfigDoesNotContainDsConfigProperty() {
+    Properties properties = new Properties();
+    properties.put(DS_CONFIG_NAME, mock(DistributionConfig.class));
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    DistributionConfigImpl result = (DistributionConfigImpl) config.distributionConfig();
+    assertThat(result.getProps()).doesNotContainKey(DS_CONFIG_NAME);
+  }
+
+  @Test
+  public void isReconnecting_isTrue_ifReconnectingPropertyIsTrue() {
+    Properties properties = new Properties();
+
+    properties.put(DS_RECONNECTING_NAME, Boolean.TRUE);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isTrue();
+  }
+
+  @Test
+  public void isReconnecting_isFalse_ifReconnectingPropertyIsFalse() {
+    Properties properties = new Properties();
+
+    properties.put(DS_RECONNECTING_NAME, Boolean.FALSE);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isFalse();
+  }
+
+  @Test
+  public void isReconnecting_isFalse_ifReconnectingPropertyDoesNotExist() {
+    Properties properties = new Properties();
+
+    properties.remove(DS_RECONNECTING_NAME);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isFalse();
+  }
+
+  @Test
+  public void isReconnecting_isFalse_ifReconnectingPropertyIsNotBoolean() {
+    Properties properties = new Properties();
+
+    properties.put(DS_RECONNECTING_NAME, "a string, not a boolean");
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isFalse();
+  }
+
+  @Test
+  public void quorumChecker_returnsQuorumCheckerProperty_ifPropertyIsAQuorumChecker() {
+    QuorumChecker quorumCheckerFromProperties = mock(QuorumChecker.class);
+    Properties properties = new Properties();
+    properties.put(DS_QUORUM_CHECKER_NAME, quorumCheckerFromProperties);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.quorumChecker())
+        .isSameAs(quorumCheckerFromProperties);
+  }
+
+  @Test
+  public void quorumChecker_returnsNull_ifQuorumCheckerPropertyDoesNotExist() {
+    Properties properties = new Properties();
+    properties.remove(DS_QUORUM_CHECKER_NAME);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.quorumChecker()).isNull();
+  }
+
+  @Test
+  public void quorumChecker_returnsNull_ifQuorumCheckerPropertyIsNotAQuorumChecker() {
+    Properties properties = new Properties();
+
+    properties.put(DS_QUORUM_CHECKER_NAME, "a string, not a quorum checker");
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.quorumChecker()).isNull();
+  }
+
+  @Test
+  public void distributionConfig_returnsConfigProperty_ifPropertyIsADistributionConfigImpl() {
+    DistributionConfigImpl distributionConfigFromProperties =
+        new DistributionConfigImpl(new Properties());
+    Properties properties = new Properties();
+    properties.put(DS_CONFIG_NAME, distributionConfigFromProperties);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.distributionConfig())
+        .isSameAs(distributionConfigFromProperties);
+  }
+
+  @Test
+  public void distributionConfig_returnsDistributionConfigImpl_ifConfigPropertyDoesNotExist() {
+    Properties properties = new Properties();
+    properties.remove(DS_CONFIG_NAME);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.distributionConfig())
+        .isInstanceOf(DistributionConfigImpl.class);
+  }
+
+  @Test
+  public void distributionConfig_returnsDistributionConfigImpl_ifConfigPropertyIsNotADistributionConfigImpl() {
+    String distributionConfigFromProperties = "a string, not a distribution config";
+    Properties properties = new Properties();
+    properties.put(DS_CONFIG_NAME, distributionConfigFromProperties);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.distributionConfig())
+        .isInstanceOf(DistributionConfigImpl.class)
+        .isNotSameAs(distributionConfigFromProperties);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemMemberMetricsSessionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemMemberMetricsSessionTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import org.apache.geode.internal.metrics.MemberMetricsSession;
+import org.apache.geode.internal.statistics.StatisticsManagerFactory;
+
+public class InternalDistributedSystemMemberMetricsSessionTest {
+  @Mock
+  public StatisticsManagerFactory statisticsManagerFactory;
+
+  @Mock
+  public DistributionManager distributionManager;
+
+  @Before
+  public void setup() {
+    initMocks(this);
+  }
+
+  @Test
+  public void delegatesGetMeterRegistryToMemberMetricsSession() {
+    Properties memberProperties = new Properties();
+    ConnectionConfig memberConfig = new ConnectionConfigImpl(memberProperties);
+    MemberMetricsSession metricsSession =
+        new MemberMetricsSession(memberConfig.distributionConfig());
+
+    InternalDistributedSystem internalDistributedSystem =
+        InternalDistributedSystem.newInstanceForTesting(distributionManager, memberProperties,
+            statisticsManagerFactory, metricsSession);
+
+    assertThat(internalDistributedSystem.getMeterRegistry())
+        .isSameAs(metricsSession.meterRegistry());
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemStatisticsManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemStatisticsManagerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -35,10 +36,11 @@ import org.mockito.Mock;
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsType;
+import org.apache.geode.internal.metrics.MemberMetricsSession;
 import org.apache.geode.internal.statistics.StatisticsManager;
 import org.apache.geode.internal.statistics.StatisticsManagerFactory;
 
-public class InternalDistributedSystemTest {
+public class InternalDistributedSystemStatisticsManagerTest {
   private static final String STATISTIC_NAME = "statistic-name";
   private static final String STATISTIC_DESCRIPTION = "statistic-description";
   private static final String STATISTIC_UNITS = "statistic-units";
@@ -52,6 +54,12 @@ public class InternalDistributedSystemTest {
   @Mock
   public StatisticsManager statisticsManager;
 
+  @Mock
+  public MemberMetricsSession metricsSession;
+
+  @Mock
+  public DistributionManager distributionManager;
+
   private InternalDistributedSystem internalDistributedSystem;
 
   @Before
@@ -60,7 +68,9 @@ public class InternalDistributedSystemTest {
     when(statisticsManagerFactory.create(any(), anyLong(), anyBoolean()))
         .thenReturn(statisticsManager);
     internalDistributedSystem =
-        InternalDistributedSystem.newInstanceForTesting(statisticsManagerFactory);
+        InternalDistributedSystem
+            .newInstanceForTesting(distributionManager, new Properties(),
+                statisticsManagerFactory, metricsSession);
   }
 
   @Test
@@ -72,10 +82,14 @@ public class InternalDistributedSystemTest {
         .create(eq(defaultMemberName), anyLong(), eq(defaultStatsDisabled)))
             .thenReturn(statisticsManagerCreatedByFactory);
 
-    InternalDistributedSystem result =
-        InternalDistributedSystem.newInstanceForTesting(statisticsManagerFactory);
+    InternalDistributedSystem internalDistributedSystem =
+        InternalDistributedSystem
+            .newInstanceForTesting(distributionManager, new Properties(), statisticsManagerFactory,
+                metricsSession);
 
-    assertThat(result.getStatisticsManager())
+    StatisticsManager result = internalDistributedSystem.getStatisticsManager();
+
+    assertThat(result)
         .isSameAs(statisticsManagerCreatedByFactory);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/MemberMetricsSessionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/MemberMetricsSessionTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+
+import org.apache.geode.distributed.internal.DistributionConfig;
+
+public class MemberMetricsSessionTest {
+  private final DistributionConfig config = mock(DistributionConfig.class);
+
+  @Test
+  public void createsARegistry() {
+    MemberMetricsSession metricsSession = new MemberMetricsSession(config);
+
+    assertThat(metricsSession.meterRegistry())
+        .isNotNull();
+  }
+
+  @Test
+  public void managedRegistry_startsWithNoDownstreamRegistries() {
+    CompositeMeterRegistry managedRegistry = new CompositeMeterRegistry();
+    MemberMetricsSession metricsSession = new MemberMetricsSession(managedRegistry, config);
+
+    MeterRegistry primaryRegistry = metricsSession.meterRegistry();
+    assertThat(primaryRegistry)
+        .isSameAs(managedRegistry);
+
+    Set<MeterRegistry> downstreamRegistries = managedRegistry.getRegistries();
+
+    assertThat(downstreamRegistries)
+        .isEmpty();
+  }
+
+  @Test
+  public void managedRegistry_addsSystemIdTag_toNewMeters() {
+    int idFromConfig = 124;
+    when(config.getDistributedSystemId()).thenReturn(idFromConfig);
+
+    MemberMetricsSession metricsSession = new MemberMetricsSession(config);
+    MeterRegistry managedRegistry = metricsSession.meterRegistry();
+
+    Meter meter = managedRegistry.counter("my.meter");
+
+    assertThat(meter.getId().getTags())
+        .contains(Tag.of("DistributedSystemID", String.valueOf(idFromConfig)));
+  }
+
+  @Test
+  public void managedRegistry_addsMemberNameTag_toNewMeters() {
+    String memberNameFromConfig = "the-member-name";
+    when(config.getName()).thenReturn(memberNameFromConfig);
+
+    MemberMetricsSession metricsSession = new MemberMetricsSession(config);
+    MeterRegistry managedRegistry = metricsSession.meterRegistry();
+
+    Meter meter = managedRegistry.counter("my.meter");
+
+    assertThat(meter.getId().getTags())
+        .contains(Tag.of("MemberName", memberNameFromConfig));
+  }
+
+  @Test
+  public void memberNameTagValueIsEmpty_ifConfigurationMemberNameIsNull() {
+    when(config.getName()).thenReturn(null);
+
+    MemberMetricsSession metricsSession = new MemberMetricsSession(config);
+    MeterRegistry managedRegistry = metricsSession.meterRegistry();
+
+    Meter meter = managedRegistry.counter("my.counter");
+
+    assertThat(meter.getId().getTags())
+        .contains(Tag.of("MemberName", ""));
+  }
+
+  @Test
+  public void remembersConnectedDownstreamRegistries() {
+    CompositeMeterRegistry managedRegistry = new CompositeMeterRegistry();
+    MemberMetricsSession metricsSession = new MemberMetricsSession(managedRegistry, config);
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    assertThat(managedRegistry.getRegistries())
+        .contains(downstreamRegistry);
+  }
+
+  @Test
+  public void forgetsDisconnectedDownstreamRegistries() {
+    CompositeMeterRegistry managedRegistry = new CompositeMeterRegistry();
+    MemberMetricsSession metricsSession = new MemberMetricsSession(managedRegistry, config);
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    metricsSession.disconnectDownstreamRegistry(downstreamRegistry);
+
+    assertThat(managedRegistry.getRegistries())
+        .doesNotContain(downstreamRegistry);
+  }
+
+  @Test
+  public void connectsExistingMetersToNewDownstreamRegistries() {
+    MemberMetricsSession metricsSession = new MemberMetricsSession(config);
+    MeterRegistry primaryRegistry = metricsSession.meterRegistry();
+
+    String counterName = "the.counter";
+    Counter primaryCounter = primaryRegistry.counter(counterName);
+
+    double amountIncrementedBeforeConnectingDownstreamRegistry = 3.0;
+    primaryCounter.increment(amountIncrementedBeforeConnectingDownstreamRegistry);
+
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    Counter downstreamCounter = downstreamRegistry.find(counterName).counter();
+    assertThat(downstreamCounter)
+        .as("downstream counter after connecting, before incrementing")
+        .isNotNull();
+
+    // Note that the newly-created downstream counter starts at zero, ignoring
+    // any increments that happened before the downstream registry was added.
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value after connecting, before incrementing")
+        .isNotEqualTo(amountIncrementedBeforeConnectingDownstreamRegistry)
+        .isEqualTo(0);
+
+    double amountIncrementedAfterConnectingDownstreamRegistry = 42.0;
+    primaryCounter.increment(amountIncrementedAfterConnectingDownstreamRegistry);
+
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value after incrementing")
+        .isEqualTo(amountIncrementedAfterConnectingDownstreamRegistry);
+  }
+
+  @Test
+  public void connectsNewMetersToExistingDownstreamRegistries() {
+    MemberMetricsSession metricsSession = new MemberMetricsSession(config);
+    MeterRegistry primaryRegistry = metricsSession.meterRegistry();
+
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    String counterName = "the.counter";
+    Counter newCounter = primaryRegistry.counter(counterName);
+
+    Counter downstreamCounter = downstreamRegistry.find(counterName).counter();
+    assertThat(downstreamCounter)
+        .as("downstream counter before incrementing")
+        .isNotNull();
+
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value before incrementing")
+        .isEqualTo(newCounter.count())
+        .isEqualTo(0);
+
+    double amountIncrementedAfterConnectingDownstreamRegistry = 93.0;
+    newCounter.increment(amountIncrementedAfterConnectingDownstreamRegistry);
+
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value after incrementing")
+        .isEqualTo(newCounter.count());
+  }
+}

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -131,6 +131,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
       <scope>compile</scope>
@@ -820,6 +825,11 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.2</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.geode</groupId>

--- a/geode-cq/src/test/resources/expected-pom.xml
+++ b/geode-cq/src/test/resources/expected-pom.xml
@@ -549,6 +549,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-dunit/src/test/resources/expected-pom.xml
+++ b/geode-dunit/src/test/resources/expected-pom.xml
@@ -668,6 +668,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-experimental-driver/src/test/resources/expected-pom.xml
+++ b/geode-experimental-driver/src/test/resources/expected-pom.xml
@@ -554,6 +554,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-json/src/test/resources/expected-pom.xml
+++ b/geode-json/src/test/resources/expected-pom.xml
@@ -537,6 +537,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -627,6 +627,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-lucene/src/test/resources/expected-pom.xml
+++ b/geode-lucene/src/test/resources/expected-pom.xml
@@ -622,6 +622,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-management/src/test/resources/expected-pom.xml
+++ b/geode-management/src/test/resources/expected-pom.xml
@@ -559,6 +559,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-old-client-support/src/test/resources/expected-pom.xml
+++ b/geode-old-client-support/src/test/resources/expected-pom.xml
@@ -544,6 +544,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-protobuf-messages/src/test/resources/expected-pom.xml
+++ b/geode-protobuf-messages/src/test/resources/expected-pom.xml
@@ -544,6 +544,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-protobuf/src/test/resources/expected-pom.xml
+++ b/geode-protobuf/src/test/resources/expected-pom.xml
@@ -569,6 +569,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-pulse/src/test/resources/expected-pom.xml
+++ b/geode-pulse/src/test/resources/expected-pom.xml
@@ -727,6 +727,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-rebalancer/src/test/resources/expected-pom.xml
+++ b/geode-rebalancer/src/test/resources/expected-pom.xml
@@ -573,6 +573,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-wan/src/test/resources/expected-pom.xml
+++ b/geode-wan/src/test/resources/expected-pom.xml
@@ -544,6 +544,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-web-api/src/test/resources/expected-pom.xml
+++ b/geode-web-api/src/test/resources/expected-pom.xml
@@ -688,6 +688,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-web-management/src/test/resources/expected-pom.xml
+++ b/geode-web-management/src/test/resources/expected-pom.xml
@@ -688,6 +688,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/geode-web/src/test/resources/expected-pom.xml
+++ b/geode-web/src/test/resources/expected-pom.xml
@@ -607,6 +607,11 @@
         <version>1.2</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>1.9.0-SNAPSHOT</version>

--- a/gradle/geode-dependency-management.gradle
+++ b/gradle/geode-dependency-management.gradle
@@ -117,6 +117,7 @@ class GeodeDependencyManagementPlugin implements Plugin<Project> {
         dependency(group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1')
         dependency(group: 'commons-validator', name: 'commons-validator', version: project.'commons-validator.version')
         dependency(group: 'io.github.classgraph', name: 'classgraph', version: '4.0.6')
+        dependency(group: 'io.micrometer', name: 'micrometer-core', version: '1.1.2')
         dependency(group: 'io.netty', name: 'netty-all', version: '4.1.31.Final')
         dependencySet(group: 'io.springfox', version: '2.9.2') {
           entry 'springfox-swagger-ui'


### PR DESCRIPTION
This PR supersedes https://github.com/apache/geode/pull/3153, which has been closed.

This PR adds a Micrometer-based metrics system to Geode. The key elements are:
- A `MeterRegistry` that maintains the set of meters for a member. The registry is configured at startup, and gives each meter it creates a set of tags that identify the member and the distributed system.
- A `MemberMetricsSession` manages the configuration and lifecycle of a member's meter registry. This class implements `MetricsSession` interface, which provides methods to connect user-implemented "downstream" registries to publish the member registry's meters to external monitoring systems.

This intent of this limited implementation is to provide the foundation to:
- Instrument Geode code using named, dimensional meters.
- Experiment with a variety of existing monitoring agents that can publish Micrometer-based metrics to external monitoring systems.
- Explore a variety of mechanisms for connecting external monitoring agents.

Some key limitations of this implementation:
- It adds no meters to Geode. It provides a *registry* to which meters can be added.
- It provides a single, limited mechanism to connect external monitoring agents. This limited implementation is designed specifically to support exploring a variety of external monitoring agents.

This implementation makes the `MeterRegistry` and the `MetricsSession` available via methods on `InternalDistributedSystem`. These methods will be moved to an appropriate non-internal interface or class in the future. Likewise, `MetricsSession`, which is currently declared in an internal package, will be moved to an appropriate non-internal package in the future. `MemberMetricsSession` will remain internal.

This implementation *neither addresses nor precludes* additional mechanisms for configuring and connecting monitoring agents. We are considering several mechanisms for possible future implementation:
- Supply a downstream registry at startup via a `CacheFactory`.
- Supply a downstream registry at startup via a service loader.
- Configure and manage a downstream registry at runtime via user-defined Geode extensions.
- Other options TBD.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
