### PR TITLE
GEODE-6442: Use PID for OS and Process stats if available

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/process/ProcessUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/ProcessUtils.java
@@ -52,13 +52,28 @@ public class ProcessUtils {
   }
 
   /**
+   * Returns the pid for this process without throwing a checked exception.
+   *
+   * @throws UncheckedPidUnavailableException if parsing the pid from the name of the RuntimeMXBean
+   *         fails
+   *
+   * @see java.lang.management.RuntimeMXBean#getName()
+   */
+  public static int identifyPidAsUnchecked() throws UncheckedPidUnavailableException {
+    try {
+      return identifyPid();
+    } catch (PidUnavailableException e) {
+      throw new UncheckedPidUnavailableException(e);
+    }
+  }
+
+  /**
    * Returns the pid for this process using the specified name from RuntimeMXBean.
    *
    * @throws PidUnavailableException if parsing the pid from the RuntimeMXBean name fails
    */
   public static int identifyPid(final String name) throws PidUnavailableException {
     notEmpty(name, "Invalid name '" + name + "' specified");
-
 
     try {
       final int index = name.indexOf('@');

--- a/geode-core/src/main/java/org/apache/geode/internal/process/UncheckedPidUnavailableException.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/UncheckedPidUnavailableException.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.process;
+
+/**
+ * Wraps an {@link PidUnavailableException} with an unchecked exception.
+ */
+public class UncheckedPidUnavailableException extends RuntimeException {
+  private static final long serialVersionUID = -4896120572252598765L;
+
+  /**
+   * Creates a new {@code UncheckedPidUnavailableException}.
+   */
+  public UncheckedPidUnavailableException(final String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a new {@code UncheckedPidUnavailableException} that was caused by a given exception
+   */
+  public UncheckedPidUnavailableException(final String message,
+      final PidUnavailableException cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Creates a new {@code UncheckedPidUnavailableException} that was caused by a given exception
+   */
+  public UncheckedPidUnavailableException(final PidUnavailableException cause) {
+    super(cause.getMessage(), cause);
+  }
+
+  /**
+   * Returns the cause of this exception.
+   *
+   * @return the {@code PidUnavailableException} which is the cause of this exception.
+   */
+  @Override
+  public PidUnavailableException getCause() {
+    return (PidUnavailableException) super.getCause();
+  }
+}

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -451,6 +451,7 @@ org/apache/geode/internal/process/ConnectionFailedException,true,562263645283675
 org/apache/geode/internal/process/FileAlreadyExistsException,true,5471082555536094256
 org/apache/geode/internal/process/MBeanInvocationFailedException,true,7991096466859690801
 org/apache/geode/internal/process/PidUnavailableException,true,-1660269538268828059
+org/apache/geode/internal/process/UncheckedPidUnavailableException,true,-4896120572252598765
 org/apache/geode/internal/process/signal/Signal,false,description:java/lang/String,name:java/lang/String,number:int,type:org/apache/geode/internal/process/signal/SignalType
 org/apache/geode/internal/process/signal/SignalEvent,false,signal:org/apache/geode/internal/process/signal/Signal
 org/apache/geode/internal/process/signal/SignalType,false,description:java/lang/String

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/HostStatSamplerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/HostStatSamplerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.util.function.IntSupplier;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.logging.LogFile;
+import org.apache.geode.internal.process.PidUnavailableException;
+import org.apache.geode.internal.process.UncheckedPidUnavailableException;
+
+public class HostStatSamplerTest {
+
+  private CancelCriterion cancelCriterion;
+  private StatSamplerStats statSamplerStats;
+  private NanoTimer timer;
+  private LogFile logFile;
+
+  private HostStatSampler hostStatSampler;
+
+  @Before
+  public void setUp() {
+    cancelCriterion = mock(CancelCriterion.class);
+    statSamplerStats = mock(StatSamplerStats.class);
+    timer = new NanoTimer();
+    logFile = null;
+  }
+
+  @Test
+  public void getSpecialStatsId_returnsPidFromPidSupplier_ifValueIsGreaterThanZero() {
+    int thePid = 42;
+    IntSupplier thePidSupplier = () -> thePid;
+    long anySystemId = 2;
+    hostStatSampler = new TestableHostStatSampler(cancelCriterion, statSamplerStats, timer, logFile,
+        thePidSupplier, anySystemId);
+
+    assertThat(hostStatSampler.getSpecialStatsId()).isEqualTo(thePid);
+  }
+
+  @Test
+  public void getSpecialStatsId_returnsSystemId_ifValueFromPidSupplierIsZero() {
+    IntSupplier thePidSupplier = () -> 0;
+    long theSystemId = 42;
+    hostStatSampler = new TestableHostStatSampler(cancelCriterion, statSamplerStats, timer, logFile,
+        thePidSupplier, theSystemId);
+
+    assertThat(hostStatSampler.getSpecialStatsId()).isEqualTo(theSystemId);
+  }
+
+  @Test
+  public void getSpecialStatsId_returnsSystemId_ifValueFromPidSupplierIsLessThanZero() {
+    IntSupplier thePidSupplier = () -> -1;
+    long theSystemId = 42;
+    hostStatSampler = new TestableHostStatSampler(cancelCriterion, statSamplerStats, timer, logFile,
+        thePidSupplier, theSystemId);
+
+    assertThat(hostStatSampler.getSpecialStatsId()).isEqualTo(theSystemId);
+  }
+
+  @Test
+  public void getSpecialStatsId_returnsSystemId_ifPidSupplierThrows() {
+    IntSupplier thePidSupplier = () -> {
+      throw new UncheckedPidUnavailableException(new PidUnavailableException("Pid not found"));
+    };
+    long theSystemId = 42;
+    hostStatSampler = new TestableHostStatSampler(cancelCriterion, statSamplerStats, timer, logFile,
+        thePidSupplier, theSystemId);
+
+    assertThat(hostStatSampler.getSpecialStatsId()).isEqualTo(theSystemId);
+  }
+
+  private static class TestableHostStatSampler extends HostStatSampler {
+
+    private final long systemId;
+
+    TestableHostStatSampler(CancelCriterion stopper, StatSamplerStats samplerStats, NanoTimer timer,
+        LogFile logFile, IntSupplier pidSupplier, long systemId) {
+      super(stopper, samplerStats, timer, logFile, pidSupplier);
+      this.systemId = systemId;
+    }
+
+    @Override
+    protected void checkListeners() {
+
+    }
+
+    @Override
+    protected int getSampleRate() {
+      return 0;
+    }
+
+    @Override
+    public boolean isSamplingEnabled() {
+      return false;
+    }
+
+    @Override
+    protected StatisticsManager getStatisticsManager() {
+      return null;
+    }
+
+    @Override
+    public File getArchiveFileName() {
+      return null;
+    }
+
+    @Override
+    public long getArchiveFileSizeLimit() {
+      return 0;
+    }
+
+    @Override
+    public long getArchiveDiskSpaceLimit() {
+      return 0;
+    }
+
+    @Override
+    public long getSystemId() {
+      return systemId;
+    }
+
+    @Override
+    public String getProductDescription() {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
If the PID is unavailable for any reason, fall back to using
DistributedSystem ID.

@demery-pivotal please review