### PR TITLE
GEODE-5604: Fix over-zealous fix for adding NOTICE to jar manifest

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -81,10 +81,8 @@ subprojects {
       }
       jar.metaInf {
         from("$rootDir/LICENSE")
-        jar.doLast {
-          if (jar.source.filter({ it.name.contains('NOTICE') }).empty) {
-            from("$rootDir/NOTICE")
-          }
+        if (jar.source.filter({ it.name.contains('NOTICE') }).empty) {
+          from("$rootDir/NOTICE")
         }
       }
     }


### PR DESCRIPTION
Removal of a bad `doLast` around the insertion of the default NOTICE,
only if the module did not have its own file

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Patrick Rhomberg <prhomberg@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
