### PR TITLE
GEODE-6365: Fixed DestroyMappingCommand bug for default 'cluster' group

### DIFF
--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandDunitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandDunitTest.java
@@ -302,6 +302,12 @@ public class DestroyMappingCommandDunitTest implements Serializable {
   public void destroysMappingForServerGroup() throws Exception {
     setupMappingWithServerGroup(TEST_GROUP1, GROUP1_REGION, true);
     CommandStringBuilder csb =
+        new CommandStringBuilder(DESTROY_MAPPING);
+    csb.addOption(REGION_NAME, GROUP1_REGION);
+
+    gfsh.executeAndAssertThat(csb.toString()).statusIsError();
+
+    csb =
         new CommandStringBuilder(DESTROY_MAPPING + " --groups=" + TEST_GROUP1);
     csb.addOption(REGION_NAME, GROUP1_REGION);
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -84,27 +84,30 @@ public class DestroyMappingCommand extends SingleGfshCommand {
 
       for (String group : groups) {
         CacheConfig cacheConfig = getCacheConfig(configService, group);
-        if(cacheConfig != null) {
+        if (cacheConfig != null) {
           for (RegionConfig regionConfig : cacheConfig.getRegions()) {
-            if(regionConfig != null && !MappingCommandUtils.getMappingsFromRegionConfig(cacheConfig, regionConfig, group).isEmpty()) {
-                isMappingInClusterConfig = true;
+            if (regionConfig != null && !MappingCommandUtils
+                .getMappingsFromRegionConfig(cacheConfig, regionConfig, group).isEmpty()) {
+              isMappingInClusterConfig = true;
             }
           }
         }
       }
 
-      if(!isMappingInClusterConfig) {
+      if (!isMappingInClusterConfig) {
         return ResultModel.createError("Mapping not found in cluster configuration.");
       }
 
       ResultModel result;
-      if(targetMembers != null) {
+      if (targetMembers != null) {
         List<CliFunctionResult> results =
             executeAndGetFunctionResult(new DestroyMappingFunction(), regionName, targetMembers);
         result =
             ResultModel.createMemberStatusResult(results, EXPERIMENTAL, null, false, true);
       } else {
-        result = ResultModel.createInfo("No members found in specified server groups containing a mapping for region \"" + regionName + "\"");
+        result = ResultModel.createInfo(
+            "No members found in specified server groups containing a mapping for region \""
+                + regionName + "\"");
       }
 
       result.setConfigObject(regionName);

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
@@ -44,6 +44,7 @@ import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.connectors.jdbc.JdbcWriter;
 import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
 import org.apache.geode.connectors.util.internal.MappingCommandUtils;
+import org.apache.geode.distributed.ConfigurationPersistenceService;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.Result;
@@ -89,7 +90,19 @@ public class DestroyMappingCommandTest {
   }
 
   @Test
-  public void destroyMappingGivenARegionNameForServerGroup() {
+  public void destroyMappingGivenARegionNameForServerGroup() throws PreconditionException {
+    ConfigurationPersistenceService service = mock(ConfigurationPersistenceService.class);
+    doReturn(service).when(destroyRegionMappingCommand).checkForClusterConfiguration();
+    when(service.getCacheConfig("testGroup1")).thenReturn(cacheConfig);
+    List<RegionConfig> list = new ArrayList<>();
+    RegionConfig region = mock(RegionConfig.class);
+    List<CacheElement> listCacheElements = new ArrayList<>();
+    RegionMapping mapping = mock(RegionMapping.class);
+    listCacheElements.add(mapping);
+    when(region.getCustomRegionElements()).thenReturn(listCacheElements);
+    list.add(region);
+    when(cacheConfig.getRegions()).thenReturn(list);
+
     doReturn(members).when(destroyRegionMappingCommand).findMembers(new String[] {"testGroup1"},
         null);
     results.add(successFunctionResult);
@@ -102,7 +115,18 @@ public class DestroyMappingCommandTest {
   }
 
   @Test
-  public void destroyMappingGivenARegionNameReturnsTheNameAsTheConfigObject() {
+  public void destroyMappingGivenARegionNameReturnsTheNameAsTheConfigObject() throws PreconditionException {
+    ConfigurationPersistenceService service = mock(ConfigurationPersistenceService.class);
+    doReturn(service).when(destroyRegionMappingCommand).checkForClusterConfiguration();
+    when(service.getCacheConfig("cluster")).thenReturn(cacheConfig);
+    List<RegionConfig> list = new ArrayList<>();
+    RegionConfig region = mock(RegionConfig.class);
+    List<CacheElement> listCacheElements = new ArrayList<>();
+    RegionMapping mapping = mock(RegionMapping.class);
+    listCacheElements.add(mapping);
+    when(region.getCustomRegionElements()).thenReturn(listCacheElements);
+    list.add(region);
+    when(cacheConfig.getRegions()).thenReturn(list);
     results.add(successFunctionResult);
 
     ResultModel result = destroyRegionMappingCommand.destroyMapping(regionName, null);
@@ -112,7 +136,18 @@ public class DestroyMappingCommandTest {
   }
 
   @Test
-  public void destroyMappingGivenARegionPathReturnsTheNoSlashRegionNameAsTheConfigObject() {
+  public void destroyMappingGivenARegionPathReturnsTheNoSlashRegionNameAsTheConfigObject()  throws PreconditionException {
+    ConfigurationPersistenceService service = mock(ConfigurationPersistenceService.class);
+    doReturn(service).when(destroyRegionMappingCommand).checkForClusterConfiguration();
+    when(service.getCacheConfig("cluster")).thenReturn(cacheConfig);
+    List<RegionConfig> list = new ArrayList<>();
+    RegionConfig region = mock(RegionConfig.class);
+    List<CacheElement> listCacheElements = new ArrayList<>();
+    RegionMapping mapping = mock(RegionMapping.class);
+    listCacheElements.add(mapping);
+    when(region.getCustomRegionElements()).thenReturn(listCacheElements);
+    list.add(region);
+    when(cacheConfig.getRegions()).thenReturn(list);
     results.add(successFunctionResult);
 
     ResultModel result = destroyRegionMappingCommand.destroyMapping("/" + regionName, null);

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
@@ -115,7 +115,8 @@ public class DestroyMappingCommandTest {
   }
 
   @Test
-  public void destroyMappingGivenARegionNameReturnsTheNameAsTheConfigObject() throws PreconditionException {
+  public void destroyMappingGivenARegionNameReturnsTheNameAsTheConfigObject()
+      throws PreconditionException {
     ConfigurationPersistenceService service = mock(ConfigurationPersistenceService.class);
     doReturn(service).when(destroyRegionMappingCommand).checkForClusterConfiguration();
     when(service.getCacheConfig("cluster")).thenReturn(cacheConfig);
@@ -136,7 +137,8 @@ public class DestroyMappingCommandTest {
   }
 
   @Test
-  public void destroyMappingGivenARegionPathReturnsTheNoSlashRegionNameAsTheConfigObject()  throws PreconditionException {
+  public void destroyMappingGivenARegionPathReturnsTheNoSlashRegionNameAsTheConfigObject()
+      throws PreconditionException {
     ConfigurationPersistenceService service = mock(ConfigurationPersistenceService.class);
     doReturn(service).when(destroyRegionMappingCommand).checkForClusterConfiguration();
     when(service.getCacheConfig("cluster")).thenReturn(cacheConfig);


### PR DESCRIPTION
- Refactored DestroyMappingCommand to fix issue causing commands run
without group parameter specified to run on all members, which resulted
in mappings being removed from servers in all groups, without updating
cluster config

Authored-by: Benjamin Ross <bross@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
