### PR TITLE
GEODE-6381: Update Jackson version to fix dependency CVEs

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -375,7 +375,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -550,7 +550,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -675,7 +675,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -895,9 +895,9 @@ lib/geode-web-0.0.0.jar
 lib/gfsh-dependencies.jar
 lib/grumpy-core-0.2.2.jar
 lib/istack-commons-runtime-2.2.jar
-lib/jackson-annotations-2.9.7.jar
-lib/jackson-core-2.9.7.jar
-lib/jackson-databind-2.9.7.jar
+lib/jackson-annotations-2.9.8.jar
+lib/jackson-core-2.9.8.jar
+lib/jackson-databind-2.9.8.jar
 lib/jansi-1.17.1.jar
 lib/javax.activation-1.2.0.jar
 lib/javax.activation-api-1.2.0.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -25,9 +25,9 @@ geode-rebalancer-0.0.0.jar
 geode-wan-0.0.0.jar
 grumpy-core-0.2.2.jar
 istack-commons-runtime-2.2.jar
-jackson-annotations-2.9.7.jar
-jackson-core-2.9.7.jar
-jackson-databind-2.9.7.jar
+jackson-annotations-2.9.8.jar
+jackson-core-2.9.8.jar
+jackson-databind-2.9.8.jar
 jansi-1.17.1.jar
 javax.activation-1.2.0.jar
 javax.activation-api-1.2.0.jar

--- a/geode-assembly/src/test/resources/expected-pom.xml
+++ b/geode-assembly/src/test/resources/expected-pom.xml
@@ -375,7 +375,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -550,7 +550,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -675,7 +675,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-common/src/test/resources/expected-pom.xml
+++ b/geode-common/src/test/resources/expected-pom.xml
@@ -374,7 +374,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -549,7 +549,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -674,7 +674,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-concurrency-test/src/test/resources/expected-pom.xml
+++ b/geode-concurrency-test/src/test/resources/expected-pom.xml
@@ -386,7 +386,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -561,7 +561,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -686,7 +686,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-connectors/src/test/resources/expected-pom.xml
+++ b/geode-connectors/src/test/resources/expected-pom.xml
@@ -448,7 +448,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -623,7 +623,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -748,7 +748,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -659,7 +659,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -834,7 +834,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -959,7 +959,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-cq/src/test/resources/expected-pom.xml
+++ b/geode-cq/src/test/resources/expected-pom.xml
@@ -386,7 +386,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -561,7 +561,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -686,7 +686,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-dunit/src/test/resources/expected-pom.xml
+++ b/geode-dunit/src/test/resources/expected-pom.xml
@@ -505,7 +505,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -680,7 +680,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -805,7 +805,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-experimental-driver/src/test/resources/expected-pom.xml
+++ b/geode-experimental-driver/src/test/resources/expected-pom.xml
@@ -391,7 +391,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -566,7 +566,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -691,7 +691,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-json/src/test/resources/expected-pom.xml
+++ b/geode-json/src/test/resources/expected-pom.xml
@@ -374,7 +374,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -549,7 +549,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -674,7 +674,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -464,7 +464,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -639,7 +639,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -764,7 +764,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-lucene/src/test/resources/expected-pom.xml
+++ b/geode-lucene/src/test/resources/expected-pom.xml
@@ -459,7 +459,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -634,7 +634,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -759,7 +759,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-management/src/test/resources/expected-pom.xml
+++ b/geode-management/src/test/resources/expected-pom.xml
@@ -396,7 +396,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -571,7 +571,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -696,7 +696,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-old-client-support/src/test/resources/expected-pom.xml
+++ b/geode-old-client-support/src/test/resources/expected-pom.xml
@@ -381,7 +381,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -556,7 +556,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -681,7 +681,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-protobuf-messages/src/test/resources/expected-pom.xml
+++ b/geode-protobuf-messages/src/test/resources/expected-pom.xml
@@ -381,7 +381,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -556,7 +556,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -681,7 +681,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-protobuf/src/test/resources/expected-pom.xml
+++ b/geode-protobuf/src/test/resources/expected-pom.xml
@@ -406,7 +406,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -581,7 +581,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -706,7 +706,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-pulse/src/test/resources/expected-pom.xml
+++ b/geode-pulse/src/test/resources/expected-pom.xml
@@ -564,7 +564,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -739,7 +739,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -864,7 +864,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-rebalancer/src/test/resources/expected-pom.xml
+++ b/geode-rebalancer/src/test/resources/expected-pom.xml
@@ -410,7 +410,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -585,7 +585,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -710,7 +710,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-wan/src/test/resources/expected-pom.xml
+++ b/geode-wan/src/test/resources/expected-pom.xml
@@ -381,7 +381,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -556,7 +556,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -681,7 +681,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-web-api/src/test/resources/expected-pom.xml
+++ b/geode-web-api/src/test/resources/expected-pom.xml
@@ -525,7 +525,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -700,7 +700,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -825,7 +825,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-web-management/src/test/resources/expected-pom.xml
+++ b/geode-web-management/src/test/resources/expected-pom.xml
@@ -525,7 +525,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -700,7 +700,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -825,7 +825,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/geode-web/src/test/resources/expected-pom.xml
+++ b/geode-web/src/test/resources/expected-pom.xml
@@ -444,7 +444,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -619,7 +619,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>mx4j</groupId>
@@ -744,7 +744,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.7</version>
+        <version>2.9.8</version>
       </dependency>
       <dependency>
         <groupId>com.palantir.docker.compose</groupId>

--- a/gradle/geode-dependency-management.gradle
+++ b/gradle/geode-dependency-management.gradle
@@ -78,7 +78,7 @@ class GeodeDependencyManagementPlugin implements Plugin<Project> {
         dependency(group: 'antlr', name: 'antlr', version: project.'antlr.version')
         dependency(group: 'cglib', name: 'cglib', version: project.'cglib.version')
         dependency(group: 'com.carrotsearch.randomizedtesting', name: 'randomizedtesting-runner', version: '2.5.0')
-        dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.7') {
+        dependencySet(group: 'com.fasterxml.jackson.core', version: '2.9.8') {
           entry 'jackson-annotations'
           entry 'jackson-core'
           entry 'jackson-databind'


### PR DESCRIPTION
The following flaws have been published by NIST since Dec 2018

* CVE-2018-1000873
* CVE-2018-19362
* CVE-2018-19361
* CVE-2018-19360

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Jianxia Chen <jchen@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon