### PR TITLE
GEODE-6395: Use md5 as Spotless cache value.

### DIFF
--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -15,6 +15,16 @@
  * limitations under the License.
  */
 
+// When a custom step changes, we need to bump the value passed to the method
+//   bumpThisNumberIfACustomStepChanges
+// This has been historicaly easy to forget, however, and can cause failures in some rare cases.
+// To safeguard against this, we instead use the (partial) md5 of this file as that method input.
+def thisFile = file("${scriptDir}/spotless.gradle")
+def thisFileMd5 = thisFile.text.md5() as String
+def thisFileMd5Piece = thisFileMd5.substring(0, 8)
+def thisFileIntegerHash = Integer.parseUnsignedInt(thisFileMd5Piece, 16)
+logger.debug("Using partial md5 (${thisFileIntegerHash}) of file ${thisFile} as spotless bump.")
+
 subprojects {
   apply plugin: "com.diffplug.gradle.spotless"
   spotless {
@@ -28,7 +38,7 @@ subprojects {
 
       // As the method name suggests, bump this number if any of the below "custom" rules change.
       // Spotless will not run on unchanged files unless this number changes.
-      bumpThisNumberIfACustomStepChanges(3)
+      bumpThisNumberIfACustomStepChanges(thisFileIntegerHash)
 
       removeUnusedImports()
 
@@ -115,7 +125,7 @@ subprojects {
 
       // As the method name suggests, bump this number if any of the below "custom" rules change.
       // Spotless will not run on unchanged files unless this number changes.
-      bumpThisNumberIfACustomStepChanges(0)
+      bumpThisNumberIfACustomStepChanges(thisFileIntegerHash)
 
       custom 'Use single-quote in project directives.', {
         it.replaceAll(/project\(":([^"]*)"\)/, 'project(\':$1\')')


### PR DESCRIPTION
* This acts as a safeguard against developers forgetting to bump the input to 'bumpThisNumberIfACustomStepChanges'

-----

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
