### PR TITLE
GEODE-4958: Lowering the log level to warn

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -848,7 +848,8 @@ public abstract class ServerConnection implements Runnable {
           } else if (uniqueId == 0) {
             logger.debug("No unique ID yet. {}, {}", messageType, this.getName());
           } else {
-            logger.error("Failed to bind the subject of uniqueId {} for message {} with {}",
+            logger.warn(
+                "Failed to bind the subject of uniqueId {} for message {} with {} : Possible re-authentication required",
                 uniqueId, messageType, this.getName());
             throw new AuthenticationRequiredException("Failed to find the authenticated user.");
           }
@@ -1211,6 +1212,8 @@ public abstract class ServerConnection implements Runnable {
       } catch (IOException ex) {
         logger.warn(ex.toString() + " : Unexpected Exception");
         setClientDisconnectedException(ex);
+      } catch (AuthenticationRequiredException ex) {
+        logger.warn(ex.toString() + " : Unexpected Exception");
       } finally {
         getAcceptor().releaseTLCommBuffer();
         // DistributedSystem.releaseThreadsSockets();


### PR DESCRIPTION
	* AuthenticationRequiredException is now caught and logged instead of an uncaught exception
	* Lowering the log level to warn from error when this exception occurs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
