### PR TITLE
GEODE-6295: Use InternalCacheBuilder for constructing GemFireCacheImpl

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
@@ -14,32 +14,24 @@
  */
 package org.apache.geode.cache;
 
-import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
-
 import java.util.Properties;
 
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.SecurityConfig;
 import org.apache.geode.internal.GemFireVersion;
-import org.apache.geode.internal.cache.CacheConfig;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.CacheFactoryStatics;
+import org.apache.geode.internal.cache.InternalCacheBuilder;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxSerializer;
 import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.AuthenticationRequiredException;
-import org.apache.geode.security.GemFireSecurityException;
 import org.apache.geode.security.PostProcessor;
 import org.apache.geode.security.SecurityManager;
 
 /**
  * Factory class used to create the singleton {@link Cache cache} and connect to the GemFire
  * singleton {@link DistributedSystem distributed system}. If the application wants to connect to
- * GemFire as a client it should use {@link org.apache.geode.cache.client.ClientCacheFactory}
- * instead.
+ * GemFire as a client it should use {@link ClientCacheFactory} instead.
  * <p>
  * Once the factory has been configured using its {@link #set(String, String)} method you produce a
  * {@link Cache} by calling the {@link #create()} method.
@@ -94,9 +86,7 @@ import org.apache.geode.security.SecurityManager;
  */
 public class CacheFactory {
 
-  private final Properties dsProps;
-
-  private final CacheConfig cacheConfig = new CacheConfig();
+  private final InternalCacheBuilder internalCacheBuilder;
 
   /**
    * Creates a default cache factory.
@@ -115,10 +105,37 @@ public class CacheFactory {
    * @since GemFire 6.5
    */
   public CacheFactory(Properties props) {
-    if (props == null) {
-      props = new Properties();
-    }
-    this.dsProps = props;
+    internalCacheBuilder = new InternalCacheBuilder(props);
+  }
+
+  /**
+   * Creates a new cache that uses the configured distributed system. If a connected distributed
+   * system already exists it will be used if it is compatible with the properties on this factory.
+   * Otherwise a a distributed system will be created with the configured properties. If a cache
+   * already exists it will be returned.
+   * <p>
+   * If the cache does need to be created it will also be initialized from cache.xml if it exists.
+   *
+   * @return the created or already existing singleton cache
+   *
+   * @throws CacheXmlException If a problem occurs while parsing the declarative caching XML file.
+   * @throws TimeoutException If a {@link Region#put(Object, Object)} times out while initializing
+   *         the cache.
+   * @throws CacheWriterException If a {@code CacheWriterException} is thrown while initializing the
+   *         cache.
+   * @throws GatewayException If a {@code GatewayException} is thrown while initializing the cache.
+   * @throws RegionExistsException If the declarative caching XML file describes a region that
+   *         already exists (including the root region).
+   * @throws IllegalStateException if cache already exists and is not compatible with the new
+   *         configuration.
+   * @throws AuthenticationFailedException if authentication fails.
+   * @throws AuthenticationRequiredException if the distributed system is in secure mode and this
+   *         new member is not configured with security credentials.
+   * @since GemFire 6.5
+   */
+  public Cache create()
+      throws TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
+    return internalCacheBuilder.create();
   }
 
   /**
@@ -131,7 +148,124 @@ public class CacheFactory {
    * @since GemFire 6.5
    */
   public CacheFactory set(String name, String value) {
-    this.dsProps.setProperty(name, value);
+    internalCacheBuilder.set(name, value);
+    return this;
+  }
+
+  /**
+   * Sets the object preference to PdxInstance type. When a cached object that was serialized as a
+   * PDX is read from the cache a {@link PdxInstance} will be returned instead of the actual domain
+   * class. The PdxInstance is an interface that provides run time access to the fields of a PDX
+   * without deserializing the entire PDX. The PdxInstance implementation is a light weight wrapper
+   * that simply refers to the raw bytes of the PDX that are kept in the cache. Using this method
+   * applications can choose to access PdxInstance instead of Java object.
+   * <p>
+   * Note that a PdxInstance is only returned if a serialized PDX is found in the cache. If the
+   * cache contains a deserialized PDX, then a domain class instance is returned instead of a
+   * PdxInstance.
+   *
+   * @param readSerialized true to prefer PdxInstance
+   * @return this CacheFactory
+   * @since GemFire 6.6
+   * @see org.apache.geode.pdx.PdxInstance
+   */
+  public CacheFactory setPdxReadSerialized(boolean readSerialized) {
+    internalCacheBuilder.setPdxReadSerialized(readSerialized);
+    return this;
+  }
+
+  /**
+   * Sets the securityManager for the cache. If this securityManager is set, it will override the
+   * security-manager property you set in your gemfire system properties.
+   *
+   * This is provided mostly for container to inject an already initialized securityManager. An
+   * object provided this way is expected to be initialized already. We are not calling the init
+   * method on this object
+   *
+   * @return this CacheFactory
+   */
+  public CacheFactory setSecurityManager(SecurityManager securityManager) {
+    internalCacheBuilder.setSecurityManager(securityManager);
+    return this;
+  }
+
+  /**
+   * Sets the postProcessor for the cache. If this postProcessor is set, it will override the
+   * security-post-processor setting in the gemfire system properties.
+   *
+   * This is provided mostly for container to inject an already initialized post processor. An
+   * object provided this way is expected to be initialized already. We are not calling the init
+   * method on this object
+   *
+   * @return this CacheFactory
+   */
+  public CacheFactory setPostProcessor(PostProcessor postProcessor) {
+    internalCacheBuilder.setPostProcessor(postProcessor);
+    return this;
+  }
+
+  /**
+   * Set the PDX serializer for the cache. If this serializer is set, it will be consulted to see if
+   * it can serialize any domain classes which are added to the cache in portable data exchange
+   * format.
+   *
+   * @param serializer the serializer to use
+   * @return this CacheFactory
+   * @since GemFire 6.6
+   * @see PdxSerializer
+   */
+  public CacheFactory setPdxSerializer(PdxSerializer serializer) {
+    internalCacheBuilder.setPdxSerializer(serializer);
+    return this;
+  }
+
+  /**
+   * Set the disk store that is used for PDX meta data. When serializing objects in the PDX format,
+   * the type definitions are persisted to disk. This setting controls which disk store is used for
+   * that persistence.
+   *
+   * If not set, the metadata will go in the default disk store.
+   *
+   * @param diskStoreName the name of the disk store to use for the PDX metadata.
+   * @return this CacheFactory
+   * @since GemFire 6.6
+   */
+  public CacheFactory setPdxDiskStore(String diskStoreName) {
+    internalCacheBuilder.setPdxDiskStore(diskStoreName);
+    return this;
+  }
+
+  /**
+   * Control whether the type metadata for PDX objects is persisted to disk. The default for this
+   * setting is false. If you are using persistent regions with PDX then you must set this to true.
+   * If you are using a {@code GatewaySender} or {@code AsyncEventQueue} with PDX then you should
+   * set this to true.
+   *
+   * @param isPersistent true if the metadata should be persistent
+   * @return this CacheFactory
+   * @since GemFire 6.6
+   */
+  public CacheFactory setPdxPersistent(boolean isPersistent) {
+    internalCacheBuilder.setPdxPersistent(isPersistent);
+    return this;
+  }
+
+  /**
+   * Control whether pdx ignores fields that were unread during deserialization. The default is to
+   * preserve unread fields be including their data during serialization. But if you configure the
+   * cache to ignore unread fields then their data will be lost during serialization.
+   * <P>
+   * You should only set this attribute to {@code true} if you know this member will only be reading
+   * cache data. In this use case you do not need to pay the cost of preserving the unread fields
+   * since you will never be reserializing pdx data.
+   *
+   * @param ignore {@code true} if fields not read during pdx deserialization should be ignored;
+   *        {@code false}, the default, if they should be preserved.
+   * @return this CacheFactory
+   * @since GemFire 6.6
+   */
+  public CacheFactory setPdxIgnoreUnreadFields(boolean ignore) {
+    internalCacheBuilder.setPdxIgnoreUnreadFields(ignore);
     return this;
   }
 
@@ -164,81 +298,9 @@ public class CacheFactory {
    * @deprecated as of 6.5 use {@link #CacheFactory(Properties)} instead.
    */
   @Deprecated
-  public static synchronized Cache create(DistributedSystem system) throws CacheExistsException,
+  public static Cache create(DistributedSystem system) throws CacheExistsException,
       TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
-    return create(system, false, new CacheConfig());
-  }
-
-  private static synchronized Cache create(DistributedSystem system, boolean existingOk,
-      CacheConfig cacheConfig) throws CacheExistsException, TimeoutException, CacheWriterException,
-      GatewayException, RegionExistsException {
-    // Moved code in this method to GemFireCacheImpl.create
-    return GemFireCacheImpl.create((InternalDistributedSystem) system, existingOk, cacheConfig);
-  }
-
-  /**
-   * Creates a new cache that uses the configured distributed system. If a connected distributed
-   * system already exists it will be used if it is compatible with the properties on this factory.
-   * Otherwise a a distributed system will be created with the configured properties. If a cache
-   * already exists it will be returned.
-   * <p>
-   * If the cache does need to be created it will also be initialized from cache.xml if it exists.
-   *
-   * @return the created or already existing singleton cache
-   *
-   * @throws CacheXmlException If a problem occurs while parsing the declarative caching XML file.
-   * @throws TimeoutException If a {@link Region#put(Object, Object)} times out while initializing
-   *         the cache.
-   * @throws CacheWriterException If a {@code CacheWriterException} is thrown while initializing the
-   *         cache.
-   * @throws GatewayException If a {@code GatewayException} is thrown while initializing the cache.
-   * @throws RegionExistsException If the declarative caching XML file describes a region that
-   *         already exists (including the root region).
-   * @throws IllegalStateException if cache already exists and is not compatible with the new
-   *         configuration.
-   * @throws AuthenticationFailedException if authentication fails.
-   * @throws AuthenticationRequiredException if the distributed system is in secure mode and this
-   *         new member is not configured with security credentials.
-   * @since GemFire 6.5
-   */
-  public Cache create()
-      throws TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
-    synchronized (CacheFactory.class) {
-      DistributedSystem ds = null;
-      if (this.dsProps.isEmpty() && !ALLOW_MULTIPLE_SYSTEMS) {
-        // any ds will do
-        ds = InternalDistributedSystem.getConnectedInstance();
-        validateUsabilityOfSecurityCallbacks(ds);
-      }
-      if (ds == null) {
-        ds = InternalDistributedSystem.connectInternal(dsProps, new SecurityConfig(
-            this.cacheConfig.getSecurityManager(),
-            this.cacheConfig.getPostProcessor()));
-      }
-      return create(ds, true, this.cacheConfig);
-    }
-  }
-
-  /**
-   * Throws GemFireSecurityException if existing DistributedSystem connection cannot use specified
-   * SecurityManager or PostProcessor.
-   */
-  private void validateUsabilityOfSecurityCallbacks(DistributedSystem ds)
-      throws GemFireSecurityException {
-    if (ds == null) {
-      return;
-    }
-    // pre-existing DistributedSystem already has an incompatible SecurityService in use
-    if (this.cacheConfig.getSecurityManager() != null) {
-      // invalid configuration
-      throw new GemFireSecurityException(
-          "Existing DistributedSystem connection cannot use specified SecurityManager");
-    }
-    if (this.cacheConfig.getPostProcessor() != null) {
-      // invalid configuration
-      throw new GemFireSecurityException(
-          "Existing DistributedSystem connection cannot use specified PostProcessor");
-    }
+    return CacheFactoryStatics.create(system);
   }
 
   /**
@@ -250,7 +312,7 @@ public class CacheFactory {
    *         {@link Cache#isClosed closed}
    */
   public static Cache getInstance(DistributedSystem system) {
-    return basicGetInstance(system, false);
+    return CacheFactoryStatics.getInstance(system);
   }
 
   /**
@@ -263,39 +325,7 @@ public class CacheFactory {
    * @since GemFire 3.5
    */
   public static Cache getInstanceCloseOk(DistributedSystem system) {
-    return basicGetInstance(system, true);
-  }
-
-  private static Cache basicGetInstance(DistributedSystem system, boolean closeOk) {
-    // Avoid synchronization if this is an initialization thread to avoid
-    // deadlock when messaging returns to this VM
-    final int initReq = LocalRegion.threadInitLevelRequirement();
-    if (initReq == LocalRegion.ANY_INIT || initReq == LocalRegion.BEFORE_INITIAL_IMAGE) { // fix bug
-                                                                                          // 33471
-      return basicGetInstancePart2(system, closeOk);
-    } else {
-      synchronized (CacheFactory.class) {
-        return basicGetInstancePart2(system, closeOk);
-      }
-    }
-  }
-
-  private static Cache basicGetInstancePart2(DistributedSystem system, boolean closeOk) {
-    InternalCache instance = GemFireCacheImpl.getInstance();
-    if (instance == null) {
-      throw new CacheClosedException(
-          "A cache has not yet been created.");
-    } else {
-      if (instance.isClosed() && !closeOk) {
-        throw instance.getCacheClosedException(
-            "The cache has been closed.", null);
-      }
-      if (!instance.getDistributedSystem().equals(system)) {
-        throw instance.getCacheClosedException(
-            "A cache has not yet been created for the given distributed system.");
-      }
-      return instance;
-    }
+    return CacheFactoryStatics.getInstanceCloseOk(system);
   }
 
   /**
@@ -313,15 +343,8 @@ public class CacheFactory {
    * @throws CacheClosedException if a cache has not been created or the only created one is
    *         {@link Cache#isClosed closed}
    */
-  public static synchronized Cache getAnyInstance() {
-    InternalCache instance = GemFireCacheImpl.getInstance();
-    if (instance == null) {
-      throw new CacheClosedException(
-          "A cache has not yet been created.");
-    } else {
-      instance.getCancelCriterion().checkCancelInProgress(null);
-      return instance;
-    }
+  public static Cache getAnyInstance() {
+    return CacheFactoryStatics.getAnyInstance();
   }
 
   /**
@@ -331,122 +354,5 @@ public class CacheFactory {
    */
   public static String getVersion() {
     return GemFireVersion.getGemFireVersion();
-  }
-
-  /**
-   * Sets the object preference to PdxInstance type. When a cached object that was serialized as a
-   * PDX is read from the cache a {@link PdxInstance} will be returned instead of the actual domain
-   * class. The PdxInstance is an interface that provides run time access to the fields of a PDX
-   * without deserializing the entire PDX. The PdxInstance implementation is a light weight wrapper
-   * that simply refers to the raw bytes of the PDX that are kept in the cache. Using this method
-   * applications can choose to access PdxInstance instead of Java object.
-   * <p>
-   * Note that a PdxInstance is only returned if a serialized PDX is found in the cache. If the
-   * cache contains a deserialized PDX, then a domain class instance is returned instead of a
-   * PdxInstance.
-   *
-   * @param readSerialized true to prefer PdxInstance
-   * @return this CacheFactory
-   * @since GemFire 6.6
-   * @see org.apache.geode.pdx.PdxInstance
-   */
-  public CacheFactory setPdxReadSerialized(boolean readSerialized) {
-    this.cacheConfig.setPdxReadSerialized(readSerialized);
-    return this;
-  }
-
-  /**
-   * Sets the securityManager for the cache. If this securityManager is set, it will override the
-   * security-manager property you set in your gemfire system properties.
-   *
-   * This is provided mostly for container to inject an already initialized securityManager. An
-   * object provided this way is expected to be initialized already. We are not calling the init
-   * method on this object
-   *
-   * @return this CacheFactory
-   */
-  public CacheFactory setSecurityManager(SecurityManager securityManager) {
-    this.cacheConfig.setSecurityManager(securityManager);
-    return this;
-  }
-
-  /**
-   * Sets the postProcessor for the cache. If this postProcessor is set, it will override the
-   * security-post-processor setting in the gemfire system properties.
-   *
-   * This is provided mostly for container to inject an already initialized post processor. An
-   * object provided this way is expected to be initialized already. We are not calling the init
-   * method on this object
-   *
-   * @return this CacheFactory
-   */
-  public CacheFactory setPostProcessor(PostProcessor postProcessor) {
-    this.cacheConfig.setPostProcessor(postProcessor);
-    return this;
-  }
-
-  /**
-   * Set the PDX serializer for the cache. If this serializer is set, it will be consulted to see if
-   * it can serialize any domain classes which are added to the cache in portable data exchange
-   * format.
-   *
-   * @param serializer the serializer to use
-   * @return this CacheFactory
-   * @since GemFire 6.6
-   * @see PdxSerializer
-   */
-  public CacheFactory setPdxSerializer(PdxSerializer serializer) {
-    this.cacheConfig.setPdxSerializer(serializer);
-    return this;
-  }
-
-  /**
-   * Set the disk store that is used for PDX meta data. When serializing objects in the PDX format,
-   * the type definitions are persisted to disk. This setting controls which disk store is used for
-   * that persistence.
-   *
-   * If not set, the metadata will go in the default disk store.
-   *
-   * @param diskStoreName the name of the disk store to use for the PDX metadata.
-   * @return this CacheFactory
-   * @since GemFire 6.6
-   */
-  public CacheFactory setPdxDiskStore(String diskStoreName) {
-    this.cacheConfig.setPdxDiskStore(diskStoreName);
-    return this;
-  }
-
-  /**
-   * Control whether the type metadata for PDX objects is persisted to disk. The default for this
-   * setting is false. If you are using persistent regions with PDX then you must set this to true.
-   * If you are using a {@code GatewaySender} or {@code AsyncEventQueue} with PDX then you should
-   * set this to true.
-   *
-   * @param isPersistent true if the metadata should be persistent
-   * @return this CacheFactory
-   * @since GemFire 6.6
-   */
-  public CacheFactory setPdxPersistent(boolean isPersistent) {
-    this.cacheConfig.setPdxPersistent(isPersistent);
-    return this;
-  }
-
-  /**
-   * Control whether pdx ignores fields that were unread during deserialization. The default is to
-   * preserve unread fields be including their data during serialization. But if you configure the
-   * cache to ignore unread fields then their data will be lost during serialization.
-   * <P>
-   * You should only set this attribute to {@code true} if you know this member will only be reading
-   * cache data. In this use case you do not need to pay the cost of preserving the unread fields
-   * since you will never be reserializing pdx data.
-   *
-   * @param ignore {@code true} if fields not read during pdx deserialization should be ignored;
-   *        {@code false}, the default, if they should be preserved.
-   * @return this CacheFactory
-   * @since GemFire 6.6
-   */
-  public CacheFactory setPdxIgnoreUnreadFields(boolean ignore) {
-    this.cacheConfig.setPdxIgnoreUnreadFields(ignore);
-    return this;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/ClientCacheFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/ClientCacheFactory.java
@@ -32,6 +32,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.cache.CacheConfig;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCacheBuilder;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxSerializer;
 import org.apache.geode.security.AuthenticationFailedException;
@@ -256,7 +257,11 @@ public class ClientCacheFactory {
 
         return instance;
       } else {
-        return GemFireCacheImpl.createClient(system, this.pf, cacheConfig);
+
+        return (InternalClientCache) new InternalCacheBuilder(cacheConfig)
+            .setIsClient(true)
+            .setPoolFactory(pf)
+            .create(system);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import org.apache.geode.distributed.internal.membership.QuorumChecker;
+
+/**
+ * Contains the distribution config and internal properties for connecting.
+ */
+public interface ConnectionConfig {
+  /**
+   * Indicates whether this config is reconnecting.
+   */
+  boolean isReconnecting();
+
+  /**
+   * Returns the quorum checker to use while reconnecting.
+   */
+  QuorumChecker quorumChecker();
+
+  /**
+   * Returns the distribution config.
+   */
+  DistributionConfig distributionConfig();
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ConnectionConfigImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_CONFIG_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_QUORUM_CHECKER_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_RECONNECTING_NAME;
+
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import org.apache.geode.distributed.internal.membership.QuorumChecker;
+
+public class ConnectionConfigImpl implements ConnectionConfig {
+  private final boolean isReconnecting;
+  private final QuorumChecker quorumChecker;
+  private final DistributionConfigImpl distributionConfig;
+
+  ConnectionConfigImpl(Properties properties) {
+    isReconnecting = convert(properties.get(DS_RECONNECTING_NAME), Boolean.class,
+        () -> Boolean.FALSE);
+    quorumChecker = convert(properties.get(DS_QUORUM_CHECKER_NAME), QuorumChecker.class,
+        () -> null);
+    distributionConfig = convert(properties.get(DS_CONFIG_NAME), DistributionConfigImpl.class,
+        () -> new DistributionConfigImpl(removeNonUserProperties(properties)));
+  }
+
+  @Override
+  public boolean isReconnecting() {
+    return isReconnecting;
+  }
+
+  @Override
+  public QuorumChecker quorumChecker() {
+    return quorumChecker;
+  }
+
+  @Override
+  public DistributionConfig distributionConfig() {
+    return distributionConfig;
+  }
+
+  /**
+   * Remove the non distribution config properties so that they are not passed to the {@code
+   * DistributionConfigImpl} constructor
+   */
+  private static Properties removeNonUserProperties(Properties properties) {
+    Properties cleanedProperties = new Properties();
+    properties.forEach(cleanedProperties::put);
+    cleanedProperties.remove(DS_QUORUM_CHECKER_NAME);
+    cleanedProperties.remove(DS_RECONNECTING_NAME);
+    cleanedProperties.remove(DS_CONFIG_NAME);
+    return cleanedProperties;
+  }
+
+  /**
+   * Casts the object to the specified type, or returns the default value if the object cannot be
+   * cast.
+   */
+  private static <T> T convert(Object object, Class<T> type, Supplier<T> defaultValueSupplier) {
+    return type.isInstance(object) ? type.cast(object) : defaultValueSupplier.get();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -463,7 +463,6 @@ public class InternalDistributedSystem extends DistributedSystem
    */
   public static InternalDistributedSystem newInstanceForTesting(
       DistributionManager distributionManager, Properties properties) {
-    DistributionConfig config = new DistributionConfigImpl(properties);
     StatisticsManagerFactory statisticsManagerFactory = defaultStatisticsManagerFactory();
 
     return newInstanceForTesting(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheConfig.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache;
 import java.util.List;
 
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.cache.client.internal.InternalClientCache;
+import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.cache.xmlcache.CacheServerCreation;
 import org.apache.geode.pdx.PdxSerializer;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
@@ -169,7 +169,7 @@ public class CacheConfig {
     this.cacheServerCreation = servers;
   }
 
-  public void validateCacheConfig(InternalClientCache cacheInstance) {
+  public void validateCacheConfig(GemFireCache cacheInstance) {
     // To fix bug 44961 only validate our attributes against the existing cache
     // if they have been explicitly set by the set.
     // So all the following "ifs" check that "*UserSet" is true.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheFactoryStatics.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheFactoryStatics.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import java.util.Properties;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.CacheExistsException;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.CacheWriterException;
+import org.apache.geode.cache.CacheXmlException;
+import org.apache.geode.cache.GatewayException;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionExistsException;
+import org.apache.geode.cache.TimeoutException;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+
+/**
+ * Implementation of static methods in {@link CacheFactory} including factory create methods and
+ * singleton getters.
+ */
+public class CacheFactoryStatics {
+
+  /**
+   * @throws IllegalArgumentException If {@code system} is not {@link DistributedSystem#isConnected
+   *         connected}.
+   * @throws CacheExistsException If an open cache already exists.
+   * @throws CacheXmlException If a problem occurs while parsing the declarative caching XML file.
+   * @throws TimeoutException If a {@link Region#put(Object, Object)} times out while initializing
+   *         the cache.
+   * @throws CacheWriterException If a {@code CacheWriterException} is thrown while initializing the
+   *         cache.
+   * @throws GatewayException If a {@code GatewayException} is thrown while initializing the cache.
+   * @throws RegionExistsException If the declarative caching XML file describes a region that
+   *         already exists (including the root region).
+   * @deprecated as of 6.5 use {@link CacheFactory#CacheFactory(Properties)} instead.
+   */
+  @Deprecated
+  public static Cache create(DistributedSystem system) throws CacheExistsException,
+      TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
+    return new InternalCacheBuilder()
+        .setIsExistingOk(false)
+        .create((InternalDistributedSystem) system);
+  }
+
+  /**
+   * @throws CacheClosedException if a cache has not been created or the created one is
+   *         {@link Cache#isClosed closed}
+   */
+  public static Cache getInstance(DistributedSystem system) {
+    return basicGetInstance(system, false);
+  }
+
+  /**
+   * @throws CacheClosedException if a cache has not been created
+   */
+  public static Cache getInstanceCloseOk(DistributedSystem system) {
+    return basicGetInstance(system, true);
+  }
+
+  /**
+   * @throws CacheClosedException if a cache has not been created or the only created one is
+   *         {@link Cache#isClosed closed}
+   */
+  public static Cache getAnyInstance() {
+    synchronized (InternalCacheBuilder.class) {
+      InternalCache instance = GemFireCacheImpl.getInstance();
+      if (instance == null) {
+        throw new CacheClosedException(
+            "A cache has not yet been created.");
+      } else {
+        instance.getCancelCriterion().checkCancelInProgress(null);
+        return instance;
+      }
+    }
+  }
+
+  private static Cache basicGetInstance(DistributedSystem system, boolean closeOk) {
+    // Avoid synchronization if this is an initialization thread to avoid
+    // deadlock when messaging returns to this VM
+    final int initReq = LocalRegion.threadInitLevelRequirement();
+    if (initReq == LocalRegion.ANY_INIT || initReq == LocalRegion.BEFORE_INITIAL_IMAGE) { // fix bug
+      // 33471
+      return basicGetInstancePart2(system, closeOk);
+    } else {
+      synchronized (InternalCacheBuilder.class) {
+        return basicGetInstancePart2(system, closeOk);
+      }
+    }
+  }
+
+  private static Cache basicGetInstancePart2(DistributedSystem system, boolean closeOk) {
+    InternalCache instance = GemFireCacheImpl.getInstance();
+    if (instance == null) {
+      throw new CacheClosedException(
+          "A cache has not yet been created.");
+    } else {
+      if (instance.isClosed() && !closeOk) {
+        throw instance.getCacheClosedException(
+            "The cache has been closed.", null);
+      }
+      if (!instance.getDistributedSystem().equals(system)) {
+        throw instance.getCacheClosedException(
+            "A cache has not yet been created for the given distributed system.");
+      }
+      return instance;
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -372,4 +372,8 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime {
   InternalCacheForClientAccess getCacheForProcessingClientRequests();
 
   HttpService getHttpService();
+
+  void initialize();
+
+  void throwCacheExistsException();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.CacheExistsException;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.CacheWriterException;
+import org.apache.geode.cache.CacheXmlException;
+import org.apache.geode.cache.GatewayException;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionExistsException;
+import org.apache.geode.cache.TimeoutException;
+import org.apache.geode.cache.client.PoolFactory;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.SecurityConfig;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.pdx.PdxSerializer;
+import org.apache.geode.pdx.internal.TypeRegistry;
+import org.apache.geode.security.AuthenticationFailedException;
+import org.apache.geode.security.AuthenticationRequiredException;
+import org.apache.geode.security.GemFireSecurityException;
+import org.apache.geode.security.PostProcessor;
+import org.apache.geode.security.SecurityManager;
+
+public class InternalCacheBuilder {
+  private static final Logger logger = LogService.getLogger();
+
+  private static final String USE_ASYNC_EVENT_LISTENERS_PROPERTY =
+      GEMFIRE_PREFIX + "Cache.ASYNC_EVENT_LISTENERS";
+
+  private static final boolean IS_EXISTING_OK_DEFAULT = true;
+  private static final boolean IS_CLIENT_DEFAULT = false;
+
+  private final Properties configProperties;
+  private final CacheConfig cacheConfig;
+  private final Supplier<InternalDistributedSystem> singletonSystemSupplier;
+  private final Supplier<InternalCache> singletonCacheSupplier;
+  private final InternalDistributedSystemConstructor internalDistributedSystemConstructor;
+  private final InternalCacheConstructor internalCacheConstructor;
+
+  private boolean isExistingOk = IS_EXISTING_OK_DEFAULT;
+  private boolean isClient = IS_CLIENT_DEFAULT;
+
+  /**
+   * Setting useAsyncEventListeners to true will invoke event listeners in asynchronously.
+   *
+   * <p>
+   * Default is specified by system property {@code gemfire.Cache.ASYNC_EVENT_LISTENERS}.
+   */
+  private boolean useAsyncEventListeners = Boolean.getBoolean(USE_ASYNC_EVENT_LISTENERS_PROPERTY);
+
+  private PoolFactory poolFactory;
+  private TypeRegistry typeRegistry;
+
+  /**
+   * Creates a cache factory with default configuration properties.
+   */
+  public InternalCacheBuilder() {
+    this(new Properties(), new CacheConfig());
+  }
+
+  /**
+   * Create a cache factory initialized with the given configuration properties. For a list of valid
+   * configuration properties and their meanings see {@link ConfigurationProperties}.
+   *
+   * @param configProperties the configuration properties to initialize the factory with.
+   */
+  public InternalCacheBuilder(Properties configProperties) {
+    this(configProperties == null ? new Properties() : configProperties, new CacheConfig());
+  }
+
+  /**
+   * Creates a cache factory with default configuration properties.
+   */
+  public InternalCacheBuilder(CacheConfig cacheConfig) {
+    this(new Properties(), cacheConfig);
+  }
+
+  private InternalCacheBuilder(Properties configProperties, CacheConfig cacheConfig) {
+    this(configProperties, cacheConfig, InternalDistributedSystem::getConnectedInstance,
+        InternalDistributedSystem::connectInternal,
+        GemFireCacheImpl::getInstance, GemFireCacheImpl::new);
+  }
+
+  @VisibleForTesting
+  InternalCacheBuilder(Properties configProperties,
+      CacheConfig cacheConfig,
+      Supplier<InternalDistributedSystem> singletonSystemSupplier,
+      InternalDistributedSystemConstructor internalDistributedSystemConstructor,
+      Supplier<InternalCache> singletonCacheSupplier,
+      InternalCacheConstructor internalCacheConstructor) {
+    this.configProperties = configProperties;
+    this.cacheConfig = cacheConfig;
+    this.singletonSystemSupplier = singletonSystemSupplier;
+    this.internalDistributedSystemConstructor = internalDistributedSystemConstructor;
+    this.internalCacheConstructor = internalCacheConstructor;
+    this.singletonCacheSupplier = singletonCacheSupplier;
+  }
+
+  /**
+   * @see CacheFactory#create()
+   *
+   * @throws CacheXmlException If a problem occurs while parsing the declarative caching XML file.
+   * @throws TimeoutException If a {@link Region#put(Object, Object)} times out while initializing
+   *         the cache.
+   * @throws CacheWriterException If a {@code CacheWriterException} is thrown while initializing the
+   *         cache.
+   * @throws GatewayException If a {@code GatewayException} is thrown while initializing the cache.
+   * @throws RegionExistsException If the declarative caching XML file describes a region that
+   *         already exists (including the root region).
+   * @throws IllegalStateException if cache already exists and is not compatible with the new
+   *         configuration.
+   * @throws AuthenticationFailedException if authentication fails.
+   * @throws AuthenticationRequiredException if the distributed system is in secure mode and this
+   *         new member is not configured with security credentials.
+   */
+  public InternalCache create()
+      throws TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
+    synchronized (InternalCacheBuilder.class) {
+      InternalDistributedSystem internalDistributedSystem = findInternalDistributedSystem()
+          .orElseGet(() -> createInternalDistributedSystem());
+      return create(internalDistributedSystem);
+    }
+  }
+
+  /**
+   * @see CacheFactory#create(DistributedSystem)
+   *
+   * @throws IllegalArgumentException If {@code system} is not {@link DistributedSystem#isConnected
+   *         connected}.
+   * @throws CacheExistsException If an open cache already exists.
+   * @throws CacheXmlException If a problem occurs while parsing the declarative caching XML file.
+   * @throws TimeoutException If a {@link Region#put(Object, Object)} times out while initializing
+   *         the cache.
+   * @throws CacheWriterException If a {@code CacheWriterException} is thrown while initializing the
+   *         cache.
+   * @throws GatewayException If a {@code GatewayException} is thrown while initializing the cache.
+   * @throws RegionExistsException If the declarative caching XML file describes a region that
+   *         already exists (including the root region).
+   */
+  public InternalCache create(InternalDistributedSystem internalDistributedSystem)
+      throws TimeoutException, CacheWriterException, GatewayException, RegionExistsException {
+    requireNonNull(internalDistributedSystem, "internalDistributedSystem");
+    try {
+      synchronized (InternalCacheBuilder.class) {
+        synchronized (GemFireCacheImpl.class) {
+          InternalCache cache =
+              existingCache(internalDistributedSystem::getCache, singletonCacheSupplier);
+          if (cache == null) {
+
+            cache =
+                internalCacheConstructor.construct(isClient, poolFactory, internalDistributedSystem,
+                    cacheConfig, useAsyncEventListeners, typeRegistry);
+
+            internalDistributedSystem.setCache(cache);
+            cache.initialize();
+
+          } else {
+            internalDistributedSystem.setCache(cache);
+          }
+
+          return cache;
+        }
+      }
+    } catch (CacheXmlException | IllegalArgumentException e) {
+      logger.error(e.getLocalizedMessage());
+      throw e;
+    } catch (Error | RuntimeException e) {
+      logger.error(e);
+      throw e;
+    }
+  }
+
+  /**
+   * @see CacheFactory#set(String, String)
+   */
+  public InternalCacheBuilder set(String name, String value) {
+    configProperties.setProperty(name, value);
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#setPdxReadSerialized(boolean)
+   */
+  public InternalCacheBuilder setPdxReadSerialized(boolean readSerialized) {
+    cacheConfig.setPdxReadSerialized(readSerialized);
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#setSecurityManager(SecurityManager)
+   */
+  public InternalCacheBuilder setSecurityManager(SecurityManager securityManager) {
+    cacheConfig.setSecurityManager(securityManager);
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#setPostProcessor(PostProcessor)
+   */
+  public InternalCacheBuilder setPostProcessor(PostProcessor postProcessor) {
+    cacheConfig.setPostProcessor(postProcessor);
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#setPdxSerializer(PdxSerializer)
+   */
+  public InternalCacheBuilder setPdxSerializer(PdxSerializer serializer) {
+    cacheConfig.setPdxSerializer(serializer);
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#setPdxDiskStore(String)
+   */
+  public InternalCacheBuilder setPdxDiskStore(String diskStoreName) {
+    cacheConfig.setPdxDiskStore(diskStoreName);
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#setPdxPersistent(boolean)
+   */
+  public InternalCacheBuilder setPdxPersistent(boolean isPersistent) {
+    cacheConfig.setPdxPersistent(isPersistent);
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#setPdxIgnoreUnreadFields(boolean)
+   */
+  public InternalCacheBuilder setPdxIgnoreUnreadFields(boolean ignore) {
+    cacheConfig.setPdxIgnoreUnreadFields(ignore);
+    return this;
+  }
+
+  public InternalCacheBuilder setCacheXMLDescription(String cacheXML) {
+    if (cacheXML != null) {
+      cacheConfig.setCacheXMLDescription(cacheXML);
+    }
+    return this;
+  }
+
+  /**
+   * @param isExistingOk default is true.
+   */
+  public InternalCacheBuilder setIsExistingOk(boolean isExistingOk) {
+    this.isExistingOk = isExistingOk;
+    return this;
+  }
+
+  /**
+   * @param isClient default is false.
+   */
+  public InternalCacheBuilder setIsClient(boolean isClient) {
+    this.isClient = isClient;
+    return this;
+  }
+
+  /**
+   * @param useAsyncEventListeners default is specified by the system property
+   *        {@code gemfire.Cache.ASYNC_EVENT_LISTENERS}.
+   */
+  public InternalCacheBuilder setUseAsyncEventListeners(boolean useAsyncEventListeners) {
+    this.useAsyncEventListeners = useAsyncEventListeners;
+    return this;
+  }
+
+  /**
+   * @param poolFactory default is null.
+   */
+  public InternalCacheBuilder setPoolFactory(PoolFactory poolFactory) {
+    this.poolFactory = poolFactory;
+    return this;
+  }
+
+  /**
+   * @param typeRegistry default is null.
+   */
+  public InternalCacheBuilder setTypeRegistry(TypeRegistry typeRegistry) {
+    this.typeRegistry = typeRegistry;
+    return this;
+  }
+
+  private Optional<InternalDistributedSystem> findInternalDistributedSystem() {
+    InternalDistributedSystem internalDistributedSystem = null;
+    if (configProperties.isEmpty() && !ALLOW_MULTIPLE_SYSTEMS) {
+      // any ds will do
+      internalDistributedSystem = singletonSystemSupplier.get();
+      validateUsabilityOfSecurityCallbacks(internalDistributedSystem, cacheConfig);
+    }
+    return Optional.ofNullable(internalDistributedSystem);
+  }
+
+  private InternalDistributedSystem createInternalDistributedSystem() {
+    SecurityConfig securityConfig = new SecurityConfig(
+        cacheConfig.getSecurityManager(),
+        cacheConfig.getPostProcessor());
+
+    return internalDistributedSystemConstructor.construct(configProperties, securityConfig);
+  }
+
+  private InternalCache existingCache(Supplier<? extends InternalCache> systemCacheSupplier,
+      Supplier<? extends InternalCache> singletonCacheSupplier) {
+    InternalCache cache = ALLOW_MULTIPLE_SYSTEMS
+        ? systemCacheSupplier.get()
+        : singletonCacheSupplier.get();
+
+    if (validateExistingCache(cache)) {
+      return cache;
+    }
+
+    return null;
+  }
+
+  /**
+   * Validates that isExistingOk is true and existing cache is compatible with cacheConfig.
+   *
+   * if instance exists and cacheConfig is incompatible
+   * if instance exists and isExistingOk is false
+   */
+  private boolean validateExistingCache(InternalCache existingCache) {
+    if (existingCache == null || existingCache.isClosed()) {
+      return false;
+    }
+
+    if (isExistingOk) {
+      cacheConfig.validateCacheConfig(existingCache);
+    } else {
+      existingCache.throwCacheExistsException();
+    }
+
+    return true;
+  }
+
+  /**
+   * if existing DistributedSystem connection cannot use specified SecurityManager or
+   * PostProcessor.
+   */
+  private static void validateUsabilityOfSecurityCallbacks(
+      InternalDistributedSystem internalDistributedSystem, CacheConfig cacheConfig)
+      throws GemFireSecurityException {
+    if (internalDistributedSystem == null) {
+      return;
+    }
+    // pre-existing DistributedSystem already has an incompatible SecurityService in use
+    if (cacheConfig.getSecurityManager() != null) {
+      throw new GemFireSecurityException(
+          "Existing DistributedSystem connection cannot use specified SecurityManager");
+    }
+    if (cacheConfig.getPostProcessor() != null) {
+      throw new GemFireSecurityException(
+          "Existing DistributedSystem connection cannot use specified PostProcessor");
+    }
+  }
+
+  @VisibleForTesting
+  interface InternalCacheConstructor {
+    InternalCache construct(boolean isClient, PoolFactory poolFactory,
+        InternalDistributedSystem internalDistributedSystem, CacheConfig cacheConfig,
+        boolean useAsyncEventListeners, TypeRegistry typeRegistry);
+  }
+
+  @VisibleForTesting
+  interface InternalDistributedSystemConstructor {
+    InternalDistributedSystem construct(Properties configProperties, SecurityConfig securityConfig);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -1223,4 +1223,14 @@ public class InternalCacheForClientAccess implements InternalCache {
   public HttpService getHttpService() {
     return delegate.getHttpService();
   }
+
+  @Override
+  public void initialize() {
+    // do nothing
+  }
+
+  @Override
+  public void throwCacheExistsException() {
+    delegate.throwCacheExistsException();
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -2380,6 +2380,11 @@ public class CacheCreation implements InternalCache {
   }
 
   @Override
+  public void initialize() {
+    throw new UnsupportedOperationException("Should not be invoked");
+  }
+
+  @Override
   public URL getCacheXmlURL() {
     throw new UnsupportedOperationException("Should not be invoked");
   }
@@ -2423,6 +2428,11 @@ public class CacheCreation implements InternalCache {
 
   @Override
   public InternalCacheForClientAccess getCacheForProcessingClientRequests() {
+    throw new UnsupportedOperationException("Should not be invoked");
+  }
+
+  @Override
+  public void throwCacheExistsException() {
     throw new UnsupportedOperationException("Should not be invoked");
   }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/ConnectionConfigImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/ConnectionConfigImplTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_CONFIG_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_QUORUM_CHECKER_NAME;
+import static org.apache.geode.distributed.internal.DistributionConfig.DS_RECONNECTING_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.apache.geode.distributed.internal.membership.QuorumChecker;
+
+public class ConnectionConfigImplTest {
+
+  @Test
+  public void distributionConfigDoesNotContainDsQuorumCheckerProperty() {
+    QuorumChecker quorumChecker = mock(QuorumChecker.class);
+    Properties properties = new Properties();
+    properties.put(DS_QUORUM_CHECKER_NAME, quorumChecker);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    DistributionConfigImpl result = (DistributionConfigImpl) config.distributionConfig();
+    assertThat(result.getProps()).doesNotContainKey(DS_QUORUM_CHECKER_NAME);
+  }
+
+  @Test
+  public void distributionConfigDoesNotContainDsReconnectingProperty() {
+    Properties properties = new Properties();
+    properties.put(DS_RECONNECTING_NAME, Boolean.TRUE);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    DistributionConfigImpl result = (DistributionConfigImpl) config.distributionConfig();
+    assertThat(result.getProps()).doesNotContainKey(DS_RECONNECTING_NAME);
+  }
+
+  @Test
+  public void distributionConfigDoesNotContainDsConfigProperty() {
+    Properties properties = new Properties();
+    properties.put(DS_CONFIG_NAME, mock(DistributionConfig.class));
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    DistributionConfigImpl result = (DistributionConfigImpl) config.distributionConfig();
+    assertThat(result.getProps()).doesNotContainKey(DS_CONFIG_NAME);
+  }
+
+  @Test
+  public void isReconnecting_isTrue_ifReconnectingPropertyIsTrue() {
+    Properties properties = new Properties();
+
+    properties.put(DS_RECONNECTING_NAME, Boolean.TRUE);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isTrue();
+  }
+
+  @Test
+  public void isReconnecting_isFalse_ifReconnectingPropertyIsFalse() {
+    Properties properties = new Properties();
+
+    properties.put(DS_RECONNECTING_NAME, Boolean.FALSE);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isFalse();
+  }
+
+  @Test
+  public void isReconnecting_isFalse_ifReconnectingPropertyDoesNotExist() {
+    Properties properties = new Properties();
+
+    properties.remove(DS_RECONNECTING_NAME);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isFalse();
+  }
+
+  @Test
+  public void isReconnecting_isFalse_ifReconnectingPropertyIsNotBoolean() {
+    Properties properties = new Properties();
+
+    properties.put(DS_RECONNECTING_NAME, "a string, not a boolean");
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.isReconnecting()).isFalse();
+  }
+
+  @Test
+  public void quorumChecker_returnsQuorumCheckerProperty_ifPropertyIsAQuorumChecker() {
+    QuorumChecker quorumCheckerFromProperties = mock(QuorumChecker.class);
+    Properties properties = new Properties();
+    properties.put(DS_QUORUM_CHECKER_NAME, quorumCheckerFromProperties);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.quorumChecker())
+        .isSameAs(quorumCheckerFromProperties);
+  }
+
+  @Test
+  public void quorumChecker_returnsNull_ifQuorumCheckerPropertyDoesNotExist() {
+    Properties properties = new Properties();
+    properties.remove(DS_QUORUM_CHECKER_NAME);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.quorumChecker()).isNull();
+  }
+
+  @Test
+  public void quorumChecker_returnsNull_ifQuorumCheckerPropertyIsNotAQuorumChecker() {
+    Properties properties = new Properties();
+
+    properties.put(DS_QUORUM_CHECKER_NAME, "a string, not a quorum checker");
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.quorumChecker()).isNull();
+  }
+
+  @Test
+  public void distributionConfig_returnsConfigProperty_ifPropertyIsADistributionConfigImpl() {
+    DistributionConfigImpl distributionConfigFromProperties =
+        new DistributionConfigImpl(new Properties());
+    Properties properties = new Properties();
+    properties.put(DS_CONFIG_NAME, distributionConfigFromProperties);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.distributionConfig())
+        .isSameAs(distributionConfigFromProperties);
+  }
+
+  @Test
+  public void distributionConfig_returnsDistributionConfigImpl_ifConfigPropertyDoesNotExist() {
+    Properties properties = new Properties();
+    properties.remove(DS_CONFIG_NAME);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.distributionConfig())
+        .isInstanceOf(DistributionConfigImpl.class);
+  }
+
+  @Test
+  public void distributionConfig_returnsDistributionConfigImpl_ifConfigPropertyIsNotADistributionConfigImpl() {
+    String distributionConfigFromProperties = "a string, not a distribution config";
+    Properties properties = new Properties();
+    properties.put(DS_CONFIG_NAME, distributionConfigFromProperties);
+
+    ConnectionConfigImpl config = new ConnectionConfigImpl(properties);
+
+    assertThat(config.distributionConfig())
+        .isInstanceOf(DistributionConfigImpl.class)
+        .isNotSameAs(distributionConfigFromProperties);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/ConnectionConfigImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/ConnectionConfigImplTest.java
@@ -26,10 +26,13 @@ import org.junit.Test;
 
 import org.apache.geode.distributed.internal.membership.QuorumChecker;
 
+/**
+ * Unit tests for {@link ConnectionConfigImpl}.
+ */
 public class ConnectionConfigImplTest {
 
   @Test
-  public void distributionConfigDoesNotContainDsQuorumCheckerProperty() {
+  public void distributionConfig_doesNotContainDsQuorumCheckerProperty() {
     QuorumChecker quorumChecker = mock(QuorumChecker.class);
     Properties properties = new Properties();
     properties.put(DS_QUORUM_CHECKER_NAME, quorumChecker);
@@ -41,7 +44,7 @@ public class ConnectionConfigImplTest {
   }
 
   @Test
-  public void distributionConfigDoesNotContainDsReconnectingProperty() {
+  public void distributionConfig_doesNotContainDsReconnectingProperty() {
     Properties properties = new Properties();
     properties.put(DS_RECONNECTING_NAME, Boolean.TRUE);
 
@@ -52,7 +55,7 @@ public class ConnectionConfigImplTest {
   }
 
   @Test
-  public void distributionConfigDoesNotContainDsConfigProperty() {
+  public void distributionConfig_doesNotContainDsConfigProperty() {
     Properties properties = new Properties();
     properties.put(DS_CONFIG_NAME, mock(DistributionConfig.class));
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemTest.java
@@ -27,6 +27,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +39,11 @@ import org.apache.geode.StatisticsType;
 import org.apache.geode.internal.statistics.StatisticsManager;
 import org.apache.geode.internal.statistics.StatisticsManagerFactory;
 
+/**
+ * Unit tests for {@link InternalDistributedSystem}.
+ */
 public class InternalDistributedSystemTest {
+
   private static final String STATISTIC_NAME = "statistic-name";
   private static final String STATISTIC_DESCRIPTION = "statistic-description";
   private static final String STATISTIC_UNITS = "statistic-units";
@@ -46,21 +51,24 @@ public class InternalDistributedSystemTest {
   private static final String STATISTICS_TEXT_ID = "statistics-text-id";
   private static final long STATISTICS_NUMERIC_ID = 2349;
 
+  @Mock(name = "autowiredDistributionManager")
+  private DistributionManager distributionManager;
+
   @Mock(name = "autowiredStatisticsManagerFactory")
-  public StatisticsManagerFactory statisticsManagerFactory;
+  private StatisticsManagerFactory statisticsManagerFactory;
 
   @Mock(name = "autowiredStatisticsManager")
-  public StatisticsManager statisticsManager;
+  private StatisticsManager statisticsManager;
 
   private InternalDistributedSystem internalDistributedSystem;
 
   @Before
-  public void setup() {
+  public void setUp() {
     initMocks(this);
     when(statisticsManagerFactory.create(any(), anyLong(), anyBoolean()))
         .thenReturn(statisticsManager);
-    internalDistributedSystem =
-        InternalDistributedSystem.newInstanceForTesting(statisticsManagerFactory);
+    internalDistributedSystem = InternalDistributedSystem.newInstanceForTesting(distributionManager,
+        new Properties(), statisticsManagerFactory);
   }
 
   @Test
@@ -73,8 +81,8 @@ public class InternalDistributedSystemTest {
         .create(any(), anyLong(), eq(false)))
             .thenReturn(statisticsManagerCreatedByFactory);
 
-    InternalDistributedSystem result =
-        InternalDistributedSystem.newInstanceForTesting(statisticsManagerFactory);
+    InternalDistributedSystem result = InternalDistributedSystem
+        .newInstanceForTesting(distributionManager, new Properties(), statisticsManagerFactory);
 
     assertThat(result.getStatisticsManager())
         .isSameAs(statisticsManagerCreatedByFactory);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -29,10 +29,8 @@ import java.io.NotSerializableException;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.SerializationException;
@@ -47,27 +45,22 @@ import org.apache.geode.internal.cache.eviction.OffHeapEvictor;
 import org.apache.geode.pdx.internal.TypeRegistry;
 import org.apache.geode.test.fake.Fakes;
 
+/**
+ * Unit tests for {@link GemFireCacheImpl}.
+ */
 public class GemFireCacheImplTest {
 
-  private InternalDistributedSystem distributedSystem;
-  private GemFireCacheImpl cache;
-  private CacheConfig cacheConfig;
-
-  @Before
-  public void setup() {
-    distributedSystem = Fakes.distributedSystem();
-    cacheConfig = new CacheConfig();
-  }
+  private GemFireCacheImpl gemFireCacheImpl;
 
   @After
   public void tearDown() {
-    if (cache != null) {
-      cache.close();
+    if (gemFireCacheImpl != null) {
+      gemFireCacheImpl.close();
     }
   }
 
   @Test
-  public void shouldBeMockable() throws Exception {
+  public void canBeMocked() {
     GemFireCacheImpl mockGemFireCacheImpl = mock(GemFireCacheImpl.class);
     InternalResourceManager mockInternalResourceManager = mock(InternalResourceManager.class);
 
@@ -79,198 +72,198 @@ public class GemFireCacheImplTest {
 
   @Test
   public void checkPurgeCCPTimer() {
-    InternalDistributedSystem ds = Fakes.distributedSystem();
-    CacheConfig cc = new CacheConfig();
-    TypeRegistry typeRegistry = mock(TypeRegistry.class);
-    SystemTimer ccpTimer = mock(SystemTimer.class);
-    GemFireCacheImpl gfc = GemFireCacheImpl.createWithAsyncEventListeners(ds, cc, typeRegistry);
-    try {
-      gfc.setCCPTimer(ccpTimer);
-      for (int i = 1; i < GemFireCacheImpl.PURGE_INTERVAL; i++) {
-        gfc.purgeCCPTimer();
-        verify(ccpTimer, times(0)).timerPurge();
-      }
-      gfc.purgeCCPTimer();
-      verify(ccpTimer, times(1)).timerPurge();
-      for (int i = 1; i < GemFireCacheImpl.PURGE_INTERVAL; i++) {
-        gfc.purgeCCPTimer();
-        verify(ccpTimer, times(1)).timerPurge();
-      }
-      gfc.purgeCCPTimer();
-      verify(ccpTimer, times(2)).timerPurge();
-    } finally {
-      gfc.close();
+    SystemTimer cacheClientProxyTimer = mock(SystemTimer.class);
+
+    gemFireCacheImpl = createGemFireCacheWithTypeRegistry();
+
+    gemFireCacheImpl.setCCPTimer(cacheClientProxyTimer);
+    for (int i = 1; i < GemFireCacheImpl.PURGE_INTERVAL; i++) {
+      gemFireCacheImpl.purgeCCPTimer();
+      verify(cacheClientProxyTimer, times(0)).timerPurge();
     }
+    gemFireCacheImpl.purgeCCPTimer();
+    verify(cacheClientProxyTimer, times(1)).timerPurge();
+    for (int i = 1; i < GemFireCacheImpl.PURGE_INTERVAL; i++) {
+      gemFireCacheImpl.purgeCCPTimer();
+      verify(cacheClientProxyTimer, times(1)).timerPurge();
+    }
+    gemFireCacheImpl.purgeCCPTimer();
+    verify(cacheClientProxyTimer, times(2)).timerPurge();
   }
 
   @Test
   public void checkEvictorsClosed() {
-    InternalDistributedSystem ds = Fakes.distributedSystem();
-    CacheConfig cc = new CacheConfig();
-    TypeRegistry typeRegistry = mock(TypeRegistry.class);
-    SystemTimer ccpTimer = mock(SystemTimer.class);
-    HeapEvictor he = mock(HeapEvictor.class);
-    OffHeapEvictor ohe = mock(OffHeapEvictor.class);
-    GemFireCacheImpl gfc = GemFireCacheImpl.createWithAsyncEventListeners(ds, cc, typeRegistry);
-    try {
-      gfc.setHeapEvictor(he);
-      gfc.setOffHeapEvictor(ohe);
-    } finally {
-      gfc.close();
-    }
-    verify(he, times(1)).close();
-    verify(ohe, times(1)).close();
+    HeapEvictor heapEvictor = mock(HeapEvictor.class);
+    OffHeapEvictor offHeapEvictor = mock(OffHeapEvictor.class);
+
+    gemFireCacheImpl = createGemFireCacheWithTypeRegistry();
+
+    gemFireCacheImpl.setHeapEvictor(heapEvictor);
+    gemFireCacheImpl.setOffHeapEvictor(offHeapEvictor);
+    gemFireCacheImpl.close();
+
+    verify(heapEvictor).close();
+    verify(offHeapEvictor).close();
   }
 
   @Test
   public void registerPdxMetaDataThrowsIfInstanceNotSerializable() {
-    InternalDistributedSystem ds = Fakes.distributedSystem();
-    CacheConfig cc = new CacheConfig();
-    TypeRegistry typeRegistry = mock(TypeRegistry.class);
-    GemFireCacheImpl gfc = GemFireCacheImpl.createWithAsyncEventListeners(ds, cc, typeRegistry);
-    try {
-      assertThatThrownBy(() -> gfc.registerPdxMetaData(new Object()))
-          .isInstanceOf(SerializationException.class).hasMessage("Serialization failed")
-          .hasCauseInstanceOf(NotSerializableException.class);
-    } finally {
-      gfc.close();
-    }
+    gemFireCacheImpl = createGemFireCacheWithTypeRegistry();
+
+    assertThatThrownBy(() -> gemFireCacheImpl.registerPdxMetaData(new Object()))
+        .isInstanceOf(SerializationException.class).hasMessage("Serialization failed")
+        .hasCauseInstanceOf(NotSerializableException.class);
   }
 
   @Test
   public void registerPdxMetaDataThrowsIfInstanceIsNotPDX() {
-    InternalDistributedSystem ds = Fakes.distributedSystem();
-    CacheConfig cc = new CacheConfig();
-    TypeRegistry typeRegistry = mock(TypeRegistry.class);
-    GemFireCacheImpl gfc = GemFireCacheImpl.createWithAsyncEventListeners(ds, cc, typeRegistry);
-    try {
-      assertThatThrownBy(() -> gfc.registerPdxMetaData("string"))
-          .isInstanceOf(SerializationException.class)
-          .hasMessage("The instance is not PDX serializable");
-    } finally {
-      gfc.close();
-    }
+    gemFireCacheImpl = createGemFireCacheWithTypeRegistry();
+
+    assertThatThrownBy(() -> gemFireCacheImpl.registerPdxMetaData("string"))
+        .isInstanceOf(SerializationException.class)
+        .hasMessage("The instance is not PDX serializable");
   }
 
   @Test
   public void checkThatAsyncEventListenersUseAllThreadsInPool() {
-    InternalDistributedSystem ds = Fakes.distributedSystem();
-    CacheConfig cc = new CacheConfig();
-    TypeRegistry typeRegistry = mock(TypeRegistry.class);
-    GemFireCacheImpl gfc = GemFireCacheImpl.createWithAsyncEventListeners(ds, cc, typeRegistry);
-    try {
-      ThreadPoolExecutor executor = (ThreadPoolExecutor) gfc.getEventThreadPool();
-      assertEquals(0, executor.getCompletedTaskCount());
-      assertEquals(0, executor.getActiveCount());
-      int MAX_THREADS = GemFireCacheImpl.EVENT_THREAD_LIMIT;
-      final CountDownLatch cdl = new CountDownLatch(MAX_THREADS);
-      for (int i = 1; i <= MAX_THREADS; i++) {
-        executor.execute(() -> {
-          cdl.countDown();
-          try {
-            cdl.await();
-          } catch (InterruptedException e) {
-          }
-        });
-      }
-      await().timeout(90, TimeUnit.SECONDS)
-          .untilAsserted(() -> assertEquals(MAX_THREADS, executor.getCompletedTaskCount()));
-    } finally {
-      gfc.close();
+    gemFireCacheImpl = createGemFireCacheWithTypeRegistry();
+
+    ThreadPoolExecutor eventThreadPoolExecutor =
+        (ThreadPoolExecutor) gemFireCacheImpl.getEventThreadPool();
+    assertEquals(0, eventThreadPoolExecutor.getCompletedTaskCount());
+    assertEquals(0, eventThreadPoolExecutor.getActiveCount());
+
+    int MAX_THREADS = GemFireCacheImpl.EVENT_THREAD_LIMIT;
+    final CountDownLatch threadLatch = new CountDownLatch(MAX_THREADS);
+    for (int i = 1; i <= MAX_THREADS; i++) {
+      eventThreadPoolExecutor.execute(() -> {
+        threadLatch.countDown();
+        try {
+          threadLatch.await();
+        } catch (InterruptedException e) {
+        }
+      });
     }
+
+    await().untilAsserted(
+        () -> assertThat(eventThreadPoolExecutor.getCompletedTaskCount()).isEqualTo(MAX_THREADS));
   }
 
   @Test
   public void getCacheClosedExceptionWithNoReasonOrCauseGivesExceptionWithoutEither() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
-    CacheClosedException e = cache.getCacheClosedException(null, null);
-    assertThat(e.getCause()).isNull();
-    assertThat(e.getMessage()).isNull();
+    gemFireCacheImpl = createGemFireCacheImpl();
+
+    CacheClosedException cacheClosedException =
+        gemFireCacheImpl.getCacheClosedException(null, null);
+
+    assertThat(cacheClosedException.getCause()).isNull();
+    assertThat(cacheClosedException.getMessage()).isNull();
   }
 
   @Test
   public void getCacheClosedExceptionWithNoCauseGivesExceptionWithReason() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
-    CacheClosedException e = cache.getCacheClosedException("message", null);
-    assertThat(e.getCause()).isNull();
-    assertThat(e.getMessage()).isEqualTo("message");
+    gemFireCacheImpl = createGemFireCacheImpl();
+
+    CacheClosedException cacheClosedException = gemFireCacheImpl
+        .getCacheClosedException("message", null);
+
+    assertThat(cacheClosedException.getCause()).isNull();
+    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
   }
 
   @Test
   public void getCacheClosedExceptionReturnsExceptionWithProvidedCauseAndReason() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
+    gemFireCacheImpl = createGemFireCacheImpl();
     Throwable cause = new Throwable();
-    CacheClosedException e = cache.getCacheClosedException("message", cause);
-    assertThat(e.getCause()).isEqualTo(cause);
-    assertThat(e.getMessage()).isEqualTo("message");
+
+    CacheClosedException cacheClosedException = gemFireCacheImpl
+        .getCacheClosedException("message", cause);
+
+    assertThat(cacheClosedException.getCause()).isEqualTo(cause);
+    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
   }
 
   @Test
   public void getCacheClosedExceptionWhenCauseGivenButDisconnectExceptionExistsPrefersCause() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
-    cache.disconnectCause = new Throwable("disconnectCause");
+    gemFireCacheImpl = createGemFireCacheImpl();
+    gemFireCacheImpl.disconnectCause = new Throwable("disconnectCause");
     Throwable cause = new Throwable();
-    CacheClosedException e = cache.getCacheClosedException("message", cause);
-    assertThat(e.getCause()).isEqualTo(cause);
-    assertThat(e.getMessage()).isEqualTo("message");
+
+    CacheClosedException cacheClosedException = gemFireCacheImpl
+        .getCacheClosedException("message", cause);
+
+    assertThat(cacheClosedException.getCause()).isEqualTo(cause);
+    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
   }
 
   @Test
   public void getCacheClosedExceptionWhenNoCauseGivenProvidesDisconnectExceptionIfExists() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
+    gemFireCacheImpl = createGemFireCacheImpl();
     Throwable disconnectCause = new Throwable("disconnectCause");
-    cache.disconnectCause = disconnectCause;
-    CacheClosedException e = cache.getCacheClosedException("message", null);
-    assertThat(e.getCause()).isEqualTo(disconnectCause);
-    assertThat(e.getMessage()).isEqualTo("message");
+    gemFireCacheImpl.disconnectCause = disconnectCause;
+
+    CacheClosedException cacheClosedException = gemFireCacheImpl
+        .getCacheClosedException("message", null);
+
+    assertThat(cacheClosedException.getCause()).isEqualTo(disconnectCause);
+    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
   }
 
   @Test
   public void getCacheClosedExceptionReturnsExceptionWithProvidedReason() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
-    CacheClosedException e = cache.getCacheClosedException("message");
-    assertThat(e.getMessage()).isEqualTo("message");
-    assertThat(e.getCause()).isNull();
+    gemFireCacheImpl = createGemFireCacheImpl();
+
+    CacheClosedException cacheClosedException = gemFireCacheImpl.getCacheClosedException("message");
+
+    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
+    assertThat(cacheClosedException.getCause()).isNull();
   }
 
   @Test
   public void getCacheClosedExceptionReturnsExceptionWithNoMessageWhenReasonNotGiven() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
-    CacheClosedException e = cache.getCacheClosedException(null);
-    assertThat(e.getMessage()).isEqualTo(null);
-    assertThat(e.getCause()).isNull();
+    gemFireCacheImpl = createGemFireCacheImpl();
+
+    CacheClosedException cacheClosedException = gemFireCacheImpl.getCacheClosedException(null);
+
+    assertThat(cacheClosedException.getMessage()).isEqualTo(null);
+    assertThat(cacheClosedException.getCause()).isNull();
   }
 
   @Test
   public void getCacheClosedExceptionReturnsExceptionWithDisconnectCause() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
+    gemFireCacheImpl = createGemFireCacheImpl();
     Throwable disconnectCause = new Throwable("disconnectCause");
-    cache.disconnectCause = disconnectCause;
-    CacheClosedException e = cache.getCacheClosedException("message");
-    assertThat(e.getMessage()).isEqualTo("message");
-    assertThat(e.getCause()).isEqualTo(disconnectCause);
+    gemFireCacheImpl.disconnectCause = disconnectCause;
+
+    CacheClosedException cacheClosedException = gemFireCacheImpl.getCacheClosedException("message");
+
+    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
+    assertThat(cacheClosedException.getCause()).isEqualTo(disconnectCause);
   }
 
   @Test
   public void removeGatewayReceiverShouldRemoveFromReceiversList() {
     GatewayReceiver receiver = mock(GatewayReceiver.class);
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
-    cache.addGatewayReceiver(receiver);
-    assertEquals(1, cache.getGatewayReceivers().size());
-    cache.removeGatewayReceiver(receiver);
-    assertEquals(0, cache.getGatewayReceivers().size());
+    gemFireCacheImpl = createGemFireCacheImpl();
+    gemFireCacheImpl.addGatewayReceiver(receiver);
+    assertEquals(1, gemFireCacheImpl.getGatewayReceivers().size());
+
+    gemFireCacheImpl.removeGatewayReceiver(receiver);
+
+    assertEquals(0, gemFireCacheImpl.getGatewayReceivers().size());
   }
 
 
   @Test
   public void removeFromCacheServerShouldRemoveFromCacheServersList() {
-    cache = GemFireCacheImpl.create(distributedSystem, cacheConfig);
-    CacheServer cacheServer = cache.addCacheServer(false);
-    assertEquals(1, cache.getCacheServers().size());
-    cache.removeCacheServer(cacheServer);
-    assertEquals(0, cache.getCacheServers().size());
-  }
+    gemFireCacheImpl = createGemFireCacheImpl();
+    CacheServer cacheServer = gemFireCacheImpl.addCacheServer(false);
+    assertEquals(1, gemFireCacheImpl.getCacheServers().size());
 
+    gemFireCacheImpl.removeCacheServer(cacheServer);
+
+    assertEquals(0, gemFireCacheImpl.getCacheServers().size());
+  }
 
   @Test
   public void testIsMisConfigured() {
@@ -326,18 +319,35 @@ public class GemFireCacheImplTest {
 
   @Test
   public void clientCacheWouldNotRequestClusterConfig() {
-    // we will need to set the value to true so that we can use a mock cache
+    // we will need to set the value to true so that we can use a mock gemFireCacheImpl
     boolean oldValue = InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
     InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = true;
 
-    cache = mock(GemFireCacheImpl.class);
-    when(distributedSystem.getCache()).thenReturn(cache);
-    GemFireCacheImpl.createClient(distributedSystem, null, cacheConfig);
+    InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
+    gemFireCacheImpl = mock(GemFireCacheImpl.class);
+    when(internalDistributedSystem.getCache()).thenReturn(gemFireCacheImpl);
 
-    verify(cache, times(0)).requestSharedConfiguration();
-    verify(cache, times(0)).applyJarAndXmlFromClusterConfig();
+    new InternalCacheBuilder()
+        .setIsClient(true)
+        .create(internalDistributedSystem);
+
+    verify(gemFireCacheImpl, times(0)).requestSharedConfiguration();
+    verify(gemFireCacheImpl, times(0)).applyJarAndXmlFromClusterConfig();
 
     // reset it back to the old value
     InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = oldValue;
+  }
+
+  private static GemFireCacheImpl createGemFireCacheImpl() {
+    return (GemFireCacheImpl) new InternalCacheBuilder().create(Fakes.distributedSystem());
+  }
+
+  private static GemFireCacheImpl createGemFireCacheWithTypeRegistry() {
+    InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
+    TypeRegistry typeRegistry = mock(TypeRegistry.class);
+    return (GemFireCacheImpl) new InternalCacheBuilder()
+        .setUseAsyncEventListeners(true)
+        .setTypeRegistry(typeRegistry)
+        .create(internalDistributedSystem);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
@@ -41,6 +41,10 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalCacheConstructor;
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalDistributedSystemConstructor;
 
+/**
+ * Unit tests for {@link InternalCacheBuilder} when
+ * {@code InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS} is set to true.
+ */
 public class InternalCacheBuilderAllowsMultipleSystemsTest {
 
   private static final int ANY_SYSTEM_ID = 12;
@@ -74,7 +78,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
   }
 
-  @Test // null Properties
+  @Test
   public void create_throwsNullPointerException_ifConfigPropertiesIsNull() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         null, new CacheConfig(),
@@ -87,7 +91,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isInstanceOf(NullPointerException.class);
   }
 
-  @Test // null CacheConfig
+  @Test
   public void create_throwsNullPointerException_andCacheConfigIsNull() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         new Properties(), null,
@@ -100,7 +104,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isInstanceOf(NullPointerException.class);
   }
 
-  @Test // scenario 13 - no system/no cache - constructs system
+  @Test
   public void create_constructsSystem_withGivenProperties_ifNoSystemExists() {
     InternalCache constructedCache = constructedCache();
 
@@ -117,7 +121,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(systemConstructor).construct(same(configProperties), any());
   }
 
-  @Test // scenario 13 - no system/no cache - returns constructed cache
+  @Test
   public void create_returnsConstructedCache_ifNoSystemExists() {
     InternalCache constructedCache = constructedCache();
 
@@ -131,7 +135,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 13 - no system/no cache - sets cache on system
+  @Test
   public void create_setsConstructedCache_onConstructedSystem_ifNoSystemExists() {
     InternalDistributedSystem constructedSystem = constructedSystem();
     InternalCache constructedCache = constructedCache();
@@ -146,7 +150,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(constructedSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 13 - no system/no cache - sets system on cache
+  @Test
   public void create_setsConstructedSystem_onConstructedCache_ifNoSystemExists() {
     InternalDistributedSystem constructedSystem = constructedSystem();
 
@@ -164,7 +168,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
   }
 
 
-  @Test // scenario 14 - given system/no cache - null system throws
+  @Test
   public void createWithSystem_throwsNullPointerException_ifSystemIsNull() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         new Properties(), new CacheConfig(),
@@ -176,7 +180,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isInstanceOf(NullPointerException.class);
   }
 
-  @Test // scenario 15 - given system/no cache - returns constructed cache
+  @Test
   public void createWithSystem_returnsConstructedCache_ifSystemCacheDoesNotExist() {
     InternalCache constructedCache = constructedCache();
 
@@ -191,7 +195,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 15 - given system/no cache - sets cache on system
+  @Test
   public void createWithSystem_setsConstructedCache_onGivenSystem_ifSystemCacheDoesNotExist() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache constructedCache = constructedCache();
@@ -207,7 +211,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 15 - given system/no cache - sets system on cache
+  @Test
   public void createWithSystem_setsGivenSystem_onConstructedCache_ifSystemCacheDoesNotExist() {
     InternalDistributedSystem givenSystem = givenSystem();
 
@@ -225,7 +229,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 16 - given system/closed cache - returns constructed cache
+  @Test
   public void createWithSystem_returnsConstructedCache_ifSystemCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
     InternalCache constructedCache = constructedCache();
@@ -241,7 +245,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 16 - given system/closed cache - sets cache on system
+  @Test
   public void createWithSystem_setsConstructedCache_onGivenSystem_ifSystemCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
     InternalCache constructedCache = constructedCache();
@@ -257,7 +261,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 16 - given system/closed cache - sets system on cache
+  @Test
   public void createWithSystem_setsGivenSystem_onConstructedCache_ifSystemCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
 
@@ -275,7 +279,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 17 - given system/open cache - notExistingOk throws
+  @Test
   public void createWithSystem_throwsCacheExistsException_ifSystemCacheIsOpen_butExistingNotOk() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -291,7 +295,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isInstanceOf(CacheExistsException.class);
   }
 
-  @Test // scenario 17 - given system/open cache - does not set cache on system
+  @Test
   public void createWithSystem_doesNotSetSystemCache_onGivenSystem__ifSystemCacheIsOpen_butExistingNotOk() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -307,7 +311,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem, never()).setCache(any());
   }
 
-  @Test // scenario 18 - given system/open cache - incompatible cache throws
+  @Test
   public void createWithSystem_propagatesCacheConfigException_ifSystemCacheIsOpen_andExistingOk_butCacheIsIncompatible() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -325,7 +329,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isSameAs(thrownByCacheConfig);
   }
 
-  @Test // scenario 18 given system/open cache - does not set cache on system
+  @Test
   public void createWithSystem_doesNotSetSystemCache_onGivenSystem_ifSystemCacheIsOpen_andExistingOk_butCacheIsNotCompatible() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -341,7 +345,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem, never()).setCache(any());
   }
 
-  @Test // scenario 19 - given system/open cache - returns singleton cache
+  @Test
   public void createWithSystem_returnsSystemCache_ifSystemCacheIsOpen_andExistingOk_andCacheIsCompatible() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache systemCache = systemCache(givenSystem, OPEN);
@@ -358,7 +362,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(result).isSameAs(systemCache);
   }
 
-  @Test // scenario 19 - given system/open cache - sets cache on system
+  @Test
   public void createWithSystem_setsSystemCache_onGivenSystem_ifSystemCacheIsOpen_andExistingOk_andCacheIsCompatible() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache systemCache = systemCache(givenSystem, OPEN);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
@@ -163,7 +163,8 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 19 - given system/no cache - null system throws
+
+  @Test // scenario 14 - given system/no cache - null system throws
   public void createWithSystem_throwsNullPointerException_ifSystemIsNull() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         new Properties(), new CacheConfig(),
@@ -175,7 +176,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isInstanceOf(NullPointerException.class);
   }
 
-  @Test // scenario 20 - given system/no cache - returns constructed cache
+  @Test // scenario 15 - given system/no cache - returns constructed cache
   public void createWithSystem_returnsConstructedCache_ifSystemCacheDoesNotExist() {
     InternalCache constructedCache = constructedCache();
 
@@ -190,7 +191,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 20 - given system/no cache - sets cache on system
+  @Test // scenario 15 - given system/no cache - sets cache on system
   public void createWithSystem_setsConstructedCache_onGivenSystem_ifSystemCacheDoesNotExist() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache constructedCache = constructedCache();
@@ -206,7 +207,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 20 - given system/no cache - sets system on cache
+  @Test // scenario 15 - given system/no cache - sets system on cache
   public void createWithSystem_setsGivenSystem_onConstructedCache_ifSystemCacheDoesNotExist() {
     InternalDistributedSystem givenSystem = givenSystem();
 
@@ -224,7 +225,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 21 - given system/closed cache - returns constructed cache
+  @Test // scenario 16 - given system/closed cache - returns constructed cache
   public void createWithSystem_returnsConstructedCache_ifSystemCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
     InternalCache constructedCache = constructedCache();
@@ -240,7 +241,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 21 - given system/closed cache - sets cache on system
+  @Test // scenario 16 - given system/closed cache - sets cache on system
   public void createWithSystem_setsConstructedCache_onGivenSystem_ifSystemCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
     InternalCache constructedCache = constructedCache();
@@ -256,7 +257,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 21 - given system/closed cache - sets system on cache
+  @Test // scenario 16 - given system/closed cache - sets system on cache
   public void createWithSystem_setsGivenSystem_onConstructedCache_ifSystemCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
 
@@ -274,7 +275,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 22 - given system/open cache - notExistingOk throws
+  @Test // scenario 17 - given system/open cache - notExistingOk throws
   public void createWithSystem_throwsCacheExistsException_ifSystemCacheIsOpen_butExistingNotOk() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -290,7 +291,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isInstanceOf(CacheExistsException.class);
   }
 
-  @Test // scenario 22 - given system/open cache - does not set cache on system
+  @Test // scenario 17 - given system/open cache - does not set cache on system
   public void createWithSystem_doesNotSetSystemCache_onGivenSystem__ifSystemCacheIsOpen_butExistingNotOk() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -306,7 +307,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem, never()).setCache(any());
   }
 
-  @Test // scenario 23 - given system/open cache - incompatible cache throws
+  @Test // scenario 18 - given system/open cache - incompatible cache throws
   public void createWithSystem_propagatesCacheConfigException_ifSystemCacheIsOpen_andExistingOk_butCacheIsIncompatible() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -324,7 +325,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(thrown).isSameAs(thrownByCacheConfig);
   }
 
-  @Test // scenario 23 given system/open cache - does not set cache on system
+  @Test // scenario 18 given system/open cache - does not set cache on system
   public void createWithSystem_doesNotSetSystemCache_onGivenSystem_ifSystemCacheIsOpen_andExistingOk_butCacheIsNotCompatible() {
     InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
 
@@ -340,7 +341,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     verify(givenSystem, never()).setCache(any());
   }
 
-  @Test // scenario 24 - given system/open cache - returns singleton cache
+  @Test // scenario 19 - given system/open cache - returns singleton cache
   public void createWithSystem_returnsSystemCache_ifSystemCacheIsOpen_andExistingOk_andCacheIsCompatible() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache systemCache = systemCache(givenSystem, OPEN);
@@ -357,7 +358,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     assertThat(result).isSameAs(systemCache);
   }
 
-  @Test // scenario 24 - given system/open cache - sets cache on system
+  @Test // scenario 19 - given system/open cache - sets cache on system
   public void createWithSystem_setsSystemCache_onGivenSystem_ifSystemCacheIsOpen_andExistingOk_andCacheIsCompatible() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache systemCache = systemCache(givenSystem, OPEN);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
@@ -1,0 +1,463 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.internal.cache.InternalCacheBuilderAllowsMultipleSystemsTest.CacheState.CLOSED;
+import static org.apache.geode.internal.cache.InternalCacheBuilderAllowsMultipleSystemsTest.CacheState.OPEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.CacheExistsException;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.InternalCacheBuilder.InternalCacheConstructor;
+import org.apache.geode.internal.cache.InternalCacheBuilder.InternalDistributedSystemConstructor;
+
+public class InternalCacheBuilderAllowsMultipleSystemsTest {
+
+  private static final int ANY_SYSTEM_ID = 12;
+  private static final String ANY_MEMBER_NAME = "a-member-name";
+
+  private static final Supplier<InternalDistributedSystem> THROWING_SYSTEM_SUPPLIER =
+      () -> {
+        throw new AssertionError("throwing system supplier");
+      };
+  private static final Supplier<InternalCache> THROWING_CACHE_SUPPLIER =
+      () -> {
+        throw new AssertionError("throwing cache supplier");
+      };
+
+  private static final InternalDistributedSystemConstructor THROWING_SYSTEM_CONSTRUCTOR =
+      (a, b) -> {
+        throw new AssertionError("throwing system constructor");
+      };
+  private static final InternalCacheConstructor THROWING_CACHE_CONSTRUCTOR =
+      (a, b, c, d, e, f) -> {
+        throw new AssertionError("throwing cache constructor");
+      };
+
+  @Before
+  public void setUp() {
+    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = true;
+  }
+
+  @After
+  public void tearDown() {
+    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
+  }
+
+  @Test // null Properties
+  public void create_throwsNullPointerException_ifConfigPropertiesIsNull() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        null, new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, constructorOf(constructedSystem()),
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache()));
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .create());
+
+    assertThat(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test // null CacheConfig
+  public void create_throwsNullPointerException_andCacheConfigIsNull() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), null,
+        THROWING_SYSTEM_SUPPLIER, constructorOf(constructedSystem()),
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache()));
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .create());
+
+    assertThat(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test // scenario 13 - no system/no cache - constructs system
+  public void create_constructsSystem_withGivenProperties_ifNoSystemExists() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalDistributedSystemConstructor systemConstructor = constructorOf(constructedSystem());
+    Properties configProperties = new Properties();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        configProperties, new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, systemConstructor,
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache));
+
+    internalCacheBuilder.create();
+
+    verify(systemConstructor).construct(same(configProperties), any());
+  }
+
+  @Test // scenario 13 - no system/no cache - returns constructed cache
+  public void create_returnsConstructedCache_ifNoSystemExists() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, constructorOf(constructedSystem()),
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder.create();
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 13 - no system/no cache - sets cache on system
+  public void create_setsConstructedCache_onConstructedSystem_ifNoSystemExists() {
+    InternalDistributedSystem constructedSystem = constructedSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, constructorOf(constructedSystem),
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache));
+
+    internalCacheBuilder.create();
+
+    verify(constructedSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 13 - no system/no cache - sets system on cache
+  public void create_setsConstructedSystem_onConstructedCache_ifNoSystemExists() {
+    InternalDistributedSystem constructedSystem = constructedSystem();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache());
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, constructorOf(constructedSystem),
+        THROWING_CACHE_SUPPLIER, cacheConstructor);
+
+    internalCacheBuilder.create();
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(constructedSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 19 - given system/no cache - null system throws
+  public void createWithSystem_throwsNullPointerException_ifSystemIsNull() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder.create(null));
+
+    assertThat(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test // scenario 20 - given system/no cache - returns constructed cache
+  public void createWithSystem_returnsConstructedCache_ifSystemCacheDoesNotExist() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder
+        .create(givenSystem());
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 20 - given system/no cache - sets cache on system
+  public void createWithSystem_setsConstructedCache_onGivenSystem_ifSystemCacheDoesNotExist() {
+    InternalDistributedSystem givenSystem = givenSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache));
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(givenSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 20 - given system/no cache - sets system on cache
+  public void createWithSystem_setsGivenSystem_onConstructedCache_ifSystemCacheDoesNotExist() {
+    InternalDistributedSystem givenSystem = givenSystem();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache());
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, cacheConstructor);
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(givenSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 21 - given system/closed cache - returns constructed cache
+  public void createWithSystem_returnsConstructedCache_ifSystemCacheIsClosed() {
+    InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder
+        .create(givenSystem);
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 21 - given system/closed cache - sets cache on system
+  public void createWithSystem_setsConstructedCache_onGivenSystem_ifSystemCacheIsClosed() {
+    InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, constructorOf(constructedCache));
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(givenSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 21 - given system/closed cache - sets system on cache
+  public void createWithSystem_setsGivenSystem_onConstructedCache_ifSystemCacheIsClosed() {
+    InternalDistributedSystem givenSystem = givenSystemWithCache(CLOSED);
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache());
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, cacheConstructor);
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(givenSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 22 - given system/open cache - notExistingOk throws
+  public void createWithSystem_throwsCacheExistsException_ifSystemCacheIsOpen_butExistingNotOk() {
+    InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(false)
+        .create(givenSystem));
+
+    assertThat(thrown).isInstanceOf(CacheExistsException.class);
+  }
+
+  @Test // scenario 22 - given system/open cache - does not set cache on system
+  public void createWithSystem_doesNotSetSystemCache_onGivenSystem__ifSystemCacheIsOpen_butExistingNotOk() {
+    InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    ignoreThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(false)
+        .create(givenSystem));
+
+    verify(givenSystem, never()).setCache(any());
+  }
+
+  @Test // scenario 23 - given system/open cache - incompatible cache throws
+  public void createWithSystem_propagatesCacheConfigException_ifSystemCacheIsOpen_andExistingOk_butCacheIsIncompatible() {
+    InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
+
+    Throwable thrownByCacheConfig = new IllegalStateException("incompatible");
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), throwingCacheConfig(thrownByCacheConfig),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem));
+
+    assertThat(thrown).isSameAs(thrownByCacheConfig);
+  }
+
+  @Test // scenario 23 given system/open cache - does not set cache on system
+  public void createWithSystem_doesNotSetSystemCache_onGivenSystem_ifSystemCacheIsOpen_andExistingOk_butCacheIsNotCompatible() {
+    InternalDistributedSystem givenSystem = givenSystemWithCache(OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), throwingCacheConfig(new IllegalStateException("incompatible")),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    ignoreThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem));
+
+    verify(givenSystem, never()).setCache(any());
+  }
+
+  @Test // scenario 24 - given system/open cache - returns singleton cache
+  public void createWithSystem_returnsSystemCache_ifSystemCacheIsOpen_andExistingOk_andCacheIsCompatible() {
+    InternalDistributedSystem givenSystem = givenSystem();
+    InternalCache systemCache = systemCache(givenSystem, OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    InternalCache result = internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem);
+
+    assertThat(result).isSameAs(systemCache);
+  }
+
+  @Test // scenario 24 - given system/open cache - sets cache on system
+  public void createWithSystem_setsSystemCache_onGivenSystem_ifSystemCacheIsOpen_andExistingOk_andCacheIsCompatible() {
+    InternalDistributedSystem givenSystem = givenSystem();
+    InternalCache systemCache = systemCache(givenSystem, OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem);
+
+    verify(givenSystem).setCache(same(systemCache));
+  }
+
+  private InternalDistributedSystem constructedSystem() {
+    return systemWith("constructedSystem", ANY_SYSTEM_ID, ANY_MEMBER_NAME);
+  }
+
+  private InternalDistributedSystem givenSystem() {
+    return systemWith("givenSystem", ANY_SYSTEM_ID, ANY_MEMBER_NAME);
+  }
+
+  private InternalDistributedSystem systemWith(String mockName, int systemId, String memberName) {
+    InternalDistributedSystem system = mock(InternalDistributedSystem.class, mockName);
+    DistributionConfig distributionConfig = mock(DistributionConfig.class);
+    when(distributionConfig.getDistributedSystemId()).thenReturn(systemId);
+    when(system.getConfig()).thenReturn(distributionConfig);
+    when(system.getName()).thenReturn(memberName);
+    return system;
+  }
+
+  private InternalDistributedSystem givenSystemWithCache(CacheState state) {
+    InternalDistributedSystem system =
+        systemWith("givenSystemWithCache", ANY_SYSTEM_ID, ANY_MEMBER_NAME);
+    systemCache(system, state);
+    return system;
+  }
+
+  private static InternalCache constructedCache() {
+    return cache("constructedCache", OPEN);
+  }
+
+  private static InternalCache systemCache(InternalDistributedSystem givenSystem,
+      CacheState state) {
+    InternalCache cache = cache("systemCache", state);
+    when(givenSystem.getCache()).thenReturn(cache);
+    return cache;
+  }
+
+  private static InternalCache cache(String name, CacheState state) {
+    InternalCache cache = mock(InternalCache.class, name);
+    when(cache.isClosed()).thenReturn(state.isClosed());
+    doThrow(new CacheExistsException(cache, "cache exists"))
+        .when(cache).throwCacheExistsException();
+    return cache;
+  }
+
+  private static InternalDistributedSystemConstructor constructorOf(
+      InternalDistributedSystem constructedSystem) {
+    InternalDistributedSystemConstructor constructor =
+        mock(InternalDistributedSystemConstructor.class, "internal distributed system constructor");
+    when(constructor.construct(any(), any())).thenReturn(constructedSystem);
+    return constructor;
+  }
+
+  private static InternalCacheConstructor constructorOf(InternalCache constructedCache) {
+    InternalCacheConstructor constructor =
+        mock(InternalCacheConstructor.class, "internal cache constructor");
+    when(constructor.construct(anyBoolean(), any(), any(), any(), anyBoolean(), any()))
+        .thenReturn(constructedCache);
+    return constructor;
+  }
+
+  private static CacheConfig throwingCacheConfig(Throwable throwable) {
+    CacheConfig cacheConfig = mock(CacheConfig.class);
+    doThrow(throwable).when(cacheConfig).validateCacheConfig(any());
+    return cacheConfig;
+  }
+
+  private static void ignoreThrowable(ThrowableAssert.ThrowingCallable shouldRaiseThrowable) {
+    try {
+      shouldRaiseThrowable.call();
+    } catch (Throwable ignored) {
+    }
+  }
+
+  enum CacheState {
+    OPEN(false),
+    CLOSED(true);
+
+    private final boolean isClosed;
+
+    CacheState(boolean isClosed) {
+      this.isClosed = isClosed;
+    }
+
+    boolean isClosed() {
+      return isClosed;
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
@@ -1,0 +1,615 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.internal.cache.InternalCacheBuilderTest.CacheState.CLOSED;
+import static org.apache.geode.internal.cache.InternalCacheBuilderTest.CacheState.OPEN;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Properties;
+import java.util.function.Supplier;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import org.apache.geode.cache.CacheExistsException;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.InternalCacheBuilder.InternalCacheConstructor;
+import org.apache.geode.internal.cache.InternalCacheBuilder.InternalDistributedSystemConstructor;
+
+public class InternalCacheBuilderTest {
+
+  private static final int ANY_SYSTEM_ID = 12;
+  private static final String ANY_MEMBER_NAME = "a-member-name";
+
+  private static final Supplier<InternalDistributedSystem> THROWING_SYSTEM_SUPPLIER =
+      () -> {
+        throw new AssertionError("throwing system supplier");
+      };
+  private static final Supplier<InternalCache> THROWING_CACHE_SUPPLIER =
+      () -> {
+        throw new AssertionError("throwing cache supplier");
+      };
+
+  private static final InternalDistributedSystemConstructor THROWING_SYSTEM_CONSTRUCTOR =
+      (a, b) -> {
+        throw new AssertionError("throwing system constructor");
+      };
+  private static final InternalCacheConstructor THROWING_CACHE_CONSTRUCTOR =
+      (a, b, c, d, e, f) -> {
+        throw new AssertionError("throwing cache constructor");
+      };
+
+  @Mock
+  private Supplier<InternalDistributedSystem> nullSingletonSystemSupplier;
+
+  @Mock
+  private Supplier<InternalCache> nullSingletonCacheSupplier;
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+
+    when(nullSingletonSystemSupplier.get()).thenReturn(null);
+    when(nullSingletonCacheSupplier.get()).thenReturn(null);
+
+    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
+  }
+
+  @Test // null Properties
+  public void create_throwsNullPointerException_ifConfigPropertiesIsNull() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        null, new CacheConfig(),
+        nullSingletonSystemSupplier, constructorOf(constructedSystem()),
+        nullSingletonCacheSupplier, constructorOf(constructedCache()));
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .create());
+
+    assertThat(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test // null CacheConfig
+  public void create_throwsNullPointerException_andCacheConfigIsNull() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), null,
+        nullSingletonSystemSupplier, constructorOf(constructedSystem()),
+        nullSingletonCacheSupplier, constructorOf(constructedCache()));
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .create());
+
+    assertThat(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test // scenario 1 - no system/no cache - constructs system
+  public void create_constructsSystem_withGivenProperties_ifNoSystemExists_andNoCacheExists() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalDistributedSystemConstructor systemConstructor = constructorOf(constructedSystem());
+    Properties configProperties = new Properties();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        configProperties, new CacheConfig(),
+        nullSingletonSystemSupplier, systemConstructor,
+        nullSingletonCacheSupplier, constructorOf(constructedCache));
+
+    internalCacheBuilder
+        .create();
+
+    verify(systemConstructor).construct(same(configProperties), any());
+  }
+
+  @Test // scenario 1 - no system/no cache - returns constructed cache
+  public void create_returnsConstructedCache_ifNoSystemExists() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        nullSingletonSystemSupplier, constructorOf(constructedSystem()),
+        nullSingletonCacheSupplier, constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder
+        .create();
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 1 - no system/no cache - sets cache on system
+  public void create_setsConstructedCache_onConstructedSystem_ifNoSystemExists() {
+    InternalDistributedSystem constructedSystem = constructedSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        nullSingletonSystemSupplier, constructorOf(constructedSystem),
+        nullSingletonCacheSupplier, constructorOf(constructedCache));
+
+    internalCacheBuilder
+        .create();
+
+    verify(constructedSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 1 - no system/no cache - sets system on cache
+  public void create_setsConstructedSystem_onConstructedCache_ifNoSystemExists_() {
+    InternalDistributedSystem constructedSystem = constructedSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        nullSingletonSystemSupplier, constructorOf(constructedSystem),
+        nullSingletonCacheSupplier, cacheConstructor);
+
+    internalCacheBuilder
+        .create();
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(constructedSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 2 - system/no cache - returns constructed cache
+  public void create_returnsConstructedCache_ifSingletonSystemExists_andNoCacheExists() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem()), THROWING_SYSTEM_CONSTRUCTOR,
+        nullSingletonCacheSupplier, constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder
+        .create();
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 2 - system/no cache - sets cache on system
+  public void create_setsSingletonSystem_onConstructedCache_ifSingletonSystemExists_andNoCacheExists() {
+    InternalDistributedSystem singletonSystem = singletonSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem), THROWING_SYSTEM_CONSTRUCTOR,
+        nullSingletonCacheSupplier, cacheConstructor);
+
+    internalCacheBuilder
+        .create();
+
+    verify(singletonSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 2 - system/no cache - sets system on cache
+  public void create_setsConstructedCache_onSingletonSystem_ifSingletonSystemExists_andNoCacheExists() {
+    InternalDistributedSystem singletonSystem = singletonSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem), THROWING_SYSTEM_CONSTRUCTOR,
+        nullSingletonCacheSupplier, cacheConstructor);
+
+    internalCacheBuilder
+        .create();
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(singletonSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 3 - system/closed cache - returns constructed cache
+  public void create_returnsConstructedCache_ifSingletonSystemExists_andSingletonCacheIsClosed() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem()), THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(CLOSED)), constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder
+        .create();
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 3 - system/closed cache - sets cache on system
+  public void create_setsConstructedCache_onSingletonSystem_ifSingletonSystemExists_andSingletonCacheIsClosed() {
+    InternalDistributedSystem singletonSystem = singletonSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem), THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(CLOSED)), constructorOf(constructedCache));
+
+    internalCacheBuilder
+        .create();
+
+    verify(singletonSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 3 - system/closed cache - sets system on cache
+  public void create_setsSingletonSystem_onConstructedCache_ifSingletonSystemExists_andSingletonCacheIsClosed() {
+    InternalDistributedSystem singletonSystem = singletonSystem();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache());
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem), THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(CLOSED)), cacheConstructor);
+
+    internalCacheBuilder
+        .create();
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(singletonSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 4 - system/open cache - notExistingOk throws
+  public void create_throwsCacheExistsException_ifSingletonSystemExists_andSingletonCacheIsOpen_butExistingIsNotOk() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem()), THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(OPEN)), THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(false)
+        .create());
+
+    assertThat(thrown).isInstanceOf(CacheExistsException.class);
+  }
+
+  @Test // scenario 5 - system/open cache - incompatible cache throws
+  public void create_propagatesCacheConfigException_ifSingletonSystemExists_andSingletonCacheIsOpen_andExistingIsOk_butCacheIsIncompatible() {
+    Throwable thrownByCacheConfig = new IllegalStateException("incompatible");
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), throwingCacheConfig(thrownByCacheConfig),
+        supplierOf(singletonSystem()), THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(OPEN)), THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(true)
+        .create());
+
+    assertThat(thrown).isSameAs(thrownByCacheConfig);
+  }
+
+  @Test // scenario 6 - system/open cache - returns singleton cache
+  public void create_returnsSingletonCache_ifSingletonCacheIsOpen() {
+    InternalCache singletonCache = singletonCache(OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        supplierOf(singletonSystem()), THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache), THROWING_CACHE_CONSTRUCTOR);
+
+    InternalCache result = internalCacheBuilder
+        .create();
+
+    assertThat(result).isSameAs(singletonCache);
+  }
+
+  @Test // scenario 7 - given system/no cache - null system throws
+  public void createWithSystem_throwsNullPointerException_ifSystemIsNull() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        THROWING_CACHE_SUPPLIER, THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .create(null));
+
+    assertThat(thrown).isInstanceOf(NullPointerException.class);
+  }
+
+  @Test // scenario 8 - given system/no cache - returns constructed cache
+  public void createWithSystem_returnsConstructedCache_ifNoCacheExists() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        nullSingletonCacheSupplier, constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder
+        .create(givenSystem());
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 8 - given system/no cache - sets cache on system
+  public void createWithSystem_setsConstructedCache_onGivenSystem_ifNoCacheExists() {
+    InternalDistributedSystem givenSystem = givenSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        nullSingletonCacheSupplier, constructorOf(constructedCache));
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(givenSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 8 - given system/no cache - sets system on cache
+  public void createWithSystem_setsGivenSystem_onConstructedCache_ifNoCacheExists() {
+    InternalDistributedSystem givenSystem = givenSystem();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache());
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        nullSingletonCacheSupplier, cacheConstructor);
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(givenSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 9 - given system/closed cache - returns constructed cache
+  public void createWithSystem_returnsConstructedCache_ifSingletonCacheIsClosed() {
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(CLOSED)), constructorOf(constructedCache));
+
+    InternalCache result = internalCacheBuilder
+        .create(givenSystem());
+
+    assertThat(result).isSameAs(constructedCache);
+  }
+
+  @Test // scenario 9 - given system/closed cache - sets cache on system
+  public void createWithSystem_setsConstructedCache_onGivenSystem_ifSingletonCacheIsClosed() {
+    InternalDistributedSystem givenSystem = givenSystem();
+    InternalCache constructedCache = constructedCache();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(CLOSED)), constructorOf(constructedCache));
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(givenSystem).setCache(same(constructedCache));
+  }
+
+  @Test // scenario 9 - given system/closed cache - sets system on cache
+  public void createWithSystem_setsGivenSystem_onConstructedCache_ifSingletonCacheIsClosed() {
+    InternalDistributedSystem givenSystem = givenSystem();
+
+    InternalCacheConstructor cacheConstructor = constructorOf(constructedCache());
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(CLOSED)), cacheConstructor);
+
+    internalCacheBuilder
+        .create(givenSystem);
+
+    verify(cacheConstructor).construct(anyBoolean(), any(), same(givenSystem), any(),
+        anyBoolean(), any());
+  }
+
+  @Test // scenario 10 - given system/open cache - notExistingOk throws
+  public void createWithSystem_throwsCacheExistsException_ifSingletonCacheIsOpen_butExistingIsNotOk() {
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(OPEN)), THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(false)
+        .create(givenSystem()));
+
+    assertThat(thrown).isInstanceOf(CacheExistsException.class);
+  }
+
+  @Test // scenario 10 - given system/open cache - does not set cache on system
+  public void createWithSystem_doesNotSetSingletonCache_onGivenSystem_ifSingletonCacheIsOpen_butExistingIsNotOk() {
+    InternalDistributedSystem givenSystem = givenSystem();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(OPEN)), THROWING_CACHE_CONSTRUCTOR);
+
+    ignoreThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(false)
+        .create(givenSystem));
+
+    verify(givenSystem, never()).setCache(any());
+  }
+
+  @Test // scenario 11 - given system/open cache - incompatible cache throws
+  public void createWithSystem_propagatesCacheConfigException_ifSingletonCacheIsOpen_andExistingIsOk_butCacheIsIncompatible() {
+    Throwable thrownByCacheConfig = new IllegalStateException("incompatible");
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), throwingCacheConfig(thrownByCacheConfig),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(OPEN)), THROWING_CACHE_CONSTRUCTOR);
+
+    Throwable thrown = catchThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem()));
+
+    assertThat(thrown).isSameAs(thrownByCacheConfig);
+  }
+
+  @Test // scenario 11 given system/open cache - does not set cache on system
+  public void createWithSystem_doesNotSetSingletonCache_onGivenSystem_ifSingletonCacheIsOpen_andExistingIsOk_butCacheIsNotCompatible() {
+    InternalDistributedSystem givenSystem = givenSystem();
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), throwingCacheConfig(new IllegalStateException("incompatible")),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache(OPEN)), THROWING_CACHE_CONSTRUCTOR);
+
+    ignoreThrowable(() -> internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem));
+
+    verifyZeroInteractions(givenSystem);
+  }
+
+  @Test // scenario 12 - given system/open cache - returns singleton cache
+  public void createWithSystem_returnsSingletonCache_ifSingletonCacheIsOpen_andExistingIsOk_andCacheIsCompatible() {
+    InternalCache singletonCache = singletonCache(OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache), THROWING_CACHE_CONSTRUCTOR);
+
+    InternalCache result = internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem());
+
+    assertThat(result).isSameAs(singletonCache);
+  }
+
+  @Test // scenario 12 - given system/open cache - sets cache on system
+  public void createWithSystem_setsSingletonCache_onGivenSystem_ifSingletonCacheIsOpen_andExistingIsOk_andCacheIsCompatible() {
+    InternalDistributedSystem givenSystem = givenSystem();
+    InternalCache singletonCache = singletonCache(OPEN);
+
+    InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
+        new Properties(), new CacheConfig(),
+        THROWING_SYSTEM_SUPPLIER, THROWING_SYSTEM_CONSTRUCTOR,
+        supplierOf(singletonCache), THROWING_CACHE_CONSTRUCTOR);
+
+    internalCacheBuilder
+        .setIsExistingOk(true)
+        .create(givenSystem);
+
+    verify(givenSystem).setCache(same(singletonCache));
+  }
+
+  private InternalDistributedSystem constructedSystem() {
+    return systemWith("constructedSystem", ANY_SYSTEM_ID, ANY_MEMBER_NAME);
+  }
+
+  private InternalDistributedSystem givenSystem() {
+    return systemWith("givenSystem", ANY_SYSTEM_ID, ANY_MEMBER_NAME);
+  }
+
+  private InternalDistributedSystem singletonSystem() {
+    return systemWith("singletonSystem", ANY_SYSTEM_ID, ANY_MEMBER_NAME);
+  }
+
+  private InternalDistributedSystem systemWith(String mockName, int systemId, String memberName) {
+    InternalDistributedSystem system = mock(InternalDistributedSystem.class, mockName);
+    DistributionConfig distributionConfig = mock(DistributionConfig.class);
+    when(distributionConfig.getDistributedSystemId()).thenReturn(systemId);
+    when(system.getConfig()).thenReturn(distributionConfig);
+    when(system.getName()).thenReturn(memberName);
+    return system;
+  }
+
+  private static InternalCache constructedCache() {
+    return cache("constructedCache", OPEN);
+  }
+
+  private static InternalCache singletonCache(CacheState state) {
+    return cache("singletonCache", state);
+  }
+
+  private static InternalCache cache(String name, CacheState state) {
+    InternalCache cache = mock(InternalCache.class, name);
+    when(cache.isClosed()).thenReturn(state.isClosed());
+    doThrow(new CacheExistsException(cache, "cache exists"))
+        .when(cache).throwCacheExistsException();
+    return cache;
+  }
+
+  private static InternalDistributedSystemConstructor constructorOf(
+      InternalDistributedSystem constructedSystem) {
+    InternalDistributedSystemConstructor constructor =
+        mock(InternalDistributedSystemConstructor.class, "internal distributed system constructor");
+    when(constructor.construct(any(), any())).thenReturn(constructedSystem);
+    return constructor;
+  }
+
+  private static InternalCacheConstructor constructorOf(InternalCache constructedCache) {
+    InternalCacheConstructor constructor =
+        mock(InternalCacheConstructor.class, "internal cache constructor");
+    when(constructor.construct(anyBoolean(), any(), any(), any(), anyBoolean(), any()))
+        .thenReturn(constructedCache);
+    return constructor;
+  }
+
+  private static <T> Supplier<T> supplierOf(T instance) {
+    return () -> instance;
+  }
+
+  private static CacheConfig throwingCacheConfig(Throwable throwable) {
+    CacheConfig cacheConfig = mock(CacheConfig.class);
+    doThrow(throwable).when(cacheConfig).validateCacheConfig(any());
+    return cacheConfig;
+  }
+
+  private static void ignoreThrowable(ThrowingCallable shouldRaiseThrowable) {
+    try {
+      shouldRaiseThrowable.call();
+    } catch (Throwable ignored) {
+    }
+  }
+
+  enum CacheState {
+    OPEN(false),
+    CLOSED(true);
+
+    private final boolean isClosed;
+
+    CacheState(boolean isClosed) {
+      this.isClosed = isClosed;
+    }
+
+    boolean isClosed() {
+      return isClosed;
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
@@ -43,6 +43,9 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalCacheConstructor;
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalDistributedSystemConstructor;
 
+/**
+ * Unit tests for {@link InternalCacheBuilder}.
+ */
 public class InternalCacheBuilderTest {
 
   private static final int ANY_SYSTEM_ID = 12;
@@ -82,7 +85,7 @@ public class InternalCacheBuilderTest {
     InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
   }
 
-  @Test // null Properties
+  @Test
   public void create_throwsNullPointerException_ifConfigPropertiesIsNull() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         null, new CacheConfig(),
@@ -95,7 +98,7 @@ public class InternalCacheBuilderTest {
     assertThat(thrown).isInstanceOf(NullPointerException.class);
   }
 
-  @Test // null CacheConfig
+  @Test
   public void create_throwsNullPointerException_andCacheConfigIsNull() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         new Properties(), null,
@@ -108,7 +111,7 @@ public class InternalCacheBuilderTest {
     assertThat(thrown).isInstanceOf(NullPointerException.class);
   }
 
-  @Test // scenario 1 - no system/no cache - constructs system
+  @Test
   public void create_constructsSystem_withGivenProperties_ifNoSystemExists_andNoCacheExists() {
     InternalCache constructedCache = constructedCache();
 
@@ -126,7 +129,7 @@ public class InternalCacheBuilderTest {
     verify(systemConstructor).construct(same(configProperties), any());
   }
 
-  @Test // scenario 1 - no system/no cache - returns constructed cache
+  @Test
   public void create_returnsConstructedCache_ifNoSystemExists() {
     InternalCache constructedCache = constructedCache();
 
@@ -141,7 +144,7 @@ public class InternalCacheBuilderTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 1 - no system/no cache - sets cache on system
+  @Test
   public void create_setsConstructedCache_onConstructedSystem_ifNoSystemExists() {
     InternalDistributedSystem constructedSystem = constructedSystem();
     InternalCache constructedCache = constructedCache();
@@ -157,7 +160,7 @@ public class InternalCacheBuilderTest {
     verify(constructedSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 1 - no system/no cache - sets system on cache
+  @Test
   public void create_setsConstructedSystem_onConstructedCache_ifNoSystemExists_() {
     InternalDistributedSystem constructedSystem = constructedSystem();
     InternalCache constructedCache = constructedCache();
@@ -176,7 +179,7 @@ public class InternalCacheBuilderTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 2 - system/no cache - returns constructed cache
+  @Test
   public void create_returnsConstructedCache_ifSingletonSystemExists_andNoCacheExists() {
     InternalCache constructedCache = constructedCache();
 
@@ -191,7 +194,7 @@ public class InternalCacheBuilderTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 2 - system/no cache - sets cache on system
+  @Test
   public void create_setsSingletonSystem_onConstructedCache_ifSingletonSystemExists_andNoCacheExists() {
     InternalDistributedSystem singletonSystem = singletonSystem();
     InternalCache constructedCache = constructedCache();
@@ -209,7 +212,7 @@ public class InternalCacheBuilderTest {
     verify(singletonSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 2 - system/no cache - sets system on cache
+  @Test
   public void create_setsConstructedCache_onSingletonSystem_ifSingletonSystemExists_andNoCacheExists() {
     InternalDistributedSystem singletonSystem = singletonSystem();
     InternalCache constructedCache = constructedCache();
@@ -228,7 +231,7 @@ public class InternalCacheBuilderTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 3 - system/closed cache - returns constructed cache
+  @Test
   public void create_returnsConstructedCache_ifSingletonSystemExists_andSingletonCacheIsClosed() {
     InternalCache constructedCache = constructedCache();
 
@@ -243,7 +246,7 @@ public class InternalCacheBuilderTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 3 - system/closed cache - sets cache on system
+  @Test
   public void create_setsConstructedCache_onSingletonSystem_ifSingletonSystemExists_andSingletonCacheIsClosed() {
     InternalDistributedSystem singletonSystem = singletonSystem();
     InternalCache constructedCache = constructedCache();
@@ -259,7 +262,7 @@ public class InternalCacheBuilderTest {
     verify(singletonSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 3 - system/closed cache - sets system on cache
+  @Test
   public void create_setsSingletonSystem_onConstructedCache_ifSingletonSystemExists_andSingletonCacheIsClosed() {
     InternalDistributedSystem singletonSystem = singletonSystem();
 
@@ -277,7 +280,7 @@ public class InternalCacheBuilderTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 4 - system/open cache - notExistingOk throws
+  @Test
   public void create_throwsCacheExistsException_ifSingletonSystemExists_andSingletonCacheIsOpen_butExistingIsNotOk() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         new Properties(), new CacheConfig(),
@@ -291,7 +294,7 @@ public class InternalCacheBuilderTest {
     assertThat(thrown).isInstanceOf(CacheExistsException.class);
   }
 
-  @Test // scenario 5 - system/open cache - incompatible cache throws
+  @Test
   public void create_propagatesCacheConfigException_ifSingletonSystemExists_andSingletonCacheIsOpen_andExistingIsOk_butCacheIsIncompatible() {
     Throwable thrownByCacheConfig = new IllegalStateException("incompatible");
 
@@ -307,7 +310,7 @@ public class InternalCacheBuilderTest {
     assertThat(thrown).isSameAs(thrownByCacheConfig);
   }
 
-  @Test // scenario 6 - system/open cache - returns singleton cache
+  @Test
   public void create_returnsSingletonCache_ifSingletonCacheIsOpen() {
     InternalCache singletonCache = singletonCache(OPEN);
 
@@ -322,7 +325,7 @@ public class InternalCacheBuilderTest {
     assertThat(result).isSameAs(singletonCache);
   }
 
-  @Test // scenario 7 - given system/no cache - null system throws
+  @Test
   public void createWithSystem_throwsNullPointerException_ifSystemIsNull() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         new Properties(), new CacheConfig(),
@@ -335,7 +338,7 @@ public class InternalCacheBuilderTest {
     assertThat(thrown).isInstanceOf(NullPointerException.class);
   }
 
-  @Test // scenario 8 - given system/no cache - returns constructed cache
+  @Test
   public void createWithSystem_returnsConstructedCache_ifNoCacheExists() {
     InternalCache constructedCache = constructedCache();
 
@@ -350,7 +353,7 @@ public class InternalCacheBuilderTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 8 - given system/no cache - sets cache on system
+  @Test
   public void createWithSystem_setsConstructedCache_onGivenSystem_ifNoCacheExists() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache constructedCache = constructedCache();
@@ -366,7 +369,7 @@ public class InternalCacheBuilderTest {
     verify(givenSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 8 - given system/no cache - sets system on cache
+  @Test
   public void createWithSystem_setsGivenSystem_onConstructedCache_ifNoCacheExists() {
     InternalDistributedSystem givenSystem = givenSystem();
 
@@ -384,7 +387,7 @@ public class InternalCacheBuilderTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 9 - given system/closed cache - returns constructed cache
+  @Test
   public void createWithSystem_returnsConstructedCache_ifSingletonCacheIsClosed() {
     InternalCache constructedCache = constructedCache();
 
@@ -399,7 +402,7 @@ public class InternalCacheBuilderTest {
     assertThat(result).isSameAs(constructedCache);
   }
 
-  @Test // scenario 9 - given system/closed cache - sets cache on system
+  @Test
   public void createWithSystem_setsConstructedCache_onGivenSystem_ifSingletonCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache constructedCache = constructedCache();
@@ -415,7 +418,7 @@ public class InternalCacheBuilderTest {
     verify(givenSystem).setCache(same(constructedCache));
   }
 
-  @Test // scenario 9 - given system/closed cache - sets system on cache
+  @Test
   public void createWithSystem_setsGivenSystem_onConstructedCache_ifSingletonCacheIsClosed() {
     InternalDistributedSystem givenSystem = givenSystem();
 
@@ -433,7 +436,7 @@ public class InternalCacheBuilderTest {
         anyBoolean(), any());
   }
 
-  @Test // scenario 10 - given system/open cache - notExistingOk throws
+  @Test
   public void createWithSystem_throwsCacheExistsException_ifSingletonCacheIsOpen_butExistingIsNotOk() {
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
         new Properties(), new CacheConfig(),
@@ -447,7 +450,7 @@ public class InternalCacheBuilderTest {
     assertThat(thrown).isInstanceOf(CacheExistsException.class);
   }
 
-  @Test // scenario 10 - given system/open cache - does not set cache on system
+  @Test
   public void createWithSystem_doesNotSetSingletonCache_onGivenSystem_ifSingletonCacheIsOpen_butExistingIsNotOk() {
     InternalDistributedSystem givenSystem = givenSystem();
 
@@ -463,7 +466,7 @@ public class InternalCacheBuilderTest {
     verify(givenSystem, never()).setCache(any());
   }
 
-  @Test // scenario 11 - given system/open cache - incompatible cache throws
+  @Test
   public void createWithSystem_propagatesCacheConfigException_ifSingletonCacheIsOpen_andExistingIsOk_butCacheIsIncompatible() {
     Throwable thrownByCacheConfig = new IllegalStateException("incompatible");
 
@@ -479,7 +482,7 @@ public class InternalCacheBuilderTest {
     assertThat(thrown).isSameAs(thrownByCacheConfig);
   }
 
-  @Test // scenario 11 given system/open cache - does not set cache on system
+  @Test
   public void createWithSystem_doesNotSetSingletonCache_onGivenSystem_ifSingletonCacheIsOpen_andExistingIsOk_butCacheIsNotCompatible() {
     InternalDistributedSystem givenSystem = givenSystem();
 
@@ -495,7 +498,7 @@ public class InternalCacheBuilderTest {
     verifyZeroInteractions(givenSystem);
   }
 
-  @Test // scenario 12 - given system/open cache - returns singleton cache
+  @Test
   public void createWithSystem_returnsSingletonCache_ifSingletonCacheIsOpen_andExistingIsOk_andCacheIsCompatible() {
     InternalCache singletonCache = singletonCache(OPEN);
 
@@ -511,7 +514,7 @@ public class InternalCacheBuilderTest {
     assertThat(result).isSameAs(singletonCache);
   }
 
-  @Test // scenario 12 - given system/open cache - sets cache on system
+  @Test
   public void createWithSystem_setsSingletonCache_onGivenSystem_ifSingletonCacheIsOpen_andExistingIsOk_andCacheIsCompatible() {
     InternalDistributedSystem givenSystem = givenSystem();
     InternalCache singletonCache = singletonCache(OPEN);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -132,11 +132,11 @@ import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.cache.BucketRegion;
-import org.apache.geode.internal.cache.CacheConfig;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.CustomerIDPartitionResolver;
 import org.apache.geode.internal.cache.ForceReattemptException;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCacheBuilder;
 import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.RegionQueue;
@@ -983,10 +983,12 @@ public class WANTestBase extends DistributedTestCase {
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "localhost[" + locPort + "]");
     InternalDistributedSystem ds = test.getSystem(props);
-    CacheConfig cacheConfig = new CacheConfig();
-    cacheConfig.setPdxPersistent(true);
-    cacheConfig.setPdxDiskStore("PDX_TEST");
-    cache = GemFireCacheImpl.create(ds, false, cacheConfig);
+
+    cache = new InternalCacheBuilder(props)
+        .setPdxPersistent(true)
+        .setPdxDiskStore("PDX_TEST")
+        .setIsExistingOk(false)
+        .create(ds);
 
     File pdxDir = new File(CacheTestCase.getDiskDir(), "pdx");
     DiskStoreFactory dsf = cache.createDiskStoreFactory();
@@ -2169,11 +2171,14 @@ public class WANTestBase extends DistributedTestCase {
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "localhost[" + locPort + "]");
     InternalDistributedSystem ds = test.getSystem(props);
-    CacheConfig cacheConfig = new CacheConfig();
     File pdxDir = new File(CacheTestCase.getDiskDir(), "pdx");
-    cacheConfig.setPdxPersistent(true);
-    cacheConfig.setPdxDiskStore("pdxStore");
-    cache = GemFireCacheImpl.create(ds, false, cacheConfig);
+
+    cache = new InternalCacheBuilder(props)
+        .setPdxPersistent(true)
+        .setPdxDiskStore("pdxStore")
+        .setIsExistingOk(false)
+        .create(ds);
+
     cache.createDiskStoreFactory().setDiskDirs(new File[] {pdxDir}).setMaxOplogSize(1)
         .create("pdxStore");
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();


### PR DESCRIPTION
All code (product and tests) now use InternalCacheBuilder to construct
instances of GemFireCacheImpl.

CacheFactory now delegates to InternalCacheBuilder which adds a few
more internal options that are not exposed on CacheFactory.

Co-authored-by: Dale Emery <demery@pivotal.io>

InternalCacheBuilder is necessary so we can create Micrometer MeterRegistry
in one place for all instances of GemFireCacheImpl.

@demery-pivotal 