### PR TITLE
GEODE-6423 availability checks sometimes immediately initiate removal

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentRegionRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentRegionRecoveryDUnitTest.java
@@ -39,6 +39,7 @@ import org.apache.geode.distributed.internal.DistributionMessageObserver;
 import org.apache.geode.internal.cache.backup.BackupOperation;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.dunit.rules.CacheRule;
@@ -73,6 +74,7 @@ public class PersistentRegionRecoveryDUnitTest extends JUnit4DistributedTestCase
     vm0 = getVM(0);
     vm1 = getVM(1);
     regionName = getClass().getSimpleName() + "-" + testName.getMethodName();
+    IgnoredException.addIgnoredException("Possible loss of quorum");
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -541,7 +541,7 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
       } catch (IOException e) {
         // this is expected if it is a connection-timeout or other failure
         // to connect
-      } catch (IllegalStateException e) {
+      } catch (IllegalStateException | GemFireConfigException e) {
         if (!isStopping) {
           logger.trace("Unexpected exception", e);
         }
@@ -555,7 +555,7 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
           // expected
         }
       }
-    } while (!passed && System.nanoTime() < giveupTime);
+    } while (!passed && !this.isShutdown() && System.nanoTime() < giveupTime);
     return passed;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -513,33 +513,50 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
    */
   boolean doTCPCheckMember(InternalDistributedMember suspectMember, int port) {
     Socket clientSocket = null;
-    try {
-      logger.debug("Checking member {} with TCP socket connection {}:{}.", suspectMember,
-          suspectMember.getInetAddress(), port);
-      clientSocket =
-          SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER)
-              .connect(suspectMember.getInetAddress(), port, (int) memberTimeout,
-                  new ConnectTimeoutTask(services.getTimer(), memberTimeout), false, -1, false);
-      clientSocket.setTcpNoDelay(true);
-      return doTCPCheckMember(suspectMember, clientSocket);
-    } catch (IOException e) {
-      // this is expected if it is a connection-timeout or other failure
-      // to connect
-    } catch (IllegalStateException e) {
-      if (!isStopping) {
-        logger.trace("Unexpected exception", e);
-      }
-    } finally {
-      try {
-        if (clientSocket != null) {
-          clientSocket.setSoLinger(true, 0); // abort the connection
-          clientSocket.close();
+    // make sure we try to check on the member for the contracted memberTimeout period
+    // in case a timed socket.connect() returns immediately
+    long giveupTime = System.nanoTime() + TimeUnit.NANOSECONDS.convert(
+        services.getConfig().getMemberTimeout(), TimeUnit.MILLISECONDS);
+    boolean passed = false;
+    int iteration = 0;
+    do {
+      iteration++;
+      if (iteration > 1) {
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return false;
         }
-      } catch (IOException e) {
-        // expected
       }
-    }
-    return false;
+      try {
+        logger.debug("Checking member {} with TCP socket connection {}:{}.", suspectMember,
+            suspectMember.getInetAddress(), port);
+        clientSocket =
+            SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER)
+                .connect(suspectMember.getInetAddress(), port, (int) memberTimeout,
+                    new ConnectTimeoutTask(services.getTimer(), memberTimeout), false, -1, false);
+        clientSocket.setTcpNoDelay(true);
+        passed = doTCPCheckMember(suspectMember, clientSocket);
+      } catch (IOException e) {
+        // this is expected if it is a connection-timeout or other failure
+        // to connect
+      } catch (IllegalStateException e) {
+        if (!isStopping) {
+          logger.trace("Unexpected exception", e);
+        }
+      } finally {
+        try {
+          if (clientSocket != null) {
+            clientSocket.setSoLinger(true, 0); // abort the connection
+            clientSocket.close();
+          }
+        } catch (IOException e) {
+          // expected
+        }
+      }
+    } while (!passed && System.nanoTime() < giveupTime);
+    return passed;
   }
 
   // Package protected for testing purposes

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1036,6 +1036,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
             this.preparedView.getCreator().equals(view.getCreator())) {
           // this can happen if we received two prepares during auto-reconnect
         } else {
+          // send the conflicting view to the creator of this new view
           services.getMessenger()
               .send(new ViewAckMessage(view.getViewId(), m.getSender(), this.preparedView));
         }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -250,7 +250,7 @@ public class ClusterStartupRule implements SerializableTestRule {
       SerializableFunction<ServerStarterRule> ruleOperator) {
     final String defaultName = "server-" + index;
     VM serverVM = getVM(index, version);
-    Server server = serverVM.invoke(() -> {
+    Server server = serverVM.invoke("startServerVM", () -> {
       memberStarter = new ServerStarterRule();
       ServerStarterRule serverStarter = (ServerStarterRule) memberStarter;
       if (logFile) {


### PR DESCRIPTION
Ensure that the availability check is performed for the contracted
member-timeout period.  This allows a suspect to survive the check if
it's having a momentary glitch like a brief garbage-collection, or if
there is short network outage.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
