### PR TITLE
GEODE-6534: Encapsulate LocalRegion entryUserAttributes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
@@ -17,8 +17,6 @@ package org.apache.geode.internal.cache;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Hashtable;
-import java.util.Map;
 
 import org.apache.geode.DataSerializable;
 import org.apache.geode.cache.CacheStatistics;
@@ -143,20 +141,13 @@ public class EntrySnapshot implements Region.Entry, DataSerializable {
   @Override
   public Object getUserAttribute() {
     checkEntryDestroyed();
-    Map userAttr = region.entryUserAttributes;
-    if (userAttr == null) {
-      return null;
-    }
-    return userAttr.get(this.regionEntry.getKey());
+    return region.getEntryUserAttributes().get(regionEntry.getKey());
   }
 
   @Override
   public Object setUserAttribute(Object value) {
     checkEntryDestroyed();
-    if (region.entryUserAttributes == null) {
-      region.entryUserAttributes = new Hashtable();
-    }
-    return region.entryUserAttributes.put(this.regionEntry.getKey(), value);
+    return region.getEntryUserAttributes().put(regionEntry.getKey(), value);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
 
@@ -408,7 +409,9 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   EvictionController getEvictionController();
 
-  default void handleWANEvent(EntryEventImpl event) {}
+  default void handleWANEvent(EntryEventImpl event) {
+    // do nothing;
+  }
 
   MemoryThresholdInfo getAtomicThresholdInfo();
 
@@ -416,7 +419,11 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   default boolean lockWhenRegionIsInitializing() {
     return false;
-  };
+  }
 
-  default void unlockWhenRegionIsInitializing() {};
+  default void unlockWhenRegionIsInitializing() {
+    // do nothing
+  }
+
+  Map<Object, Object> getEntryUserAttributes();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntry.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache;
 
-import java.util.Hashtable;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.cache.CacheStatistics;
@@ -185,10 +184,7 @@ public class TXEntry implements Region.Entry {
       return tx.setPendingValue(value);
     } else {
       checkEntryDestroyed();
-      if (this.localRegion.entryUserAttributes == null) {
-        this.localRegion.entryUserAttributes = new Hashtable();
-      }
-      return this.localRegion.entryUserAttributes.put(keyInfo, value);
+      return localRegion.getEntryUserAttributes().put(keyInfo, value);
     }
   }
 


### PR DESCRIPTION
[Part of GEODE-6534: Refactor LocalRegion]

Make entryUserAttributes final and thread safe.

Lots of threads were checking for null and constructing it as either
ConcurrentHashMap or HashTable. Now it is a final ConcurrentHashMap.

Reduced visibility to private and added accessor.

Please review: @demery-pivotal 