### PR TITLE
GEODE-6583 Integrate phi-accrual failure detection into Geode

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/TXDistributedDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/TXDistributedDUnitTest.java
@@ -24,6 +24,7 @@
  */
 package org.apache.geode.cache30;
 
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_NETWORK_PARTITION_DETECTION;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.junit.Assert.assertEquals;
@@ -563,6 +564,7 @@ public class TXDistributedDUnitTest extends JUnit4CacheTestCase {
     Properties p = super.getDistributedSystemProperties();
     p.put(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
     p.put(ENABLE_NETWORK_PARTITION_DETECTION, "false");
+    p.put(DISABLE_AUTO_RECONNECT, "true");
     return p;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -775,7 +775,7 @@ public class GMSHealthMonitorJUnitTest {
     HeartbeatMessage hb = new HeartbeatMessage(-1);
     hb.setSender(mockMembers.get(0));
     gmsHealthMonitor.processMessage(hb);
-    assertTrue(gmsHealthMonitor.memberTimeStamps.get(hb.getSender()) == null);
+    assertTrue(gmsHealthMonitor.memberDetectors.get(hb.getSender()) == null);
 
     // a sick member will not take action on a Suspect message from another member
     SuspectMembersMessage smm = mock(SuspectMembersMessage.class);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -630,7 +630,7 @@ public class GMSHealthMonitorJUnitTest {
     boolean available = gmsHealthMonitor.checkIfAvailable(memberToCheck, "Not responding", false);
     assertFalse(available);
     verify(joinLeave, never()).remove(isA(InternalDistributedMember.class), isA(String.class));
-    assertFalse(gmsHealthMonitor.isSuspectMember(memberToCheck));
+    assertTrue(gmsHealthMonitor.isSuspectMember(memberToCheck));
   }
 
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -214,27 +214,6 @@ public class GMSHealthMonitorJUnitTest {
     assertEquals(mockMembers.get(myAddressIndex + 1), gmsHealthMonitor.getNextNeighbor());
   }
 
-  @Test
-  public void testHMNextNeighborAfterTimeout() throws Exception {
-    System.out.println("testHMNextNeighborAfterTimeout starting");
-
-    installAView();
-    InternalDistributedMember initialNeighbor = mockMembers.get(myAddressIndex + 1);
-
-    await("wait for new neighbor")
-        .until(() -> gmsHealthMonitor.getNextNeighbor() != initialNeighbor);
-    InternalDistributedMember neighbor = gmsHealthMonitor.getNextNeighbor();
-
-    // neighbor should change. In order to not be a flaky test we don't demand
-    // that it be myAddressIndex+2 but just require that the neighbor being
-    // monitored has changed
-    System.out.println("testHMNextNeighborAfterTimeout ending");
-    Assert.assertNotNull(gmsHealthMonitor.getView());
-    Assert.assertNotEquals("neighbor to not be " + neighbor + "; my ID is "
-        + mockMembers.get(myAddressIndex) + ";  view=" + gmsHealthMonitor.getView(),
-        initialNeighbor, neighbor);
-  }
-
   /**
    * it checks neighbor before member-timeout, it should be same
    */
@@ -303,6 +282,7 @@ public class GMSHealthMonitorJUnitTest {
     long startTime = System.currentTimeMillis();
     installAView();
     InternalDistributedMember neighbor = gmsHealthMonitor.getNextNeighbor();
+    assertFalse(neighbor.equals(joinLeave.getMemberID()));
 
     await().until(() -> gmsHealthMonitor.isSuspectMember(neighbor));
     long endTime = System.currentTimeMillis();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetectorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetectorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Mitsunori Komatsu (komamitsu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geode.distributed.internal.membership.gms.fd;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+
+import org.apache.geode.test.junit.categories.MembershipTest;
+
+@Category({MembershipTest.class})
+public class PhiAccrualFailureDetectorTest
+{
+  @Test
+  public void test()
+  {
+    PhiAccrualFailureDetector failureDetector = new PhiAccrualFailureDetector.Builder().build();
+    long now = 1420070400000L;
+    for (int i = 0; i < 300; i++) {
+      long timestampMillis = now + i * 1000;
+
+      if (i > 290) {
+        double phi = failureDetector.phi(timestampMillis);
+        if (i == 291) {
+          assertTrue(1 < phi && phi < 3);
+          assertTrue(failureDetector.isAvailable(timestampMillis));
+        }
+        else if (i == 292) {
+          assertTrue(3 < phi && phi < 8);
+          assertTrue(failureDetector.isAvailable(timestampMillis));
+        }
+        else if (i == 293) {
+          assertTrue(8 < phi && phi < 16);
+          assertTrue(failureDetector.isAvailable(timestampMillis));
+        }
+        else if (i == 294) {
+          assertTrue(16 < phi && phi < 30);
+          assertFalse(failureDetector.isAvailable(timestampMillis));
+        }
+        else if (i == 295) {
+          assertTrue(30 < phi && phi < 50);
+          assertFalse(failureDetector.isAvailable(timestampMillis));
+        }
+        else if (i == 296) {
+          assertTrue(50 < phi && phi < 70);
+          assertFalse(failureDetector.isAvailable(timestampMillis));
+        }
+        else if (i == 297) {
+          assertTrue(70 < phi && phi < 100);
+          assertFalse(failureDetector.isAvailable(timestampMillis));
+        }
+        else {
+          assertTrue(100 < phi);
+          assertFalse(failureDetector.isAvailable(timestampMillis));
+        }
+        continue;
+      }
+      else if (i > 200) {
+        if (i % 5 == 0) {
+          double phi = failureDetector.phi(timestampMillis);
+          assertTrue(0.1 < phi && phi < 0.5);
+          assertTrue(failureDetector.isAvailable(timestampMillis));
+          continue;
+        }
+      }
+      failureDetector.heartbeat(timestampMillis);
+      assertTrue(failureDetector.phi(timestampMillis) < 0.1);
+      assertTrue(failureDetector.isAvailable(timestampMillis));
+    }
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetectorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetectorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,19 +16,18 @@
 
 package org.apache.geode.distributed.internal.membership.gms.fd;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
-import static org.junit.Assert.*;
 
 import org.apache.geode.test.junit.categories.MembershipTest;
 
 @Category({MembershipTest.class})
-public class PhiAccrualFailureDetectorTest
-{
+public class PhiAccrualFailureDetectorTest {
   @Test
-  public void test()
-  {
+  public void test() {
     PhiAccrualFailureDetector failureDetector = new PhiAccrualFailureDetector.Builder().build();
     long now = 1420070400000L;
     for (int i = 0; i < 300; i++) {
@@ -39,38 +38,30 @@ public class PhiAccrualFailureDetectorTest
         if (i == 291) {
           assertTrue(1 < phi && phi < 3);
           assertTrue(failureDetector.isAvailable(timestampMillis));
-        }
-        else if (i == 292) {
+        } else if (i == 292) {
           assertTrue(3 < phi && phi < 8);
           assertTrue(failureDetector.isAvailable(timestampMillis));
-        }
-        else if (i == 293) {
+        } else if (i == 293) {
           assertTrue(8 < phi && phi < 16);
           assertTrue(failureDetector.isAvailable(timestampMillis));
-        }
-        else if (i == 294) {
+        } else if (i == 294) {
           assertTrue(16 < phi && phi < 30);
           assertFalse(failureDetector.isAvailable(timestampMillis));
-        }
-        else if (i == 295) {
+        } else if (i == 295) {
           assertTrue(30 < phi && phi < 50);
           assertFalse(failureDetector.isAvailable(timestampMillis));
-        }
-        else if (i == 296) {
+        } else if (i == 296) {
           assertTrue(50 < phi && phi < 70);
           assertFalse(failureDetector.isAvailable(timestampMillis));
-        }
-        else if (i == 297) {
+        } else if (i == 297) {
           assertTrue(70 < phi && phi < 100);
           assertFalse(failureDetector.isAvailable(timestampMillis));
-        }
-        else {
+        } else {
           assertTrue(100 < phi);
           assertFalse(failureDetector.isAvailable(timestampMillis));
         }
         continue;
-      }
-      else if (i > 200) {
+      } else if (i > 200) {
         if (i % 5 == 0) {
           double phi = failureDetector.phi(timestampMillis);
           assertTrue(0.1 < phi && phi < 0.5);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetectorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetectorTest.java
@@ -92,23 +92,19 @@ public class PhiAccrualFailureDetectorTest {
         new PhiAccrualFailureDetector(threshold, historySize, stddev,
             acceptableHeartbeatPauseMillis, now);
     long heartbeatTime = 0;
-    for (long l = 1; l <= historySize; l++) {
-      long deviation = getDeviation(heartbeatInterval, random);
-      detector.heartbeat(now + (l * heartbeatInterval) + deviation);
-    }
     for (long l : intervals) {
       if (l > 0) {
         long deviation = getDeviation(heartbeatInterval, random);
-        detector.heartbeat(now + (heartbeatInterval * (l + historySize)) + deviation);
+        detector.heartbeat(now + (heartbeatInterval * l) + deviation);
       }
       l = Math.abs(l);
-      heartbeatTime = now + (heartbeatInterval * (l + historySize));
+      heartbeatTime = now + (heartbeatInterval * l);
       System.out.println("heartbeat " + l + " phi= " + detector.phi(heartbeatTime));
     }
     assertFalse("phi=" + detector.phi(heartbeatTime), detector.isAvailable(heartbeatTime));
   }
 
   public int getDeviation(int heartbeatInterval, Random random) {
-    return 0; // random.nextInt(heartbeatInterval / 4);
+    return random.nextInt(heartbeatInterval / 4);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -407,6 +407,7 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
       // it's okay to not synchronize here - if we happen to create another detector
       // for this member in another thread it will be pretty equivalent to the one created here
       logger.info("Creating new failure detector for {}", member);
+      // TODO consider giving different kinds of members different thresholds
       final int threshold = Integer.getInteger("geode.phiAccrualThreshold", 10);
       final int sampleSize = Integer.getInteger("geode.phiAccrualSampleSize", 200);
       final int minStdDev = Integer.getInteger("geode.phiAccrualMinimumStandardDeviation", 100);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
@@ -1,20 +1,4 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
- */
-package org.apache.geode.distributed.internal.membership.gms.fd;
-
-/*
  * Copyright 2018 Mitsunori Komatsu (komamitsu)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,37 +14,37 @@ package org.apache.geode.distributed.internal.membership.gms.fd;
  * limitations under the License.
  */
 
+package org.apache.geode.distributed.internal.membership.gms.fd;
+
 import java.util.LinkedList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.logging.log4j.Logger;
-
-import org.apache.geode.internal.logging.LogService;
-
 /**
+ * <p>Ported to Geode from https://github.com/komamitsu/phi-accural-failure-detector.  Javadoc
+ * from that repo follows...</p>
+ * <p>
  * This is a port of
  * https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
  *
  * Implementation of 'The Phi Accrual Failure Detector' by Hayashibara et al. as defined in their
  * paper:
  * [http://ddg.jaist.ac.jp/pub/HDY+04.pdf]
- *
+ *<p>
  * The suspicion level of failure is given by a value called φ (phi).
  * The basic idea of the φ failure detector is to express the value of φ on a scale that
  * is dynamically adjusted to reflect current network conditions. A configurable
  * threshold is used to decide if φ is considered to be a failure.
- *
+ *<p>
  * The value of φ is calculated as:
- *
- * {{{
+ *<pre>
  * φ = -log10(1 - F(timeSinceLastHeartbeat)
- * }}}
+ * </pre>
  * where F is the cumulative distribution function of a normal distribution with mean
  * and standard deviation estimated from historical heartbeat inter-arrival times.
+ *
  */
 public class PhiAccrualFailureDetector {
-  private static final Logger logger = LogService.getLogger();
   private final double threshold;
   private final double minStdDeviationMillis;
   private final long acceptableHeartbeatPauseMillis;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
@@ -21,8 +21,10 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * <p>Ported to Geode from https://github.com/komamitsu/phi-accural-failure-detector.  Javadoc
- * from that repo follows...</p>
+ * <p>
+ * Ported to Geode from https://github.com/komamitsu/phi-accural-failure-detector. Javadoc
+ * from that repo follows...
+ * </p>
  * <p>
  * This is a port of
  * https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
@@ -30,16 +32,18 @@ import java.util.concurrent.atomic.AtomicReference;
  * Implementation of 'The Phi Accrual Failure Detector' by Hayashibara et al. as defined in their
  * paper:
  * [http://ddg.jaist.ac.jp/pub/HDY+04.pdf]
- *<p>
+ * <p>
  * The suspicion level of failure is given by a value called φ (phi).
  * The basic idea of the φ failure detector is to express the value of φ on a scale that
  * is dynamically adjusted to reflect current network conditions. A configurable
  * threshold is used to decide if φ is considered to be a failure.
- *<p>
+ * <p>
  * The value of φ is calculated as:
- *<pre>
+ *
+ * <pre>
  * φ = -log10(1 - F(timeSinceLastHeartbeat)
  * </pre>
+ *
  * where F is the cumulative distribution function of a normal distribution with mean
  * and standard deviation estimated from historical heartbeat inter-arrival times.
  *

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.membership.gms.fd;
+
+/*
+ * Copyright 2018 Mitsunori Komatsu (komamitsu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.util.LinkedList;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.internal.logging.LogService;
+
+/**
+ * This is a port of
+ * https://github.com/akka/akka/blob/master/akka-remote/src/main/scala/akka/remote/PhiAccrualFailureDetector.scala
+ *
+ * Implementation of 'The Phi Accrual Failure Detector' by Hayashibara et al. as defined in their
+ * paper:
+ * [http://ddg.jaist.ac.jp/pub/HDY+04.pdf]
+ *
+ * The suspicion level of failure is given by a value called φ (phi).
+ * The basic idea of the φ failure detector is to express the value of φ on a scale that
+ * is dynamically adjusted to reflect current network conditions. A configurable
+ * threshold is used to decide if φ is considered to be a failure.
+ *
+ * The value of φ is calculated as:
+ *
+ * {{{
+ * φ = -log10(1 - F(timeSinceLastHeartbeat)
+ * }}}
+ * where F is the cumulative distribution function of a normal distribution with mean
+ * and standard deviation estimated from historical heartbeat inter-arrival times.
+ */
+public class PhiAccrualFailureDetector {
+  private static final Logger logger = LogService.getLogger();
+  private final double threshold;
+  private final double minStdDeviationMillis;
+  private final long acceptableHeartbeatPauseMillis;
+
+  private final HeartbeatHistory heartbeatHistory;
+  private final AtomicReference<Long> lastTimestampMillis = new AtomicReference<Long>();
+
+  /**
+   * @param threshold A low threshold is prone to generate many wrong suspicions but ensures a quick
+   *        detection in the event
+   *        of a real crash. Conversely, a high threshold generates fewer mistakes but needs more
+   *        time to detect
+   *        actual crashes
+   *
+   * @param maxSampleSize Number of samples to use for calculation of mean and standard deviation of
+   *        inter-arrival times.
+   *
+   * @param minStdDeviationMillis Minimum standard deviation to use for the normal distribution used
+   *        when calculating phi.
+   *        Too low standard deviation might result in too much sensitivity for sudden, but normal,
+   *        deviations
+   *        in heartbeat inter arrival times.
+   *
+   * @param acceptableHeartbeatPauseMillis Duration corresponding to number of potentially
+   *        lost/delayed
+   *        heartbeats that will be accepted before considering it to be an anomaly.
+   *        This margin is important to be able to survive sudden, occasional, pauses in heartbeat
+   *        arrivals, due to for example garbage collect or network drop.
+   *
+   * @param firstHeartbeatEstimateMillis Bootstrap the stats with heartbeats that corresponds to
+   *        to this duration, with a with rather high standard deviation (since environment is
+   *        unknown
+   *        in the beginning)
+   *
+   *        <p>
+   *        Note for Geode use: this class was originally called PhiAccuralFailureDetector and is
+   *        from
+   *        https://github.com/komamitsu/phi-accural-failure-detector
+   *        </p>
+   */
+  protected PhiAccrualFailureDetector(double threshold, int maxSampleSize,
+      double minStdDeviationMillis,
+      long acceptableHeartbeatPauseMillis, long firstHeartbeatEstimateMillis) {
+    if (threshold <= 0) {
+      throw new IllegalArgumentException("Threshold must be > 0: " + threshold);
+    }
+    if (maxSampleSize <= 0) {
+      throw new IllegalArgumentException("Sample size must be > 0: " + maxSampleSize);
+    }
+    if (minStdDeviationMillis <= 0) {
+      throw new IllegalArgumentException(
+          "Minimum standard deviation must be > 0: " + minStdDeviationMillis);
+    }
+    if (acceptableHeartbeatPauseMillis < 0) {
+      throw new IllegalArgumentException(
+          "Acceptable heartbeat pause millis must be >= 0: " + acceptableHeartbeatPauseMillis);
+    }
+    if (firstHeartbeatEstimateMillis <= 0) {
+      throw new IllegalArgumentException(
+          "First heartbeat value must be > 0: " + firstHeartbeatEstimateMillis);
+    }
+
+    this.threshold = threshold;
+    this.minStdDeviationMillis = minStdDeviationMillis;
+    this.acceptableHeartbeatPauseMillis = acceptableHeartbeatPauseMillis;
+
+    long stdDeviationMillis = firstHeartbeatEstimateMillis / 4;
+    heartbeatHistory = new HeartbeatHistory(maxSampleSize);
+    heartbeatHistory.add(firstHeartbeatEstimateMillis - stdDeviationMillis)
+        .add(firstHeartbeatEstimateMillis + stdDeviationMillis);
+  }
+
+  private double ensureValidStdDeviation(double stdDeviationMillis) {
+    return Math.max(stdDeviationMillis, minStdDeviationMillis);
+  }
+
+  public synchronized double phi(long timestampMillis) {
+    Long lastTimestampMillis = this.lastTimestampMillis.get();
+    if (lastTimestampMillis == null) {
+      return 0.0;
+    }
+
+    long timeDiffMillis = timestampMillis - lastTimestampMillis;
+    double meanMillis = heartbeatHistory.mean() + acceptableHeartbeatPauseMillis;
+    double stdDeviationMillis = ensureValidStdDeviation(heartbeatHistory.stdDeviation());
+
+    double y = (timeDiffMillis - meanMillis) / stdDeviationMillis;
+    double e = Math.exp(-y * (1.5976 + 0.070566 * y * y));
+    if (timeDiffMillis > meanMillis) {
+      return -Math.log10(e / (1.0 + e));
+    } else {
+      return -Math.log10(1.0 - 1.0 / (1.0 + e));
+    }
+  }
+
+  public synchronized double phi() {
+    return phi(System.currentTimeMillis());
+  }
+
+  public boolean isAvailable(long timestampMillis) {
+    double currentPhi = phi(timestampMillis);
+    return currentPhi < threshold;
+  }
+
+  public boolean isAvailable() {
+    double currentPhi = phi(System.currentTimeMillis());
+    return currentPhi < threshold;
+  }
+
+  public synchronized void heartbeat(long timestampMillis) {
+    Long lastTimestampMillis = this.lastTimestampMillis.getAndSet(timestampMillis);
+    if (lastTimestampMillis != null) {
+      long interval = timestampMillis - lastTimestampMillis;
+      if (isAvailable(timestampMillis)) {
+        heartbeatHistory.add(interval);
+      }
+    }
+  }
+
+  public void heartbeat() {
+    heartbeat(System.currentTimeMillis());
+  }
+
+  public static class Builder {
+    private double threshold = 16.0;
+    private int maxSampleSize = 200;
+    private double minStdDeviationMillis = 500;
+    private long acceptableHeartbeatPauseMillis = 0;
+    private long firstHeartbeatEstimateMillis = 500;
+
+    public Builder setThreshold(double threshold) {
+      this.threshold = threshold;
+      return this;
+    }
+
+    public Builder setMaxSampleSize(int maxSampleSize) {
+      this.maxSampleSize = maxSampleSize;
+      return this;
+    }
+
+    public Builder setMinStdDeviationMillis(double minStdDeviationMillis) {
+      this.minStdDeviationMillis = minStdDeviationMillis;
+      return this;
+    }
+
+    public Builder setAcceptableHeartbeatPauseMillis(long acceptableHeartbeatPauseMillis) {
+      this.acceptableHeartbeatPauseMillis = acceptableHeartbeatPauseMillis;
+      return this;
+    }
+
+    public Builder setFirstHeartbeatEstimateMillis(long firstHeartbeatEstimateMillis) {
+      this.firstHeartbeatEstimateMillis = firstHeartbeatEstimateMillis;
+      return this;
+    }
+
+    public PhiAccrualFailureDetector build() {
+      return new PhiAccrualFailureDetector(threshold, maxSampleSize, minStdDeviationMillis,
+          acceptableHeartbeatPauseMillis, firstHeartbeatEstimateMillis);
+    }
+  }
+
+  private static class HeartbeatHistory {
+    private final int maxSampleSize;
+    private final LinkedList<Long> intervals = new LinkedList<Long>();
+    private final AtomicLong intervalSum = new AtomicLong();
+    private final AtomicLong squaredIntervalSum = new AtomicLong();
+
+    public HeartbeatHistory(int maxSampleSize) {
+      if (maxSampleSize < 1) {
+        throw new IllegalArgumentException("maxSampleSize must be >= 1, got " + maxSampleSize);
+      }
+      this.maxSampleSize = maxSampleSize;
+    }
+
+    public double mean() {
+      return (double) intervalSum.get() / intervals.size();
+    }
+
+    public double variance() {
+      return ((double) squaredIntervalSum.get() / intervals.size()) - (mean() * mean());
+    }
+
+    public double stdDeviation() {
+      return Math.sqrt(variance());
+    }
+
+    public HeartbeatHistory add(long interval) {
+      if (intervals.size() >= maxSampleSize) {
+        Long dropped = intervals.pollFirst();
+        intervalSum.addAndGet(-dropped);
+        squaredIntervalSum.addAndGet(-pow2(dropped));
+      }
+      intervals.add(interval);
+      intervalSum.addAndGet(interval);
+      squaredIntervalSum.addAndGet(pow2(interval));
+      return this;
+    }
+
+    private long pow2(long x) {
+      return x * x;
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
@@ -160,6 +160,10 @@ public class PhiAccrualFailureDetector {
 
   public synchronized void heartbeat(long timestampMillis) {
     Long lastTimestampMillis = this.lastTimestampMillis.getAndSet(timestampMillis);
+    /** bruce s.: for Apache Geode, don't record duplicate heartbeats */
+    if (lastTimestampMillis != null && lastTimestampMillis == timestampMillis) {
+      return;
+    }
     if (lastTimestampMillis != null) {
       long interval = timestampMillis - lastTimestampMillis;
       if (isAvailable(timestampMillis)) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/PhiAccrualFailureDetector.java
@@ -121,10 +121,14 @@ public class PhiAccrualFailureDetector {
     this.minStdDeviationMillis = minStdDeviationMillis;
     this.acceptableHeartbeatPauseMillis = acceptableHeartbeatPauseMillis;
 
-    long stdDeviationMillis = firstHeartbeatEstimateMillis / 4;
     heartbeatHistory = new HeartbeatHistory(maxSampleSize);
-    heartbeatHistory.add(firstHeartbeatEstimateMillis - stdDeviationMillis)
-        .add(firstHeartbeatEstimateMillis + stdDeviationMillis);
+    for (int i = 0; i < maxSampleSize; i++) {
+      heartbeatHistory.add(acceptableHeartbeatPauseMillis);
+    }
+
+    // long stdDeviationMillis = acceptableHeartbeatPauseMillis / 4;
+    // heartbeatHistory.add(acceptableHeartbeatPauseMillis - stdDeviationMillis)
+    // .add(acceptableHeartbeatPauseMillis + stdDeviationMillis);
 
     // Bruce: record the estimate as the last timestamp received
     lastTimestampMillis.set(firstHeartbeatEstimateMillis);

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -1861,12 +1861,12 @@ public class Connection implements Runnable {
    * initiate suspect processing if a shared/ordered connection is lost and we're not shutting down
    */
   private void initiateSuspicionIfSharedUnordered() {
-    if (this.isReceiver && this.handshakeRead && !this.preserveOrder && this.sharedResource) {
-      if (!this.owner.getConduit().getCancelCriterion().isCancelInProgress()) {
-        this.owner.getDM().getMembershipManager().suspectMember(this.getRemoteAddress(),
-            INITIATING_SUSPECT_PROCESSING);
-      }
-    }
+    // if (this.isReceiver && this.handshakeRead && !this.preserveOrder && this.sharedResource) {
+    // if (!this.owner.getConduit().getCancelCriterion().isCancelInProgress()) {
+    // this.owner.getDM().getMembershipManager().suspectMember(this.getRemoteAddress(),
+    // INITIATING_SUSPECT_PROCESSING);
+    // }
+    // }
   }
 
   /**


### PR DESCRIPTION
*Not ready for review*

This experimental code integrates a history-based heartbeat failure
detector with the existing Membership failure detector.  Final checks
remain the same - pretty much everything is the same except I've
replaced the single heartbeat timestamp per member with a
PhiAccrualFailureDetector object.  GMSHealthMonitorJUnitTest is passing
as are a handful of other distributed and integration tests.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
