### PR TITLE
GEODE-6558: Add addMeterSubregistry to CacheFactory

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/CacheFactoryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/CacheFactoryIntegrationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.geode.internal.cache.InternalCache;
+
+public class CacheFactoryIntegrationTest {
+
+  private InternalCache cache;
+
+  @After
+  public void tearDown() {
+    cache.close();
+  }
+
+  @Test
+  public void addMeterSubregistryAddsSubregistryToCacheMeterRegistry() {
+    MeterRegistry theMeterRegistry = new SimpleMeterRegistry();
+
+    cache = (InternalCache) new CacheFactory()
+        .addMeterSubregistry(theMeterRegistry)
+        .create();
+
+    assertThat(getCacheMeterRegistry(cache).getRegistries())
+        .containsExactly(theMeterRegistry);
+  }
+
+  @Test
+  public void addMeterSubregistryAddsMultipleSubregistriesToCacheMeterRegistry() {
+    MeterRegistry firstMeterRegistry = new SimpleMeterRegistry();
+    MeterRegistry secondMeterRegistry = new SimpleMeterRegistry();
+    MeterRegistry thirdMeterRegistry = new SimpleMeterRegistry();
+
+    cache = (InternalCache) new CacheFactory()
+        .addMeterSubregistry(firstMeterRegistry)
+        .addMeterSubregistry(secondMeterRegistry)
+        .addMeterSubregistry(thirdMeterRegistry)
+        .create();
+
+    assertThat(getCacheMeterRegistry(cache).getRegistries())
+        .containsExactlyInAnyOrder(firstMeterRegistry, secondMeterRegistry, thirdMeterRegistry);
+  }
+
+  private CompositeMeterRegistry getCacheMeterRegistry(InternalCache cache) {
+    return (CompositeMeterRegistry) cache.getMeterRegistry();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
@@ -16,6 +16,9 @@ package org.apache.geode.cache;
 
 import java.util.Properties;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedSystem;
@@ -267,6 +270,25 @@ public class CacheFactory {
    */
   public CacheFactory setPdxIgnoreUnreadFields(boolean ignore) {
     internalCacheBuilder.setPdxIgnoreUnreadFields(ignore);
+    return this;
+  }
+
+  /**
+   * Adds the given meter registry to the cache's composite registry for publishing cache metrics
+   * to external monitoring systems.
+   *
+   * <p>
+   * Experimental: Micrometer metrics is a new addition to Geode and the API may change.
+   *
+   * @param subregistry the registry to add
+   * @return this CacheFactory
+   *
+   * @see <a href="https://micrometer.io/docs">Micrometer Documentation</a>
+   * @see <a href="https://micrometer.io/docs/concepts">Micrometer Concepts</a>
+   */
+  @Experimental("Micrometer metrics is a new addition to Geode and the API may change")
+  public CacheFactory addMeterSubregistry(MeterRegistry subregistry) {
+    internalCacheBuilder.addMeterSubregistry(subregistry);
     return this;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/CacheFactory.java
@@ -278,6 +278,32 @@ public class CacheFactory {
    * to external monitoring systems.
    *
    * <p>
+   * Example adding a meter sub-registry:
+   *
+   * <pre>
+   * MeterRegistry prometheusRegistry = new PrometheusMeterRegistry(...);
+   *
+   * Cache cache = new CacheFactory()
+   *     .addMeterSubregistry(prometheusRegistry)
+   *     .create();
+   * </pre>
+   *
+   * <p>
+   * Example adding multiple meter sub-registries:
+   *
+   * <pre>
+   * MeterRegistry prometheusRegistry = new PrometheusMeterRegistry(...);
+   * MeterRegistry influxRegistry = new InfluxMeterRegistry(...);
+   * MeterRegistry newRelicRegistry = new NewRelicMeterRegistry(...);
+   *
+   * Cache cache = new CacheFactory()
+   *     .addMeterSubregistry(prometheusRegistry)
+   *     .addMeterSubregistry(influxRegistry)
+   *     .addMeterSubregistry(newRelicRegistry)
+   *     .create();
+   * </pre>
+   *
+   * <p>
    * Experimental: Micrometer metrics is a new addition to Geode and the API may change.
    *
    * @param subregistry the registry to add

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
@@ -18,8 +18,10 @@ import static java.util.Objects.requireNonNull;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
 import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -61,6 +63,8 @@ public class InternalCacheBuilder {
 
   private static final boolean IS_EXISTING_OK_DEFAULT = true;
   private static final boolean IS_CLIENT_DEFAULT = false;
+
+  private final Set<MeterRegistry> meterSubregistries = new HashSet<>();
 
   private final Properties configProperties;
   private final CacheConfig cacheConfig;
@@ -197,6 +201,10 @@ public class InternalCacheBuilder {
             CompositeMeterRegistry compositeMeterRegistry = compositeMeterRegistryFactory
                 .create(systemId, memberName, hostName);
 
+            for (MeterRegistry meterSubregistry : meterSubregistries) {
+              compositeMeterRegistry.add(meterSubregistry);
+            }
+
             metricsSessionInitializer.accept(compositeMeterRegistry);
 
             cache =
@@ -331,6 +339,14 @@ public class InternalCacheBuilder {
    */
   public InternalCacheBuilder setTypeRegistry(TypeRegistry typeRegistry) {
     this.typeRegistry = typeRegistry;
+    return this;
+  }
+
+  /**
+   * @see CacheFactory#addMeterSubregistry(MeterRegistry)
+   */
+  public InternalCacheBuilder addMeterSubregistry(MeterRegistry subregistry) {
+    meterSubregistries.add(subregistry);
     return this;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/metrics/MetricsPublishingService.java
+++ b/geode-core/src/main/java/org/apache/geode/metrics/MetricsPublishingService.java
@@ -67,6 +67,9 @@ import org.apache.geode.annotations.Experimental;
  * <p>
  * {@code com.application.MyMetricsPublishingService}
  *
+ * <p>
+ * Experimental: Micrometer metrics is a new addition to Geode and the API may change.
+ *
  * @see <a href="https://micrometer.io/docs">Micrometer Documentation</a>
  * @see <a href="https://micrometer.io/docs/concepts">Micrometer Concepts</a>
  */

--- a/geode-core/src/main/java/org/apache/geode/metrics/MetricsSession.java
+++ b/geode-core/src/main/java/org/apache/geode/metrics/MetricsSession.java
@@ -21,9 +21,16 @@ import org.apache.geode.annotations.Experimental;
 /**
  * Provides the ability to add and remove a meter registry for publishing cache metrics to external
  * monitoring systems.
+ *
+ * <p>
+ * Experimental: Micrometer metrics is a new addition to Geode and the API may change.
+ *
+ * @see <a href="https://micrometer.io/docs">Micrometer Documentation</a>
+ * @see <a href="https://micrometer.io/docs/concepts">Micrometer Concepts</a>
  */
 @Experimental("Micrometer metrics is a new addition to Geode and the API may change")
 public interface MetricsSession {
+
   /**
    * Adds the given registry to the cache's composite registry.
    *


### PR DESCRIPTION
Provides an API to add meter registries to the cache's composite
registry for publishing cache metrics to external monitoring systems.

Update the Javadocs of all metrics APIs.

Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>

Please review: @demery-pivotal @mhansonp 