### PR TITLE
GEODE-6527: when user explicitly specify PartitionedAttributes, such as

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/util/internal/MappingCommandUtils.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/util/internal/MappingCommandUtils.java
@@ -90,6 +90,7 @@ public class MappingCommandUtils {
   public static boolean isAccessor(RegionAttributesType attributesType) {
     if (attributesType.getDataPolicy() == RegionAttributesDataPolicy.EMPTY
         || (attributesType.getPartitionAttributes() != null
+            && attributesType.getPartitionAttributes().getLocalMaxMemory() != null
             && attributesType.getPartitionAttributes().getLocalMaxMemory().equals("0"))) {
       return true;
     } else {


### PR DESCRIPTION
redundency=1, the PartitionedAttributes will not be null, but its LocalMaxMeory
could be null if the region is not accessor.

    Co-authored-by: Xiaojian Zhou <gzhou@pivotal.io>
    Co-authored-by: Benjamin Ross <bross@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
