### PR TITLE
GEODE-6449: Roll back docker-java to 3.0.14 rather than using custom …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://dl.bintray.com/palantir/releases" }
     jcenter()
-    maven { url "http://geode-maven.s3-website-us-west-2.amazonaws.com" }
   }
 
   dependencies {
@@ -58,7 +57,7 @@ allprojects {
   repositories {
     mavenLocal()
     mavenCentral()
-    maven { url "http://repo.spring.io/release" }
+    maven { url "https://repo.spring.io/release" }
   }
 
   buildRoot = buildRoot.trim()

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -18,7 +18,6 @@
 
 repositories {
   mavenCentral()
-  maven { url "http://geode-maven.s3-website-us-west-2.amazonaws.com" }
 }
 
 dependencies {
@@ -28,7 +27,7 @@ dependencies {
   compile gradleApi()
   compile 'org.apache.commons:commons-lang3:3.3.2'
   compile 'org.apache.maven:maven-artifact:3.3.3'
-  compile 'com.github.docker-java:docker-java:3.1.2-GEODE'
+  compile 'com.github.docker-java:docker-java:3.0.14'
 
   compile 'junit:junit:4.12'
 


### PR DESCRIPTION
…jar.

----

This is an alternative to PR #3238 

-----

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
