### PR TITLE
GEODE-6519: Fix CreateGatewaySenderCommand Flags

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -51,25 +51,32 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
       interceptor = "org.apache.geode.management.internal.cli.commands.CreateGatewaySenderCommand$Interceptor")
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
       operation = ResourcePermission.Operation.MANAGE, target = ResourcePermission.Target.GATEWAY)
-  public ResultModel createGatewaySender(@CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS},
-      optionContext = ConverterHint.MEMBERGROUP,
-      help = CliStrings.CREATE_GATEWAYSENDER__GROUP__HELP) String[] onGroups,
+  public ResultModel createGatewaySender(
+
+      @CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS},
+          optionContext = ConverterHint.MEMBERGROUP,
+          help = CliStrings.CREATE_GATEWAYSENDER__GROUP__HELP) String[] onGroups,
 
       @CliOption(key = {CliStrings.MEMBER, CliStrings.MEMBERS},
           optionContext = ConverterHint.MEMBERIDNAME,
           help = CliStrings.CREATE_GATEWAYSENDER__MEMBER__HELP) String[] onMember,
 
-      @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__ID, mandatory = true,
+      @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__ID,
+          mandatory = true,
           help = CliStrings.CREATE_GATEWAYSENDER__ID__HELP) String id,
 
-      @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID, mandatory = true,
+      @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID,
+          mandatory = true,
           help = CliStrings.CREATE_GATEWAYSENDER__REMOTEDISTRIBUTEDSYSTEMID__HELP) Integer remoteDistributedSystemId,
 
-      @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__PARALLEL, specifiedDefaultValue = "true",
+      @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__PARALLEL,
+          specifiedDefaultValue = "true",
           unspecifiedDefaultValue = "false",
           help = CliStrings.CREATE_GATEWAYSENDER__PARALLEL__HELP) boolean parallel,
 
-      @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__MANUALSTART,
+      // Users must avoid this feature, it might cause data loss and other issues during startup.
+      @Deprecated @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__MANUALSTART,
+          unspecifiedDefaultValue = "false",
           help = CliStrings.CREATE_GATEWAYSENDER__MANUALSTART__HELP) Boolean manualStart,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__SOCKETBUFFERSIZE,
@@ -79,6 +86,8 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
           help = CliStrings.CREATE_GATEWAYSENDER__SOCKETREADTIMEOUT__HELP) Integer socketReadTimeout,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__ENABLEBATCHCONFLATION,
+          specifiedDefaultValue = "true",
+          unspecifiedDefaultValue = "false",
           help = CliStrings.CREATE_GATEWAYSENDER__ENABLEBATCHCONFLATION__HELP) Boolean enableBatchConflation,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__BATCHSIZE,
@@ -88,12 +97,16 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
           help = CliStrings.CREATE_GATEWAYSENDER__BATCHTIMEINTERVAL__HELP) Integer batchTimeInterval,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__ENABLEPERSISTENCE,
+          specifiedDefaultValue = "true",
+          unspecifiedDefaultValue = "false",
           help = CliStrings.CREATE_GATEWAYSENDER__ENABLEPERSISTENCE__HELP) Boolean enablePersistence,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__DISKSTORENAME,
           help = CliStrings.CREATE_GATEWAYSENDER__DISKSTORENAME__HELP) String diskStoreName,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__DISKSYNCHRONOUS,
+          specifiedDefaultValue = "true",
+          unspecifiedDefaultValue = "true",
           help = CliStrings.CREATE_GATEWAYSENDER__DISKSYNCHRONOUS__HELP) Boolean diskSynchronous,
 
       @CliOption(key = CliStrings.CREATE_GATEWAYSENDER__MAXQUEUEMEMORY,
@@ -205,18 +218,19 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
   }
 
   private String int2string(Integer i) {
-    return Optional.ofNullable(i).map(in -> in.toString()).orElse(null);
+    return Optional.ofNullable(i).map(String::valueOf).orElse(null);
   }
 
   public static class Interceptor extends AbstractCliAroundInterceptor {
     @Override
     public Result preExecution(GfshParseResult parseResult) {
-      Integer dispatcherThreads =
-          (Integer) parseResult.getParamValue(CliStrings.CREATE_GATEWAYSENDER__DISPATCHERTHREADS);
-      OrderPolicy orderPolicy =
-          (OrderPolicy) parseResult.getParamValue(CliStrings.CREATE_GATEWAYSENDER__ORDERPOLICY);
       Boolean parallel =
           (Boolean) parseResult.getParamValue(CliStrings.CREATE_GATEWAYSENDER__PARALLEL);
+      OrderPolicy orderPolicy =
+          (OrderPolicy) parseResult.getParamValue(CliStrings.CREATE_GATEWAYSENDER__ORDERPOLICY);
+      Integer dispatcherThreads =
+          (Integer) parseResult.getParamValue(CliStrings.CREATE_GATEWAYSENDER__DISPATCHERTHREADS);
+
       if (dispatcherThreads != null && dispatcherThreads > 1 && orderPolicy == null) {
         return ResultBuilder.createUserErrorResult(
             "Must specify --order-policy when --dispatcher-threads is larger than 1.");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -2163,7 +2163,9 @@ public class CliStrings {
   public static final String CREATE_GATEWAYSENDER__PARALLEL = "parallel";
   public static final String CREATE_GATEWAYSENDER__PARALLEL__HELP =
       "Whether this is Parallel GatewaySender.";
+  @Deprecated
   public static final String CREATE_GATEWAYSENDER__MANUALSTART = "manual-start";
+  @Deprecated
   public static final String CREATE_GATEWAYSENDER__MANUALSTART__HELP =
       "Whether manual start is to be enabled or the sender will start automatically after creation.\n"
           + "Deprecated: Since Geode 1.4. Manual start of senders is deprecated and will be removed in a later release.";


### PR DESCRIPTION
GEODE-6519: Fix `CreateGatewaySenderCommand` Flags

- Fixed minor warnings.
- Parameter `manual-start` from `create gateway-sender` command is set
as `false` by default when specified without a value.
- Parameters `parallel`, `disk-synchronous`, `enable-persistence` and
`enable-batch-conflation` from `create gateway-sender` command are set
as `true` by default when specified without a value.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
