### PR TITLE
GEODE-6526: Removing call to removeTombstone during entry destroy

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -102,6 +102,8 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion);
 
+  void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion, boolean reschedule);
+
   boolean isEntryExpiryPossible();
 
   void addExpiryTaskIfAbsent(RegionEntry entry);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -3296,7 +3296,8 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     scheduleTombstone(entry, destroyedVersion, false);
   }
 
-  private void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion,
+  @Override
+  public void scheduleTombstone(RegionEntry entry, VersionTag destroyedVersion,
       boolean reschedule) {
     if (destroyedVersion == null) {
       throw new NullPointerException("destroyed version tag cannot be null");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -257,6 +257,7 @@ public abstract class AbstractRegionEntry implements HashRegionEntry<Object, Obj
       throws RegionClearedException {
     assert region.getVersionVector() != null;
     assert version != null;
+
     if (isTombstone()) {
       // unschedule the old tombstone
       region.unscheduleTombstone(this);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -257,27 +257,17 @@ public abstract class AbstractRegionEntry implements HashRegionEntry<Object, Obj
       throws RegionClearedException {
     assert region.getVersionVector() != null;
     assert version != null;
-    if (region.getServerProxy() == null && region.getVersionVector()
-        .isTombstoneTooOld(version.getMemberID(), version.getRegionVersion())) {
-      // distributed gc with higher vector version preempts this operation
-      if (!isTombstone()) {
-        basicMakeTombstone(region);
-        region.getCachePerfStats().incTombstoneCount(1);
-      }
-      ((DiskRecoveryStore) region).getRegionMap().removeTombstone(this, version, false, true);
-    } else {
-      if (isTombstone()) {
-        // unschedule the old tombstone
-        region.unscheduleTombstone(this);
-      }
-      setRecentlyUsed(region);
-      boolean newEntry = getValueAsToken() == Token.REMOVED_PHASE1;
-      basicMakeTombstone(region);
-      region.scheduleTombstone(this, version);
-      if (newEntry) {
-        // bug #46631 - entry count is decremented by scheduleTombstone but this is a new entry
-        region.getCachePerfStats().incEntryCount(1);
-      }
+    if (isTombstone()) {
+      // unschedule the old tombstone
+      region.unscheduleTombstone(this);
+    }
+    setRecentlyUsed(region);
+    boolean newEntry = getValueAsToken() == Token.REMOVED_PHASE1;
+    basicMakeTombstone(region);
+    region.scheduleTombstone(this, version);
+    if (newEntry) {
+      // bug #46631 - entry count is decremented by scheduleTombstone but this is a new entry
+      region.getCachePerfStats().incEntryCount(1);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -258,14 +258,11 @@ public abstract class AbstractRegionEntry implements HashRegionEntry<Object, Obj
     assert region.getVersionVector() != null;
     assert version != null;
 
-    if (isTombstone()) {
-      // unschedule the old tombstone
-      region.unscheduleTombstone(this);
-    }
+    boolean wasTombstone = isTombstone();
     setRecentlyUsed(region);
     boolean newEntry = getValueAsToken() == Token.REMOVED_PHASE1;
     basicMakeTombstone(region);
-    region.scheduleTombstone(this, version);
+    region.scheduleTombstone(this, version, wasTombstone);
     if (newEntry) {
       // bug #46631 - entry count is decremented by scheduleTombstone but this is a new entry
       region.getCachePerfStats().incEntryCount(1);


### PR DESCRIPTION
During destroy entry (tombstone) under region entry lock, if the
entry had a lower region version than the recorded gc version for
that member, the entry was removed immediately which could result
in dead-lock with tombstone gc thread.

Instead of removing the entry during destroy, it was scheduled to
remove during tombstone gc.

### For all changes:
- [Y] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [Y] Is your initial contribution a single, squashed commit?

- [Y] Does `gradlew build` run cleanly?

- [Y] Have you written or updated unit tests to verify your changes?

- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
