### PR TITLE
GEODE-6470: Making double-checked locking thread-safe

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImpl.java
@@ -117,7 +117,7 @@ public class GatewaySenderEventImpl
   /**
    * The serialized new value for this event's key. May not be computed at construction time.
    */
-  protected byte[] value;
+  protected volatile byte[] value;
 
   /**
    * The "object" form of the value. Will be null after this object is deserialized.

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -137,7 +137,7 @@ public class Gfsh extends JLineShell {
   protected static PrintStream gfsherr = System.err;
   protected static final ThreadLocal<Gfsh> gfshThreadLocal = new ThreadLocal<>();
   @MakeNotStatic
-  private static Gfsh instance;
+  private static volatile Gfsh instance;
   // This flag is used to restrict column trimming to table only types
   private static final ThreadLocal<Boolean> resultTypeTL = new ThreadLocal<>();
   private static final String OS = System.getProperty("os.name").toLowerCase();
@@ -247,11 +247,14 @@ public class Gfsh extends JLineShell {
   }
 
   public static Gfsh getInstance(boolean launchShell, String[] args, GfshConfig gfshConfig) {
-    if (instance == null) {
+    Gfsh localGfshInstance = instance;
+    if (localGfshInstance == null) {
       synchronized (INSTANCE_LOCK) {
-        if (instance == null) {
-          instance = new Gfsh(launchShell, args, gfshConfig);
-          instance.executeInitFileIfPresent();
+        localGfshInstance = instance;
+        if (localGfshInstance == null) {
+          localGfshInstance = new Gfsh(launchShell, args, gfshConfig);
+          localGfshInstance.executeInitFileIfPresent();
+          instance = localGfshInstance;
         }
       }
     }


### PR DESCRIPTION
	* A repeated check on a non-volatile field is not thread-safe, and could result in unexpected behavior.
	* Fixed using volatile and local variables

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
