### PR TITLE
GEODE-6551: Fix Constraints Check in Alter Region

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1223,16 +1223,6 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
-  /**
-   * @deprecated as of 10.0 use
-   *             {@link PartitionedRegion#updatePRConfigWithNewSetOfAsynchronousEventDispatchers(Set)}
-   *             instead
-   */
-  @Deprecated
-  public void updatePRConfigWithNewSetOfGatewaySenders(Set<String> gatewaySendersToAdd) {
-    updatePRConfigWithNewSetOfAsynchronousEventDispatchers(gatewaySendersToAdd);
-  }
-
   public void updatePRConfigWithNewSetOfAsynchronousEventDispatchers(
       Set<String> asynchronousEventDispatchers) {
     PartitionRegionHelper.assignBucketsToPartitions(this);
@@ -1493,15 +1483,6 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
-  /**
-   * @deprecated as of 10.0 use
-   *             {@link PartitionedRegion#validateParallelAsynchronousEventDispatcherIds()} instead.
-   */
-  @Deprecated
-  public void validateParallelGatewaySenderIds() throws PRLocallyDestroyedException {
-    validateParallelAsynchronousEventDispatcherIds();
-  }
-
   public void validateParallelAsynchronousEventDispatcherIds() throws PRLocallyDestroyedException {
     validateParallelAsynchronousEventDispatcherIds(this.getParallelGatewaySenderIds());
   }
@@ -1543,17 +1524,6 @@ public class PartitionedRegion extends LocalRegion
     parallelAsyncEventQueues.retainAll(allParallelQueues);
 
     return parallelAsyncEventQueues;
-  }
-
-  /**
-   * @deprecated as of 10.0 use
-   *             {@link PartitionedRegion#validateParallelAsynchronousEventDispatcherIds(Set)}
-   *             instead.
-   */
-  @Deprecated
-  public void validateParallelGatewaySenderIds(Set<String> parallelGatewaySenderIds)
-      throws PRLocallyDestroyedException {
-    validateParallelAsynchronousEventDispatcherIds(parallelGatewaySenderIds);
   }
 
   public void validateParallelAsynchronousEventDispatcherIds(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -90,6 +90,7 @@ import org.apache.geode.cache.TimeoutException;
 import org.apache.geode.cache.TransactionDataNotColocatedException;
 import org.apache.geode.cache.TransactionDataRebalancedException;
 import org.apache.geode.cache.TransactionException;
+import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
 import org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl;
 import org.apache.geode.cache.client.internal.ClientMetadataService;
 import org.apache.geode.cache.execute.EmptyRegionFunctionException;
@@ -231,6 +232,7 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySenderEventProcessor;
+import org.apache.geode.internal.cache.wan.AsyncEventQueueConfigurationException;
 import org.apache.geode.internal.cache.wan.GatewaySenderConfigurationException;
 import org.apache.geode.internal.cache.wan.GatewaySenderException;
 import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySenderQueue;
@@ -1221,10 +1223,21 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
+  /**
+   * @deprecated as of 10.0 use
+   *             {@link PartitionedRegion#updatePRConfigWithNewSetOfAsynchronousEventDispatchers(Set)}
+   *             instead
+   */
+  @Deprecated
   public void updatePRConfigWithNewSetOfGatewaySenders(Set<String> gatewaySendersToAdd) {
+    updatePRConfigWithNewSetOfAsynchronousEventDispatchers(gatewaySendersToAdd);
+  }
+
+  public void updatePRConfigWithNewSetOfAsynchronousEventDispatchers(
+      Set<String> asynchronousEventDispatchers) {
     PartitionRegionHelper.assignBucketsToPartitions(this);
     updatePartitionRegionConfig(prConfig -> {
-      prConfig.setGatewaySenderIds(gatewaySendersToAdd);
+      prConfig.setGatewaySenderIds(asynchronousEventDispatchers);
     });
   }
 
@@ -1375,7 +1388,7 @@ public class PartitionedRegion extends LocalRegion
       prConfig = getPRRoot().get(getRegionIdentifier());
 
       if (prConfig == null) {
-        validateParallelGatewaySenderIds();
+        validateParallelAsynchronousEventDispatcherIds();
         this.partitionedRegionId = generatePRId(getSystem());
         prConfig = new PartitionRegionConfig(this.partitionedRegionId, this.getFullPath(),
             prAttribs, this.getScope(), getAttributes().getEvictionAttributes(),
@@ -1480,35 +1493,97 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
+  /**
+   * @deprecated as of 10.0 use
+   *             {@link PartitionedRegion#validateParallelAsynchronousEventDispatcherIds()} instead.
+   */
+  @Deprecated
   public void validateParallelGatewaySenderIds() throws PRLocallyDestroyedException {
-    validateParallelGatewaySenderIds(this.getParallelGatewaySenderIds());
+    validateParallelAsynchronousEventDispatcherIds();
   }
 
-  /*
-   * filterOutNonParallelGatewaySenders takes in a set of gateway sender IDs and returns
-   * a set of parallel gateway senders present in the input set.
+  public void validateParallelAsynchronousEventDispatcherIds() throws PRLocallyDestroyedException {
+    validateParallelAsynchronousEventDispatcherIds(this.getParallelGatewaySenderIds());
+  }
+
+  /**
+   * Filters out non parallel GatewaySenders.
+   *
+   * @param senderIds set of gateway sender IDs.
+   * @return set of parallel gateway senders present in the input set.
    */
   public Set<String> filterOutNonParallelGatewaySenders(Set<String> senderIds) {
-    Set<String> allParallelSenders = cache.getAllGatewaySenders().parallelStream()
-        .filter(GatewaySender::isParallel).map(GatewaySender::getId).collect(toSet());
-    Set<String> parallelSenders = new HashSet<>();
-    senderIds.parallelStream().forEach(gatewaySenderId -> {
-      if (allParallelSenders.contains(gatewaySenderId)) {
-        parallelSenders.add(gatewaySenderId);
-      }
-    });
+    Set<String> allParallelSenders = cache.getAllGatewaySenders()
+        .parallelStream()
+        .filter(GatewaySender::isParallel)
+        .map(GatewaySender::getId)
+        .collect(toSet());
+
+    Set<String> parallelSenders = new HashSet<>(senderIds);
+    parallelSenders.retainAll(allParallelSenders);
+
     return parallelSenders;
   }
 
+  /**
+   * Filters out non parallel AsyncEventQueues.
+   *
+   * @param queueIds set of async-event-queue IDs.
+   * @return set of parallel async-event-queues present in the input set.
+   */
+  public Set<String> filterOutNonParallelAsyncEventQueues(Set<String> queueIds) {
+    Set<String> allParallelQueues = cache.getAsyncEventQueues()
+        .parallelStream()
+        .filter(AsyncEventQueue::isParallel)
+        .map(asyncEventQueue -> AsyncEventQueueImpl
+            .getAsyncEventQueueIdFromSenderId(asyncEventQueue.getId()))
+        .collect(toSet());
+
+    Set<String> parallelAsyncEventQueues = new HashSet<>(queueIds);
+    parallelAsyncEventQueues.retainAll(allParallelQueues);
+
+    return parallelAsyncEventQueues;
+  }
+
+  /**
+   * @deprecated as of 10.0 use
+   *             {@link PartitionedRegion#validateParallelAsynchronousEventDispatcherIds(Set)}
+   *             instead.
+   */
+  @Deprecated
   public void validateParallelGatewaySenderIds(Set<String> parallelGatewaySenderIds)
       throws PRLocallyDestroyedException {
-    for (String senderId : parallelGatewaySenderIds) {
-      for (PartitionRegionConfig config : getPRRoot().values()) {
-        if (config.getGatewaySenderIds().contains(senderId)) {
+    validateParallelAsynchronousEventDispatcherIds(parallelGatewaySenderIds);
+  }
+
+  public void validateParallelAsynchronousEventDispatcherIds(
+      Set<String> asynchronousEventDispatcherIds) throws PRLocallyDestroyedException {
+    for (String dispatcherId : asynchronousEventDispatcherIds) {
+      GatewaySender sender = getCache().getGatewaySender(dispatcherId);
+      AsyncEventQueue asyncEventQueue = getCache()
+          .getAsyncEventQueue(AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(dispatcherId));
+
+      // Can't attach a non persistent parallel gateway / async-event-queue to a persistent
+      // partitioned region.
+      if (getDataPolicy().withPersistence()) {
+        if ((sender != null) && (!sender.isPersistenceEnabled())) {
+          throw new GatewaySenderConfigurationException(String.format(
+              "Non persistent gateway sender %s can not be attached to persistent region %s",
+              dispatcherId, getFullPath()));
+        } else if ((asyncEventQueue != null) && (!asyncEventQueue.isPersistent())) {
+          throw new AsyncEventQueueConfigurationException(String.format(
+              "Non persistent asynchronous event queue %s can not be attached to persistent region %s",
+              dispatcherId, getFullPath()));
+        }
+      }
+
+      for (PartitionRegionConfig config : this.prRoot.values()) {
+        if (config.getGatewaySenderIds().contains(dispatcherId)) {
           if (this.getFullPath().equals(config.getFullPath())) {
             // The sender is already attached to this region
             continue;
           }
+
           Map<String, PartitionedRegion> colocationMap =
               ColocationHelper.getAllColocationRegions(this);
           if (!colocationMap.isEmpty()) {
@@ -1518,28 +1593,23 @@ public class PartitionedRegion extends LocalRegion
               int prID = config.getPRId();
               PartitionedRegion colocatedPR = PartitionedRegion.getPRFromId(prID);
               PartitionedRegion leader = ColocationHelper.getLeaderRegion(colocatedPR);
+
               if (colocationMap.containsValue(leader)) {
                 continue;
               } else {
-                throw new IllegalStateException(
-                    String.format(
-                        "Non colocated regions %s, %s cannot have the same parallel %s id %s configured.",
-                        new Object[] {this.getFullPath(), config.getFullPath(),
-                            senderId.contains(AsyncEventQueueImpl.ASYNC_EVENT_QUEUE_PREFIX)
-                                ? "async event queue" : "gateway sender",
-                            senderId}));
+                throw new IllegalStateException(String.format(
+                    "Non colocated regions %s, %s cannot have the same parallel %s id %s configured.",
+                    this.getFullPath(), config.getFullPath(),
+                    (asyncEventQueue != null ? "async event queue" : "gateway sender"),
+                    dispatcherId));
               }
             }
           } else {
-            throw new IllegalStateException(
-                String.format(
-                    "Non colocated regions %s, %s cannot have the same parallel %s id %s configured.",
-                    new Object[] {this.getFullPath(), config.getFullPath(),
-                        senderId.contains(AsyncEventQueueImpl.ASYNC_EVENT_QUEUE_PREFIX)
-                            ? "async event queue" : "gateway sender",
-                        senderId}));
+            throw new IllegalStateException(String.format(
+                "Non colocated regions %s, %s cannot have the same parallel %s id %s configured.",
+                this.getFullPath(), config.getFullPath(),
+                (asyncEventQueue != null ? "async event queue" : "gateway sender"), dispatcherId));
           }
-
         }
       }
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl.getSenderIdFromAsyncEventQueueId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -33,6 +34,7 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -45,6 +47,8 @@ import org.apache.geode.cache.CacheLoader;
 import org.apache.geode.cache.CacheWriter;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
+import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
@@ -53,14 +57,9 @@ import org.apache.geode.test.fake.Fakes;
 
 @RunWith(JUnitParamsRunner.class)
 public class PartitionedRegionTest {
-
-  String regionName = "prTestRegion";
-
-  InternalCache internalCache;
-
-  PartitionedRegion partitionedRegion;
-
-  Properties gemfireProperties = new Properties();
+  private InternalCache internalCache;
+  private PartitionedRegion partitionedRegion;
+  private Properties gemfireProperties = new Properties();
 
   @Before
   public void setup() {
@@ -69,25 +68,38 @@ public class PartitionedRegionTest {
     InternalResourceManager resourceManager =
         mock(InternalResourceManager.class, RETURNS_DEEP_STUBS);
     when(internalCache.getInternalResourceManager()).thenReturn(resourceManager);
+    @SuppressWarnings("deprecation")
     AttributesFactory attributesFactory = new AttributesFactory();
     attributesFactory.setPartitionAttributes(
         new PartitionAttributesFactory().setTotalNumBuckets(1).setRedundantCopies(1).create());
-    partitionedRegion = new PartitionedRegion(regionName, attributesFactory.create(),
-        null, internalCache, mock(InternalRegionArguments.class));
+    partitionedRegion = new PartitionedRegion("prTestRegion", attributesFactory.create(), null,
+        internalCache, mock(InternalRegionArguments.class));
     DistributedSystem mockDistributedSystem = mock(DistributedSystem.class);
     when(internalCache.getDistributedSystem()).thenReturn(mockDistributedSystem);
     when(mockDistributedSystem.getProperties()).thenReturn(gemfireProperties);
   }
 
+  @SuppressWarnings("unused")
+  private Object[] parametersToTestUpdatePRNodeInformation() {
+    CacheLoader mockLoader = mock(CacheLoader.class);
+    CacheWriter mockWriter = mock(CacheWriter.class);
+    return new Object[] {
+        new Object[] {mockLoader, null, (byte) 0x01},
+        new Object[] {null, mockWriter, (byte) 0x02},
+        new Object[] {mockLoader, mockWriter, (byte) 0x03},
+        new Object[] {null, null, (byte) 0x00}
+    };
+  }
+
   @Test
   @Parameters(method = "parametersToTestUpdatePRNodeInformation")
   public void verifyPRConfigUpdatedAfterLoaderUpdate(CacheLoader mockLoader, CacheWriter mockWriter,
-      byte configByte) {
+      @SuppressWarnings("unused") byte configByte) {
     LocalRegion prRoot = mock(LocalRegion.class);
     PartitionRegionConfig mockConfig = mock(PartitionRegionConfig.class);
     PartitionedRegion prSpy = spy(partitionedRegion);
 
-    doReturn(prRoot).when(prSpy).getPRRoot();
+    when(prSpy.getPRRoot()).thenReturn(prRoot);
     when(prRoot.get(prSpy.getRegionIdentifier())).thenReturn(mockConfig);
 
     InternalDistributedMember ourMember = prSpy.getDistributionManager().getId();
@@ -99,8 +111,8 @@ public class PartitionedRegionTest {
     when(ourNode.getMemberId()).thenReturn(ourMember);
     when(otherNode1.getMemberId()).thenReturn(otherMember1);
     when(otherNode2.getMemberId()).thenReturn(otherMember2);
-    when(ourNode.isCacheLoaderAttached()).thenReturn(mockLoader == null ? false : true);
-    when(ourNode.isCacheWriterAttached()).thenReturn(mockWriter == null ? false : true);
+    when(ourNode.isCacheLoaderAttached()).thenReturn(mockLoader != null);
+    when(ourNode.isCacheWriterAttached()).thenReturn(mockWriter != null);
 
 
     VersionedArrayList prNodes = new VersionedArrayList();
@@ -118,7 +130,7 @@ public class PartitionedRegionTest {
     prSpy.updatePRNodeInformation();
 
     Node verifyOurNode = null;
-    assertThat(mockConfig.getNodes().contains(ourNode));
+    assertThat(mockConfig.getNodes().contains(ourNode)).isTrue();
     for (Node node : mockConfig.getNodes()) {
       if (node.getMemberId().equals(ourMember)) {
         verifyOurNode = node;
@@ -130,23 +142,12 @@ public class PartitionedRegionTest {
     verify(prRoot).put(prSpy.getRegionIdentifier(), mockConfig);
 
     assertThat(verifyOurNode).isNotNull();
-    assertThat(verifyOurNode.isCacheLoaderAttached()).isEqualTo(mockLoader == null ? false : true);
-    assertThat(verifyOurNode.isCacheWriterAttached()).isEqualTo(mockWriter == null ? false : true);
-  }
-
-  private Object[] parametersToTestUpdatePRNodeInformation() {
-    CacheLoader mockLoader = mock(CacheLoader.class);
-    CacheWriter mockWriter = mock(CacheWriter.class);
-    return new Object[] {
-        new Object[] {mockLoader, null, (byte) 0x01},
-        new Object[] {null, mockWriter, (byte) 0x02},
-        new Object[] {mockLoader, mockWriter, (byte) 0x03},
-        new Object[] {null, null, (byte) 0x00}
-    };
+    assertThat(verifyOurNode.isCacheLoaderAttached()).isEqualTo(mockLoader != null);
+    assertThat(verifyOurNode.isCacheWriterAttached()).isEqualTo(mockWriter != null);
   }
 
   @Test
-  public void getBucketNodeForReadOrWriteReturnsPrimaryNodeForRegisterInterest() throws Exception {
+  public void getBucketNodeForReadOrWriteReturnsPrimaryNodeForRegisterInterest() {
     int bucketId = 0;
     InternalDistributedMember primaryMember = mock(InternalDistributedMember.class);
     InternalDistributedMember secondaryMember = mock(InternalDistributedMember.class);
@@ -155,7 +156,6 @@ public class PartitionedRegionTest {
     PartitionedRegion spyPR = spy(partitionedRegion);
     doReturn(primaryMember).when(spyPR).getNodeForBucketWrite(eq(bucketId), isNull());
     doReturn(secondaryMember).when(spyPR).getNodeForBucketRead(eq(bucketId));
-
     InternalDistributedMember memberForRegisterInterestRead =
         spyPR.getBucketNodeForReadOrWrite(bucketId, clientEvent);
 
@@ -164,8 +164,7 @@ public class PartitionedRegionTest {
   }
 
   @Test
-  public void getBucketNodeForReadOrWriteReturnsSecondaryNodeForNonRegisterInterest()
-      throws Exception {
+  public void getBucketNodeForReadOrWriteReturnsSecondaryNodeForNonRegisterInterest() {
     int bucketId = 0;
     InternalDistributedMember primaryMember = mock(InternalDistributedMember.class);
     InternalDistributedMember secondaryMember = mock(InternalDistributedMember.class);
@@ -174,7 +173,6 @@ public class PartitionedRegionTest {
     PartitionedRegion spyPR = spy(partitionedRegion);
     doReturn(primaryMember).when(spyPR).getNodeForBucketWrite(eq(bucketId), isNull());
     doReturn(secondaryMember).when(spyPR).getNodeForBucketRead(eq(bucketId));
-
     InternalDistributedMember memberForRegisterInterestRead =
         spyPR.getBucketNodeForReadOrWrite(bucketId, clientEvent);
 
@@ -183,15 +181,13 @@ public class PartitionedRegionTest {
   }
 
   @Test
-  public void getBucketNodeForReadOrWriteReturnsSecondaryNodeWhenClientEventIsNotPresent()
-      throws Exception {
+  public void getBucketNodeForReadOrWriteReturnsSecondaryNodeWhenClientEventIsNotPresent() {
     int bucketId = 0;
     InternalDistributedMember primaryMember = mock(InternalDistributedMember.class);
     InternalDistributedMember secondaryMember = mock(InternalDistributedMember.class);
     PartitionedRegion spyPR = spy(partitionedRegion);
     doReturn(primaryMember).when(spyPR).getNodeForBucketWrite(eq(bucketId), isNull());
     doReturn(secondaryMember).when(spyPR).getNodeForBucketRead(eq(bucketId));
-
     InternalDistributedMember memberForRegisterInterestRead =
         spyPR.getBucketNodeForReadOrWrite(bucketId, null);
 
@@ -200,8 +196,7 @@ public class PartitionedRegionTest {
   }
 
   @Test
-  public void getBucketNodeForReadOrWriteReturnsSecondaryNodeWhenClientEventOperationIsNotPresent()
-      throws Exception {
+  public void getBucketNodeForReadOrWriteReturnsSecondaryNodeWhenClientEventOperationIsNotPresent() {
     int bucketId = 0;
     InternalDistributedMember primaryMember = mock(InternalDistributedMember.class);
     InternalDistributedMember secondaryMember = mock(InternalDistributedMember.class);
@@ -210,7 +205,6 @@ public class PartitionedRegionTest {
     PartitionedRegion spyPR = spy(partitionedRegion);
     doReturn(primaryMember).when(spyPR).getNodeForBucketWrite(eq(bucketId), isNull());
     doReturn(secondaryMember).when(spyPR).getNodeForBucketRead(eq(bucketId));
-
     InternalDistributedMember memberForRegisterInterestRead =
         spyPR.getBucketNodeForReadOrWrite(bucketId, null);
 
@@ -221,18 +215,15 @@ public class PartitionedRegionTest {
   @Test
   public void updateBucketMapsForInterestRegistrationWithSetOfKeysFetchesPrimaryBucketsForRead() {
     Integer[] bucketIds = new Integer[] {0, 1};
-
     InternalDistributedMember primaryMember = mock(InternalDistributedMember.class);
     InternalDistributedMember secondaryMember = mock(InternalDistributedMember.class);
     PartitionedRegion spyPR = spy(partitionedRegion);
     doReturn(primaryMember).when(spyPR).getNodeForBucketWrite(anyInt(), isNull());
     doReturn(secondaryMember).when(spyPR).getNodeForBucketRead(anyInt());
-    HashMap<InternalDistributedMember, HashSet<Integer>> nodeToBuckets =
-        new HashMap<InternalDistributedMember, HashSet<Integer>>();
-    Set buckets = Arrays.stream(bucketIds).collect(Collectors.toCollection(HashSet::new));
+    HashMap<InternalDistributedMember, HashSet<Integer>> nodeToBuckets = new HashMap<>();
+    Set<Integer> buckets = Arrays.stream(bucketIds).collect(Collectors.toCollection(HashSet::new));
 
     spyPR.updateNodeToBucketMap(nodeToBuckets, buckets);
-
     verify(spyPR, times(2)).getNodeForBucketWrite(anyInt(), isNull());
   }
 
@@ -245,15 +236,70 @@ public class PartitionedRegionTest {
     PartitionedRegion spyPR = spy(partitionedRegion);
     doReturn(primaryMember).when(spyPR).getNodeForBucketWrite(anyInt(), isNull());
     doReturn(secondaryMember).when(spyPR).getNodeForBucketRead(anyInt());
-    HashMap<InternalDistributedMember, HashMap<Integer, HashSet>> nodeToBuckets =
-        new HashMap<InternalDistributedMember, HashMap<Integer, HashSet>>();
+    HashMap<InternalDistributedMember, HashMap<Integer, HashSet>> nodeToBuckets = new HashMap<>();
     HashSet buckets = Arrays.stream(bucketIds).collect(Collectors.toCollection(HashSet::new));
     HashMap<Integer, HashSet> bucketKeys = new HashMap<>();
-    bucketKeys.put(Integer.valueOf(0), buckets);
+    bucketKeys.put(0, buckets);
 
     spyPR.updateNodeToBucketMap(nodeToBuckets, bucketKeys);
-
     verify(spyPR, times(1)).getNodeForBucketWrite(anyInt(), isNull());
   }
 
+  @Test
+  public void filterOutNonParallelGatewaySendersShouldReturnCorrectly() {
+    GatewaySender parallelSender = mock(GatewaySender.class);
+    when(parallelSender.isParallel()).thenReturn(true);
+    when(parallelSender.getId()).thenReturn("parallel");
+    GatewaySender anotherParallelSender = mock(GatewaySender.class);
+    when(anotherParallelSender.isParallel()).thenReturn(true);
+    when(anotherParallelSender.getId()).thenReturn("anotherParallel");
+    GatewaySender serialSender = mock(GatewaySender.class);
+    when(serialSender.isParallel()).thenReturn(false);
+    when(serialSender.getId()).thenReturn("serial");
+    Set<GatewaySender> mockSenders =
+        Stream.of(parallelSender, anotherParallelSender, serialSender).collect(Collectors.toSet());
+
+    when(internalCache.getAllGatewaySenders()).thenReturn(mockSenders);
+    assertThat(partitionedRegion
+        .filterOutNonParallelGatewaySenders(Stream.of("serial").collect(Collectors.toSet())))
+            .isEmpty();
+    assertThat(partitionedRegion
+        .filterOutNonParallelGatewaySenders(Stream.of("unknownSender").collect(Collectors.toSet())))
+            .isEmpty();
+    assertThat(partitionedRegion.filterOutNonParallelGatewaySenders(
+        Stream.of("parallel", "serial").collect(Collectors.toSet()))).isNotEmpty()
+            .containsExactly("parallel");
+    assertThat(partitionedRegion.filterOutNonParallelGatewaySenders(
+        Stream.of("parallel", "serial", "anotherParallel").collect(Collectors.toSet())))
+            .isNotEmpty().containsExactly("parallel", "anotherParallel");
+  }
+
+  @Test
+  public void filterOutNonParallelAsyncEventQueuesShouldReturnCorrectly() {
+    AsyncEventQueue parallelQueue = mock(AsyncEventQueue.class);
+    when(parallelQueue.isParallel()).thenReturn(true);
+    when(parallelQueue.getId()).thenReturn(getSenderIdFromAsyncEventQueueId("parallel"));
+    AsyncEventQueue anotherParallelQueue = mock(AsyncEventQueue.class);
+    when(anotherParallelQueue.isParallel()).thenReturn(true);
+    when(anotherParallelQueue.getId())
+        .thenReturn(getSenderIdFromAsyncEventQueueId("anotherParallel"));
+    AsyncEventQueue serialQueue = mock(AsyncEventQueue.class);
+    when(serialQueue.isParallel()).thenReturn(false);
+    when(serialQueue.getId()).thenReturn(getSenderIdFromAsyncEventQueueId("serial"));
+    Set<AsyncEventQueue> mockQueues =
+        Stream.of(parallelQueue, anotherParallelQueue, serialQueue).collect(Collectors.toSet());
+
+    when(internalCache.getAsyncEventQueues()).thenReturn(mockQueues);
+    assertThat(partitionedRegion
+        .filterOutNonParallelAsyncEventQueues(Stream.of("serial").collect(Collectors.toSet())))
+            .isEmpty();
+    assertThat(partitionedRegion.filterOutNonParallelAsyncEventQueues(
+        Stream.of("unknownSender").collect(Collectors.toSet()))).isEmpty();
+    assertThat(partitionedRegion.filterOutNonParallelAsyncEventQueues(
+        Stream.of("parallel", "serial").collect(Collectors.toSet()))).isNotEmpty()
+            .containsExactly("parallel");
+    assertThat(partitionedRegion.filterOutNonParallelAsyncEventQueues(
+        Stream.of("parallel", "serial", "anotherParallel").collect(Collectors.toSet())))
+            .isNotEmpty().containsExactly("parallel", "anotherParallel");
+  }
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@Category(WanTest.class)
+public class AlterRegionCommandDUnitTest {
+  private static MemberVM locator;
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Rule
+  public TestName testName = new SerializableTestName();
+
+  @Rule
+  public ClusterStartupRule lsRule = new ClusterStartupRule();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void before() throws Exception {
+    locator = lsRule.startLocatorVM(0);
+    lsRule.startServerVM(1, locator.getPort());
+
+    gfsh.connectAndVerify(locator);
+    gfsh.executeAndAssertThat(
+        "create disk-store --name=diskStore --dir=" + temporaryFolder.getRoot()).statusIsSuccess();
+  }
+
+  @Test
+  public void alterPartitionRegionWithParallelAsynchronousEventQueueShouldPersistTheChangesIntoTheClusterConfigurationService() {
+    String regionName = testName.getMethodName();
+    String asyncEventQueueName = "asyncEventQueue1";
+
+    gfsh.executeAndAssertThat(
+        "create async-event-queue --parallel=true --persistent=false --listener=org.apache.geode.internal.cache.wan.MyAsyncEventListener --id="
+            + asyncEventQueueName)
+        .statusIsSuccess();
+    locator.waitUntilAsyncEventQueuesAreReadyOnExactlyThisManyServers(asyncEventQueueName, 1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + regionName)
+        .statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+
+    // Associate the async-event-queue
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --async-event-queue-id=" + asyncEventQueueName)
+        .statusIsSuccess().containsOutput("server-1", "OK", "Region " + regionName + " altered");
+
+    // Check the cluster configuration service.
+    locator.invoke(() -> {
+      InternalLocator internalLocator = ClusterStartupRule.getLocator();
+      assertThat(internalLocator).isNotNull();
+      CacheConfig config =
+          internalLocator.getConfigurationPersistenceService().getCacheConfig("cluster");
+
+      RegionConfig regionConfig = CacheElement.findElement(config.getRegions(), regionName);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getRegionAttributes()).isNotNull();
+      assertThat(regionConfig.getRegionAttributes().getAsyncEventQueueIds()).isNotEmpty()
+          .isEqualTo(asyncEventQueueName);
+    });
+  }
+
+  @Test
+  public void alterNonColocatedPartitionRegionWithTheSameParallelAsynchronousEventQueueShouldThrowExceptionAndPreventTheClusterConfigurationServiceFromBeingUpdated() {
+    IgnoredException.addIgnoredException(
+        "Non colocated regions (.*) cannot have the same parallel async event queue id (.*) configured.");
+
+    String asyncEventQueue = "asyncEventQueue";
+    String region1Name = testName.getMethodName() + "1";
+    String region2Name = testName.getMethodName() + "2";
+
+    gfsh.executeAndAssertThat(
+        "create async-event-queue --parallel=true --persistent=false --listener=org.apache.geode.internal.cache.wan.MyAsyncEventListener --id="
+            + asyncEventQueue)
+        .statusIsSuccess();
+    locator.waitUntilAsyncEventQueuesAreReadyOnExactlyThisManyServers(asyncEventQueue, 1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region1Name)
+        .statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region1Name, 1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region2Name)
+        .statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region2Name, 1);
+
+    // Associate the async-event-queue to both regions (second one should fail because they are not
+    // co-located)
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + region1Name + " --async-event-queue-id=" + asyncEventQueue)
+        .statusIsSuccess().containsOutput("server-1", "OK", "Region " + region1Name + " altered");
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + region2Name + " --async-event-queue-id=" + asyncEventQueue)
+        .statusIsError().containsOutput("server-1", "ERROR",
+            "Non colocated regions /" + region2Name + ", /" + region1Name
+                + " cannot have the same parallel async event queue id " + asyncEventQueue
+                + " configured.");
+
+    // The exception must be thrown early in the initialization, so the change shouldn't be
+    // persisted to the cluster configuration service for the second region.
+    locator.invoke(() -> {
+      InternalLocator internalLocator = ClusterStartupRule.getLocator();
+      assertThat(internalLocator).isNotNull();
+      CacheConfig config =
+          internalLocator.getConfigurationPersistenceService().getCacheConfig("cluster");
+
+      RegionConfig regionConfig = CacheElement.findElement(config.getRegions(), region1Name);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getRegionAttributes()).isNotNull();
+      assertThat(regionConfig.getRegionAttributes().getAsyncEventQueueIds())
+          .isEqualTo(asyncEventQueue);
+
+      RegionConfig region2Config = CacheElement.findElement(config.getRegions(), region2Name);
+      assertThat(region2Config).isNotNull();
+      assertThat(region2Config.getRegionAttributes()).isNotNull();
+      assertThat(region2Config.getRegionAttributes().getAsyncEventQueueIds()).isBlank();
+    });
+  }
+
+  @Test
+  public void alterPartitionPersistentRegionWithParallelNonPersistentAsynchronousEventQueueShouldThrowExceptionAndPreventTheClusterConfigurationServiceFromBeingUpdated() {
+    IgnoredException.addIgnoredException(
+        "Non persistent asynchronous event queue (.*) can not be attached to persistent region (.*)");
+    String regionName = testName.getMethodName();
+    String asyncEventQueueName = "asyncEventQueue";
+
+    gfsh.executeAndAssertThat(
+        "create async-event-queue --parallel=true --persistent=false --listener=org.apache.geode.internal.cache.wan.MyAsyncEventListener --id="
+            + asyncEventQueueName)
+        .statusIsSuccess();
+    locator.waitUntilAsyncEventQueuesAreReadyOnExactlyThisManyServers(asyncEventQueueName, 1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION_PERSISTENT --name=" + regionName
+        + " --disk-store=diskStore").statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+
+    // Make sure that the next invocations also fail and that the changes are not persisted to the
+    // cluster configuration service. See GEODE-6551.
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --async-event-queue-id=" + asyncEventQueueName)
+        .statusIsError()
+        .containsOutput("server-1", "ERROR", "Non persistent asynchronous event queue "
+            + asyncEventQueueName + " can not be attached to persistent region /" + regionName);
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --async-event-queue-id=" + asyncEventQueueName)
+        .statusIsError()
+        .containsOutput("server-1", "ERROR", "Non persistent asynchronous event queue "
+            + asyncEventQueueName + " can not be attached to persistent region /" + regionName);
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --async-event-queue-id=" + asyncEventQueueName)
+        .statusIsError()
+        .containsOutput("server-1", "ERROR", "Non persistent asynchronous event queue "
+            + asyncEventQueueName + " can not be attached to persistent region /" + regionName);
+
+    // The exception must be thrown early in the initialization, so the change shouldn't be
+    // persisted to the cluster configuration service.
+    locator.invoke(() -> {
+      InternalLocator internalLocator = ClusterStartupRule.getLocator();
+      assertThat(internalLocator).isNotNull();
+      CacheConfig config =
+          internalLocator.getConfigurationPersistenceService().getCacheConfig("cluster");
+
+      RegionConfig regionConfig = CacheElement.findElement(config.getRegions(), regionName);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getRegionAttributes()).isNotNull();
+      assertThat(regionConfig.getRegionAttributes().getAsyncEventQueueIds()).isBlank();
+    });
+  }
+
+  @Test
+  public void alterPartitionRegionWithParallelGatewaySenderShouldPersistTheChangesIntoTheClusterConfigurationService() {
+    IgnoredException.addIgnoredException("could not get remote locator information");
+    String regionName = testName.getMethodName();
+    String gatewaySenderName = "gatewaySender";
+
+    gfsh.executeAndAssertThat(
+        "create gateway-sender --parallel=true --enable-persistence=false --remote-distributed-system-id=2 --id="
+            + gatewaySenderName)
+        .statusIsSuccess();
+    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + regionName)
+        .statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+
+    // Associate the gateway-sender
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --gateway-sender-id=" + gatewaySenderName)
+        .statusIsSuccess().containsOutput("server-1", "OK", "Region " + regionName + " altered");
+
+    // Check the cluster configuration service.
+    locator.invoke(() -> {
+      InternalLocator internalLocator = ClusterStartupRule.getLocator();
+      assertThat(internalLocator).isNotNull();
+      CacheConfig config =
+          internalLocator.getConfigurationPersistenceService().getCacheConfig("cluster");
+
+      RegionConfig regionConfig = CacheElement.findElement(config.getRegions(), regionName);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getRegionAttributes()).isNotNull();
+      assertThat(regionConfig.getRegionAttributes().getGatewaySenderIds()).isNotEmpty()
+          .isEqualTo(gatewaySenderName);
+    });
+  }
+
+  @Test
+  public void alterNonColocatedPartitionRegionWithTheSameParallelGatewaySenderShouldThrowExceptionAndPreventTheClusterConfigurationServiceFromBeingUpdated() {
+    IgnoredException.addIgnoredException("could not get remote locator information");
+    IgnoredException.addIgnoredException(
+        "Non colocated regions (.*) cannot have the same parallel gateway sender id (.*) configured.");
+
+    String gatewaySenderName = "gatewaySender";
+    String region1Name = testName.getMethodName() + "1";
+    String region2Name = testName.getMethodName() + "2";
+
+    gfsh.executeAndAssertThat(
+        "create gateway-sender --parallel=true --enable-persistence=false --remote-distributed-system-id=2 --id="
+            + gatewaySenderName)
+        .statusIsSuccess();
+    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region1Name)
+        .statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region1Name, 1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region2Name)
+        .statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region2Name, 1);
+
+    // Associate the gateway-sender to both regions (second one should fail because they are not
+    // co-located)
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + region1Name + " --gateway-sender-id=" + gatewaySenderName)
+        .statusIsSuccess().containsOutput("server-1", "OK", "Region " + region1Name + " altered");
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + region2Name + " --gateway-sender-id=" + gatewaySenderName)
+        .statusIsError().containsOutput("server-1", "ERROR",
+            "Non colocated regions /" + region2Name + ", /" + region1Name
+                + " cannot have the same parallel gateway sender id " + gatewaySenderName
+                + " configured.");
+
+    // The exception must be thrown early in the initialization, so the change shouldn't be
+    // persisted to the cluster configuration service for the second region.
+    locator.invoke(() -> {
+      InternalLocator internalLocator = ClusterStartupRule.getLocator();
+      assertThat(internalLocator).isNotNull();
+      CacheConfig config =
+          internalLocator.getConfigurationPersistenceService().getCacheConfig("cluster");
+
+      RegionConfig regionConfig = CacheElement.findElement(config.getRegions(), region1Name);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getRegionAttributes()).isNotNull();
+      assertThat(regionConfig.getRegionAttributes().getGatewaySenderIds())
+          .isEqualTo(gatewaySenderName);
+
+      RegionConfig region2Config = CacheElement.findElement(config.getRegions(), region2Name);
+      assertThat(region2Config).isNotNull();
+      assertThat(region2Config.getRegionAttributes()).isNotNull();
+      assertThat(region2Config.getRegionAttributes().getGatewaySenderIds()).isBlank();
+    });
+  }
+
+  @Test
+  public void alterPartitionPersistentRegionWithParallelNonPersistentGatewaySenderShouldThrowExceptionAndPreventTheClusterConfigurationServiceFromBeingUpdated() {
+    IgnoredException.addIgnoredException("could not get remote locator information");
+    IgnoredException.addIgnoredException(
+        "Non persistent gateway sender (.*) can not be attached to persistent region (.*)");
+    String regionName = testName.getMethodName();
+    String gatewaySenderName = "gatewaySender";
+
+    gfsh.executeAndAssertThat(
+        "create gateway-sender --parallel=true --enable-persistence=false --remote-distributed-system-id=2 --id="
+            + gatewaySenderName)
+        .statusIsSuccess();
+    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+
+    gfsh.executeAndAssertThat("create region --type=PARTITION_PERSISTENT --name=" + regionName
+        + " --disk-store=diskStore").statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+
+    // Make sure that the next invocations also fail and that the changes are not persisted to the
+    // cluster configuration service. See GEODE-6551.
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --gateway-sender-id=" + gatewaySenderName)
+        .statusIsError().containsOutput("server-1", "ERROR", "Non persistent gateway sender "
+            + gatewaySenderName + " can not be attached to persistent region /" + regionName);
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --gateway-sender-id=" + gatewaySenderName)
+        .statusIsError().containsOutput("server-1", "ERROR", "Non persistent gateway sender "
+            + gatewaySenderName + " can not be attached to persistent region /" + regionName);
+    gfsh.executeAndAssertThat(
+        "alter region --name=" + regionName + " --gateway-sender-id=" + gatewaySenderName)
+        .statusIsError().containsOutput("server-1", "ERROR", "Non persistent gateway sender "
+            + gatewaySenderName + " can not be attached to persistent region /" + regionName);
+
+    // The exception must be thrown early in the initialization, so the change shouldn't be
+    // persisted to the cluster configuration service.
+    locator.invoke(() -> {
+      InternalLocator internalLocator = ClusterStartupRule.getLocator();
+      assertThat(internalLocator).isNotNull();
+      CacheConfig config =
+          internalLocator.getConfigurationPersistenceService().getCacheConfig("cluster");
+
+      RegionConfig regionConfig = CacheElement.findElement(config.getRegions(), regionName);
+      assertThat(regionConfig).isNotNull();
+      assertThat(regionConfig.getRegionAttributes()).isNotNull();
+      assertThat(regionConfig.getRegionAttributes().getGatewaySenderIds()).isBlank();
+    });
+  }
+}


### PR DESCRIPTION
GEODE-6551: Fix Constraints Check in Alter Region

Some persistence constraints were not correctly validated for a
partitioned region before associating an async-event-queue and/or
gateway-sender, leaving the region and the cluster configuration
service inconsistent.

- Fixed minor warnings.
- Fixed the internal validation implemented by PartitionedRegion.
- Some method's signatures were changed from "parallelGatewaySender" to
"parallelAsynchronousEventDispatcher" as they are used alike for
both a gateway-sender and async-event-queue.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
