### PR TITLE
GEODE-6425: fix rollover of get stats

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
@@ -334,7 +334,7 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
           public void run() {
             CCRegion.put(invalidationKey, "initialValue");
 
-            int invalidationCount = CCRegion.getCachePerfStats().getInvalidates();
+            long invalidationCount = CCRegion.getCachePerfStats().getInvalidates();
             CCRegion.invalidate(invalidationKey);
             CCRegion.invalidate(invalidationKey);
             assertEquals(invalidationCount + 1, CCRegion.getCachePerfStats().getInvalidates());

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
@@ -340,7 +340,7 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
             assertEquals(invalidationCount + 1, CCRegion.getCachePerfStats().getInvalidates());
 
             // also test destroy() while we're at it. It should throw an exception
-            int destroyCount = CCRegion.getCachePerfStats().getDestroys();
+            long destroyCount = CCRegion.getCachePerfStats().getDestroys();
             CCRegion.destroy(invalidationKey);
             try {
               CCRegion.destroy(invalidationKey);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ConflationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ConflationDUnitTest.java
@@ -479,8 +479,6 @@ public class ConflationDUnitTest extends JUnit4DistributedTestCase {
     };
     GeodeAwaitility.await().untilAsserted(ev);
 
-    // assertIndexDetailsEquals("destroys", 2, counterDestroy);
-    // assertTrue("updates", 20000 >= counterUpdate);
     ev = new WaitCriterion() {
       @Override
       public boolean done() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
@@ -4834,7 +4834,7 @@ public class TXJUnitTest {
     long creates;
     long destroys;
     long puts;
-    int invalidates;
+    long invalidates;
 
     creates = cacheStats.getCreates();
     destroys = cacheStats.getDestroys();

--- a/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
@@ -4832,7 +4832,7 @@ public class TXJUnitTest {
     CachePerfStats cacheStats = this.cache.getCachePerfStats();
     // quick sanity check to make sure perf stats work non-tx
     long creates;
-    int destroys;
+    long destroys;
     long puts;
     int invalidates;
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
@@ -4833,7 +4833,7 @@ public class TXJUnitTest {
     // quick sanity check to make sure perf stats work non-tx
     int creates;
     int destroys;
-    int puts;
+    long puts;
     int invalidates;
 
     creates = cacheStats.getCreates();

--- a/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/TXJUnitTest.java
@@ -4831,7 +4831,7 @@ public class TXJUnitTest {
   public void testCacheStats() throws CacheException {
     CachePerfStats cacheStats = this.cache.getCachePerfStats();
     // quick sanity check to make sure perf stats work non-tx
-    int creates;
+    long creates;
     int destroys;
     long puts;
     int invalidates;

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/ClientAccessToInternalStatsTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/ClientAccessToInternalStatsTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/ClientAccessToInternalStatsTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/ClientAccessToInternalStatsTest.java
@@ -1,0 +1,24 @@
+package org.apache.geode.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+
+public class ClientAccessToInternalStatsTest {
+
+  @Test
+  public void canGetLongCounterAsInteger() {
+    try (ClientCache cache = new ClientCacheFactory().create()) {
+      Region region = cache.createClientRegionFactory(ClientRegionShortcut.LOCAL).create("local");
+      region.put("key", "value");
+      Statistics[] stats = cache.getDistributedSystem().findStatisticsByTextId("cachePerfStats");
+      assertThat(stats).hasSize(1);
+      assertThat(stats[0].getInt("puts")).isEqualTo(1);
+    }
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
@@ -642,7 +642,7 @@ public class ProxyJUnitTest {
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
     expee.r = r;
     expee.key = "key";
-    int creates = getStats().getCreates();
+    long creates = getStats().getCreates();
     int destroys = getStats().getDestroys();
     int invalidates = getStats().getInvalidates();
     long gets = getStats().getGets();
@@ -834,7 +834,7 @@ public class ProxyJUnitTest {
     checkNoCW();
     checkCL(expre);
 
-    int creates = getStats().getCreates();
+    long creates = getStats().getCreates();
     int destroys = getStats().getDestroys();
     long gets = getStats().getGets();
     long misses = getStats().getMisses();
@@ -923,7 +923,7 @@ public class ProxyJUnitTest {
     checkNoTL();
     checkCL(expre);
 
-    int creates = getStats().getCreates();
+    long creates = getStats().getCreates();
     int destroys = getStats().getDestroys();
     int invalidates = getStats().getInvalidates();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
@@ -643,7 +643,7 @@ public class ProxyJUnitTest {
     expee.r = r;
     expee.key = "key";
     long creates = getStats().getCreates();
-    int destroys = getStats().getDestroys();
+    long destroys = getStats().getDestroys();
     int invalidates = getStats().getInvalidates();
     long gets = getStats().getGets();
     long misses = getStats().getMisses();
@@ -835,7 +835,7 @@ public class ProxyJUnitTest {
     checkCL(expre);
 
     long creates = getStats().getCreates();
-    int destroys = getStats().getDestroys();
+    long destroys = getStats().getDestroys();
     long gets = getStats().getGets();
     long misses = getStats().getMisses();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
@@ -924,7 +924,7 @@ public class ProxyJUnitTest {
     checkCL(expre);
 
     long creates = getStats().getCreates();
-    int destroys = getStats().getDestroys();
+    long destroys = getStats().getDestroys();
     int invalidates = getStats().getInvalidates();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
     expee.r = r;

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
@@ -644,7 +644,7 @@ public class ProxyJUnitTest {
     expee.key = "key";
     long creates = getStats().getCreates();
     long destroys = getStats().getDestroys();
-    int invalidates = getStats().getInvalidates();
+    long invalidates = getStats().getInvalidates();
     long gets = getStats().getGets();
     long misses = getStats().getMisses();
 
@@ -925,7 +925,7 @@ public class ProxyJUnitTest {
 
     long creates = getStats().getCreates();
     long destroys = getStats().getDestroys();
-    int invalidates = getStats().getInvalidates();
+    long invalidates = getStats().getInvalidates();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
     expee.r = r;
     expee.key = "key";

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/ProxyJUnitTest.java
@@ -643,12 +643,10 @@ public class ProxyJUnitTest {
     expee.r = r;
     expee.key = "key";
     int creates = getStats().getCreates();
-    // int puts = getStats().getPuts();
-    // int updates = getStats().getUpdates();
     int destroys = getStats().getDestroys();
     int invalidates = getStats().getInvalidates();
-    int gets = getStats().getGets();
-    int misses = getStats().getMisses();
+    long gets = getStats().getGets();
+    long misses = getStats().getMisses();
 
     r.put("key", "value", cbArg);
     expee.op = Operation.CREATE;
@@ -837,12 +835,9 @@ public class ProxyJUnitTest {
     checkCL(expre);
 
     int creates = getStats().getCreates();
-    // int puts = getStats().getPuts();
-    // int updates = getStats().getUpdates();
     int destroys = getStats().getDestroys();
-    // int invalidates = getStats().getInvalidates();
-    int gets = getStats().getGets();
-    int misses = getStats().getMisses();
+    long gets = getStats().getGets();
+    long misses = getStats().getMisses();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
     expee.r = r;
     expee.key = "key";
@@ -929,12 +924,8 @@ public class ProxyJUnitTest {
     checkCL(expre);
 
     int creates = getStats().getCreates();
-    // int puts = getStats().getPuts();
-    // int updates = getStats().getUpdates();
     int destroys = getStats().getDestroys();
     int invalidates = getStats().getInvalidates();
-    // int gets = getStats().getGets();
-    // int misses = getStats().getMisses();
     ExpectedEntryEvent expee = new ExpectedEntryEvent();
     expee.r = r;
     expee.key = "key";

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/asyncqueue/AsyncEventQueueEvictionAndExpirationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/asyncqueue/AsyncEventQueueEvictionAndExpirationJUnitTest.java
@@ -207,7 +207,7 @@ public class AsyncEventQueueEvictionAndExpirationJUnitTest {
     LocalRegion lr = (LocalRegion) region;
     // Wait for region to evict/expire events.
     await()
-        .untilAsserted(() -> assertEquals(2, lr.getCachePerfStats().getInvalidates()));
+        .untilAsserted(() -> assertEquals(2L, lr.getCachePerfStats().getInvalidates()));
     // The AQListner should get expected events.
     await()
         .untilAsserted(() -> assertEquals(2, events.size()));
@@ -226,7 +226,7 @@ public class AsyncEventQueueEvictionAndExpirationJUnitTest {
     LocalRegion lr = (LocalRegion) region;
     // Wait for region to evict/expire events.
     await()
-        .untilAsserted(() -> assertEquals(2, lr.getCachePerfStats().getInvalidates()));
+        .untilAsserted(() -> assertEquals(2L, lr.getCachePerfStats().getInvalidates()));
     // The AQListner should get expected events.
     await()
         .untilAsserted(() -> assertEquals(2, events.size()));
@@ -376,7 +376,7 @@ public class AsyncEventQueueEvictionAndExpirationJUnitTest {
     // Wait for region to evict/expire events.
     LocalRegion lr = (LocalRegion) region;
     await()
-        .untilAsserted(() -> assertEquals(2, lr.getCachePerfStats().getInvalidates()));
+        .untilAsserted(() -> assertEquals(2L, lr.getCachePerfStats().getInvalidates()));
 
     // The AQListner should get expected events.
     await()
@@ -397,7 +397,7 @@ public class AsyncEventQueueEvictionAndExpirationJUnitTest {
     // Wait for region to evict/expire events.
     LocalRegion lr = (LocalRegion) region;
     await()
-        .untilAsserted(() -> assertEquals(2, lr.getCachePerfStats().getInvalidates()));
+        .untilAsserted(() -> assertEquals(2L, lr.getCachePerfStats().getInvalidates()));
 
     // The AQListner should get expected events.
     await()

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
@@ -108,7 +108,7 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
     logger.info("<ExpectedException action=add>" + expectedExceptions + "</ExpectedException>");
     try {
       pr.put(new Integer(1), val);
-      fail("testPut()- Expected PartitionedRegionException not thrown for localMaxMemory = 0");
+      fail("testPut()- The expected PartitionedRegionException was not thrown for localMaxMemory = 0");
     } catch (PartitionedRegionStorageException ex) {
       if (logWriter.fineEnabled()) {
         logWriter.fine(

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
@@ -108,7 +108,8 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
     logger.info("<ExpectedException action=add>" + expectedExceptions + "</ExpectedException>");
     try {
       pr.put(new Integer(1), val);
-      fail("testPut()- The expected PartitionedRegionException was not thrown for localMaxMemory = 0");
+      fail(
+          "testPut()- The expected PartitionedRegionException was not thrown for localMaxMemory = 0");
     } catch (PartitionedRegionStorageException ex) {
       if (logWriter.fineEnabled()) {
         logWriter.fine(
@@ -206,7 +207,7 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
 
     for (int num = 0; num < 3; num++) {
       pr.put(new Integer(num), val);
-      final int initialDestroyCount = getDestroyCount(pr);
+      final long initialDestroyCount = getDestroyCount(pr);
       pr.destroy(new Integer(num));
       assertEquals(initialDestroyCount + 1, getDestroyCount(pr));
     }
@@ -234,7 +235,7 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
     }
   }
 
-  private int getDestroyCount(PartitionedRegion pr) {
+  private long getDestroyCount(PartitionedRegion pr) {
     return ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getDestroys();
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleNodeOperationsJUnitTest.java
@@ -238,7 +238,7 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
     return ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getDestroys();
   }
 
-  private int getCreateCount(PartitionedRegion pr) {
+  private long getCreateCount(PartitionedRegion pr) {
     return ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getCreates();
   }
 
@@ -1081,7 +1081,7 @@ public class PartitionedRegionSingleNodeOperationsJUnitTest {
     final String expectedExceptions = EntryExistsException.class.getName();
     for (int num = 0; num < 3; num++) {
       key++;
-      final int initialCreates = getCreateCount(pr);
+      final long initialCreates = getCreateCount(pr);
       pr.create(new Integer(key), val + num);
       assertEquals(initialCreates + 1, getCreateCount(pr));
       final Object getObj1 = pr.get(new Integer(key));

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/DistributedSystemStatisticsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/DistributedSystemStatisticsIntegrationTest.java
@@ -187,9 +187,8 @@ public class DistributedSystemStatisticsIntegrationTest {
     Statistics stats = setUpLongStatistics(1);
 
     assertThat(stats.getLong(this.statName1)).isEqualTo(0L);
+    assertThat(stats.getInt(this.statName1)).isEqualTo(0);
     assertThatThrownBy(() -> stats.getDouble(this.statName1))
-        .isExactlyInstanceOf(IllegalArgumentException.class);
-    assertThatThrownBy(() -> stats.getInt(this.statName1))
         .isExactlyInstanceOf(IllegalArgumentException.class);
 
     stats.setLong(this.statName1, 4L);

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -496,10 +496,10 @@ toData,16
 
 org/apache/geode/internal/admin/remote/ClientHealthStats,6
 fromData,73
-fromDataPre_GFE_8_0_0_0,67
+fromDataPre_GFE_8_0_0_0,68
 fromDataPre_GEODE_1_9_0_0,14
 toData,73
-toDataPre_GFE_8_0_0_0,67
+toDataPre_GFE_8_0_0_0,68
 toDataPre_GEODE_1_9_0_0,14
 
 org/apache/geode/internal/admin/remote/CompactRequest,2

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -494,11 +494,13 @@ org/apache/geode/internal/admin/remote/ChangeRefreshIntervalMessage,2
 fromData,16
 toData,16
 
-org/apache/geode/internal/admin/remote/ClientHealthStats,4
+org/apache/geode/internal/admin/remote/ClientHealthStats,6
 fromData,73
 fromDataPre_GFE_8_0_0_0,65
+fromDataPre_GEODE_1_9_0_0,77
 toData,73
 toDataPre_GFE_8_0_0_0,65
+toDataPre_GEODE_1_9_0_0,77
 
 org/apache/geode/internal/admin/remote/CompactRequest,2
 fromData,6

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -496,11 +496,11 @@ toData,16
 
 org/apache/geode/internal/admin/remote/ClientHealthStats,6
 fromData,73
-fromDataPre_GFE_8_0_0_0,65
-fromDataPre_GEODE_1_9_0_0,77
+fromDataPre_GFE_8_0_0_0,67
+fromDataPre_GEODE_1_9_0_0,14
 toData,73
-toDataPre_GFE_8_0_0_0,65
-toDataPre_GEODE_1_9_0_0,77
+toDataPre_GFE_8_0_0_0,67
+toDataPre_GEODE_1_9_0_0,14
 
 org/apache/geode/internal/admin/remote/CompactRequest,2
 fromData,6

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
@@ -479,11 +479,11 @@ public class ConnectionStats implements MessageStats {
                   "Total amount of time, in nanoseconds spent doing puts", "nanoseconds"),
               f.createIntGauge("destroysInProgress", "Current number of destroys being executed",
                   "destroys"),
-              f.createIntCounter("destroys", "Total number of destroys completed successfully",
+              f.createLongCounter("destroys", "Total number of destroys completed successfully",
                   "destroys"),
-              f.createIntCounter("destroyFailures",
+              f.createLongCounter("destroyFailures",
                   "Total number of destroy attempts that have failed", "destroys"),
-              f.createIntCounter("destroyTimeouts",
+              f.createLongCounter("destroyTimeouts",
                   "Total number of destroy attempts that have timed out", "destroys"),
               f.createLongCounter("destroyTime",
                   "Total amount of time, in nanoseconds spent doing destroys", "nanoseconds"),
@@ -1908,7 +1908,7 @@ public class ConnectionStats implements MessageStats {
     } else {
       endDestroyId = destroyId;
     }
-    this.stats.incInt(endDestroyId, 1);
+    this.stats.incLong(endDestroyId, 1);
     this.stats.incLong(destroyDurationId, duration);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
@@ -470,10 +470,10 @@ public class ConnectionStats implements MessageStats {
               f.createLongCounter("getTime",
                   "Total amount of time, in nanoseconds spent doing gets", "nanoseconds"),
               f.createIntGauge("putsInProgress", "Current number of puts being executed", "puts"),
-              f.createIntCounter("puts", "Total number of puts completed successfully", "puts"),
-              f.createIntCounter("putFailures", "Total number of put attempts that have failed",
+              f.createLongCounter("puts", "Total number of puts completed successfully", "puts"),
+              f.createLongCounter("putFailures", "Total number of put attempts that have failed",
                   "puts"),
-              f.createIntCounter("putTimeouts", "Total number of put attempts that have timed out",
+              f.createLongCounter("putTimeouts", "Total number of put attempts that have timed out",
                   "puts"),
               f.createLongCounter("putTime",
                   "Total amount of time, in nanoseconds spent doing puts", "nanoseconds"),
@@ -1842,7 +1842,7 @@ public class ConnectionStats implements MessageStats {
     } else {
       endPutId = putId;
     }
-    this.stats.incInt(endPutId, 1);
+    this.stats.incLong(endPutId, 1L);
     this.stats.incLong(putDurationId, duration);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
@@ -600,11 +600,11 @@ public class ConnectionStats implements MessageStats {
 
               f.createIntGauge("invalidatesInProgress",
                   "Current number of invalidates being executed", "invalidates"),
-              f.createIntCounter("invalidates",
+              f.createLongCounter("invalidates",
                   "Total number of invalidates completed successfully", "invalidates"),
-              f.createIntCounter("invalidateFailures",
+              f.createLongCounter("invalidateFailures",
                   "Total number of invalidate attempts that have failed", "invalidates"),
-              f.createIntCounter("invalidateTimeouts",
+              f.createLongCounter("invalidateTimeouts",
                   "Total number of invalidate attempts that have timed out", "invalidates"),
               f.createLongCounter("invalidateTime",
                   "Total amount of time, in nanoseconds spent doing invalidates", "nanoseconds"),
@@ -3599,7 +3599,7 @@ public class ConnectionStats implements MessageStats {
     } else {
       endInvalidateId = invalidateId;
     }
-    this.stats.incInt(endInvalidateId, 1);
+    this.stats.incLong(endInvalidateId, 1L);
     this.stats.incLong(invalidateDurationId, duration);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
@@ -499,11 +499,12 @@ public class ConnectionStats implements MessageStats {
                   "Total amount of time, in nanoseconds spent doing destroyRegions", "nanoseconds"),
               f.createIntGauge("clearsInProgress", "Current number of clears being executed",
                   "clears"),
-              f.createIntCounter("clears", "Total number of clears completed successfully",
+              f.createLongCounter("clears", "Total number of clears completed successfully",
                   "clears"),
-              f.createIntCounter("clearFailures", "Total number of clear attempts that have failed",
+              f.createLongCounter("clearFailures",
+                  "Total number of clear attempts that have failed",
                   "clears"),
-              f.createIntCounter("clearTimeouts",
+              f.createLongCounter("clearTimeouts",
                   "Total number of clear attempts that have timed out", "clears"),
               f.createLongCounter("clearTime",
                   "Total amount of time, in nanoseconds spent doing clears", "nanoseconds"),
@@ -2024,7 +2025,7 @@ public class ConnectionStats implements MessageStats {
     } else {
       endClearId = clearId;
     }
-    this.stats.incInt(endClearId, 1);
+    this.stats.incLong(endClearId, 1L);
     this.stats.incLong(clearDurationId, duration);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionStats.java
@@ -462,10 +462,10 @@ public class ConnectionStats implements MessageStats {
                */
               ///////////////////////////////////////////////////////////////////////
               f.createIntGauge("getsInProgress", "Current number of gets being executed", "gets"),
-              f.createIntCounter("gets", "Total number of gets completed successfully", "gets"),
-              f.createIntCounter("getFailures", "Total number of get attempts that have failed",
+              f.createLongCounter("gets", "Total number of gets completed successfully", "gets"),
+              f.createLongCounter("getFailures", "Total number of get attempts that have failed",
                   "gets"),
-              f.createIntCounter("getTimeouts", "Total number of get attempts that have timed out",
+              f.createLongCounter("getTimeouts", "Total number of get attempts that have timed out",
                   "gets"),
               f.createLongCounter("getTime",
                   "Total amount of time, in nanoseconds spent doing gets", "nanoseconds"),
@@ -1776,7 +1776,7 @@ public class ConnectionStats implements MessageStats {
     } else {
       endGetId = getId;
     }
-    this.stats.incInt(endGetId, 1);
+    this.stats.incLong(endGetId, 1L);
     this.stats.incLong(getDurationId, duration);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/ClientStatsManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/ClientStatsManager.java
@@ -195,13 +195,13 @@ public class ClientStatsManager {
     ClientHealthStats stats = new ClientHealthStats();
 
     long gets = -1;
-    int puts = -1;
+    long puts = -1;
     long misses = -1;
     int cacheListenerCalls = -1;
 
     if (cachePerfStats != null) {
       gets = cachePerfStats.getLong("gets");
-      puts = cachePerfStats.getInt("puts");
+      puts = cachePerfStats.getLong("puts");
       misses = cachePerfStats.getLong("misses");
       cacheListenerCalls = cachePerfStats.getInt("cacheListenerCallsCompleted");
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/ClientStatsManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/ClientStatsManager.java
@@ -194,15 +194,15 @@ public class ClientStatsManager {
     }
     ClientHealthStats stats = new ClientHealthStats();
 
-    int gets = -1;
+    long gets = -1;
     int puts = -1;
-    int misses = -1;
+    long misses = -1;
     int cacheListenerCalls = -1;
 
     if (cachePerfStats != null) {
-      gets = cachePerfStats.getInt("gets");
+      gets = cachePerfStats.getLong("gets");
       puts = cachePerfStats.getInt("puts");
-      misses = cachePerfStats.getInt("misses");
+      misses = cachePerfStats.getLong("misses");
       cacheListenerCalls = cachePerfStats.getInt("cacheListenerCallsCompleted");
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ClientHealthStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ClientHealthStats.java
@@ -40,7 +40,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    * "numOfGets", IntCounter, "The total number of times a successful get has been done on this
    * cache." Java: CachePerfStats.gets Native: Not yet Defined
    */
-  protected int numOfGets;
+  protected long numOfGets;
 
   /**
    * "numOfPuts", IntCounter, "The total number of times an entry is added or replaced in this cache
@@ -54,7 +54,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    * Represents number of cache misses in this client. IntCounter, "Total number of times a get on
    * the cache did not find a value already in local memory." Java: CachePerfStats.misses
    */
-  protected int numOfMisses;
+  protected long numOfMisses;
 
   /**
    * Represents number of cache listners calls completed. IntCounter, "Total number of times a cache
@@ -93,7 +93,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
 
   /** The versions in which this message was modified */
   @Immutable
-  private static final Version[] dsfidVersions = new Version[] {Version.GFE_80};
+  private static final Version[] dsfidVersions = new Version[] {Version.GFE_80, Version.GEODE_190};
 
   public ClientHealthStats() {}
 
@@ -102,7 +102,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    *
    * @return total number of get requests completed successfully.
    */
-  public int getNumOfGets() {
+  public long getNumOfGets() {
     return numOfGets;
   }
 
@@ -111,7 +111,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    *
    * @param numOfGets Total number of get requests to be set.
    */
-  public void setNumOfGets(int numOfGets) {
+  public void setNumOfGets(long numOfGets) {
     this.numOfGets = numOfGets;
   }
 
@@ -138,7 +138,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    *
    * @return total number of cache misses.
    */
-  public int getNumOfMisses() {
+  public long getNumOfMisses() {
     return numOfMisses;
   }
 
@@ -147,7 +147,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    *
    * @param numOfMisses total number of cache misses.
    */
-  public void setNumOfMisses(int numOfMisses) {
+  public void setNumOfMisses(long numOfMisses) {
     this.numOfMisses = numOfMisses;
   }
 
@@ -223,9 +223,9 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
 
   @Override
   public void toData(DataOutput out) throws IOException {
-    DataSerializer.writePrimitiveInt(numOfGets, out);
+    DataSerializer.writePrimitiveLong(numOfGets, out);
     DataSerializer.writePrimitiveInt(numOfPuts, out);
-    DataSerializer.writePrimitiveInt(numOfMisses, out);
+    DataSerializer.writePrimitiveLong(numOfMisses, out);
     DataSerializer.writePrimitiveInt(numOfCacheListenerCalls, out);
     DataSerializer.writePrimitiveInt(numOfThreads, out);
     DataSerializer.writePrimitiveInt(cpus, out);
@@ -235,9 +235,9 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
   }
 
   public void toDataPre_GFE_8_0_0_0(DataOutput out) throws IOException {
-    DataSerializer.writePrimitiveInt(numOfGets, out);
+    DataSerializer.writePrimitiveInt((int) numOfGets, out);
     DataSerializer.writePrimitiveInt(numOfPuts, out);
-    DataSerializer.writePrimitiveInt(numOfMisses, out);
+    DataSerializer.writePrimitiveInt((int) numOfMisses, out);
     DataSerializer.writePrimitiveInt(numOfCacheListenerCalls, out);
     DataSerializer.writePrimitiveInt(numOfThreads, out);
     DataSerializer.writePrimitiveInt(cpus, out);
@@ -245,11 +245,16 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
     DataSerializer.writeDate(updateTime, out);
   }
 
+  public void toDataPre_GEODE_1_9_0_0(DataOutput out) throws IOException {
+    toDataPre_GFE_8_0_0_0(out);
+    DataSerializer.writeHashMap((poolStats), out);
+  }
+
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    this.numOfGets = DataSerializer.readPrimitiveInt(in);
+    this.numOfGets = DataSerializer.readPrimitiveLong(in);
     this.numOfPuts = DataSerializer.readPrimitiveInt(in);
-    this.numOfMisses = DataSerializer.readPrimitiveInt(in);
+    this.numOfMisses = DataSerializer.readPrimitiveLong(in);
     this.numOfCacheListenerCalls = DataSerializer.readPrimitiveInt(in);
     this.numOfThreads = DataSerializer.readPrimitiveInt(in);
     this.cpus = DataSerializer.readPrimitiveInt(in);
@@ -267,6 +272,11 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
     this.cpus = DataSerializer.readPrimitiveInt(in);
     this.processCpuTime = DataSerializer.readPrimitiveLong(in);
     this.updateTime = DataSerializer.readDate(in);
+  }
+
+  public void fromDataPre_GEODE_1_9_0_0(DataInput in) throws IOException, ClassNotFoundException {
+    fromDataPre_GFE_8_0_0_0(in);
+    this.poolStats = DataSerializer.readHashMap(in);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ClientHealthStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ClientHealthStats.java
@@ -48,7 +48,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    * or netloading a value). Note that this only counts puts done explicitly on this cache. It does
    * not count updates pushed from other caches." Java: CachePerfStats.puts Native: Not yet Defined
    */
-  protected int numOfPuts;
+  protected long numOfPuts;
 
   /**
    * Represents number of cache misses in this client. IntCounter, "Total number of times a get on
@@ -120,7 +120,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    *
    * @return Total number of put requests completed.
    */
-  public int getNumOfPuts() {
+  public long getNumOfPuts() {
     return numOfPuts;
   }
 
@@ -129,7 +129,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
    *
    * @param numOfPuts Total number of put requests to be set.
    */
-  public void setNumOfPuts(int numOfPuts) {
+  public void setNumOfPuts(long numOfPuts) {
     this.numOfPuts = numOfPuts;
   }
 
@@ -224,7 +224,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
   @Override
   public void toData(DataOutput out) throws IOException {
     DataSerializer.writePrimitiveLong(numOfGets, out);
-    DataSerializer.writePrimitiveInt(numOfPuts, out);
+    DataSerializer.writePrimitiveLong(numOfPuts, out);
     DataSerializer.writePrimitiveLong(numOfMisses, out);
     DataSerializer.writePrimitiveInt(numOfCacheListenerCalls, out);
     DataSerializer.writePrimitiveInt(numOfThreads, out);
@@ -236,7 +236,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
 
   public void toDataPre_GFE_8_0_0_0(DataOutput out) throws IOException {
     DataSerializer.writePrimitiveInt((int) numOfGets, out);
-    DataSerializer.writePrimitiveInt(numOfPuts, out);
+    DataSerializer.writePrimitiveInt((int) numOfPuts, out);
     DataSerializer.writePrimitiveInt((int) numOfMisses, out);
     DataSerializer.writePrimitiveInt(numOfCacheListenerCalls, out);
     DataSerializer.writePrimitiveInt(numOfThreads, out);
@@ -253,7 +253,7 @@ public class ClientHealthStats implements DataSerializableFixedID, Serializable 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
     this.numOfGets = DataSerializer.readPrimitiveLong(in);
-    this.numOfPuts = DataSerializer.readPrimitiveInt(in);
+    this.numOfPuts = DataSerializer.readPrimitiveLong(in);
     this.numOfMisses = DataSerializer.readPrimitiveLong(in);
     this.numOfCacheListenerCalls = DataSerializer.readPrimitiveInt(in);
     this.numOfThreads = DataSerializer.readPrimitiveInt(in);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -63,8 +63,8 @@ public class CachePerfStats {
   static final int createsId;
   static final int putsId;
   protected static final int putTimeId;
-  static final int putallsId;
-  static final int putallTimeId;
+  static final int putAllsId;
+  static final int putAllTimeId;
   static final int removeAllsId;
   private static final int removeAllTimeId;
   protected static final int updatesId;
@@ -386,7 +386,7 @@ public class CachePerfStats {
             f.createIntCounter("invalidates", invalidatesDesc, "operations"),
             f.createLongCounter("gets", getsDesc, "operations"),
             f.createLongCounter("misses", missesDesc, "operations"),
-            f.createIntCounter("creates", createsDesc, "operations"),
+            f.createLongCounter("creates", createsDesc, "operations"),
             f.createLongCounter("puts", putsDesc, "operations"),
             f.createLongCounter("putTime", putTimeDesc, "nanoseconds", false),
             f.createIntCounter("putalls", putallsDesc, "operations"),
@@ -528,8 +528,8 @@ public class CachePerfStats {
     createsId = type.nameToId("creates");
     putsId = type.nameToId("puts");
     putTimeId = type.nameToId("putTime");
-    putallsId = type.nameToId("putalls");
-    putallTimeId = type.nameToId("putallTime");
+    putAllsId = type.nameToId("putalls");
+    putAllTimeId = type.nameToId("putallTime");
     removeAllsId = type.nameToId("removeAlls");
     removeAllTimeId = type.nameToId("removeAllTime");
     updatesId = type.nameToId("updates");
@@ -711,8 +711,8 @@ public class CachePerfStats {
     return stats.getInt(destroysId);
   }
 
-  public int getCreates() {
-    return stats.getInt(createsId);
+  public long getCreates() {
+    return stats.getLong(createsId);
   }
 
   public long getPuts() {
@@ -724,7 +724,7 @@ public class CachePerfStats {
   }
 
   public int getPutAlls() {
-    return stats.getInt(putallsId);
+    return stats.getInt(putAllsId);
   }
 
   int getRemoveAlls() {
@@ -1080,7 +1080,7 @@ public class CachePerfStats {
   }
 
   public void incCreates() {
-    stats.incInt(createsId, 1);
+    stats.incLong(createsId, 1L);
   }
 
   public void incInvalidates() {
@@ -1131,9 +1131,9 @@ public class CachePerfStats {
   }
 
   public void endPutAll(long start) {
-    stats.incInt(putallsId, 1);
+    stats.incInt(putAllsId, 1);
     if (enableClockStats)
-      stats.incLong(putallTimeId, getClockTime() - start);
+      stats.incLong(putAllTimeId, getClockTime() - start);
   }
 
   public void endRemoveAll(long start) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -383,7 +383,7 @@ public class CachePerfStats {
             f.createLongCounter("destroys", destroysDesc, "operations"),
             f.createLongCounter("updates", updatesDesc, "operations"),
             f.createLongCounter("updateTime", updateTimeDesc, "nanoseconds"),
-            f.createIntCounter("invalidates", invalidatesDesc, "operations"),
+            f.createLongCounter("invalidates", invalidatesDesc, "operations"),
             f.createLongCounter("gets", getsDesc, "operations"),
             f.createLongCounter("misses", missesDesc, "operations"),
             f.createLongCounter("creates", createsDesc, "operations"),
@@ -735,8 +735,8 @@ public class CachePerfStats {
     return stats.getLong(updatesId);
   }
 
-  public int getInvalidates() {
-    return stats.getInt(invalidatesId);
+  public long getInvalidates() {
+    return stats.getLong(invalidatesId);
   }
 
   public long getGets() {
@@ -1084,7 +1084,7 @@ public class CachePerfStats {
   }
 
   public void incInvalidates() {
-    stats.incInt(invalidatesId, 1);
+    stats.incLong(invalidatesId, 1L);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -445,7 +445,7 @@ public class CachePerfStats {
             f.createIntCounter("retries",
                 "Number of times a concurrent destroy followed by a create has caused an entry operation to need to retry.",
                 "operations"),
-            f.createIntCounter("clears", clearsDesc, "operations"),
+            f.createLongCounter("clears", clearsDesc, "operations"),
             f.createIntGauge("diskTasksWaiting",
                 "Current number of disk tasks (oplog compactions, asynchronous recoveries, etc) that are waiting for a thread to run the operation",
                 "operations"),
@@ -1390,12 +1390,12 @@ public class CachePerfStats {
     };
   }
 
-  public int getClearCount() {
-    return stats.getInt(clearsId);
+  public long getClearCount() {
+    return stats.getLong(clearsId);
   }
 
   public void incClearCount() {
-    stats.incInt(clearsId, 1);
+    stats.incLong(clearsId, 1L);
   }
 
   public long getConflatedEventsCount() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -380,7 +380,7 @@ public class CachePerfStats {
                 "keys"),
             f.createIntGauge("regions", regionsDesc, "regions"),
             f.createIntGauge("partitionedRegions", partitionedRegionsDesc, "partitionedRegions"),
-            f.createIntCounter("destroys", destroysDesc, "operations"),
+            f.createLongCounter("destroys", destroysDesc, "operations"),
             f.createLongCounter("updates", updatesDesc, "operations"),
             f.createLongCounter("updateTime", updateTimeDesc, "nanoseconds"),
             f.createIntCounter("invalidates", invalidatesDesc, "operations"),
@@ -707,8 +707,8 @@ public class CachePerfStats {
     return stats.getInt(regionsId);
   }
 
-  public int getDestroys() {
-    return stats.getInt(destroysId);
+  public long getDestroys() {
+    return stats.getLong(destroysId);
   }
 
   public long getCreates() {
@@ -1076,7 +1076,7 @@ public class CachePerfStats {
   }
 
   public void incDestroys() {
-    stats.incInt(destroysId, 1);
+    stats.incLong(destroysId, 1L);
   }
 
   public void incCreates() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -384,8 +384,8 @@ public class CachePerfStats {
             f.createIntCounter("updates", updatesDesc, "operations"),
             f.createLongCounter("updateTime", updateTimeDesc, "nanoseconds"),
             f.createIntCounter("invalidates", invalidatesDesc, "operations"),
-            f.createIntCounter("gets", getsDesc, "operations"),
-            f.createIntCounter("misses", missesDesc, "operations"),
+            f.createLongCounter("gets", getsDesc, "operations"),
+            f.createLongCounter("misses", missesDesc, "operations"),
             f.createIntCounter("creates", createsDesc, "operations"),
             f.createIntCounter("puts", putsDesc, "operations"),
             f.createLongCounter("putTime", putTimeDesc, "nanoseconds", false),
@@ -739,16 +739,16 @@ public class CachePerfStats {
     return stats.getInt(invalidatesId);
   }
 
-  public int getGets() {
-    return stats.getInt(getsId);
+  public long getGets() {
+    return stats.getLong(getsId);
   }
 
   public long getGetTime() {
     return stats.getLong(getTimeId);
   }
 
-  public int getMisses() {
-    return stats.getInt(missesId);
+  public long getMisses() {
+    return stats.getLong(missesId);
   }
 
   public int getReliableQueuedOps() {
@@ -1102,9 +1102,9 @@ public class CachePerfStats {
       long delta = getClockTime() - start;
       stats.incLong(getTimeId, delta);
     }
-    stats.incInt(getsId, 1);
+    stats.incLong(getsId, 1L);
     if (miss) {
-      stats.incInt(missesId, 1);
+      stats.incLong(missesId, 1L);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -381,13 +381,13 @@ public class CachePerfStats {
             f.createIntGauge("regions", regionsDesc, "regions"),
             f.createIntGauge("partitionedRegions", partitionedRegionsDesc, "partitionedRegions"),
             f.createIntCounter("destroys", destroysDesc, "operations"),
-            f.createIntCounter("updates", updatesDesc, "operations"),
+            f.createLongCounter("updates", updatesDesc, "operations"),
             f.createLongCounter("updateTime", updateTimeDesc, "nanoseconds"),
             f.createIntCounter("invalidates", invalidatesDesc, "operations"),
             f.createLongCounter("gets", getsDesc, "operations"),
             f.createLongCounter("misses", missesDesc, "operations"),
             f.createIntCounter("creates", createsDesc, "operations"),
-            f.createIntCounter("puts", putsDesc, "operations"),
+            f.createLongCounter("puts", putsDesc, "operations"),
             f.createLongCounter("putTime", putTimeDesc, "nanoseconds", false),
             f.createIntCounter("putalls", putallsDesc, "operations"),
             f.createLongCounter("putallTime", putallTimeDesc, "nanoseconds", false),
@@ -715,8 +715,8 @@ public class CachePerfStats {
     return stats.getInt(createsId);
   }
 
-  public int getPuts() {
-    return stats.getInt(putsId);
+  public long getPuts() {
+    return stats.getLong(putsId);
   }
 
   public long getPutTime() {
@@ -731,8 +731,8 @@ public class CachePerfStats {
     return stats.getInt(removeAllsId);
   }
 
-  public int getUpdates() {
-    return stats.getInt(updatesId);
+  public long getUpdates() {
+    return stats.getLong(updatesId);
   }
 
   public int getInvalidates() {
@@ -1115,13 +1115,13 @@ public class CachePerfStats {
   public long endPut(long start, boolean isUpdate) {
     long total = 0;
     if (isUpdate) {
-      stats.incInt(updatesId, 1);
+      stats.incLong(updatesId, 1L);
       if (enableClockStats) {
         total = getClockTime() - start;
         stats.incLong(updateTimeId, total);
       }
     } else {
-      stats.incInt(putsId, 1);
+      stats.incLong(putsId, 1L);
       if (enableClockStats) {
         total = getClockTime() - start;
         stats.incLong(putTimeId, total);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -97,8 +97,8 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getInvalidates() {
-    return 0;
+  public long getInvalidates() {
+    return 0l;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -82,8 +82,8 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getPuts() {
-    return 0;
+  public long getPuts() {
+    return 0L;
   }
 
   @Override
@@ -92,7 +92,7 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getUpdates() {
+  public long getUpdates() {
     return 0;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -72,8 +72,8 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getDestroys() {
-    return 0;
+  public long getDestroys() {
+    return 0L;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -102,13 +102,13 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getGets() {
-    return 0;
+  public long getGets() {
+    return 0L;
   }
 
   @Override
-  public int getMisses() {
-    return 0;
+  public long getMisses() {
+    return 0L;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -77,7 +77,7 @@ public class DummyCachePerfStats extends CachePerfStats {
   }
 
   @Override
-  public int getCreates() {
+  public long getCreates() {
     return 0;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -11264,7 +11264,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     @Override
     public void incInvalidates() {
-      this.stats.incInt(invalidatesId, 1);
+      this.stats.incLong(invalidatesId, 1L);
       this.cachePerfStats.incInvalidates();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -11476,7 +11476,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     @Override
     public void incClearCount() {
-      this.stats.incInt(clearsId, 1);
+      this.stats.incLong(clearsId, 1L);
       this.cachePerfStats.incClearCount();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -11252,7 +11252,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     @Override
     public void incDestroys() {
-      this.stats.incInt(destroysId, 1);
+      this.stats.incLong(destroysId, 1L);
       this.cachePerfStats.incDestroys();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -11258,7 +11258,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     @Override
     public void incCreates() {
-      this.stats.incInt(createsId, 1);
+      this.stats.incLong(createsId, 1L);
       this.cachePerfStats.incCreates();
     }
 
@@ -11333,9 +11333,9 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     @Override
     public void endPutAll(long start) {
-      this.stats.incInt(putallsId, 1);
+      this.stats.incInt(putAllsId, 1);
       if (enableClockStats) {
-        this.stats.incLong(putallTimeId, getStatTime() - start);
+        this.stats.incLong(putAllTimeId, getStatTime() - start);
       }
       this.cachePerfStats.endPutAll(start);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -11315,13 +11315,13 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     public long endPut(long start, boolean isUpdate) {
       long total = 0;
       if (isUpdate) {
-        this.stats.incInt(updatesId, 1);
+        this.stats.incLong(updatesId, 1L);
         if (enableClockStats) {
           total = getStatTime() - start;
           this.stats.incLong(updateTimeId, total);
         }
       } else {
-        this.stats.incInt(putsId, 1);
+        this.stats.incLong(putsId, 1L);
         if (enableClockStats) {
           total = getStatTime() - start;
           this.stats.incLong(putTimeId, total);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -11300,9 +11300,9 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       if (enableClockStats) {
         this.stats.incLong(getTimeId, getStatTime() - start);
       }
-      this.stats.incInt(getsId, 1);
+      this.stats.incLong(getsId, 1L);
       if (miss) {
-        this.stats.incInt(missesId, 1);
+        this.stats.incLong(missesId, 1L);
       }
       this.cachePerfStats.endGet(start, miss);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsImpl.java
@@ -277,7 +277,14 @@ public abstract class StatisticsImpl implements Statistics {
 
   @Override
   public int getInt(StatisticDescriptor descriptor) {
-    return getInt(getIntId(descriptor));
+    try {
+      return getInt(getIntId(descriptor));
+    } catch (IllegalArgumentException e) {
+      if (descriptor.getType() == long.class) {
+        return (int) getLong(descriptor);
+      }
+      throw e;
+    }
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/management/ClientHealthStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/management/ClientHealthStatus.java
@@ -45,7 +45,7 @@ public class ClientHealthStatus {
    * "numOfGets", IntCounter, "The total number of times a successful get has been done on this
    * cache." Java: CachePerfStats.gets Native: Not yet Defined
    */
-  private long numOfGets;
+  private int numOfGets;
 
   /**
    * "numOfPuts", IntCounter, "The total number of times an entry is added or replaced in this cache
@@ -59,7 +59,7 @@ public class ClientHealthStatus {
    * Represents number of cache misses in this client. IntCounter, "Total number of times a get on
    * the cache did not find a value already in local memory." Java: CachePerfStats.misses
    */
-  private long numOfMisses;
+  private int numOfMisses;
 
   /**
    * Represents number of cache listners calls completed. IntCounter, "Total number of times a cache
@@ -119,7 +119,7 @@ public class ClientHealthStatus {
   /**
    * Returns the number of times a successful get operation has occurred.
    */
-  public long getNumOfGets() {
+  public int getNumOfGets() {
     return numOfGets;
   }
 
@@ -136,7 +136,7 @@ public class ClientHealthStatus {
   /**
    * Returns the number of times a cache miss has occurred.
    */
-  public long getNumOfMisses() {
+  public int getNumOfMisses() {
     return numOfMisses;
   }
 
@@ -185,7 +185,7 @@ public class ClientHealthStatus {
   /**
    * Sets the number of times a successful get operation has occurred.
    */
-  public void setNumOfGets(long numOfGets) {
+  public void setNumOfGets(int numOfGets) {
     this.numOfGets = numOfGets;
   }
 
@@ -200,7 +200,7 @@ public class ClientHealthStatus {
   /**
    * Sets the number of times a cache miss has occurred.
    */
-  public void setNumOfMisses(long numOfMisses) {
+  public void setNumOfMisses(int numOfMisses) {
     this.numOfMisses = numOfMisses;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/ClientHealthStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/management/ClientHealthStatus.java
@@ -45,7 +45,7 @@ public class ClientHealthStatus {
    * "numOfGets", IntCounter, "The total number of times a successful get has been done on this
    * cache." Java: CachePerfStats.gets Native: Not yet Defined
    */
-  private int numOfGets;
+  private long numOfGets;
 
   /**
    * "numOfPuts", IntCounter, "The total number of times an entry is added or replaced in this cache
@@ -59,7 +59,7 @@ public class ClientHealthStatus {
    * Represents number of cache misses in this client. IntCounter, "Total number of times a get on
    * the cache did not find a value already in local memory." Java: CachePerfStats.misses
    */
-  private int numOfMisses;
+  private long numOfMisses;
 
   /**
    * Represents number of cache listners calls completed. IntCounter, "Total number of times a cache
@@ -119,7 +119,7 @@ public class ClientHealthStatus {
   /**
    * Returns the number of times a successful get operation has occurred.
    */
-  public int getNumOfGets() {
+  public long getNumOfGets() {
     return numOfGets;
   }
 
@@ -136,7 +136,7 @@ public class ClientHealthStatus {
   /**
    * Returns the number of times a cache miss has occurred.
    */
-  public int getNumOfMisses() {
+  public long getNumOfMisses() {
     return numOfMisses;
   }
 
@@ -185,7 +185,7 @@ public class ClientHealthStatus {
   /**
    * Sets the number of times a successful get operation has occurred.
    */
-  public void setNumOfGets(int numOfGets) {
+  public void setNumOfGets(long numOfGets) {
     this.numOfGets = numOfGets;
   }
 
@@ -200,7 +200,7 @@ public class ClientHealthStatus {
   /**
    * Sets the number of times a cache miss has occurred.
    */
-  public void setNumOfMisses(int numOfMisses) {
+  public void setNumOfMisses(long numOfMisses) {
     this.numOfMisses = numOfMisses;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
@@ -529,7 +529,7 @@ public class CacheServerBridge extends ServerBridge {
       status.setNumOfCacheListenerCalls(stats.getNumOfCacheListenerCalls());
       status.setNumOfGets((int) stats.getNumOfGets());
       status.setNumOfMisses((int) stats.getNumOfMisses());
-      status.setNumOfPuts(stats.getNumOfPuts());
+      status.setNumOfPuts((int) stats.getNumOfPuts());
       status.setNumOfThreads(stats.getNumOfThreads());
       status.setProcessCpuTime(stats.getProcessCpuTime());
       status.setPoolStats(stats.getPoolStats());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
@@ -527,8 +527,8 @@ public class CacheServerBridge extends ServerBridge {
     if (stats != null) {
       status.setCpus(stats.getCpus());
       status.setNumOfCacheListenerCalls(stats.getNumOfCacheListenerCalls());
-      status.setNumOfGets(stats.getNumOfGets());
-      status.setNumOfMisses(stats.getNumOfMisses());
+      status.setNumOfGets((int) stats.getNumOfGets());
+      status.setNumOfMisses((int) stats.getNumOfMisses());
       status.setNumOfPuts(stats.getNumOfPuts());
       status.setNumOfThreads(stats.getNumOfThreads());
       status.setProcessCpuTime(stats.getProcessCpuTime());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -343,24 +343,24 @@ public class CachePerfStatsTest {
 
   @Test
   public void getInvalidatesDelegatesToStatistics() {
-    statistics.incInt(invalidatesId, Integer.MAX_VALUE);
+    statistics.incLong(invalidatesId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getInvalidates()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getInvalidates()).isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
   public void incInvalidatesIncrementsInvalidates() {
     cachePerfStats.incInvalidates();
 
-    assertThat(statistics.getInt(invalidatesId)).isEqualTo(1);
+    assertThat(statistics.getLong(invalidatesId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code invalidates} currently wraps to negative from max integer value.
+   * Characterization test: {@code invalidates} currently wraps to negative from max long value.
    */
   @Test
-  public void invalidatesWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(invalidatesId, Integer.MAX_VALUE);
+  public void invalidatesWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(invalidatesId, Long.MAX_VALUE);
 
     cachePerfStats.incInvalidates();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -425,24 +425,24 @@ public class CachePerfStatsTest {
 
   @Test
   public void getClearsDelegatesToStatistics() {
-    statistics.incInt(clearsId, Integer.MAX_VALUE);
+    statistics.incLong(clearsId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getClearCount()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getClearCount()).isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
   public void incClearCountIncrementsClears() {
     cachePerfStats.incClearCount();
 
-    assertThat(statistics.getInt(clearsId)).isEqualTo(1);
+    assertThat(statistics.getLong(clearsId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code clears} currently wraps to negative from max integer value.
+   * Characterization test: {@code clears} currently wraps to negative from max long value.
    */
   @Test
-  public void clearsWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(clearsId, Integer.MAX_VALUE);
+  public void clearsWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(clearsId, Long.MAX_VALUE);
 
     cachePerfStats.incClearCount();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -103,9 +103,9 @@ public class CachePerfStatsTest {
 
   @Test
   public void getPutsDelegatesToStatistics() {
-    statistics.incInt(putsId, Integer.MAX_VALUE);
+    statistics.incLong(putsId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getPuts()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getPuts()).isEqualTo(Long.MAX_VALUE);
   }
 
   /**
@@ -116,15 +116,15 @@ public class CachePerfStatsTest {
   public void endPutIncrementsPuts() {
     cachePerfStats.endPut(0, false);
 
-    assertThat(statistics.getInt(putsId)).isEqualTo(1);
+    assertThat(statistics.getLong(putsId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code puts} currently wraps to negative from max integer value.
+   * Characterization test: {@code puts} currently wraps to negative from max long value.
    */
   @Test
-  public void putsWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(putsId, Integer.MAX_VALUE);
+  public void putsWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(putsId, Long.MAX_VALUE);
 
     cachePerfStats.endPut(0, false);
 
@@ -313,9 +313,9 @@ public class CachePerfStatsTest {
 
   @Test
   public void getUpdatesDelegatesToStatistics() {
-    statistics.incInt(updatesId, Integer.MAX_VALUE);
+    statistics.incLong(updatesId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getUpdates()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getUpdates()).isEqualTo(Long.MAX_VALUE);
   }
 
   /**
@@ -326,15 +326,15 @@ public class CachePerfStatsTest {
   public void endPutIncrementsUpdates() {
     cachePerfStats.endPut(0, true);
 
-    assertThat(statistics.getInt(updatesId)).isEqualTo(1);
+    assertThat(statistics.getLong(updatesId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code updates} currently wraps to negative from max integer value.
+   * Characterization test: {@code updates} currently wraps to negative from max long value.
    */
   @Test
-  public void updatesWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(updatesId, Integer.MAX_VALUE);
+  public void updatesWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(updatesId, Long.MAX_VALUE);
 
     cachePerfStats.endPut(0, true);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -133,9 +133,9 @@ public class CachePerfStatsTest {
 
   @Test
   public void getGetsDelegatesToStatistics() {
-    statistics.incInt(getsId, Integer.MAX_VALUE);
+    statistics.incLong(getsId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getGets()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getGets()).isEqualTo(Long.MAX_VALUE);
   }
 
   /**
@@ -146,15 +146,15 @@ public class CachePerfStatsTest {
   public void endGetIncrementsGets() {
     cachePerfStats.endGet(0, false);
 
-    assertThat(statistics.getInt(getsId)).isEqualTo(1);
+    assertThat(statistics.getLong(getsId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code gets} currently wraps to negative from max integer value.
+   * Characterization test: {@code gets} currently wraps to negative from max long value.
    */
   @Test
-  public void getsWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(getsId, Integer.MAX_VALUE);
+  public void getsWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(getsId, Long.MAX_VALUE);
 
     cachePerfStats.endGet(0, false);
 
@@ -369,9 +369,9 @@ public class CachePerfStatsTest {
 
   @Test
   public void getMissesDelegatesToStatistics() {
-    statistics.incInt(missesId, Integer.MAX_VALUE);
+    statistics.incLong(missesId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getMisses()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getMisses()).isEqualTo(Long.MAX_VALUE);
   }
 
   /**
@@ -382,15 +382,15 @@ public class CachePerfStatsTest {
   public void endGetIncrementsMisses() {
     cachePerfStats.endGet(0, true);
 
-    assertThat(statistics.getInt(missesId)).isEqualTo(1);
+    assertThat(statistics.getLong(missesId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code misses} currently wraps to negative from max integer value.
+   * Characterization test: {@code misses} currently wraps to negative from max long value.
    */
   @Test
-  public void missesWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(missesId, Integer.MAX_VALUE);
+  public void missesWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(missesId, Long.MAX_VALUE);
 
     cachePerfStats.endGet(0, true);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -37,8 +37,8 @@ import static org.apache.geode.internal.cache.CachePerfStats.loadsCompletedId;
 import static org.apache.geode.internal.cache.CachePerfStats.missesId;
 import static org.apache.geode.internal.cache.CachePerfStats.netloadsCompletedId;
 import static org.apache.geode.internal.cache.CachePerfStats.netsearchesCompletedId;
+import static org.apache.geode.internal.cache.CachePerfStats.putAllsId;
 import static org.apache.geode.internal.cache.CachePerfStats.putTimeId;
-import static org.apache.geode.internal.cache.CachePerfStats.putallsId;
 import static org.apache.geode.internal.cache.CachePerfStats.putsId;
 import static org.apache.geode.internal.cache.CachePerfStats.queryExecutionsId;
 import static org.apache.geode.internal.cache.CachePerfStats.removeAllsId;
@@ -227,24 +227,24 @@ public class CachePerfStatsTest {
 
   @Test
   public void getCreatesDelegatesToStatistics() {
-    statistics.incInt(createsId, Integer.MAX_VALUE);
+    statistics.incLong(createsId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getCreates()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getCreates()).isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
-  public void incCreatesIncrementsDestroys() {
+  public void incCreatesIncrementsCreates() {
     cachePerfStats.incCreates();
 
-    assertThat(statistics.getInt(createsId)).isEqualTo(1);
+    assertThat(statistics.getLong(createsId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code creates} currently wraps to negative from max integer value.
+   * Characterization test: {@code creates} currently wraps to negative from max long value.
    */
   @Test
-  public void createsWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(createsId, Integer.MAX_VALUE);
+  public void createsWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(createsId, Long.MAX_VALUE);
 
     cachePerfStats.incCreates();
 
@@ -253,7 +253,7 @@ public class CachePerfStatsTest {
 
   @Test
   public void getPutAllsDelegatesToStatistics() {
-    statistics.incInt(putallsId, Integer.MAX_VALUE);
+    statistics.incInt(putAllsId, Integer.MAX_VALUE);
 
     assertThat(cachePerfStats.getPutAlls()).isEqualTo(Integer.MAX_VALUE);
   }
@@ -263,10 +263,10 @@ public class CachePerfStatsTest {
    * endPutAll}.
    */
   @Test
-  public void endPutAllIncrementsDestroys() {
+  public void endPutAllIncrementsPutAlls() {
     cachePerfStats.endPutAll(0);
 
-    assertThat(statistics.getInt(putallsId)).isEqualTo(1);
+    assertThat(statistics.getInt(putAllsId)).isEqualTo(1);
   }
 
   /**
@@ -274,7 +274,7 @@ public class CachePerfStatsTest {
    */
   @Test
   public void putAllsWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(putallsId, Integer.MAX_VALUE);
+    statistics.incInt(putAllsId, Integer.MAX_VALUE);
 
     cachePerfStats.endPutAll(0);
 
@@ -293,7 +293,7 @@ public class CachePerfStatsTest {
    * {@code endRemoveAll}.
    */
   @Test
-  public void endRemoveAllIncrementsDestroys() {
+  public void endRemoveAllIncrementsRemoveAll() {
     cachePerfStats.endRemoveAll(0);
 
     assertThat(statistics.getInt(removeAllsId)).isEqualTo(1);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -201,24 +201,24 @@ public class CachePerfStatsTest {
 
   @Test
   public void getDestroysDelegatesToStatistics() {
-    statistics.incInt(destroysId, Integer.MAX_VALUE);
+    statistics.incLong(destroysId, Long.MAX_VALUE);
 
-    assertThat(cachePerfStats.getDestroys()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(cachePerfStats.getDestroys()).isEqualTo(Long.MAX_VALUE);
   }
 
   @Test
   public void incDestroysIncrementsDestroys() {
     cachePerfStats.incDestroys();
 
-    assertThat(statistics.getInt(destroysId)).isEqualTo(1);
+    assertThat(statistics.getLong(destroysId)).isEqualTo(1L);
   }
 
   /**
-   * Characterization test: {@code destroys} currently wraps to negative from max integer value.
+   * Characterization test: {@code destroys} currently wraps to negative from max long value.
    */
   @Test
-  public void destroysWrapsFromMaxIntegerToNegativeValue() {
-    statistics.incInt(destroysId, Integer.MAX_VALUE);
+  public void destroysWrapsFromMaxLongToNegativeValue() {
+    statistics.incLong(destroysId, Long.MAX_VALUE);
 
     cachePerfStats.incDestroys();
 

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/RegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/RegionTestCase.java
@@ -1035,7 +1035,7 @@ public abstract class RegionTestCase extends JUnit4CacheTestCase {
     Region region = createRegion(name);
     region.put(key, value);
 
-    int beforeInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
+    long beforeInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
         .getCachePerfStats().getInvalidates();
     Region.Entry entry = region.getEntry(key);
     region.invalidate(key);
@@ -1043,7 +1043,7 @@ public abstract class RegionTestCase extends JUnit4CacheTestCase {
       assertNull(entry.getValue());
     }
     assertNull(region.get(key));
-    int afterInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
+    long afterInvalidates = ((org.apache.geode.internal.cache.GemFireCacheImpl) getCache())
         .getCachePerfStats().getInvalidates();
     assertEquals("Invalidate CachePerfStats incorrect", beforeInvalidates + 1, afterInvalidates);
   }

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
@@ -422,7 +422,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
         assertTrue(success);
 
         Number newputs = getNumPuts(stats);
-        assertEquals("stats not updated properly or replace malfunctioned", newputs.longValue(), puts.longValue() + 1);
+        assertEquals("stats not updated properly or replace malfunctioned", newputs.longValue(),
+            puts.longValue() + 1);
 
       }
 

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
@@ -412,10 +412,10 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
         // replace with null oldvalue matches invalidated entry
         pr.putIfAbsent("otherKeyForNull", null);
-        int puts = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
+        long puts = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
         boolean success = pr.replace("otherKeyForNull", null, "no longer invalid");
         assertTrue(success);
-        int newputs = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
+        long newputs = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
         assertEquals("stats not updated properly or replace malfunctioned", newputs, puts + 1);
 
       }

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
@@ -30,6 +30,8 @@ import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
@@ -74,6 +76,7 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.OSProcess;
+import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.LocalRegion;
@@ -412,12 +415,35 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
         // replace with null oldvalue matches invalidated entry
         pr.putIfAbsent("otherKeyForNull", null);
-        long puts = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
+        CachePerfStats stats = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats();
+
+        Number puts = getNumPuts(stats);
         boolean success = pr.replace("otherKeyForNull", null, "no longer invalid");
         assertTrue(success);
-        long newputs = ((GemFireCacheImpl) pr.getCache()).getCachePerfStats().getPuts();
-        assertEquals("stats not updated properly or replace malfunctioned", newputs, puts + 1);
 
+        Number newputs = getNumPuts(stats);
+        assertEquals("stats not updated properly or replace malfunctioned", newputs.longValue(), puts.longValue() + 1);
+
+      }
+
+      public Number getNumPuts(CachePerfStats stats) {
+        Method getPutsMethod = null;
+        try {
+          getPutsMethod = stats.getClass().getMethod("getPuts");
+        } catch (NoSuchMethodException e) {
+          fail(e.getMessage());
+        }
+
+        Number puts = null;
+        try {
+          puts = (Number) getPutsMethod.invoke(stats);
+        } catch (IllegalAccessException e) {
+          fail(e.getMessage());
+        } catch (InvocationTargetException e) {
+          fail(e.getMessage());
+        }
+
+        return puts;
       }
     });
   }


### PR DESCRIPTION
Changes gets, misses, getFailures, and getTimeouts stats from int to
long so that they don't rollover as quickly.

Signed-off-by: Jacob Barrett <jbarrett@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
