### PR TITLE
GEODE-6532: Using implementation/api in geode-core instead of compile

### DIFF
--- a/extensions/geode-modules-session/build.gradle
+++ b/extensions/geode-modules-session/build.gradle
@@ -48,6 +48,7 @@ dependencies {
   integrationTestCompile('org.eclipse.jetty:jetty-http:' + DependencyConstraints.get('jetty.version') + ':tests')
   integrationTestCompile('org.eclipse.jetty:jetty-server')
   integrationTestCompile('org.eclipse.jetty:jetty-servlet:' + DependencyConstraints.get('jetty.version') + ':tests')
+  integrationTestCompile('org.eclipse.jetty:jetty-servlet:' + DependencyConstraints.get('jetty.version'))
   integrationTestCompile('org.eclipse.jetty:jetty-util')
   integrationTestCompile('org.httpunit:httpunit') {
     exclude group: 'javax.servlet'

--- a/geode-connectors/build.gradle
+++ b/geode-connectors/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     exclude module: 'spring-core'
     ext.optional = true
   }
+  compile('com.healthmarketscience.rmiio:rmiio')
 
   testCompile('pl.pragmatists:JUnitParams')
 

--- a/geode-connectors/src/test/resources/expected-pom.xml
+++ b/geode-connectors/src/test/resources/expected-pom.xml
@@ -118,5 +118,10 @@
       </exclusions>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.healthmarketscience.rmiio</groupId>
+      <artifactId>rmiio</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -149,13 +149,15 @@ task jcaJar(type: Jar, dependsOn: raJar) {
 
 configurations {
   classesOutput {
-    extendsFrom compile
+    extendsFrom api
     description 'a dependency that exposes the compiled classes'
   }
 }
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+
+  //These bom dependencies are used to constrain the versions of the dependencies listed below
+  api(platform(project(':boms:geode-all-bom')))
   compileOnly(platform(project(':boms:geode-all-bom')))
   // As plugin configurations that do not extend from compile,
   // we must explicitly impose version constraints on these configurations.
@@ -163,93 +165,162 @@ dependencies {
   jcaAnnotationProcessor(platform(project(':boms:geode-all-bom')))
   jmhCompile(platform(project(':boms:geode-all-bom')))
 
+  
+  //A dependency that contains the compiled output of the source. What is this for?
   classesOutput sourceSets.main.output
 
 
   // Source Dependencies
+  //------------------------------------------------------------
+
+  //  The antlr configuration is used by the antlr plugin, which compiles grammar
+  // files used by the query engine
   antlr 'antlr:antlr'
 
   // External
+  //------------------------------------------------------------
+
+
+  //tools.jar seems to be used by gfsh is some cases to control processes using
+  //the sun attach API? But this code path may not even be used?
   compileOnly files("${System.getProperty('java.home')}/../lib/tools.jar")
-  compile('com.github.stephenc.findbugs:findbugs-annotations')
-  compile('org.jgroups:jgroups')
-  compile('antlr:antlr')
-  compile('com.fasterxml.jackson.core:jackson-annotations')
-  compile('com.fasterxml.jackson.core:jackson-databind')
-  compile('commons-io:commons-io')
-  compile('commons-validator:commons-validator')
-  compile('commons-digester:commons-digester')
-  compile('com.sun.activation:javax.activation')
-  compile('javax.xml.bind:jaxb-api')
-  compile('com.sun.xml.bind:jaxb-impl')
-  compile('com.sun.istack:istack-commons-runtime') {
+
+  //Find bugs is used in multiple places in the code to suppress findbugs warnings
+  implementation('com.github.stephenc.findbugs:findbugs-annotations')
+
+  //Jgroups is a core component of our membership system.
+  implementation('org.jgroups:jgroups')
+
+  //Antlr is used by the query engine.
+  implementation('antlr:antlr')
+
+  //Jackson annotations is used in gfsh
+  implementation('com.fasterxml.jackson.core:jackson-annotations')
+
+  //Jackson databind is used in gfsh, and also in pdx
+  implementation('com.fasterxml.jackson.core:jackson-databind')
+
+  //Commons IO is used in persistence and management
+  implementation('commons-io:commons-io')
+
+  //Commons validator is used to validate inet addresses in membership
+  implementation('commons-validator:commons-validator')
+
+  //javax.activation is runtime dependency for gfsh with java 11 (used by gfsh-over-http)
+  runtimeOnly('com.sun.activation:javax.activation')
+
+  //jaxb is used by cluster configuration
+  implementation('javax.xml.bind:jaxb-api')
+
+  //jaxb is used by cluster configuration
+  implementation('com.sun.xml.bind:jaxb-impl')
+
+  //istack appears to be used only by jaxb, not in our code. jaxb doesn't
+  //declare this as required dependency though. It's unclear if this is needed
+  //Runtime
+  runtimeOnly('com.sun.istack:istack-commons-runtime') {
     exclude group: '*'
   }
 
-  compile('org.apache.commons:commons-lang3')
-  compile('commons-modeler:commons-modeler') {
-    exclude module: 'commons-digester'
+  //Commons lang is used in many different places in core
+  implementation('org.apache.commons:commons-lang3')
+  
+  //Commons modeler is used by the (deprecated) admin API
+  implementation('commons-modeler:commons-modeler') {
     exclude module: 'commons-logging-api'
     exclude module: 'mx4j-jmx'
     exclude module: 'xml-apis'
     ext.optional = true
   }
-  compile('io.micrometer:micrometer-core')
     
-  compile('it.unimi.dsi:fastutil')
-  compile('javax.mail:javax.mail-api') {
-    ext.optional = true
-  }
-  compile('javax.resource:javax.resource-api')
-  compile('mx4j:mx4j') {
-    ext.optional = true
-  }
-  compile('mx4j:mx4j-remote') {
-    ext.optional = true
-  }
-  compile('mx4j:mx4j-tools') {
-    ext.optional = true
-  }
-  compile('net.java.dev.jna:jna')
+  //micrometer is used for micrometer based metrics from geode geode
+  api('io.micrometer:micrometer-core')
 
-  compile('net.sf.jopt-simple:jopt-simple')
 
-  compile('org.apache.logging.log4j:log4j-api')
-  compile('org.apache.logging.log4j:log4j-core')
+  //FastUtil contains optimized collections that are used in multiple places in core
+  implementation('it.unimi.dsi:fastutil')
 
+  //Mail API is used by the deprecated admin API
+  implementation('javax.mail:javax.mail-api') {
+    ext.optional = true
+  }
+
+  //The resource-API is used by the JCA support.
+  api('javax.resource:javax.resource-api')
+
+
+  //MX4J is used by the old admin API
+  implementation('mx4j:mx4j') {
+    ext.optional = true
+  }
+
+  //MX4J remote is used by the old admin API 
+  implementation('mx4j:mx4j-remote') {
+    ext.optional = true
+  }
+
+  //MX4J tools is used by the old admin API
+  implementation('mx4j:mx4j-tools') {
+    ext.optional = true
+  }
+
+  //JNA is used for locking memory and preallocating disk files.
+  implementation('net.java.dev.jna:jna')
+
+  //JOptSimple is used by gfsh. A couple of usages have leaked into DiskStore
+  implementation('net.sf.jopt-simple:jopt-simple')
+
+  //Log4j is used everywhere
+  implementation('org.apache.logging.log4j:log4j-api')
+  implementation('org.apache.logging.log4j:log4j-core')
+
+  //Jansi is used by the CLI (maybe? it is a runtime dependency)
   runtimeOnly('org.fusesource.jansi:jansi') {
     ext.optional = true
   }
-  runtimeOnly('org.slf4j:slf4j-api')
 
+  //This routes slf4j logs to log4j. Shiro and micrometer use slf4j
   runtimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
     exclude module: 'slf4j-api'
     ext.optional = true
   }
+  //This routes commons logging logs to log4j. Several apache commons dependencies use commons logging
   runtimeOnly('org.apache.logging.log4j:log4j-jcl') {
     ext.optional = true
   }
+  //This routes jdk logs to log4j. Several dependencies use JDK logs (jackson, jaxb, ...)
   runtimeOnly('org.apache.logging.log4j:log4j-jul') {
     ext.optional = true
   }
-  compile('org.eclipse.jetty:jetty-webapp') {
+  //Jetty is used by the http service, which is used for the developer and management rest APIs
+  implementation('org.eclipse.jetty:jetty-webapp') {
     ext.optional = true
   }
-  compile('org.eclipse.jetty:jetty-server')
+  //Jetty is used by the http service, which is used for the developer and management rest APIs
+  implementation('org.eclipse.jetty:jetty-server')
+
+
+  //Spring webmvc is used by the REST management API
   compileOnly('org.springframework:spring-webmvc') {
     exclude module: 'aopalliance'
     exclude module: 'spring-aop'
     ext.optional = true
   }
+  //Spring webmvc is used by the REST management API
   testCompile('org.springframework:spring-webmvc') {
     exclude module: 'aopalliance'
     exclude module: 'spring-aop'
     ext.optional = true
   }
-  compile('org.springframework:spring-core') {
+  //Spring core is used by the REST API, and the gfsh cli
+  implementation('org.springframework:spring-core') {
     ext.optional = true
   }
-  compile('org.springframework.shell:spring-shell') {
+
+  //Spring shell is used by the gfsh cli. It's unclear why we can exclude
+  //So many transitive dependencies - are these really optional?
+  //GfshCommand is a public API class that depends on spring shell
+  api('org.springframework.shell:spring-shell') {
     exclude module: 'aopalliance'
     exclude module: 'asm'
     exclude module: 'cglib'
@@ -258,18 +329,31 @@ dependencies {
     exclude module: 'spring-context-support'
     exclude module: 'spring-core'
   }
-  compile('org.iq80.snappy:snappy') {
+
+  //Snappy is used for compressing values, if enabled
+  implementation('org.iq80.snappy:snappy') {
     ext.optional = true
   }
 
-  compile('org.apache.shiro:shiro-core')
+  //Shiro is used for security checks throughout geode-core
+  //API - Shiro is exposed in geode's ResourcePermission class
+  api('org.apache.shiro:shiro-core')
 
-  compile('io.github.classgraph:classgraph')
+  //Classgraph is used by the gfsh cli, and also for function deployment (which happens in a server
+  //in response to a gfsh command)
+  implementation('io.github.classgraph:classgraph')
 
-  compile('com.healthmarketscience.rmiio:rmiio')
+  //RMIIO is used for uploading jar files and copying them between locator an servers
+  implementation('com.healthmarketscience.rmiio:rmiio')
 
-  compile(project(':geode-common'))
-  compile(project(':geode-management'))
+  //Geode-common has annotations and other pieces used geode-core
+  //Currently it has ExpirationAction in it, which is an API dependency in core, but
+  //probably does not belong in this project
+  api(project(':geode-common'))
+  
+  //geode-management currently has pieces of the public API
+  //copied into it, so it is an API dependency
+  api(project(':geode-management'))
 
   jcaAnnotationProcessor 'org.apache.logging.log4j:log4j-core'
 

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -47,99 +47,9 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>com.github.stephenc.findbugs</groupId>
-      <artifactId>findbugs-annotations</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jgroups</groupId>
-      <artifactId>jgroups</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>antlr</groupId>
       <artifactId>antlr</artifactId>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-validator</groupId>
-      <artifactId>commons-validator</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-digester</groupId>
-      <artifactId>commons-digester</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.activation</groupId>
-      <artifactId>javax.activation</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.istack</groupId>
-      <artifactId>istack-commons-runtime</artifactId>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-modeler</groupId>
-      <artifactId>commons-modeler</artifactId>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-logging-api</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>commons-digester</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>xml-apis</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>mx4j-jmx</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
@@ -147,75 +57,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>it.unimi.dsi</groupId>
-      <artifactId>fastutil</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>javax.mail-api</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>javax.resource</groupId>
       <artifactId>javax.resource-api</artifactId>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>mx4j</groupId>
-      <artifactId>mx4j</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>mx4j</groupId>
-      <artifactId>mx4j-remote</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>mx4j</groupId>
-      <artifactId>mx4j-tools</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>net.java.dev.jna</groupId>
-      <artifactId>jna</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.jopt-simple</groupId>
-      <artifactId>jopt-simple</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-webapp</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.springframework.shell</groupId>
@@ -253,24 +97,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.iq80.snappy</groupId>
-      <artifactId>snappy</artifactId>
-      <scope>compile</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.github.classgraph</groupId>
-      <artifactId>classgraph</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.healthmarketscience.rmiio</groupId>
-      <artifactId>rmiio</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -284,15 +112,173 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi</artifactId>
+      <groupId>com.github.stephenc.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jgroups</groupId>
+      <artifactId>jgroups</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-modeler</groupId>
+      <artifactId>commons-modeler</artifactId>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>commons-logging-api</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>xml-apis</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>mx4j-jmx</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.mail</groupId>
+      <artifactId>javax.mail-api</artifactId>
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <groupId>mx4j</groupId>
+      <artifactId>mx4j</artifactId>
       <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>mx4j</groupId>
+      <artifactId>mx4j-remote</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>mx4j</groupId>
+      <artifactId>mx4j-tools</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>net.java.dev.jna</groupId>
+      <artifactId>jna</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.jopt-simple</groupId>
+      <artifactId>jopt-simple</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.iq80.snappy</groupId>
+      <artifactId>snappy</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.github.classgraph</groupId>
+      <artifactId>classgraph</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.healthmarketscience.rmiio</groupId>
+      <artifactId>rmiio</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.activation</groupId>
+      <artifactId>javax.activation</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.istack</groupId>
+      <artifactId>istack-commons-runtime</artifactId>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.fusesource.jansi</groupId>
+      <artifactId>jansi</artifactId>
+      <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -47,6 +47,11 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-json</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <scope>compile</scope>

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -47,11 +47,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-json</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
       <scope>compile</scope>

--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -22,6 +22,7 @@ dependencies {
   compile(project(':geode-core'))
   compile('com.github.davidmoten:geo')
   compile('io.netty:netty-all')
+  compile('org.apache.logging.log4j:log4j-api')
   distributedTestCompile(project(':geode-dunit'))
   integrationTestCompile('redis.clients:jedis')
   distributedTestCompile('redis.clients:jedis')

--- a/geode-redis/src/test/resources/expected-pom.xml
+++ b/geode-redis/src/test/resources/expected-pom.xml
@@ -61,5 +61,10 @@
       <artifactId>netty-all</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-web-api/build.gradle
+++ b/geode-web-api/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     exclude module: 'spring-core'
     exclude module: 'spring-beans'
   }
+  compileOnly('org.apache.logging.log4j:log4j-api')
 
 
   testCompile(project(':geode-junit')) {

--- a/geode-web-management/build.gradle
+++ b/geode-web-management/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     exclude module: 'spring-core'
     exclude module: 'spring-beans'
   }
+  compileOnly('org.apache.logging.log4j:log4j-api')
 
   commonTestCompile(project(':geode-core'))
   commonTestCompile(project(':geode-junit')) {

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -23,6 +23,7 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compileOnly('javax.servlet:javax.servlet-api')
+  testCompile('javax.servlet:javax.servlet-api')
   compileOnly(project(path: ':geode-core', configuration: 'classesOutput'))
 
   runtimeOnly('org.springframework:spring-aspects') {
@@ -60,9 +61,7 @@ dependencies {
   }
 
 
-  integrationTestCompile(project(':geode-dunit')) {
-    exclude module: 'geode-core'
-  }
+  integrationTestCompile(project(':geode-dunit'));
 
   integrationTestRuntime(files(war.destinationDir))
   integrationTestRuntime('org.springframework:spring-webmvc') {
@@ -71,9 +70,8 @@ dependencies {
   }
 
 
-  distributedTestCompile(project(':geode-dunit')){
-    exclude module: 'geode-core'
-  }
+  distributedTestCompile(project(':geode-common'))
+  distributedTestCompile(project(':geode-dunit'))
   distributedTestCompile('pl.pragmatists:JUnitParams')
 
   distributedTestRuntime(files(war.destinationDir))

--- a/gradle/publish.gradle
+++ b/gradle/publish.gradle
@@ -84,11 +84,19 @@ publishing {
           def runtimeDeps = project.configurations.runtime.dependencies.collectEntries {
             [it.name, it]
           }
+          depMap.putAll(runtimeDeps)
           def runtimeOnlyDeps = project.configurations.runtimeOnly.dependencies.collectEntries {
             [it.name, it]
           }
-          depMap.putAll(runtimeDeps)
           depMap.putAll(runtimeOnlyDeps)
+          def implementationDependencies = project.configurations.implementation.dependencies.collectEntries {
+            [it.name, it]
+          }
+          depMap.putAll(implementationDependencies)
+          def apiDependencies = project.configurations.api.dependencies.collectEntries {
+            [it.name, it]
+          }
+          depMap.putAll(apiDependencies)
           asNode().dependencies.dependency.findAll {
             def dep = depMap.get(it.artifactId.text())
             return dep?.hasProperty('optional') && dep.optional


### PR DESCRIPTION
* Using implementation or api where appropriate in geode-core
dependencies. This allows downstream consumers of geode-core to get this
dependencies as runtime dependencies instead of compile.

* Adding first order dependencies to other subprojects that needed them.

* Removing a couple of dependencies from geode-core that we were only
using transitively.

*  Adding comments to geode-core dependencies

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
