### PR TITLE
GEODE-6523 Disables Geode Management API with feature flag

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/StandaloneClientManagementAPIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/StandaloneClientManagementAPIAcceptanceTest.java
@@ -91,8 +91,7 @@ public class StandaloneClientManagementAPIAcceptanceTest {
     jarBuilder.buildJar(outputJar, new File(filePath));
 
     GfshExecution startCluster =
-        GfshScript.of("start locator --J=-Denable-experimental-cluster-management-service=true "
-            + getSslParameters(),
+        GfshScript.of("start locator " + getSslParameters(),
             "start server --locators=localhost[10334]")
             .withName("startCluster").execute(gfsh);
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/StandaloneClientManagementAPIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/StandaloneClientManagementAPIAcceptanceTest.java
@@ -91,9 +91,11 @@ public class StandaloneClientManagementAPIAcceptanceTest {
     jarBuilder.buildJar(outputJar, new File(filePath));
 
     GfshExecution startCluster =
-        GfshScript.of("start locator " + getSslParameters(),
-            "start server --locators=localhost[10334] " + getSslParameters())
+        GfshScript.of("start locator --J=-Denable-experimental-cluster-management-service=true "
+            + getSslParameters(),
+            "start server --locators=localhost[10334]")
             .withName("startCluster").execute(gfsh);
+
 
     assertThat(startCluster.getProcess().exitValue())
         .as("Cluster did not start correctly").isEqualTo(0);

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GeodeManagementFeatureFlagDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GeodeManagementFeatureFlagDUnitTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.rest;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.management.api.ClusterManagementService;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.rules.GeodeDevRestClient;
+
+public class GeodeManagementFeatureFlagDUnitTest {
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  private MemberVM locator;
+
+  private GeodeDevRestClient restClient;
+
+  @Test
+  public void geodeManagementShouldNotBeAvailableByDefault() throws Exception {
+    locator = cluster.startLocatorVM(0,
+        l -> l.withSystemProperty(ClusterManagementService.FEATURE_FLAG, "false")
+            .withHttpService());
+    restClient =
+        new GeodeDevRestClient("/geode-management/v2", "localhost", locator.getHttpPort(), false);
+    restClient.doGetAndAssert("/ping").hasStatusCode(404);
+  }
+
+  @Test
+  public void geodeManagementIsEnabledWithFeatureFlag() throws Exception {
+    locator = cluster.startLocatorVM(0, l -> l.withHttpService());
+    restClient =
+        new GeodeDevRestClient("/geode-management/v2", "localhost", locator.getHttpPort(), false);
+    restClient.doGetAndAssert("/ping").hasStatusCode(200).hasResponseBody().isEqualTo("pong");
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -708,14 +708,23 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
         new ImmutablePair<>(HttpService.CLUSTER_MANAGEMENT_SERVICE_CONTEXT_PARAM,
             clusterManagementService);
 
-    myCache.getHttpService().ifPresent(x -> {
-      try {
-        x.addWebApplication("/geode-management", gemfireManagementWar, securityServiceAttr,
-            cmServiceAttr);
-      } catch (Throwable e) {
-        logger.warn("Unable to start geode-management service: {}", e.getMessage());
-      }
-    });
+    if (Boolean.getBoolean(ClusterManagementService.FEATURE_FLAG)) {
+      logger.info(
+          "System Property " + ClusterManagementService.FEATURE_FLAG
+              + "=true Geode Management API is enabled.");
+      myCache.getHttpService().ifPresent(x -> {
+        try {
+          x.addWebApplication("/geode-management", gemfireManagementWar, securityServiceAttr,
+              cmServiceAttr);
+        } catch (Throwable e) {
+          logger.warn("Unable to start geode-management service: {}", e.getMessage());
+        }
+      });
+    } else {
+      logger.info(
+          "System Property " + ClusterManagementService.FEATURE_FLAG
+              + "=false Geode Management API is disabled.");
+    }
   }
 
   /**

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -380,5 +380,4 @@ public class ClusterStartupRule implements SerializableTestRule {
       clientCacheRule = null;
     }
   }
-
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/accessible/AccessibleRestoreSystemProperties.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/accessible/AccessibleRestoreSystemProperties.java
@@ -14,12 +14,15 @@
  */
 package org.apache.geode.test.junit.rules.accessible;
 
+import java.io.Serializable;
+
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 /**
  * Subclass RestoreSystemProperties in order to invoke protected methods from different package.
  */
-public class AccessibleRestoreSystemProperties extends RestoreSystemProperties {
+public class AccessibleRestoreSystemProperties extends RestoreSystemProperties implements
+    Serializable {
 
   @Override
   public void before() throws Throwable {

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/DebuggableCommand.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/DebuggableCommand.java
@@ -19,11 +19,14 @@ public class DebuggableCommand {
   final String command;
 
   public DebuggableCommand(String command) {
-    this.command = command;
-    this.debugPort = -1;
+    this(command, -1);
   }
 
   public DebuggableCommand(String command, int debugPort) {
+
+    if (command.startsWith("start locator")) {
+      command += " --J=-Denable-experimental-cluster-management-service=true ";
+    }
     this.command = command;
     this.debugPort = debugPort;
   }

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
@@ -25,6 +25,8 @@ import org.apache.geode.cache.configuration.CacheElement;
 @Experimental
 public interface ClusterManagementService {
 
+  String FEATURE_FLAG = "enable-experimental-cluster-management-service";
+
   /**
    * This method will create the element on all the applicable members in the cluster and persist
    * the configuration in the cluster configuration if persistence is enabled.


### PR DESCRIPTION
* The Geode Management API is disabled
* A feature flag has been added to allow people to use this experimental
feature using System Property `enable-experimental-cluster-management-service`

Co-authored-by: Jinmei Liao <jiliao@pivotal.io>
Co-authored-by: Peter Tran <ptran@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
