### PR TITLE
GEODE-6389 CI Failure: ConcurrentWANPropagation_1_DUnitTest.testRepli…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCloser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCloser.java
@@ -169,7 +169,7 @@ public class SocketCloser {
    *
    * @param socket the socket to close
    * @param address identifies who the socket is connected to
-   * @param extra an optional Runnable with stuff to execute in the async thread
+   * @param extra an optional Runnable with stuff to execute before the socket is closed
    */
   public void asyncClose(final Socket socket, final String address, final Runnable extra) {
     if (socket == null || socket.isClosed()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -1578,10 +1578,6 @@ public class Connection implements Runnable {
         }
         asyncClose(false);
         this.owner.removeAndCloseThreadOwnedSockets();
-
-        if (this.isSharedResource()) {
-          releaseInputBuffer();
-        }
       }
       // make sure that if the reader thread exits we notify a thread waiting
       // for the handshake.


### PR DESCRIPTION
…catedSerialPropagation

I found a place where we were releasing pooled buffers twice.  The place
to release the buffer is in asyncClose but we were also doing it just
after calling that method in the run() method if the connection wasn't
thread-owned.  Both GEODE-6389 and GEODE-6377 were using
conserve-sockets=true so I think this is the source of the problem.

The GEODE-6389 failure, in particular, could only have come from
improper use of the buffer pool because it occured in a MessageStreamer
and they don't involve multithreaded use of a buffer.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
