### PR TITLE
GEODE-6598: Fix alertMessageIsReceivedByManager test

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/alerting/AlertingServiceWithoutListenerDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/alerting/AlertingServiceWithoutListenerDistributedTest.java
@@ -33,7 +33,9 @@ import static org.apache.geode.test.dunit.VM.getVM;
 import static org.apache.geode.test.dunit.VM.toArray;
 import static org.apache.geode.test.dunit.internal.DUnitLauncher.getDistributedSystemProperties;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.io.Serializable;
@@ -47,6 +49,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.DistributedMember;
@@ -146,7 +149,13 @@ public class AlertingServiceWithoutListenerDistributedTest implements Serializab
   public void alertMessageIsReceivedByManager() {
     memberVM.invoke(() -> logger.fatal(alertMessage));
 
-    managerVM.invoke(() -> verifyNoMoreInteractions(messageListener));
+    managerVM.invoke(() -> {
+      await().untilAsserted(() -> {
+        ArgumentCaptor<AlertListenerMessage> captor = forClass(AlertListenerMessage.class);
+        verify(messageListener).received(captor.capture());
+        assertThat(captor.getValue().getMessage()).isEqualTo(alertMessage);
+      });
+    });
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AlertListenerMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AlertListenerMessage.java
@@ -158,6 +158,11 @@ public class AlertListenerMessage extends PooledDistributionMessage implements A
   }
 
   @VisibleForTesting
+  public String getMessage() {
+    return message;
+  }
+
+  @VisibleForTesting
   public static void addListener(Listener listener) {
     listenerRef.compareAndSet(null, listener);
   }


### PR DESCRIPTION
Implement the test alertMessageIsReceivedByManager correctly. The
Manager VM should receive the AlertListenerMessage and its message
should match the alert message.

