### PR TITLE
GEODE-6550: Use cache-writer in AlterRegionCommand

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommand.java
@@ -153,7 +153,7 @@ public class AlterRegionCommand extends SingleGfshCommand {
 
     if (cacheWriter != null) {
       regionAttributesType.setCacheWriter(
-          new DeclarableType(cacheLoader.getClassName(), cacheLoader.getInitProperties()));
+          new DeclarableType(cacheWriter.getClassName(), cacheWriter.getInitProperties()));
     }
 
     if (cacheListeners != null) {


### PR DESCRIPTION
GEODE-6550: Use cache-writer in AlterRegionCommand

- Fixed minor warnings.
- Parameter `cache-writer`, instead of `cache-loader`, is now used to
configure the internal `CacheWriter` for the region.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
