### PR TITLE
GEODE-6440: synchronize when getting and setting

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StripedStatisticsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StripedStatisticsImpl.java
@@ -54,35 +54,47 @@ public class StripedStatisticsImpl extends StatisticsImpl {
 
   @Override
   protected void _setInt(int offset, int value) {
-    intAdders[offset].reset();
-    intAdders[offset].add(value);
+    synchronized (intAdders[offset]) {
+      intAdders[offset].reset();
+      intAdders[offset].add(value);
+    }
   }
 
   @Override
   protected void _setLong(int offset, long value) {
-    longAdders[offset].reset();
-    longAdders[offset].add(value);
+    synchronized (longAdders[offset]) {
+      longAdders[offset].reset();
+      longAdders[offset].add(value);
+    }
   }
 
   @Override
   protected void _setDouble(int offset, double value) {
-    doubleAdders[offset].reset();
-    doubleAdders[offset].add(value);
+    synchronized (doubleAdders[offset]) {
+      doubleAdders[offset].reset();
+      doubleAdders[offset].add(value);
+    }
   }
 
   @Override
   protected int _getInt(int offset) {
-    return intAdders[offset].intValue();
+    synchronized (intAdders[offset]) {
+      return intAdders[offset].intValue();
+    }
   }
 
   @Override
   protected long _getLong(int offset) {
-    return longAdders[offset].sum();
+    synchronized (longAdders[offset]) {
+      return longAdders[offset].sum();
+    }
   }
 
   @Override
   protected double _getDouble(int offset) {
-    return doubleAdders[offset].sum();
+    synchronized (doubleAdders[offset]) {
+      return doubleAdders[offset].sum();
+    }
   }
 
   @Override


### PR DESCRIPTION
Synchronize on getting and setting stats to avoid a race condition that
could occur when multiple threads were trying to set gauge stats.

Signed-off-by: Jacob Barrett <jbarrett@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
