### PR TITLE
GEODE-6451 CI Failure: Hang cleaning up after ClusterConfigLocatorRes…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://dl.bintray.com/palantir/releases" }
     jcenter()
-    maven { url "http://geode-maven.s3-website-us-west-2.amazonaws.com" }
   }
 
   dependencies {
@@ -58,7 +57,7 @@ allprojects {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
   }
 
   buildRoot = buildRoot.trim()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -18,7 +18,6 @@
 
 repositories {
   mavenCentral()
-  maven { url "http://geode-maven.s3-website-us-west-2.amazonaws.com" }
 }
 
 dependencies {
@@ -28,7 +27,7 @@ dependencies {
   compile gradleApi()
   compile 'org.apache.commons:commons-lang3:3.3.2'
   compile 'org.apache.maven:maven-artifact:3.3.3'
-  compile 'com.github.docker-java:docker-java:3.1.2-GEODE'
+  compile 'com.github.docker-java:docker-java:3.0.14'
 
   compile 'junit:junit:4.12'
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -136,7 +136,8 @@ public class LocatorDUnitTest implements java.io.Serializable {
 
   private static void expectSystemToContainThisManyMembers(final int expectedMembers) {
     assertThat(system).isNotNull();
-    assertEquals(expectedMembers, system.getDM().getViewMembers().size());
+    await()
+        .untilAsserted(() -> assertEquals(expectedMembers, system.getDM().getViewMembers().size()));
   }
 
   private static boolean isSystemConnected() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
@@ -55,6 +55,8 @@ public class ClusterConfigLocatorRestartDUnitTest {
   @Test
   public void serverRestartsAfterLocatorReconnects() throws Exception {
     IgnoredException.addIgnoredException("org.apache.geode.ForcedDisconnectException: for testing");
+    IgnoredException.addIgnoredException("cluster configuration service not available");
+    IgnoredException.addIgnoredException("This thread has been stalled");
 
     MemberVM locator0 = rule.startLocatorVM(0);
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
@@ -59,6 +59,8 @@ public class ClusterConfigLocatorRestartDUnitTest {
     IgnoredException.addIgnoredException("This thread has been stalled");
     IgnoredException
         .addIgnoredException("member unexpectedly shut down shared, unordered connection");
+    IgnoredException.addIgnoredException("cluster configuration service not available");
+    IgnoredException.addIgnoredException("This thread has been stalled");
 
     MemberVM locator0 = rule.startLocatorVM(0);
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2985,6 +2985,14 @@ public class InternalDistributedSystem extends DistributedSystem
     this.attemptingToReconnect = false;
   }
 
+  public void stopReconnectingNoDisconnect() {
+    this.reconnectCancelled = true;
+    synchronized (this.reconnectLock) {
+      this.reconnectLock.notify();
+    }
+    this.attemptingToReconnect = false;
+  }
+
   /**
    * Provides hook for dunit to generate and store a detailed creation stack trace that includes the
    * keys/values of DistributionConfig including security related attributes without introducing

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2355,8 +2355,6 @@ public class InternalDistributedSystem extends DistributedSystem
   @Override
   public boolean isReconnecting() {
     InternalDistributedSystem rds = this.reconnectDS;
-    logger.info("BRUCE: attemptingToReconnect={} reconnectCancelled={} rds={} isconnected={}",
-        attemptingToReconnect, reconnectCancelled, rds, (rds == null ? "" : rds.isConnected()));
     if (!attemptingToReconnect) {
       return false;
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2354,6 +2354,8 @@ public class InternalDistributedSystem extends DistributedSystem
   @Override
   public boolean isReconnecting() {
     InternalDistributedSystem rds = this.reconnectDS;
+    logger.info("BRUCE: attemptingToReconnect={} reconnectCancelled={} rds={} isconnected={}",
+        attemptingToReconnect, reconnectCancelled, rds, (rds == null ? "" : rds.isConnected()));
     if (!attemptingToReconnect) {
       return false;
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1032,7 +1032,13 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
             setLocator(this);
           }
         }
-        ds.waitUntilReconnected(waitTime, TimeUnit.MILLISECONDS);
+        try {
+          ds.waitUntilReconnected(waitTime, TimeUnit.MILLISECONDS);
+        } catch (CancelException e) {
+          logger.info("Attempt to reconnect failed and further attempts have been terminated");
+          this.stoppedForReconnect = false;
+          return false;
+        }
       }
       InternalDistributedSystem newSystem = (InternalDistributedSystem) ds.getReconnectedSystem();
       if (newSystem != null) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
@@ -35,7 +35,7 @@ public class ServiceConfig {
   private final int[] membershipPortRange;
   private final long memberTimeout;
 
-  private final boolean isReconnecting;
+  private boolean isReconnecting;
   private Integer lossThreshold;
   private final Integer memberWeight;
   private boolean networkPartitionDetectionEnabled;
@@ -157,4 +157,7 @@ public class ServiceConfig {
     networkPartitionDetectionEnabled = theConfig.getEnableNetworkPartitionDetection();
   }
 
+  public void setIsReconnecting(boolean b) {
+    this.isReconnecting = false;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
@@ -225,6 +225,7 @@ public class Services {
     }
     logger.info("Stopping membership services");
     this.stopping = true;
+    config.setIsReconnecting(false);
     try {
       this.timer.cancel();
     } finally {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -344,6 +344,9 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
             if (attemptToJoin()) {
               return true;
             }
+            if (this.isStopping) {
+              break;
+            }
             if (!state.possibleCoordinator.equals(localAddress)) {
               state.alreadyTried.add(state.possibleCoordinator);
             }
@@ -447,12 +450,13 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
       return isJoined;
     }
 
-    logger.debug("received join response {}", response);
+    logger.info("received join response {}", response);
     joinResponse[0] = null;
     String failReason = response.getRejectionMessage();
     if (failReason != null) {
       if (failReason.contains("Rejecting the attempt of a member using an older version")
-          || failReason.contains("15806")) {
+          || failReason.contains("15806")
+          || failReason.contains("ForcedDisconnectException")) {
         throw new SystemConnectException(failReason);
       } else if (failReason.contains("Failed to find credentials")) {
         throw new AuthenticationRequiredException(failReason);
@@ -1073,7 +1077,19 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
 
   private void forceDisconnect(String reason) {
     this.isStopping = true;
-    services.getManager().forceDisconnect(reason);
+    if (!isJoined) {
+      logger.fatal("BRUCE: forcedDisconnect invoked.  isReconnecting={} isJoined={}",
+          services.getConfig().isReconnecting(), isJoined);
+      joinResponse[0] =
+          new JoinResponseMessage(
+              "Stopping due to ForcedDisconnectException caused by '" + reason + "'", -1);
+      isJoined = false;
+      synchronized (joinResponse) {
+        joinResponse.notifyAll();
+      }
+    } else {
+      services.getManager().forceDisconnect(reason);
+    }
   }
 
   private void ackView(InstallViewMessage m) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -2330,8 +2330,8 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
             }
           } // synchronized
           if (requests != null && !requests.isEmpty()) {
-            logger.info("View Creator is processing {} requests for the next membership view",
-                requests.size());
+            logger.info("View Creator is processing {} requests for the next membership view ({})",
+                requests.size(), requests);
             try {
               createAndSendView(requests);
               if (shutdown) {
@@ -2441,14 +2441,6 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
             JoinRequestMessage jmsg = (JoinRequestMessage) msg;
             mbr = jmsg.getMemberID();
             int port = jmsg.getFailureDetectionPort();
-            // see if an old member ID is being reused. If
-            // so we'll remove it from the new view
-            for (InternalDistributedMember m : oldMembers) {
-              if (mbr.compareTo(m, false) == 0) {
-                oldIDs.add(m);
-                break;
-              }
-            }
             if (!joinReqs.contains(mbr)) {
               joinReqs.add(mbr);
               joinPorts.put(mbr, port);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -563,7 +563,8 @@ public class JGroupsMessenger implements Messenger {
     gmsMember.setMemberWeight((byte) (services.getConfig().getMemberWeight() & 0xff));
     gmsMember.setNetworkPartitionDetectionEnabled(
         services.getConfig().getDistributionConfig().getEnableNetworkPartitionDetection());
-    logger.info("Established local address {}", localAddress);
+    logger.info("Established local address {} with net-member {}", localAddress,
+        localAddress.getNetMember());
     services.setLocalAddress(localAddress);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -2143,8 +2143,13 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       return;
     }
 
-    if (systemFailureCause == null
+    if (!keepDS && systemFailureCause == null // normal cache close
         && (this.isReconnecting() || this.system.getReconnectedSystem() != null)) {
+      logger.debug(
+          "Cache is shutting down distributed system connection.  "
+              + "isReconnecting={}  reconnectedSystem={} keepAlive={} keepDS={}",
+          this.isReconnecting(), system.getReconnectedSystem(), keepAlive, keepDS);
+
       this.system.stopReconnectingNoDisconnect();
       if (this.system.getReconnectedSystem() != null) {
         this.system.getReconnectedSystem().disconnect();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -2143,7 +2143,14 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       return;
     }
 
-    // stopReconnecting();
+    if (systemFailureCause == null
+        && (this.isReconnecting() || this.system.getReconnectedSystem() != null)) {
+      this.system.stopReconnectingNoDisconnect();
+      if (this.system.getReconnectedSystem() != null) {
+        this.system.getReconnectedSystem().disconnect();
+      }
+      return;
+    }
 
     final boolean isDebugEnabled = logger.isDebugEnabled();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -2142,6 +2142,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     if (isClosed()) {
       return;
     }
+
+    // stopReconnecting();
+
     final boolean isDebugEnabled = logger.isDebugEnabled();
 
     synchronized (GemFireCacheImpl.class) {

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.locks;
+
+import static java.util.concurrent.TimeUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.TransactionDataNodeHasDepartedException;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+
+public class DLockGrantorTest {
+  private DLockService dLockService;
+  private DistributionManager distributionManager;
+  private DLockGrantor grantor;
+
+  @Before
+  public void setup() {
+    dLockService = mock(DLockService.class, RETURNS_DEEP_STUBS);
+    distributionManager = mock(DistributionManager.class);
+    when(dLockService.getDistributionManager()).thenReturn(distributionManager);
+    CancelCriterion cancelCriterion = mock(CancelCriterion.class);
+    when(distributionManager.getCancelCriterion()).thenReturn(cancelCriterion);
+    grantor = DLockGrantor.createGrantor(dLockService, 1);
+  }
+
+  @Test
+  public void handleLockBatchThrowsIfRequesterHasDeparted() {
+    DLockLessorDepartureHandler handler = mock(DLockLessorDepartureHandler.class);
+    InternalDistributedMember requester = mock(InternalDistributedMember.class);
+    DLockRequestProcessor.DLockRequestMessage requestMessage =
+        mock(DLockRequestProcessor.DLockRequestMessage.class);
+    when(dLockService.getDLockLessorDepartureHandler()).thenReturn(handler);
+    DLockBatch lockBatch = mock(DLockBatch.class);
+    when(requestMessage.getObjectName()).thenReturn(lockBatch);
+    when(lockBatch.getOwner()).thenReturn(requester);
+
+    grantor.makeReady(true);
+    grantor.getLockBatches(requester);
+
+    assertThatThrownBy(() -> grantor.handleLockBatch(requestMessage)).isInstanceOf(
+        TransactionDataNodeHasDepartedException.class);
+  }
+
+  @Test
+  public void recordMemberDepartedTimeRecords() {
+    InternalDistributedMember owner = mock(InternalDistributedMember.class);
+    grantor.recordMemberDepartedTime(owner);
+
+    assertThat(grantor.getMembersDepartedTimeRecords()).containsKey(owner);
+  }
+
+  @Test
+  public void recordMemberDepartedTimeRemovesExpiredMembers() {
+    DLockGrantor spy = spy(grantor);
+    long currentTime = System.currentTimeMillis();
+    doReturn(currentTime).doReturn(currentTime).doReturn(currentTime + 1 + DAYS.toMillis(1))
+        .when(spy).getCurrentTime();
+
+    for (int i = 0; i < 2; i++) {
+      spy.recordMemberDepartedTime(mock(InternalDistributedMember.class));
+    }
+    assertThat(spy.getMembersDepartedTimeRecords().size()).isEqualTo(2);
+
+    InternalDistributedMember owner = mock(InternalDistributedMember.class);
+    spy.recordMemberDepartedTime(owner);
+
+    assertThat(spy.getMembersDepartedTimeRecords().size()).isEqualTo(1);
+    assertThat(spy.getMembersDepartedTimeRecords()).containsKey(owner);
+  }
+
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
@@ -53,7 +53,7 @@ public abstract class VMProvider {
   }
 
   public void stop(boolean cleanWorkingDir) {
-    getVM().invoke(() -> {
+    getVM().invoke("stop cluster elements", () -> {
       // this did not clean up the files
       ClusterStartupRule.stopElementInsideVM();
       MemberStarterRule.disconnectDSIfAny();
@@ -66,19 +66,19 @@ public abstract class VMProvider {
   }
 
   public boolean isClient() {
-    return getVM().invoke(() -> {
+    return getVM().invoke("isClient", () -> {
       return ClusterStartupRule.clientCacheRule != null;
     });
   }
 
   public boolean isLocator() {
-    return getVM().invoke(() -> ClusterStartupRule.getLocator() != null);
+    return getVM().invoke("isLocator", () -> ClusterStartupRule.getLocator() != null);
   }
 
   // a server can be started without a cache server, so as long as this member has no locator,
   // it's deemed as a server
   public boolean isServer() {
-    return getVM().invoke(() -> ClusterStartupRule.getLocator() == null);
+    return getVM().invoke("isServer", () -> ClusterStartupRule.getLocator() == null);
   }
 
   public void invoke(final SerializableRunnableIF runnable) {


### PR DESCRIPTION
…tartDUnitTest.serverRestartsAfterLocatorReconnects

Removed code that scrubbed the current membership view of IDs matching a
new join request.  This code is no longer needed now that we generate a
new UUID for a member when it tries to auto-reconnect.  The new ID of
such a member would never match an old ID.

In practice this code was causing test failures in situations where the
auto-reconnect time was set to a small value.  A member would end up
sending multiple join requests to the same coordinator.  The first would
be used to allow the new member into the cluster but the second, due to
this code, would cause that member to be immediately removed from the
cluster.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
