### PR TITLE
GEODE-6577: performance gain by removing lazy init

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -550,7 +550,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   private final PersistentMemberManager persistentMemberManager;
 
-  private ClientMetadataService clientMetadataService;
+  private final ClientMetadataService clientMetadataService;
 
   private final AtomicBoolean isShutDownAll = new AtomicBoolean();
   private final CountDownLatch shutDownAllFinished = new CountDownLatch(1);
@@ -935,7 +935,13 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       }
     } // synchronized
 
-    clientMetadataService = new ClientMetadataService(this);
+    if (this.isClient) {
+      logger.info("Running in client mode.");
+      resourceEventsListener = null;
+      clientMetadataService = new ClientMetadataService(this);
+    } else {
+      clientMetadataService = null;
+    }
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -824,11 +824,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
           }
         }
 
-        clientMetadataService = null;
       } else {
         logger.info("Running in client mode");
         this.resourceEventsListener = null;
-        clientMetadataService = new ClientMetadataService(this);
       }
 
       // Don't let admin-only VMs create Cache's just yet.
@@ -937,6 +935,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         }
       }
     } // synchronized
+
+    clientMetadataService = new ClientMetadataService(this);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -823,9 +823,12 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
                 .info("Running in local mode since no locators were specified.");
           }
         }
+
+        clientMetadataService = null;
       } else {
         logger.info("Running in client mode");
         this.resourceEventsListener = null;
+        clientMetadataService = new ClientMetadataService(this);
       }
 
       // Don't let admin-only VMs create Cache's just yet.
@@ -934,14 +937,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         }
       }
     } // synchronized
-
-    if (this.isClient) {
-      logger.info("Running in client mode.");
-      resourceEventsListener = null;
-      clientMetadataService = new ClientMetadataService(this);
-    } else {
-      clientMetadataService = null;
-    }
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -550,9 +550,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   private final PersistentMemberManager persistentMemberManager;
 
-  private ClientMetadataService clientMetadataService = null;
-
-  private final Object clientMetaDatServiceLock = new Object();
+  private ClientMetadataService clientMetadataService;
 
   private final AtomicBoolean isShutDownAll = new AtomicBoolean();
   private final CountDownLatch shutDownAllFinished = new CountDownLatch(1);
@@ -936,6 +934,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         }
       }
     } // synchronized
+
+    clientMetadataService = new ClientMetadataService(this);
   }
 
   @Override
@@ -2022,13 +2022,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   @Override
   public ClientMetadataService getClientMetadataService() {
-    synchronized (this.clientMetaDatServiceLock) {
-      this.stopper.checkCancelInProgress(null);
-      if (this.clientMetadataService == null) {
-        this.clientMetadataService = new ClientMetadataService(this);
-      }
-      return this.clientMetadataService;
-    }
+    this.stopper.checkCancelInProgress(null);
+
+    return this.clientMetadataService;
   }
 
   private final boolean DISABLE_DISCONNECT_DS_ON_CACHE_CLOSE = Boolean


### PR DESCRIPTION
There was lock contention for checking if the clientMetadataService
needed to be initialized. The object is not expensive to construct, so
the initialization has been moved the GemFireCacheImpl's constructor,
allowing the lock object to be removed completely.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
