### PR TITLE
GEODE-6529: Add timers for LocalRegion operations

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,6 +41,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.shiro.subject.Subject;
 import org.junit.Assert;
 import org.junit.Test;
@@ -81,6 +83,7 @@ public class CacheClientNotifierIntegrationTest {
     final CountDownLatch notifyClientLatch = new CountDownLatch(1);
 
     InternalCache mockInternalCache = createMockInternalCache();
+    assertThat(mockInternalCache.getMeterRegistry()).isNotNull();
 
     CacheClientNotifier cacheClientNotifier =
         CacheClientNotifier.getInstance(mockInternalCache, mock(CacheServerStats.class),
@@ -213,6 +216,7 @@ public class CacheClientNotifierIntegrationTest {
     InternalCache mockInternalCache = mock(InternalCache.class);
     doReturn(mock(SystemTimer.class)).when(mockInternalCache).getCCPTimer();
     doReturn(mock(CancelCriterion.class)).when(mockInternalCache).getCancelCriterion();
+    doReturn(new SimpleMeterRegistry()).when(mockInternalCache).getMeterRegistry();
 
     InternalDistributedSystem mockInteralDistributedSystem = createMockInternalDistributedSystem();
     doReturn(mockInteralDistributedSystem).when(mockInternalCache).getInternalDistributedSystem();

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierIntegrationTest.java
@@ -12,18 +12,18 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -43,10 +43,11 @@ import java.util.concurrent.Future;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.apache.shiro.subject.Subject;
-import org.junit.Assert;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.stubbing.Answer;
+import org.junit.rules.Timeout;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.Statistics;
@@ -74,14 +75,27 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
-@Category({ClientSubscriptionTest.class})
+@Category(ClientSubscriptionTest.class)
 public class CacheClientNotifierIntegrationTest {
+
+  private final CountDownLatch messageDispatcherInitLatch = new CountDownLatch(1);
+  private final CountDownLatch notifyClientLatch = new CountDownLatch(1);
+
+  private final ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+  @Rule
+  public Timeout timeout = Timeout.millis(getTimeout().getValueInMS());
+
+  @After
+  public void tearDown() {
+    messageDispatcherInitLatch.countDown();
+    notifyClientLatch.countDown();
+    executorService.shutdownNow();
+  }
+
   @Test
   public void testCacheClientNotifier_NotifyClients_QRMCausesPrematureRemovalFromHAContainer()
       throws Exception {
-    final CountDownLatch messageDispatcherInitLatch = new CountDownLatch(1);
-    final CountDownLatch notifyClientLatch = new CountDownLatch(1);
-
     InternalCache mockInternalCache = createMockInternalCache();
     assertThat(mockInternalCache.getMeterRegistry()).isNotNull();
 
@@ -89,8 +103,8 @@ public class CacheClientNotifierIntegrationTest {
         CacheClientNotifier.getInstance(mockInternalCache, mock(CacheServerStats.class),
             100000, 100000, mock(ConnectionListener.class), null, false);
 
-    final String mockRegionNameProxyOne = "mockHARegionProxyOne";
-    final String mockRegionNameProxyTwo = "mockHARegionProxyTwo";
+    String mockRegionNameProxyOne = "mockHARegionProxyOne";
+    String mockRegionNameProxyTwo = "mockHARegionProxyTwo";
 
     CacheClientProxy cacheClientProxyOne =
         createMockCacheClientProxy(cacheClientNotifier, mockRegionNameProxyOne);
@@ -107,9 +121,7 @@ public class CacheClientNotifierIntegrationTest {
     createMockHARegion(mockInternalCache, cacheClientProxyOne, mockRegionNameProxyOne, true);
     createMockHARegion(mockInternalCache, cacheClientProxyTwo, mockRegionNameProxyTwo, false);
 
-    ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-    ArrayList<Callable<Void>> initAndNotifyTasks = new ArrayList<>();
+    List<Callable<Void>> initAndNotifyTasks = new ArrayList<>();
 
     // On one thread, we are initializing the message dispatchers for the two CacheClientProxy
     // objects. For the second client's initialization,
@@ -159,23 +171,21 @@ public class CacheClientNotifierIntegrationTest {
       return false;
     });
 
-    Assert.assertEquals("Expected the HAContainer to be empty", 0,
-        cacheClientNotifier.getHaContainer().size());
+    assertThat(cacheClientNotifier.getHaContainer()).as("Expected the HAContainer to be empty")
+        .isEmpty();
   }
 
-  private HARegion createMockHARegion(InternalCache internalCache,
-      CacheClientProxy cacheClientProxy,
-      String haRegionName,
-      boolean simulateQrm)
+  private void createMockHARegion(InternalCache internalCache,
+      CacheClientProxy cacheClientProxy, String haRegionName, boolean simulateQrm)
       throws IOException, ClassNotFoundException {
     HARegion mockHARegion = mock(HARegion.class);
 
-    doReturn(internalCache).when(mockHARegion).getCache();
-    doReturn(internalCache).when(mockHARegion).getGemFireCache();
-    doReturn(mock(CancelCriterion.class)).when(mockHARegion).getCancelCriterion();
-    doReturn(mock(AttributesMutator.class)).when(mockHARegion).getAttributesMutator();
-    doReturn(mockHARegion).when(internalCache).createVMRegion(eq(haRegionName),
-        any(RegionAttributes.class), any(InternalRegionArguments.class));
+    when(mockHARegion.getAttributesMutator()).thenReturn(mock(AttributesMutator.class));
+    when(mockHARegion.getCache()).thenReturn(internalCache);
+    when(mockHARegion.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    when(mockHARegion.getGemFireCache()).thenReturn(internalCache);
+    when(internalCache.createVMRegion(eq(haRegionName), any(RegionAttributes.class),
+        any(InternalRegionArguments.class))).thenReturn(mockHARegion);
 
     // We use a mock of the HARegion.put() method to simulate an queue removal message
     // immediately after the event was successfully put. In production when a queue removal takes
@@ -184,72 +194,73 @@ public class CacheClientNotifierIntegrationTest {
     // removal later on
     // when CacheClientNotifier.checkAndRemoveFromClientMsgsRegion() is called.
 
-    Map<Object, Object> events = new HashMap<Object, Object>();
+    Map<Object, Object> events = new HashMap<>();
 
-    doAnswer(invocation -> {
-      long position = invocation.getArgument(0);
-      HAEventWrapper haEventWrapper = invocation.getArgument(1);
+    when(mockHARegion.put(any(long.class), any(HAEventWrapper.class)))
+        .thenAnswer(invocation -> {
+          long position = invocation.getArgument(0);
+          HAEventWrapper haEventWrapper = invocation.getArgument(1);
 
-      if (simulateQrm) {
-        // This call is ultimately what a QRM message will do when it is processed, so we simulate
-        // that here.
-        cacheClientProxy.getHARegionQueue().destroyFromAvailableIDs(position);
-        events.remove(position);
-        cacheClientProxy.getHARegionQueue()
-            .decAndRemoveFromHAContainer((HAEventWrapper) haEventWrapper);
-      } else {
-        events.put(position, haEventWrapper);
-      }
+          if (simulateQrm) {
+            // This call is ultimately what a QRM message will do when it is processed, so we
+            // simulate
+            // that here.
+            cacheClientProxy.getHARegionQueue().destroyFromAvailableIDs(position);
+            events.remove(position);
+            cacheClientProxy.getHARegionQueue()
+                .decAndRemoveFromHAContainer(haEventWrapper);
+          } else {
+            events.put(position, haEventWrapper);
+          }
 
-      return null;
-    }).when(mockHARegion).put(any(long.class), any(HAEventWrapper.class));
+          return null;
+        });
 
     // This is so that when peek() is called, the object is returned. Later we want to verify that
     // it was successfully "delivered" to the client and subsequently removed from the HARegion.
-    doAnswer((Answer<Object>) invocation -> events.get(invocation.getArgument(0)))
-        .when(mockHARegion).get(any(long.class));
-
-    return mockHARegion;
+    when(mockHARegion.get(any(long.class)))
+        .thenAnswer(invocation -> events.get(invocation.getArgument(0)));
   }
 
   private InternalCache createMockInternalCache() {
     InternalCache mockInternalCache = mock(InternalCache.class);
-    doReturn(mock(SystemTimer.class)).when(mockInternalCache).getCCPTimer();
-    doReturn(mock(CancelCriterion.class)).when(mockInternalCache).getCancelCriterion();
-    doReturn(new SimpleMeterRegistry()).when(mockInternalCache).getMeterRegistry();
+    InternalDistributedSystem mockInternalDistributedSystem = createMockInternalDistributedSystem();
 
-    InternalDistributedSystem mockInteralDistributedSystem = createMockInternalDistributedSystem();
-    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getInternalDistributedSystem();
-    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getDistributedSystem();
+    when(mockInternalCache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    when(mockInternalCache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
+    when(mockInternalCache.getDistributedSystem()).thenReturn(mockInternalDistributedSystem);
+    when(mockInternalCache.getInternalDistributedSystem())
+        .thenReturn(mockInternalDistributedSystem);
+    when(mockInternalCache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
 
     return mockInternalCache;
   }
 
   private InternalDistributedSystem createMockInternalDistributedSystem() {
-    InternalDistributedSystem mockInternalDistributedSystem = mock(InternalDistributedSystem.class);
     DistributionManager mockDistributionManager = mock(DistributionManager.class);
+    InternalDistributedSystem mockInternalDistributedSystem = mock(InternalDistributedSystem.class);
 
-    doReturn(mock(InternalDistributedMember.class)).when(mockInternalDistributedSystem)
-        .getDistributedMember();
-    doReturn(mock(Statistics.class)).when(mockInternalDistributedSystem)
-        .createAtomicStatistics(any(StatisticsType.class), any(String.class));
-    doReturn(mock(DistributionConfig.class)).when(mockDistributionManager).getConfig();
-    doReturn(mockDistributionManager).when(mockInternalDistributedSystem).getDistributionManager();
-    doReturn(mock(DSClock.class)).when(mockInternalDistributedSystem).getClock();
+    when(mockDistributionManager.getConfig()).thenReturn(mock(DistributionConfig.class));
+    when(mockInternalDistributedSystem.getDistributedMember())
+        .thenReturn(mock(InternalDistributedMember.class));
+    when(mockInternalDistributedSystem.createAtomicStatistics(any(StatisticsType.class),
+        any(String.class))).thenReturn(mock(Statistics.class));
+    when(mockInternalDistributedSystem.getDistributionManager())
+        .thenReturn(mockDistributionManager);
+    when(mockInternalDistributedSystem.getClock()).thenReturn(mock(DSClock.class));
 
     return mockInternalDistributedSystem;
   }
 
   private CacheClientProxy createMockCacheClientProxy(CacheClientNotifier cacheClientNotifier,
-      String haRegionName)
-      throws IOException {
-    Socket mockSocket = mock(Socket.class);
-    doReturn(mock(InetAddress.class)).when(mockSocket).getInetAddress();
-
+      String haRegionName) throws IOException {
     ClientProxyMembershipID mockClientProxyMembershipID = mock(ClientProxyMembershipID.class);
-    doReturn(mock(DistributedMember.class)).when(mockClientProxyMembershipID)
-        .getDistributedMember();
-    doReturn(haRegionName).when(mockClientProxyMembershipID).getHARegionName();
+    Socket mockSocket = mock(Socket.class);
+
+    when(mockClientProxyMembershipID.getDistributedMember())
+        .thenReturn(mock(DistributedMember.class));
+    when(mockClientProxyMembershipID.getHARegionName()).thenReturn(haRegionName);
+    when(mockSocket.getInetAddress()).thenReturn(mock(InetAddress.class));
 
     CacheClientProxy cacheClientProxy =
         spy(new CacheClientProxy(cacheClientNotifier, mockSocket, mockClientProxyMembershipID, true,
@@ -261,32 +272,29 @@ public class CacheClientNotifierIntegrationTest {
   }
 
   private EntryEventImpl createMockEntryEvent(List<CacheClientProxy> proxies) {
-    FilterRoutingInfo.FilterInfo mockFilterInfo = mock(FilterRoutingInfo.FilterInfo.class);
-    Set mockInterestedClients = mock(Set.class);
-    doReturn(mockInterestedClients).when(mockFilterInfo).getInterestedClients();
-    doReturn(null).when(mockFilterInfo).getInterestedClientsInv();
-
     EntryEventImpl mockEntryEventImpl = mock(EntryEventImpl.class);
-    doReturn(mockFilterInfo).when(mockEntryEventImpl).getLocalFilterInfo();
-
+    EventID mockEventId = mock(EventID.class);
     FilterProfile mockFilterProfile = mock(FilterProfile.class);
-    Set mockRealClientIDs = new HashSet<ClientProxyMembershipID>();
+    FilterRoutingInfo.FilterInfo mockFilterInfo = mock(FilterRoutingInfo.FilterInfo.class);
+    LocalRegion mockLocalRegion = mock(LocalRegion.class);
+    Set mockInterestedClients = mock(Set.class);
 
+    when(mockEntryEventImpl.getEventId()).thenReturn(mockEventId);
+    when(mockEntryEventImpl.getEventType()).thenReturn(EnumListenerEvent.AFTER_CREATE);
+    when(mockEntryEventImpl.getLocalFilterInfo()).thenReturn(mockFilterInfo);
+    when(mockEntryEventImpl.getOperation()).thenReturn(Operation.CREATE);
+    when(mockEntryEventImpl.getRegion()).thenReturn(mockLocalRegion);
+    when(mockEventId.getMembershipID()).thenReturn(new byte[] {1});
+    when(mockFilterInfo.getInterestedClients()).thenReturn(mockInterestedClients);
+    when(mockFilterInfo.getInterestedClientsInv()).thenReturn(null);
+
+    Set<ClientProxyMembershipID> mockRealClientIDs = new HashSet<>();
     for (CacheClientProxy proxy : proxies) {
       mockRealClientIDs.add(proxy.getProxyID());
     }
 
-    doReturn(mockRealClientIDs).when(mockFilterProfile).getRealClientIDs(any(Collection.class));
-
-    LocalRegion mockLocalRegion = mock(LocalRegion.class);
-    doReturn(mockFilterProfile).when(mockLocalRegion).getFilterProfile();
-
-    doReturn(mockLocalRegion).when(mockEntryEventImpl).getRegion();
-    doReturn(EnumListenerEvent.AFTER_CREATE).when(mockEntryEventImpl).getEventType();
-    doReturn(Operation.CREATE).when(mockEntryEventImpl).getOperation();
-    EventID mockEventId = mock(EventID.class);
-    doReturn(new byte[] {1}).when(mockEventId).getMembershipID();
-    doReturn(mockEventId).when(mockEntryEventImpl).getEventId();
+    when(mockFilterProfile.getRealClientIDs(any(Collection.class))).thenReturn(mockRealClientIDs);
+    when(mockLocalRegion.getFilterProfile()).thenReturn(mockFilterProfile);
 
     return mockEntryEventImpl;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -69,7 +69,6 @@ import org.apache.geode.cache.StatisticsDisabledException;
 import org.apache.geode.cache.SubscriptionAttributes;
 import org.apache.geode.cache.TimeoutException;
 import org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl;
-import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.client.internal.PoolImpl;
 import org.apache.geode.cache.query.FunctionDomainException;
 import org.apache.geode.cache.query.NameResolutionException;
@@ -268,9 +267,13 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
 
   protected final InternalCache cache;
 
+  private final PoolFinder poolFinder;
+
   /** Creates a new instance of AbstractRegion */
   protected AbstractRegion(InternalCache cache, RegionAttributes attrs, String regionName,
-      InternalRegionArguments internalRegionArgs) {
+      InternalRegionArguments internalRegionArgs, PoolFinder poolFinder) {
+    this.poolFinder = poolFinder;
+
     this.cache = cache;
     this.serialNumber = DistributionAdvisor.createSerialNumber();
     this.isPdxTypesRegion = PeerTypeRegistration.REGION_NAME.equals(regionName);
@@ -385,6 +388,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
     this.lastAccessedTime = new AtomicLong(0);
     this.lastModifiedTime = new AtomicLong(0);
     evictionAttributes = new EvictionAttributesImpl();
+    poolFinder = (a) -> null;
   }
 
   /**
@@ -1676,7 +1680,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
   private PoolImpl getPool() {
     PoolImpl result = null;
     if (getPoolName() != null) {
-      result = (PoolImpl) PoolManager.find(getPoolName());
+      result = poolFinder.find(getPoolName());
     }
     return result;
   }
@@ -1864,4 +1868,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
     // nothing
   }
 
+  protected interface PoolFinder {
+    PoolImpl find(String poolName);
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionMetricsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionMetricsTest.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.LENIENT;
+
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.Statistics;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.client.internal.PoolImpl;
+import org.apache.geode.cache.client.internal.ServerRegionProxy;
+import org.apache.geode.distributed.internal.DSClock;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.statistics.StatisticsManager;
+
+public class LocalRegionMetricsTest {
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule().strictness(LENIENT);
+
+  private final String myRegion = "MyRegion";
+  private final AtomicLong clockTime = new AtomicLong();
+
+  private MeterRegistry meterRegistry;
+
+  @Mock
+  private RegionAttributes<?, ?> regionAttributes;
+  @Mock
+  private InternalCache cache;
+  @Mock
+  private InternalRegionArguments internalRegionArgs;
+  @Mock
+  private InternalDistributedSystem internalDistributedSystem;
+  @Mock
+  private DataPolicy dataPolicy;
+  @Mock
+  private RegionMap regionMap;
+  @Mock
+  private EntryEventImpl entryEvent;
+  @Mock
+  private InternalDataView internalDataView;
+  @Mock
+  private StatisticsManager statisticsManager;
+  @Mock
+  private EntryEventFactory entryEventFactory;
+  @Mock
+  private ServerRegionProxy serverRegionProxy;
+  @Mock
+  private PoolImpl pool;
+  @Mock
+  private Clock clock;
+
+  @Before
+  public void setUp() {
+    meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+
+    when(cache.getCachePerfStats()).thenReturn(mock(CachePerfStats.class));
+    when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    when(cache.getDistributedSystem()).thenReturn(internalDistributedSystem);
+    when(cache.getInternalDistributedSystem()).thenReturn(internalDistributedSystem);
+    when(cache.getMeterRegistry()).thenReturn(meterRegistry);
+
+    when(clock.monotonicTime()).thenAnswer(invocation -> clockTime.incrementAndGet());
+
+    when(entryEvent.setCreate(anyBoolean())).thenReturn(entryEvent);
+
+    when(entryEventFactory.create(any(), any(), any(), any(), any(), anyBoolean(), any()))
+        .thenReturn(entryEvent);
+
+    when(internalDataView
+        .putEntry(any(), anyBoolean(), anyBoolean(), any(), anyBoolean(), anyLong(), anyBoolean()))
+            .thenReturn(true);
+
+    when(internalDistributedSystem.getClock()).thenReturn(mock(DSClock.class));
+    when(internalDistributedSystem.getConfig()).thenReturn(mock(DistributionConfig.class));
+    when(internalDistributedSystem.getStatisticsManager()).thenReturn(statisticsManager);
+
+    when(regionAttributes.getDataPolicy()).thenReturn(dataPolicy);
+    when(regionAttributes.getDiskWriteAttributes())
+        .thenReturn(new DiskWriteAttributesImpl(new Properties()));
+    when(regionAttributes.getEntryIdleTimeout()).thenReturn(new ExpirationAttributes());
+    when(regionAttributes.getEntryTimeToLive()).thenReturn(new ExpirationAttributes());
+    when(regionAttributes.getEvictionAttributes()).thenReturn(new EvictionAttributesImpl());
+    when(regionAttributes.getRegionIdleTimeout()).thenReturn(new ExpirationAttributes());
+    when(regionAttributes.getRegionTimeToLive()).thenReturn(new ExpirationAttributes());
+    when(regionAttributes.getScope()).thenReturn(Scope.LOCAL);
+
+    when(statisticsManager.createAtomicStatistics(any(), any()))
+        .thenReturn(mock(Statistics.class));
+  }
+
+  @Test
+  public void create_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.create("", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "create")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void createWithCallbackArgument_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.create("", "", null);
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "create")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void put_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.put("", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "put")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void putWithCallback_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.put("", "", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "put")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void putIfAbsent_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.putIfAbsent("", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "put-if-absent")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void putIfAbsentWithCallback_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.putIfAbsent("", "", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "put-if-absent")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void replace_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.replace("", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "replace")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void replaceWithOldAndNewValues_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.replace("", "", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.puts")
+        .tag("region.name", myRegion)
+        .tag("put.type", "replace")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void get_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.get("");
+
+    Timer timer = meterRegistry.find("cache.region.operations.gets")
+        .tag("region.name", myRegion)
+        .tag("get.type", "get")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void getWithCallback_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.get("", "");
+
+    Timer timer = meterRegistry.find("cache.region.operations.gets")
+        .tag("region.name", myRegion)
+        .tag("get.type", "get")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void getEntry_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.getEntry("");
+
+    Timer timer = meterRegistry.find("cache.region.operations.gets")
+        .tag("region.name", myRegion)
+        .tag("get.type", "get-entry")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void containsKey_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.containsKey("");
+
+    Timer timer = meterRegistry.find("cache.region.operations.contains")
+        .tag("region.name", myRegion)
+        .tag("contains.type", "contains-key")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void containsValue_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegion(myRegion);
+
+    localRegion.containsValue("");
+
+    Timer timer = meterRegistry.find("cache.region.operations.contains")
+        .tag("region.name", myRegion)
+        .tag("contains.type", "contains-value")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void containsKeyOnServer_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegionForClient(myRegion);
+
+    localRegion.containsKeyOnServer("");
+
+    Timer timer = meterRegistry.find("cache.region.operations.contains")
+        .tag("region.name", myRegion)
+        .tag("contains.type", "contains-key-on-server")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  @Test
+  public void containsValueForKey_timesHowLongItTook() {
+    LocalRegion localRegion = createLocalRegionForClient(myRegion);
+
+    localRegion.containsValueForKey("");
+
+    Timer timer = meterRegistry.find("cache.region.operations.contains")
+        .tag("region.name", myRegion)
+        .tag("contains.type", "contains-value-for-key")
+        .timer();
+
+    assertThat(timer).isNotNull();
+    assertThat(timer.count()).isEqualTo(1L);
+    assertThat(timer.totalTime(TimeUnit.NANOSECONDS)).isGreaterThan(0);
+  }
+
+  private LocalRegion createLocalRegion(String regionName) {
+    return new LocalRegion(regionName, regionAttributes, null, cache, internalRegionArgs,
+        internalDataView, (a, b, c) -> regionMap, (a) -> null, entryEventFactory, (a) -> null);
+  }
+
+  private LocalRegion createLocalRegionForClient(String regionName) {
+    when(regionAttributes.getPoolName()).thenReturn("pool");
+    return new LocalRegion(regionName, regionAttributes, null, cache, internalRegionArgs,
+        internalDataView, (a, b, c) -> regionMap, (a) -> serverRegionProxy, entryEventFactory,
+        (a) -> pool);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.LogWriter;
 import org.apache.geode.Statistics;
@@ -102,6 +104,7 @@ public class Fakes {
     when(cache.getTxManager()).thenReturn(txManager);
     when(cache.getLogger()).thenReturn(logger);
     when(cache.getQueryMonitor()).thenReturn(queryMonitor);
+    when(cache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
 
     when(system.getDistributedMember()).thenReturn(member);
     when(system.getConfig()).thenReturn(config);


### PR DESCRIPTION
* Add cache.region.operations.puts create timer.
* Add cache.region.operations.puts put timer.
* Add cache.region.operations.puts put-if-absent timer.
* Add cache.region.operations.puts replace timer.
* Add cache.region.operations.gets get timer.
* Add cache.region.operations.gets get-entry timer.
* Add cache.region.operations.contains containsKey timer.
* Add cache.region.operations.contains containsValue timer.
* Add cache.region.operations.contains containsKeyOnServer timer.
* Add cache.region.operations.contains containsValueForKey timer.

Co-authored-by: Michael Oleske <moleske@pivotal.io>
Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>

Please review: @demery-pivotal @mhansonp 

Includes:
```
commit 30c1c4af10fb962f19b6f0ddd23ded2de4c808cc
Author: Kirk Lund <klund@apache.org>
Date:   Thu Mar 21 15:21:52 2019 -0700

    GEODE-6529: Add Timeout to CacheClientNotifierIntegrationTest
    
    Fix Mockito syntax and reorganize test.
    
    Co-authored-by: Michael Oleske <moleske@pivotal.io>
    Co-authored-by: Kirk Lund <klund@apache.org>
```
```
commit 484c7447db50164bfb734c19bff7cfeab82fa2a6
Author: Kirk Lund <klund@apache.org>
Date:   Thu Mar 21 14:53:47 2019 -0700

    GEODE-6529: Stub getMeterRegistry in CacheClientNotifierIntegrationTest
    
    Stub InternalCache.getMeterRegistry to prevent hang when meters are
    added to LocalRegion
    
    Co-authored-by: Michael Oleske <moleske@pivotal.io>
    Co-authored-by: Kirk Lund <klund@apache.org>
```