### PR TITLE
GEODE-6391: Adding the event ID to the messages

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -897,9 +897,11 @@ org/apache/geode/internal/cache/DestroyOperation$DestroyWithContextMessage,2
 fromData,14
 toData,14
 
-org/apache/geode/internal/cache/DestroyPartitionedRegionMessage,2
-fromData,76
-toData,77
+org/apache/geode/internal/cache/DestroyPartitionedRegionMessage,4
+fromData,17
+fromDataPre_GEODE_1_9_0_0,76
+toData,14
+toDataPre_GEODE_1_9_0_0,77
 
 org/apache/geode/internal/cache/DestroyRegionOperation$DestroyRegionMessage,2
 fromData,41
@@ -1117,9 +1119,11 @@ org/apache/geode/internal/cache/InvalidateOperation$InvalidateWithContextMessage
 fromData,14
 toData,14
 
-org/apache/geode/internal/cache/InvalidatePartitionedRegionMessage,2
-fromData,14
+org/apache/geode/internal/cache/InvalidatePartitionedRegionMessage,4
+fromData,17
+fromDataPre_GEODE_1_9_0_0,14
 toData,14
+toDataPre_GEODE_1_9_0_0,14
 
 org/apache/geode/internal/cache/InvalidateRegionOperation$InvalidateRegionMessage,2
 fromData,17

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEventImpl.java
@@ -26,7 +26,6 @@ import org.apache.geode.cache.RegionEvent;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.DSFIDFactory;
 import org.apache.geode.internal.DataSerializableFixedID;
 import org.apache.geode.internal.InternalDataSerializer;
@@ -105,8 +104,6 @@ public class RegionEventImpl
     this.callbackArgument = callbackArgument;
     this.originRemote = originRemote;
     this.distributedMember = distributedMember;
-    // TODO:ASIF: Remove this Assert from production env.
-    Assert.assertTrue(eventID != null);
     this.eventId = eventID;
   }
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/DestroyPartitionedRegionMessageDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/DestroyPartitionedRegionMessageDUnitTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.cq.dunit;
+
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.query.CqAttributes;
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.data.Portfolio;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
+import org.apache.geode.test.junit.rules.VMProvider;
+
+@RunWith(JUnitParamsRunner.class)
+@Category(ClientSubscriptionTest.class)
+public class DestroyPartitionedRegionMessageDUnitTest implements Serializable {
+  private MemberVM server1, server2;
+  private TestCqListener testListener;
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule();
+
+  @Before
+  public void before() throws Exception {
+    MemberVM locator = clusterStartupRule.startLocatorVM(0, new Properties());
+    Integer locator1Port = locator.getPort();
+    server1 = clusterStartupRule.startServerVM(1, locator1Port);
+    server2 = clusterStartupRule.startServerVM(2, locator1Port);
+
+    VMProvider.invokeInEveryMember(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
+      cache.createRegionFactory(RegionShortcut.PARTITION).create("region");
+    }, server1, server2);
+
+    ClientCacheFactory clientCacheFactory = new ClientCacheFactory();
+    clientCacheFactory.addPoolServer("localhost", server1.getPort());
+    clientCacheFactory.setPoolSubscriptionEnabled(true);
+    ClientCache clientCache = clientCacheFactory.create();
+    clientCache.createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+    QueryService queryService = clientCache.getQueryService();
+    CqAttributesFactory cqaf = new CqAttributesFactory();
+    testListener = new TestCqListener();
+    cqaf.addCqListener(testListener);
+    CqAttributes cqAttributes = cqaf.create();
+
+    queryService.newCq("Select * from /region r where r.ID + 3 > 4", cqAttributes).execute();
+  }
+
+  @Test
+  @Parameters({"1", "2"})
+  @TestCaseName("[{index}] {method}: server{params}")
+  public void closeMethodShouldBeCalledWhenRegionIsDestroyed(int serverIndex) {
+    // The test is run twice with destroy being invoked in each server
+    clusterStartupRule.getMember(serverIndex).invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
+      Region<Integer, Portfolio> regionOnServer = cache.getRegion("region");
+      regionOnServer.destroyRegion();
+    });
+
+    // Wait until region destroy operation has been distributed.
+    VMProvider.invokeInEveryMember(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
+      await().until(() -> cache.getRegion("region") == null);
+    }, server1, server2);
+
+    assertThat(testListener.closeInvoked.get()).isTrue();
+  }
+
+  private class TestCqListener implements CqListener, Serializable {
+    AtomicBoolean closeInvoked = new AtomicBoolean();
+
+    @Override
+    public void onEvent(CqEvent aCqEvent) {}
+
+    @Override
+    public void onError(CqEvent aCqEvent) {}
+
+    @Override
+    public void close() {
+      closeInvoked.set(true);
+    }
+  }
+}

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/InvalidatePartitionedRegionMessageDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/InvalidatePartitionedRegionMessageDUnitTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.cq.dunit;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.query.CqAttributes;
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.data.Portfolio;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
+import org.apache.geode.test.junit.rules.VMProvider;
+
+@RunWith(JUnitParamsRunner.class)
+@Category(ClientSubscriptionTest.class)
+public class InvalidatePartitionedRegionMessageDUnitTest implements Serializable {
+  private MemberVM server1, server2;
+  private TestCqListener testListener;
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule();
+
+  @Before
+  public void before() throws Exception {
+    MemberVM locator = clusterStartupRule.startLocatorVM(0, new Properties());
+    Integer locator1Port = locator.getPort();
+    server1 = clusterStartupRule.startServerVM(1, locator1Port);
+    server2 = clusterStartupRule.startServerVM(2, locator1Port);
+
+    VMProvider.invokeInEveryMember(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
+      cache.createRegionFactory(RegionShortcut.PARTITION).create("region");
+    }, server1, server2);
+
+    ClientCacheFactory clientCacheFactory = new ClientCacheFactory();
+    clientCacheFactory.addPoolServer("localhost", server1.getPort());
+    clientCacheFactory.setPoolSubscriptionEnabled(true);
+    ClientCache clientCache = clientCacheFactory.create();
+    clientCache.createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+    QueryService queryService = clientCache.getQueryService();
+    CqAttributesFactory cqaf = new CqAttributesFactory();
+    testListener = new TestCqListener();
+    cqaf.addCqListener(testListener);
+    CqAttributes cqAttributes = cqaf.create();
+
+    queryService.newCq("Select * from /region r where r.ID + 3 > 4", cqAttributes).execute();
+  }
+
+  @Test
+  @Parameters({"1", "2"})
+  @TestCaseName("[{index}] {method}: server{params}")
+  public void closeMethodShouldBeCalledWhenRegionIsDestroyed(int serverIndex) {
+    // The test is run twice with destroy being invoked in each server
+    clusterStartupRule.getMember(serverIndex).invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      assertThat(cache).isNotNull();
+      Region<Integer, Portfolio> regionOnServer = cache.getRegion("region");
+      regionOnServer.invalidateRegion();
+    });
+
+  }
+
+  private class TestCqListener implements CqListener, Serializable {
+    AtomicBoolean closeInvoked = new AtomicBoolean();
+
+    @Override
+    public void onEvent(CqEvent aCqEvent) {}
+
+    @Override
+    public void onError(CqEvent aCqEvent) {}
+
+    @Override
+    public void close() {
+      closeInvoked.set(true);
+    }
+  }
+}


### PR DESCRIPTION
	* Event id is included in the DestroyPartitionedRegionMessage and InvalidatePartitionedRegionMessage
	* This is to prevent the NPE
	* The NPE occurs when server tries to notify the clients after receiving the message
	* While getting the thread id and sequence id it ends up with an NPE and event id is null.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
