### PR TITLE
GEODE-6396: Make ServerContainer tolerate IOExceptions while dumping logs

### DIFF
--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatContainer.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatContainer.java
@@ -55,7 +55,7 @@ public class TomcatContainer extends ServerContainer {
     super(install, containerConfigHome, containerDescriptors, portSupplier);
 
     // Setup container specific XML files
-    contextXMLFile = new File(logDir.getAbsolutePath() + "/context.xml");
+    contextXMLFile = new File(cargoLogDir.getAbsolutePath() + "/context.xml");
     serverXMLFile = new File(DEFAULT_CONF_DIR + "server.xml");
 
     // Copy the default container context XML file from the install to the specified path

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/GenericAppServerContainer.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/GenericAppServerContainer.java
@@ -62,7 +62,7 @@ public class GenericAppServerContainer extends ServerContainer {
     modifyWarScript.setExecutable(true);
 
     // Setup modify_war script logging file
-    modifyWarScriptLog = new File(logDir + "/warScript.log");
+    modifyWarScriptLog = new File(cargoLogDir + "/warScript.log");
     modifyWarScriptLog.createNewFile();
 
     // Ignore tests that are running on windows, since they can't run the modify war script


### PR DESCRIPTION
Changed `ServerContainer` to catch and IOExceptions while dumping container logs.

Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Michael Oleske <moleske@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
