### PR TITLE
GEODE-6295: Extract default from CompositeMeterRegistryFactory

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
@@ -43,6 +43,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.SecurityConfig;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.metrics.CacheLifecycleMetricsSession;
+import org.apache.geode.internal.metrics.CacheMeterRegistryFactory;
 import org.apache.geode.internal.metrics.CompositeMeterRegistryFactory;
 import org.apache.geode.pdx.PdxSerializer;
 import org.apache.geode.pdx.internal.TypeRegistry;
@@ -111,7 +112,7 @@ public class InternalCacheBuilder {
   private InternalCacheBuilder(Properties configProperties, CacheConfig cacheConfig) {
     this(configProperties,
         cacheConfig,
-        new CompositeMeterRegistryFactory() {},
+        new CacheMeterRegistryFactory(),
         CacheLifecycleMetricsSession.builder()::build,
         InternalDistributedSystem::getConnectedInstance,
         InternalDistributedSystem::connectInternal,

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
+import org.apache.geode.annotations.VisibleForTesting;
+
+public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory {
+
+  @VisibleForTesting
+  static final String CLUSTER_ID_TAG = "cluster.id";
+  @VisibleForTesting
+  static final String MEMBER_NAME_TAG = "member.name";
+  @VisibleForTesting
+  static final String HOST_NAME_TAG = "host.name";
+
+  @Override
+  public CompositeMeterRegistry create(int systemId, String memberName, String hostName) {
+    CompositeMeterRegistry registry = new CompositeMeterRegistry();
+
+    MeterRegistry.Config registryConfig = registry.config();
+    registryConfig.commonTags(CLUSTER_ID_TAG, String.valueOf(systemId));
+    registryConfig.commonTags(MEMBER_NAME_TAG, memberName == null ? "" : memberName);
+    registryConfig.commonTags(HOST_NAME_TAG, hostName == null ? "" : hostName);
+
+    return registry;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
@@ -14,31 +14,12 @@
  */
 package org.apache.geode.internal.metrics;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-
-import org.apache.geode.annotations.VisibleForTesting;
 
 /**
  * Creates {@code CompositeMeterRegistry} and configures commonTags.
  */
 public interface CompositeMeterRegistryFactory {
 
-  @VisibleForTesting
-  String CLUSTER_ID_TAG = "ClusterId";
-  @VisibleForTesting
-  String MEMBER_NAME_TAG = "MemberName";
-  @VisibleForTesting
-  String HOST_NAME_TAG = "HostName";
-
-  default CompositeMeterRegistry create(int systemId, String memberName, String hostName) {
-    CompositeMeterRegistry registry = new CompositeMeterRegistry();
-
-    MeterRegistry.Config registryConfig = registry.config();
-    registryConfig.commonTags(CLUSTER_ID_TAG, String.valueOf(systemId));
-    registryConfig.commonTags(MEMBER_NAME_TAG, memberName == null ? "" : memberName);
-    registryConfig.commonTags(HOST_NAME_TAG, hostName == null ? "" : hostName);
-
-    return registry;
-  }
+  CompositeMeterRegistry create(int systemId, String memberName, String hostName);
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
@@ -14,9 +14,9 @@
  */
 package org.apache.geode.internal.metrics;
 
-import static org.apache.geode.internal.metrics.CompositeMeterRegistryFactory.CLUSTER_ID_TAG;
-import static org.apache.geode.internal.metrics.CompositeMeterRegistryFactory.HOST_NAME_TAG;
-import static org.apache.geode.internal.metrics.CompositeMeterRegistryFactory.MEMBER_NAME_TAG;
+import static org.apache.geode.internal.metrics.CacheMeterRegistryFactory.CLUSTER_ID_TAG;
+import static org.apache.geode.internal.metrics.CacheMeterRegistryFactory.HOST_NAME_TAG;
+import static org.apache.geode.internal.metrics.CacheMeterRegistryFactory.MEMBER_NAME_TAG;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.Meter;
@@ -24,7 +24,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import org.junit.Test;
 
-public class CompositeMeterRegistryFactoryTest {
+public class CacheMeterRegistryFactoryTest {
 
   private static final int CLUSTER_ID = 42;
   private static final String MEMBER_NAME = "member-name";
@@ -32,7 +32,7 @@ public class CompositeMeterRegistryFactoryTest {
 
   @Test
   public void createsCompositeMeterRegistry() {
-    CompositeMeterRegistryFactory factory = new CompositeMeterRegistryFactory() {};
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
 
     assertThat(factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME))
         .isInstanceOf(CompositeMeterRegistry.class);
@@ -40,7 +40,7 @@ public class CompositeMeterRegistryFactoryTest {
 
   @Test
   public void addsMemberNameCommonTag() {
-    CompositeMeterRegistryFactory factory = new CompositeMeterRegistryFactory() {};
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
     String theMemberName = "the-member-name";
 
     CompositeMeterRegistry registry = factory.create(CLUSTER_ID, theMemberName, HOST_NAME);
@@ -53,7 +53,7 @@ public class CompositeMeterRegistryFactoryTest {
 
   @Test
   public void addsClusterIdCommonTag() {
-    CompositeMeterRegistryFactory factory = new CompositeMeterRegistryFactory() {};
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
     int theSystemId = 21;
 
     CompositeMeterRegistry registry = factory.create(theSystemId, MEMBER_NAME, HOST_NAME);
@@ -66,7 +66,7 @@ public class CompositeMeterRegistryFactoryTest {
 
   @Test
   public void addsHostNameCommonTag() {
-    CompositeMeterRegistryFactory factory = new CompositeMeterRegistryFactory() {};
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
     String theHostName = "the-host-name";
 
     CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, theHostName);


### PR DESCRIPTION
Extract default from CompositeMeterRegistryFactory to concrete class
CompositeMeterRegistryFactory.

Please review: @demery-pivotal @upthewaterspout @moleske 