### PR TITLE
GEODE-6582: get max message size only once

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
@@ -132,7 +132,9 @@ public class Message {
   }
 
   /**
-   * maximum size of an outgoing message. See GEODE-478
+   * The maximum size of an outgoing message. If the message is larger than this maximum, it may
+   * cause the receiver to throw an exception on message part length mismatch due to overflow in
+   * message size.
    */
   private static final int maxMessageSize =
       Integer.getInteger(MAX_MESSAGE_SIZE_PROPERTY, DEFAULT_MAX_MESSAGE_SIZE);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
@@ -134,7 +134,8 @@ public class Message {
   /**
    * maximum size of an outgoing message. See GEODE-478
    */
-  private final int maxMessageSize;
+  private static final int maxMessageSize =
+      Integer.getInteger(MAX_MESSAGE_SIZE_PROPERTY, DEFAULT_MAX_MESSAGE_SIZE);
 
   protected int messageType;
   private int payloadLength = 0;
@@ -170,7 +171,6 @@ public class Message {
    * Creates a new message with the given number of parts
    */
   public Message(int numberOfParts, Version destVersion) {
-    this.maxMessageSize = Integer.getInteger(MAX_MESSAGE_SIZE_PROPERTY, DEFAULT_MAX_MESSAGE_SIZE);
     this.version = destVersion;
     Assert.assertTrue(destVersion != null, "Attempt to create an unversioned message");
     this.partsList = new Part[numberOfParts];

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
@@ -135,6 +135,10 @@ public class Message {
    * The maximum size of an outgoing message. If the message is larger than this maximum, it may
    * cause the receiver to throw an exception on message part length mismatch due to overflow in
    * message size.
+   *
+   * This value is STATIC because getting a system property requires holding a lock. It is costly to
+   * do this for every message sent. If this value needs to be modified for testing, please add a
+   * new constructor.
    */
   private static final int maxMessageSize =
       Integer.getInteger(MAX_MESSAGE_SIZE_PROPERTY, DEFAULT_MAX_MESSAGE_SIZE);


### PR DESCRIPTION
The max message size did not change over the course of execution but was
being re-fetched every time a new message was constructed. To improve
message performance, this value is now static and fetched only once.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
