### PR TITLE
GEODE-6565: Close IntegratedSecurityService during disconnect

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemSecurityIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalDistributedSystemSecurityIntegrationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.security.PostProcessor;
+import org.apache.geode.security.SecurityManager;
+import org.apache.geode.test.junit.categories.SecurityTest;
+
+@Category(SecurityTest.class)
+public class InternalDistributedSystemSecurityIntegrationTest {
+
+  private InternalDistributedSystem system;
+
+  @After
+  public void tearDown() {
+    system.disconnect();
+  }
+
+  @Test
+  public void disconnectClosesSecurityManager() {
+    SecurityManager theSecurityManager = mock(SecurityManager.class);
+
+    SecurityConfig securityConfig =
+        new SecurityConfig(theSecurityManager, mock(PostProcessor.class));
+    Properties configProperties = new Properties();
+
+    system = InternalDistributedSystem.connectInternal(configProperties, securityConfig);
+
+    system.disconnect();
+
+    verify(theSecurityManager).close();
+  }
+
+  @Test
+  public void disconnectClosesPostProcessor() {
+    PostProcessor thePostProcessor = mock(PostProcessor.class);
+
+    SecurityConfig securityConfig =
+        new SecurityConfig(mock(SecurityManager.class), thePostProcessor);
+    Properties configProperties = new Properties();
+
+    system = InternalDistributedSystem.connectInternal(configProperties, securityConfig);
+
+    system.disconnect();
+
+    verify(thePostProcessor).close();
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/security/SecurityManagerLifecycleIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/security/SecurityManagerLifecycleIntegrationTest.java
@@ -31,41 +31,36 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
-@Category({SecurityTest.class})
+@Category(SecurityTest.class)
 public class SecurityManagerLifecycleIntegrationTest {
 
-  private Properties securityProps;
   private InternalCache cache;
   private SecurityService securityService;
 
   @Before
   public void before() {
-    this.securityProps = new Properties();
-    this.securityProps.setProperty(SECURITY_MANAGER, SpySecurityManager.class.getName());
+    Properties configProperties = new Properties();
+    configProperties.setProperty(SECURITY_MANAGER, SpySecurityManager.class.getName());
+    configProperties.setProperty(MCAST_PORT, "0");
+    configProperties.setProperty(LOCATORS, "");
 
-    Properties props = new Properties();
-    props.putAll(this.securityProps);
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(LOCATORS, "");
+    cache = (InternalCache) new CacheFactory(configProperties).create();
 
-    this.cache = (InternalCache) new CacheFactory(props).create();
-
-    this.securityService = this.cache.getSecurityService();
+    securityService = cache.getSecurityService();
   }
 
   @After
   public void after() {
-    if (this.cache != null && !this.cache.isClosed()) {
-      this.cache.close();
+    if (cache != null && !cache.isClosed()) {
+      cache.close();
     }
   }
 
   @Test
   public void initAndCloseTest() {
-    SpySecurityManager ssm = (SpySecurityManager) this.securityService.getSecurityManager();
+    SpySecurityManager ssm = (SpySecurityManager) securityService.getSecurityManager();
     assertThat(ssm.getInitInvocationCount()).isEqualTo(1);
-    this.cache.close();
+    cache.close();
     assertThat(ssm.getCloseInvocationCount()).isEqualTo(1);
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -1665,6 +1665,8 @@ public class InternalDistributedSystem extends DistributedSystem
           } // synchronized (this)
         } // synchronized (GemFireCache.class)
 
+        securityService.close();
+
         if (!isShutdownHook) {
           shutdownListeners = doDisconnects(attemptingToReconnect);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -21,6 +21,7 @@ import java.security.AccessController;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.SerializationException;
 import org.apache.commons.lang3.StringUtils;
@@ -56,8 +57,10 @@ import org.apache.geode.security.SecurityManager;
  */
 public class IntegratedSecurityService implements SecurityService {
   private static final Logger logger = LogService.getLogger(SECURITY_LOGGER_NAME);
+
   public static final String CREDENTIALS_SESSION_ATTRIBUTE = "credentials";
 
+  private final AtomicBoolean closed = new AtomicBoolean();
   private final PostProcessor postProcessor;
   private final SecurityManager securityManager;
 
@@ -73,18 +76,18 @@ public class IntegratedSecurityService implements SecurityService {
     assert provider.getShiroSecurityManager() != null;
     SecurityUtils.setSecurityManager(provider.getShiroSecurityManager());
 
-    this.securityManager = provider.getSecurityManager();
+    securityManager = provider.getSecurityManager();
     this.postProcessor = postProcessor;
   }
 
   @Override
   public PostProcessor getPostProcessor() {
-    return this.postProcessor;
+    return postProcessor;
   }
 
   @Override
   public SecurityManager getSecurityManager() {
-    return this.securityManager;
+    return securityManager;
   }
 
   /**
@@ -180,8 +183,9 @@ public class IntegratedSecurityService implements SecurityService {
    *   state = securityService.bindSubject(subject);
    *   // do the rest of the work as this subject
    * } finally {
-   *   if (state != null)
+   *   if (state != null) {
    *     state.clear();
+   *   }
    * }
    * </pre>
    */
@@ -234,9 +238,9 @@ public class IntegratedSecurityService implements SecurityService {
     try {
       currentUser.checkPermission(context);
     } catch (ShiroException e) {
-      String msg = currentUser.getPrincipal() + " not authorized for " + context;
-      logger.info("NotAuthorizedException: {}", msg);
-      throw new NotAuthorizedException(msg, e);
+      String message = currentUser.getPrincipal() + " not authorized for " + context;
+      logger.info("NotAuthorizedException: {}", message);
+      throw new NotAuthorizedException(message, e);
     }
   }
 
@@ -252,23 +256,26 @@ public class IntegratedSecurityService implements SecurityService {
     try {
       currentUser.checkPermission(context);
     } catch (ShiroException e) {
-      String msg = currentUser.getPrincipal() + " not authorized for " + context;
-      logger.info("NotAuthorizedException: {}", msg);
-      throw new NotAuthorizedException(msg, e);
+      String message = currentUser.getPrincipal() + " not authorized for " + context;
+      logger.info("NotAuthorizedException: {}", message);
+      throw new NotAuthorizedException(message, e);
     }
   }
 
   @Override
   public void close() {
-    if (this.securityManager != null) {
-      this.securityManager.close();
-    }
-    if (this.postProcessor != null) {
-      this.postProcessor.close();
-    }
+    // subsequent calls to close are no-op
+    if (closed.compareAndSet(false, true)) {
+      if (securityManager != null) {
+        securityManager.close();
+      }
+      if (postProcessor != null) {
+        postProcessor.close();
+      }
 
-    ThreadContext.remove();
-    SecurityUtils.setSecurityManager(null);
+      ThreadContext.remove();
+      SecurityUtils.setSecurityManager(null);
+    }
   }
 
   /**
@@ -278,7 +285,7 @@ public class IntegratedSecurityService implements SecurityService {
    */
   @Override
   public boolean needPostProcess() {
-    return this.postProcessor != null;
+    return postProcessor != null;
   }
 
   @Override
@@ -306,13 +313,13 @@ public class IntegratedSecurityService implements SecurityService {
     if (valueIsSerialized && value instanceof byte[]) {
       try {
         Object oldObj = EntryEventImpl.deserialize((byte[]) value);
-        Object newObj = this.postProcessor.processRegionValue(principal, regionName, key, oldObj);
+        Object newObj = postProcessor.processRegionValue(principal, regionName, key, oldObj);
         newValue = BlobHelper.serializeToBlob(newObj);
       } catch (IOException | SerializationException e) {
         throw new GemFireIOException("Exception de/serializing entry value", e);
       }
     } else {
-      newValue = this.postProcessor.processRegionValue(principal, regionName, key, value);
+      newValue = postProcessor.processRegionValue(principal, regionName, key, value);
     }
 
     return newValue;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityDUnitTest.java
@@ -77,9 +77,7 @@ public class LuceneClientSecurityDUnitTest extends LuceneQueriesAccessorBase {
   }
 
   private int startCacheServer() throws IOException {
-    Properties props = new Properties();
-    props.put(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
-        "org.apache.geode.cache.lucene.test.TestObject");
+    Properties props = getDistributedSystemProperties();
     props.setProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName());
     final Cache cache = getCache(props);
     final CacheServer server = cache.addCacheServer();


### PR DESCRIPTION
IntegratedSecurityService needs to be closed when InternalDistributedSystem is disconnected and no cache was ever created.

Invoke IntegratedSecurityService.close() during InternalDistributedSystem.disconnect().

Make IntegratedSecurityService.close() idempotent so that subsequent invocations are ignored. (Without this other tests that verify number of invocations of close() will fail).

Fix LuceneClientSecurityDUnitTest: The base class overrides getDistributedSystemProperties() so startCacheServer needs to use compatible properties when it invokes getCache(Properties).