### PR TITLE
GEODE-6558: Add InternalDistributedSystem.Builder

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemBuilderForTestingIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemBuilderForTestingIntegrationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.internal.statistics.StatisticsManager;
+import org.apache.geode.internal.statistics.StatisticsManagerFactory;
+
+public class InternalDistributedSystemBuilderForTestingIntegrationTest {
+
+  @Test
+  public void builderForTesting() {
+    Properties configProperties = new Properties();
+
+    DistributionManager distributionManager = mock(DistributionManager.class);
+    when(distributionManager.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+
+    StatisticsManager statisticsManager = mock(StatisticsManager.class);
+    StatisticsManagerFactory statisticsManagerFactory = mock(StatisticsManagerFactory.class);
+    when(statisticsManagerFactory.create(any(), anyLong(), anyBoolean()))
+        .thenReturn(statisticsManager);
+
+    InternalDistributedSystem system =
+        new InternalDistributedSystem.BuilderForTesting(configProperties)
+            .setDistributionManager(distributionManager)
+            .setStatisticsManagerFactory(statisticsManagerFactory)
+            .build();
+
+    assertThat(system.isConnected()).isTrue();
+    assertThat(system.getDistributionManager()).isSameAs(distributionManager);
+    assertThat(system.getStatisticsManager()).isSameAs(statisticsManager);
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemBuilderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemBuilderIntegrationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.distributed.ConfigurationProperties.NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.geode.security.PostProcessor;
+import org.apache.geode.security.SecurityManager;
+
+public class InternalDistributedSystemBuilderIntegrationTest {
+
+  private InternalDistributedSystem system;
+
+  @After
+  public void tearDown() {
+    system.disconnect();
+  }
+
+  @Test
+  public void buildBuildsAndInitializesSystem() {
+    String theName = "theName";
+    Properties configProperties = new Properties();
+    configProperties.setProperty(NAME, theName);
+
+    system = new InternalDistributedSystem.Builder(configProperties)
+        .build();
+
+    assertThat(system.isConnected()).isTrue();
+    assertThat(system.getName()).isEqualTo(theName);
+  }
+
+  @Test
+  public void buildUsesSecurityConfig() {
+    SecurityManager theSecurityManager = mock(SecurityManager.class);
+    PostProcessor thePostProcessor = mock(PostProcessor.class);
+
+    SecurityConfig securityConfig = new SecurityConfig(theSecurityManager, thePostProcessor);
+    Properties configProperties = new Properties();
+
+    system = new InternalDistributedSystem.Builder(configProperties)
+        .setSecurityConfig(securityConfig)
+        .build();
+
+    assertThat(system.getSecurityService().getSecurityManager())
+        .isSameAs(theSecurityManager);
+    assertThat(system.getSecurityService().getPostProcessor())
+        .isSameAs(thePostProcessor);
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemJUnitTest.java
@@ -642,7 +642,8 @@ public class InternalDistributedSystemJUnitTest {
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "");
     Config config1 = new DistributionConfigImpl(props, false);
-    InternalDistributedSystem sys = InternalDistributedSystem.newInstance(config1.toProperties());
+    InternalDistributedSystem sys =
+        new InternalDistributedSystem.Builder(config1.toProperties()).build();
     try {
 
       props.put(MCAST_PORT, "1");

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -135,8 +135,9 @@ public class GMSHealthMonitorJUnitTest {
     nonDefault.put(LOCATORS, "localhost[10344]");
     DistributionManager dm = mock(DistributionManager.class);
     SocketCreatorFactory.setDistributionConfig(new DistributionConfigImpl(new Properties()));
-    InternalDistributedSystem system =
-        InternalDistributedSystem.newInstanceForTesting(dm, nonDefault);
+    InternalDistributedSystem system = new InternalDistributedSystem.BuilderForTesting(nonDefault)
+        .setDistributionManager(dm)
+        .build();
 
     when(mockConfig.getDistributionConfig()).thenReturn(mockDistConfig);
     when(mockConfig.getMemberTimeout()).thenReturn(memberTimeout);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
@@ -103,6 +103,7 @@ import org.apache.geode.internal.Version;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.alerting.AlertingAction;
 import org.apache.geode.internal.cache.DistributedCacheOperation;
+import org.apache.geode.internal.statistics.StatisticsRegistry;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
 @Category({MembershipTest.class})
@@ -166,7 +167,11 @@ public class JGroupsMessengerJUnitTest {
 
     DistributionManager dm = mock(DistributionManager.class);
     InternalDistributedSystem system =
-        InternalDistributedSystem.newInstanceForTesting(dm, nonDefault);
+        new InternalDistributedSystem.BuilderForTesting(nonDefault)
+            .setDistributionManager(dm)
+            .setStatisticsManagerFactory(
+                (name, startTime, statsDisabled) -> new StatisticsRegistry(name, startTime))
+            .build();
     when(services.getStatistics()).thenReturn(new DistributionStats(system, statsId));
 
     messenger = new JGroupsMessenger();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManagerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManagerJUnitTest.java
@@ -82,6 +82,7 @@ import org.apache.geode.distributed.internal.membership.gms.interfaces.Messenger
 import org.apache.geode.distributed.internal.membership.gms.mgr.GMSMembershipManager.StartupEvent;
 import org.apache.geode.internal.admin.remote.AlertListenerMessage;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
+import org.apache.geode.internal.statistics.DummyStatisticsRegistry;
 import org.apache.geode.internal.tcp.ConnectExceptions;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
@@ -422,7 +423,11 @@ public class GMSMembershipManagerJUnitTest {
     DMStats stats = mock(DMStats.class);
 
     InternalDistributedSystem system =
-        InternalDistributedSystem.newInstanceForTesting(dm, distProperties);
+        new InternalDistributedSystem.BuilderForTesting(distProperties)
+            .setDistributionManager(dm)
+            .setStatisticsManagerFactory(
+                (name, startTime, statsDisabled) -> new DummyStatisticsRegistry(name, startTime))
+            .build();
 
     when(dm.getStats()).thenReturn(stats);
     when(dm.getSystem()).thenReturn(system);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal.cache;
 
 import static java.util.Objects.requireNonNull;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
-import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS_PROPERTY;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -352,7 +352,7 @@ public class InternalCacheBuilder {
 
   private Optional<InternalDistributedSystem> findInternalDistributedSystem() {
     InternalDistributedSystem internalDistributedSystem = null;
-    if (configProperties.isEmpty() && !ALLOW_MULTIPLE_SYSTEMS) {
+    if (configProperties.isEmpty() && !allowMultipleSystems()) {
       // any ds will do
       internalDistributedSystem = singletonSystemSupplier.get();
       validateUsabilityOfSecurityCallbacks(internalDistributedSystem, cacheConfig);
@@ -370,7 +370,7 @@ public class InternalCacheBuilder {
 
   private InternalCache existingCache(Supplier<? extends InternalCache> systemCacheSupplier,
       Supplier<? extends InternalCache> singletonCacheSupplier) {
-    InternalCache cache = ALLOW_MULTIPLE_SYSTEMS
+    InternalCache cache = allowMultipleSystems()
         ? systemCacheSupplier.get()
         : singletonCacheSupplier.get();
 
@@ -420,6 +420,10 @@ public class InternalCacheBuilder {
       throw new GemFireSecurityException(
           "Existing DistributedSystem connection cannot use specified PostProcessor");
     }
+  }
+
+  private static boolean allowMultipleSystems() {
+    return Boolean.getBoolean(ALLOW_MULTIPLE_SYSTEMS_PROPERTY);
   }
 
   @VisibleForTesting

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemIntegrationTest.java
@@ -30,13 +30,19 @@ import org.apache.geode.distributed.DistributedSystem;
 public class InternalDistributedSystemIntegrationTest {
 
   private InternalDistributedSystem system;
+  private InternalDistributedSystem system2;
 
   @Rule
   public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   @After
   public void tearDown() {
-    system.disconnect();
+    if (system != null) {
+      system.disconnect();
+    }
+    if (system2 != null) {
+      system2.disconnect();
+    }
   }
 
   @Test
@@ -55,13 +61,24 @@ public class InternalDistributedSystemIntegrationTest {
   public void connectWithAllowsMultipleSystems() {
     System.setProperty(ALLOW_MULTIPLE_SYSTEMS_PROPERTY, "true");
 
-    String theName = "theName";
-    Properties configProperties = new Properties();
-    configProperties.setProperty(NAME, theName);
+    String name1 = "name1";
+    Properties configProperties1 = new Properties();
+    configProperties1.setProperty(NAME, name1);
 
-    system = (InternalDistributedSystem) DistributedSystem.connect(configProperties);
+    system = (InternalDistributedSystem) DistributedSystem.connect(configProperties1);
+
+    String name2 = "name2";
+    Properties configProperties2 = new Properties();
+    configProperties2.setProperty(NAME, name2);
+
+    system2 = (InternalDistributedSystem) DistributedSystem.connect(configProperties2);
 
     assertThat(system.isConnected()).isTrue();
-    assertThat(system.getName()).isEqualTo(theName);
+    assertThat(system.getName()).isEqualTo(name1);
+
+    assertThat(system2.isConnected()).isTrue();
+    assertThat(system2.getName()).isEqualTo(name2);
+
+    assertThat(system2).isNotSameAs(system);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemIntegrationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.distributed.ConfigurationProperties.NAME;
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import org.apache.geode.distributed.DistributedSystem;
+
+public class InternalDistributedSystemIntegrationTest {
+
+  private InternalDistributedSystem system;
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @After
+  public void tearDown() {
+    system.disconnect();
+  }
+
+  @Test
+  public void connect() {
+    String theName = "theName";
+    Properties configProperties = new Properties();
+    configProperties.setProperty(NAME, theName);
+
+    system = (InternalDistributedSystem) DistributedSystem.connect(configProperties);
+
+    assertThat(system.isConnected()).isTrue();
+    assertThat(system.getName()).isEqualTo(theName);
+  }
+
+  @Test
+  public void connectWithAllowsMultipleSystems() {
+    System.setProperty(ALLOW_MULTIPLE_SYSTEMS_PROPERTY, "true");
+
+    String theName = "theName";
+    Properties configProperties = new Properties();
+    configProperties.setProperty(NAME, theName);
+
+    system = (InternalDistributedSystem) DistributedSystem.connect(configProperties);
+
+    assertThat(system.isConnected()).isTrue();
+    assertThat(system.getName()).isEqualTo(theName);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemStatisticsManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalDistributedSystemStatisticsManagerTest.java
@@ -67,8 +67,10 @@ public class InternalDistributedSystemStatisticsManagerTest {
     initMocks(this);
     when(statisticsManagerFactory.create(any(), anyLong(), anyBoolean()))
         .thenReturn(statisticsManager);
-    internalDistributedSystem = InternalDistributedSystem.newInstanceForTesting(distributionManager,
-        new Properties(), statisticsManagerFactory);
+    internalDistributedSystem = new InternalDistributedSystem.BuilderForTesting(new Properties())
+        .setDistributionManager(distributionManager)
+        .setStatisticsManagerFactory(statisticsManagerFactory)
+        .build();
   }
 
   @Test
@@ -81,8 +83,11 @@ public class InternalDistributedSystemStatisticsManagerTest {
         .create(any(), anyLong(), eq(false)))
             .thenReturn(statisticsManagerCreatedByFactory);
 
-    InternalDistributedSystem result = InternalDistributedSystem
-        .newInstanceForTesting(distributionManager, new Properties(), statisticsManagerFactory);
+    InternalDistributedSystem result =
+        new InternalDistributedSystem.BuilderForTesting(new Properties())
+            .setDistributionManager(distributionManager)
+            .setStatisticsManagerFactory(statisticsManagerFactory)
+            .build();
 
     assertThat(result.getStatisticsManager())
         .isSameAs(statisticsManagerCreatedByFactory);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS_PROPERTY;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,7 +33,9 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import org.apache.geode.SerializationException;
 import org.apache.geode.cache.CacheClosedException;
@@ -51,12 +54,13 @@ import org.apache.geode.test.fake.Fakes;
  */
 public class GemFireCacheImplTest {
 
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
   private GemFireCacheImpl gemFireCacheImpl;
 
   @After
   public void tearDown() {
-    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
-
     if (gemFireCacheImpl != null) {
       gemFireCacheImpl.close();
     }
@@ -322,9 +326,7 @@ public class GemFireCacheImplTest {
 
   @Test
   public void clientCacheWouldNotRequestClusterConfig() {
-    // we will need to set the value to true so that we can use a mock gemFireCacheImpl
-    boolean oldValue = InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS;
-    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = true;
+    System.setProperty(ALLOW_MULTIPLE_SYSTEMS_PROPERTY, "true");
 
     InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
     gemFireCacheImpl = mock(GemFireCacheImpl.class);
@@ -336,9 +338,6 @@ public class GemFireCacheImplTest {
 
     verify(gemFireCacheImpl, times(0)).requestSharedConfiguration();
     verify(gemFireCacheImpl, times(0)).applyJarAndXmlFromClusterConfig();
-
-    // reset it back to the old value
-    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = oldValue;
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS_PROPERTY;
 import static org.apache.geode.internal.cache.InternalCacheBuilderAllowsMultipleSystemsTest.CacheState.CLOSED;
 import static org.apache.geode.internal.cache.InternalCacheBuilderAllowsMultipleSystemsTest.CacheState.OPEN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,9 +35,10 @@ import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import org.assertj.core.api.ThrowableAssert;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.mockito.Mock;
 
 import org.apache.geode.cache.CacheExistsException;
@@ -52,6 +54,9 @@ import org.apache.geode.internal.metrics.CompositeMeterRegistryFactory;
  * {@code InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS} is set to true.
  */
 public class InternalCacheBuilderAllowsMultipleSystemsTest {
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   private static final int ANY_SYSTEM_ID = 12;
   private static final String ANY_MEMBER_NAME = "a-member-name";
@@ -85,12 +90,7 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
   public void setUp() {
     initMocks(this);
 
-    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = true;
-  }
-
-  @After
-  public void tearDown() {
-    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
+    System.setProperty(ALLOW_MULTIPLE_SYSTEMS_PROPERTY, "true");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
@@ -96,8 +96,6 @@ public class InternalCacheBuilderTest {
 
     when(nullSingletonSystemSupplier.get()).thenReturn(null);
     when(nullSingletonCacheSupplier.get()).thenReturn(null);
-
-    InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS = false;
   }
 
   @Test


### PR DESCRIPTION
* Remove all but one constructor.
* Replace newInstance methods with InternalDistributedSystem.Builder.
* Replace newInstanceForTesting methods with
InternalDistributedSystem.BuilderForTesting.
* Replace public static boolean var ALLOW_MULTIPLE_SYSTEMS with usage
of Boolean.getBoolean(ALLOW_MULTIPLE_SYSTEMS_PROPERTY) in
connectInternal.

Most code paths are using DistributedSystem.connect or
InternalDistributedSystem.connectInternal to construct a system.
connectInternal now uses InternalDistributedSystem.Builder.

Several tests are using  InternalDistributedSystem.BuilderForTesting.

NOTES FOR REVIEWERS (PLEASE READ):

NOTE: this is NOT the final refactoring/change to InternalDistributedSystem involving the Builder. We need to make some changes to reconnect for Micrometer. We will also be injecting a Micrometer MeterRegistry into InternalDistributedSystem. And finally, I think we'll be looking into making connectInternal private and changing internal code paths to use the Builder instead of connectInternal. Then there would be two code paths to create a InternalDistributedSystem: 
1) DistributedSystem.connect which would delegate to InternalDistributedSystem.Builder
2) InternalDistributedSystem.Builder which would be used from internal code paths such as InternalCacheBuilder and reconnect

ALSO: I'd love to delete BuilderForTesting and replace it with mocking in every test where that's possible.

Please review: @demery-pivotal @mhansonp 