### PR TITLE
GEODE-6562: Inject new DistributedSystem into Locator Cache

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/pdx/internal/MultipleCacheJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/pdx/internal/MultipleCacheJUnitTest.java
@@ -42,7 +42,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalDistributedSystem.ConnectListener;
-import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 /**
@@ -56,7 +55,7 @@ public class MultipleCacheJUnitTest {
 
   private List<Cache> caches = new ArrayList<>();
   private Properties configProperties;
-  private InternalLocator locator;
+  private Locator locator;
   private ConnectListener connectListener;
 
   @Before
@@ -66,8 +65,7 @@ public class MultipleCacheJUnitTest {
     connectListener = mock(ConnectListener.class);
     InternalDistributedSystem.addConnectListener(connectListener);
 
-    locator =
-        (InternalLocator) Locator.startLocatorAndDS(0, locatorFolder.newFile("locator.log"), null);
+    locator = Locator.startLocatorAndDS(0, locatorFolder.newFile("locator.log"), null);
     configProperties = new Properties();
     configProperties.setProperty(ConfigurationProperties.LOCATORS,
         "locahost[" + locator.getPort() + "]");

--- a/geode-core/src/integrationTest/java/org/apache/geode/pdx/internal/MultipleCacheJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/pdx/internal/MultipleCacheJUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.pdx.internal;
 
+import static org.apache.geode.cache.RegionShortcut.REPLICATE;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -36,8 +38,6 @@ import org.junit.rules.TemporaryFolder;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.RegionShortcut;
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
@@ -67,8 +67,7 @@ public class MultipleCacheJUnitTest {
 
     locator = Locator.startLocatorAndDS(0, locatorFolder.newFile("locator.log"), null);
     configProperties = new Properties();
-    configProperties.setProperty(ConfigurationProperties.LOCATORS,
-        "locahost[" + locator.getPort() + "]");
+    configProperties.setProperty(LOCATORS, "locahost[" + locator.getPort() + "]");
   }
 
   @After
@@ -110,9 +109,9 @@ public class MultipleCacheJUnitTest {
     Cache cache2 = createCache("cache2");
 
     Region<String, String> region1 =
-        cache1.<String, String>createRegionFactory(RegionShortcut.REPLICATE).create("region");
+        cache1.<String, String>createRegionFactory(REPLICATE).create("region");
     Region<String, String> region2 =
-        cache2.<String, String>createRegionFactory(RegionShortcut.REPLICATE).create("region");
+        cache2.<String, String>createRegionFactory(REPLICATE).create("region");
 
     assertThat(region2).isNotSameAs(region1);
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2068,6 +2068,14 @@ public class InternalDistributedSystem extends DistributedSystem
     }
   }
 
+  public static void removeConnectListener(ConnectListener listener) {
+    synchronized (existingSystemsLock) {
+      synchronized (connectListeners) {
+        connectListeners.remove(listener);
+      }
+    }
+  }
+
   /**
    * Makes note of a <code>ReconnectListener</code> whose <code>onReconnect</code> method will be
    * invoked when a connection is recreated to a distributed system during auto-reconnect.

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -42,7 +42,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.annotations.internal.MakeNotStatic;
-import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.cache.client.internal.locator.ClientConnectionRequest;
 import org.apache.geode.cache.client.internal.locator.ClientReplacementRequest;
@@ -69,6 +68,7 @@ import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.HttpService;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheBuilder;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.cache.wan.WANServiceProvider;
 import org.apache.geode.internal.logging.InternalLogWriter;
@@ -671,7 +671,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     InternalCache internalCache = GemFireCacheImpl.getInstance();
     if (internalCache == null) {
       logger.info("Creating cache for locator.");
-      this.myCache = (InternalCache) new CacheFactory(ds.getProperties()).create();
+      this.myCache = new InternalCacheBuilder(ds.getProperties())
+          .create((InternalDistributedSystem) ds);
       internalCache = this.myCache;
     } else {
       logger.info("Using existing cache for locator.");


### PR DESCRIPTION
This change prevents startLocator from creating two DistributedSystem connections when ALLOWS_MULTIPLE_SYSTEMS is true.