### PR TITLE
GEODE-6389 CI Failure: ConcurrentWANPropagation_1_DUnitTest.testRepli…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
@@ -55,7 +55,9 @@ public class NioPlainEngine implements NioFilter {
       Buffers.BufferType bufferType, DMStats stats) {
     ByteBuffer buffer = wrappedBuffer;
 
-    if (buffer.capacity() > amount) {
+    if (buffer == null) {
+      buffer = Buffers.acquireBuffer(bufferType, amount, stats);
+    } else if (buffer.capacity() > amount) {
       // we already have a buffer that's big enough
       if (buffer.capacity() - lastProcessedPosition < amount) {
         buffer.limit(lastReadPosition);

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
@@ -57,6 +57,9 @@ public class NioPlainEngine implements NioFilter {
 
     if (buffer == null) {
       buffer = Buffers.acquireBuffer(bufferType, amount, stats);
+      buffer.clear();
+      lastProcessedPosition = 0;
+      lastReadPosition = 0;
     } else if (buffer.capacity() > amount) {
       // we already have a buffer that's big enough
       if (buffer.capacity() - lastProcessedPosition < amount) {

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -316,6 +316,9 @@ public class NioSslEngine implements NioFilter {
   @Override
   public ByteBuffer ensureWrappedCapacity(int amount, ByteBuffer wrappedBuffer,
       Buffers.BufferType bufferType, DMStats stats) {
+    if (wrappedBuffer == null) {
+      wrappedBuffer = Buffers.acquireBuffer(bufferType, amount, stats);
+    }
     return wrappedBuffer;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -779,8 +779,6 @@ public class Connection implements Runnable {
     // we do the close in a background thread because the operation may hang if
     // there is a problem with the network. See bug #46659
 
-    releaseInputBuffer();
-
     // if simulating sickness, sockets must be closed in-line so that tests know
     // that the vm is sick when the beSick operation completes
     if (beingSickForTests) {
@@ -1448,6 +1446,11 @@ public class Connection implements Runnable {
         }
         // make sure our socket is closed
         asyncClose(false);
+        if (!this.isReceiver) {
+          // receivers release the input buffer when exiting run(). Senders use the
+          // inputBuffer for reading direct-reply responses
+          releaseInputBuffer();
+        }
         lengthSet = false;
       } // synchronized
 
@@ -1585,7 +1588,14 @@ public class Connection implements Runnable {
         }
         asyncClose(false);
         this.owner.removeAndCloseThreadOwnedSockets();
+      } else {
+        if (getConduit().useSSL()) {
+          ByteBuffer buffer = ioFilter.getUnwrappedBuffer(inputBuffer);
+          buffer.position(0).limit(0);
+        }
       }
+      releaseInputBuffer();
+
       // make sure that if the reader thread exits we notify a thread waiting
       // for the handshake.
       // see bug 37524 for an example of listeners hung in waitForHandshake
@@ -2828,7 +2838,7 @@ public class Connection implements Runnable {
     DMStats stats = owner.getConduit().getStats();
     final Version version = getRemoteVersion();
     try {
-      msgReader = new MsgReader(this, ioFilter, getInputBuffer(), version);
+      msgReader = new MsgReader(this, ioFilter, version);
 
       Header header = msgReader.readHeader();
 
@@ -2902,6 +2912,9 @@ public class Connection implements Runnable {
         logger.info("Finished waiting for reply from {}",
             getRemoteAddress());
         this.ackTimedOut = false;
+      }
+      if (msgReader != null) {
+        msgReader.close();
       }
     }
     synchronized (stateLock) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
@@ -46,14 +46,9 @@ public class MsgReader {
 
 
 
-  MsgReader(Connection conn, NioFilter nioFilter, ByteBuffer peerNetData, Version version) {
+  MsgReader(Connection conn, NioFilter nioFilter, Version version) {
     this.conn = conn;
     this.ioFilter = nioFilter;
-    this.peerNetData = peerNetData;
-    if (conn.getConduit().useSSL()) {
-      ByteBuffer buffer = ioFilter.getUnwrappedBuffer(peerNetData);
-      buffer.position(0).limit(0);
-    }
     this.byteBufferInputStream =
         version == null ? new ByteBufferInputStream() : new VersionedByteBufferInputStream(version);
   }
@@ -132,6 +127,12 @@ public class MsgReader {
     peerNetData = ioFilter.ensureWrappedCapacity(bytes, peerNetData,
         Buffers.BufferType.TRACKED_RECEIVER, getStats());
     return ioFilter.readAtLeast(conn.getSocket().getChannel(), bytes, peerNetData, getStats());
+  }
+
+  public void close() {
+    if (peerNetData != null) {
+      Buffers.releaseReceiveBuffer(peerNetData, getStats());
+    }
   }
 
 


### PR DESCRIPTION
…catedSerialPropagation_withoutRemoteSite

This removes the sharing of buffers between threads in Connection.java
and MsgReader.java.  The Buffers buffer pooling mechanism isn't up to
handling sharing of buffers between threads and I determined that it
wasn't really necessary to retain the handshake buffer for follow-up TLS
communications.

ClusterCommunicationsDUnitTest already covers testing of this change.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
