### PR TITLE
GEODE-5971: refactor DescribeRegionCommand to use ResultModel

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DeployWithGroupsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DeployWithGroupsDUnitTest.java
@@ -169,10 +169,10 @@ public class DeployWithGroupsDUnitTest implements Serializable {
         .statusIsSuccess()
         .hasTableSection("jars")
         .hasRowSize(4)
-        .hasRowContaining("server-1", "DeployCommandsDUnit3.jar")
-        .hasRowContaining("server-1", "DeployCommandsDUnit4.jar")
-        .hasRowContaining("server-2", "DeployCommandsDUnit3.jar", "JAR not deployed")
-        .hasRowContaining("server-2", "DeployCommandsDUnit4.jar", "JAR not deployed");
+        .hasAnyRow().contains("server-1", "DeployCommandsDUnit3.jar")
+        .hasAnyRow().contains("server-1", "DeployCommandsDUnit4.jar")
+        .hasAnyRow().contains("server-2", "DeployCommandsDUnit3.jar", "JAR not deployed")
+        .hasAnyRow().contains("server-2", "DeployCommandsDUnit4.jar", "JAR not deployed");
     server1.invoke(() -> {
       assertThatCannotLoad(jarName3, class3);
       assertThatCannotLoad(jarName4, class4);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeRegionDUnitTest.java
@@ -39,7 +39,6 @@ import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.compression.SnappyCompressor;
 import org.apache.geode.internal.cache.RegionEntryContext;
-import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.management.internal.cli.util.RegionAttributesNames;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -169,20 +168,16 @@ public class DescribeRegionDUnitTest {
 
   @Test
   public void describeRegionWithCustomExpiry() {
-    CommandResult result = gfsh.executeAndAssertThat("describe region --name=" + PR1)
-        .statusIsSuccess().getCommandResult();
+    CommandResultAssert result = gfsh.executeAndAssertThat("describe region --name=" + PR1)
+        .statusIsSuccess();
 
-    List<String> names = result.getColumnFromTableContent("Name", "0", "0");
-    assertThat(names).containsOnlyOnce(RegionAttributesNames.ENTRY_IDLE_TIME_CUSTOM_EXPIRY);
+    result.hasTableSection("non-default-1")
+        .hasColumn("Name").containsOnlyOnce(RegionAttributesNames.ENTRY_IDLE_TIME_CUSTOM_EXPIRY)
+        .hasColumn("Value").containsOnlyOnce(TestCustomIdleExpiry.class.getName());
 
-    List<String> values = result.getColumnFromTableContent("Value", "0", "0");
-    assertThat(values).containsOnlyOnce(TestCustomIdleExpiry.class.getName());
-
-    names = result.getColumnFromTableContent("Name", "0", "1");
-    assertThat(names).containsOnlyOnce(RegionAttributesNames.ENTRY_TIME_TO_LIVE_CUSTOM_EXPIRY);
-
-    values = result.getColumnFromTableContent("Value", "0", "1");
-    assertThat(values).containsOnlyOnce(TestCustomTTLExpiry.class.getName());
+    result.hasTableSection("member-non-default-1")
+        .hasColumn("Name").containsOnlyOnce(RegionAttributesNames.ENTRY_TIME_TO_LIVE_CUSTOM_EXPIRY)
+        .hasColumn("Value").containsOnlyOnce(TestCustomTTLExpiry.class.getName());
   }
 
   /**
@@ -221,8 +216,8 @@ public class DescribeRegionDUnitTest {
 
     commandResultAssert.hasTableSection("non-default-1")
         .hasColumn("Type").containsExactly("Region", "", "Partition")
-        .hasColumn("Name").containsExactly("size", "data-policy", "local-max-memory")
-        .hasColumn("Value").containsExactly("PARTITION", "0", "0");
+        .hasColumn("Name").contains("data-policy", "size", "local-max-memory")
+        .hasColumn("Value").contains("PARTITION", "0", "0");
 
     commandResultAssert.hasDataSection("region-2").hasContent()
         .containsEntry("Name", HOSTING_AND_ACCESSOR_REGION_NAME)
@@ -231,8 +226,8 @@ public class DescribeRegionDUnitTest {
         .asList()
         .containsExactlyInAnyOrder("server-1", "server-2", "server-3", "server-4");
 
-    commandResultAssert.hasTableSection("member-non-default-2")
-        .hasColumn("Type").containsExactly("Type", "Region")
+    commandResultAssert.hasTableSection("non-default-2")
+        .hasColumn("Type").containsExactly("Region", "")
         .hasColumn("Name").containsExactly("size", "data-policy")
         .hasColumn("Value").containsExactly("0", "PARTITION");
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DestroyAsyncEventQueueCommandDUnitTest.java
@@ -173,8 +173,8 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
     gfsh.executeAndAssertThat("destroy async-event-queue --id=queue1").statusIsSuccess()
         .hasTableSection()
         .hasRowSize(2)
-        .hasRowContaining("server-1", "OK", "Async event queue \"queue1\" destroyed")
-        .hasRowContaining("server-2", "ERROR", "Async event queue \"queue1\" not found");
+        .hasAnyRow().contains("server-1", "OK", "Async event queue \"queue1\" destroyed")
+        .hasAnyRow().contains("server-2", "ERROR", "Async event queue \"queue1\" not found");
 
     gfsh.executeAndAssertThat("list async-event-queues").statusIsSuccess()
         .containsOutput("No Async Event Queues Found");
@@ -197,7 +197,7 @@ public class DestroyAsyncEventQueueCommandDUnitTest {
         .statusIsSuccess().containsOutput(String.format(
             DestroyAsyncEventQueueCommand.DESTROY_ASYNC_EVENT_QUEUE__AEQ_0_DESTROYED, "queue1"));
     gfsh.executeAndAssertThat("list async-event-queues").statusIsSuccess()
-        .hasTableSection().hasRowContaining("server-3", "queue3");
+        .hasTableSection().hasAnyRow().contains("server-3", "queue3");
 
     // verify that cluster config aeq entry for destroyed queue is deleted
     locator.invoke(() -> {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/result/model/TabularResultModelTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/result/model/TabularResultModelTest.java
@@ -113,7 +113,7 @@ public class TabularResultModelTest {
     assertThat(table1.getValuesInRow(1)).containsExactly("v2", "k2", "t2");
     assertThat(table1.getValuesInRow(2)).containsExactly("v3", "k3", "t3");
 
-    new TabularResultModelAssert(table1).hasRowContaining("v1", "k1", "t1")
-        .hasRowContaining("v3", "k3", "t3");
+    new TabularResultModelAssert(table1).hasAnyRow().contains("v1", "k1", "t1")
+        .hasAnyRow().contains("v3", "k3", "t3");
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/FunctionCommandsDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/FunctionCommandsDUnitTestBase.java
@@ -138,7 +138,7 @@ public class FunctionCommandsDUnitTestBase {
         "execute function --id=" + TEST_FUNCTION1 + " --region=/" + REGION_ONE).statusIsSuccess()
         .hasTableSection()
         .hasRowSize(1)
-        .hasRowContaining("OK", "[false, false]");
+        .hasAnyRow().contains("OK", "[false, false]");
   }
 
   @Test
@@ -161,7 +161,7 @@ public class FunctionCommandsDUnitTestBase {
         .statusIsSuccess()
         .hasTableSection()
         .hasRowSize(1)
-        .hasRowContaining("OK", "[ARG1, ARG1]");
+        .hasAnyRow().contains("OK", "[ARG1, ARG1]");
   }
 
   @Test
@@ -171,7 +171,7 @@ public class FunctionCommandsDUnitTestBase {
         .statusIsSuccess()
         .hasTableSection()
         .hasRowSize(1)
-        .hasRowContaining("server-1", "OK", "[false]");
+        .hasAnyRow().contains("server-1", "OK", "[false]");
   }
 
   @Test
@@ -185,8 +185,8 @@ public class FunctionCommandsDUnitTestBase {
     gfsh.executeAndAssertThat("execute function --id=" + TEST_FUNCTION1).statusIsSuccess()
         .hasTableSection()
         .hasRowSize(2)
-        .hasRowContaining("server-1", "OK", "[false]")
-        .hasRowContaining("server-2", "OK", "[false]");
+        .hasAnyRow().contains("server-1", "OK", "[false]")
+        .hasAnyRow().contains("server-2", "OK", "[false]");
   }
 
   @Test
@@ -195,8 +195,8 @@ public class FunctionCommandsDUnitTestBase {
         + Strings.join(server1.getName(), server2.getName()).with(",")).statusIsSuccess()
         .hasTableSection()
         .hasRowSize(2)
-        .hasRowContaining("server-1", "OK", "[false]")
-        .hasRowContaining("server-2", "OK", "[false]");
+        .hasAnyRow().contains("server-1", "OK", "[false]")
+        .hasAnyRow().contains("server-2", "OK", "[false]");
   }
 
   @Test
@@ -206,8 +206,8 @@ public class FunctionCommandsDUnitTestBase {
         .statusIsSuccess()
         .hasTableSection()
         .hasRowSize(2)
-        .hasRowContaining("server-1", "OK", "[ARG1]")
-        .hasRowContaining("server-2", "OK", "[ARG1]");
+        .hasAnyRow().contains("server-1", "OK", "[ARG1]")
+        .hasAnyRow().contains("server-2", "OK", "[ARG1]");
   }
 
   @Test
@@ -216,8 +216,8 @@ public class FunctionCommandsDUnitTestBase {
         .statusIsError()
         .hasTableSection()
         .hasRowSize(2)
-        .hasRowContaining("server-1", "OK", "[false]")
-        .hasRowContaining("server-2", "ERROR",
+        .hasAnyRow().contains("server-1", "OK", "[false]")
+        .hasAnyRow().contains("server-2", "ERROR",
             "Function : executeFunctionOnOneMemberToReturnArgs is not registered on member.");
   }
 
@@ -227,7 +227,7 @@ public class FunctionCommandsDUnitTestBase {
         .statusIsSuccess()
         .hasTableSection()
         .hasRowSize(1)
-        .hasRowContaining("server-1", "OK", "[false]");
+        .hasAnyRow().contains("server-1", "OK", "[false]");
   }
 
   @Test
@@ -301,7 +301,7 @@ public class FunctionCommandsDUnitTestBase {
         .statusIsError()
         .hasTableSection()
         .hasRowSize(2)
-        .hasRowContaining("server-1", "ERROR", errorMessage)
-        .hasRowContaining("server-2", "ERROR", errorMessage);
+        .hasAnyRow().contains("server-1", "ERROR", errorMessage)
+        .hasAnyRow().contains("server-2", "ERROR", errorMessage);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAnyRowAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAnyRowAssert.java
@@ -1,0 +1,78 @@
+package org.apache.geode.test.junit.assertions;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class TabularResultModelAnyRowAssert<T extends String> {
+  protected TabularResultModelAssert parent;
+
+  TabularResultModelAnyRowAssert(TabularResultModelAssert tabularResultModelAssert) {
+    this.parent = tabularResultModelAssert;
+  }
+
+  /**
+   * Verifies that any row contains the given values, in any order.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert contains(T... rowValues) {
+    for (int i = 0; i < parent.getActual().getRowSize(); i++) {
+      try {
+        parent.hasRow(i).contains(rowValues);
+        return parent;
+      } catch (AssertionError ignore) {
+      }
+    }
+    fail("Did not find " + StringUtils.join(rowValues, " and ") + " in any rows");
+    return parent;
+  }
+
+  /**
+   * Verifies that any row contains only the given values and nothing else, in any order and
+   * ignoring duplicates (i.e. once a value is found, its duplicates are also considered found).
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsOnly(T... rowValues) {
+    for (int i = 0; i < parent.getActual().getRowSize(); i++) {
+      try {
+        parent.hasRow(i).containsOnly(rowValues);
+        return parent;
+      } catch (AssertionError ignore) {
+      }
+    }
+    fail("Did not find only " + StringUtils.join(rowValues, " and ") + " in any rows");
+    return parent;
+  }
+
+  /**
+   * Verifies that any row contains exactly the given values and nothing else, <b>in order</b>.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsExactly(T... rowValues) {
+    for (int i = 0; i < parent.getActual().getRowSize(); i++) {
+      try {
+        parent.hasRow(i).containsExactly(rowValues);
+        return parent;
+      } catch (AssertionError ignore) {
+      }
+    }
+    fail("Did not find exactly [" + StringUtils.join(rowValues, ", ") + "] in any rows");
+    return parent;
+  }
+
+  /**
+   * Verifies that any row contains at least one of the given values.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsAnyOf(T... rowValues) {
+    for (int i = 0; i < parent.getActual().getRowSize(); i++) {
+      try {
+        parent.hasRow(i).containsAnyOf(rowValues);
+        return parent;
+      } catch (AssertionError ignore) {
+      }
+    }
+    fail("Did not find " + StringUtils.join(rowValues, " or ") + " in any rows");
+    return parent;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAnyRowAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAnyRowAssert.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.geode.test.junit.assertions;
 
 import static org.assertj.core.api.Assertions.fail;

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAssert.java
@@ -17,6 +17,8 @@ package org.apache.geode.test.junit.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
 
 public class TabularResultModelAssert
@@ -60,7 +62,9 @@ public class TabularResultModelAssert
    * return a ListAssert-like handle to assert on the values of a named column
    */
   public TabularResultModelColumnAssert<String> hasColumn(String header) {
-    return new TabularResultModelColumnAssert<>(this, actual.getValuesInColumn(header));
+    List<String> values = actual.getValuesInColumn(header);
+    assertThat(values).withFailMessage("Column not found: %s", header).isNotNull();
+    return new TabularResultModelColumnAssert<>(this, values);
   }
 
   /**

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelAssert.java
@@ -16,10 +16,6 @@
 package org.apache.geode.test.junit.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
-import org.apache.commons.lang3.StringUtils;
-import org.assertj.core.api.ListAssert;
 
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
 
@@ -30,45 +26,54 @@ public class TabularResultModelAssert
     super(resultModel, TabularResultModelAssert.class);
   }
 
+  /**
+   * verifies that the table has the expected number of rows
+   */
   public TabularResultModelAssert hasRowSize(int expectedSize) {
     assertThat(actual.getRowSize()).isEqualTo(expectedSize);
     return this;
   }
 
-  public TabularResultModelAssert hasRowContaining(String... rowValues) {
-
-    for (int i = 0; i < actual.getRowSize(); i++) {
-      try {
-        hasRow(i).contains(rowValues);
-        return this;
-      } catch (AssertionError ignore) {
-      } ;
-    }
-    fail("Did not find [" + StringUtils.join(rowValues, ", ") + "] in any rows");
-    return null;
-  }
-
-
+  /**
+   * verifies that the table has the expected number of columns
+   */
   public TabularResultModelAssert hasColumnSize(int expectedSize) {
     assertThat(actual.getColumnSize()).isEqualTo(expectedSize);
     return this;
   }
 
-  public ListAssert<String> hasColumns() {
-    return assertThat(actual.getHeaders());
+  /**
+   * verifies that the table is empty
+   */
+  public void isEmpty() {
+    hasRowSize(0);
   }
 
   /**
-   * return a ListAssert for a column of values
+   * return a ListAssert-like handle to assert on the header row
    */
-  public ListAssert<String> hasColumn(String header) {
-    return assertThat(actual.getValuesInColumn(header));
+  public TabularResultModelRowAssert<String> hasColumns() {
+    return new TabularResultModelRowAssert<>(this, actual.getHeaders());
   }
 
   /**
-   * return a ListAssert for a row of values
+   * return a ListAssert-like handle to assert on the values of a named column
    */
-  public ListAssert<String> hasRow(int rowIndex) {
-    return assertThat(actual.getValuesInRow(rowIndex));
+  public TabularResultModelColumnAssert<String> hasColumn(String header) {
+    return new TabularResultModelColumnAssert<>(this, actual.getValuesInColumn(header));
+  }
+
+  /**
+   * return a ListAssert-like handle to assert on a specific row
+   */
+  public TabularResultModelRowAssert<String> hasRow(int rowIndex) {
+    return new TabularResultModelRowAssert<>(this, actual.getValuesInRow(rowIndex));
+  }
+
+  /**
+   * return a ListAssert-like handle to assert on any row
+   */
+  public TabularResultModelAnyRowAssert<String> hasAnyRow() {
+    return new TabularResultModelAnyRowAssert<>(this);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelColumnAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelColumnAssert.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.geode.test.junit.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelColumnAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelColumnAssert.java
@@ -1,0 +1,39 @@
+package org.apache.geode.test.junit.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+public class TabularResultModelColumnAssert<T> extends TabularResultModelSliceAssert<T> {
+  TabularResultModelColumnAssert(TabularResultModelAssert tabularResultModelAssert,
+      List<T> valuesInColumn) {
+    super(tabularResultModelAssert, valuesInColumn);
+  }
+
+  /**
+   * Verifies that the selected column contains the given values only once.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsOnlyOnce(T... values) {
+    assertThat(this.values).containsOnlyOnce(values);
+    return parent;
+  }
+
+  /**
+   * Verifies that the selected column contains exactly the given values and nothing else, <b>in any
+   * order</b>.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsExactlyInAnyOrder(T... values) {
+    assertThat(this.values).containsExactlyInAnyOrder(values);
+    return parent;
+  }
+
+  /**
+   * verifies the expected number of values in the column
+   */
+  public final TabularResultModelColumnAssert<T> hasSize(int expected) {
+    assertThat(this.values).hasSize(expected);
+    return this;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelRowAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelRowAssert.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.geode.test.junit.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelRowAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelRowAssert.java
@@ -1,0 +1,20 @@
+package org.apache.geode.test.junit.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+public class TabularResultModelRowAssert<T> extends TabularResultModelSliceAssert<T> {
+  TabularResultModelRowAssert(TabularResultModelAssert tabularResultModelAssert,
+      List<T> valuesInRow) {
+    super(tabularResultModelAssert, valuesInRow);
+  }
+
+  /**
+   * verifies the expected number of values in the row
+   */
+  public final TabularResultModelRowAssert<T> hasSize(int expected) {
+    assertThat(this.values).hasSize(expected);
+    return this;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelSliceAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelSliceAssert.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.geode.test.junit.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelSliceAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelSliceAssert.java
@@ -1,0 +1,73 @@
+package org.apache.geode.test.junit.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+class TabularResultModelSliceAssert<T> {
+  protected TabularResultModelAssert parent;
+  protected List<T> values;
+
+  TabularResultModelSliceAssert(TabularResultModelAssert tabularResultModelAssert,
+      List<T> valuesInSlice) {
+    this.parent = tabularResultModelAssert;
+    this.values = valuesInSlice;
+  }
+
+  /**
+   * Verifies that the selected row or column contains the given values, in any order.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert contains(T... values) {
+    assertThat(this.values).contains(values);
+    return parent;
+  }
+
+  /**
+   * Verifies that the selected row or column contains only the given values and nothing else, in
+   * any order and ignoring duplicates (i.e. once a value is found, its duplicates are also
+   * considered found).
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsOnly(T... values) {
+    assertThat(this.values).containsOnly(values);
+    return parent;
+  }
+
+  /**
+   * Verifies that the selected row or column contains exactly the given values and nothing else,
+   * <b>in order</b>.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsExactly(T... values) {
+    assertThat(this.values).containsExactly(values);
+    return parent;
+  }
+
+  /**
+   * Verifies that the selected row or column contains at least one of the given values.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert containsAnyOf(T... values) {
+    assertThat(this.values).containsAnyOf(values);
+    return parent;
+  }
+
+  /**
+   * Verifies that the selected row or column does not contain the given values.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert doesNotContain(T... values) {
+    assertThat(this.values).doesNotContain(values);
+    return parent;
+  }
+
+  /**
+   * Verifies that all values in the selected row or column are present in the given values.
+   */
+  @SafeVarargs
+  public final TabularResultModelAssert isSubsetOf(T... values) {
+    assertThat(this.values).isSubsetOf(values);
+    return parent;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelSliceAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/TabularResultModelSliceAssert.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
+import org.assertj.core.api.ListAssert;
+
 class TabularResultModelSliceAssert<T> {
   protected TabularResultModelAssert parent;
   protected List<T> values;
@@ -84,5 +86,14 @@ class TabularResultModelSliceAssert<T> {
   public final TabularResultModelAssert isSubsetOf(T... values) {
     assertThat(this.values).isSubsetOf(values);
     return parent;
+  }
+
+  /**
+   * Provides the flexibility to verify the selected row or column using the full power of
+   * ListAssert (with the tradeoff that you will not be able to chain verifications for other rows
+   * or columns in the table after this).
+   */
+  public final ListAssert<T> asList() {
+    return new ListAssert<>(this.values);
   }
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/ListGatewaysCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/ListGatewaysCommandDUnitTest.java
@@ -180,7 +180,7 @@ public class ListGatewaysCommandDUnitTest implements Serializable {
         .hasTableSection("gatewayReceivers")
         .hasRowSize(2)
         .hasColumns()
-        .containsExactlyInAnyOrder("Member", "Port", "Sender Count", "Senders Connected");
+        .containsExactly("Member", "Port", "Sender Count", "Senders Connected");
   }
 
   @Test


### PR DESCRIPTION
 also improves Tabular asserts so individual rows or columns can be selected and asserted on much like a ListAssert, but chain-able at the table level so all rows or columns of a table can be checked in a single assert chain.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.