### PR TITLE
GEODE-6539: Use RegionStats-regionName for RegionPerfStats TextId

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionPerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionPerfStats.java
@@ -31,7 +31,7 @@ class RegionPerfStats extends CachePerfStats {
   @VisibleForTesting
   RegionPerfStats(StatisticsFactory statisticsFactory, CachePerfStats cachePerfStats,
       String regionName, Clock clock) {
-    super(statisticsFactory, regionName, clock);
+    super(statisticsFactory, "RegionStats-" + regionName, clock);
     this.cachePerfStats = cachePerfStats;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.internal.cache.CachePerfStats.Clock;
+
+public class RegionPerfStatsTest {
+
+  private StatisticsFactory statisticsFactory;
+  private CachePerfStats cachePerfStats;
+  private Clock clock;
+
+  @Before
+  public void setUp() {
+    statisticsFactory = mock(StatisticsFactory.class);
+    cachePerfStats = mock(CachePerfStats.class);
+    clock = mock(Clock.class);
+  }
+
+  @Test
+  public void textIdIsRegionStatsHyphenRegionName() throws Exception {
+    String theRegionName = "TheRegionName";
+
+    new RegionPerfStats(statisticsFactory, cachePerfStats,
+        theRegionName, clock);
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(statisticsFactory).createAtomicStatistics(any(), captor.capture());
+
+    assertThat(captor.getValue()).isEqualTo("RegionStats-" + theRegionName);
+  }
+}


### PR DESCRIPTION
Please review: @demery-pivotal @mhansonp 

GEODE-6539 was caused by this commit:
```
commit 02eda0a6af6d84a1e26e44248280c0de7feb4a88
Author: Kirk Lund <klund@apache.org>
Date:   Tue Mar 19 16:25:52 2019 -0700

    GEODE-6534: Extract RegionPerfStats from LocalRegion (#3315)
    
    Set enableClockStats before constructing CachePerfStats.
```