### PR TITLE
GEODE-6271: Ignore failures from other pools

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/pdx/PdxMultiClusterClientServerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/pdx/PdxMultiClusterClientServerDUnitTest.java
@@ -136,6 +136,25 @@ public class PdxMultiClusterClientServerDUnitTest extends JUnit4CacheTestCase {
         getCache().getRegion("regionA").get("key")));
   }
 
+  /**
+   * If a client has multiple pools, but one of the pools has no available servers, creating
+   * a new type should still succeed.
+   */
+  @Test
+  public void sendingTypeIgnoresClustersThatAreNotRunning() {
+
+    ClientCache client = createScenario();
+
+    Region regionA = client.getRegion("regionA");
+
+    createType(serverA, "regionA");
+
+    serverB.invoke(JUnit4CacheTestCase::closeCache);
+
+    // Put from the client serverA. This will try to send the type to serverB
+    regionA.put("key", new SimpleClass(5, (byte) 6));
+  }
+
   private void createType(VM vm, String region) {
     vm.invoke(() -> {
       getCache().getRegion(region).put("createType", new SimpleClass(5, (byte) 6));

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/ClientTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/ClientTypeRegistration.java
@@ -68,7 +68,7 @@ public class ClientTypeRegistration implements TypeRegistration {
       try {
         newTypeId = GetPDXIdForTypeOp.execute((ExecutablePool) pool, newType);
         newType.setTypeId(newTypeId);
-        sendTypeToAllPools(newType, newTypeId, getAllPoolsExcept(pool));
+        copyTypeToOtherPools(newType, newTypeId, pool);
         return newTypeId;
       } catch (ServerConnectivityException e) {
         // ignore, try the next pool.
@@ -76,6 +76,15 @@ public class ClientTypeRegistration implements TypeRegistration {
       }
     }
     throw returnCorrectExceptionForFailure(pools, newTypeId, lastException);
+  }
+
+  private void copyTypeToOtherPools(PdxType newType, int newTypeId, Pool pool) {
+    try {
+      sendTypeToAllPools(newType, newTypeId, getAllPoolsExcept(pool));
+    } catch (Exception e) {
+      logger.debug("Received an exception sending pdx type to pool {}, {}", pool, e.getMessage(),
+          e);
+    }
   }
 
   private Collection<Pool> getAllPoolsExcept(Pool pool) {
@@ -181,8 +190,7 @@ public class ClientTypeRegistration implements TypeRegistration {
     for (Pool pool : pools) {
       try {
         int result = GetPDXIdForEnumOp.execute((ExecutablePool) pool, enumInfo);
-
-        sendEnumToAllPools(enumInfo, result, getAllPoolsExcept(pool));
+        copyEnumToOtherPools(enumInfo, result, pool);
         return result;
       } catch (ServerConnectivityException e) {
         // ignore, try the next pool.
@@ -190,6 +198,16 @@ public class ClientTypeRegistration implements TypeRegistration {
       }
     }
     throw returnCorrectExceptionForFailure(pools, -1, lastException);
+  }
+
+
+  private void copyEnumToOtherPools(EnumInfo enumInfo, int newTypeId, Pool pool) {
+    try {
+      sendEnumToAllPools(enumInfo, newTypeId, getAllPoolsExcept(pool));
+    } catch (Exception e) {
+      logger.debug("Received an exception sending pdx enum to pool {}, {}", pool, e.getMessage(),
+          e);
+    }
   }
 
   private void sendEnumIdToPool(EnumInfo enumInfo, int id, Pool pool) {


### PR DESCRIPTION
Copying a type to additional pools on the client may fail if not servers
are running in those additional pools. Ignoring failures due to copying
a type from one pool to another.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, you check travis-ci for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
