### PR TITLE
GEODE-2275: Update and cleanup ClearTXLockingDUnitTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearTXLockingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearTXLockingDUnitTest.java
@@ -12,19 +12,20 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-/*
- * ClearRvvLockingDUnitTest.java
- *
- * Created on September 6, 2005, 2:57 PM
- */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.test.dunit.VM.getController;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.internal.DUnitLauncher.getDistributedSystemProperties;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -38,59 +39,71 @@ import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
+import org.apache.geode.test.dunit.rules.DistributedRule;
 
 /**
  * Test class to verify proper locking interaction between transactions and the CLEAR region
  * operation.
  *
+ * <p>
  * GEODE-1740: It was observed that operations performed within a transaction were not holding
  * region modification locks for the duration of commit processing. This lock is used to ensure
  * region consistency during CLEAR processing. By not holding the lock for the duration of commit
  * processing, a window was opened that allowed region operations such as clear to occur in
  * mid-commit.
  *
+ * <p>
  * The fix for GEODE-1740 was to acquire and hold read locks for any region involved in the commit.
  * This forces CLEAR to wait until commit processing is complete.
+ *
+ * <p>
+ * This test performs operations within a transaction and during commit processing schedules a
+ * clear to be performed on the relevant region. The scheduled clear should wait until commit
+ * processing is complete before clearing the region. Failure to do so, would result in region
+ * inconsistencies.
  */
 @SuppressWarnings("serial")
+public class ClearTXLockingDUnitTest implements Serializable {
 
-public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
-
-  @Rule
-  public transient JUnitSoftAssertions softly = new JUnitSoftAssertions();
-  /*
-   * This test performs operations within a transaction and during commit processing schedules a
-   * clear to be performed on the relevant region. The scheduled clear should wait until commit
-   * processing is complete before clearing the region. Failure to do so, would result in region
-   * inconsistencies.
-   */
   private static final String THE_KEY = "theKey";
   private static final String THE_VALUE = "theValue";
   private static final int NUMBER_OF_PUTS = 2;
   private static final String REGION_NAME1 = "testRegion1";
   private static final String REGION_NAME2 = "testRegion2";
 
-  static Cache cache;
-  static CountDownLatch opsLatch;
-  private static CountDownLatch regionLatch;
-  private static CountDownLatch verifyLatch;
+  private static final CountDownLatch opsLatch = new CountDownLatch(1);
+  private static final CountDownLatch regionLatch = new CountDownLatch(1);
+  private static final CountDownLatch verifyLatch = new CountDownLatch(1);
+
+  private static volatile InternalCache cache;
 
   private VM vm0;
   private VM vm1;
   private VM opsVM;
   private VM regionVM;
 
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
   @Before
-  public void setup() {
-    Host host = Host.getHost(0);
-    vm0 = host.getVM(0);
-    vm1 = host.getVM(1);
+  public void setUp() {
+    vm0 = getVM(0);
+    vm1 = getVM(1);
 
     createCache(vm0);
     createCache(vm1);
+  }
+
+  @After
+  public void tearDown() {
+    for (VM vm : VM.toArray(vm0, vm1, getController())) {
+      vm.invoke(() -> {
+        opsLatch.countDown();
+        regionLatch.countDown();
+        verifyLatch.countDown();
+      });
+    }
   }
 
   @Test
@@ -107,7 +120,7 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     performTestAndCheckResults();
   }
 
-  /*
+  /**
    * The CLOSE tests are ignored until the close operation has been updated to acquire a write lock
    * during processing.
    */
@@ -119,6 +132,10 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     performTestAndCheckResults();
   }
 
+  /**
+   * The CLOSE tests are ignored until the close operation has been updated to acquire a write lock
+   * during processing.
+   */
   @Ignore
   @Test
   public void testPutWithCloseDifferentVM() {
@@ -127,7 +144,7 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     performTestAndCheckResults();
   }
 
-  /*
+  /**
    * The DESTROY_REGION tests are ignored until the destroy operation has been updated to acquire a
    * write lock during processing.
    */
@@ -139,6 +156,10 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     performTestAndCheckResults();
   }
 
+  /**
+   * The DESTROY_REGION tests are ignored until the destroy operation has been updated to acquire a
+   * write lock during processing.
+   */
   @Ignore
   @Test
   public void testPutWithDestroyRegionDifferentVM() {
@@ -147,9 +168,7 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     performTestAndCheckResults();
   }
 
-  // Local methods
-
-  /*
+  /**
    * This method executes a runnable test and then checks for region consistency
    */
   private void performTestAndCheckResults() {
@@ -162,7 +181,7 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  /*
+  /**
    * Set which vm will perform the transaction and which will perform the region operation and
    * create the regions on the vms
    */
@@ -176,10 +195,10 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
   }
 
   private void putOperationsTest() {
-    opsVM.invoke(() -> doPuts(getCache(), regionVM));
+    opsVM.invoke(() -> doPuts(cache, regionVM));
   }
 
-  /*
+  /**
    * Set arm hook to detect when region operation is attempting to acquire write lock and stage the
    * clear that will be released half way through commit processing.
    */
@@ -188,21 +207,18 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     whereClear.invokeAsync(() -> stageClear(rname, whereOps));
   }
 
-  // remote test methods
-
-  /*
+  /**
    * Wait to be notified and then execute the clear. Once the clear completes, notify waiter to
    * perform region verification.
    */
   private static void stageClear(String rname, VM whereOps) throws InterruptedException {
-    regionLatch = new CountDownLatch(1);
     regionOperationWait(regionLatch);
     LocalRegion r = (LocalRegion) cache.getRegion(rname);
     r.clear();
     whereOps.invoke(() -> releaseVerify());
   }
 
-  /*
+  /**
    * Set and stage method for close and destroy are the same as clear
    */
   private void setCloseHook(String rname, VM whereOps, VM whereClear) {
@@ -211,7 +227,6 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
   }
 
   private static void stageClose(String rname, VM whereOps) throws InterruptedException {
-    regionLatch = new CountDownLatch(1);
     regionOperationWait(regionLatch);
     LocalRegion r = (LocalRegion) cache.getRegion(rname);
     r.close();
@@ -224,14 +239,13 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
   }
 
   private static void stageDestroyRegion(String rname, VM whereOps) throws InterruptedException {
-    regionLatch = new CountDownLatch(1);
     regionOperationWait(regionLatch);
     LocalRegion r = (LocalRegion) cache.getRegion(rname);
     r.destroyRegion();
     whereOps.invoke(() -> releaseVerify());
   }
 
-  /*
+  /**
    * Set the abstract region map lock hook to detect attempt to acquire write lock by region
    * operation.
    */
@@ -241,7 +255,7 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     ((AbstractRegionMap) r.entries).setARMLockTestHook(theArmHook);
   }
 
-  /*
+  /**
    * Cleanup arm lock hook by setting it null
    */
   private void resetArmHook(String rname) {
@@ -249,26 +263,20 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     ((AbstractRegionMap) r.entries).setARMLockTestHook(null);
   }
 
-  /*
+  /**
    * Wait to be notified it is time to perform region operation (i.e. CLEAR)
    */
   private static void regionOperationWait(CountDownLatch latch) throws InterruptedException {
     latch.await();
-    /*
-     * regionLatch = new CountDownLatch(1); regionLatch.await();
-     */
   }
 
-  /*
+  /**
    * A simple transaction that will have a region operation execute during commit. opsLatch is used
    * to wait until region operation has been scheduled during commit and verifyLatch is used to
    * ensure commit and clear processing have both completed.
    */
   private static void doPuts(Cache cache, VM whereRegion) throws InterruptedException {
     TXManagerImpl txManager = (TXManagerImpl) cache.getCacheTransactionManager();
-
-    opsLatch = new CountDownLatch(1);
-    verifyLatch = new CountDownLatch(1);
 
     txManager.begin();
     TXStateInterface txState = ((TXStateProxyImpl) txManager.getTXState()).getRealDeal(null, null);
@@ -285,21 +293,21 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     verifyLatch.await();
   }
 
-  /*
+  /**
    * Release the region operation that has been previously staged
    */
   private static void releaseRegionOperation(VM whereRegion) {
     whereRegion.invoke(() -> regionLatch.countDown());
   }
 
-  /*
+  /**
    * Region operation has been scheduled, now resume commit processing
    */
   private static void releaseOps() {
     opsLatch.countDown();
   }
 
-  /*
+  /**
    * Notify waiter it is time to verify region contents
    */
   private static void releaseVerify() {
@@ -308,8 +316,9 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
 
   private InternalDistributedMember createCache(VM vm) {
     return vm.invoke(() -> {
-      cache = getCache(new CacheFactory().set("conserve-sockets", "true"));
-      return getSystem().getDistributedMember();
+      cache = (InternalCache) new CacheFactory(getDistributedSystemProperties())
+          .set("conserve-sockets", "true").create();
+      return cache.getInternalDistributedSystem().getDistributedMember();
     });
   }
 
@@ -320,7 +329,7 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     factory.create(rgnName);
   }
 
-  /*
+  /**
    * Get region contents from each member and verify they are consistent
    */
   private void checkForConsistencyErrors(String regionName) {
@@ -330,46 +339,46 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     for (int i = 0; i < NUMBER_OF_PUTS; i++) {
       String theKey = regionName + THE_KEY + i;
       if (r0Contents.containsKey(theKey)) {
-        softly.assertThat(r1Contents.get(theKey))
+        assertThat(r1Contents.get(theKey))
             .as("region contents are not consistent for key %s", theKey)
             .isEqualTo(r0Contents.get(theKey));
       } else {
-        softly.assertThat(r1Contents).as("expected containsKey for %s to return false", theKey)
+        assertThat(r1Contents).as("expected containsKey for %s to return false", theKey)
             .doesNotContainKey(theKey);
       }
     }
   }
 
-  @SuppressWarnings("rawtypes")
   private static Map<Object, Object> getRegionContents(String rname) {
     LocalRegion r = (LocalRegion) cache.getRegion(rname);
     Map<Object, Object> result = new HashMap<>();
-    for (Iterator i = r.entrySet().iterator(); i.hasNext();) {
-      Region.Entry e = (Region.Entry) i.next();
+    for (Object o : r.entrySet()) {
+      Region.Entry e = (Region.Entry) o;
       result.put(e.getKey(), e.getValue());
     }
     return result;
   }
 
-  /*
+  /**
    * Test callback called for each operation during commit processing. Half way through commit
    * processing, release the region operation.
    */
-  static class CommitTestCallback implements Runnable {
-    private VM whereRegionOperation;
-    private int callCount;
-    /* entered twice for each put lap since there are 2 regions */
-    private int releasePoint = NUMBER_OF_PUTS;
+  private static class CommitTestCallback implements Runnable {
+
+    /** entered twice for each put lap since there are 2 regions */
+    private final int releasePoint = NUMBER_OF_PUTS;
+    private final AtomicInteger callCount = new AtomicInteger();
+
+    private final VM whereRegionOperation;
 
     CommitTestCallback(VM whereRegion) {
       whereRegionOperation = whereRegion;
-      callCount = 0;
     }
 
     @Override
     public void run() {
-      callCount++;
-      if (callCount == releasePoint) {
+      callCount.incrementAndGet();
+      if (callCount.get() == releasePoint) {
         releaseRegionOperation(whereRegionOperation);
         try {
           opsLatch.await();
@@ -379,13 +388,13 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  /*
+  /**
    * The region operations attempt to acquire the write lock will hang while commit processing is
    * occurring. Before this occurs, resume commit processing.
    */
-  public class ArmLockHook extends ARMLockTestHookAdapter {
+  private static class ArmLockHook extends ARMLockTestHookAdapter {
     @Override
-    public void beforeLock(InternalRegion owner, CacheEvent event) {
+    public void beforeLock(InternalRegion region, CacheEvent event) {
       if (event != null) {
         if (event.getOperation().isClear() || event.getOperation().isRegionDestroy()
             || event.getOperation().isClose()) {
@@ -394,5 +403,4 @@ public class ClearTXLockingDUnitTest extends JUnit4CacheTestCase {
       }
     }
   }
-
 }


### PR DESCRIPTION
Making the latches static final should fix the intermittent NPE.