### PR TITLE
GEODE-4240: Printing out cache server log

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DeprecatedCacheServerLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DeprecatedCacheServerLauncherIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeFalse;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -43,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -144,6 +146,17 @@ public class DeprecatedCacheServerLauncherIntegrationTest {
     unexportObject(this.status);
     unexportObject(this.registry);
     destroy(this.processWrapper);
+
+    if (logFile.exists()) {
+
+      System.out.println("------------------------------------------------------------");
+      System.out.println("Log file for launched process");
+      System.out.println("------------------------------------------------------------");
+      try (FileInputStream input = new FileInputStream(logFile)) {
+        IOUtils.copy(input, System.out);
+      }
+      System.out.println("------------------------------------------------------------");
+    }
   }
 
   @AfterClass


### PR DESCRIPTION
This test is failing occasionally in CI. Printing out the log of the
server in the test so that we will have some clue if the server fails to
start in future test runs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
