### PR TITLE
GEODE-6422: Fix test timeout issue

### DIFF
--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
@@ -409,7 +409,7 @@ public class ConcurrencyRuleTest {
 
     retVal.set(false); // reset in case it has already been used
 
-    concurrencyRule.setTimeout(Duration.ofSeconds(3));
+    concurrencyRule.setTimeout(Duration.ofSeconds(60));
     concurrencyRule.add(callWithEventuallyCorrectRetVal).repeatUntilValue(expectedVal);
     concurrencyRule.add(() -> {
       Thread.sleep(500);


### PR DESCRIPTION
This test was timing out when run in CI. Since it never fails locally,
the issue appears to be with resource contention. Increasing the timeout
should reduce the frequency of failures as it gives the test more time
to spin up the required threads. This test will still fail if it fails
to start two threads within a minute.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
