### PR TITLE
GEODE-6295: Add Micrometer-based metrics system DO NOT REVIEW

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -173,6 +173,11 @@
         <version>4.0.6</version>
       </dependency>
       <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>1.1.3</version>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>4.1.31.Final</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -111,6 +111,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1')
         api(group: 'commons-validator', name: 'commons-validator', version: get('commons-validator.version'))
         api(group: 'io.github.classgraph', name: 'classgraph', version: '4.0.6')
+        api(group: 'io.micrometer', name: 'micrometer-core', version: '1.1.3')
         api(group: 'io.netty', name: 'netty-all', version: '4.1.31.Final')
         api(group: 'it.unimi.dsi', name: 'fastutil', version: get('fastutil.version'))
         api(group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2')

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
@@ -92,8 +92,8 @@ public class TomcatInstall extends ContainerInstall {
   private static final String[] tomcatRequiredJars =
       {"antlr", "commons-io", "commons-lang", "commons-validator", "fastutil", "geode-common",
           "geode-core", "geode-management", "javax.transaction-api", "jgroups", "log4j-api",
-          "log4j-core", "log4j-jul", "shiro-core", "jetty-server", "jetty-util", "jetty-http",
-          "jetty-io"};
+          "log4j-core", "log4j-jul", "micrometer", "shiro-core", "jetty-server", "jetty-util",
+          "jetty-http", "jetty-io"};
 
   private final TomcatVersion version;
 

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -874,7 +874,9 @@ javadoc/package-list
 javadoc/script.js
 javadoc/serialized-form.html
 javadoc/stylesheet.css
+lib/HdrHistogram-2.1.9.jar
 lib/HikariCP-3.2.0.jar
+lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
 lib/classgraph-4.0.6.jar
 lib/commons-beanutils-1.9.3.jar
@@ -943,6 +945,7 @@ lib/lucene-analyzers-phonetic-6.6.2.jar
 lib/lucene-core-6.6.2.jar
 lib/lucene-queries-6.6.2.jar
 lib/lucene-queryparser-6.6.2.jar
+lib/micrometer-core-1.1.2.jar
 lib/mx4j-3.0.2.jar
 lib/mx4j-remote-3.0.2.jar
 lib/mx4j-tools-3.0.1.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -1,4 +1,6 @@
+HdrHistogram-2.1.9.jar
 HikariCP-3.2.0.jar
+LatencyUtils-2.0.3.jar
 antlr-2.7.7.jar
 classgraph-4.0.6.jar
 commons-beanutils-1.9.3.jar
@@ -59,6 +61,7 @@ lucene-analyzers-phonetic-6.6.2.jar
 lucene-core-6.6.2.jar
 lucene-queries-6.6.2.jar
 lucene-queryparser-6.6.2.jar
+micrometer-core-1.1.2.jar
 netty-all-4.1.31.Final.jar
 protobuf-java-3.6.1.jar
 rmiio-2.1.2.jar

--- a/geode-assembly/src/integrationTest/resources/expected_jars.txt
+++ b/geode-assembly/src/integrationTest/resources/expected_jars.txt
@@ -1,4 +1,6 @@
+HdrHistogram
 HikariCP
+LatencyUtils
 animal-sniffer-annotations
 antlr
 aopalliance
@@ -66,6 +68,7 @@ lucene-core
 lucene-queries
 lucene-queryparser
 mapstruct
+micrometer-core
 mx4j
 mx4j-remote
 mx4j-tools

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -725,4 +725,6 @@ domain:
   - AOP Alliance v1.0 (http://aopalliance.sourceforge.net)
   - CompactConcurrentHashSet2, derived from JSR-166 ConcurrentHashMap v1.43
     (http://gee.cs.oswego.edu/dl/concurrency-interest).
+  - HdrHistogram (https://github.com/HdrHistogram/HdrHistogram)
+  - LatencyUtils (https://github.com/LatencyUtils/LatencyUtils)
   - tooltip.js v1.2.6 (https://github.com/jquerytools/jquerytools)

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -194,6 +194,8 @@ dependencies {
     exclude module: 'xml-apis'
     ext.optional = true
   }
+  compile('io.micrometer:micrometer-core')
+
   compile('io.netty:netty-all') {
     ext.optional = true
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -280,7 +280,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    * The {@code CacheLifecycleListener} s that have been registered in this VM
    */
   @MakeNotStatic
-  private static final Set<CacheLifecycleListener> cacheLifecycleListeners = new HashSet<>();
+  private static final Set<CacheLifecycleListener> cacheLifecycleListeners =
+      new CopyOnWriteArraySet<>();
 
   /**
    * Define gemfire.Cache.ASYNC_EVENT_LISTENERS=true to invoke event listeners in the background

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -76,6 +76,7 @@ import javax.transaction.TransactionManager;
 
 import com.sun.jna.Native;
 import com.sun.jna.Platform;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
@@ -611,6 +612,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   private HttpService httpService;
 
+  private final MeterRegistry meterRegistry;
+
   static {
     // this works around jdk bug 6427854, reported in ticket #44434
     String propertyName = "sun.nio.ch.bugLevel";
@@ -761,6 +764,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    * @deprecated Rather than fishing for a cache with this static method, use a cache that is passed
    *             in to your method.
    */
+  @Deprecated
   public static GemFireCacheImpl getForPdx(String reason) {
 
     InternalDistributedSystem system = getAnyInstance();
@@ -782,12 +786,13 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    * Currently only unit tests set the typeRegistry parameter to a non-null value
    */
   GemFireCacheImpl(boolean isClient, PoolFactory poolFactory,
-      InternalDistributedSystem internalDistributedSystem,
-      CacheConfig cacheConfig, boolean useAsyncEventListeners, TypeRegistry typeRegistry) {
+      InternalDistributedSystem internalDistributedSystem, CacheConfig cacheConfig,
+      boolean useAsyncEventListeners, TypeRegistry typeRegistry, MeterRegistry meterRegistry) {
     this.isClient = isClient;
     this.poolFactory = poolFactory;
     this.cacheConfig = cacheConfig; // do early for bug 43213
     this.pdxRegistry = typeRegistry;
+    this.meterRegistry = meterRegistry;
 
     // Synchronized to prevent a new cache from being created
     // before an old one has finished closing
@@ -944,6 +949,11 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   public void throwCacheExistsException() {
     throw new CacheExistsException(this, String.format("%s: An open cache already exists.", this),
         creationStack);
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -26,6 +26,8 @@ import java.util.concurrent.Executor;
 
 import javax.transaction.TransactionManager;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Declarable;
@@ -376,4 +378,6 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime {
   void initialize();
 
   void throwCacheExistsException();
+
+  MeterRegistry getMeterRegistry();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -31,6 +31,8 @@ import java.util.concurrent.TimeUnit;
 import javax.naming.Context;
 import javax.transaction.TransactionManager;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.LogWriter;
 import org.apache.geode.cache.Cache;
@@ -1232,5 +1234,10 @@ public class InternalCacheForClientAccess implements InternalCache {
   @Override
   public void throwCacheExistsException() {
     delegate.throwCacheExistsException();
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return delegate.getMeterRegistry();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -39,6 +39,8 @@ import java.util.concurrent.TimeUnit;
 import javax.naming.Context;
 import javax.transaction.TransactionManager;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.GemFireIOException;
 import org.apache.geode.LogWriter;
@@ -2438,6 +2440,11 @@ public class CacheCreation implements InternalCache {
 
   @Override
   public HttpService getHttpService() {
+    throw new UnsupportedOperationException("Should not be invoked");
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
     throw new UnsupportedOperationException("Should not be invoked");
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
+import org.apache.geode.annotations.VisibleForTesting;
+
+/**
+ * Creates {@code CompositeMeterRegistry} and configures commonTags for {@code "ClusterId"} and
+ * {@code "MemberName"}.
+ */
+public interface CompositeMeterRegistryFactory {
+
+  @VisibleForTesting
+  String CLUSTER_ID_TAG = "ClusterId";
+  @VisibleForTesting
+  String MEMBER_NAME_TAG = "MemberName";
+
+  default CompositeMeterRegistry create(int systemId, String memberName) {
+    CompositeMeterRegistry registry = new CompositeMeterRegistry();
+
+    MeterRegistry.Config registryConfig = registry.config();
+    registryConfig.commonTags(CLUSTER_ID_TAG, String.valueOf(systemId));
+    registryConfig.commonTags(MEMBER_NAME_TAG, memberName == null ? "" : memberName);
+
+    return registry;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/MetricsPublishingServiceLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/MetricsPublishingServiceLoader.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.apache.geode.metrics.MetricsPublishingService;
+
+public interface MetricsPublishingServiceLoader {
+
+  default Collection<MetricsPublishingService> loadServices() {
+    List<MetricsPublishingService> services = new ArrayList<>();
+    ServiceLoader.load(MetricsPublishingService.class).iterator().forEachRemaining(services::add);
+    return services;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/metrics/MetricsPublishingService.java
+++ b/geode-core/src/main/java/org/apache/geode/metrics/MetricsPublishingService.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.metrics;
+
+public interface MetricsPublishingService {
+
+  void start(MetricsSession session);
+
+  void stop();
+}

--- a/geode-core/src/main/java/org/apache/geode/metrics/MetricsSession.java
+++ b/geode-core/src/main/java/org/apache/geode/metrics/MetricsSession.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Manages the lifecycle of a meter registry and allows connecting "downstream" meter registries to
+ * publish the managed registry's meters to external monitoring systems.
+ */
+public interface MetricsSession {
+  /**
+   * Connects the given "downstream" registry to the managed registry. For each meter in the
+   * managed registry, a corresponding meter is created or discovered in the downstream registry.
+   * Subsequent operations on the managed registry's meters are forwarded to the corresponding
+   * meters in the downstream registry. When meters are subsequently added or removed in the
+   * managed registry, corresponding meters are added or removed in the downstream registry.
+   *
+   * @param downstream the registry to connect to the managed registry
+   */
+  void connectDownstreamRegistry(MeterRegistry downstream);
+
+  /**
+   * Disconnects the given registry from the managed registry. For each meter in the managed
+   * registry, the corresponding meter in the downstream registry is removed. Subsequent additions
+   * and removals of meters in the managed registry have no effect on disconnected registries.
+   *
+   * @param downstream the registry to disconnect from the managed registry
+   */
+  void disconnectDownstreamRegistry(MeterRegistry downstream);
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemStatisticsManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemStatisticsManagerTest.java
@@ -42,7 +42,7 @@ import org.apache.geode.internal.statistics.StatisticsManagerFactory;
 /**
  * Unit tests for {@link InternalDistributedSystem}.
  */
-public class InternalDistributedSystemTest {
+public class InternalDistributedSystemStatisticsManagerTest {
 
   private static final String STATISTIC_NAME = "statistic-name";
   private static final String STATISTIC_DESCRIPTION = "statistic-description";

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.After;
 import org.junit.Test;
 
@@ -54,6 +55,8 @@ public class GemFireCacheImplTest {
 
   @After
   public void tearDown() {
+    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
+
     if (gemFireCacheImpl != null) {
       gemFireCacheImpl.close();
     }
@@ -336,6 +339,13 @@ public class GemFireCacheImplTest {
 
     // reset it back to the old value
     InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = oldValue;
+  }
+
+  @Test
+  public void getMeterRegistryReturnsTheMeterRegistry() {
+    gemFireCacheImpl = createGemFireCacheImpl();
+
+    assertThat(gemFireCacheImpl.getMeterRegistry()).isInstanceOf(MeterRegistry.class);
   }
 
   private static GemFireCacheImpl createGemFireCacheImpl() {

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMetricsSessionBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMetricsSessionBuilderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.internal.metrics.CacheMetricsSession.Builder;
+import org.apache.geode.internal.metrics.CacheMetricsSession.CacheLifecycle;
+import org.apache.geode.metrics.MetricsPublishingService;
+
+public class CacheMetricsSessionBuilderTest {
+
+  private CompositeMeterRegistry registry;
+  private Builder builder;
+  private CacheLifecycle cacheLifecycle;
+
+  @Before
+  public void setUp() {
+    cacheLifecycle = mock(CacheLifecycle.class);
+    registry = new CompositeMeterRegistry();
+    builder = CacheMetricsSession
+        .builder()
+        .setCacheLifecycle(cacheLifecycle);
+  }
+
+  @Test
+  public void buildsCacheMetricsSession() {
+    assertThat(builder.build(registry)).isInstanceOf(CacheMetricsSession.class);
+  }
+
+  @Test
+  public void buildsCacheMetricsSession_withGivenMeterRegistry() {
+    CompositeMeterRegistry givenRegistry = new CompositeMeterRegistry();
+
+    CacheMetricsSession session = builder
+        .build(givenRegistry);
+
+    assertThat(session.meterRegistry()).isSameAs(givenRegistry);
+  }
+
+  @Test
+  public void addsSessionAsCacheLifecycleListener() {
+    CacheLifecycle theCacheLifecycle = mock(CacheLifecycle.class);
+
+    CacheMetricsSession session = builder
+        .setCacheLifecycle(theCacheLifecycle)
+        .build(registry);
+
+    verify(theCacheLifecycle).addListener(same(session));
+  }
+
+  @Test
+  public void loadsMetricsPublishingServices() {
+    MetricsPublishingServiceLoader theMetricsPublishingServicesLoader =
+        mock(MetricsPublishingServiceLoader.class);
+
+    CacheMetricsSession session = builder
+        .setMetricsPublishingServicesLoader(theMetricsPublishingServicesLoader)
+        .build(registry);
+
+    verify(theMetricsPublishingServicesLoader).loadServices();
+  }
+
+  @Test
+  public void buildsCacheMetricsSession_withMetricsPublishingServices() {
+    MetricsPublishingServiceLoader theMetricsPublishingServicesLoader =
+        mock(MetricsPublishingServiceLoader.class);
+    Collection<MetricsPublishingService> theMetricsPublishingServices = Arrays.asList(
+        metricsPublishingService("metricsPublishingService1"),
+        metricsPublishingService("metricsPublishingService2"),
+        metricsPublishingService("metricsPublishingService3"));
+    when(theMetricsPublishingServicesLoader.loadServices())
+        .thenReturn(theMetricsPublishingServices);
+
+    CacheMetricsSession session = builder
+        .setMetricsPublishingServicesLoader(theMetricsPublishingServicesLoader)
+        .build(registry);
+
+    assertThat(session.metricsPublishingServices())
+        .hasSameElementsAs(theMetricsPublishingServices);
+  }
+
+  private MetricsPublishingService metricsPublishingService(String name) {
+    return mock(MetricsPublishingService.class, name);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMetricsSessionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMetricsSessionTest.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.metrics.CacheMetricsSession.CacheLifecycle;
+import org.apache.geode.metrics.MetricsPublishingService;
+
+public class CacheMetricsSessionTest {
+
+  private final CompositeMeterRegistry compositeRegistry = new CompositeMeterRegistry();
+
+  private CacheMetricsSession metricsSession;
+
+  @After
+  public void tearDown() {
+    if (metricsSession != null) {
+      GemFireCacheImpl.removeCacheLifecycleListener(metricsSession);
+    }
+  }
+
+  @Test
+  public void startsWithNoDownstreamRegistries() {
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        Collections.emptyList());
+
+    Set<MeterRegistry> downstreamRegistries = compositeRegistry.getRegistries();
+
+    assertThat(downstreamRegistries)
+        .isEmpty();
+  }
+
+  @Test
+  public void remembersConnectedDownstreamRegistries() {
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        Collections.emptyList());
+
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    assertThat(compositeRegistry.getRegistries())
+        .contains(downstreamRegistry);
+  }
+
+  @Test
+  public void forgetsDisconnectedDownstreamRegistries() {
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        Collections.emptyList());
+
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    metricsSession.disconnectDownstreamRegistry(downstreamRegistry);
+
+    assertThat(compositeRegistry.getRegistries())
+        .doesNotContain(downstreamRegistry);
+  }
+
+  @Test
+  public void connectsExistingMetersToNewDownstreamRegistries() {
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        Collections.emptyList());
+
+    String counterName = "the.counter";
+    Counter primaryCounter = compositeRegistry.counter(counterName);
+
+    double amountIncrementedBeforeConnectingDownstreamRegistry = 3.0;
+    primaryCounter.increment(amountIncrementedBeforeConnectingDownstreamRegistry);
+
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    Counter downstreamCounter = downstreamRegistry.find(counterName).counter();
+    assertThat(downstreamCounter)
+        .as("downstream counter after connecting, before incrementing")
+        .isNotNull();
+
+    // Note that the newly-created downstream counter starts at zero, ignoring
+    // any increments that happened before the downstream registry was added.
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value after connecting, before incrementing")
+        .isNotEqualTo(amountIncrementedBeforeConnectingDownstreamRegistry)
+        .isEqualTo(0);
+
+    double amountIncrementedAfterConnectingDownstreamRegistry = 42.0;
+    primaryCounter.increment(amountIncrementedAfterConnectingDownstreamRegistry);
+
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value after incrementing")
+        .isEqualTo(amountIncrementedAfterConnectingDownstreamRegistry);
+  }
+
+  @Test
+  public void connectsNewMetersToExistingDownstreamRegistries() {
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        Collections.emptyList());
+
+    MeterRegistry downstreamRegistry = new SimpleMeterRegistry();
+    metricsSession.connectDownstreamRegistry(downstreamRegistry);
+
+    String counterName = "the.counter";
+    Counter newCounter = compositeRegistry.counter(counterName);
+
+    Counter downstreamCounter = downstreamRegistry.find(counterName).counter();
+    assertThat(downstreamCounter)
+        .as("downstream counter before incrementing")
+        .isNotNull();
+
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value before incrementing")
+        .isEqualTo(newCounter.count())
+        .isEqualTo(0);
+
+    double amountIncrementedAfterConnectingDownstreamRegistry = 93.0;
+    newCounter.increment(amountIncrementedAfterConnectingDownstreamRegistry);
+
+    assertThat(downstreamCounter.count())
+        .as("downstream counter value after incrementing")
+        .isEqualTo(newCounter.count());
+  }
+
+  @Test
+  public void cacheCreatedStartsEachMetricsPublishingService() {
+    List<MetricsPublishingService> metricsPublishingServices = Arrays.asList(
+        metricsPublishingService("metricsPublishingService1"),
+        metricsPublishingService("metricsPublishingService2"),
+        metricsPublishingService("metricsPublishingService3"));
+
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        metricsPublishingServices);
+
+    metricsSession.cacheCreated(mock(InternalCache.class));
+
+    for (MetricsPublishingService metricsPublishingService : metricsPublishingServices) {
+      verify(metricsPublishingService).start(same(metricsSession));
+    }
+  }
+
+  @Test
+  public void cacheClosedStopsEachMetricsPublishingService() {
+    List<MetricsPublishingService> metricsPublishingServices = Arrays.asList(
+        metricsPublishingService("metricsPublishingService1"),
+        metricsPublishingService("metricsPublishingService2"),
+        metricsPublishingService("metricsPublishingService3"));
+
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        metricsPublishingServices);
+
+    metricsSession.cacheClosed(mock(InternalCache.class));
+
+    for (MetricsPublishingService metricsPublishingService : metricsPublishingServices) {
+      verify(metricsPublishingService).stop();
+    }
+  }
+
+  @Test
+  public void cacheClosedDisconnectsAllDownstreamRegistries() {
+    metricsSession = new CacheMetricsSession(mock(CacheLifecycle.class), compositeRegistry,
+        Collections.emptyList());
+
+    MeterRegistry downstreamMeterRegistry1 = new SimpleMeterRegistry();
+    MeterRegistry downstreamMeterRegistry2 = new SimpleMeterRegistry();
+    MeterRegistry downstreamMeterRegistry3 = new SimpleMeterRegistry();
+
+    metricsSession.connectDownstreamRegistry(downstreamMeterRegistry1);
+    metricsSession.connectDownstreamRegistry(downstreamMeterRegistry2);
+    metricsSession.connectDownstreamRegistry(downstreamMeterRegistry3);
+
+    metricsSession.cacheClosed(mock(InternalCache.class));
+
+    assertThat(compositeRegistry.getRegistries()).isEmpty();
+  }
+
+  @Test
+  public void cacheClosedRemovesSessionAsCacheLifecycleListener() {
+    CacheLifecycle theCacheLifecycle = mock(CacheLifecycle.class);
+    metricsSession =
+        new CacheMetricsSession(theCacheLifecycle, compositeRegistry, Collections.emptyList());
+
+    metricsSession.cacheClosed(mock(InternalCache.class));
+
+    verify(theCacheLifecycle).removeListener(same(metricsSession));
+  }
+
+  private MetricsPublishingService metricsPublishingService(String name) {
+    return mock(MetricsPublishingService.class, name);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactoryTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import static org.apache.geode.internal.metrics.CompositeMeterRegistryFactory.CLUSTER_ID_TAG;
+import static org.apache.geode.internal.metrics.CompositeMeterRegistryFactory.MEMBER_NAME_TAG;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import org.junit.Test;
+
+public class CompositeMeterRegistryFactoryTest {
+
+  private static final int CLUSTER_ID = 42;
+  private static final String MEMBER_NAME = "member-name";
+
+  @Test
+  public void createsCompositeMeterRegistry() {
+    CompositeMeterRegistryFactory factory = new CompositeMeterRegistryFactory() {};
+
+    assertThat(factory.create(CLUSTER_ID, MEMBER_NAME)).isInstanceOf(CompositeMeterRegistry.class);
+  }
+
+  @Test
+  public void addsMemberNameCommonTag() {
+    CompositeMeterRegistryFactory factory = new CompositeMeterRegistryFactory() {};
+    String theMemberName = "the-member-name";
+
+    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, theMemberName);
+
+    Meter meter = registry.counter("my.meter");
+
+    assertThat(meter.getId().getTags())
+        .contains(Tag.of(MEMBER_NAME_TAG, theMemberName));
+  }
+
+  @Test
+  public void addsClusterIdCommonTag() {
+    CompositeMeterRegistryFactory factory = new CompositeMeterRegistryFactory() {};
+    int theSystemId = 21;
+
+    CompositeMeterRegistry registry = factory.create(theSystemId, MEMBER_NAME);
+
+    Meter meter = registry.counter("my.meter");
+
+    assertThat(meter.getId().getTags())
+        .contains(Tag.of(CLUSTER_ID_TAG, String.valueOf(theSystemId)));
+  }
+}

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -142,6 +142,11 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
DO NOT REVIEW

- Pass MeterRegistry to GemFireCacheImpl and add getMeterRegistry.
- Load and start MetricsPublishingServices

GEODE-6295: Fixup session upgradeTests

- Add micrometer dependency to explicit list in TomcatInstall.java
  in geode-assembly/geode-assembly-test.

GEODE-6295: Add Micrometer-based metrics system

- Added MetricsSession interface that represents the lifecycle of a
  meter registry, and allows connecting "downstream" registries.
- Added MemberMetricsSession class that creates and configures the meter
  registry for a particular member, and manages connections to the meter
  registry.
- Added methods to InternalDistributedSystem to retrieve both the meter
  registry and the metrics session.
- Added ConnectionConfig interface that extends DistributionConfig, and
  ConnectionConfigImpl that extends DistributionConfigImpl. See below for
  details and rationale.

Constructing a MemberMetricsSession requires a member name and a
distributed system ID. These values were previously available only via a
DistributionConfigImpl constructed by InternalDistributedSystem, based
on properties passed to the InternalDistributedSystem constructor,
supplemented by default values supplied by DistributionConfigImpl. This
made it impossible to inject an already-constructed MemberMetricsSession
into InternalDistributedSystem.

Constructing a DistributionConfigImpl outside of the
InternalDistributedSystem constructor was complicated by several
factors:
- DistributionConfigImpl throws an exception if passed a property that
  it does not recognize.
- Some calls to InternalDistributedSystem.newInstance() pass special
  properties intended for use only in the InternalDistributedSystem
  constructor. DistributionConfigImpl does not recognize these special
  properties.
- The responsibility for extracting and retaining those properties was
  implemented in the InternalDistributedSystem constructor.

We moved the responsibility to extract those special properties from
InternalDistributionConfig to the new ConnectionConfigImpl class.
ConnectionConfigImpl extracts and retains the properties before passing
the properties to its DistributionConfigImpl superclass. The resulting
ConnectionConfigImpl object is a valid DistributionConfigImpl, and also
supplies the special properties needed by the InternalDistributedSystem
constructor.

Given these changes, we now:
- Construct a ConnectionConfigImpl outside of the
  InternalDistributedSystem constructor
- Use the ConnectionConfig to create the MemberMetricsSession
- Inject both the ConnectionConfigImpl and the MemberMetricsSession into
  the InternalDistributedSystem constructor.

Co-Authored-By: Dale Emery <demery@pivotal.io>
Co-Authored-By: Michael Oleske <moleske@pivotal.io>
Co-Authored-By: Mark Hanson <mhanson@pivotal.io>
Co-Authored-By: Kirk Lund <klund@apache.org>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
