### PR TITLE
Feature/geode 6570 processing of cached join request delays view installation

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Timer;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -723,6 +724,34 @@ public class GMSJoinLeaveJUnitTest {
     gmsJoinLeave.processMessage(msg);
     assertTrue("Expected becomeCoordinator to be invoked", gmsJoinLeave.isCoordinator());
     await().until(() -> gmsJoinLeave.getView().size() == 1);
+  }
+
+  /**
+   * Given a view with [A, B, C, D] where C is coordinator, a failed availability check on A
+   * and a pending join request from E show that B becomes coordinator when C sends it a
+   * Leave request and that E is allowed into the system and retains its view ID.
+   * See GEODE-6570
+   */
+  @Test
+  public void testBecomeCoordinatorAndAcceptMemberWithViewID() throws Exception {
+    initMocks();
+    InternalDistributedMember A = mockMembers[0],
+        B = gmsJoinLeaveMemberId,
+        C = mockMembers[1],
+        D = mockMembers[2],
+        E = mockMembers[3];
+    prepareAndInstallView(C, createMemberList(A, B, C, D));
+    when(healthMonitor.getMembersFailingAvailabilityCheck()).thenReturn(Collections.singleton(A));
+    E.setVmViewId(1);
+    gmsJoinLeave.processMessage(new JoinRequestMessage(B, E, null, 1, 1));
+    LeaveRequestMessage msg = new LeaveRequestMessage(B, C, "leaving for test");
+    msg.setSender(C);
+    gmsJoinLeave.processMessage(msg);
+    assertTrue("Expected becomeCoordinator to be invoked", gmsJoinLeave.isCoordinator());
+    await().atMost(15, TimeUnit.SECONDS).until(() -> {
+      NetView preparedView = gmsJoinLeave.getPreparedView();
+      return preparedView != null && preparedView.contains(E);
+    });
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Timer;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -748,7 +747,7 @@ public class GMSJoinLeaveJUnitTest {
     msg.setSender(C);
     gmsJoinLeave.processMessage(msg);
     assertTrue("Expected becomeCoordinator to be invoked", gmsJoinLeave.isCoordinator());
-    await().atMost(15, TimeUnit.SECONDS).until(() -> {
+    await().until(() -> {
       NetView preparedView = gmsJoinLeave.getPreparedView();
       return preparedView != null && preparedView.contains(E);
     });


### PR DESCRIPTION
GEODE-6570 processing of cached join request delays view installation

Ignore join requests from a member that's already joined.  Also, never  overwrite an established vmViewID in a member's ID because the member knows about the old vmViewID and will ignore the newly assigned number.



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
