### PR TITLE
GEODE-6443: Log all requests to REST ManagementService

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -190,6 +190,10 @@ dependencies {
   distributedTestCompile(project(':geode-assembly:geode-assembly-test'))
   distributedTestCompile('org.apache.httpcomponents:httpclient')
   distributedTestCompile('org.springframework:spring-web')
+  distributedTestCompile(project(':geode-management'))
+  distributedTestCompile(project(':geode-web-management'))
+  distributedTestCompile('org.apache.logging.log4j:log4j-core::tests')
+  distributedTestCompile('org.apache.logging.log4j:log4j-core::test-sources')
 
   distributedTestRuntime(project(':extensions:geode-modules-session-internal')) {
     exclude group: 'org.apache.tomcat'

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDUnitTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.test.appender.ListAppender;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.rules.GeodeDevRestClient;
+
+public class ManagementRequestLoggingDUnitTest {
+
+  @ClassRule
+  public static ClusterStartupRule cluster = new ClusterStartupRule();
+
+  private static MemberVM locator, server;
+
+  private static GeodeDevRestClient restClient;
+
+  @BeforeClass
+  public static void beforeClass() {
+    locator = cluster.startLocatorVM(0, l -> l.withHttpService());
+    server = cluster.startServerVM(1, locator.getPort());
+    restClient =
+        new GeodeDevRestClient("/geode-management/v2", "localhost", locator.getHttpPort(), false);
+  }
+
+  @Test
+  public void checkRequestsAreLogged() throws Exception {
+    locator.invoke(() -> {
+      Logger logger = (Logger) LogManager.getLogger(ManagementLoggingFilter.class);
+      logger.addAppender(new ListAppender("ListAppender"));
+    });
+
+    RegionConfig regionConfig = new RegionConfig();
+    regionConfig.setName("customers");
+    regionConfig.setType("REPLICATE");
+    ObjectMapper mapper = new ObjectMapper();
+    String json = mapper.writeValueAsString(regionConfig);
+
+    ClusterManagementResult result =
+        restClient.doPostAndAssert("/regions", json)
+            .hasStatusCode(201)
+            .getClusterManagementResult();
+
+    assertThat(result.isRealizedOnAllOrNone()).isTrue();
+
+    locator.invoke(() -> {
+      Logger logger = (Logger) LogManager.getLogger(ManagementLoggingFilter.class);
+      Map<String, Appender> appenders = logger.getAppenders();
+      ListAppender listAppender = (ListAppender) appenders.get("ListAppender");
+      List<LogEvent> logEvents = listAppender.getEvents();
+
+      assertThat(logEvents.size()).as("Expected LogEvents").isEqualTo(1);
+      assertThat(logEvents.get(0).getMessage().getFormattedMessage())
+          .startsWith("Management request:");
+
+      logger.removeAppender(listAppender);
+    });
+  }
+}

--- a/geode-web-management/build.gradle
+++ b/geode-web-management/build.gradle
@@ -111,9 +111,9 @@ dependencies {
   integrationTestRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
     exclude module: 'slf4j-api'
   }
-    
+
   distributedTestCompile(sourceSets.commonTest.output)
-  
+
   distributedTestCompile('org.springframework:spring-test')
   distributedTestCompile('org.springframework:spring-webmvc')
   distributedTestCompile('org.springframework.security:spring-security-test')
@@ -124,7 +124,7 @@ dependencies {
   distributedTestCompile(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
-    
+
   distributedTestRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
     exclude module: 'slf4j-api'
   }

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/ManagementLoggingFilter.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/ManagementLoggingFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.web.filter.AbstractRequestLoggingFilter;
+
+public class ManagementLoggingFilter extends AbstractRequestLoggingFilter {
+
+  // Because someone is going to want to disable this.
+  private static final Boolean ENABLE_REQUEST_LOGGING =
+      Boolean.parseBoolean(System.getProperty("geode.management.request.logging", "true"));
+
+  public ManagementLoggingFilter() {
+    super.setIncludeQueryString(true);
+    super.setIncludePayload(true);
+    super.setMaxPayloadLength(1000);
+    super.setAfterMessagePrefix("Management request: [");
+  }
+
+  @Override
+  protected void beforeRequest(HttpServletRequest request, String message) {
+    // No logging here - this would not display the payload
+  }
+
+  @Override
+  protected void afterRequest(HttpServletRequest request, String message) {
+    if (ENABLE_REQUEST_LOGGING) {
+      logger.info(message);
+    }
+  }
+}

--- a/geode-web-management/src/main/webapp/WEB-INF/web.xml
+++ b/geode-web-management/src/main/webapp/WEB-INF/web.xml
@@ -34,6 +34,16 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 
+  <filter>
+    <filter-name>requestLoggingFilter</filter-name>
+    <filter-class>org.apache.geode.management.internal.rest.ManagementLoggingFilter</filter-class>
+  </filter>
+
+  <filter-mapping>
+    <filter-name>requestLoggingFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
   <servlet>
     <description>
       The Spring DispatcherServlet (FrontController) handling all HTTP requests to the Geode Management REST API.


### PR DESCRIPTION
- Requests are logged simply with a prefix of 'Management request'. This
  could easily be customized in the future.
- Request logging can be disabled by setting the system property
  `geode.management.request.logging=false`

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
