### PR TITLE
GEODE-6593: fix test elapsed time computation

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
@@ -632,7 +632,6 @@ public class ConnectionManagerJUnitTest {
 
     }
     long elapsed = elapsedMillis(startTime);
-    System.out.println("DEBUG: " + elapsed);
     Assert.assertTrue("Should have blocked for 100 millis for a connection", elapsed >= 100);
 
     Thread returnThread = new Thread() {


### PR DESCRIPTION
The test was using System.currentTimeMillis to verify that
the product has blocked for as long as expected.
But the product is using System.nanoTime.
This can cause race conditions because these two different
clocks can be updated at different times.
The test now also uses System.nanoTime.
Also removed some dead test code.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
