### PR TITLE
GEODE-6404: work around possible sync issue with computeIfAbsent

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/TableMetaDataManager.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/TableMetaDataManager.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.apache.geode.connectors.jdbc.JdbcConnectorException;
 import org.apache.geode.connectors.jdbc.internal.TableMetaData.ColumnMetaData;
 import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
+import org.apache.geode.internal.util.JavaWorkarounds;
 
 /**
  * Given a tableName this manager will determine which column should correspond to the Geode Region
@@ -46,7 +47,7 @@ public class TableMetaDataManager {
 
   public TableMetaDataView getTableMetaDataView(Connection connection,
       RegionMapping regionMapping) {
-    return tableToMetaDataMap.computeIfAbsent(computeTableName(regionMapping),
+    return JavaWorkarounds.computeIfAbsent(tableToMetaDataMap, computeTableName(regionMapping),
         k -> computeTableMetaDataView(connection, k, regionMapping));
   }
 

--- a/geode-core/src/jmh/java/org/apache/geode/internal/util/ComputeIfAbsentBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/internal/util/ComputeIfAbsentBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.util;
+
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/**
+ * Test spins up threads that constantly do computeIfAbsent
+ * The tests will measure throughput
+ * The benchmark tests computeIfAbsent in the presence of other threads contending for the same key
+ */
+
+@State(Scope.Thread)
+@Fork(1)
+public class ComputeIfAbsentBenchmark {
+
+  public Map map = new ConcurrentHashMap();
+  /*
+   * After load is established, how many measurements shall we take?
+   */
+  private static final double BENCHMARK_ITERATIONS = 10;
+
+  private static final int TIME_TO_QUIESCE_BEFORE_SAMPLING = 1;
+
+  private static final int THREAD_POOL_PROCESSOR_MULTIPLE = 2;
+
+  private ScheduledThreadPoolExecutor loadGenerationExecutorService;
+
+  private static boolean testRunning = true;
+
+  @Setup(Level.Trial)
+  public void trialSetup() throws InterruptedException {
+
+    final int numberOfThreads =
+        THREAD_POOL_PROCESSOR_MULTIPLE * Runtime.getRuntime().availableProcessors();
+
+    loadGenerationExecutorService =
+        (ScheduledThreadPoolExecutor) Executors.newScheduledThreadPool(
+            numberOfThreads);
+
+    System.out.println(String.format("Pool has %d threads", numberOfThreads));
+
+    loadGenerationExecutorService.setRemoveOnCancelPolicy(true);
+
+    generateLoad(
+        loadGenerationExecutorService, numberOfThreads);
+
+    // allow system to quiesce
+    Thread.sleep(TIME_TO_QUIESCE_BEFORE_SAMPLING);
+  }
+
+  @TearDown(Level.Trial)
+  public void trialTeardown() {
+    testRunning = false;
+    loadGenerationExecutorService.shutdownNow();
+  }
+
+  @Benchmark
+  @Measurement(iterations = (int) BENCHMARK_ITERATIONS)
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.SECONDS)
+  // @Warmup we don't warm up because our @Setup warms us up
+  public Object computeIfAbsent() {
+    return JavaWorkarounds.computeIfAbsent(map, 1, k -> k);
+  }
+
+  private void generateLoad(final ScheduledExecutorService executorService, int numThreads) {
+    for (int i = 0; i < numThreads; i++) {
+      executorService.schedule(() -> {
+        while (testRunning) {
+          JavaWorkarounds.computeIfAbsent(map, 1, k -> k);
+        }
+      }, 0, TimeUnit.MILLISECONDS);
+    }
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/AttributeDescriptor.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/AttributeDescriptor.java
@@ -34,6 +34,7 @@ import org.apache.geode.cache.query.NameNotFoundException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.internal.cache.Token;
+import org.apache.geode.internal.util.JavaWorkarounds;
 import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxSerializationException;
 import org.apache.geode.pdx.internal.InternalPdxInstance;
@@ -152,7 +153,7 @@ public class AttributeDescriptor {
     key.add(targetClass);
     key.add(_name);
 
-    Member m = _localCache.computeIfAbsent(key, k -> {
+    Member m = JavaWorkarounds.computeIfAbsent(_localCache, key, k -> {
       Member member = getReadField(targetClass);
       return member == null ? getReadMethod(targetClass) : member;
     });

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -116,6 +116,7 @@ import org.apache.geode.internal.statistics.StatisticsManagerFactory;
 import org.apache.geode.internal.statistics.StatisticsRegistry;
 import org.apache.geode.internal.statistics.platform.LinuxProcFsStatistics;
 import org.apache.geode.internal.tcp.ConnectionTable;
+import org.apache.geode.internal.util.JavaWorkarounds;
 import org.apache.geode.management.ManagementException;
 import org.apache.geode.pdx.internal.TypeRegistry;
 import org.apache.geode.security.GemFireSecurityException;
@@ -2006,7 +2007,7 @@ public class InternalDistributedSystem extends DistributedSystem
   private FunctionServiceStats functionServiceStats = null;
 
   public FunctionStats getFunctionStats(String textId) {
-    return functionExecutionStatsMap.computeIfAbsent(textId,
+    return JavaWorkarounds.computeIfAbsent(functionExecutionStatsMap, textId,
         key -> new FunctionStats(this, key));
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
@@ -36,6 +36,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.NetView;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator;
+import org.apache.geode.internal.util.JavaWorkarounds;
 
 public final class GMSEncrypt {
   // Parameters for the Diffie-Hellman key exchange
@@ -197,7 +198,7 @@ public final class GMSEncrypt {
 
   private GMSEncryptionCipherPool getPeerEncryptor(InternalDistributedMember member)
       throws Exception {
-    return peerEncryptors.computeIfAbsent(member, (mbr) -> {
+    return JavaWorkarounds.computeIfAbsent(peerEncryptors, member, (mbr) -> {
       try {
         return new GMSEncryptionCipherPool(this, generateSecret(lookupKeyByMember(member)));
       } catch (Exception ex) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupDefinition.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupDefinition.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.geode.cache.DiskStore;
+import org.apache.geode.internal.util.JavaWorkarounds;
 
 class BackupDefinition {
 
@@ -79,7 +80,8 @@ class BackupDefinition {
   }
 
   void addOplogFileToBackup(DiskStore diskStore, Path fileLocation) {
-    Set<Path> files = oplogFilesByDiskStore.computeIfAbsent(diskStore, k -> new HashSet<>());
+    Set<Path> files =
+        JavaWorkarounds.computeIfAbsent(oplogFilesByDiskStore, diskStore, k -> new HashSet<>());
     files.add(fileLocation);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientHealthMonitor.java
@@ -41,6 +41,7 @@ import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.cache.tier.ServerSideHandshake;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingThread;
+import org.apache.geode.internal.util.JavaWorkarounds;
 
 /**
  * Class <code>ClientHealthMonitor</code> is a server-side singleton that monitors the health of
@@ -658,7 +659,8 @@ public class ClientHealthMonitor {
   }
 
   public ServerConnectionCollection getProxyIdCollection(ClientProxyMembershipID proxyID) {
-    return proxyIdConnections.computeIfAbsent(proxyID, key -> new ServerConnectionCollection());
+    return JavaWorkarounds.computeIfAbsent(proxyIdConnections, proxyID,
+        key -> new ServerConnectionCollection());
   }
 
   public Map<ClientProxyMembershipID, MutableInt> getCleanupProxyIdTable() {

--- a/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
@@ -19,26 +19,16 @@ import java.util.function.Function;
 
 public class JavaWorkarounds {
 
-  public static final boolean postJava8 = calcIfJDKIsPost8();
-
-  private static boolean calcIfJDKIsPost8() {
-    String version = System.getProperty("java.version");
-    return !version.matches("1\\.[0-8]\\.");
-  }
 
   // This is a workaround for computeIfAbsent which unnecessarily takes out a write lock in the case
-  // where the entry for the key exists already.  This only affects pre Java 9 jdks
+  // where the entry for the key exists already. This only affects pre Java 9 jdks
   // https://bugs.openjdk.java.net/browse/JDK-8161372
   public static <K, V> V computeIfAbsent(Map<K, V> map, K key,
-      Function<? super K, ? extends V> mappingFunction) {
-    if (postJava8) {
+                                         Function<? super K, ? extends V> mappingFunction) {
+    V existingValue = map.get(key);
+    if (existingValue == null) {
       return map.computeIfAbsent(key, mappingFunction);
-    } else {
-      V existingValue = map.get(key);
-      if (existingValue == null) {
-        return map.computeIfAbsent(key, mappingFunction);
-      }
-      return existingValue;
     }
+    return existingValue;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
@@ -19,14 +19,26 @@ import java.util.function.Function;
 
 public class JavaWorkarounds {
 
+  public static final boolean postJava8 = calcIfJDKIsPost8();
+
+  private static boolean calcIfJDKIsPost8() {
+    String version = System.getProperty("java.version");
+    return !version.matches("1\\.[0-8]\\.");
+  }
+
   // This is a workaround for computeIfAbsent not being concurrent in pre Java 9
   // https://bugs.openjdk.java.net/browse/JDK-8161372
   public static <K, V> V computeIfAbsent(Map<K, V> map, K key,
       Function<? super K, ? extends V> mappingFunction) {
-    V existingValue = map.get(key);
-    if (existingValue == null) {
+    if (postJava8) {
       return map.computeIfAbsent(key, mappingFunction);
     }
-    return existingValue;
+    else {
+      V existingValue = map.get(key);
+      if (existingValue == null) {
+        return map.computeIfAbsent(key, mappingFunction);
+      }
+      return existingValue;
+    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
@@ -26,14 +26,14 @@ public class JavaWorkarounds {
     return !version.matches("1\\.[0-8]\\.");
   }
 
-  // This is a workaround for computeIfAbsent not being concurrent in pre Java 9
+  // This is a workaround for computeIfAbsent which unnecessarily takes out a write lock in the case
+  // where the entry for the key exists already.  This only affects pre Java 9 jdks
   // https://bugs.openjdk.java.net/browse/JDK-8161372
   public static <K, V> V computeIfAbsent(Map<K, V> map, K key,
       Function<? super K, ? extends V> mappingFunction) {
     if (postJava8) {
       return map.computeIfAbsent(key, mappingFunction);
-    }
-    else {
+    } else {
       V existingValue = map.get(key);
       if (existingValue == null) {
         return map.computeIfAbsent(key, mappingFunction);

--- a/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.util;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class JavaWorkarounds {
+
+  // This is a workaround for computeIfAbsent not being concurrent in pre Java 9
+  // https://bugs.openjdk.java.net/browse/JDK-8161372
+  public static <K, V> V computeIfAbsent(Map<K, V> map, K key,
+      Function<? super K, ? extends V> mappingFunction) {
+    V existingValue = map.get(key);
+    if (existingValue == null) {
+      return map.computeIfAbsent(key, mappingFunction);
+    }
+    return existingValue;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/JavaWorkarounds.java
@@ -24,7 +24,7 @@ public class JavaWorkarounds {
   // where the entry for the key exists already. This only affects pre Java 9 jdks
   // https://bugs.openjdk.java.net/browse/JDK-8161372
   public static <K, V> V computeIfAbsent(Map<K, V> map, K key,
-                                         Function<? super K, ? extends V> mappingFunction) {
+      Function<? super K, ? extends V> mappingFunction) {
     V existingValue = map.get(key);
     if (existingValue == null) {
       return map.computeIfAbsent(key, mappingFunction);

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/CqServiceImpl.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/CqServiceImpl.java
@@ -80,6 +80,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.Part;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.util.JavaWorkarounds;
 
 /**
  * Implements the CqService functionality.
@@ -867,7 +868,8 @@ public class CqServiceImpl implements CqService {
   @Override
   public String constructServerCqName(String cqName, ClientProxyMembershipID clientProxyId) {
     ConcurrentHashMap<ClientProxyMembershipID, String> cache =
-        serverCqNameCache.computeIfAbsent(cqName, key -> new ConcurrentHashMap<>());
+        JavaWorkarounds.computeIfAbsent(serverCqNameCache, cqName,
+            key -> new ConcurrentHashMap<>());
 
     String cName = cache.get(clientProxyId);
     if (null == cName) {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/FlatFormatSerializer.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/FlatFormatSerializer.java
@@ -28,6 +28,7 @@ import org.apache.lucene.document.Document;
 
 import org.apache.geode.cache.lucene.internal.repository.serializer.SerializerUtil;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.util.JavaWorkarounds;
 import org.apache.geode.pdx.PdxInstance;
 
 /**
@@ -84,8 +85,9 @@ public class FlatFormatSerializer implements LuceneSerializer {
   }
 
   private List<String> tokenizeField(String indexedFieldName) {
-    List<String> tokenizedFields = tokenizedFieldCache.computeIfAbsent(indexedFieldName,
-        field -> Arrays.asList(indexedFieldName.split("\\.")));
+    List<String> tokenizedFields =
+        JavaWorkarounds.computeIfAbsent(tokenizedFieldCache, indexedFieldName,
+            field -> Arrays.asList(indexedFieldName.split("\\.")));
     return tokenizedFields;
   }
 


### PR DESCRIPTION
…Absent

  *  Tries to do the get() outside of a lock before computing


Please suggest a better name than JavaWorkarounds... I just haven't thought of anything good...

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
