### PR TITLE
GEODE-6425: Fixes region stat counter rollover

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
@@ -334,13 +334,13 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
           public void run() {
             CCRegion.put(invalidationKey, "initialValue");
 
-            int invalidationCount = CCRegion.getCachePerfStats().getInvalidates();
+            long invalidationCount = CCRegion.getCachePerfStats().getInvalidates();
             CCRegion.invalidate(invalidationKey);
             CCRegion.invalidate(invalidationKey);
             assertEquals(invalidationCount + 1, CCRegion.getCachePerfStats().getInvalidates());
 
             // also test destroy() while we're at it. It should throw an exception
-            int destroyCount = CCRegion.getCachePerfStats().getDestroys();
+            long destroyCount = CCRegion.getCachePerfStats().getDestroys();
             CCRegion.destroy(invalidationKey);
             try {
               CCRegion.destroy(invalidationKey);

--- a/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
@@ -247,9 +247,9 @@ public class TXJUnitTest {
       cmtre.setUserAttribute("uaValue1");
       assertEquals("uaValue1", cmtre.getUserAttribute());
 
-      int txRollbackChanges = stats.getTxRollbackChanges();
-      int txCommitChanges = stats.getTxCommitChanges();
-      int txFailureChanges = stats.getTxFailureChanges();
+      long txRollbackChanges = stats.getTxRollbackChanges();
+      long txCommitChanges = stats.getTxCommitChanges();
+      long txFailureChanges = stats.getTxFailureChanges();
       this.txMgr.begin();
       Region.Entry txre = this.region.getEntry("uaKey");
       assertEquals(this.region, txre.getRegion());
@@ -299,9 +299,9 @@ public class TXJUnitTest {
     }
 
     {
-      int txRollbackChanges = stats.getTxRollbackChanges();
-      int txCommitChanges = stats.getTxCommitChanges();
-      int txFailureChanges = stats.getTxFailureChanges();
+      long txRollbackChanges = stats.getTxRollbackChanges();
+      long txCommitChanges = stats.getTxCommitChanges();
+      long txFailureChanges = stats.getTxFailureChanges();
       this.region.create("key1", "value1");
       this.txMgr.begin();
       this.region.invalidate("key1");
@@ -432,7 +432,7 @@ public class TXJUnitTest {
   @Test
   public void testTwoRegionTxs() throws CacheException {
     final CachePerfStats stats = this.cache.getCachePerfStats();
-    int txCommitChanges;
+    long txCommitChanges;
     TransactionId myTxId;
 
     AttributesFactory<String, String> attributesFactory = new AttributesFactory<>();
@@ -2739,7 +2739,7 @@ public class TXJUnitTest {
   }
 
   private void doNonTxInvalidateRegionOp(CachePerfStats stats) throws Exception {
-    int txRollbackChanges = stats.getTxRollbackChanges();
+    long txRollbackChanges = stats.getTxRollbackChanges();
     this.region.create("key1", "value1");
     this.region.create("key2", "value2");
     this.txMgr.begin();
@@ -2771,7 +2771,7 @@ public class TXJUnitTest {
   }
 
   private void doNonTxDestroyRegionOp(CachePerfStats stats) throws Exception {
-    int txRollbackChanges = stats.getTxRollbackChanges();
+    long txRollbackChanges = stats.getTxRollbackChanges();
     this.region.put("key1", "value1");
     this.region.put("key2", "value2");
     this.txMgr.begin();
@@ -4627,15 +4627,15 @@ public class TXJUnitTest {
       private long txSuccessLifeTime;
       private long txFailedLifeTime;
       private long txRollbackLifeTime;
-      private int txCommits;
-      private int txFailures;
-      private int txRollbacks;
+      private long txCommits;
+      private long txFailures;
+      private long txRollbacks;
       private long txCommitTime;
       private long txFailureTime;
       private long txRollbackTime;
-      private int txCommitChanges;
-      private int txFailureChanges;
-      private int txRollbackChanges;
+      private long txCommitChanges;
+      private long txFailureChanges;
+      private long txRollbackChanges;
 
       private CachePerfStats stats;
 
@@ -4670,15 +4670,15 @@ public class TXJUnitTest {
         this.txRollbackLifeTime = txRollbackLifeTime;
       }
 
-      private void setTxCommits(int txCommits) {
+      private void setTxCommits(long txCommits) {
         this.txCommits = txCommits;
       }
 
-      private void setTxFailures(int txFailures) {
+      private void setTxFailures(long txFailures) {
         this.txFailures = txFailures;
       }
 
-      private void setTxRollbacks(int txRollbacks) {
+      private void setTxRollbacks(long txRollbacks) {
         this.txRollbacks = txRollbacks;
       }
 
@@ -4694,15 +4694,15 @@ public class TXJUnitTest {
         this.txRollbackTime = txRollbackTime;
       }
 
-      private void setTxCommitChanges(int txCommitChanges) {
+      private void setTxCommitChanges(long txCommitChanges) {
         this.txCommitChanges = txCommitChanges;
       }
 
-      private void setTxFailureChanges(int txFailureChanges) {
+      private void setTxFailureChanges(long txFailureChanges) {
         this.txFailureChanges = txFailureChanges;
       }
 
-      private void setTxRollbackChanges(int txRollbackChanges) {
+      private void setTxRollbackChanges(long txRollbackChanges) {
         this.txRollbackChanges = txRollbackChanges;
       }
 
@@ -4831,10 +4831,10 @@ public class TXJUnitTest {
   public void testCacheStats() throws CacheException {
     CachePerfStats cacheStats = this.cache.getCachePerfStats();
     // quick sanity check to make sure perf stats work non-tx
-    int creates;
-    int destroys;
-    int puts;
-    int invalidates;
+    long creates;
+    long destroys;
+    long puts;
+    long invalidates;
 
     creates = cacheStats.getCreates();
     destroys = cacheStats.getDestroys();
@@ -5778,7 +5778,7 @@ public class TXJUnitTest {
 
     { // distributed invalidate
       // first make sure invalidate is counted as a change
-      int txRollbackChanges = stats.getTxRollbackChanges();
+      long txRollbackChanges = stats.getTxRollbackChanges();
       this.region.create("key1", "value1");
       this.txMgr.begin();
       this.region.invalidate("key1");
@@ -5837,7 +5837,7 @@ public class TXJUnitTest {
 
     { // local invalidate
       // first make sure invalidate is counted as a change
-      int txRollbackChanges = stats.getTxRollbackChanges();
+      long txRollbackChanges = stats.getTxRollbackChanges();
       this.region.create("key1", "value1");
       this.txMgr.begin();
       this.region.localInvalidate("key1");

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
@@ -642,13 +642,13 @@ public class ProxyJUnitTest {
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
     expee.r = r;
     expee.key = "key";
-    int creates = getStats().getCreates();
+    long creates = getStats().getCreates();
     // int puts = getStats().getPuts();
     // int updates = getStats().getUpdates();
-    int destroys = getStats().getDestroys();
-    int invalidates = getStats().getInvalidates();
-    int gets = getStats().getGets();
-    int misses = getStats().getMisses();
+    long destroys = getStats().getDestroys();
+    long invalidates = getStats().getInvalidates();
+    long gets = getStats().getGets();
+    long misses = getStats().getMisses();
 
     r.put("key", "value", cbArg);
     expee.op = Operation.CREATE;
@@ -836,13 +836,13 @@ public class ProxyJUnitTest {
     checkNoCW();
     checkCL(expre);
 
-    int creates = getStats().getCreates();
+    long creates = getStats().getCreates();
     // int puts = getStats().getPuts();
     // int updates = getStats().getUpdates();
-    int destroys = getStats().getDestroys();
+    long destroys = getStats().getDestroys();
     // int invalidates = getStats().getInvalidates();
-    int gets = getStats().getGets();
-    int misses = getStats().getMisses();
+    long gets = getStats().getGets();
+    long misses = getStats().getMisses();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
     expee.r = r;
     expee.key = "key";
@@ -928,11 +928,11 @@ public class ProxyJUnitTest {
     checkNoTL();
     checkCL(expre);
 
-    int creates = getStats().getCreates();
+    long creates = getStats().getCreates();
     // int puts = getStats().getPuts();
     // int updates = getStats().getUpdates();
-    int destroys = getStats().getDestroys();
-    int invalidates = getStats().getInvalidates();
+    long destroys = getStats().getDestroys();
+    long invalidates = getStats().getInvalidates();
     // int gets = getStats().getGets();
     // int misses = getStats().getMisses();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
@@ -200,7 +200,7 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
 
     for (int num = 0; num < 3; num++) {
       pr.put(new Integer(num), val);
-      final int initialDestroyCount = getDestroyCount(pr);
+      final long initialDestroyCount = getDestroyCount(pr);
       pr.destroy(new Integer(num));
       assertEquals(initialDestroyCount + 1, getDestroyCount(pr));
     }
@@ -228,11 +228,11 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
     }
   }
 
-  private int getDestroyCount(PartitionedRegion pr) {
+  private long getDestroyCount(PartitionedRegion pr) {
     return ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getDestroys();
   }
 
-  private int getCreateCount(PartitionedRegion pr) {
+  private long getCreateCount(PartitionedRegion pr) {
     return ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getCreates();
   }
 
@@ -1075,7 +1075,7 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
     final String expectedExceptions = EntryExistsException.class.getName();
     for (int num = 0; num < 3; num++) {
       key++;
-      final int initialCreates = getCreateCount(pr);
+      final long initialCreates = getCreateCount(pr);
       pr.create(new Integer(key), val + num);
       assertEquals(initialCreates + 1, getCreateCount(pr));
       final Object getObj1 = pr.get(new Integer(key));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -338,22 +338,22 @@ public class CachePerfStats {
     type = f.createType("CachePerfStats", "Statistics about GemFire cache performance",
         new StatisticDescriptor[] {
             f.createIntGauge("loadsInProgress", loadsInProgressDesc, "operations"),
-            f.createIntCounter("loadsCompleted", loadsCompletedDesc, "operations"),
+            f.createLongCounter("loadsCompleted", loadsCompletedDesc, "operations"),
             f.createLongCounter("loadTime", loadTimeDesc, "nanoseconds", false),
             f.createIntGauge("netloadsInProgress", netloadsInProgressDesc, "operations"),
-            f.createIntCounter("netloadsCompleted", netloadsCompletedDesc, "operations"),
+            f.createLongCounter("netloadsCompleted", netloadsCompletedDesc, "operations"),
             f.createLongCounter("netloadTime", netloadTimeDesc, "nanoseconds", false),
             f.createIntGauge("netsearchesInProgress", netsearchesInProgressDesc, "operations"),
-            f.createIntCounter("netsearchesCompleted", netsearchesCompletedDesc, "operations"),
+            f.createLongCounter("netsearchesCompleted", netsearchesCompletedDesc, "operations"),
             f.createLongCounter("netsearchTime", netsearchTimeDesc, "nanoseconds"),
             f.createIntGauge("cacheWriterCallsInProgress", cacheWriterCallsInProgressDesc,
                 "operations"),
-            f.createIntCounter("cacheWriterCallsCompleted", cacheWriterCallsCompletedDesc,
+            f.createLongCounter("cacheWriterCallsCompleted", cacheWriterCallsCompletedDesc,
                 "operations"),
             f.createLongCounter("cacheWriterCallTime", cacheWriterCallTimeDesc, "nanoseconds"),
             f.createIntGauge("cacheListenerCallsInProgress", cacheListenerCallsInProgressDesc,
                 "operations"),
-            f.createIntCounter("cacheListenerCallsCompleted", cacheListenerCallsCompletedDesc,
+            f.createLongCounter("cacheListenerCallsCompleted", cacheListenerCallsCompletedDesc,
                 "operations"),
             f.createLongCounter("cacheListenerCallTime", cacheListenerCallTimeDesc, "nanoseconds"),
             f.createIntGauge("indexUpdateInProgress", "Current number of ops in progress",
@@ -380,18 +380,18 @@ public class CachePerfStats {
                 "keys"),
             f.createIntGauge("regions", regionsDesc, "regions"),
             f.createIntGauge("partitionedRegions", partitionedRegionsDesc, "partitionedRegions"),
-            f.createIntCounter("destroys", destroysDesc, "operations"),
-            f.createIntCounter("updates", updatesDesc, "operations"),
+            f.createLongCounter("destroys", destroysDesc, "operations"),
+            f.createLongCounter("updates", updatesDesc, "operations"),
             f.createLongCounter("updateTime", updateTimeDesc, "nanoseconds"),
-            f.createIntCounter("invalidates", invalidatesDesc, "operations"),
-            f.createIntCounter("gets", getsDesc, "operations"),
-            f.createIntCounter("misses", missesDesc, "operations"),
-            f.createIntCounter("creates", createsDesc, "operations"),
-            f.createIntCounter("puts", putsDesc, "operations"),
+            f.createLongCounter("invalidates", invalidatesDesc, "operations"),
+            f.createLongCounter("gets", getsDesc, "operations"),
+            f.createLongCounter("misses", missesDesc, "operations"),
+            f.createLongCounter("creates", createsDesc, "operations"),
+            f.createLongCounter("puts", putsDesc, "operations"),
             f.createLongCounter("putTime", putTimeDesc, "nanoseconds", false),
-            f.createIntCounter("putalls", putallsDesc, "operations"),
+            f.createLongCounter("putalls", putallsDesc, "operations"),
             f.createLongCounter("putallTime", putallTimeDesc, "nanoseconds", false),
-            f.createIntCounter("removeAlls", removeAllsDesc, "operations"),
+            f.createLongCounter("removeAlls", removeAllsDesc, "operations"),
             f.createLongCounter("removeAllTime", removeAllTimeDesc, "nanoseconds", false),
             f.createLongCounter("getTime", getTimeDesc, "nanoseconds", false),
             f.createIntGauge("eventQueueSize", eventQueueSizeDesc, "messages"),
@@ -399,7 +399,7 @@ public class CachePerfStats {
             f.createLongCounter("eventQueueThrottleTime", eventQueueThrottleTimeDesc, "nanoseconds",
                 false),
             f.createIntGauge("eventThreads", eventThreadsDesc, "threads"),
-            f.createIntCounter("queryExecutions", queryExecutionsDesc, "operations"),
+            f.createLongCounter("queryExecutions", queryExecutionsDesc, "operations"),
             f.createLongCounter("queryExecutionTime", queryExecutionTimeDesc, "nanoseconds"),
             f.createIntCounter("queryResultsHashCollisions", queryResultsHashCollisionsDesc,
                 "operations"),
@@ -408,18 +408,18 @@ public class CachePerfStats {
             f.createLongCounter("partitionedRegionQueryRetries",
                 partitionedRegionOQLQueryRetriesDesc, "retries"),
 
-            f.createIntCounter("txCommits", txCommitsDesc, "commits"),
-            f.createIntCounter("txCommitChanges", txCommitChangesDesc, "changes"),
+            f.createLongCounter("txCommits", txCommitsDesc, "commits"),
+            f.createLongCounter("txCommitChanges", txCommitChangesDesc, "changes"),
             f.createLongCounter("txCommitTime", txCommitTimeDesc, "nanoseconds", false),
             f.createLongCounter("txSuccessLifeTime", txSuccessLifeTimeDesc, "nanoseconds", false),
 
-            f.createIntCounter("txFailures", txFailuresDesc, "failures"),
-            f.createIntCounter("txFailureChanges", txFailureChangesDesc, "changes"),
+            f.createLongCounter("txFailures", txFailuresDesc, "failures"),
+            f.createLongCounter("txFailureChanges", txFailureChangesDesc, "changes"),
             f.createLongCounter("txFailureTime", txFailureTimeDesc, "nanoseconds", false),
             f.createLongCounter("txFailedLifeTime", txFailedLifeTimeDesc, "nanoseconds", false),
 
-            f.createIntCounter("txRollbacks", txRollbacksDesc, "rollbacks"),
-            f.createIntCounter("txRollbackChanges", txRollbackChangesDesc, "changes"),
+            f.createLongCounter("txRollbacks", txRollbacksDesc, "rollbacks"),
+            f.createLongCounter("txRollbackChanges", txRollbackChangesDesc, "changes"),
             f.createLongCounter("txRollbackTime", txRollbackTimeDesc, "nanoseconds", false),
             f.createLongCounter("txRollbackLifeTime", txRollbackLifeTimeDesc, "nanoseconds", false),
             f.createLongCounter("txConflictCheckTime", txConflictCheckTimeDesc, "nanoseconds",
@@ -442,16 +442,16 @@ public class CachePerfStats {
                 "entries"),
             f.createLongCounter("eventsQueued",
                 "Number of events attached to " + "other events for callback invocation", "events"),
-            f.createIntCounter("retries",
+            f.createLongCounter("retries",
                 "Number of times a concurrent destroy followed by a create has caused an entry operation to need to retry.",
                 "operations"),
-            f.createIntCounter("clears", clearsDesc, "operations"),
+            f.createLongCounter("clears", clearsDesc, "operations"),
             f.createIntGauge("diskTasksWaiting",
                 "Current number of disk tasks (oplog compactions, asynchronous recoveries, etc) that are waiting for a thread to run the operation",
                 "operations"),
             f.createLongCounter("conflatedEvents", conflatedEventsDesc, "operations"),
             f.createIntGauge("tombstones", tombstoneCountDesc, "entries"),
-            f.createIntCounter("tombstoneGCs", tombstoneGCCountDesc, "operations"),
+            f.createLongCounter("tombstoneGCs", tombstoneGCCountDesc, "operations"),
             f.createLongGauge("replicatedTombstonesSize", tombstoneOverhead1Desc, "bytes"),
             f.createLongGauge("nonReplicatedTombstonesSize", tombstoneOverhead2Desc, "bytes"),
             f.createIntCounter("clearTimeouts", clearTimeoutsDesc, "timeouts"),
@@ -463,14 +463,14 @@ public class CachePerfStats {
                 "Total time spent doing eviction work in background threads", "nanoseconds", false),
             f.createLongCounter("metaDataRefreshCount", metaDataRefreshCountDesc,
                 "refreshes", false),
-            f.createIntCounter("deltaUpdates", deltaUpdatesDesc, "operations"),
+            f.createLongCounter("deltaUpdates", deltaUpdatesDesc, "operations"),
             f.createLongCounter("deltaUpdatesTime", deltaUpdatesTimeDesc, "nanoseconds", false),
-            f.createIntCounter("deltaFailedUpdates", deltaFailedUpdatesDesc, "operations"),
-            f.createIntCounter("deltasPrepared", deltasPreparedDesc, "operations"),
+            f.createLongCounter("deltaFailedUpdates", deltaFailedUpdatesDesc, "operations"),
+            f.createLongCounter("deltasPrepared", deltasPreparedDesc, "operations"),
             f.createLongCounter("deltasPreparedTime", deltasPreparedTimeDesc, "nanoseconds", false),
-            f.createIntCounter("deltasSent", deltasSentDesc, "operations"),
-            f.createIntCounter("deltaFullValuesSent", deltaFullValuesSentDesc, "operations"),
-            f.createIntCounter("deltaFullValuesRequested", deltaFullValuesRequestedDesc,
+            f.createLongCounter("deltasSent", deltasSentDesc, "operations"),
+            f.createLongCounter("deltaFullValuesSent", deltaFullValuesSentDesc, "operations"),
+            f.createLongCounter("deltaFullValuesRequested", deltaFullValuesRequestedDesc,
                 "operations"),
 
             f.createLongCounter("importedEntries", importedEntriesCountDesc, "entries"),
@@ -671,20 +671,20 @@ public class CachePerfStats {
     return clock.getTime();
   }
 
-  public int getLoadsCompleted() {
-    return stats.getInt(loadsCompletedId);
+  public long getLoadsCompleted() {
+    return stats.getLong(loadsCompletedId);
   }
 
   public long getLoadTime() {
     return stats.getLong(loadTimeId);
   }
 
-  public int getNetloadsCompleted() {
-    return stats.getInt(netloadsCompletedId);
+  public long getNetloadsCompleted() {
+    return stats.getLong(netloadsCompletedId);
   }
 
-  public int getNetsearchesCompleted() {
-    return stats.getInt(netsearchesCompletedId);
+  public long getNetsearchesCompleted() {
+    return stats.getLong(netsearchesCompletedId);
   }
 
   public long getNetsearchTime() {
@@ -707,48 +707,48 @@ public class CachePerfStats {
     return stats.getInt(regionsId);
   }
 
-  public int getDestroys() {
-    return stats.getInt(destroysId);
+  public long getDestroys() {
+    return stats.getLong(destroysId);
   }
 
-  public int getCreates() {
-    return stats.getInt(createsId);
+  public long getCreates() {
+    return stats.getLong(createsId);
   }
 
-  public int getPuts() {
-    return stats.getInt(putsId);
+  public long getPuts() {
+    return stats.getLong(putsId);
   }
 
   public long getPutTime() {
     return stats.getLong(putTimeId);
   }
 
-  public int getPutAlls() {
-    return stats.getInt(putallsId);
+  public long getPutAlls() {
+    return stats.getLong(putallsId);
   }
 
-  int getRemoveAlls() {
-    return stats.getInt(removeAllsId);
+  long getRemoveAlls() {
+    return stats.getLong(removeAllsId);
   }
 
-  public int getUpdates() {
-    return stats.getInt(updatesId);
+  public long getUpdates() {
+    return stats.getLong(updatesId);
   }
 
-  public int getInvalidates() {
-    return stats.getInt(invalidatesId);
+  public long getInvalidates() {
+    return stats.getLong(invalidatesId);
   }
 
-  public int getGets() {
-    return stats.getInt(getsId);
+  public long getGets() {
+    return stats.getLong(getsId);
   }
 
   public long getGetTime() {
     return stats.getLong(getTimeId);
   }
 
-  public int getMisses() {
-    return stats.getInt(missesId);
+  public long getMisses() {
+    return stats.getLong(missesId);
   }
 
   public int getReliableQueuedOps() {
@@ -811,36 +811,36 @@ public class CachePerfStats {
     stats.incLong(eventsQueuedId, inc);
   }
 
-  int getDeltaUpdates() {
-    return stats.getInt(deltaUpdatesId);
+  long getDeltaUpdates() {
+    return stats.getLong(deltaUpdatesId);
   }
 
   long getDeltaUpdatesTime() {
     return stats.getLong(deltaUpdatesTimeId);
   }
 
-  public int getDeltaFailedUpdates() {
-    return stats.getInt(deltaFailedUpdatesId);
+  public long getDeltaFailedUpdates() {
+    return stats.getLong(deltaFailedUpdatesId);
   }
 
-  int getDeltasPrepared() {
-    return stats.getInt(deltasPreparedId);
+  long getDeltasPrepared() {
+    return stats.getLong(deltasPreparedId);
   }
 
   long getDeltasPreparedTime() {
     return stats.getLong(deltasPreparedTimeId);
   }
 
-  public int getDeltasSent() {
-    return stats.getInt(deltasSentId);
+  public long getDeltasSent() {
+    return stats.getLong(deltasSentId);
   }
 
-  public int getDeltaFullValuesSent() {
-    return stats.getInt(deltaFullValuesSentId);
+  public long getDeltaFullValuesSent() {
+    return stats.getLong(deltaFullValuesSentId);
   }
 
-  int getDeltaFullValuesRequested() {
-    return stats.getInt(deltaFullValuesRequestedId);
+  long getDeltaFullValuesRequested() {
+    return stats.getLong(deltaFullValuesRequestedId);
   }
 
   public long getTotalCompressionTime() {
@@ -908,7 +908,7 @@ public class CachePerfStats {
     long ts = NanoTimer.getTime(); // don't use getStatTime so always enabled
     stats.incLong(loadTimeId, ts - start);
     stats.incInt(loadsInProgressId, -1);
-    stats.incInt(loadsCompletedId, 1);
+    stats.incLong(loadsCompletedId, 1);
   }
 
   /**
@@ -927,7 +927,7 @@ public class CachePerfStats {
       stats.incLong(netloadTimeId, getClockTime() - start);
     }
     stats.incInt(netloadsInProgressId, -1);
-    stats.incInt(netloadsCompletedId, 1);
+    stats.incLong(netloadsCompletedId, 1);
   }
 
   /**
@@ -947,7 +947,7 @@ public class CachePerfStats {
     long ts = NanoTimer.getTime(); // don't use getStatTime so always enabled
     stats.incLong(netsearchTimeId, ts - start);
     stats.incInt(netsearchesInProgressId, -1);
-    stats.incInt(netsearchesCompletedId, 1);
+    stats.incLong(netsearchesCompletedId, 1);
   }
 
   /**
@@ -966,11 +966,11 @@ public class CachePerfStats {
       stats.incLong(cacheWriterCallTimeId, getClockTime() - start);
     }
     stats.incInt(cacheWriterCallsInProgressId, -1);
-    stats.incInt(cacheWriterCallsCompletedId, 1);
+    stats.incLong(cacheWriterCallsCompletedId, 1);
   }
 
-  int getCacheWriterCallsCompleted() {
-    return stats.getInt(cacheWriterCallsCompletedId);
+  long getCacheWriterCallsCompleted() {
+    return stats.getLong(cacheWriterCallsCompletedId);
   }
 
   /**
@@ -991,11 +991,11 @@ public class CachePerfStats {
       stats.incLong(cacheListenerCallTimeId, getClockTime() - start);
     }
     stats.incInt(cacheListenerCallsInProgressId, -1);
-    stats.incInt(cacheListenerCallsCompletedId, 1);
+    stats.incLong(cacheListenerCallsCompletedId, 1);
   }
 
-  int getCacheListenerCallsCompleted() {
-    return stats.getInt(cacheListenerCallsCompletedId);
+  long getCacheListenerCallsCompleted() {
+    return stats.getLong(cacheListenerCallsCompletedId);
   }
 
   /**
@@ -1076,15 +1076,15 @@ public class CachePerfStats {
   }
 
   public void incDestroys() {
-    stats.incInt(destroysId, 1);
+    stats.incLong(destroysId, 1);
   }
 
   public void incCreates() {
-    stats.incInt(createsId, 1);
+    stats.incLong(createsId, 1);
   }
 
   public void incInvalidates() {
-    stats.incInt(invalidatesId, 1);
+    stats.incLong(invalidatesId, 1);
   }
 
   /**
@@ -1102,9 +1102,9 @@ public class CachePerfStats {
       long delta = getClockTime() - start;
       stats.incLong(getTimeId, delta);
     }
-    stats.incInt(getsId, 1);
+    stats.incLong(getsId, 1);
     if (miss) {
-      stats.incInt(missesId, 1);
+      stats.incLong(missesId, 1);
     }
   }
 
@@ -1115,13 +1115,13 @@ public class CachePerfStats {
   public long endPut(long start, boolean isUpdate) {
     long total = 0;
     if (isUpdate) {
-      stats.incInt(updatesId, 1);
+      stats.incLong(updatesId, 1);
       if (enableClockStats) {
         total = getClockTime() - start;
         stats.incLong(updateTimeId, total);
       }
     } else {
-      stats.incInt(putsId, 1);
+      stats.incLong(putsId, 1);
       if (enableClockStats) {
         total = getClockTime() - start;
         stats.incLong(putTimeId, total);
@@ -1131,26 +1131,26 @@ public class CachePerfStats {
   }
 
   public void endPutAll(long start) {
-    stats.incInt(putallsId, 1);
+    stats.incLong(putallsId, 1);
     if (enableClockStats)
       stats.incLong(putallTimeId, getClockTime() - start);
   }
 
   public void endRemoveAll(long start) {
-    stats.incInt(removeAllsId, 1);
+    stats.incLong(removeAllsId, 1);
     if (enableClockStats)
       stats.incLong(removeAllTimeId, getClockTime() - start);
   }
 
   public void endQueryExecution(long executionTime) {
-    stats.incInt(queryExecutionsId, 1);
+    stats.incLong(queryExecutionsId, 1);
     if (enableClockStats) {
       stats.incLong(queryExecutionTimeId, executionTime);
     }
   }
 
-  public int getQueryExecutions() {
-    return stats.getInt(queryExecutionsId);
+  public long getQueryExecutions() {
+    return stats.getLong(queryExecutionsId);
   }
 
   public void endQueryResultsHashCollisionProbe(long start) {
@@ -1163,12 +1163,12 @@ public class CachePerfStats {
     stats.incInt(queryResultsHashCollisionsId, 1);
   }
 
-  public int getTxCommits() {
-    return stats.getInt(txCommitsId);
+  public long getTxCommits() {
+    return stats.getLong(txCommitsId);
   }
 
-  public int getTxCommitChanges() {
-    return stats.getInt(txCommitChangesId);
+  public long getTxCommitChanges() {
+    return stats.getLong(txCommitChangesId);
   }
 
   public long getTxCommitTime() {
@@ -1179,12 +1179,12 @@ public class CachePerfStats {
     return stats.getLong(txSuccessLifeTimeId);
   }
 
-  public int getTxFailures() {
-    return stats.getInt(txFailuresId);
+  public long getTxFailures() {
+    return stats.getLong(txFailuresId);
   }
 
-  public int getTxFailureChanges() {
-    return stats.getInt(txFailureChangesId);
+  public long getTxFailureChanges() {
+    return stats.getLong(txFailureChangesId);
   }
 
   public long getTxFailureTime() {
@@ -1195,12 +1195,12 @@ public class CachePerfStats {
     return stats.getLong(txFailedLifeTimeId);
   }
 
-  public int getTxRollbacks() {
-    return stats.getInt(txRollbacksId);
+  public long getTxRollbacks() {
+    return stats.getLong(txRollbacksId);
   }
 
-  public int getTxRollbackChanges() {
-    return stats.getInt(txRollbackChangesId);
+  public long getTxRollbackChanges() {
+    return stats.getLong(txRollbackChangesId);
   }
 
   public long getTxRollbackTime() {
@@ -1216,54 +1216,54 @@ public class CachePerfStats {
   }
 
   public void txSuccess(long opTime, long txLifeTime, int txChanges) {
-    stats.incInt(txCommitsId, 1);
-    stats.incInt(txCommitChangesId, txChanges);
+    stats.incLong(txCommitsId, 1);
+    stats.incLong(txCommitChangesId, txChanges);
     stats.incLong(txCommitTimeId, opTime);
     stats.incLong(txSuccessLifeTimeId, txLifeTime);
   }
 
   public void txFailure(long opTime, long txLifeTime, int txChanges) {
-    stats.incInt(txFailuresId, 1);
-    stats.incInt(txFailureChangesId, txChanges);
+    stats.incLong(txFailuresId, 1);
+    stats.incLong(txFailureChangesId, txChanges);
     stats.incLong(txFailureTimeId, opTime);
     stats.incLong(txFailedLifeTimeId, txLifeTime);
   }
 
   public void txRollback(long opTime, long txLifeTime, int txChanges) {
-    stats.incInt(txRollbacksId, 1);
-    stats.incInt(txRollbackChangesId, txChanges);
+    stats.incLong(txRollbacksId, 1);
+    stats.incLong(txRollbackChangesId, txChanges);
     stats.incLong(txRollbackTimeId, opTime);
     stats.incLong(txRollbackLifeTimeId, txLifeTime);
   }
 
   void endDeltaUpdate(long start) {
-    stats.incInt(deltaUpdatesId, 1);
+    stats.incLong(deltaUpdatesId, 1);
     if (enableClockStats) {
       stats.incLong(deltaUpdatesTimeId, getClockTime() - start);
     }
   }
 
   public void incDeltaFailedUpdates() {
-    stats.incInt(deltaFailedUpdatesId, 1);
+    stats.incLong(deltaFailedUpdatesId, 1);
   }
 
   public void endDeltaPrepared(long start) {
-    stats.incInt(deltasPreparedId, 1);
+    stats.incLong(deltasPreparedId, 1);
     if (enableClockStats) {
       stats.incLong(deltasPreparedTimeId, getClockTime() - start);
     }
   }
 
   public void incDeltasSent() {
-    stats.incInt(deltasSentId, 1);
+    stats.incLong(deltasSentId, 1);
   }
 
   public void incDeltaFullValuesSent() {
-    stats.incInt(deltaFullValuesSentId, 1);
+    stats.incLong(deltaFullValuesSentId, 1);
   }
 
   public void incDeltaFullValuesRequested() {
-    stats.incInt(deltaFullValuesRequestedId, 1);
+    stats.incLong(deltaFullValuesRequestedId, 1);
   }
 
   /**
@@ -1314,11 +1314,11 @@ public class CachePerfStats {
   }
 
   public void incRetries() {
-    stats.incInt(retriesId, 1);
+    stats.incLong(retriesId, 1);
   }
 
-  public int getRetries() {
-    return stats.getInt(retriesId);
+  public long getRetries() {
+    return stats.getLong(retriesId);
   }
 
   public void incDiskTasksWaiting() {
@@ -1390,12 +1390,12 @@ public class CachePerfStats {
     };
   }
 
-  public int getClearCount() {
-    return stats.getInt(clearsId);
+  public long getClearCount() {
+    return stats.getLong(clearsId);
   }
 
   public void incClearCount() {
-    stats.incInt(clearsId, 1);
+    stats.incLong(clearsId, 1);
   }
 
   public long getConflatedEventsCount() {
@@ -1406,20 +1406,20 @@ public class CachePerfStats {
     stats.incLong(conflatedEventsId, 1);
   }
 
-  public int getTombstoneCount() {
-    return stats.getInt(tombstoneCountId);
+  public long getTombstoneCount() {
+    return stats.getLong(tombstoneCountId);
   }
 
   public void incTombstoneCount(int amount) {
-    stats.incInt(tombstoneCountId, amount);
+    stats.incLong(tombstoneCountId, amount);
   }
 
-  public int getTombstoneGCCount() {
-    return stats.getInt(tombstoneGCCountId);
+  public long getTombstoneGCCount() {
+    return stats.getLong(tombstoneGCCountId);
   }
 
   public void incTombstoneGCCount() {
-    stats.incInt(tombstoneGCCountId, 1);
+    stats.incLong(tombstoneGCCountId, 1);
   }
 
   void setReplicatedTombstonesSize(long size) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -32,7 +32,7 @@ public class DummyCachePerfStats extends CachePerfStats {
   // //////////////////// Accessing Stats //////////////////////
 
   @Override
-  public int getLoadsCompleted() {
+  public long getLoadsCompleted() {
     return 0;
   }
 
@@ -42,12 +42,12 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getNetloadsCompleted() {
+  public long getNetloadsCompleted() {
     return 0;
   }
 
   @Override
-  public int getNetsearchesCompleted() {
+  public long getNetsearchesCompleted() {
     return 0;
   }
 
@@ -72,42 +72,42 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getDestroys() {
+  public long getDestroys() {
     return 0;
   }
 
   @Override
-  public int getCreates() {
+  public long getCreates() {
     return 0;
   }
 
   @Override
-  public int getPuts() {
+  public long getPuts() {
     return 0;
   }
 
   @Override
-  public int getPutAlls() {
+  public long getPutAlls() {
     return 0;
   }
 
   @Override
-  public int getUpdates() {
+  public long getUpdates() {
     return 0;
   }
 
   @Override
-  public int getInvalidates() {
+  public long getInvalidates() {
     return 0;
   }
 
   @Override
-  public int getGets() {
+  public long getGets() {
     return 0;
   }
 
   @Override
-  public int getMisses() {
+  public long getMisses() {
     return 0;
   }
 
@@ -257,12 +257,12 @@ public class DummyCachePerfStats extends CachePerfStats {
   public void endQueryExecution(long executionTime) {}
 
   @Override
-  public int getTxCommits() {
+  public long getTxCommits() {
     return 0;
   }
 
   @Override
-  public int getTxCommitChanges() {
+  public long getTxCommitChanges() {
     return 0;
   }
 
@@ -277,12 +277,12 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getTxFailures() {
+  public long getTxFailures() {
     return 0;
   }
 
   @Override
-  public int getTxFailureChanges() {
+  public long getTxFailureChanges() {
     return 0;
   }
 
@@ -297,12 +297,12 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getTxRollbacks() {
+  public long getTxRollbacks() {
     return 0;
   }
 
   @Override
-  public int getTxRollbackChanges() {
+  public long getTxRollbackChanges() {
     return 0;
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/RegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/RegionTestCase.java
@@ -1035,7 +1035,7 @@ public abstract class RegionTestCase extends JUnit4CacheTestCase {
     Region region = createRegion(name);
     region.put(key, value);
 
-    int beforeInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
+    long beforeInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
         .getCachePerfStats().getInvalidates();
     Region.Entry entry = region.getEntry(key);
     region.invalidate(key);
@@ -1043,7 +1043,7 @@ public abstract class RegionTestCase extends JUnit4CacheTestCase {
       assertNull(entry.getValue());
     }
     assertNull(region.get(key));
-    int afterInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
+    long afterInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
         .getCachePerfStats().getInvalidates();
     assertEquals("Invalidate CachePerfStats incorrect", beforeInvalidates + 1, afterInvalidates);
   }

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
@@ -412,10 +412,10 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
         // replace with null oldvalue matches invalidated entry
         pr.putIfAbsent("otherKeyForNull", null);
-        int puts = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
+        long puts = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
         boolean success = pr.replace("otherKeyForNull", null, "no longer invalid");
         assertTrue(success);
-        int newputs = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
+        long newputs = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
         assertEquals("stats not updated properly or replace malfunctioned", newputs, puts + 1);
 
       }


### PR DESCRIPTION
After fixing GEODE-6424 operations can execute fast enough that some
int counters roll over too frequently to provide meaningful information.
Converting to long counters delays this rollover, which allows for more
meaningful analysis.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
