### PR TITLE
GEODE-6580: use ConcurrentHashMap for host names

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -43,7 +43,6 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Enumeration;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
@@ -52,6 +51,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.naming.Context;
 import javax.naming.NamingEnumeration;
@@ -150,7 +150,7 @@ public class SocketCreator {
       && Boolean.getBoolean("java.net.preferIPv6Addresses");
 
   @MakeNotStatic
-  private static final Map<InetAddress, String> hostNames = new HashMap<>();
+  private static final ConcurrentHashMap<InetAddress, String> hostNames = new ConcurrentHashMap<>();
 
   /**
    * flag to force always using DNS (regardless of the fact that these lookups can hang)
@@ -300,7 +300,7 @@ public class SocketCreator {
    * returns the host name for the given inet address, using a local cache of names to avoid dns
    * hits and duplicate strings
    */
-  public static synchronized String getHostName(InetAddress addr) {
+  public static String getHostName(InetAddress addr) {
     String result = hostNames.get(addr);
     if (result == null) {
       result = addr.getHostName();
@@ -313,7 +313,7 @@ public class SocketCreator {
    * returns the host name for the given inet address, using a local cache of names to avoid dns
    * hits and duplicate strings
    */
-  public static synchronized String getCanonicalHostName(InetAddress addr, String hostName) {
+  public static String getCanonicalHostName(InetAddress addr, String hostName) {
     String result = hostNames.get(addr);
     if (result == null) {
       hostNames.put(addr, hostName);
@@ -325,7 +325,7 @@ public class SocketCreator {
   /**
    * Reset the hostNames caches
    */
-  public static synchronized void resetHostNameCache() {
+  public static void resetHostNameCache() {
     hostNames.clear();
   }
 


### PR DESCRIPTION
Use a ConcurrentHashMap instead of a HashMap accessed in synchronized
blocks to store host names in SocketCreator. This reduces lock
contention for getting host names by reducing the amount of time spent
holding the lock.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
