### PR TITLE
GEODE-6033: Support dynamic VMs in DistributedUseJacksonForJsonPathRule

### DIFF
--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedUseJacksonForJsonPathRuleDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedUseJacksonForJsonPathRuleDistributedTest.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.rules.tests;
+
+import static org.apache.geode.test.dunit.VM.getAllVMs;
+import static org.apache.geode.test.dunit.VM.getController;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.VM.getVMCount;
+import static org.apache.geode.test.dunit.VM.toArray;
+import static org.apache.geode.test.junit.runners.TestRunner.runTestWithValidation;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.dunit.rules.DistributedUseJacksonForJsonPathRule;
+
+/**
+ * Distributed tests for {@link DistributedUseJacksonForJsonPathRule}.
+ */
+@SuppressWarnings("serial")
+public class DistributedUseJacksonForJsonPathRuleDistributedTest implements Serializable {
+
+  private static final Map<VM, String> jsonProviderMap = new ConcurrentHashMap<>();
+  private static final Map<VM, String> mappingProviderMap = new ConcurrentHashMap<>();
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  private String defaultJsonProvider;
+  private String defaultMappingProvider;
+  private int initialVmCount;
+
+  @Before
+  public void setUp() {
+    Configuration config = Configuration.defaultConfiguration();
+    defaultJsonProvider = config.jsonProvider().getClass().getName();
+    defaultMappingProvider = config.mappingProvider().getClass().getName();
+    initialVmCount = getVMCount();
+  }
+
+  @After
+  public void tearDown() {
+    jsonProviderMap.clear();
+    mappingProviderMap.clear();
+  }
+
+  @Test
+  public void setsJsonProviderToJacksonJsonProviderBeforeTest() {
+    runTestWithValidation(CaptureJsonProvider.class);
+
+    for (VM vm : toArray(getAllVMs(), getController())) {
+      assertThat(jsonProviderMap.get(vm)).isEqualTo(JacksonJsonProvider.class.getName());
+    }
+  }
+
+  @Test
+  public void setsMappingProviderToJacksonMappingProviderBeforeTest() {
+    runTestWithValidation(CaptureMappingProvider.class);
+
+    for (VM vm : toArray(getAllVMs(), getController())) {
+      assertThat(mappingProviderMap.get(vm)).isEqualTo(JacksonMappingProvider.class.getName());
+    }
+  }
+
+  @Test
+  public void restoresJsonProviderToDefaultAfterTest() {
+    runTestWithValidation(HasUseJacksonForJsonPathRule.class);
+
+    for (VM vm : toArray(getAllVMs(), getController())) {
+      vm.invoke(() -> {
+        Configuration config = Configuration.defaultConfiguration();
+        assertThat(config.jsonProvider().getClass().getName()).isEqualTo(defaultJsonProvider);
+      });
+    }
+  }
+
+  @Test
+  public void restoresMappingProviderToDefaultAfterTest() {
+    runTestWithValidation(HasUseJacksonForJsonPathRule.class);
+
+    for (VM vm : toArray(getAllVMs(), getController())) {
+      vm.invoke(() -> {
+        Configuration config = Configuration.defaultConfiguration();
+        assertThat(config.mappingProvider().getClass().getName()).isEqualTo(defaultMappingProvider);
+      });
+    }
+  }
+
+  @Test
+  public void setsJsonProviderToJacksonJsonProviderBeforeTest_inNewVm() {
+    runTestWithValidation(CaptureJsonProviderInNewVm.class);
+
+    VM newVM = getVM(initialVmCount);
+    assertThat(jsonProviderMap.get(newVM)).isEqualTo(JacksonJsonProvider.class.getName());
+  }
+
+  @Test
+  public void setsMappingProviderToJacksonMappingProviderBeforeTest_inNewVm() {
+    runTestWithValidation(CaptureMappingProviderInNewVm.class);
+
+    VM newVM = getVM(initialVmCount);
+    assertThat(mappingProviderMap.get(newVM)).isEqualTo(JacksonMappingProvider.class.getName());
+  }
+
+  @Test
+  public void restoresJsonProviderToDefaultAfterTest_inNewVm() {
+    runTestWithValidation(UseJacksonForJsonPathRuleWithNewVm.class);
+
+    VM newVM = getVM(initialVmCount);
+    newVM.invoke(() -> {
+      Configuration config = Configuration.defaultConfiguration();
+      assertThat(config.jsonProvider().getClass().getName()).isEqualTo(defaultJsonProvider);
+    });
+  }
+
+  @Test
+  public void restoresMappingProviderToDefaultAfterTest_inNewVm() {
+    runTestWithValidation(UseJacksonForJsonPathRuleWithNewVm.class);
+
+    VM newVM = getVM(initialVmCount);
+    newVM.invoke(() -> {
+      Configuration config = Configuration.defaultConfiguration();
+      assertThat(config.mappingProvider().getClass().getName()).isEqualTo(defaultMappingProvider);
+    });
+  }
+
+  @Test
+  public void setsJsonProviderToJacksonJsonProviderBeforeTest_inBouncedVm() {
+    runTestWithValidation(CaptureJsonProviderInBouncedVm.class);
+
+    VM bouncedVM = getVM(0);
+    assertThat(jsonProviderMap.get(bouncedVM)).isEqualTo(JacksonJsonProvider.class.getName());
+  }
+
+  @Test
+  public void setsMappingProviderToJacksonMappingProviderBeforeTest_inBouncedVm() {
+    runTestWithValidation(CaptureMappingProviderInBouncedVm.class);
+
+    VM bouncedVM = getVM(0);
+    assertThat(mappingProviderMap.get(bouncedVM)).isEqualTo(JacksonMappingProvider.class.getName());
+  }
+
+  @Test
+  public void restoresJsonProviderToDefaultAfterTest_inBouncedVm() {
+    runTestWithValidation(UseJacksonForJsonPathRuleWithBouncedVm.class);
+
+    VM bouncedVM = getVM(0);
+    bouncedVM.invoke(() -> {
+      Configuration config = Configuration.defaultConfiguration();
+      assertThat(config.jsonProvider().getClass().getName()).isEqualTo(defaultJsonProvider);
+    });
+  }
+
+  @Test
+  public void restoresMappingProviderToDefaultAfterTest_inBouncedVm() {
+    runTestWithValidation(UseJacksonForJsonPathRuleWithBouncedVm.class);
+
+    VM bouncedVM = getVM(0);
+    bouncedVM.invoke(() -> {
+      Configuration config = Configuration.defaultConfiguration();
+      assertThat(config.mappingProvider().getClass().getName()).isEqualTo(defaultMappingProvider);
+    });
+  }
+
+  public static class HasUseJacksonForJsonPathRule implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void doNothing() {
+      assertThat(useJacksonForJsonPathRule).isNotNull();
+    }
+  }
+
+  public static class CaptureJsonProvider implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void captureJsonProvider() {
+      for (VM vm : toArray(getAllVMs(), getController())) {
+        Class<? extends JsonProvider> jsonProviderClass = vm.invoke(() -> {
+          Configuration config = Configuration.defaultConfiguration();
+          return config.jsonProvider().getClass();
+        });
+        assertThat(jsonProviderClass).isNotNull();
+        jsonProviderMap.put(vm, jsonProviderClass.getName());
+      }
+    }
+  }
+
+  public static class CaptureMappingProvider implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void captureMappingProvider() {
+      for (VM vm : toArray(getAllVMs(), getController())) {
+        Class<? extends MappingProvider> mappingProviderClass = vm.invoke(() -> {
+          Configuration config = Configuration.defaultConfiguration();
+          return config.mappingProvider().getClass();
+        });
+        assertThat(mappingProviderClass).isNotNull();
+        mappingProviderMap.put(vm, mappingProviderClass.getName());
+      }
+    }
+  }
+
+  public static class CaptureJsonProviderInNewVm implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void captureJsonProviderInNewVm() {
+      VM newVM = getVM(getVMCount());
+      Class<? extends JsonProvider> jsonProviderClass = newVM.invoke(() -> {
+        Configuration config = Configuration.defaultConfiguration();
+        return config.jsonProvider().getClass();
+      });
+      assertThat(jsonProviderClass).isNotNull();
+      jsonProviderMap.put(newVM, jsonProviderClass.getName());
+    }
+  }
+
+  public static class CaptureMappingProviderInNewVm implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void captureMappingProviderInNewVm() {
+      VM newVM = getVM(getVMCount());
+      Class<? extends MappingProvider> mappingProviderClass = newVM.invoke(() -> {
+        Configuration config = Configuration.defaultConfiguration();
+        return config.mappingProvider().getClass();
+      });
+      assertThat(mappingProviderClass).isNotNull();
+      mappingProviderMap.put(newVM, mappingProviderClass.getName());
+    }
+  }
+
+  public static class UseJacksonForJsonPathRuleWithNewVm implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void getNewVm() {
+      getVM(getVMCount());
+    }
+  }
+
+  public static class CaptureJsonProviderInBouncedVm implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void captureJsonProviderInBouncedVm() {
+      VM vm = getVM(0);
+      vm.bounce();
+      Class<? extends JsonProvider> jsonProviderClass = vm.invoke(() -> {
+        Configuration config = Configuration.defaultConfiguration();
+        return config.jsonProvider().getClass();
+      });
+      assertThat(jsonProviderClass).isNotNull();
+      jsonProviderMap.put(vm, jsonProviderClass.getName());
+    }
+  }
+
+  public static class CaptureMappingProviderInBouncedVm implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void captureMappingProviderInBouncedVm() {
+      VM vm = getVM(0);
+      vm.bounce();
+      Class<? extends MappingProvider> mappingProviderClass = vm.invoke(() -> {
+        Configuration config = Configuration.defaultConfiguration();
+        return config.mappingProvider().getClass();
+      });
+      assertThat(mappingProviderClass).isNotNull();
+      mappingProviderMap.put(vm, mappingProviderClass.getName());
+    }
+  }
+
+  public static class UseJacksonForJsonPathRuleWithBouncedVm implements Serializable {
+
+    @Rule
+    public DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule =
+        new DistributedUseJacksonForJsonPathRule();
+
+    @Test
+    public void getNewVm() {
+      VM vm = getVM(0);
+      vm.bounce();
+    }
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
@@ -19,7 +19,7 @@ package org.apache.geode.test.dunit.rules;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductStringProperty;
-import static org.apache.geode.test.dunit.Host.getHost;
+import static org.apache.geode.test.dunit.VM.DEFAULT_VM_COUNT;
 import static org.apache.geode.test.dunit.VM.getCurrentVMNum;
 
 import java.io.File;
@@ -85,25 +85,31 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
 
   private final SerializableTemporaryFolder temporaryFolder;
   private final SerializableTestName testName;
+  private final int vmCount;
   private final RemoteInvoker invoker;
   private final VMEventListener vmEventListener;
 
   private String testClassName;
 
   public DistributedDiskDirRule() {
-    this(new SerializableTemporaryFolder(), new SerializableTestName());
+    this(DEFAULT_VM_COUNT, new SerializableTemporaryFolder(), new SerializableTestName());
   }
 
-  private DistributedDiskDirRule(SerializableTemporaryFolder temporaryFolder,
+  public DistributedDiskDirRule(int vmCount) {
+    this(vmCount, new SerializableTemporaryFolder(), new SerializableTestName());
+  }
+
+  private DistributedDiskDirRule(int vmCount, SerializableTemporaryFolder temporaryFolder,
       SerializableTestName testName) {
-    this(temporaryFolder, testName, new RemoteInvoker());
+    this(vmCount, temporaryFolder, testName, new RemoteInvoker());
   }
 
-  private DistributedDiskDirRule(SerializableTemporaryFolder temporaryFolder,
+  private DistributedDiskDirRule(int vmCount, SerializableTemporaryFolder temporaryFolder,
       SerializableTestName testName, RemoteInvoker invoker) {
     super(null, null);
     this.temporaryFolder = temporaryFolder;
     this.testName = testName;
+    this.vmCount = vmCount;
     this.invoker = invoker;
     vmEventListener = new InternalVMEventListener();
   }
@@ -117,7 +123,7 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
 
   @Override
   protected void before(Description description) throws Exception {
-    DUnitLauncher.launchIfNeeded();
+    DUnitLauncher.launchIfNeeded(vmCount);
     VM.addVMEventListener(vmEventListener);
 
     initializeHelperRules(description);
@@ -182,14 +188,6 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
       System.clearProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
     } else {
       System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, data.originalValue());
-    }
-  }
-
-  private int getVMCount() {
-    try {
-      return getHost(0).getVMCount();
-    } catch (IllegalArgumentException e) {
-      throw new IllegalStateException("DUnit VMs have not been launched");
     }
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedUseJacksonForJsonPathRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedUseJacksonForJsonPathRule.java
@@ -14,51 +14,106 @@
  */
 package org.apache.geode.test.dunit.rules;
 
-import static org.apache.geode.test.dunit.VM.getVMCount;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.apache.geode.test.dunit.VM.DEFAULT_VM_COUNT;
 
+import java.io.Serializable;
+
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.VMEventListener;
 import org.apache.geode.test.dunit.internal.DUnitLauncher;
 import org.apache.geode.test.junit.rules.UseJacksonForJsonPathRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestRule;
 
-public class DistributedUseJacksonForJsonPathRule extends UseJacksonForJsonPathRule {
+/**
+ * Distributed version of UseJacksonForJsonPathRule JUnit Rule that configures json-path to use
+ * {@code JacksonJsonProvider} in all DUnit VMs (except for the hidden Locator VM) in addition to
+ * the JVM running JUnit (known as the Controller VM).
+ *
+ * <p>
+ * DistributedUseJacksonForJsonPathRule can be used in tests that need to use json-path-assert:
+ *
+ * <pre>
+ * {@literal @}ClassRule
+ * public static DistributedUseJacksonForJsonPathRule useJacksonForJsonPathRule = new DistributedUseJacksonForJsonPathRule();
+ *
+ * {@literal @}Test
+ * public void hasAssertionsUsingJsonPathMatchers() {
+ *   ...
+ *   assertThat(json, isJson());
+ *   assertThat(json, hasJsonPath("$.result"));
+ * }
+ * </pre>
+ */
+@SuppressWarnings("serial,unused")
+public class DistributedUseJacksonForJsonPathRule extends UseJacksonForJsonPathRule implements
+    SerializableTestRule {
 
   private static volatile UseJacksonForJsonPathRule instance = new UseJacksonForJsonPathRule();
 
+  private final int vmCount;
   private final RemoteInvoker invoker;
-
-  private volatile int beforeVmCount;
+  private final VMEventListener vmEventListener;
 
   public DistributedUseJacksonForJsonPathRule() {
-    this(new RemoteInvoker());
+    this(DEFAULT_VM_COUNT, new RemoteInvoker());
   }
 
-  public DistributedUseJacksonForJsonPathRule(final RemoteInvoker invoker) {
+  public DistributedUseJacksonForJsonPathRule(final int vmCount) {
+    this(vmCount, new RemoteInvoker());
+  }
+
+  private DistributedUseJacksonForJsonPathRule(final int vmCount, final RemoteInvoker invoker) {
+    this.vmCount = vmCount;
     this.invoker = invoker;
+    vmEventListener = new InternalVMEventListener();
   }
 
   @Override
   public void before() {
-    DUnitLauncher.launchIfNeeded();
-    beforeVmCount = getVMCount();
+    DUnitLauncher.launchIfNeeded(vmCount);
+    VM.addVMEventListener(vmEventListener);
 
-    invoker.invokeInEveryVMAndController(() -> invokeBefore());
+    invoker.invokeInEveryVMAndController(() -> doBefore());
   }
 
   @Override
   public void after() {
-    int afterVmCount = getVMCount();
-    assertThat(afterVmCount).isEqualTo(beforeVmCount);
+    VM.removeVMEventListener(vmEventListener);
 
-    invoker.invokeInEveryVMAndController(() -> invokeAfter());
+    invoker.invokeInEveryVMAndController(() -> doAfter());
   }
 
-  private static void invokeBefore() {
+  private void afterCreateVM(VM vm) {
+    vm.invoke(() -> doBefore());
+  }
+
+  private void afterBounceVM(VM vm) {
+    vm.invoke(() -> doBefore());
+  }
+
+  private void doBefore() {
     instance = new UseJacksonForJsonPathRule();
     instance.before();
   }
 
-  private static void invokeAfter() {
+  private void doAfter() {
     instance.after();
     instance = null;
+  }
+
+  /**
+   * VMEventListener for DistributedUseJacksonForJsonPathRule.
+   */
+  private class InternalVMEventListener implements VMEventListener, Serializable {
+
+    @Override
+    public void afterCreateVM(VM vm) {
+      DistributedUseJacksonForJsonPathRule.this.afterCreateVM(vm);
+    }
+
+    @Override
+    public void afterBounceVM(VM vm) {
+      DistributedUseJacksonForJsonPathRule.this.afterBounceVM(vm);
+    }
   }
 }

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -26,24 +26,23 @@ dependencies {
   compile('com.github.stefanbirkner:system-rules') {
     exclude module: 'junit-dep'
   }
-  compile('com.jayway.jsonpath:json-path')
-  compile('org.assertj:assertj-core')
-  compile('commons-io:commons-io')
-  compile('org.apache.commons:commons-lang3')
   compile('com.google.guava:guava')
-  compile('org.mockito:mockito-core')
-  compile('org.awaitility:awaitility')
-  compile('org.apache.logging.log4j:log4j-api')
-  compile('org.apache.logging.log4j:log4j-core')
+  compile('com.jayway.jsonpath:json-path')
+  compile('commons-io:commons-io')
   compile('junit:junit') {
     exclude module: 'hamcrest-core'
   }
+  compile('org.apache.commons:commons-lang3')
+  compile('org.apache.logging.log4j:log4j-api')
+  compile('org.apache.logging.log4j:log4j-core')
+  compile('org.assertj:assertj-core')
+  compile('org.awaitility:awaitility')
+  compile('org.bouncycastle:bcpkix-jdk15on')
   compile('org.hamcrest:hamcrest-all')
+  compile('org.mockito:mockito-core')
   compile('org.skyscreamer:jsonassert') {
     exclude module: 'android-json'
   }
-
-  compile('org.bouncycastle:bcpkix-jdk15on')
 
   testCompile('pl.pragmatists:JUnitParams')
 

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -23,6 +23,8 @@ dependencies {
 
   compileOnly(project(':geode-core'))
 
+  compile('com.fasterxml.jackson.core:jackson-annotations')
+  compile('com.fasterxml.jackson.core:jackson-databind')
   compile('com.github.stefanbirkner:system-rules') {
     exclude module: 'junit-dep'
   }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/UseJacksonForJsonPathRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/UseJacksonForJsonPathRule.java
@@ -48,14 +48,11 @@ import org.apache.geode.test.junit.rules.serializable.SerializableExternalResour
 @SuppressWarnings({"serial", "unused"})
 public class UseJacksonForJsonPathRule extends SerializableExternalResource {
 
-  private boolean hadDefaults;
+  private boolean restoreDefaults;
   private JsonProvider jsonProvider;
   private MappingProvider mappingProvider;
   private Set<Option> options;
 
-  /**
-   * Override to set up your specific external resource.
-   */
   @Override
   public void before() {
     saveDefaults();
@@ -82,30 +79,26 @@ public class UseJacksonForJsonPathRule extends SerializableExternalResource {
     });
   }
 
-  /**
-   * Override to tear down your specific external resource.
-   */
   @Override
   public void after() {
-    restoreDefaults();
+    if (restoreDefaults) {
+      restoreDefaults();
+    }
   }
 
   private void saveDefaults() {
     try {
       Configuration defaultConfiguration = Configuration.defaultConfiguration();
-      this.jsonProvider = defaultConfiguration.jsonProvider();
-      this.mappingProvider = defaultConfiguration.mappingProvider();
-      this.options = defaultConfiguration.getOptions();
-      this.hadDefaults = true;
+      jsonProvider = defaultConfiguration.jsonProvider();
+      mappingProvider = defaultConfiguration.mappingProvider();
+      options = defaultConfiguration.getOptions();
+      restoreDefaults = true;
     } catch (NoClassDefFoundError ignore) {
-      this.hadDefaults = false;
+      restoreDefaults = false;
     }
   }
 
   private void restoreDefaults() {
-    if (!this.hadDefaults) {
-      return;
-    }
     Configuration.setDefaults(new Defaults() {
 
       @Override

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/UseJacksonForJsonPathRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/UseJacksonForJsonPathRuleTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.rules;
+
+import static org.apache.geode.test.junit.runners.TestRunner.runTestWithValidation;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link UseJacksonForJsonPathRule}.
+ */
+public class UseJacksonForJsonPathRuleTest {
+
+  private static final AtomicReference<JsonProvider> jsonProviderRef = new AtomicReference<>();
+  private static final AtomicReference<MappingProvider> mappingProviderRef =
+      new AtomicReference<>();
+
+  private JsonProvider defaultJsonProvider;
+  private MappingProvider defaultMappingProvider;
+
+  @Before
+  public void setUp() {
+    Configuration configuration = Configuration.defaultConfiguration();
+    defaultJsonProvider = configuration.jsonProvider();
+    defaultMappingProvider = configuration.mappingProvider();
+  }
+
+  @After
+  public void tearDown() {
+    jsonProviderRef.set(null);
+    mappingProviderRef.set(null);
+  }
+
+  @Test
+  public void setsJsonProviderToJacksonJsonProviderBeforeTest() {
+    runTestWithValidation(CaptureJsonProvider.class);
+
+    assertThat(jsonProviderRef.get()).isInstanceOf(JacksonJsonProvider.class);
+  }
+
+  @Test
+  public void setsMappingProviderToJacksonMappingProviderBeforeTest() {
+    runTestWithValidation(CaptureMappingProvider.class);
+
+    assertThat(mappingProviderRef.get()).isInstanceOf(JacksonMappingProvider.class);
+  }
+
+  @Test
+  public void restoresJsonProviderToDefaultAfterTest() {
+    runTestWithValidation(HasUseJacksonForJsonPathRule.class);
+
+    Configuration configuration = Configuration.defaultConfiguration();
+    assertThat(configuration.jsonProvider()).isSameAs(defaultJsonProvider);
+  }
+
+  @Test
+  public void restoresMappingProviderToDefaultAfterTest() {
+    runTestWithValidation(HasUseJacksonForJsonPathRule.class);
+
+
+    Configuration configuration = Configuration.defaultConfiguration();
+    assertThat(configuration.mappingProvider()).isSameAs(defaultMappingProvider);
+  }
+
+  public static class HasUseJacksonForJsonPathRule {
+
+    @Rule
+    public UseJacksonForJsonPathRule useJacksonForJsonPathRule = new UseJacksonForJsonPathRule();
+
+    @Test
+    public void doNothing() {
+      assertThat(useJacksonForJsonPathRule).isNotNull();
+    }
+  }
+
+  public static class CaptureJsonProvider {
+
+    @Rule
+    public UseJacksonForJsonPathRule useJacksonForJsonPathRule = new UseJacksonForJsonPathRule();
+
+    @Test
+    public void captureJsonProvider() {
+      Configuration configuration = Configuration.defaultConfiguration();
+      jsonProviderRef.set(configuration.jsonProvider());
+      assertThat(jsonProviderRef.get()).isNotNull();
+    }
+  }
+
+  public static class CaptureMappingProvider {
+
+    @Rule
+    public UseJacksonForJsonPathRule useJacksonForJsonPathRule = new UseJacksonForJsonPathRule();
+
+    @Test
+    public void captureMappingProvider() {
+      Configuration configuration = Configuration.defaultConfiguration();
+      mappingProviderRef.set(configuration.mappingProvider());
+      assertThat(mappingProviderRef.get()).isNotNull();
+    }
+  }
+}

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -47,6 +47,16 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <scope>compile</scope>
@@ -58,48 +68,18 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -114,8 +94,43 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -128,11 +143,6 @@
           <groupId>*</groupId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
* Add vmCount constructor to DistributedDiskDirRule
* Order geode-junit compile dependencies alphabetically
* Add jackson compile dependencies to geode-junit
* Cleanup IDE warnings in UseJacksonForJsonPathRule
* Cleanup and javadoc DistributedUseJacksonForJsonPathRule
* Add new test DistributedUseJacksonForJsonPathRuleDistributedTest
* Make DistributedUseJacksonForJsonPathRule support create and bounce VMs

@demery-pivotal please review

Background: By default json-path uses json-smart. UseJacksonForJsonPathRule and DistributedUseJacksonForJsonPathRule configure json-path to use Jackson instead of json-smart. This helps us narrow our json library usage to Jackson while using json-path in tests that involve json.