### PR TITLE
GEODE-6488: Migrating cancellation state to execution context

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
@@ -52,10 +52,13 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.functional.StructSetOrResultsSet;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
 import org.apache.geode.cache.query.internal.IndexTrackingQueryObserver;
+import org.apache.geode.cache.query.internal.QueryExecutionContext;
 import org.apache.geode.cache.query.internal.QueryObserverHolder;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalDataSet;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.execute.PRClientServerTestBase;
@@ -673,9 +676,11 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
 
       try {
         Query query = queryService.newQuery((String) args[0]);
+        final ExecutionContext executionContext =
+            new QueryExecutionContext(null, (InternalCache) cache, query);
         context.getResultSender()
             .lastResult((ArrayList) ((SelectResults) ((LocalDataSet) localDataSet)
-                .executeQuery((DefaultQuery) query, null, buckets)).asList());
+                .executeQuery((DefaultQuery) query, executionContext, null, buckets)).asList());
       } catch (Exception e) {
         throw new FunctionException(e);
       }
@@ -866,9 +871,13 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
     QueryService qservice = CacheFactory.getAnyInstance().getQueryService();
 
     Query query = qservice.newQuery(queryStr);
+    final ExecutionContext executionContext =
+        new QueryExecutionContext(null, (InternalCache) cache, query);
+
     SelectResults results;
     try {
       results = (SelectResults) ((LocalDataSet) localDataSet).executeQuery((DefaultQuery) query,
+          executionContext,
           null, buckets);
 
       return (ArrayList) results.asList();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
@@ -57,6 +57,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.cache30.ClientServerTestCase;
@@ -1296,7 +1297,8 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
     public boolean rejectedObjects = false;
 
     @Override
-    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored,
+        final ExecutionContext executionContext) {
       switch (spot) {
         case BEFORE_QUERY_EXECUTION:
           try {
@@ -1327,7 +1329,8 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
     private int numObjectsBeforeCancel = 5;
 
     @Override
-    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored,
+        final ExecutionContext executionContext) {
       switch (spot) {
         case LOW_MEMORY_WHEN_DESERIALIZING_STREAMINGOPERATION:
           rejectedObjects = true;
@@ -1350,7 +1353,8 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
     public boolean rejectedObjects = false;
 
     @Override
-    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored,
+        final ExecutionContext executionContext) {
       switch (spot) {
         case BEFORE_BUILD_CUMULATIVE_RESULT:
           if (triggeredOOME == false) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRQueryDUnitTest.java
@@ -42,6 +42,8 @@ import org.apache.geode.cache.query.QueryException;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
+import org.apache.geode.cache.query.internal.QueryExecutionContext;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionQueryEvaluator;
 import org.apache.geode.test.dunit.VM;
@@ -113,6 +115,7 @@ public class PRQueryDUnitTest extends CacheTestCase {
 
     DefaultQuery query = (DefaultQuery) getCache().getQueryService()
         .newQuery("select distinct * from " + region.getFullPath());
+    final ExecutionContext executionContext = new QueryExecutionContext(null, getCache(), query);
     SelectResults results =
         query.getSimpleSelect().getEmptyResultSet(EMPTY_PARAMETERS, getCache(), query);
 
@@ -124,6 +127,7 @@ public class PRQueryDUnitTest extends CacheTestCase {
     PartitionedRegion partitionedRegion = (PartitionedRegion) region;
     PartitionedRegionQueryEvaluator queryEvaluator =
         new PartitionedRegionQueryEvaluator(partitionedRegion.getSystem(), partitionedRegion, query,
+            executionContext,
             EMPTY_PARAMETERS, results, buckets);
 
     DisconnectingTestHook testHook = new DisconnectingTestHook();
@@ -164,13 +168,15 @@ public class PRQueryDUnitTest extends CacheTestCase {
 
       for (int i = 0; i < queries.length; i++) {
         DefaultQuery query = (DefaultQuery) getCache().getQueryService().newQuery(queries[i]);
+        final ExecutionContext executionContext =
+            new QueryExecutionContext(null, getCache(), query);
         SelectResults results =
             query.getSimpleSelect().getEmptyResultSet(EMPTY_PARAMETERS, getCache(), query);
 
         PartitionedRegion partitionedRegion = (PartitionedRegion) region;
         PartitionedRegionQueryEvaluator queryEvaluator =
             new PartitionedRegionQueryEvaluator(partitionedRegion.getSystem(), partitionedRegion,
-                query, EMPTY_PARAMETERS, results, bucketsToQuery);
+                query, executionContext, EMPTY_PARAMETERS, results, bucketsToQuery);
 
         CollatingTestHook testHook = new CollatingTestHook(queryEvaluator);
         queryEvaluator.queryBuckets(testHook);
@@ -212,13 +218,14 @@ public class PRQueryDUnitTest extends CacheTestCase {
 
     for (int i = 0; i < queries.length; i++) {
       DefaultQuery query = (DefaultQuery) getCache().getQueryService().newQuery(queries[i]);
+      final ExecutionContext executionContext = new QueryExecutionContext(null, getCache(), query);
       SelectResults results =
           query.getSimpleSelect().getEmptyResultSet(EMPTY_PARAMETERS, getCache(), query);
 
       PartitionedRegion partitionedRegion = (PartitionedRegion) region;
       PartitionedRegionQueryEvaluator queryEvaluator =
           new PartitionedRegionQueryEvaluator(partitionedRegion.getSystem(), partitionedRegion,
-              query, EMPTY_PARAMETERS, results, buckets);
+              query, executionContext, EMPTY_PARAMETERS, results, buckets);
 
       CollatingTestHook testHook = new CollatingTestHook(queryEvaluator);
       queryEvaluator.queryBuckets(testHook);
@@ -258,6 +265,7 @@ public class PRQueryDUnitTest extends CacheTestCase {
 
       DefaultQuery query = (DefaultQuery) getCache().getQueryService()
           .newQuery("select distinct * from /" + regionName);
+      final ExecutionContext executionContext = new QueryExecutionContext(null, getCache(), query);
       SelectResults results =
           query.getSimpleSelect().getEmptyResultSet(EMPTY_PARAMETERS, getCache(), query);
 
@@ -270,7 +278,7 @@ public class PRQueryDUnitTest extends CacheTestCase {
       PartitionedRegion partitionedRegion = (PartitionedRegion) region;
       PartitionedRegionQueryEvaluator queryEvaluator =
           new PartitionedRegionQueryEvaluator(partitionedRegion.getSystem(), partitionedRegion,
-              query, EMPTY_PARAMETERS, results, buckets);
+              query, executionContext, EMPTY_PARAMETERS, results, buckets);
 
       assertThatThrownBy(() -> queryEvaluator.queryBuckets(null))
           .isInstanceOf(QueryException.class);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryDistributedTest.java
@@ -42,6 +42,7 @@ import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.DefaultQuery.TestHook;
+import org.apache.geode.cache.query.internal.ExecutionContext;
 import org.apache.geode.cache.query.internal.index.IndexManager;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
@@ -575,7 +576,8 @@ public class PRQueryDistributedTest implements Serializable {
     }
 
     @Override
-    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored,
+        final ExecutionContext executionContext) {
       hooks.put(spot, Boolean.TRUE);
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/LocalDataSetIndexingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/LocalDataSetIndexingDUnitTest.java
@@ -39,6 +39,8 @@ import org.apache.geode.cache.query.IndexType;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
+import org.apache.geode.cache.query.internal.QueryExecutionContext;
 import org.apache.geode.cache.query.internal.QueryObserverAdapter;
 import org.apache.geode.cache.query.internal.QueryObserverHolder;
 import org.apache.geode.cache30.CacheSerializableRunnable;
@@ -149,6 +151,8 @@ public class LocalDataSetIndexingDUnitTest extends JUnit4CacheTestCase {
                   QueryService qs = pr1.getCache().getQueryService();
                   DefaultQuery query = (DefaultQuery) qs.newQuery(
                       "select distinct e1.value from /pr1 e1, /pr2  e2 where e1.value=e2.value");
+                  final ExecutionContext executionContext =
+                      new QueryExecutionContext(null, cache, query);
 
                   GemFireCacheImpl.getInstance().getLogger()
                       .fine(" Num BUCKET SET: " + localCust.getBucketSet());
@@ -175,7 +179,8 @@ public class LocalDataSetIndexingDUnitTest extends JUnit4CacheTestCase {
                   }
 
                   SelectResults r =
-                      (SelectResults) localCust.executeQuery(query, null, localCust.getBucketSet());
+                      (SelectResults) localCust.executeQuery(query, executionContext, null,
+                          localCust.getBucketSet());
 
                   GemFireCacheImpl.getInstance().getLogger().fine("Result :" + r.asList());
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryJUnitTest.java
@@ -52,6 +52,7 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.data.Position;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 
@@ -396,7 +397,8 @@ public class QueryJUnitTest {
     }
 
     @Override
-    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored,
+        final ExecutionContext executionContext) {
       if (spot == SPOTS.BEFORE_QUERY_EXECUTION) {
         try {
           barrier.await(8, TimeUnit.SECONDS);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryServiceRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryServiceRegressionTest.java
@@ -42,9 +42,12 @@ import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.data.Position;
 import org.apache.geode.cache.query.data.TestData.MyValue;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
+import org.apache.geode.cache.query.internal.QueryExecutionContext;
 import org.apache.geode.cache.query.internal.QueryObserverAdapter;
 import org.apache.geode.cache.query.internal.QueryObserverHolder;
 import org.apache.geode.cache.query.internal.QueryUtils;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalDataSet;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
@@ -442,7 +445,9 @@ public class QueryServiceRegressionTest {
     String query =
         "select distinct e1.value from /pr1 e1, " + "/pr2  e2" + " where e1.value=e2.value";
     DefaultQuery cury = (DefaultQuery) CacheUtils.getQueryService().newQuery(query);
-    SelectResults r = (SelectResults) lds.executeQuery(cury, null, set);
+    final ExecutionContext executionContext =
+        new QueryExecutionContext(null, (InternalCache) cache, cury);
+    SelectResults r = (SelectResults) lds.executeQuery(cury, executionContext, null, set);
 
     if (!observer.isIndexesUsed) {
       fail("Indexes should have been used");
@@ -513,7 +518,9 @@ public class QueryServiceRegressionTest {
     String query =
         "select distinct e1.key from /pr1.entries e1,/pr2.entries  e2" + " where e1.value=e2.value";
     DefaultQuery cury = (DefaultQuery) CacheUtils.getQueryService().newQuery(query);
-    SelectResults r = (SelectResults) lds.executeQuery(cury, null, set);
+    final ExecutionContext executionContext =
+        new QueryExecutionContext(null, (InternalCache) cache, cury);
+    SelectResults r = (SelectResults) lds.executeQuery(cury, executionContext, null, set);
 
     if (!observer.isIndexesUsed) {
       fail("Indexes should have been used");

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryWithBucketParameterIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryWithBucketParameterIntegrationTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.cache.PartitionResolver;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
 import org.apache.geode.internal.cache.LocalDataSet;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
@@ -105,23 +106,28 @@ public class QueryWithBucketParameterIntegrationTest {
 
   @Test
   public void testQueryExecuteWithEmptyBucketListExpectNoResults() throws Exception {
-    SelectResults r = (SelectResults) lds.executeQuery(queryExecutor, null, new HashSet<Integer>());
+    final ExecutionContext executionContext = new ExecutionContext(null, CacheUtils.getCache());
+    SelectResults r = (SelectResults) lds.executeQuery(queryExecutor, executionContext, null,
+        new HashSet<Integer>());
     assertTrue("Received: A non-empty result collection, expected : Empty result collection",
         r.isEmpty());
   }
 
   @Test
   public void testQueryExecuteWithNullBucketListExpectNonEmptyResultSet() throws Exception {
-    SelectResults r = (SelectResults) lds.executeQuery(queryExecutor, null, null);
+    final ExecutionContext executionContext = new ExecutionContext(null, CacheUtils.getCache());
+    SelectResults r = (SelectResults) lds.executeQuery(queryExecutor, executionContext, null, null);
     assertFalse("Received: An empty result collection, expected : Non-empty result collection",
         r.isEmpty());
   }
 
   @Test
   public void testQueryExecuteWithNonEmptyBucketListExpectNonEmptyResultSet() throws Exception {
+    final ExecutionContext executionContext = new ExecutionContext(null, CacheUtils.getCache());
     int nTestBucketNumber = 15;
     Set<Integer> nonEmptySet = createAndPopulateSet(nTestBucketNumber);
-    SelectResults r = (SelectResults) lds.executeQuery(queryExecutor, null, nonEmptySet);
+    SelectResults r =
+        (SelectResults) lds.executeQuery(queryExecutor, executionContext, null, nonEmptySet);
     assertFalse("Received: An empty result collection, expected : Non-empty result collection",
         r.isEmpty());
   }
@@ -129,8 +135,10 @@ public class QueryWithBucketParameterIntegrationTest {
   @Test(expected = QueryInvocationTargetException.class)
   public void testQueryExecuteWithLargerBucketListThanExistingExpectQueryInvocationTargetException()
       throws Exception {
+    final ExecutionContext executionContext = new ExecutionContext(null, CacheUtils.getCache());
     int nTestBucketNumber = 45;
     Set<Integer> overflowSet = createAndPopulateSet(nTestBucketNumber);
-    SelectResults r = (SelectResults) lds.executeQuery(queryExecutor, null, overflowSet);
+    SelectResults r =
+        (SelectResults) lds.executeQuery(queryExecutor, executionContext, null, overflowSet);
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/QueryMonitorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/QueryMonitorIntegrationTest.java
@@ -135,7 +135,7 @@ public class QueryMonitorIntegrationTest {
   }
 
   @Test
-  public void monitorQueryExecutionThenStopMonitoringNoRemainingCancellationTasksRunning() {
+  public void monitorMultipleQueryExecutionsThenStopMonitoringNoRemainingCancellationTasksRunning() {
     cache = (InternalCache) new CacheFactory().set(LOCATORS, "").set(MCAST_PORT, "0").create();
     final DefaultQuery query =
         (DefaultQuery) cache.getQueryService().newQuery("SELECT DISTINCT * FROM /exampleRegion");
@@ -149,6 +149,9 @@ public class QueryMonitorIntegrationTest {
         cache,
         NEVER_EXPIRE_MILLIS);
 
+    // We want to ensure isolation of cancellation tasks for different query threads/executions.
+    // Here we ensure that if we monitor/unmonitor two executions in different threads that
+    // both cancellation tasks are removed from the executor queue.
     final Thread firstClientQueryThread = new Thread(() -> {
       queryMonitor.monitorQueryExecution(executionContext);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/QueryMonitorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/QueryMonitorIntegrationTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,10 +26,13 @@ import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.stubbing.Answer;
 
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.CacheRuntimeException;
 import org.apache.geode.cache.query.QueryExecutionLowMemoryException;
 import org.apache.geode.internal.cache.InternalCache;
@@ -40,21 +45,21 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
  */
 public class QueryMonitorIntegrationTest {
 
-  // query expiration duration so long that the query never expires
+  // executionContext expiration duration so long that the executionContext never expires
   private static final int NEVER_EXPIRE_MILLIS = 100000;
 
   // much much smaller than default maximum wait time of GeodeAwaitility
   private static final int EXPIRE_QUICK_MILLIS = 1;
 
   private InternalCache cache;
-  private DefaultQuery query;
+  private ExecutionContext executionContext;
   private volatile CacheRuntimeException cacheRuntimeException;
   private volatile QueryExecutionCanceledException queryExecutionCanceledException;
 
   @Before
   public void before() {
     cache = mock(InternalCache.class);
-    query = mock(DefaultQuery.class);
+    executionContext = mock(ExecutionContext.class);
     cacheRuntimeException = null;
     queryExecutionCanceledException = null;
   }
@@ -73,15 +78,15 @@ public class QueryMonitorIntegrationTest {
           cache,
           NEVER_EXPIRE_MILLIS);
 
-      queryMonitor.monitorQueryThread(query);
+      queryMonitor.monitorQueryExecution(executionContext);
 
       queryMonitor.setLowMemory(true, 1);
 
-      verify(query, times(1))
+      verify(executionContext, times(1))
           .setQueryCanceledException(any(QueryExecutionLowMemoryException.class));
 
       assertThatThrownBy(QueryMonitor::throwExceptionIfQueryOnCurrentThreadIsCanceled,
-          "Expected setLowMemory(true,_) to cancel query immediately, but it didn't.",
+          "Expected setLowMemory(true,_) to cancel executionContext immediately, but it didn't.",
           QueryExecutionCanceledException.class);
     } finally {
       if (queryMonitor != null) {
@@ -98,7 +103,7 @@ public class QueryMonitorIntegrationTest {
   }
 
   @Test
-  public void monitorQueryThreadCancelsLongRunningQueriesAndSetsExceptionAndThrowsException() {
+  public void monitorQueryExecutionCancelsLongRunningQueriesAndSetsExceptionAndThrowsException() {
 
     QueryMonitor queryMonitor = new QueryMonitor(
         new ScheduledThreadPoolExecutor(1),
@@ -116,10 +121,10 @@ public class QueryMonitorIntegrationTest {
       return null;
     };
 
-    doAnswer(processSetQueryCanceledException).when(query)
+    doAnswer(processSetQueryCanceledException).when(executionContext)
         .setQueryCanceledException(any(CacheRuntimeException.class));
 
-    startQueryThread(queryMonitor, query);
+    startQueryThread(queryMonitor, executionContext);
 
     GeodeAwaitility.await().until(() -> cacheRuntimeException != null);
 
@@ -129,11 +134,52 @@ public class QueryMonitorIntegrationTest {
     assertThat(queryExecutionCanceledException).isNotNull();
   }
 
+  @Test
+  public void monitorQueryExecutionThenStopMonitoringNoRemainingCancellationTasksRunning() {
+    cache = (InternalCache) new CacheFactory().set(LOCATORS, "").set(MCAST_PORT, "0").create();
+    final DefaultQuery query =
+        (DefaultQuery) cache.getQueryService().newQuery("SELECT DISTINCT * FROM /exampleRegion");
+    executionContext = new QueryExecutionContext(null, cache, query);
+    final ExecutionContext executionContext2 = new QueryExecutionContext(null, cache, query);
+
+    final ScheduledThreadPoolExecutor queryMonitorExecutor = new ScheduledThreadPoolExecutor(1);
+
+    final QueryMonitor queryMonitor = new QueryMonitor(
+        queryMonitorExecutor,
+        cache,
+        NEVER_EXPIRE_MILLIS);
+
+    final Thread firstClientQueryThread = new Thread(() -> {
+      queryMonitor.monitorQueryExecution(executionContext);
+
+      final Thread secondClientQueryThread = new Thread(() -> {
+        queryMonitor.monitorQueryExecution(executionContext2);
+        queryMonitor.stopMonitoringQueryExecution(executionContext2);
+      });
+
+      secondClientQueryThread.start();
+      try {
+        secondClientQueryThread.join();
+      } catch (final InterruptedException ex) {
+        Assert.fail("Unexpected exception while executing query. Details:\n"
+            + ExceptionUtils.getStackTrace(ex));
+      }
+
+      queryMonitor.stopMonitoringQueryExecution(executionContext);
+    });
+
+    firstClientQueryThread.start();
+
+    // Both cancellation tasks should have been removed upon stopping monitoring the queries on
+    // each thread, so the task queue size should be 0
+    GeodeAwaitility.await().until(() -> queryMonitorExecutor.getQueue().size() == 0);
+  }
+
   private void startQueryThread(final QueryMonitor queryMonitor,
-      final DefaultQuery query) {
+      final ExecutionContext executionContext) {
 
     final Thread queryThread = new Thread(() -> {
-      queryMonitor.monitorQueryThread(query);
+      queryMonitor.monitorQueryExecution(executionContext);
 
       while (true) {
         try {
@@ -144,7 +190,7 @@ public class QueryMonitorIntegrationTest {
           break;
         } catch (final InterruptedException e) {
           Thread.currentThread().interrupt();
-          throw new AssertionError("Simulated query thread unexpectedly interrupted.");
+          throw new AssertionError("Simulated executionContext thread unexpectedly interrupted.");
         }
       }
     });

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
@@ -41,6 +41,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.DefaultQuery.TestHook;
+import org.apache.geode.cache.query.internal.ExecutionContext;
 import org.apache.geode.internal.cache.persistence.query.CloseableIterator;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
 
@@ -346,7 +347,8 @@ public class CompactRangeIndexJUnitTest {
     }
 
     @Override
-    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored,
+        final ExecutionContext executionContext) {
       try {
         switch (spot) {
           case ATTEMPT_REMOVE:
@@ -395,7 +397,8 @@ public class CompactRangeIndexJUnitTest {
     }
 
     @Override
-    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored) {
+    public void doTestHook(final SPOTS spot, final DefaultQuery _ignored,
+        final ExecutionContext executionContext) {
       try {
         switch (spot) {
           case ATTEMPT_REMOVE:

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorIntegrationTest.java
@@ -80,7 +80,8 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
 
     // running the algorithm and getting the list of bucktes to grab
     PartitionedRegionQueryEvaluator evalr =
-        new PartitionedRegionQueryEvaluator(pr.getSystem(), pr, null, null, null, bucketsToQuery);
+        new PartitionedRegionQueryEvaluator(pr.getSystem(), pr, null, null, null, null,
+            bucketsToQuery);
     Map n2bMap = null;
     try {
       n2bMap = evalr.buildNodeToBucketMap();
@@ -99,7 +100,8 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
       assertTrue(" Bucket with Id = " + i + " not present in bucketList.",
           buckList.contains(new Integer(i)));
     }
-    clearAllPartitionedRegion(pr);
+
+    pr.destroyRegion();
   }
 
   /**
@@ -134,12 +136,6 @@ public class PartitionedRegionQueryEvaluatorIntegrationTest {
         assertTrue(ra.getBucket(i).getBucketAdvisor().putProfile(bp, forceBadProfile));
       }
     }
-  }
-
-  private void clearAllPartitionedRegion(PartitionedRegion pr) {
-    InternalCache cache = pr.getCache();
-    Region allPR = PartitionedRegionHelper.getPRRoot(cache);
-    allPR.clear();
   }
 
   /**

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -351,7 +351,7 @@ fromData,16
 toData,16
 
 org/apache/geode/distributed/internal/streaming/StreamingOperation$StreamingReplyMessage,2
-fromData,420
+fromData,422
 toData,85
 
 org/apache/geode/distributed/internal/tcpserver/InfoRequest,2

--- a/geode-core/src/jmh/java/org/apache/geode/cache/query/internal/MonitorQueryUnderContentionBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/cache/query/internal/MonitorQueryUnderContentionBenchmark.java
@@ -54,7 +54,7 @@ public class MonitorQueryUnderContentionBenchmark {
   private static final int START_DELAY_RANGE_MILLIS = 100;
 
   /*
-   * Delay, from time startOneSimulatedQuery() is called, until monitorQueryThread() is called.
+   * Delay, from time startOneSimulatedQuery() is called, until monitorQueryExecution() is called.
    */
   private static final int QUERY_INITIAL_DELAY = 0;
 
@@ -136,8 +136,8 @@ public class MonitorQueryUnderContentionBenchmark {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   // @Warmup we don't warm up because our @Setup warms us up
   public void monitorQuery() {
-    queryMonitor.monitorQueryThread(query);
-    queryMonitor.stopMonitoringQueryThread(query);
+    queryMonitor.monitorQueryExecution(query);
+    queryMonitor.stopMonitoringQueryExecution(query);
   }
 
   private void generateLoad(final ScheduledExecutorService executorService,
@@ -160,9 +160,9 @@ public class MonitorQueryUnderContentionBenchmark {
       int startDelayRangeMillis, int completeDelayRangeMillis) {
     executorService.schedule(() -> {
       final DefaultQuery query = createDefaultQuery();
-      queryMonitor.monitorQueryThread(query);
+      queryMonitor.monitorQueryExecution(query);
       executorService.schedule(() -> {
-        queryMonitor.stopMonitoringQueryThread(query);
+        queryMonitor.stopMonitoringQueryExecution(query);
       },
           gaussianLong(completeDelayRangeMillis),
           TimeUnit.MILLISECONDS);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryExecutionContext.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryExecutionContext.java
@@ -72,6 +72,7 @@ public class QueryExecutionContext extends ExecutionContext {
   public QueryExecutionContext(Object[] bindArguments, InternalCache cache, Query query) {
     super(bindArguments, cache);
     this.query = query;
+    this.cqQueryContext = ((DefaultQuery) query).isCqQuery();
   }
 
   @Override
@@ -139,11 +140,6 @@ public class QueryExecutionContext extends ExecutionContext {
   @Override
   int nextFieldNum() {
     return this.nextFieldNum++;
-  }
-
-  @Override
-  public void setCqQueryContext(boolean cqQuery) {
-    this.cqQueryContext = cqQuery;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryExecutor.java
@@ -27,8 +27,9 @@ import org.apache.geode.cache.query.TypeMismatchException;
  * @since GemFire 5.5
  */
 public interface QueryExecutor {
-  // TODO Yogesh , fix this signature
-  Object executeQuery(DefaultQuery query, Object[] parameters, Set buckets)
+  Object executeQuery(DefaultQuery query,
+      ExecutionContext executionContext,
+      Object[] parameters, Set buckets)
       throws FunctionDomainException, TypeMismatchException, NameResolutionException,
       QueryInvocationTargetException;
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
@@ -192,7 +192,7 @@ public class HashIndex extends AbstractIndex {
       if (DefaultQuery.testHook != null) {
         DefaultQuery.testHook.doTestHook(
             DefaultQuery.TestHook.SPOTS.BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION,
-            null);
+            null, null);
       }
       Object newKey = TypeUtils.indexKeyFor(key);
       if (newKey.equals(QueryService.UNDEFINED)) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -103,7 +103,7 @@ public class MemoryIndexStore implements IndexStore {
       if (DefaultQuery.testHook != null) {
         DefaultQuery.testHook.doTestHook(
             DefaultQuery.TestHook.SPOTS.BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION,
-            null);
+            null, null);
       }
 
       // Check if reverse-map is present.
@@ -152,7 +152,8 @@ public class MemoryIndexStore implements IndexStore {
           IndexElemArray elemArray = new IndexElemArray();
           if (DefaultQuery.testHook != null) {
             DefaultQuery.testHook.doTestHook(
-                DefaultQuery.TestHook.SPOTS.BEGIN_TRANSITION_FROM_REGION_ENTRY_TO_ELEMARRAY, null);
+                DefaultQuery.TestHook.SPOTS.BEGIN_TRANSITION_FROM_REGION_ENTRY_TO_ELEMARRAY, null,
+                null);
           }
           elemArray.add(regionEntries);
           elemArray.add(re);
@@ -162,12 +163,12 @@ public class MemoryIndexStore implements IndexStore {
           if (DefaultQuery.testHook != null) {
             DefaultQuery.testHook
                 .doTestHook(DefaultQuery.TestHook.SPOTS.TRANSITIONED_FROM_REGION_ENTRY_TO_ELEMARRAY,
-                    null);
+                    null, null);
           }
           if (DefaultQuery.testHook != null) {
             DefaultQuery.testHook.doTestHook(
                 DefaultQuery.TestHook.SPOTS.COMPLETE_TRANSITION_FROM_REGION_ENTRY_TO_ELEMARRAY,
-                null);
+                null, null);
           }
         } else if (regionEntries instanceof IndexConcurrentHashSet) {
           // This synchronized is for avoiding conflcts with remove of
@@ -191,7 +192,7 @@ public class MemoryIndexStore implements IndexStore {
               if (DefaultQuery.testHook != null) {
                 DefaultQuery.testHook.doTestHook(
                     DefaultQuery.TestHook.SPOTS.BEGIN_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET,
-                    null);
+                    null, null);
               }
               // on a remove from the elem array, another thread could start and complete its remove
               // at this point, that is why we need to replace before adding the elem array elements
@@ -205,7 +206,7 @@ public class MemoryIndexStore implements IndexStore {
                 if (DefaultQuery.testHook != null) {
                   DefaultQuery.testHook
                       .doTestHook(DefaultQuery.TestHook.SPOTS.TRANSITIONED_FROM_ELEMARRAY_TO_TOKEN,
-                          null);
+                          null, null);
                 }
                 set.add(re);
                 set.addAll(elemArray);
@@ -221,7 +222,7 @@ public class MemoryIndexStore implements IndexStore {
                 if (DefaultQuery.testHook != null) {
                   DefaultQuery.testHook.doTestHook(
                       DefaultQuery.TestHook.SPOTS.COMPLETE_TRANSITION_FROM_ELEMARRAY_TO_CONCURRENT_HASH_SET,
-                      null);
+                      null, null);
                 }
               }
             } else {
@@ -304,7 +305,7 @@ public class MemoryIndexStore implements IndexStore {
     try {
       Object newKey = convertToIndexKey(key, entry);
       if (DefaultQuery.testHook != null) {
-        DefaultQuery.testHook.doTestHook(DefaultQuery.TestHook.SPOTS.ATTEMPT_REMOVE, null);
+        DefaultQuery.testHook.doTestHook(DefaultQuery.TestHook.SPOTS.ATTEMPT_REMOVE, null, null);
       }
       boolean retry = false;
       do {
@@ -312,7 +313,7 @@ public class MemoryIndexStore implements IndexStore {
         Object regionEntries = this.valueToEntriesMap.get(newKey);
         if (regionEntries == TRANSITIONING_TOKEN) {
           if (DefaultQuery.testHook != null) {
-            DefaultQuery.testHook.doTestHook(DefaultQuery.TestHook.SPOTS.ATTEMPT_RETRY, null);
+            DefaultQuery.testHook.doTestHook(DefaultQuery.TestHook.SPOTS.ATTEMPT_RETRY, null, null);
           }
           retry = true;
           continue;
@@ -332,12 +333,13 @@ public class MemoryIndexStore implements IndexStore {
             Collection entries = (Collection) regionEntries;
             if (DefaultQuery.testHook != null) {
               DefaultQuery.testHook
-                  .doTestHook(DefaultQuery.TestHook.SPOTS.BEGIN_REMOVE_FROM_ELEM_ARRAY, null);
+                  .doTestHook(DefaultQuery.TestHook.SPOTS.BEGIN_REMOVE_FROM_ELEM_ARRAY, null, null);
             }
             found = entries.remove(entry);
             if (DefaultQuery.testHook != null) {
               DefaultQuery.testHook
-                  .doTestHook(DefaultQuery.TestHook.SPOTS.REMOVE_CALLED_FROM_ELEM_ARRAY, null);
+                  .doTestHook(DefaultQuery.TestHook.SPOTS.REMOVE_CALLED_FROM_ELEM_ARRAY, null,
+                      null);
             }
             // This could be IndexElementArray and might be changing to Set
             // If the remove occurred before changing to a set, then next time it will not be
@@ -365,7 +367,8 @@ public class MemoryIndexStore implements IndexStore {
             }
             if (DefaultQuery.testHook != null) {
               DefaultQuery.testHook
-                  .doTestHook(DefaultQuery.TestHook.SPOTS.COMPLETE_REMOVE_FROM_ELEM_ARRAY, null);
+                  .doTestHook(DefaultQuery.TestHook.SPOTS.COMPLETE_REMOVE_FROM_ELEM_ARRAY, null,
+                      null);
             }
           }
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
@@ -547,7 +547,7 @@ public abstract class StreamingOperation {
             if (DefaultQuery.testHook != null) {
               DefaultQuery.testHook.doTestHook(
                   DefaultQuery.TestHook.SPOTS.BEFORE_ADD_OR_UPDATE_MAPPING_OR_DESERIALIZING_NTH_STREAMINGOPERATION,
-                  null);
+                  null, null);
             }
             if (isQueryMessageProcessor && QueryMonitor.isLowMemory()) {
               lowMemoryDetected = true;
@@ -571,7 +571,7 @@ public abstract class StreamingOperation {
             if (DefaultQuery.testHook != null) {
               DefaultQuery.testHook.doTestHook(
                   DefaultQuery.TestHook.SPOTS.LOW_MEMORY_WHEN_DESERIALIZING_STREAMINGOPERATION,
-                  null);
+                  null, null);
             }
           }
         } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
@@ -52,6 +52,8 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
+import org.apache.geode.cache.query.internal.QueryExecutionContext;
 import org.apache.geode.cache.query.internal.QueryExecutor;
 import org.apache.geode.cache.query.internal.QueryObserver;
 import org.apache.geode.cache.snapshot.RegionSnapshotService;
@@ -141,8 +143,9 @@ public class LocalDataSet implements Region, QueryExecutor {
     QueryService qs = getCache().getLocalQueryService();
     DefaultQuery query = (DefaultQuery) qs
         .newQuery("select * from " + getFullPath() + " this where " + queryPredicate);
+    final ExecutionContext executionContext = new QueryExecutionContext(null, getCache(), query);
     Object[] params = null;
-    return (SelectResults) this.executeQuery(query, params, getBucketSet());
+    return (SelectResults) this.executeQuery(query, executionContext, params, getBucketSet());
   }
 
   @Override
@@ -170,7 +173,9 @@ public class LocalDataSet implements Region, QueryExecutor {
    * MULTI REGION PR BASED QUERIES.
    */
   @Override
-  public Object executeQuery(DefaultQuery query, Object[] parameters, Set buckets)
+  public Object executeQuery(DefaultQuery query,
+      final ExecutionContext executionContext,
+      Object[] parameters, Set buckets)
       throws FunctionDomainException, TypeMismatchException, NameResolutionException,
       QueryInvocationTargetException {
     long startTime = 0L;
@@ -183,7 +188,7 @@ public class LocalDataSet implements Region, QueryExecutor {
     QueryObserver indexObserver = query.startTrace();
 
     try {
-      result = this.proxy.executeQuery(query, parameters, buckets);
+      result = this.proxy.executeQuery(query, executionContext, parameters, buckets);
     } finally {
       query.endTrace(indexObserver, startTime, result);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRQueryProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRQueryProcessor.java
@@ -233,7 +233,6 @@ public class PRQueryProcessor {
       throws ForceReattemptException, QueryInvocationTargetException, QueryException {
     // Check if QueryMonitor is enabled, if so add query to be monitored.
     QueryMonitor queryMonitor = null;
-    context.setCqQueryContext(query.isCqQuery());
     if (GemFireCacheImpl.getInstance() != null) {
       queryMonitor = GemFireCacheImpl.getInstance().getQueryMonitor();
     }
@@ -241,7 +240,7 @@ public class PRQueryProcessor {
     try {
       if (queryMonitor != null) {
         // Add current thread to be monitored by QueryMonitor.
-        queryMonitor.monitorQueryThread(query);
+        queryMonitor.monitorQueryExecution(context);
       }
 
       Object results = query.executeUsingContext(context);
@@ -270,7 +269,7 @@ public class PRQueryProcessor {
       throw qe;
     } finally {
       if (queryMonitor != null) {
-        queryMonitor.stopMonitoringQueryThread(query);
+        queryMonitor.stopMonitoringQueryExecution(context);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1878,12 +1878,15 @@ public class PartitionedRegion extends LocalRegion
    * @since GemFire 5.1
    */
   @Override
-  public Object executeQuery(DefaultQuery query, Object[] parameters, Set buckets)
+  public Object executeQuery(final DefaultQuery query,
+      final ExecutionContext executionContext,
+      final Object[] parameters,
+      final Set buckets)
       throws FunctionDomainException, TypeMismatchException, NameResolutionException,
       QueryInvocationTargetException {
     for (;;) {
       try {
-        return doExecuteQuery(query, parameters, buckets);
+        return doExecuteQuery(query, executionContext, parameters, buckets);
       } catch (ForceReattemptException ignore) {
         // fall through and loop
       }
@@ -1895,7 +1898,10 @@ public class PartitionedRegion extends LocalRegion
    *
    * @throws ForceReattemptException if one of the buckets moved out from under us
    */
-  private Object doExecuteQuery(DefaultQuery query, Object[] parameters, Set buckets)
+  private Object doExecuteQuery(final DefaultQuery query,
+      final ExecutionContext executionContext,
+      final Object[] parameters,
+      final Set buckets)
       throws FunctionDomainException, TypeMismatchException, NameResolutionException,
       QueryInvocationTargetException, ForceReattemptException {
     if (logger.isDebugEnabled()) {
@@ -1948,7 +1954,7 @@ public class PartitionedRegion extends LocalRegion
     SelectResults results = selectExpr.getEmptyResultSet(parameters, getCache(), query);
 
     PartitionedRegionQueryEvaluator prqe = new PartitionedRegionQueryEvaluator(this.getSystem(),
-        this, query, parameters, results, allBuckets);
+        this, query, executionContext, parameters, results, allBuckets);
     for (;;) {
       this.getCancelCriterion().checkCancelInProgress(null);
       boolean interrupted = Thread.interrupted();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query.java
@@ -27,7 +27,6 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.types.CollectionTypeImpl;
 import org.apache.geode.cache.query.types.CollectionType;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.Command;
 import org.apache.geode.internal.cache.tier.sockets.BaseCommandQuery;
 import org.apache.geode.internal.cache.tier.sockets.Message;
@@ -71,9 +70,8 @@ public class Query extends BaseCommandQuery {
     }
     try {
       // Create query
-      final InternalCache cache = serverConnection.getCachedRegionHelper().getCache();
       QueryService queryService =
-          cache.getLocalQueryService();
+          serverConnection.getCachedRegionHelper().getCache().getLocalQueryService();
       org.apache.geode.cache.query.Query query = queryService.newQuery(queryString);
       Set regionNames = ((DefaultQuery) query).getRegionsInQuery(null);
 
@@ -93,8 +91,8 @@ public class Query extends BaseCommandQuery {
         }
       }
 
-      processQuery(clientMessage, query, queryString, regionNames, start, null,
-          queryContext, serverConnection, true, securityService);
+      processQuery(clientMessage, query, queryString, regionNames, start, null, queryContext,
+          serverConnection, true, securityService);
     } catch (QueryInvalidException e) {
       throw new QueryInvalidException(e.getMessage() + queryString);
     } catch (QueryExecutionLowMemoryException e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query.java
@@ -27,6 +27,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.types.CollectionTypeImpl;
 import org.apache.geode.cache.query.types.CollectionType;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.Command;
 import org.apache.geode.internal.cache.tier.sockets.BaseCommandQuery;
 import org.apache.geode.internal.cache.tier.sockets.Message;
@@ -70,8 +71,9 @@ public class Query extends BaseCommandQuery {
     }
     try {
       // Create query
+      final InternalCache cache = serverConnection.getCachedRegionHelper().getCache();
       QueryService queryService =
-          serverConnection.getCachedRegionHelper().getCache().getLocalQueryService();
+          cache.getLocalQueryService();
       org.apache.geode.cache.query.Query query = queryService.newQuery(queryString);
       Set regionNames = ((DefaultQuery) query).getRegionsInQuery(null);
 
@@ -91,8 +93,8 @@ public class Query extends BaseCommandQuery {
         }
       }
 
-      processQuery(clientMessage, query, queryString, regionNames, start, null, queryContext,
-          serverConnection, true, securityService);
+      processQuery(clientMessage, query, queryString, regionNames, start, null,
+          queryContext, serverConnection, true, securityService);
     } catch (QueryInvalidException e) {
       throw new QueryInvalidException(e.getMessage() + queryString);
     } catch (QueryExecutionLowMemoryException e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query651.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query651.java
@@ -26,7 +26,6 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.types.CollectionTypeImpl;
 import org.apache.geode.cache.query.types.CollectionType;
-import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.Command;
 import org.apache.geode.internal.cache.tier.MessageType;
 import org.apache.geode.internal.cache.tier.sockets.BaseCommandQuery;
@@ -96,9 +95,8 @@ public class Query651 extends BaseCommandQuery {
     }
     try {
       // Create query
-      final InternalCache cache = serverConnection.getCachedRegionHelper().getCache();
       QueryService queryService =
-          cache.getLocalQueryService();
+          serverConnection.getCachedRegionHelper().getCache().getLocalQueryService();
       org.apache.geode.cache.query.Query query = null;
 
       if (queryParams != null) {
@@ -134,9 +132,8 @@ public class Query651 extends BaseCommandQuery {
         }
       }
 
-      processQueryUsingParams(clientMessage, query, queryString, regionNames,
-          start,
-          null, queryContext, serverConnection, true, queryParams, securityService);
+      processQueryUsingParams(clientMessage, query, queryString, regionNames, start, null,
+          queryContext, serverConnection, true, queryParams, securityService);
     } catch (QueryInvalidException e) {
       throw new QueryInvalidException(e.getMessage() + queryString);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query651.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Query651.java
@@ -26,6 +26,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.types.CollectionTypeImpl;
 import org.apache.geode.cache.query.types.CollectionType;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.Command;
 import org.apache.geode.internal.cache.tier.MessageType;
 import org.apache.geode.internal.cache.tier.sockets.BaseCommandQuery;
@@ -95,8 +96,9 @@ public class Query651 extends BaseCommandQuery {
     }
     try {
       // Create query
+      final InternalCache cache = serverConnection.getCachedRegionHelper().getCache();
       QueryService queryService =
-          serverConnection.getCachedRegionHelper().getCache().getLocalQueryService();
+          cache.getLocalQueryService();
       org.apache.geode.cache.query.Query query = null;
 
       if (queryParams != null) {
@@ -132,8 +134,9 @@ public class Query651 extends BaseCommandQuery {
         }
       }
 
-      processQueryUsingParams(clientMessage, query, queryString, regionNames, start, null,
-          queryContext, serverConnection, true, queryParams, securityService);
+      processQueryUsingParams(clientMessage, query, queryString, regionNames,
+          start,
+          null, queryContext, serverConnection, true, queryParams, securityService);
     } catch (QueryInvalidException e) {
       throw new QueryInvalidException(e.getMessage() + queryString);
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
@@ -34,6 +34,8 @@ import org.apache.geode.cache.query.Query;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
+import org.apache.geode.cache.query.internal.QueryExecutionContext;
 import org.apache.geode.internal.InternalEntity;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.InternalCache;
@@ -153,7 +155,8 @@ public class QueryDataFunction implements Function, InternalEntity {
             }
             LocalDataSet lds = new LocalDataSet(parRegion, localPrimaryBucketSet);
             DefaultQuery query = (DefaultQuery) cache.getQueryService().newQuery(queryString);
-            results = lds.executeQuery(query, null, localPrimaryBucketSet);
+            final ExecutionContext executionContext = new QueryExecutionContext(null, cache, query);
+            results = lds.executeQuery(query, executionContext, null, localPrimaryBucketSet);
           }
         } else {
           rcollector = FunctionService.onRegion(cache.getRegion(regionName))

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledIteratorDefJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledIteratorDefJUnitTest.java
@@ -32,7 +32,7 @@ public class CompiledIteratorDefJUnitTest {
     CompiledValue compiledValue = mock(CompiledValue.class);
     CompiledIteratorDef compiledIteratorDef =
         new CompiledIteratorDef("TestIterator", TypeUtils.OBJECT_TYPE, compiledValue);
-    ExecutionContext executionContext = mock(ExecutionContext.class);
+    final ExecutionContext executionContext = mock(ExecutionContext.class);
     RuntimeIterator runtimeIterator = mock(RuntimeIterator.class);
 
     when(runtimeIterator.evaluateCollection(executionContext))

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorTest.java
@@ -41,6 +41,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.internal.CompiledSelect;
 import org.apache.geode.cache.query.internal.CompiledValue;
 import org.apache.geode.cache.query.internal.DefaultQuery;
+import org.apache.geode.cache.query.internal.ExecutionContext;
 import org.apache.geode.cache.query.internal.LinkedResultSet;
 import org.apache.geode.cache.query.internal.types.ObjectTypeImpl;
 import org.apache.geode.distributed.internal.DistributionMessage;
@@ -90,6 +91,7 @@ public class PartitionedRegionQueryEvaluatorTest {
     when(pr.getDataStore()).thenReturn(dataStore);
     when(pr.getCache()).thenReturn(cache);
 
+
   }
 
   @Test
@@ -114,7 +116,8 @@ public class PartitionedRegionQueryEvaluatorTest {
     dataStore.setScenarios(scenarios);
 
     PartitionedRegionQueryEvaluator prqe = new ExtendedPartitionedRegionQueryEvaluator(system, pr,
-        query, null, new LinkedResultSet(), allBucketsToQuery, scenarios);
+        query, mock(ExecutionContext.class), null, new LinkedResultSet(), allBucketsToQuery,
+        scenarios);
     Collection results = prqe.queryBuckets(null).asList();
     assertNotNull(results);
     assertEquals(resultsForMember1.size(), results.size());
@@ -145,7 +148,8 @@ public class PartitionedRegionQueryEvaluatorTest {
     dataStore.setScenarios(scenarios);
 
     PartitionedRegionQueryEvaluator prqe = new ExtendedPartitionedRegionQueryEvaluator(system, pr,
-        query, null, new LinkedResultSet(), allBucketsToQuery, scenarios);
+        query, mock(ExecutionContext.class), null, new LinkedResultSet(), allBucketsToQuery,
+        scenarios);
     Collection results = prqe.queryBuckets(null).asList();
     List expectedResults = new LinkedList();
     expectedResults.addAll(resultsForMember1);
@@ -198,7 +202,8 @@ public class PartitionedRegionQueryEvaluatorTest {
     dataStore.setScenarios(scenarios);
 
     PartitionedRegionQueryEvaluator prqe = new ExtendedPartitionedRegionQueryEvaluator(system, pr,
-        query, null, new LinkedResultSet(), allBucketsToQuery, scenarios);
+        query, mock(ExecutionContext.class), null, new LinkedResultSet(), allBucketsToQuery,
+        scenarios);
     Collection results = prqe.queryBuckets(null).asList();
 
     List expectedResults = new LinkedList();
@@ -215,8 +220,9 @@ public class PartitionedRegionQueryEvaluatorTest {
   public void testGetAllNodesShouldBeRandomized() {
     List bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     Set bucketSet = new HashSet(bucketList);
-    PartitionedRegionQueryEvaluator prqe = new PartitionedRegionQueryEvaluator(system, pr, query,
-        null, new LinkedResultSet(), bucketSet);
+    PartitionedRegionQueryEvaluator prqe =
+        new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
+            null, new LinkedResultSet(), bucketSet);
     RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
     when(regionAdvisor.adviseDataStore()).thenReturn(bucketSet);
     await()
@@ -287,11 +293,15 @@ public class PartitionedRegionQueryEvaluatorTest {
     // pass through so we can fake out the executeQuery locally
     PRQueryProcessor extendedPRQueryProcessor;
 
-    public ExtendedPartitionedRegionQueryEvaluator(InternalDistributedSystem sys,
-        PartitionedRegion pr, DefaultQuery query, Object[] parameters,
-        SelectResults cumulativeResults, Set<Integer> bucketsToQuery,
-        Queue<PartitionedQueryScenario> scenarios) {
-      super(sys, pr, query, parameters, cumulativeResults, bucketsToQuery);
+    public ExtendedPartitionedRegionQueryEvaluator(final InternalDistributedSystem sys,
+        final PartitionedRegion pr,
+        final DefaultQuery query,
+        final ExecutionContext executionContext,
+        final Object[] parameters,
+        final SelectResults cumulativeResults,
+        final Set<Integer> bucketsToQuery,
+        final Queue<PartitionedQueryScenario> scenarios) {
+      super(sys, pr, query, executionContext, parameters, cumulativeResults, bucketsToQuery);
       this.scenarios = scenarios;
       extendedPRQueryProcessor =
           new ExtendedPRQueryProcessor(pr, query, null, new LinkedList(bucketsToQuery));

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/ExecuteCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/ExecuteCQ.java
@@ -132,8 +132,9 @@ public class ExecuteCQ extends BaseCQCommand {
         cqRegionNames = ((DefaultQuery) query).getRegionsInQuery(null);
       }
       ((DefaultQuery) query).setIsCqQuery(true);
-      successQuery = processQuery(clientMessage, query, cqQueryString, cqRegionNames, start,
-          cqQuery, executeCQContext, serverConnection, sendResults, securityService);
+      successQuery =
+          processQuery(clientMessage, query, cqQueryString, cqRegionNames,
+              start, cqQuery, executeCQContext, serverConnection, sendResults, securityService);
 
       // Update the CQ statistics.
       cqQuery.getVsdStats().setCqInitialResultsTime(DistributionStats.getStatTime() - start);

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/ExecuteCQ61.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/ExecuteCQ61.java
@@ -179,8 +179,9 @@ public class ExecuteCQ61 extends BaseCQCommand {
           cqRegionNames = ((DefaultQuery) query).getRegionsInQuery(null);
         }
         ((DefaultQuery) query).setIsCqQuery(true);
-        successQuery = processQuery(clientMessage, query, cqQueryString, cqRegionNames, start,
-            cqQuery, executeCQContext, serverConnection, sendResults, securityService);
+        successQuery =
+            processQuery(clientMessage, query, cqQueryString, cqRegionNames,
+                start, cqQuery, executeCQContext, serverConnection, sendResults, securityService);
 
 
         // Update the CQ statistics.

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/LocatorStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/LocatorStarterRule.java
@@ -50,7 +50,7 @@ import org.apache.geode.internal.cache.InternalCache;
  *
  * <p>
  * If you need a rule to start a server/locator in different VMs for Distributed tests, You should
- * use {@code LocatorServerStartupRule}.
+ * use {@code ClusterStartupRule}.
  */
 public class LocatorStarterRule extends MemberStarterRule<LocatorStarterRule> implements Locator {
   private transient InternalLocator locator;

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/ServerStarterRule.java
@@ -50,7 +50,7 @@ import org.apache.geode.pdx.PdxSerializer;
  *
  * <p>
  * If you need a rule to start a server/locator in different VMs for Distributed tests, You should
- * use {@code LocatorServerStartupRule}.
+ * use {@code ClusterStartupRule}.
  */
 public class ServerStarterRule extends MemberStarterRule<ServerStarterRule> implements Server {
   private transient InternalCache cache;


### PR DESCRIPTION
This work solves two problems.  One is that the query cancellation task
reference in DefaultQuery could be overwritten and thus never removed
from monitoring upon successful completion of a query.  Second is that
once a query execution timed out once, the query object was in an
unusable state which is undesirable.

The solution is to attach the cancellation state to the execution
context rather than the query object, so that cancellation is associated
with each independent execution of a query rather than having
cancellation state that applies to the entire query object.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
