### PR TITLE
GEODE-6528: Add host.jvm.memory.used meter for heap and nonheap

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
@@ -14,6 +14,12 @@
  */
 package org.apache.geode.internal.metrics;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.util.function.Function;
+
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
@@ -27,6 +33,10 @@ public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory 
   static final String MEMBER_NAME_TAG = "member.name";
   @VisibleForTesting
   static final String HOST_NAME_TAG = "host.name";
+  @VisibleForTesting
+  static final String HOST_JVM_MEMORY_USED = "host.jvm.memory.used";
+  @VisibleForTesting
+  static final String JVM_MEMORY_AREA_TAG = "area";
 
   @Override
   public CompositeMeterRegistry create(int systemId, String memberName, String hostName) {
@@ -37,6 +47,47 @@ public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory 
     registryConfig.commonTags(MEMBER_NAME_TAG, memberName == null ? "" : memberName);
     registryConfig.commonTags(HOST_NAME_TAG, hostName == null ? "" : hostName);
 
+    createMemoryMeter(registry);
+
     return registry;
+  }
+
+  private void createMemoryMeter(CompositeMeterRegistry registry) {
+    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+
+    String meterName = HOST_JVM_MEMORY_USED;
+    String description = "The amount of memory in bytes that is used by the Java virtual machine";
+    String unit = "bytes";
+
+    Gauge
+        .builder(meterName, memoryMXBean, m -> getUsageValue(m, MemoryMXBean::getHeapMemoryUsage))
+        .tags(JVM_MEMORY_AREA_TAG, "heap")
+        .description(description)
+        .baseUnit(unit)
+        .register(registry);
+
+    Gauge
+        .builder(meterName, memoryMXBean,
+            m -> getUsageValue(m, MemoryMXBean::getNonHeapMemoryUsage))
+        .tags(JVM_MEMORY_AREA_TAG, "nonheap")
+        .description(description)
+        .baseUnit(unit)
+        .register(registry);
+  }
+
+  private double getUsageValue(MemoryMXBean memoryMXBean,
+      Function<MemoryMXBean, MemoryUsage> extractor) {
+    MemoryUsage usage = null;
+    try {
+      usage = extractor.apply(memoryMXBean);
+    } catch (InternalError e) {
+      // Defensive for potential InternalError with some specific JVM options. Based on its Javadoc,
+      // MemoryMXBean.getUsage() should return null, not throwing InternalError, so it seems to be a
+      // JVM bug.
+    }
+    if (usage == null) {
+      return Double.NaN;
+    }
+    return usage.getUsed();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
@@ -14,80 +14,23 @@
  */
 package org.apache.geode.internal.metrics;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.lang.management.MemoryUsage;
-import java.util.function.Function;
-
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
-import org.apache.geode.annotations.VisibleForTesting;
-
 public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory {
-
-  @VisibleForTesting
-  static final String CLUSTER_ID_TAG = "cluster.id";
-  @VisibleForTesting
-  static final String MEMBER_NAME_TAG = "member.name";
-  @VisibleForTesting
-  static final String HOST_NAME_TAG = "host.name";
-  @VisibleForTesting
-  static final String HOST_JVM_MEMORY_USED = "host.jvm.memory.used";
-  @VisibleForTesting
-  static final String JVM_MEMORY_AREA_TAG = "area";
 
   @Override
   public CompositeMeterRegistry create(int systemId, String memberName, String hostName) {
     CompositeMeterRegistry registry = new CompositeMeterRegistry();
 
     MeterRegistry.Config registryConfig = registry.config();
-    registryConfig.commonTags(CLUSTER_ID_TAG, String.valueOf(systemId));
-    registryConfig.commonTags(MEMBER_NAME_TAG, memberName == null ? "" : memberName);
-    registryConfig.commonTags(HOST_NAME_TAG, hostName == null ? "" : hostName);
+    registryConfig.commonTags("cluster.id", String.valueOf(systemId));
+    registryConfig.commonTags("member.name", memberName == null ? "" : memberName);
+    registryConfig.commonTags("host.name", hostName == null ? "" : hostName);
 
-    createMemoryMeter(registry);
+    new JvmMemoryMetrics().bindTo(registry);
 
     return registry;
-  }
-
-  private void createMemoryMeter(CompositeMeterRegistry registry) {
-    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
-
-    String meterName = HOST_JVM_MEMORY_USED;
-    String description = "The amount of memory in bytes that is used by the Java virtual machine";
-    String unit = "bytes";
-
-    Gauge
-        .builder(meterName, memoryMXBean, m -> getUsageValue(m, MemoryMXBean::getHeapMemoryUsage))
-        .tags(JVM_MEMORY_AREA_TAG, "heap")
-        .description(description)
-        .baseUnit(unit)
-        .register(registry);
-
-    Gauge
-        .builder(meterName, memoryMXBean,
-            m -> getUsageValue(m, MemoryMXBean::getNonHeapMemoryUsage))
-        .tags(JVM_MEMORY_AREA_TAG, "nonheap")
-        .description(description)
-        .baseUnit(unit)
-        .register(registry);
-  }
-
-  private double getUsageValue(MemoryMXBean memoryMXBean,
-      Function<MemoryMXBean, MemoryUsage> extractor) {
-    MemoryUsage usage = null;
-    try {
-      usage = extractor.apply(memoryMXBean);
-    } catch (InternalError e) {
-      // Defensive for potential InternalError with some specific JVM options. Based on its Javadoc,
-      // MemoryMXBean.getUsage() should return null, not throwing InternalError, so it seems to be a
-      // JVM bug.
-    }
-    if (usage == null) {
-      return Double.NaN;
-    }
-    return usage.getUsed();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
@@ -82,18 +82,32 @@ public class CacheMeterRegistryFactoryTest {
   }
 
   @Test
-  public void addsGaugesForHeapAndNonHeapUsedMemory() {
+  public void addsGaugesForHeapMemory() {
     CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
 
     CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
     registry.add(new SimpleMeterRegistry());
 
-    Collection<Gauge> gauges = registry
-        .find("host.jvm.memory.used")
+    Collection<Gauge> heapGauges = registry
+        .find("jvm.memory.used")
+        .tag("area", "heap")
         .gauges();
 
-    assertThat(gauges)
-        .extracting(g -> g.getId().getTag("area"))
-        .containsExactlyInAnyOrder("heap", "nonheap");
+    assertThat(heapGauges).isNotEmpty();
+  }
+
+  @Test
+  public void addsGaugesForNonHeapUsedMemory() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+
+    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
+    registry.add(new SimpleMeterRegistry());
+
+    Collection<Gauge> nonheapGauges = registry
+        .find("jvm.memory.used")
+        .tag("area", "nonheap")
+        .gauges();
+
+    assertThat(nonheapGauges).isNotEmpty();
   }
 }


### PR DESCRIPTION
Co-Authored-By: Dale Emery demery@pivotal.io
Co-Authored-By: Michael Oleske moleske@pivotal.io

Please review: @demery-pivotal @moleske 