### PR TITLE
GEODE-4318: Ensure that passwords are correctly redacted in the gfsh history file

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/HistoryCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/HistoryCommandIntegrationTest.java
@@ -19,10 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -88,7 +87,6 @@ public class HistoryCommandIntegrationTest {
     assertThat(gfsh.getGfsh().getGfshHistory().size()).isEqualTo(1);
   }
 
-
   @Test
   public void testHistoryContainsRedactedPasswordWithEquals() throws IOException {
     gfsh.executeCommand("connect --password=redacted");
@@ -101,11 +99,9 @@ public class HistoryCommandIntegrationTest {
 
     assertThat(historyFile).exists();
 
-    List<String> historyLines = FileUtils.readLines(historyFile, Charset.defaultCharset());
-
+    List<String> historyLines = Files.readAllLines(historyFile.toPath());
     assertThat(historyLines.get(0)).isEqualTo("0: connect --password=********");
   }
-
 
   @Test
   public void testHistoryContainsRedactedPasswordWithoutEquals() throws IOException {
@@ -119,8 +115,7 @@ public class HistoryCommandIntegrationTest {
 
     assertThat(historyFile).exists();
 
-    List<String> historyLines = FileUtils.readLines(historyFile, Charset.defaultCharset());
-
+    List<String> historyLines = Files.readAllLines(historyFile.toPath());
     assertThat(historyLines.get(0)).isEqualTo("0: connect --password ********");
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/HistoryCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/HistoryCommandIntegrationTest.java
@@ -19,9 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
@@ -33,8 +37,8 @@ public class HistoryCommandIntegrationTest {
   @ClassRule
   public static GfshCommandRule gfsh = new GfshCommandRule();
 
-  @ClassRule
-  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @After
   public void tearDown() throws Exception {
@@ -82,5 +86,41 @@ public class HistoryCommandIntegrationTest {
 
     // only the history --clear is in the history now.
     assertThat(gfsh.getGfsh().getGfshHistory().size()).isEqualTo(1);
+  }
+
+
+  @Test
+  public void testHistoryContainsRedactedPasswordWithEquals() throws IOException {
+    gfsh.executeCommand("connect --password=redacted");
+    File historyFile = temporaryFolder.newFile("history.txt");
+    historyFile.delete();
+    assertThat(historyFile).doesNotExist();
+
+    String command = "history --file=" + historyFile.getAbsolutePath();
+    gfsh.executeAndAssertThat(command).statusIsSuccess();
+
+    assertThat(historyFile).exists();
+
+    List<String> historyLines = FileUtils.readLines(historyFile, Charset.defaultCharset());
+
+    assertThat(historyLines.get(0)).isEqualTo("0: connect --password=********");
+  }
+
+
+  @Test
+  public void testHistoryContainsRedactedPasswordWithoutEquals() throws IOException {
+    gfsh.executeCommand("connect --password redacted");
+    File historyFile = temporaryFolder.newFile("history.txt");
+    historyFile.delete();
+    assertThat(historyFile).doesNotExist();
+
+    String command = "history --file=" + historyFile.getAbsolutePath();
+    gfsh.executeAndAssertThat(command).statusIsSuccess();
+
+    assertThat(historyFile).exists();
+
+    List<String> historyLines = FileUtils.readLines(historyFile, Charset.defaultCharset());
+
+    assertThat(historyLines.get(0)).isEqualTo("0: connect --password ********");
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/shell/GfshHistoryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/shell/GfshHistoryJUnitTest.java
@@ -75,7 +75,7 @@ public class GfshHistoryJUnitTest {
     gfsh.executeScriptLine("connect --password=foo");
 
     List<String> lines = Files.readAllLines(gfshHistoryFile.toPath());
-    assertEquals("connect --password=*****", lines.get(1));
+    assertEquals("connect --password=********", lines.get(1));
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/internal/util/ArgumentRedactor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/ArgumentRedactor.java
@@ -190,7 +190,7 @@ public class ArgumentRedactor {
   /**
    * Determine whether a option's argument should be redacted.
    *
-   * @param option The option option in question.
+   * @param option The option in question.
    *
    * @return true if the value should be redacted, otherwise false.
    */

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/Launcher.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/Launcher.java
@@ -28,10 +28,10 @@ import org.apache.geode.internal.ExitCode;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.PureJavaMode;
 import org.apache.geode.internal.lang.StringUtils;
+import org.apache.geode.internal.util.ArgumentRedactor;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.GfshConfig;
-import org.apache.geode.management.internal.cli.shell.jline.GfshHistory;
 
 /**
  * Launcher class for :
@@ -228,7 +228,7 @@ public class Launcher {
             String command = commandsToExecute.get(i);
             // sanitize the output string to not show the password
             System.out.println(GfshParser.LINE_SEPARATOR + "(" + (i + 1) + ") Executing - "
-                + GfshHistory.redact(command) + GfshParser.LINE_SEPARATOR);
+                + ArgumentRedactor.redact(command) + GfshParser.LINE_SEPARATOR);
             if (!gfsh.executeScriptLine(command) || gfsh.getLastExecutionStatus() != 0) {
               exitRequest = ExitShellRequest.FATAL_EXIT;
             }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -778,11 +778,11 @@ public class Gfsh extends JLineShell {
     String originalString = expandedPropCommandsMap.get(processedLine);
     if (originalString != null) {
       // In history log the original command string & expanded line as a comment
-      super.logCommandToOutput(GfshHistory.redact(originalString));
-      super.logCommandToOutput(GfshHistory.redact("// Post substitution"));
-      super.logCommandToOutput(GfshHistory.redact("//" + processedLine));
+      super.logCommandToOutput(ArgumentRedactor.redact(originalString));
+      super.logCommandToOutput(ArgumentRedactor.redact("// Post substitution"));
+      super.logCommandToOutput(ArgumentRedactor.redact("//" + processedLine));
     } else {
-      super.logCommandToOutput(GfshHistory.redact(processedLine));
+      super.logCommandToOutput(ArgumentRedactor.redact(processedLine));
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/jline/GfshHistory.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/jline/GfshHistory.java
@@ -14,10 +14,9 @@
  */
 package org.apache.geode.management.internal.cli.shell.jline;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import jline.console.history.MemoryHistory;
+
+import org.apache.geode.internal.util.ArgumentRedactor;
 
 /**
  * Overrides jline.History to add History without newline characters.
@@ -26,23 +25,12 @@ import jline.console.history.MemoryHistory;
  */
 public class GfshHistory extends MemoryHistory {
 
-  // Pattern which is intended to pick up any params containing the word 'password'.
-  private static final Pattern passwordRe =
-      Pattern.compile("(--[^=\\s]*password[^=\\s]*\\s*=\\s*)([^\\s]*)");
-
   // let the history from history file get added initially
   private boolean autoFlush = true;
 
-  public static String redact(String buffer) {
-    String trimmed = buffer.trim();
-    Matcher matcher = passwordRe.matcher(trimmed);
-    String sanitized = matcher.replaceAll("$1*****");
-    return sanitized;
-  }
-
   public void addToHistory(String buffer) {
     if (isAutoFlush()) {
-      super.add(redact(buffer));
+      super.add(ArgumentRedactor.redact(buffer.trim()));
     }
   }
 


### PR DESCRIPTION
- Remove redact method in GfshHistory in favor of
  ArgumentRedactor.redact

Co-authored-by: Jens Deppe <jdeppe@pivotal.io>
Co-authored-by: Donal Evans <donalevans86@gmail.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
