### PR TITLE
GEODE-6430: Add test to query PDX-based entries from gfsh

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -238,6 +238,11 @@
         <version>4.1.0</version>
       </dependency>
       <dependency>
+        <groupId>net.openhft</groupId>
+        <artifactId>compiler</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+      <dependency>
         <groupId>net.sf.jopt-simple</groupId>
         <artifactId>jopt-simple</artifactId>
         <version>5.0.4</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -124,6 +124,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'mx4j', name: 'mx4j-tools', version: '3.0.1')
         api(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')
         api(group: 'net.java.dev.jna', name: 'jna', version: '4.1.0')
+        api(group: 'net.openhft', name: 'compiler', version: '2.3.1')
         api(group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '5.0.4')
         api(group: 'net.spy', name: 'spymemcached', version: '2.12.2')
         api(group: 'org.apache.bcel', name: 'bcel', version: '6.2')

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -392,6 +392,7 @@ dependencies {
   }
   distributedTestCompile('pl.pragmatists:JUnitParams')
   distributedTestCompile('com.jayway.jsonpath:json-path-assert')
+  distributedTestCompile('net.openhft:compiler')
 
   distributedTestRuntime(project(':geode-old-versions'))
   distributedTestRuntime('org.apache.derby:derby')

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/QueryPdxDataDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/QueryPdxDataDUnitTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+
+import net.openhft.compiler.CompilerUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientRegionFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
+import org.apache.geode.pdx.internal.AutoSerializableManager;
+import org.apache.geode.test.dunit.Invoke;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.GfshTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@Category({GfshTest.class})
+public class QueryPdxDataDUnitTest {
+
+  private static MemberVM locator;
+  private static MemberVM server1;
+  private static MemberVM server2;
+  private static ClientVM client;
+
+  @ClassRule
+  public static ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Invoke.invokeInEveryVM(
+        () -> System.setProperty(AutoSerializableManager.NO_HARDCODED_EXCLUDES_PARAM, "true"));
+
+    locator = cluster.startLocatorVM(0);
+    gfsh.connectAndVerify(locator);
+    gfsh.executeAndAssertThat(
+        "configure pdx --read-serialized=true --auto-serializable-classes=org.apache.geode.management.*")
+        .statusIsSuccess();
+
+    server1 = cluster.startServerVM(1, locator.getPort());
+    server2 = cluster.startServerVM(2, locator.getPort());
+
+    gfsh.executeAndAssertThat("create region --name=BOZ --type=PARTITION");
+
+    int port = locator.getPort();
+    client = cluster.startClientVM(3, cf -> {
+      cf.withLocatorConnection(port);
+      cf.withCacheSetup(c -> c
+          .setPdxSerializer(new ReflectionBasedAutoSerializer("org.apache.geode.management.*")));
+    });
+
+    client.invoke(() -> {
+      ClientRegionFactory factory =
+          ClusterStartupRule.getClientCache().createClientRegionFactory(ClientRegionShortcut.PROXY);
+      Region<Object, Object> region = factory.create("BOZ");
+
+      buildClass("org.apache.geode.management.Address",
+          "/org/apache/geode/management/Address.java");
+      Class<?> customerClass =
+          buildClass("org.apache.geode.management.Customer",
+              "/org/apache/geode/management/Customer.java");
+
+      Constructor<?> constructor =
+          customerClass.getConstructor(String.class, String.class, String.class);
+      for (int i = 0; i < 100; i++) {
+        Object customer = constructor.newInstance("name_" + i, "Main " + i, "City " + i);
+        region.put(i + "", customer);
+      }
+    });
+  }
+
+  private static Class<?> buildClass(String className, String javaResourceName) throws Exception {
+    URL resourceFileURL = QueryPdxDataDUnitTest.class.getResource(javaResourceName);
+    assertThat(resourceFileURL).isNotNull();
+
+    URI resourceUri = resourceFileURL.toURI();
+    String javaCode = new String(Files.readAllBytes(new File(resourceUri).toPath()));
+
+    return CompilerUtils.CACHED_COMPILER.loadFromJava(className, javaCode);
+  }
+
+  @Test
+  public void queryForPdxBackedEntriesShouldSucceed() {
+    gfsh.executeAndAssertThat("query --query=\"select * from /BOZ.values\"").statusIsSuccess();
+  }
+
+}

--- a/geode-core/src/distributedTest/resources/org/apache/geode/management/Address.java
+++ b/geode-core/src/distributedTest/resources/org/apache/geode/management/Address.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management;
+
+import org.apache.geode.internal.PdxSerializerObject;
+
+public class Address implements PdxSerializerObject {
+  public String street;
+  public String city;
+
+  public Address() {}
+
+  public Address(String street, String city) {
+    this.street = street;
+    this.city = city;
+  }
+}

--- a/geode-core/src/distributedTest/resources/org/apache/geode/management/Customer.java
+++ b/geode-core/src/distributedTest/resources/org/apache/geode/management/Customer.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management;
+
+import org.apache.geode.internal.PdxSerializerObject;
+
+public class Customer implements PdxSerializerObject {
+  public String name;
+  public Address address;
+  public String street;
+  public String city;
+
+  public Customer() {}
+
+  public Customer(String name, String street, String city) {
+    this.name = name;
+    this.street = street;
+    this.city = city;
+    this.address = new Address(street, city);
+  }
+
+  public String toString() {
+    return name + street + city;
+  }
+}


### PR DESCRIPTION
- This test ensures that the classes, backing PDX instance objects are
  created dynamically.

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
