### PR TITLE
GEODE-6365: Group support for mapping logic in DestroyRegionCommand

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
@@ -100,7 +100,7 @@ public class DestroyRegionCommand extends InternalGfshCommand {
     Set<String> groupNames = new HashSet<String>();
     groupNames.addAll(ccService.getGroups());
     groupNames.add("cluster");
-    for(String groupName : groupNames) {
+    for (String groupName : groupNames) {
       CacheConfig cacheConfig = ccService.getCacheConfig(groupName);
       if (cacheConfig == null) {
         return;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -95,19 +96,25 @@ public class DestroyRegionCommand extends InternalGfshCommand {
     if (ccService == null) {
       return;
     }
-    CacheConfig cacheConfig = ccService.getCacheConfig(null);
-    if (cacheConfig == null) {
-      return;
-    }
-    RegionConfig regionConfig = CacheElement.findElement(cacheConfig.getRegions(), regionName);
-    if (regionConfig == null) {
-      return;
-    }
-    CacheElement element =
-        CacheElement.findElement(regionConfig.getCustomRegionElements(), "jdbc-mapping");
-    if (element != null) {
-      throw new IllegalStateException("Cannot destroy region \"" + regionName
-          + "\" because JDBC mapping exists. Use \"destroy jdbc-mapping\" first.");
+
+    Set<String> groupNames = new HashSet<String>();
+    groupNames.addAll(ccService.getGroups());
+    groupNames.add("cluster");
+    for(String groupName : groupNames) {
+      CacheConfig cacheConfig = ccService.getCacheConfig(groupName);
+      if (cacheConfig == null) {
+        return;
+      }
+      RegionConfig regionConfig = CacheElement.findElement(cacheConfig.getRegions(), regionName);
+      if (regionConfig == null) {
+        return;
+      }
+      CacheElement element =
+          CacheElement.findElement(regionConfig.getCustomRegionElements(), "jdbc-mapping");
+      if (element != null) {
+        throw new IllegalStateException("Cannot destroy region \"" + regionName
+            + "\" because JDBC mapping exists. Use \"destroy jdbc-mapping\" first.");
+      }
     }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommandTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -165,7 +166,7 @@ public class DestroyRegionCommandTest {
   }
 
   private void setupJDBCMappingOnRegion(String regionName) {
-    doReturn(cacheConfig).when(ccService).getCacheConfig(null);
+    doReturn(cacheConfig).when(ccService).getCacheConfig("cluster");
     doReturn(regionConfigList).when(cacheConfig).getRegions();
     doReturn(regionName).when(regionConfig).getName();
     doReturn(regionName).when(regionConfig).getId();
@@ -187,6 +188,17 @@ public class DestroyRegionCommandTest {
     command.checkForJDBCMapping("regionName");
   }
 
+  @Test(expected = IllegalStateException.class)
+  public void checkForJDBCMappingWithRegionNameThrowsIllegalStateExceptionForGroup() {
+    Set<String> groups = new HashSet<String>();
+    groups.add("Group1");
+    doReturn(groups).when(ccService).getGroups();
+    setupJDBCMappingOnRegion("regionName");
+    doReturn(cacheConfig).when(ccService).getCacheConfig("Group1");
+
+    command.checkForJDBCMapping("regionName");
+  }
+
   @Test
   public void checkForJDBCMappingWithNoClusterConfigDoesNotThrowException() {
     setupJDBCMappingOnRegion("regionName");
@@ -198,7 +210,7 @@ public class DestroyRegionCommandTest {
   @Test
   public void checkForJDBCMappingWithNoCacheConfigDoesNotThrowException() {
     setupJDBCMappingOnRegion("regionName");
-    doReturn(null).when(ccService).getCacheConfig(null);
+    doReturn(null).when(ccService).getCacheConfig("cluster");
 
     command.checkForJDBCMapping("regionName");
   }


### PR DESCRIPTION
- Added server group support for the logic in destroy region which
checks for an existing jdbc-mapping

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
