### PR TITLE
GEODE-1703: Fix PersistentRecoveryOrderDUnitTest time based flakiness

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
@@ -16,41 +16,46 @@ package org.apache.geode.internal.cache.persistence;
 
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.apache.geode.internal.cache.CacheObserverHolder.setInstance;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.apache.geode.internal.cache.TombstoneService.EXPIRED_TOMBSTONE_LIMIT_DEFAULT;
+import static org.apache.geode.internal.cache.TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT_DEFAULT;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
+import static org.apache.geode.test.dunit.VM.getAllVMs;
+import static org.apache.geode.test.dunit.VM.getController;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.VM.toArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.After;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.AttributesFactory;
-import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
-import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskAccessException;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
-import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.Scope;
-import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
-import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
 import org.apache.geode.internal.HeapDataOutputStream;
@@ -62,429 +67,72 @@ import org.apache.geode.internal.cache.DiskStoreFactoryImpl;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.DiskStoreObserver;
 import org.apache.geode.internal.cache.EntrySnapshot;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InitialImageOperation;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.NonTXEntry;
-import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.internal.cache.Token.Tombstone;
 import org.apache.geode.internal.cache.TombstoneService;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.cache.versions.VersionTag;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.AsyncInvocation;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.LogWriterUtils;
-import org.apache.geode.test.dunit.SerializableCallable;
-import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
+import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
+import org.apache.geode.test.dunit.rules.SharedErrorCollector;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 
-@Category({PersistenceTest.class})
+@Category(PersistenceTest.class)
+@RunWith(JUnitParamsRunner.class)
 public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase {
 
-  private static final int TEST_REPLICATED_TOMBSTONE_TIMEOUT = 1000;
+  private static final int TEST_REPLICATED_TOMBSTONE_TIMEOUT = 1_000;
 
-  public PersistentRVVRecoveryDUnitTest() {
-    super();
-  }
+  @Rule
+  public DistributedRestoreSystemProperties restoreSystemProperties =
+      new DistributedRestoreSystemProperties();
 
-  @Override
-  protected final void postTearDownPersistentReplicatedTestBase() throws Exception {
-    Invoke.invokeInEveryVM(() -> resetAckWaitThreshold());
+  @Rule
+  public SharedErrorCollector errorCollector = new SharedErrorCollector();
+
+  @After
+  public void tearDown() {
+    for (VM vm : toArray(getAllVMs(), getController())) {
+      vm.invoke(() -> {
+        LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
+        CacheObserverHolder.setInstance(null);
+        DiskStoreObserver.setInstance(null);
+        TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT = REPLICATE_TOMBSTONE_TIMEOUT_DEFAULT;
+        TombstoneService.EXPIRED_TOMBSTONE_LIMIT = EXPIRED_TOMBSTONE_LIMIT_DEFAULT;
+      });
+    }
   }
 
   @Test
   public void testNoConcurrencyChecks() {
-    Cache cache = getCache();
-    RegionFactory rf = new RegionFactory();
-    rf.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-    rf.setConcurrencyChecksEnabled(false);
-    try {
-      LocalRegion region = (LocalRegion) rf.create(REGION_NAME);
-      fail("Expected to get an IllegalStateException because concurrency checks can't be disabled");
-    } catch (IllegalStateException expected) {
-      // do nothing
-    }
+    getCache();
+
+    RegionFactory regionFactory = new RegionFactory();
+    regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+    regionFactory.setConcurrencyChecksEnabled(false);
+
+    Throwable thrown = catchThrowable(() -> regionFactory.create(regionName));
+    assertThat(thrown).isInstanceOf(IllegalStateException.class);
   }
 
   /**
-   * Test that we can recover the RVV information with some normal usage.
+   * Test that we can recover the RVV information.
    */
   @Test
-  public void testRecoveryWithKRF() throws Throwable {
-    doTestRecovery(new Runnable() {
-      @Override
-      public void run() {
-        // do nothing
-      }
-    });
-  }
-
-  /**
-   * Test that we can recover the RVV information if the krf is missing
-   */
-  @Test
-  public void testRecoveryWithoutKRF() throws Throwable {
-    doTestRecovery(new Runnable() {
-      @Override
-      public void run() {
-        Host host = Host.getHost(0);
-        VM vm0 = host.getVM(0);
-        VM vm1 = host.getVM(1);
-        VM vm2 = host.getVM(2);
-        deleteKRFs(vm0);
-      }
-    });
-  }
-
-  /**
-   * Test that we correctly recover and expire recovered tombstones, with compaction enabled
-   */
-  @Test
-  public void testLotsOfTombstones() throws Throwable {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(0);
-
-    // I think we just need to assert the number of tombstones, maybe?
-    // Bruce has code that won't even let the tombstones expire for 10 minutes
-    // That means on recovery we need to recover them all? Or do we need to recover
-    // any? We're doing a GII. Won't we GII tombstones anyway? Ahh, but we need
-    // to know that we don't need to record the new tombstones.
-
-    LocalRegion region = createRegion(vm0);
-
-    int initialCount = getTombstoneCount(region);
-    assertEquals(0, initialCount);
-
-    final int entryCount = 20;
-    for (int i = 0; i < entryCount; i++) {
-      region.put(i, new byte[100]);
-      // destroy each entry.
-      region.destroy(i);
-    }
-
-    assertEquals(entryCount, getTombstoneCount(region));
-
-
-    // roll to a new oplog
-    region.getDiskStore().forceRoll();
-
-    // Force a compaction. This should do nothing, because
-    // The tombstones are not garbage, so only 50% of the oplog
-    // is garbage (the creates).
-    region.getDiskStore().forceCompaction();
-
-    assertEquals(0, region.getDiskStore().numCompactableOplogs());
-
-    assertEquals(entryCount, getTombstoneCount(region));
-
-    getCache().close();
-
-    region = createRegion(vm0);
-
-    assertEquals(entryCount, getTombstoneCount(region));
-
-    GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-    TombstoneService tombstoneService = cache.getTombstoneService();
-
-    // Before expiring tombstones, no oplogs are available for compaction
-    assertEquals(0, region.getDiskStore().numCompactableOplogs());
-    region.getDiskStore().forceCompaction();
-    assertTrue(tombstoneService.forceBatchExpirationForTests(entryCount / 2));
-
-    assertEquals(entryCount / 2, getTombstoneCount(region));
-
-    // After expiring, we should have an oplog available for compaction.
-    assertEquals(1, region.getDiskStore().numCompactableOplogs());
-
-    // Test after restart the tombstones are still missing
-    getCache().close();
-    region = createRegion(vm0);
-    assertEquals(entryCount / 2, getTombstoneCount(region));
-
-    // We should have an oplog available for compaction, because the tombstones
-    // were garbage collected
-    assertEquals(1, region.getDiskStore().numCompactableOplogs());
-    // This should compact some oplogs
-    region.getDiskStore().forceCompaction();
-    assertEquals(0, region.getDiskStore().numCompactableOplogs());
-
-    // Restart again, and make sure the compaction didn't mess up our tombstone
-    // count
-    getCache().close();
-    region = createRegion(vm0);
-    assertEquals(entryCount / 2, getTombstoneCount(region));
-    cache = (GemFireCacheImpl) getCache();
-
-    // Add a test hook that will shutdown the system as soon as we write a GC RVV record
-    DiskStoreObserver.setInstance(new DiskStoreObserver() {
-      @Override
-      public void afterWriteGCRVV(DiskRegion dr) {
-        // This will cause the disk store to shut down,
-        // preventing us from writing any other records.
-        throw new DiskAccessException();
-      }
-
-    });
-    IgnoredException ex = IgnoredException.addIgnoredException("DiskAccessException");
-    try {
-      // Force expiration, with our test hook that should close the cache
-      tombstoneService = cache.getTombstoneService();
-      tombstoneService.forceBatchExpirationForTests(entryCount / 4);
-
-      getCache().close();
-      assertTrue(cache.isClosed());
-
-      // Restart again, and make sure the tombstones are in fact removed
-      region = createRegion(vm0);
-      assertEquals(entryCount / 4, getTombstoneCount(region));
-    } finally {
-      ex.remove();
-    }
-
-
-  }
-
-  /**
-   * Test that we correctly recover and expire recovered tombstones, with compaction enabled.
-   *
-   * This test differs from above test in that we need to make sure tombstones start expiring based
-   * on their original time-stamp, NOT the time-stamp assigned during scheduling for expiration
-   * after recovery.
-   */
-  @Ignore
-  @Test
-  public void testLotsOfTombstonesExpiration() throws Throwable {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(0);
-
-    vm0.invoke(new CacheSerializableRunnable("") {
-
-      @Override
-      public void run2() throws CacheException {
-        long replicatedTombstoneTomeout = TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT;
-        int expiriredTombstoneLimit = TombstoneService.EXPIRED_TOMBSTONE_LIMIT;
-
-        try {
-          LocalRegion region = createRegion(vm0);
-
-          int initialCount = getTombstoneCount(region);
-          assertEquals(0, initialCount);
-
-          final int entryCount = 20;
-          for (int i = 0; i < entryCount; i++) {
-            region.put(i, new byte[100]);
-            // destroy each entry.
-            region.destroy(i);
-          }
-
-          assertEquals(entryCount, getTombstoneCount(region));
-
-          // roll to a new oplog
-          region.getDiskStore().forceRoll();
-
-          // Force a compaction. This should do nothing, because
-          // The tombstones are not garbage, so only 50% of the oplog
-          // is garbage (the creates).
-          region.getDiskStore().forceCompaction();
-
-          assertEquals(0, region.getDiskStore().numCompactableOplogs());
-
-          assertEquals(entryCount, getTombstoneCount(region));
-
-          getCache().close();
-
-          // We should wait for timeout time so that tomstones are expired
-          // right away when they are gIId based on their original timestamp.
-          Wait.pause((int) TEST_REPLICATED_TOMBSTONE_TIMEOUT);
-
-          TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT = TEST_REPLICATED_TOMBSTONE_TIMEOUT;
-          TombstoneService.EXPIRED_TOMBSTONE_LIMIT = entryCount;
-          // Do region GII
-          region = createRegion(vm0);
-
-          assertEquals(entryCount, getTombstoneCount(region));
-
-          getCache().getLogger().fine("Waiting for maximumSleepTime ms");
-          Wait.pause(10000); // maximumSleepTime+500 in TombstoneSweeper GC thread
-
-          // Tombstones should have been expired and garbage collected by now by
-          // TombstoneService.
-          assertEquals(0, getTombstoneCount(region));
-
-          // This should compact some oplogs
-          region.getDiskStore().forceCompaction();
-          assertEquals(0, region.getDiskStore().numCompactableOplogs());
-
-          // Test after restart the tombstones are still missing
-          getCache().close();
-          region = createRegion(vm0);
-          assertEquals(0, getTombstoneCount(region));
-
-          // We should have an oplog available for compaction, because the
-          // tombstones
-          // were garbage collected
-          assertEquals(0, region.getDiskStore().numCompactableOplogs());
-
-          GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-
-          cache.close();
-        } finally {
-          TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT = replicatedTombstoneTomeout;
-          TombstoneService.EXPIRED_TOMBSTONE_LIMIT = expiriredTombstoneLimit;
-        }
-      }
-    });
-  }
-
-  /**
-   * This test creates 2 VMs in a distributed system with a persistent PartitionedRegion and one VM
-   * (VM1) puts an entry in region. Second VM (VM2) starts later and does a delta GII. During Delta
-   * GII in VM2 a DESTROY operation happens in VM1 and gets propagated to VM2 concurrently with GII.
-   * At this point if entry version is greater than the once received from GII then it must not get
-   * applied. Which is Bug #45921.
-   *
-   */
-  @Test
-  public void testConflictChecksDuringConcurrentDeltaGIIAndOtherOp() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    vm0.invoke(new CacheSerializableRunnable("Create PR and put an entry") {
-
-      @Override
-      public void run2() throws CacheException {
-        Cache cache = getCache();
-
-        PartitionAttributes attrs =
-            new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create();
-        AttributesFactory factory = new AttributesFactory();
-        factory.setPartitionAttributes(attrs);
-        RegionAttributes rAttrs = factory.create();
-        Region region = cache.createRegionFactory(rAttrs).create("prRegion");
-
-        region.put("testKey", "testValue");
-        assertEquals(1, region.size());
-      }
-    });
-
-    // Create a cache and region, do an update to change the version no. and
-    // restart the cache and region.
-    vm1.invoke(new CacheSerializableRunnable("Create PR and put an entry") {
-
-      @Override
-      public void run2() throws CacheException {
-        Cache cache = getCache();
-        PartitionAttributes attrs =
-            new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create();
-        AttributesFactory factory = new AttributesFactory();
-        factory.setPartitionAttributes(attrs);
-        RegionAttributes rAttrs = factory.create();
-        Region region = cache.createRegionFactory(rAttrs).create("prRegion");
-        region.put("testKey", "testValue2");
-        cache.close();
-
-        // Restart
-        cache = getCache();
-        region = cache.createRegionFactory(rAttrs).create("prRegion");
-      }
-    });
-
-    // Do a DESTROY in vm0 when delta GII is in progress in vm1 (Hopefully, Not
-    // guaranteed).
-    AsyncInvocation async =
-        vm0.invokeAsync(new CacheSerializableRunnable("Detroy entry in region") {
-
-          @Override
-          public void run2() throws CacheException {
-            Cache cache = getCache();
-            Region region = cache.getRegion("prRegion");
-            while (!region.get("testKey").equals("testValue2")) {
-              Wait.pause(100);
-            }
-            region.destroy("testKey");
-          }
-        });
-
-    try {
-      async.join(3000);
-    } catch (InterruptedException e) {
-      new AssertionError("VM1 entry destroy did not finish in 3000 ms");
-    }
-
-    vm1.invoke(new CacheSerializableRunnable("Verifying entry version in new node VM1") {
-
-      @Override
-      public void run2() throws CacheException {
-        Cache cache = getCache();
-        Region region = cache.getRegion("prRegion");
-
-        Region.Entry entry =
-            ((PartitionedRegion) region).getEntry("testKey", true /* Entry is destroyed */);
-        RegionEntry re = ((EntrySnapshot) entry).getRegionEntry();
-        LogWriterUtils.getLogWriter().fine("RegionEntry for testKey: " + re.getKey() + " "
-            + re.getValueInVM((LocalRegion) region));
-        assertTrue(re.getValueInVM((LocalRegion) region) instanceof Tombstone);
-
-        VersionTag tag = re.getVersionStamp().asVersionTag();
-        assertEquals(3 /* Two puts and a Destroy */, tag.getEntryVersion());
-      }
-    });
-
-    closeCache(vm0);
-    closeCache(vm1);
-  }
-
-  private LocalRegion createRegion(final VM vm0) {
-    Cache cache = getCache();
-    DiskStoreFactory dsf = cache.createDiskStoreFactory();
-    File dir = getDiskDirForVM(vm0);
-    dir.mkdirs();
-    dsf.setDiskDirs(new File[] {dir});
-    dsf.setMaxOplogSize(1);
-    // Turn of automatic compaction
-    dsf.setAllowForceCompaction(true);
-    dsf.setAutoCompact(false);
-    // The compaction javadocs seem to be wrong. This
-    // is the amount of live data in the oplog
-    dsf.setCompactionThreshold(40);
-    DiskStore ds = dsf.create(REGION_NAME);
-    RegionFactory rf = new RegionFactory();
-    rf.setDiskStoreName(ds.getName());
-    rf.setDiskSynchronous(true);
-    rf.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-    rf.setScope(Scope.DISTRIBUTED_ACK);
-    LocalRegion region = (LocalRegion) rf.create(REGION_NAME);
-    return region;
-  }
-
-  private int getTombstoneCount(LocalRegion region) {
-    int regionCount = region.getTombstoneCount();
-    int actualCount = 0;
-    for (RegionEntry entry : region.entries.regionEntries()) {
-      if (entry.isTombstone()) {
-        actualCount++;
-      }
-    }
-
-    assertEquals(actualCount, regionCount);
-
-    return actualCount;
-  }
-
-
-  public void doTestRecovery(Runnable doWhileOffline) throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}({params})")
+  public void testRecoveryWithOrWithoutKRF(boolean deleteKRFs) throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
     // Create the region in few members to test recovery
     createPersistentRegion(vm0);
@@ -499,12 +147,10 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     delete(vm1, 0, 1);
     delete(vm0, 10, 11);
 
-
     // Make sure the RVVs are the same in the members
     RegionVersionVector vm0RVV = getRVV(vm0);
     RegionVersionVector vm1RVV = getRVV(vm1);
     RegionVersionVector vm2RVV = getRVV(vm2);
-
 
     assertSameRVV(vm0RVV, vm1RVV);
     assertSameRVV(vm0RVV, vm2RVV);
@@ -514,14 +160,16 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     closeCache(vm1);
     closeCache(vm0);
 
-    doWhileOffline.run();
+    if (deleteKRFs) {
+      deleteKRFs(getVM(0));
+    }
 
     // Make sure we can recover the RVV
     createPersistentRegion(vm0);
 
     RegionVersionVector new0RVV = getRVV(vm0);
     assertSameRVV(vm0RVV, new0RVV);
-    assertEquals(vm0RVV.getOwnerId(), new0RVV.getOwnerId());
+    assertThat(new0RVV.getOwnerId()).isEqualTo(vm0RVV.getOwnerId());
 
     createData(vm0, 12, 15, "value");
 
@@ -535,12 +183,260 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     closeCache(vm0);
     closeCache(vm1);
 
-    doWhileOffline.run();
+    if (deleteKRFs) {
+      deleteKRFs(getVM(0));
+    }
 
     // Make the sure member that GII'd the RVV can also recover it
     createPersistentRegion(vm1);
-    RegionVersionVector new1RVV = getRVV(vm1);
     assertSameRVV(new0RVV, getRVV(vm1));
+  }
+
+  /**
+   * Test that we correctly recover and expire recovered tombstones, with compaction enabled
+   */
+  @Test
+  public void testLotsOfTombstones() throws Exception {
+    VM vm0 = getVM(0);
+
+    // I think we just need to assert the number of tombstones, maybe?
+    // Bruce has code that won't even let the tombstones expire for 10 minutes
+    // That means on recovery we need to recover them all? Or do we need to recover
+    // any? We're doing a GII. Won't we GII tombstones anyway? Ahh, but we need
+    // to know that we don't need to record the new tombstones.
+
+    InternalRegion region = createRegion(vm0);
+
+    int initialCount = getTombstoneCount(region);
+    assertThat(initialCount).isEqualTo(0);
+
+    int entryCount = 20;
+    for (int i = 0; i < entryCount; i++) {
+      region.put(i, new byte[100]);
+      region.destroy(i);
+    }
+
+    assertThat(getTombstoneCount(region)).isEqualTo(entryCount);
+
+    // roll to a new oplog
+    region.getDiskStore().forceRoll();
+
+    // Force a compaction. This should do nothing, because the tombstones are not garbage, so only
+    // 50% of the oplog is garbage (the creates).
+    region.getDiskStore().forceCompaction();
+
+    assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(0);
+    assertThat(getTombstoneCount(region)).isEqualTo(entryCount);
+
+    getCache().close();
+
+    region = createRegion(vm0);
+
+    assertThat(getTombstoneCount(region)).isEqualTo(entryCount);
+
+    TombstoneService tombstoneService = getCache().getTombstoneService();
+
+    // Before expiring tombstones, no oplogs are available for compaction
+    assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(0);
+
+    region.getDiskStore().forceCompaction();
+
+    assertThat(tombstoneService.forceBatchExpirationForTests(entryCount / 2)).isTrue();
+    assertThat(getTombstoneCount(region)).isEqualTo(entryCount / 2);
+
+    // After expiring, we should have an oplog available for compaction.
+    assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(1);
+
+    // Test after restart the tombstones are still missing
+    getCache().close();
+    region = createRegion(vm0);
+    assertThat(getTombstoneCount(region)).isEqualTo(entryCount / 2);
+
+    // Should have an oplog available for compaction, because the tombstones were garbage collected
+    assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(1);
+
+    // This should compact some oplogs
+    region.getDiskStore().forceCompaction();
+    assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(0);
+
+    // Restart again, and make sure the compaction didn't mess up our tombstone count
+    getCache().close();
+    region = createRegion(vm0);
+    assertThat(getTombstoneCount(region)).isEqualTo(entryCount / 2);
+
+    // Add a test hook that will shutdown the system as soon as we write a GC RVV record
+    DiskStoreObserver.setInstance(new DiskStoreObserver() {
+
+      @Override
+      public void afterWriteGCRVV(DiskRegion dr) {
+        // This will cause the disk store to shut down, preventing us from writing any other records
+        throw new DiskAccessException();
+      }
+    });
+
+    try (IgnoredException e = addIgnoredException(DiskAccessException.class)) {
+      // Force expiration, with our test hook that should close the cache
+      tombstoneService = getCache().getTombstoneService();
+      tombstoneService.forceBatchExpirationForTests(entryCount / 4);
+
+      getCache().close();
+
+      // Restart again, and make sure the tombstones are in fact removed
+      region = createRegion(vm0);
+      assertThat(getTombstoneCount(region)).isEqualTo(entryCount / 4);
+    }
+  }
+
+  /**
+   * Test that we correctly recover and expire recovered tombstones, with compaction enabled.
+   *
+   * This test differs from above test in that we need to make sure tombstones start expiring based
+   * on their original time-stamp, NOT the time-stamp assigned during scheduling for expiration
+   * after recovery.
+   */
+  @Ignore
+  @Test
+  public void testLotsOfTombstonesExpiration() {
+    VM vm0 = getVM(0);
+
+    vm0.invoke(() -> {
+      InternalRegion region = createRegion(vm0);
+
+      int initialCount = getTombstoneCount(region);
+      assertThat(initialCount).isEqualTo(0);
+
+      int entryCount = 20;
+      for (int i = 0; i < entryCount; i++) {
+        region.put(i, new byte[100]);
+        region.destroy(i);
+      }
+
+      assertThat(getTombstoneCount(region)).isEqualTo(entryCount);
+
+      // roll to a new oplog
+      region.getDiskStore().forceRoll();
+
+      // Force a compaction. This should do nothing, because the tombstones are not garbage, so
+      // only 50% of the oplog is garbage (the creates).
+      region.getDiskStore().forceCompaction();
+
+      assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(0);
+      assertThat(getTombstoneCount(region)).isEqualTo(entryCount);
+
+      getCache().close();
+
+      // We should wait for timeout time so that tombstones are expired
+      // right away when they are gIId based on their original timestamp.
+      Wait.pause(TEST_REPLICATED_TOMBSTONE_TIMEOUT);
+
+      TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT = TEST_REPLICATED_TOMBSTONE_TIMEOUT;
+      TombstoneService.EXPIRED_TOMBSTONE_LIMIT = entryCount;
+
+      // Do region GII
+      region = createRegion(vm0);
+
+      assertThat(getTombstoneCount(region)).isEqualTo(entryCount);
+
+      // maximumSleepTime+500 in TombstoneSweeper GC thread
+      Wait.pause(10_000);
+
+      // Tombstones should have been expired and garbage collected by now by TombstoneService.
+      assertThat(getTombstoneCount(region)).isEqualTo(0);
+
+      // This should compact some oplogs
+      region.getDiskStore().forceCompaction();
+      assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(0);
+
+      // Test after restart the tombstones are still missing
+      getCache().close();
+      region = createRegion(vm0);
+      assertThat(getTombstoneCount(region)).isEqualTo(0);
+
+      // should have an oplog available for compaction because the tombstones were garbage collected
+      assertThat(region.getDiskStore().numCompactableOplogs()).isEqualTo(0);
+
+      getCache().close();
+    });
+  }
+
+  /**
+   * This test creates 2 VMs in a distributed system with a persistent PartitionedRegion and one VM
+   * (VM1) puts an entry in region. Second VM (VM2) starts later and does a delta GII. During Delta
+   * GII in VM2 a DESTROY operation happens in VM1 and gets propagated to VM2 concurrently with GII.
+   * At this point if entry version is greater than the once received from GII then it must not get
+   * applied. Which is Bug #45921.
+   */
+  @Test
+  public void testConflictChecksDuringConcurrentDeltaGIIAndOtherOp() throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+
+    vm0.invoke(() -> {
+      PartitionAttributesFactory<String, String> partitionAttributesFactory =
+          new PartitionAttributesFactory<>();
+      partitionAttributesFactory.setRedundantCopies(1);
+      partitionAttributesFactory.setTotalNumBuckets(1);
+
+      AttributesFactory<String, String> attributesFactory = new AttributesFactory<>();
+      attributesFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+      RegionFactory<String, String> regionFactory =
+          getCache().createRegionFactory(attributesFactory.create());
+
+      Region<String, String> region = regionFactory.create("prRegion");
+
+      region.put("testKey", "testValue");
+      assertThat(region.size()).isEqualTo(1);
+    });
+
+    // Create a cache and region, do an update to change the version no. and
+    // restart the cache and region.
+    vm1.invoke(() -> {
+      PartitionAttributesFactory<String, String> partitionAttributesFactory =
+          new PartitionAttributesFactory<>();
+      partitionAttributesFactory.setRedundantCopies(1);
+      partitionAttributesFactory.setTotalNumBuckets(1);
+
+      AttributesFactory<String, String> attributesFactory = new AttributesFactory<>();
+      attributesFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+      RegionFactory<String, String> regionFactory =
+          getCache().createRegionFactory(attributesFactory.create());
+      Region<String, String> region = regionFactory.create("prRegion");
+
+      region.put("testKey", "testValue2");
+
+      getCache().close();
+
+      // Restart
+      regionFactory = getCache().createRegionFactory(attributesFactory.create());
+      regionFactory.create("prRegion");
+    });
+
+    // Do a DESTROY in vm0 when delta GII is in progress in vm1 (Hopefully, Not guaranteed).
+    AsyncInvocation destroyDuringDeltaGiiInVM0 = vm0.invokeAsync(() -> {
+      Region<String, String> region = getCache().getRegion("prRegion");
+
+      await().until(() -> region.get("testKey").equals("testValue2"));
+
+      region.destroy("testKey");
+    });
+
+    destroyDuringDeltaGiiInVM0.await();
+
+    vm1.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion("prRegion");
+
+      Region.Entry entry = region.getEntry("testKey", true);
+      RegionEntry regionEntry = ((EntrySnapshot) entry).getRegionEntry();
+      assertThat(regionEntry.getValueInVM(region)).isInstanceOf(Tombstone.class);
+
+      VersionTag tag = regionEntry.getVersionStamp().asVersionTag();
+      assertThat(tag.getEntryVersion()).isEqualTo(3 /* Two puts and a Destroy */);
+    });
+
+    closeCache(vm0);
+    closeCache(vm1);
   }
 
   /**
@@ -548,10 +444,9 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
    * in as part of a GII
    */
   @Test
-  public void testSkipConflictChecksForGIIdEntries() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testSkipConflictChecksForGIIdEntries() throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Create the region in few members to test recovery
     createPersistentRegion(vm0);
@@ -564,27 +459,18 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     closeCache(vm1);
 
     // Reset the entry version in vm0.
-    // This means that if we did a conflict check, vm0's key will have
-    // a lower entry version than vm1, which would cause us to prefer vm1's
-    // value
-    SerializableRunnable createData = new SerializableRunnable("rollEntryVersion") {
+    // This means that if we did a conflict check, vm0's key will have a lower entry version than
+    // vm1, which would cause us to prefer vm1's value
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        LocalRegion region = (LocalRegion) cache.getRegion(REGION_NAME);
-        region.put(0, "value3");
-        RegionEntry entry = region.getRegionEntry(0);
-        entry = region.getRegionEntry(0);
-        // Sneak in and change the version number for an entry to generate
-        // a conflict.
-        VersionTag tag = entry.getVersionStamp().asVersionTag();
-        tag.setEntryVersion(tag.getEntryVersion() - 2);
-        entry.getVersionStamp().setVersions(tag);
-      }
-    };
-
-    vm0.invoke(createData);
+    vm0.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion(regionName);
+      region.put(0, "value3");
+      RegionEntry regionEntry = region.getRegionEntry(0);
+      // Sneak in and change the version number for an entry to generate a conflict.
+      VersionTag tag = regionEntry.getVersionStamp().asVersionTag();
+      tag.setEntryVersion(tag.getEntryVersion() - 2);
+      regionEntry.getVersionStamp().setVersions(tag);
+    });
 
     // Create vm1, doing a GII
     createPersistentRegion(vm1);
@@ -599,10 +485,9 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
    * in as part of a concurrent operation
    */
   @Test
-  public void testSkipConflictChecksForConcurrentOps() throws Throwable {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testSkipConflictChecksForConcurrentOps() throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Create the region in few members to test recovery
     createPersistentRegion(vm0);
@@ -615,50 +500,35 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
 
     closeCache(vm1);
 
-    // Update the keys in vm0 until the entry version rolls over.
-    // This means that if we did a conflict check, vm0's key will have
-    // a lower entry version than vm1, which would cause us to prefer vm1's
-    // value
-    SerializableRunnable createData = new SerializableRunnable("rollEntryVersion") {
+    // Update the keys in vm0 until the entry version rolls over. This means that if we did a
+    // conflict check, vm0's key will have a lower entry version than vm1, which would cause us to
+    // prefer vm1's value
+    vm0.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion(regionName);
+      region.put(0, "value3");
+      RegionEntry regionEntry = region.getRegionEntry(0);
+      // Sneak in and change the version number for an entry to generate a conflict.
+      VersionTag tag = regionEntry.getVersionStamp().asVersionTag();
+      tag.setEntryVersion(tag.getEntryVersion() - 2);
+      regionEntry.getVersionStamp().setVersions(tag);
+    });
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        LocalRegion region = (LocalRegion) cache.getRegion(REGION_NAME);
-        region.put(0, "value3");
-        RegionEntry entry = region.getRegionEntry(0);
-        entry = region.getRegionEntry(0);
-        // Sneak in and change the version number for an entry to generate
-        // a conflict.
-        VersionTag tag = entry.getVersionStamp().asVersionTag();
-        tag.setEntryVersion(tag.getEntryVersion() - 2);
-        entry.getVersionStamp().setVersions(tag);
-      }
-    };
-    vm0.invoke(createData);
+    // Add an observer to vm0 which will perform a concurrent operation during the GII. If we do a
+    // conflict check, this operation will be rejected because it will have a lower entry version
+    // that what vm1 recovered from disk
+    vm0.invoke(() -> {
+      DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
 
-    // Add an observer to vm0 which will perform a concurrent operation during
-    // the GII. If we do a conflict check, this operation will be rejected
-    // because it will have a lower entry version that what vm1 recovered from
-    // disk
-    vm0.invoke(new SerializableRunnable() {
-      @Override
-      public void run() {
-        DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
-
-          @Override
-          public void beforeProcessMessage(ClusterDistributionManager dm, DistributionMessage msg) {
-            if (msg instanceof InitialImageOperation.RequestImageMessage) {
-              if (((InitialImageOperation.RequestImageMessage) msg).regionPath
-                  .contains(REGION_NAME)) {
-                createData(vm0, 0, 1, "value4");
-                DistributionMessageObserver.setInstance(null);
-              }
+        @Override
+        public void beforeProcessMessage(ClusterDistributionManager dm, DistributionMessage msg) {
+          if (msg instanceof InitialImageOperation.RequestImageMessage) {
+            if (((InitialImageOperation.RequestImageMessage) msg).regionPath.contains(regionName)) {
+              createData(vm0, 0, 1, "value4");
+              DistributionMessageObserver.setInstance(null);
             }
           }
-
-        });
-      }
+        }
+      });
     });
 
     // Create vm1, doing a GII
@@ -673,85 +543,53 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
    * Test that with concurrent updates to an async disk region, we correctly update the RVV On disk
    */
   @Test
-  public void testUpdateRVVWithAsyncPersistence() throws Throwable {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(1);
-
-    SerializableRunnable createRegion = new SerializableRunnable("Create persistent region") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DiskStoreFactory dsf = cache.createDiskStoreFactory();
-        File dir = getDiskDirForVM(vm0);
-        dir.mkdirs();
-        dsf.setDiskDirs(new File[] {dir});
-        dsf.setMaxOplogSize(1);
-        dsf.setQueueSize(100);
-        dsf.setTimeInterval(1000);
-        DiskStore ds = dsf.create(REGION_NAME);
-        RegionFactory rf = new RegionFactory();
-        rf.setDiskStoreName(ds.getName());
-        rf.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-        rf.setScope(Scope.DISTRIBUTED_ACK);
-        rf.setDiskSynchronous(false);
-        rf.create(REGION_NAME);
-      }
-    };
+  public void testUpdateRVVWithAsyncPersistence() throws Exception {
+    VM vm1 = getVM(1);
 
     // Create a region with async persistence
-    vm0.invoke(createRegion);
+    vm1.invoke(() -> createRegionWithAsyncPersistence(vm1));
 
     // In two different threads, perform updates to the same key on the same region
-    AsyncInvocation ins0 = vm0.invokeAsync(new SerializableRunnable("change the entry at vm0") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        for (int i = 0; i < 500; i++) {
-          region.put("A", "vm0-" + i);
-        }
+    AsyncInvocation doPutsInThread1InVM0 = vm1.invokeAsync(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      for (int i = 0; i < 500; i++) {
+        region.put("A", "vm0-" + i);
       }
     });
-    AsyncInvocation ins1 = vm0.invokeAsync(new SerializableRunnable("change the entry at vm1") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        for (int i = 0; i < 500; i++) {
-          region.put("A", "vm1-" + i);
-        }
+
+    AsyncInvocation doPutsInThread2InVM0 = vm1.invokeAsync(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      for (int i = 0; i < 500; i++) {
+        region.put("A", "vm1-" + i);
       }
     });
 
     // Wait for the update threads to finish.
-    ins0.getResult(MAX_WAIT);
-    ins1.getResult(MAX_WAIT);
+    doPutsInThread1InVM0.await();
+    doPutsInThread2InVM0.await();
 
     // Make sure the async queue is flushed to disk
-    vm0.invoke(new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DiskStore ds = cache.findDiskStore(REGION_NAME);
-        ds.flush();
-      }
+    vm1.invoke(() -> {
+      DiskStore diskStore = getCache().findDiskStore(regionName);
+      diskStore.flush();
     });
 
     // Assert that the disk has seen all of the updates
-    RegionVersionVector rvv = getRVV(vm0);
-    RegionVersionVector diskRVV = getDiskRVV(vm0);
+    RegionVersionVector rvv = getRVV(vm1);
+    RegionVersionVector diskRVV = getDiskRVV(vm1);
     assertSameRVV(rvv, diskRVV);
 
     // Bounce the cache and make the same assertion
-    closeCache(vm0);
-    vm0.invoke(createRegion);
+    closeCache(vm1);
+
+    vm1.invoke(() -> createRegionWithAsyncPersistence(vm1));
 
     // Assert that the recovered RVV is the same as before the restart
-    RegionVersionVector rvv2 = getRVV(vm0);
+    RegionVersionVector rvv2 = getRVV(vm1);
     assertSameRVV(rvv, rvv2);
 
     // The disk RVV should also match.
-    RegionVersionVector diskRVV2 = getDiskRVV(vm0);
+    RegionVersionVector diskRVV2 = getDiskRVV(vm1);
     assertSameRVV(rvv2, diskRVV2);
   }
 
@@ -759,12 +597,10 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
    * Test that when we generate a krf, we write the version tag that matches the entry in the crf.
    */
   @Test
-  public void testWriteCorrectVersionToKrf() throws Throwable {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(1);
+  public void testWriteCorrectVersionToKrf() throws Exception {
+    VM vm1 = getVM(1);
 
-    final LocalRegion region = (LocalRegion) createAsyncRegionWithSmallQueue(vm0);
-
+    InternalRegion region = (InternalRegion) createAsyncRegionWithSmallQueue(vm1);
 
     // The idea here is to do a bunch of puts with async persistence
     // At some point the oplog will switch. At that time, we wait for a krf
@@ -777,37 +613,27 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     // and then do the wait in the flusher thread.
 
     // Setup the callbacks to wait for krf creation and throw an exception
-    IgnoredException ex = IgnoredException.addIgnoredException("DiskAccessException");
     LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = true;
-    try {
-      final CountDownLatch krfCreated = new CountDownLatch(1);
-      final AtomicBoolean oplogSwitched = new AtomicBoolean(false);
-      setInstance(new CacheObserverAdapter() {
+    try (IgnoredException e = addIgnoredException(DiskAccessException.class)) {
+      CountDownLatch krfCreated = new CountDownLatch(1);
+      AtomicBoolean oplogSwitched = new AtomicBoolean(false);
 
+      CacheObserverHolder.setInstance(new CacheObserverAdapter() {
 
         @Override
         public void afterKrfCreated() {
           krfCreated.countDown();
         }
 
-
         @Override
         public void afterWritingBytes() {
           if (oplogSwitched.get()) {
-            try {
-              if (!krfCreated.await(3000, SECONDS)) {
-                fail("KRF was not created in 30 seconds!");
-              }
-            } catch (InterruptedException e) {
-              fail("interrupted");
-            }
+            errorCollector
+                .checkSucceeds(() -> assertThat(krfCreated.await(3_000, SECONDS)).isTrue());
 
-            // Force a failure
             throw new DiskAccessException();
           }
         }
-
-
 
         @Override
         public void afterSwitchingOplog() {
@@ -816,8 +642,8 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
       });
 
       // This is just to make sure the first oplog is not completely garbage.
-
       region.put("testkey", "key");
+
       // Do some puts to trigger an oplog roll.
       try {
         // Starting with a value of 1 means the value should match
@@ -834,29 +660,15 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
 
       // Wait for the region to be destroyed. The region won't be destroyed
       // until the async flusher thread ends up switching oplogs
-      GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-
-        @Override
-        public boolean done() {
-          return region.isDestroyed();
-        }
-
-        @Override
-        public String description() {
-          return "Region was not destroyed : " + region.isDestroyed();
-        }
-      });
+      await().until(() -> region.isDestroyed());
       closeCache();
     } finally {
-      ex.remove();
       LocalRegion.ISSUE_CALLBACKS_TO_CACHE_OBSERVER = false;
       CacheObserverHolder.setInstance(null);
     }
 
-
-
     // Get the version tags from the krf
-    LocalRegion recoveredRegion = (LocalRegion) createAsyncRegionWithSmallQueue(vm0);
+    InternalRegion recoveredRegion = (InternalRegion) createAsyncRegionWithSmallQueue(vm1);
     VersionTag[] tagsFromKrf = new VersionTag[3];
     for (int i = 0; i < 3; i++) {
       NonTXEntry entry = (NonTXEntry) recoveredRegion.getEntry("key" + i);
@@ -870,170 +682,183 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     // Set a system property to skip recovering from the krf so we can
     // get the version tag from the crf.
     System.setProperty(DiskStoreImpl.RECOVER_VALUES_SYNC_PROPERTY_NAME, "true");
-    try {
-      // Get the version tags from the crf
-      recoveredRegion = (LocalRegion) createAsyncRegionWithSmallQueue(vm0);
-      VersionTag[] tagsFromCrf = new VersionTag[3];
-      for (int i = 0; i < 3; i++) {
-        NonTXEntry entry = (NonTXEntry) recoveredRegion.getEntry("key" + i);
-        tagsFromCrf[i] = entry.getRegionEntry().getVersionStamp().asVersionTag();
-        LogWriterUtils.getLogWriter()
-            .info("crfTag[" + i + "]=" + tagsFromCrf[i] + ",value=" + entry.getValue());
-      }
 
-      // Make sure the version tags from the krf and the crf match.
-      for (int i = 0; i < 3; i++) {
-        assertEquals(tagsFromCrf[i], tagsFromKrf[i]);
-      }
-    } finally {
-      System.setProperty(DiskStoreImpl.RECOVER_VALUES_SYNC_PROPERTY_NAME, "false");
+    // Get the version tags from the crf
+    recoveredRegion = (InternalRegion) createAsyncRegionWithSmallQueue(vm1);
+    VersionTag[] tagsFromCrf = new VersionTag[3];
+    for (int i = 0; i < 3; i++) {
+      NonTXEntry entry = (NonTXEntry) recoveredRegion.getEntry("key" + i);
+      tagsFromCrf[i] = entry.getRegionEntry().getVersionStamp().asVersionTag();
+      LogWriterUtils.getLogWriter()
+          .info("crfTag[" + i + "]=" + tagsFromCrf[i] + ",value=" + entry.getValue());
+    }
+
+    // Make sure the version tags from the krf and the crf match.
+    for (int i = 0; i < 3; i++) {
+      assertThat(tagsFromKrf[i]).isEqualTo(tagsFromCrf[i]);
     }
   }
 
-  private Region createAsyncRegionWithSmallQueue(final VM vm0) {
-    Cache cache = getCache();
-    DiskStoreFactoryImpl dsf = (DiskStoreFactoryImpl) cache.createDiskStoreFactory();
-    File dir = getDiskDirForVM(vm0);
+  private void createRegionWithAsyncPersistence(VM vm) {
+    File dir = getDiskDirForVM(vm);
     dir.mkdirs();
-    dsf.setDiskDirs(new File[] {dir});
-    dsf.setMaxOplogSizeInBytes(500);
-    dsf.setQueueSize(1000);
-    dsf.setTimeInterval(1000);
-    DiskStore ds = dsf.create(REGION_NAME);
-    RegionFactory rf = new RegionFactory();
-    rf.setDiskStoreName(ds.getName());
-    rf.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-    rf.setScope(Scope.DISTRIBUTED_ACK);
-    rf.setDiskSynchronous(false);
-    Region region = rf.create(REGION_NAME);
-    return region;
+
+    DiskStoreFactory diskStoreFactory = getCache().createDiskStoreFactory();
+    diskStoreFactory.setDiskDirs(new File[] {dir});
+    diskStoreFactory.setMaxOplogSize(1);
+    diskStoreFactory.setQueueSize(100);
+    diskStoreFactory.setTimeInterval(1000);
+
+    DiskStore diskStore = diskStoreFactory.create(regionName);
+
+    RegionFactory regionFactory = new RegionFactory();
+    regionFactory.setDiskStoreName(diskStore.getName());
+    regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+    regionFactory.setScope(Scope.DISTRIBUTED_ACK);
+    regionFactory.setDiskSynchronous(false);
+
+    regionFactory.create(regionName);
   }
 
+  private InternalRegion createRegion(VM vm0) {
+    File dir = getDiskDirForVM(vm0);
+    dir.mkdirs();
 
-  private void deleteKRFs(final VM vm0) {
-    vm0.invoke(new SerializableRunnable() {
-      @Override
-      public void run() {
-        File file = getDiskDirForVM(vm0);
-        File[] krfs = file.listFiles(new FilenameFilter() {
+    DiskStoreFactory diskStoreFactory = getCache().createDiskStoreFactory();
+    diskStoreFactory.setDiskDirs(new File[] {dir});
+    diskStoreFactory.setMaxOplogSize(1);
+    // Turn off automatic compaction
+    diskStoreFactory.setAllowForceCompaction(true);
+    diskStoreFactory.setAutoCompact(false);
+    // The compaction javadocs seem to be wrong. This is the amount of live data in the oplog
+    diskStoreFactory.setCompactionThreshold(40);
 
-          @Override
-          public boolean accept(File dir, String name) {
-            return name.endsWith(".krf");
-          }
-        });
-        assertTrue(krfs.length > 0);
-        for (File krf : krfs) {
-          assertTrue(krf.delete());
-        }
+    DiskStore diskStore = diskStoreFactory.create(regionName);
 
+    RegionFactory regionFactory = new RegionFactory();
+    regionFactory.setDiskStoreName(diskStore.getName());
+    regionFactory.setDiskSynchronous(true);
+    regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+    regionFactory.setScope(Scope.DISTRIBUTED_ACK);
+
+    return (InternalRegion) regionFactory.create(regionName);
+  }
+
+  private int getTombstoneCount(InternalRegion region) {
+    int regionCount = region.getTombstoneCount();
+    int actualCount = 0;
+    for (RegionEntry entry : region.getRegionMap().regionEntries()) {
+      if (entry.isTombstone()) {
+        actualCount++;
+      }
+    }
+
+    assertThat(actualCount).isEqualTo(regionCount);
+
+    return actualCount;
+  }
+
+  private Region createAsyncRegionWithSmallQueue(VM vm0) {
+    File dir = getDiskDirForVM(vm0);
+    dir.mkdirs();
+
+    DiskStoreFactoryImpl diskStoreFactory =
+        (DiskStoreFactoryImpl) getCache().createDiskStoreFactory();
+    diskStoreFactory.setDiskDirs(new File[] {dir});
+    diskStoreFactory.setMaxOplogSizeInBytes(500);
+    diskStoreFactory.setQueueSize(1000);
+    diskStoreFactory.setTimeInterval(1000);
+
+    DiskStore diskStore = diskStoreFactory.create(regionName);
+
+    RegionFactory regionFactory = new RegionFactory();
+    regionFactory.setDiskStoreName(diskStore.getName());
+    regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+    regionFactory.setScope(Scope.DISTRIBUTED_ACK);
+    regionFactory.setDiskSynchronous(false);
+
+    return regionFactory.create(regionName);
+  }
+
+  private void deleteKRFs(VM vm) {
+    vm.invoke(() -> {
+      File file = getDiskDirForVM(vm);
+      File[] krfs = file.listFiles((dir, name) -> name.endsWith(".krf"));
+
+      assertThat(krfs.length).isGreaterThan(0);
+      for (File krf : krfs) {
+        assertThat(krf.delete()).isTrue();
       }
     });
   }
 
-  private void assertSameRVV(RegionVersionVector rvv1, RegionVersionVector rvv2) {
-    if (!rvv1.sameAs(rvv2)) {
-      fail("Expected " + rvv1 + " but was " + rvv2);
-    }
+  private void assertSameRVV(RegionVersionVector expectedRVV, RegionVersionVector actualRVV) {
+    assertThat(expectedRVV.sameAs(actualRVV))
+        .as("Expected " + expectedRVV + " but was " + actualRVV)
+        .isTrue();
   }
 
-  protected void createData(VM vm, final int startKey, final int endKey, final String value) {
-    SerializableRunnable createData = new SerializableRunnable("createData") {
+  private void createData(VM vm, int startKey, int endKey, String value) {
+    vm.invoke(() -> {
+      Region<Integer, String> region = getCache().getRegion(regionName);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-
-        for (int i = startKey; i < endKey; i++) {
-          region.put(i, value);
-        }
+      for (int i = startKey; i < endKey; i++) {
+        region.put(i, value);
       }
-    };
-    vm.invoke(createData);
+    });
   }
 
-  protected void checkData(VM vm0, final int startKey, final int endKey, final String value) {
-    SerializableRunnable checkData = new SerializableRunnable("CheckData") {
+  private void checkData(VM vm, int startKey, int endKey, String value) {
+    vm.invoke(() -> {
+      Region<Integer, String> region = getCache().getRegion(regionName);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-
-        for (int i = startKey; i < endKey; i++) {
-          assertEquals("For key " + i, value, region.get(i));
-        }
+      for (int i = startKey; i < endKey; i++) {
+        assertThat(region.get(i)).as("Value for key " + i).isEqualTo(value);
       }
-    };
-
-    vm0.invoke(checkData);
+    });
   }
 
-  protected void delete(VM vm, final int startKey, final int endKey) {
-    SerializableRunnable createData = new SerializableRunnable("destroy") {
+  protected void delete(VM vm, int startKey, int endKey) {
+    vm.invoke(() -> {
+      Region<Integer, String> region = getCache().getRegion(regionName);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-
-        for (int i = startKey; i < endKey; i++) {
-          region.destroy(i);
-        }
+      for (int i = startKey; i < endKey; i++) {
+        region.destroy(i);
       }
-    };
-    vm.invoke(createData);
+    });
   }
 
-  protected RegionVersionVector getRVV(VM vm) throws IOException, ClassNotFoundException {
-    SerializableCallable createData = new SerializableCallable("getRVV") {
+  private RegionVersionVector getRVV(VM vm) throws IOException, ClassNotFoundException {
+    byte[] result = vm.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion(regionName);
 
-      @Override
-      public Object call() throws Exception {
-        Cache cache = getCache();
-        LocalRegion region = (LocalRegion) cache.getRegion(REGION_NAME);
-        RegionVersionVector rvv = region.getVersionVector();
-        rvv = rvv.getCloneForTransmission();
-        HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
+      RegionVersionVector rvv = region.getVersionVector();
+      rvv = rvv.getCloneForTransmission();
+      HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
 
-        // Using gemfire serialization because
-        // RegionVersionVector is not java serializable
-        DataSerializer.writeObject(rvv, hdos);
-        return hdos.toByteArray();
-      }
-    };
-    byte[] result = (byte[]) vm.invoke(createData);
+      // Using gemfire serialization because RegionVersionVector is not java serializable
+      DataSerializer.writeObject(rvv, hdos);
+      return hdos.toByteArray();
+    });
+
     ByteArrayInputStream bais = new ByteArrayInputStream(result);
     return DataSerializer.readObject(new DataInputStream(bais));
   }
 
-  protected RegionVersionVector getDiskRVV(VM vm) throws IOException, ClassNotFoundException {
-    SerializableCallable createData = new SerializableCallable("getRVV") {
+  private RegionVersionVector getDiskRVV(VM vm) throws IOException, ClassNotFoundException {
+    byte[] result = vm.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion(regionName);
 
-      @Override
-      public Object call() throws Exception {
-        Cache cache = getCache();
-        LocalRegion region = (LocalRegion) cache.getRegion(REGION_NAME);
-        RegionVersionVector rvv = region.getDiskRegion().getRegionVersionVector();
-        rvv = rvv.getCloneForTransmission();
-        HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
+      RegionVersionVector rvv = region.getDiskRegion().getRegionVersionVector();
+      rvv = rvv.getCloneForTransmission();
+      HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
 
-        // Using gemfire serialization because
-        // RegionVersionVector is not java serializable
-        DataSerializer.writeObject(rvv, hdos);
-        return hdos.toByteArray();
-      }
-    };
-    byte[] result = (byte[]) vm.invoke(createData);
+      // Using gemfire serialization because RegionVersionVector is not java serializable
+      DataSerializer.writeObject(rvv, hdos);
+      return hdos.toByteArray();
+    });
+
     ByteArrayInputStream bais = new ByteArrayInputStream(result);
     return DataSerializer.readObject(new DataInputStream(bais));
-  }
-
-  private void resetAckWaitThreshold() {
-    if (SAVED_ACK_WAIT_THRESHOLD != null) {
-      System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "ack_wait_threshold",
-          SAVED_ACK_WAIT_THRESHOLD);
-    }
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
@@ -17,42 +17,42 @@ package org.apache.geode.internal.cache.persistence;
 import static org.apache.geode.admin.AdminDistributedSystemFactory.defineDistributedSystem;
 import static org.apache.geode.admin.AdminDistributedSystemFactory.getDistributedSystem;
 import static org.apache.geode.distributed.ConfigurationProperties.ACK_WAIT_THRESHOLD;
-import static org.apache.geode.test.dunit.Host.getHost;
+import static org.apache.geode.internal.net.SocketCreator.getLocalHost;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
-import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
+import static org.apache.geode.test.dunit.VM.getAllVMs;
+import static org.apache.geode.test.dunit.VM.getController;
 import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.VM.toArray;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.After;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.admin.AdminDistributedSystem;
-import org.apache.geode.admin.AdminDistributedSystemFactory;
-import org.apache.geode.admin.AdminException;
 import org.apache.geode.admin.DistributedSystemConfig;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.CacheTransactionManager;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
@@ -68,9 +68,9 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.LockServiceDestroyedException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
-import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.HeapDataOutputStream;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.AbstractUpdateOperation.AbstractUpdateMessage;
@@ -78,44 +78,51 @@ import org.apache.geode.internal.cache.DestroyRegionOperation.DestroyRegionMessa
 import org.apache.geode.internal.cache.DiskRegion;
 import org.apache.geode.internal.cache.DiskRegionStats;
 import org.apache.geode.internal.cache.DistributedRegion;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InitialImageOperation.RequestImageMessage;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.InternalRegionArguments;
-import org.apache.geode.internal.cache.LocalRegion;
-import org.apache.geode.internal.cache.TXManagerImpl;
-import org.apache.geode.internal.cache.versions.RegionVersionHolder;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
-import org.apache.geode.test.dunit.SerializableCallable;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.WaitCriterion;
+import org.apache.geode.test.dunit.rules.DistributedDiskDirRule;
 import org.apache.geode.test.junit.categories.PersistenceTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableErrorCollector;
 
 /**
  * This is a test of how persistent distributed regions recover. This test makes sure that when
  * multiple VMs are persisting the same region, they recover with the latest data during recovery.
  */
-@Category({PersistenceTest.class})
+@Category(PersistenceTest.class)
+@RunWith(JUnitParamsRunner.class)
 public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBase {
+
+  private static final AtomicBoolean SAW_REQUEST_IMAGE_MESSAGE = new AtomicBoolean();
+
+  private static volatile InternalDistributedSystem system;
+
+  @Rule
+  public DistributedDiskDirRule diskDirRule = new DistributedDiskDirRule();
+
+  @Rule
+  public SerializableErrorCollector errorCollector = new SerializableErrorCollector();
+
+  @After
+  public void tearDown() {
+    for (VM vm : toArray(getAllVMs(), getController())) {
+      vm.invoke(() -> {
+        DistributionMessageObserver.setInstance(null);
+      });
+    }
+    disconnectAllFromDS();
+  }
 
   @Override
   public Properties getDistributedSystemProperties() {
-    LogWriterUtils.getLogWriter().info("Looking for ack-wait-threshold");
-    String s = System.getProperty(DistributionConfig.GEMFIRE_PREFIX + "ack-wait-threshold");
-    if (s != null) {
-      SAVED_ACK_WAIT_THRESHOLD = s;
-      LogWriterUtils.getLogWriter().info("removing system property gemfire.ack-wait-threshold");
-      System.getProperties().remove(DistributionConfig.GEMFIRE_PREFIX + "ack-wait-threshold");
-    }
-    Properties props = super.getDistributedSystemProperties();
-    props.put(ACK_WAIT_THRESHOLD, "5");
-    return props;
+    Properties configProperties = super.getDistributedSystemProperties();
+    configProperties.setProperty(ACK_WAIT_THRESHOLD, "5");
+    return configProperties;
   }
 
   /**
@@ -124,44 +131,26 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testWaitForLatestMember() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
 
     putAnEntry(vm0);
-
-    LogWriterUtils.getLogWriter().info("closing region in vm0");
     closeRegion(vm0);
 
     updateTheEntry(vm1);
-
-    LogWriterUtils.getLogWriter().info("closing region in vm1");
     closeRegion(vm1);
 
-
     // This ought to wait for VM1 to come back
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
-    AsyncInvocation future = createPersistentRegionAsync(vm0);
-
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0);
     waitForBlockedInitialization(vm0);
+    assertThat(createPersistentRegionInVM0.isAlive()).isTrue();
 
-    assertTrue(future.isAlive());
-
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
 
-    future.join(MAX_WAIT);
-    if (future.isAlive()) {
-      fail("Region not created within " + MAX_WAIT);
-    }
-    if (future.exceptionOccurred()) {
-      throw new Exception(future.getException());
-    }
+    createPersistentRegionInVM0.await();
 
     checkForEntry(vm0);
     checkForEntry(vm1);
@@ -175,115 +164,71 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testRevokeAMember() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
 
     putAnEntry(vm0);
 
-    vm0.invoke(new SerializableRunnable("Check for waiting regions") {
-
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        PersistentMemberManager mm = cache.getPersistentMemberManager();
-        Map<String, Set<PersistentMemberID>> waitingRegions = mm.getWaitingRegions();
-        assertEquals(0, waitingRegions.size());
-      }
+    vm0.invoke(() -> {
+      PersistentMemberManager persistentMemberManager = getCache().getPersistentMemberManager();
+      Map<String, Set<PersistentMemberID>> waitingRegions =
+          persistentMemberManager.getWaitingRegions();
+      assertThat(waitingRegions).isEmpty();
     });
 
-    LogWriterUtils.getLogWriter().info("closing region in vm0");
     closeRegion(vm0);
 
     updateTheEntry(vm1);
 
-    LogWriterUtils.getLogWriter().info("closing region in vm1");
     closeCache(vm1);
 
-
     // This ought to wait for VM1 to come back
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
-    AsyncInvocation future = createPersistentRegionAsync(vm0);
-
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0);
     waitForBlockedInitialization(vm0);
+    assertThat(createPersistentRegionInVM0.isAlive()).isTrue();
 
-    assertTrue(future.isAlive());
+    vm2.invoke(() -> {
+      getCache();
+      AdminDistributedSystem adminDS = null;
+      try {
+        DistributedSystemConfig config = defineDistributedSystem(getSystem(), "");
+        adminDS = getDistributedSystem(config);
+        adminDS.connect();
 
-    vm2.invoke(new SerializableRunnable("Revoke the member") {
+        Set<PersistentID> missingIds = adminDS.getMissingPersistentMembers();
+        assertThat(missingIds).hasSize(1);
 
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        DistributedSystemConfig config;
-        AdminDistributedSystem adminDS = null;
-        try {
-          config = AdminDistributedSystemFactory.defineDistributedSystem(getSystem(), "");
-          adminDS = AdminDistributedSystemFactory.getDistributedSystem(config);
-          adminDS.connect();
-          Set<PersistentID> missingIds = adminDS.getMissingPersistentMembers();
-          LogWriterUtils.getLogWriter().info("waiting members=" + missingIds);
-          assertEquals(1, missingIds.size());
-          PersistentID missingMember = missingIds.iterator().next();
-          adminDS.revokePersistentMember(missingMember.getUUID());
-        } catch (AdminException e) {
-          throw new RuntimeException(e);
-        } finally {
-          if (adminDS != null) {
-            adminDS.disconnect();
-          }
+        PersistentID missingMember = missingIds.iterator().next();
+        adminDS.revokePersistentMember(missingMember.getUUID());
+      } finally {
+        if (adminDS != null) {
+          adminDS.disconnect();
         }
       }
     });
 
-    future.join(MAX_WAIT);
-    if (future.isAlive()) {
-      fail("Region not created within" + MAX_WAIT);
-    }
-
-    if (future.exceptionOccurred()) {
-      throw new Exception(future.getException());
-    }
+    createPersistentRegionInVM0.await();
 
     checkForRecoveryStat(vm0, true);
 
+    // Check to make sure we recovered the old value of the entry.
+    vm0.invoke(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      assertThat(region.get("A")).isEqualTo("B");
+    });
 
-
-    // Check to make sure we recovered the old
-    // value of the entry.
-    SerializableRunnable checkForEntry = new SerializableRunnable("check for the entry") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        assertEquals("B", region.get("A"));
-      }
-    };
-    vm0.invoke(checkForEntry);
-
-    // Now, we should not be able to create a region
-    // in vm1, because the this member was revoked
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
-    IgnoredException e =
-        addIgnoredException(RevokedPersistentDataException.class.getSimpleName(), vm1);
-    try {
-      createPersistentRegion(vm1);
-      fail("We should have received a split distributed system exception");
-    } catch (RuntimeException expected) {
-      if (!(expected.getCause() instanceof RevokedPersistentDataException)) {
-        throw expected;
-      }
-    } finally {
-      e.remove();
+    // Now, we should not be able to create a region in vm1, because the this member was revoked
+    try (IgnoredException ignored = addIgnoredException(RevokedPersistentDataException.class)) {
+      Throwable thrown = catchThrowable(() -> createPersistentRegion(vm1));
+      assertThat(thrown).hasRootCauseInstanceOf(RevokedPersistentDataException.class);
     }
 
     closeCache(vm1);
+
     // Restart vm0
     closeCache(vm0);
     createPersistentRegion(vm0);
@@ -295,95 +240,60 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testRevokeAHostBeforeInitialization() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
 
     putAnEntry(vm0);
 
-    vm0.invoke(new SerializableRunnable("Check for waiting regions") {
-
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        PersistentMemberManager mm = cache.getPersistentMemberManager();
-        Map<String, Set<PersistentMemberID>> waitingRegions = mm.getWaitingRegions();
-        assertEquals(0, waitingRegions.size());
-      }
+    vm0.invoke(() -> {
+      PersistentMemberManager persistentMemberManager = getCache().getPersistentMemberManager();
+      Map<String, Set<PersistentMemberID>> waitingRegions =
+          persistentMemberManager.getWaitingRegions();
+      assertThat(waitingRegions).isEmpty();
     });
 
-    LogWriterUtils.getLogWriter().info("closing region in vm0");
     closeRegion(vm0);
 
     updateTheEntry(vm1);
 
-    LogWriterUtils.getLogWriter().info("closing region in vm1");
     closeRegion(vm1);
 
-    final File dirToRevoke = getDiskDirForVM(vm1);
-    vm2.invoke(new SerializableRunnable("Revoke the member") {
-
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        DistributedSystemConfig config;
-        AdminDistributedSystem adminDS = null;
-        try {
-          config = AdminDistributedSystemFactory.defineDistributedSystem(getSystem(), "");
-          adminDS = AdminDistributedSystemFactory.getDistributedSystem(config);
-          adminDS.connect();
-          adminDS.revokePersistentMember(InetAddress.getLocalHost(),
-              dirToRevoke.getCanonicalPath());
-        } catch (Exception e) {
-          Assert.fail("Unexpected exception", e);
-        } finally {
-          if (adminDS != null) {
-            adminDS.disconnect();
-          }
+    File dirToRevoke = getDiskDirForVM(vm1);
+    vm2.invoke(() -> {
+      getCache();
+      AdminDistributedSystem adminDS = null;
+      try {
+        DistributedSystemConfig config = defineDistributedSystem(getSystem(), "");
+        adminDS = getDistributedSystem(config);
+        adminDS.connect();
+        adminDS.revokePersistentMember(getLocalHost(), dirToRevoke.getCanonicalPath());
+      } finally {
+        if (adminDS != null) {
+          adminDS.disconnect();
         }
       }
     });
 
     // This shouldn't wait, because we revoked the member
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
 
     checkForRecoveryStat(vm0, true);
 
-    // Check to make sure we recovered the old
-    // value of the entry.
-    SerializableRunnable checkForEntry = new SerializableRunnable("check for the entry") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        assertEquals("B", region.get("A"));
-      }
-    };
-    vm0.invoke(checkForEntry);
+    // Check to make sure we recovered the old value of the entry.
+    vm0.invoke(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      assertThat(region.get("A")).isEqualTo("B");
+    });
 
     // Now, we should not be able to create a region
     // in vm1, because the this member was revoked
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
-    IgnoredException e =
-        addIgnoredException(RevokedPersistentDataException.class.getSimpleName(), vm1);
-    try {
-      createPersistentRegion(vm1);
-      fail("We should have received a split distributed system exception");
-    } catch (RuntimeException expected) {
-      if (!(expected.getCause() instanceof RevokedPersistentDataException)) {
-        throw expected;
-      }
-      // Do nothing
-    } finally {
-      e.remove();
+    try (IgnoredException e = addIgnoredException(RevokedPersistentDataException.class)) {
+      Throwable thrown = catchThrowable(() -> createPersistentRegion(vm1));
+      assertThat(thrown).hasRootCauseInstanceOf(RevokedPersistentDataException.class);
     }
   }
 
@@ -392,141 +302,81 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testWaitingMemberList() throws Exception {
-    Host host = getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-    VM vm3 = host.getVM(3);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
+    VM vm3 = getVM(3);
 
-    getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
-    getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
     createPersistentRegion(vm2);
 
     putAnEntry(vm0);
 
-    vm0.invoke(new SerializableRunnable("Check for waiting regions") {
-
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        PersistentMemberManager mm = cache.getPersistentMemberManager();
-        Map<String, Set<PersistentMemberID>> waitingRegions = mm.getWaitingRegions();
-        assertEquals(0, waitingRegions.size());
-      }
+    vm0.invoke(() -> {
+      PersistentMemberManager persistentMemberManager = getCache().getPersistentMemberManager();
+      Map<String, Set<PersistentMemberID>> waitingRegions =
+          persistentMemberManager.getWaitingRegions();
+      assertThat(waitingRegions).isEmpty();
     });
 
-    getLogWriter().info("closing region in vm0");
     closeCache(vm0);
 
     updateTheEntry(vm1);
-
-    getLogWriter().info("closing region in vm1");
     closeCache(vm1);
 
     updateTheEntry(vm2, "D");
-
-    getLogWriter().info("closing region in vm2");
     closeCache(vm2);
 
-
     // These ought to wait for VM2 to come back
-    getLogWriter().info("Creating region in VM0");
-    AsyncInvocation future0 = createPersistentRegionAsync(vm0);
-
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0);
     waitForBlockedInitialization(vm0);
-    assertTrue(future0.isAlive());
+    assertThat(createPersistentRegionInVM0.isAlive()).isTrue();
 
-    getLogWriter().info("Creating region in VM1");
-    final AsyncInvocation future1 = createPersistentRegionAsync(vm1);
+    AsyncInvocation createPersistentRegionInVM1 = createPersistentRegionAsync(vm1);
     waitForBlockedInitialization(vm1);
-    assertTrue(future1.isAlive());
+    assertThat(createPersistentRegionInVM1.isAlive()).isTrue();
 
-    vm3.invoke(new SerializableRunnable("check waiting members") {
+    vm3.invoke(() -> {
+      getCache();
+      AdminDistributedSystem adminDS = null;
+      try {
+        DistributedSystemConfig config = defineDistributedSystem(getSystem(), "");
+        adminDS = getDistributedSystem(config);
+        adminDS.connect();
 
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        DistributedSystemConfig config;
-        AdminDistributedSystem adminDS = null;
-        try {
-          config = defineDistributedSystem(getSystem(), "");
-          adminDS = getDistributedSystem(config);
-          adminDS.connect();
-          Set<PersistentID> missingIds = adminDS.getMissingPersistentMembers();
-          getLogWriter().info("waiting members=" + missingIds);
-          assertEquals(1, missingIds.size());
-        } catch (AdminException e) {
-          throw new RuntimeException(e);
-        } finally {
-          if (adminDS != null) {
-            adminDS.disconnect();
-          }
+        Set<PersistentID> missingIds = adminDS.getMissingPersistentMembers();
+        assertThat(missingIds).hasSize(1);
+      } finally {
+        if (adminDS != null) {
+          adminDS.disconnect();
         }
       }
     });
 
-    vm1.invoke(new SerializableRunnable("close cache") {
-
-      @Override
-      public void run() {
-        getCache().close();
-      }
+    vm1.invoke(() -> {
+      getCache().close();
     });
 
-    GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-
-      @Override
-      public boolean done() {
-        return !future1.isAlive();
-      }
-
-      @Override
-      public String description() {
-        return "Waiting for blocked initialization to terminate because the cache was closed.";
-      }
-    });
+    await().until(() -> !createPersistentRegionInVM1.isAlive());
 
     // Now we should be missing 2 members
-    vm3.invoke(new SerializableRunnable("check waiting members again") {
+    vm3.invoke(() -> {
+      getCache();
+      AdminDistributedSystem adminDS = null;
+      try {
+        DistributedSystemConfig config = defineDistributedSystem(getSystem(), "");
+        adminDS = getDistributedSystem(config);
+        adminDS.connect();
 
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        DistributedSystemConfig config;
-        AdminDistributedSystem adminDS = null;
-        try {
-          config = defineDistributedSystem(getSystem(), "");
-          adminDS = getDistributedSystem(config);
-          adminDS.connect();
-          final AdminDistributedSystem connectedDS = adminDS;
-          GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-
-            @Override
-            public String description() {
-              return "Waiting for waiting members to have 2 members";
-            }
-
-            @Override
-            public boolean done() {
-              Set<PersistentID> missingIds;
-              try {
-                missingIds = connectedDS.getMissingPersistentMembers();
-              } catch (AdminException e) {
-                throw new RuntimeException(e);
-              }
-              return 2 == missingIds.size();
-            }
-
-          });
-
-        } catch (AdminException e) {
-          throw new RuntimeException(e);
-        } finally {
-          if (adminDS != null) {
-            adminDS.disconnect();
-          }
+        AdminDistributedSystem connectedDS = adminDS;
+        await().until(() -> {
+          Set<PersistentID> missingIds = connectedDS.getMissingPersistentMembers();
+          return 2 == missingIds.size();
+        });
+      } finally {
+        if (adminDS != null) {
+          adminDS.disconnect();
         }
       }
     });
@@ -536,26 +386,21 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    * Use Case AB are alive A crashes. B crashes. B starts up. It should not wait for A.
    */
   @Test
-  public void testDontWaitForOldMember() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testDoNotWaitForOldMember() throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     createPersistentRegion(vm0);
     createPersistentRegion(vm1);
 
     putAnEntry(vm0);
-
     closeRegion(vm0);
 
     updateTheEntry(vm1);
-
     closeRegion(vm1);
-
 
     // This shouldn't wait for vm0 to come back
     createPersistentRegion(vm1);
-
     checkForEntry(vm1);
 
     checkForRecoveryStat(vm1, true);
@@ -567,18 +412,15 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testSimultaneousCrash() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     createPersistentRegion(vm0);
     createPersistentRegion(vm1);
     putAnEntry(vm0);
     updateTheEntry(vm1);
 
-
-    // Copy the regions as they are with both
-    // members online.
+    // Copy the regions as they are with both members online.
     backupDir(vm0);
     backupDir(vm1);
 
@@ -591,21 +433,13 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
     restoreBackup(vm1);
 
     // This ought to wait for VM1 to come back
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
-    AsyncInvocation future = createPersistentRegionAsync(vm0);
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0);
     waitForBlockedInitialization(vm0);
-    assertTrue(future.isAlive());
+    assertThat(createPersistentRegionInVM0.isAlive()).isTrue();
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
 
-    future.join(MAX_WAIT);
-    if (future.isAlive()) {
-      fail("Region not created within" + MAX_WAIT);
-    }
-    if (future.exceptionOccurred()) {
-      throw new Exception(future.getException());
-    }
+    createPersistentRegionInVM0.await();
 
     checkForEntry(vm0);
     checkForEntry(vm1);
@@ -618,39 +452,34 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testTransmitCrashedMembers() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
     createPersistentRegion(vm0);
     createPersistentRegion(vm1);
 
     putAnEntry(vm0);
-
     closeRegion(vm0);
 
-    // VM 2 should be told about the fact
-    // that VM1 has crashed.
+    // VM 2 should be told about the fact that VM1 has crashed.
     createPersistentRegion(vm2);
 
     updateTheEntry(vm1);
-
     closeRegion(vm1);
 
     closeRegion(vm2);
 
-
     // This ought to wait for VM1 to come back
-    AsyncInvocation future = createPersistentRegionAsync(vm0);
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0);
     waitForBlockedInitialization(vm0);
-    assertTrue(future.isAlive());
+    assertThat(createPersistentRegionInVM0.isAlive()).isTrue();
 
     // VM2 has the most recent data, it should start
     createPersistentRegion(vm2);
 
     // VM0 should be informed that VM2 is older, so it should start
-    future.getResult(MAX_WAIT);
+    createPersistentRegionInVM0.await();
 
     checkForEntry(vm0);
     checkForEntry(vm2);
@@ -660,26 +489,18 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    * Tests that a persistent region cannot recover from a non persistent region.
    */
   @Test
-  public void testRecoverFromNonPeristentRegion() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testRecoverFromNonPersistentRegion() throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     createPersistentRegion(vm0);
     createNonPersistentRegion(vm1);
 
     putAnEntry(vm0);
-
     closeRegion(vm0);
 
-    try {
-      updateTheEntry(vm1);
-      fail("expected PersistentReplicatesOfflineException not thrown");
-    } catch (Exception expected) {
-      if (!(expected.getCause() instanceof PersistentReplicatesOfflineException)) {
-        throw expected;
-      }
-    }
+    Throwable thrown = catchThrowable(() -> updateTheEntry(vm1));
+    assertThat(thrown).hasRootCauseInstanceOf(PersistentReplicatesOfflineException.class);
 
     // This should initialize from vm1
     createPersistentRegion(vm0);
@@ -693,129 +514,72 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
 
   @Test
   public void testFinishIncompleteInitializationNoSend() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Add a hook which will disconnect the DS before sending a prepare message
-    vm1.invoke(new SerializableRunnable() {
+    vm1.invoke(() -> {
+      DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
 
-      @Override
-      public void run() {
-
-        DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
-
-          @Override
-          public void beforeSendMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-            if (message instanceof PrepareNewPersistentMemberMessage) {
-              DistributionMessageObserver.setInstance(null);
-              getSystem().disconnect();
-            }
+        @Override
+        public void beforeSendMessage(ClusterDistributionManager dm,
+            DistributionMessage message) {
+          if (message instanceof PrepareNewPersistentMemberMessage) {
+            DistributionMessageObserver.setInstance(null);
+            getSystem().disconnect();
           }
-
-          @Override
-          public void afterProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-
-          }
-        });
-      }
+        }
+      });
     });
+
     createPersistentRegion(vm0);
 
     putAnEntry(vm0);
     updateTheEntry(vm0);
 
-    try {
-      createPersistentRegion(vm1);
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof DistributedSystemDisconnectedException)) {
-        throw e;
-      }
-    }
+    Throwable thrown = catchThrowable(() -> createPersistentRegion(vm1));
+    assertThat(thrown).hasRootCauseInstanceOf(DistributedSystemDisconnectedException.class);
 
     closeRegion(vm0);
 
     // This wait for VM0 to come back
-    AsyncInvocation async1 = createPersistentRegionAsync(vm1);
-
+    AsyncInvocation createPersistentRegionInVM1 = createPersistentRegionAsync(vm1);
     waitForBlockedInitialization(vm1);
 
     createPersistentRegion(vm0);
 
-    async1.getResult();
+    createPersistentRegionInVM1.await();
 
     checkForEntry(vm1);
 
-    vm0.invoke(new SerializableRunnable("check for offline members") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DistributedRegion region = (DistributedRegion) cache.getRegion(REGION_NAME);
-        PersistentMembershipView view = region.getPersistenceAdvisor().getMembershipView();
-        DiskRegion dr = region.getDiskRegion();
+    vm0.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion(regionName);
+      DiskRegion diskRegion = region.getDiskRegion();
 
-        assertEquals(Collections.emptySet(), dr.getOfflineMembers());
-        assertEquals(1, dr.getOnlineMembers().size());
-      }
+      assertThat(diskRegion.getOfflineMembers()).isEmpty();
+      assertThat(diskRegion.getOnlineMembers()).hasSize(1);
     });
   }
 
-  HashMap<DiskStoreID, RegionVersionHolder<DiskStoreID>> getAllMemberToVersion(
-      RegionVersionVector rvv) {
-    HashMap<DiskStoreID, RegionVersionHolder<DiskStoreID>> allMemberToVersion =
-        new HashMap(rvv.getMemberToVersion());
-    RegionVersionHolder localHolder = rvv.getLocalExceptions().clone();
-    localHolder.setVersion(rvv.getCurrentVersion());
-    allMemberToVersion.put((DiskStoreID) rvv.getOwnerId(), localHolder);
-    return allMemberToVersion;
+  private Object getEntry(VM vm, String key) {
+    return vm.invoke(() -> getCache().getRegion(regionName).get(key));
   }
 
-  protected Object getEntry(VM vm, final String key) {
-    SerializableCallable getEntry = new SerializableCallable("get entry") {
+  private RegionVersionVector getRVV(VM vm) throws IOException, ClassNotFoundException {
+    byte[] result = vm.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion(regionName);
 
-      @Override
-      public Object call() throws Exception {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        return region.get(key);
-      }
-    };
+      RegionVersionVector regionVersionVector = region.getVersionVector();
+      regionVersionVector = regionVersionVector.getCloneForTransmission();
+      HeapDataOutputStream outputStream = new HeapDataOutputStream(Version.CURRENT);
 
-    return (vm.invoke(getEntry));
-  }
+      // Using gemfire serialization because RegionVersionVector is not java serializable
+      DataSerializer.writeObject(regionVersionVector, outputStream);
+      return outputStream.toByteArray();
+    });
 
-  protected RegionVersionVector getRVV(VM vm) throws IOException, ClassNotFoundException {
-    SerializableCallable createData = new SerializableCallable("getRVV") {
-
-      @Override
-      public Object call() throws Exception {
-        Cache cache = getCache();
-        LocalRegion region = (LocalRegion) cache.getRegion(REGION_NAME);
-        RegionVersionVector rvv = region.getVersionVector();
-        rvv = rvv.getCloneForTransmission();
-        HeapDataOutputStream hdos = new HeapDataOutputStream(Version.CURRENT);
-
-        // Using gemfire serialization because
-        // RegionVersionVector is not java serializable
-        DataSerializer.writeObject(rvv, hdos);
-        return hdos.toByteArray();
-      }
-    };
-    byte[] result = (byte[]) vm.invoke(createData);
-    ByteArrayInputStream bais = new ByteArrayInputStream(result);
-    return DataSerializer.readObject(new DataInputStream(bais));
-  }
-
-  @Test
-  public void testPersistConflictOperations() throws Exception {
-    doTestPersistConflictOperations(true);
-  }
-
-  @Test
-  public void testPersistConflictOperationsAsync() throws Exception {
-    doTestPersistConflictOperations(false);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(result);
+    return DataSerializer.readObject(new DataInputStream(inputStream));
   }
 
   /**
@@ -824,17 +588,106 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    * message. One of the member will persist the conflict version tag, while another member will
    * persist both of the 2 operations. Overall, their RVV should match after the operations.
    */
-  private void doTestPersistConflictOperations(boolean diskSync) throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  @Test
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}({params})")
+  public void testPersistConflictOperations(boolean diskSync) throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
-    // Add a hook which will disconnect the DS before sending a prepare message
-    SerializableRunnable addObserver = new SerializableRunnable() {
+    vm0.invoke(() -> addSleepBeforeSendAbstractUpdateMessage());
+    vm1.invoke(() -> addSleepBeforeSendAbstractUpdateMessage());
+
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0, diskSync);
+    AsyncInvocation createPersistentRegionInVM1 = createPersistentRegionAsync(vm1, diskSync);
+    createPersistentRegionInVM0.await();
+    createPersistentRegionInVM1.await();
+
+    AsyncInvocation putInVM0 = vm0.invokeAsync(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      region.put("A", "vm0");
+    });
+    AsyncInvocation putInVM1 = vm1.invokeAsync(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      region.put("A", "vm1");
+    });
+    putInVM0.await();
+    putInVM1.await();
+
+    RegionVersionVector rvv0 = getRVV(vm0);
+    RegionVersionVector rvv1 = getRVV(vm1);
+    assertSameRVV(rvv1, rvv0);
+
+    Object value0 = getEntry(vm0, "A");
+    Object value1 = getEntry(vm1, "A");
+    assertThat(value1).isEqualTo(value0);
+
+    closeRegion(vm0);
+    closeRegion(vm1);
+
+    // recover
+    createPersistentRegionInVM1 = createPersistentRegionAsync(vm1, diskSync);
+    createPersistentRegionInVM0 = createPersistentRegionAsync(vm0, diskSync);
+    createPersistentRegionInVM1.await();
+    createPersistentRegionInVM0.await();
+
+    value0 = getEntry(vm0, "A");
+    value1 = getEntry(vm1, "A");
+    assertThat(value1).isEqualTo(value0);
+
+    rvv0 = getRVV(vm0);
+    rvv1 = getRVV(vm1);
+    assertSameRVV(rvv1, rvv0);
+
+    // round 2: async disk write
+    vm0.invoke(() -> addSleepBeforeSendAbstractUpdateMessage());
+    vm1.invoke(() -> addSleepBeforeSendAbstractUpdateMessage());
+
+    putInVM0 = vm0.invokeAsync(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      for (int i = 0; i < 1000; i++) {
+        region.put("A", "vm0-" + i);
+      }
+    });
+    putInVM1 = vm1.invokeAsync(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      for (int i = 0; i < 1000; i++) {
+        region.put("A", "vm1-" + i);
+      }
+    });
+    putInVM0.await();
+    putInVM1.await();
+
+    rvv0 = getRVV(vm0);
+    rvv1 = getRVV(vm1);
+    assertSameRVV(rvv1, rvv0);
+
+    value0 = getEntry(vm0, "A");
+    value1 = getEntry(vm1, "A");
+    assertThat(value1).isEqualTo(value0);
+
+    closeCache(vm0);
+    closeCache(vm1);
+
+    // recover again
+    createPersistentRegionInVM1 = createPersistentRegionAsync(vm1, diskSync);
+    createPersistentRegionInVM0 = createPersistentRegionAsync(vm0, diskSync);
+    createPersistentRegionInVM1.await();
+    createPersistentRegionInVM0.await();
+
+    value0 = getEntry(vm0, "A");
+    value1 = getEntry(vm1, "A");
+    assertThat(value1).isEqualTo(value0);
+
+    rvv0 = getRVV(vm0);
+    rvv1 = getRVV(vm1);
+    assertSameRVV(rvv1, rvv0);
+  }
+
+  private SerializableRunnable addSleepBeforeSendAbstractUpdateMessage() {
+    return new SerializableRunnable() {
       @Override
       public void run() {
-        // System.setProperty("disk.TRACE_WRITES", "true");
-        // System.setProperty("disk.TRACE_RECOVERY", "true");
         DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
 
           @Override
@@ -843,9 +696,8 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
             if (message instanceof AbstractUpdateMessage) {
               try {
                 Thread.sleep(2000);
-                getCache().getLogger().info("testPersistConflictOperations, beforeSendMessage");
               } catch (InterruptedException e) {
-                e.printStackTrace();
+                errorCollector.addError(e);
               }
             }
           }
@@ -854,119 +706,12 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
           public void afterProcessMessage(ClusterDistributionManager dm,
               DistributionMessage message) {
             if (message instanceof AbstractUpdateMessage) {
-              getCache().getLogger().info("testPersistConflictOperations, beforeSendMessage");
               DistributionMessageObserver.setInstance(null);
             }
           }
         });
       }
     };
-    vm0.invoke(addObserver);
-    vm1.invoke(addObserver);
-
-    AsyncInvocation future0 = createPersistentRegionAsync(vm0, diskSync);
-    AsyncInvocation future1 = createPersistentRegionAsync(vm1, diskSync);
-    future0.join(MAX_WAIT);
-    future1.join(MAX_WAIT);
-    // createPersistentRegion(vm0);
-    // createPersistentRegion(vm1);
-
-    AsyncInvocation ins0 = vm0.invokeAsync(new SerializableRunnable("change the entry") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        region.put("A", "vm0");
-      }
-    });
-    AsyncInvocation ins1 = vm1.invokeAsync(new SerializableRunnable("change the entry") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        region.put("A", "vm1");
-      }
-    });
-    ins0.join(MAX_WAIT);
-    ins1.join(MAX_WAIT);
-
-    RegionVersionVector rvv0 = getRVV(vm0);
-    RegionVersionVector rvv1 = getRVV(vm1);
-    assertSameRVV(rvv1, rvv0);
-
-
-    Object value0 = getEntry(vm0, "A");
-    Object value1 = getEntry(vm1, "A");
-    assertEquals(value0, value1);
-
-    closeRegion(vm0);
-    closeRegion(vm1);
-
-    // recover
-    future1 = createPersistentRegionAsync(vm1, diskSync);
-    future0 = createPersistentRegionAsync(vm0, diskSync);
-    future1.join(MAX_WAIT);
-    future0.join(MAX_WAIT);
-
-    value0 = getEntry(vm0, "A");
-    value1 = getEntry(vm1, "A");
-    assertEquals(value0, value1);
-
-    rvv0 = getRVV(vm0);
-    rvv1 = getRVV(vm1);
-    assertSameRVV(rvv1, rvv0);
-
-    // round 2: async disk write
-    vm0.invoke(addObserver);
-    vm1.invoke(addObserver);
-
-    ins0 = vm0.invokeAsync(new SerializableRunnable("change the entry at vm0") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        for (int i = 0; i < 1000; i++) {
-          region.put("A", "vm0-" + i);
-        }
-      }
-    });
-    ins1 = vm1.invokeAsync(new SerializableRunnable("change the entry at vm1") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        for (int i = 0; i < 1000; i++) {
-          region.put("A", "vm1-" + i);
-        }
-      }
-    });
-    ins0.join(MAX_WAIT);
-    ins1.join(MAX_WAIT);
-
-    rvv0 = getRVV(vm0);
-    rvv1 = getRVV(vm1);
-    assertSameRVV(rvv1, rvv0);
-
-    value0 = getEntry(vm0, "A");
-    value1 = getEntry(vm1, "A");
-    assertEquals(value0, value1);
-
-    closeCache(vm0);
-    closeCache(vm1);
-
-    // recover again
-    future1 = createPersistentRegionAsync(vm1, diskSync);
-    future0 = createPersistentRegionAsync(vm0, diskSync);
-    future1.join(MAX_WAIT);
-    future0.join(MAX_WAIT);
-
-    value0 = getEntry(vm0, "A");
-    value1 = getEntry(vm1, "A");
-    assertEquals(value0, value1);
-
-    rvv0 = getRVV(vm0);
-    rvv1 = getRVV(vm1);
-    assertSameRVV(rvv1, rvv0);
   }
 
   /**
@@ -975,11 +720,10 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    * recovery.
    */
   @Test
-  public void testTransmitCrashedMembersWithNonPeristentRegion() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+  public void testTransmitCrashedMembersWithNonPersistentRegion() throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
     createPersistentRegion(vm0);
     createNonPersistentRegion(vm1);
@@ -988,30 +732,25 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
 
     closeRegion(vm0);
 
-    // VM 2 should not do a GII from vm1,
-    // it should wait for vm0
-    AsyncInvocation future = createPersistentRegionWithWait(vm2);
+    // VM 2 should not do a GII from vm1, it should wait for vm0
+    AsyncInvocation createPersistentRegionInVM2 = createPersistentRegionWithWait(vm2);
 
     createPersistentRegion(vm0);
 
-    future.getResult(MAX_WAIT);
+    createPersistentRegionInVM2.await();
 
     closeRegion(vm0);
 
     updateTheEntry(vm1);
 
     closeRegion(vm1);
-
     closeRegion(vm2);
-
 
     // VM2 has the most recent data, it should start
     createPersistentRegion(vm2);
 
-    // VM0 should be informed that it has older data than VM2, so
-    // it should initialize from vm2
+    // VM0 should be informed that it has older data than VM2, so it should initialize from vm2
     createPersistentRegion(vm0);
-
 
     checkForEntry(vm0);
     checkForEntry(vm2);
@@ -1019,40 +758,26 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
 
   @Test
   public void testSplitBrain() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     createPersistentRegion(vm0);
-
     putAnEntry(vm0);
-
     closeRegion(vm0);
 
     createPersistentRegion(vm1);
-
     updateTheEntry(vm1);
-
     closeRegion(vm1);
-
 
     // VM0 doesn't know that VM1 ever existed
     // so it will start up.
     createPersistentRegion(vm0);
 
-    IgnoredException e =
-        addIgnoredException(ConflictingPersistentDataException.class.getSimpleName(), vm1);
-    try {
+    try (IgnoredException e = addIgnoredException(ConflictingPersistentDataException.class)) {
       // VM1 should not start up, because we should detect that vm1
       // was never in the same distributed system as vm0
-      createPersistentRegion(vm1);
-      fail("Should have thrown an exception, vm1 is from a 'different' distributed system");
-    } catch (RuntimeException ok) {
-      if (!(ok.getCause() instanceof ConflictingPersistentDataException)) {
-        throw ok;
-      }
-    } finally {
-      e.remove();
+      Throwable thrown = catchThrowable(() -> createPersistentRegion(vm1));
+      assertThat(thrown).hasRootCauseInstanceOf(ConflictingPersistentDataException.class);
     }
   }
 
@@ -1062,97 +787,72 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testCrashDuringGII() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
 
     putAnEntry(vm0);
-
-    LogWriterUtils.getLogWriter().info("closing region in vm0");
     closeRegion(vm0);
 
     updateTheEntry(vm1);
-
-    LogWriterUtils.getLogWriter().info("closing region in vm1");
     closeRegion(vm1);
 
-
     // This ought to wait for VM1 to come back
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
-    AsyncInvocation future = createPersistentRegionAsync(vm0);
-
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0);
     waitForBlockedInitialization(vm0);
+    assertThat(createPersistentRegionInVM0.isAlive()).isTrue();
 
-    assertTrue(future.isAlive());
+    // Add a hook which will disconnect from the system when the initial image message shows up.
+    vm1.invoke(() -> {
+      SAW_REQUEST_IMAGE_MESSAGE.set(false);
 
-    // Add a hook which will disconnect from the distributed
-    // system when the initial image message shows up.
-    vm1.invoke(new SerializableRunnable() {
+      DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
 
-      @Override
-      public void run() {
-        sawRequestImageMessage.set(false);
-
-        DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
-
-          @Override
-          public void beforeProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-            if (message instanceof RequestImageMessage) {
-              DistributionMessageObserver.setInstance(null);
-              disconnectFromDS();
-              synchronized (sawRequestImageMessage) {
-                sawRequestImageMessage.set(true);
-                sawRequestImageMessage.notifyAll();
-              }
+        @Override
+        public void beforeProcessMessage(ClusterDistributionManager dm,
+            DistributionMessage message) {
+          if (message instanceof RequestImageMessage) {
+            DistributionMessageObserver.setInstance(null);
+            disconnectFromDS();
+            synchronized (SAW_REQUEST_IMAGE_MESSAGE) {
+              SAW_REQUEST_IMAGE_MESSAGE.set(true);
+              SAW_REQUEST_IMAGE_MESSAGE.notifyAll();
             }
           }
+        }
 
-          @Override
-          public void afterProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
+        @Override
+        public void afterProcessMessage(ClusterDistributionManager dm,
+            DistributionMessage message) {
 
-          }
-        });
-      }
+        }
+      });
     });
 
     createPersistentRegion(vm1);
 
-    vm1.invoke(new SerializableRunnable() {
-      @Override
-      public void run() {
-        synchronized (sawRequestImageMessage) {
-          try {
-            while (!sawRequestImageMessage.get()) {
-              sawRequestImageMessage.wait();
-            }
-          } catch (InterruptedException ex) {
+    vm1.invoke(() -> {
+      synchronized (SAW_REQUEST_IMAGE_MESSAGE) {
+        try {
+          while (!SAW_REQUEST_IMAGE_MESSAGE.get()) {
+            SAW_REQUEST_IMAGE_MESSAGE.wait();
           }
+        } catch (InterruptedException e) {
+          errorCollector.addError(e);
         }
       }
     });
 
     waitForBlockedInitialization(vm0);
-
-    assertTrue(future.isAlive());
+    assertThat(createPersistentRegionInVM0.isAlive()).isTrue();
 
     // Now create the region again. The initialization should
     // work (the observer was cleared when we disconnected from the DS.
-    createPersistentRegion(vm1);;
+    createPersistentRegion(vm1);
 
-    future.join(MAX_WAIT);
-    if (future.isAlive()) {
-      fail("Region not created within" + MAX_WAIT);
-    }
-    if (future.exceptionOccurred()) {
-      throw new Exception(future.getException());
-    }
+    createPersistentRegionInVM0.await();
 
     checkForEntry(vm0);
     checkForEntry(vm1);
@@ -1167,106 +867,54 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testGIIDuringDestroy() throws Exception {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(0);
-    final VM vm1 = host.getVM(1);
-    final VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
 
     // Add a hook which will disconnect from the distributed
     // system when the initial image message shows up.
-    vm1.invoke(new SerializableRunnable() {
+    vm1.invoke(() -> {
+      DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
 
-      @Override
-      public void run() {
-
-        DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
-
-          @Override
-          public void beforeProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-            if (message instanceof DestroyRegionMessage) {
-              createPersistentRegionAsync(vm2);
-              try {
-                Thread.sleep(10000);
-              } catch (InterruptedException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-              } finally {
-                DistributionMessageObserver.setInstance(null);
-              }
+        @Override
+        public void beforeProcessMessage(ClusterDistributionManager dm,
+            DistributionMessage message) {
+          if (message instanceof DestroyRegionMessage) {
+            createPersistentRegionAsync(vm2);
+            try {
+              Thread.sleep(10_000);
+            } catch (InterruptedException e) {
+              errorCollector.addError(e);
+            } finally {
+              DistributionMessageObserver.setInstance(null);
             }
           }
-
-          @Override
-          public void afterProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-
-          }
-
-          @Override
-          public void beforeSendMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {}
-        });
-      }
+        }
+      });
     });
 
     createPersistentRegion(vm1);
 
-    vm0.invoke(new SerializableRunnable("Destroy region") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        region.destroyRegion();
-      }
+    vm0.invoke(() -> {
+      getCache().getRegion(regionName).destroyRegion();
     });
 
 
-    vm1.invoke(new SerializableRunnable("check destroyed") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        assertNull(cache.getRegion(REGION_NAME));
-      }
+    vm1.invoke(() -> {
+      assertThat(getCache().getRegion(regionName)).isNull();
     });
 
-    vm2.invoke(new SerializableRunnable("Wait for region creation") {
-
-      @Override
-      public void run() {
-        final Cache cache = getCache();
-        GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-
-          @Override
-          public String description() {
-            return "Waiting for creation of region " + REGION_NAME;
-          }
-
-          @Override
-          public boolean done() {
-            Region region = cache.getRegion(REGION_NAME);
-            return region != null;
-          }
-
-        });
-      }
+    vm2.invoke(() -> {
+      Cache cache = getCache();
+      await().until(() -> cache.getRegion(regionName) != null);
     });
 
-    vm2.invoke(new SerializableRunnable("Check offline members") {
-
-      @Override
-      public void run() {
-        final Cache cache = getCache();
-        DistributedRegion region = (DistributedRegion) cache.getRegion(REGION_NAME);
-        PersistenceAdvisor persistAdvisor = region.getPersistenceAdvisor();
-        assertEquals(Collections.emptySet(),
-            persistAdvisor.getMembershipView().getOfflineMembers());
-      }
+    vm2.invoke(() -> {
+      DistributedRegion region = (DistributedRegion) getCache().getRegion(regionName);
+      PersistenceAdvisor persistAdvisor = region.getPersistenceAdvisor();
+      assertThat(persistAdvisor.getMembershipView().getOfflineMembers()).isEmpty();
     });
   }
 
@@ -1280,36 +928,34 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
 
     // Add a hook which will disconnect from the distributed
     // system when the initial image message shows up.
-    vm0.invoke(new SerializableRunnable() {
-      @Override
-      public void run() {
-        DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
-          @Override
-          public void beforeProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-            if (message instanceof PrepareNewPersistentMemberMessage) {
-              DistributionMessageObserver.setInstance(null);
-              disconnectFromDS();
-            }
+    vm0.invoke(() -> {
+      DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
+        @Override
+        public void beforeProcessMessage(ClusterDistributionManager dm,
+            DistributionMessage message) {
+          if (message instanceof PrepareNewPersistentMemberMessage) {
+            DistributionMessageObserver.setInstance(null);
+            system = dm.getSystem();
+            disconnectFromDS();
           }
-        });
-      }
+        }
+      });
     });
 
     createPersistentRegion(vm0);
     putAnEntry(vm0);
     updateTheEntry(vm0);
 
-    AsyncInvocation async1 = createPersistentRegionAsync(vm1);
-
-    // Wait for vm 1 to get stuck waiting for vm0, because vm0 has crashed
+    AsyncInvocation createPersistentRegionInVM1 = createPersistentRegionAsync(vm1);
     waitForBlockedInitialization(vm1);
-
-    // closeCache(vm0);
     closeCache(vm1);
 
-    Throwable thrown = catchThrowable(() -> async1.await());
+    Throwable thrown = catchThrowable(() -> createPersistentRegionInVM1.await());
     assertThat(thrown).hasRootCauseInstanceOf(CacheClosedException.class);
+
+    vm0.invoke(() -> {
+      await().until(() -> system != null && system.isDisconnected());
+    });
 
     createPersistentRegion(vm0);
     createPersistentRegion(vm1);
@@ -1320,86 +966,51 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
 
   @Test
   public void testSplitBrainWithNonPersistentRegion() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     createPersistentRegion(vm1);
-
     putAnEntry(vm1);
     updateTheEntry(vm1);
-
     closeRegion(vm1);
 
     createNonPersistentRegion(vm0);
 
-    IgnoredException e =
-        addIgnoredException(IllegalStateException.class.getSimpleName(), vm1);
-    try {
-      createPersistentRegion(vm1);
-      fail("Should have received an IllegalState exception");
-    } catch (Exception expected) {
-      if (!(expected.getCause() instanceof IllegalStateException)) {
-        throw expected;
-      }
-    } finally {
-      e.remove();
+    try (IgnoredException e = addIgnoredException(IllegalStateException.class)) {
+      Throwable thrown = catchThrowable(() -> createPersistentRegion(vm1));
+      assertThat(thrown).hasRootCauseInstanceOf(IllegalStateException.class);
     }
 
     closeRegion(vm0);
 
     createPersistentRegion(vm1);
-
     checkForEntry(vm1);
-
     checkForRecoveryStat(vm1, true);
   }
 
   @Test
   public void testMissingEntryOnDisk() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Add a hook which will perform some updates while the region is initializing
-    vm0.invoke(new SerializableRunnable() {
+    vm0.invoke(() -> {
+      DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
 
-      @Override
-      public void run() {
+        @Override
+        public void beforeProcessMessage(ClusterDistributionManager dm,
+            DistributionMessage message) {
+          if (message instanceof RequestImageMessage) {
+            Region<String, String> region = getCache().getRegion(regionName);
 
-        DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
+            errorCollector.checkSucceeds(() -> assertThat(region).isNotNull());
 
-          @Override
-          public void beforeProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-            if (message instanceof RequestImageMessage) {
-              Cache cache = getCache();
-              Region region = cache.getRegion(REGION_NAME);
-              if (region == null) {
-                LogWriterUtils.getLogWriter().severe(
-                    "removing listener for PersistentRecoveryOrderDUnitTest because region was not found: "
-                        + REGION_NAME);
-                Object old = DistributionMessageObserver.setInstance(null);
-                if (old != this) {
-                  LogWriterUtils.getLogWriter().severe(
-                      "removed listener was not the invoked listener",
-                      new Exception("stack trace"));
-                }
-                return;
-              }
-              region.put("A", "B");
-              region.destroy("A");
-              region.put("A", "C");
-            }
+            region.put("A", "B");
+            region.destroy("A");
+            region.put("A", "C");
           }
-
-          @Override
-          public void afterProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-
-          }
-        });
-      }
+        }
+      });
     });
     createPersistentRegion(vm0);
 
@@ -1422,198 +1033,159 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    *
    */
   @Test
-  public void testCompactFromAdmin() throws Exception {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+  public void testCompactFromAdmin() {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
     createPersistentRegionWithoutCompaction(vm0);
     createPersistentRegionWithoutCompaction(vm1);
 
-    vm1.invoke(new SerializableRunnable("Create some data") {
+    vm1.invoke(() -> {
+      Region region = getCache().getRegion(regionName);
 
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        for (int i = 0; i < 1024; i++) {
-          region.put(i, new byte[1024]);
-        }
-
-        for (int i = 2; i < 1024; i++) {
-          assertTrue(region.destroy(i) != null);
-        }
-        DiskStore store = cache.findDiskStore(REGION_NAME);
-        store.forceRoll();
+      for (int i = 0; i < 1024; i++) {
+        region.put(i, new byte[1024]);
       }
+
+      for (int i = 2; i < 1024; i++) {
+        assertThat(region.destroy(i) != null).isTrue();
+      }
+
+      DiskStore store = cache.findDiskStore(regionName);
+      store.forceRoll();
     });
 
-    vm2.invoke(new SerializableRunnable("Compact") {
+    vm2.invoke(() -> {
+      getCache();
+      AdminDistributedSystem adminDS = null;
+      try {
+        DistributedSystemConfig config = defineDistributedSystem(getSystem(), "");
+        adminDS = getDistributedSystem(config);
+        adminDS.connect();
 
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        DistributedSystemConfig config;
-        AdminDistributedSystem adminDS = null;
-        try {
-          config = AdminDistributedSystemFactory.defineDistributedSystem(getSystem(), "");
-          adminDS = AdminDistributedSystemFactory.getDistributedSystem(config);
-          adminDS.connect();
-          Map<DistributedMember, Set<PersistentID>> missingIds = adminDS.compactAllDiskStores();
-          assertEquals(2, missingIds.size());
-          for (Set<PersistentID> value : missingIds.values()) {
-            assertEquals(1, value.size());
-          }
-        } catch (AdminException e) {
-          throw new RuntimeException(e);
-        } finally {
-          if (adminDS != null) {
-            adminDS.disconnect();
-          }
+        Map<DistributedMember, Set<PersistentID>> missingIds = adminDS.compactAllDiskStores();
+        assertThat(missingIds).hasSize(2);
+
+        for (Set<PersistentID> value : missingIds.values()) {
+          assertThat(value).hasSize(1);
+        }
+      } finally {
+        if (adminDS != null) {
+          adminDS.disconnect();
         }
       }
     });
 
-    SerializableRunnable compactVM = new SerializableRunnable("compact") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DiskStore ds = cache.findDiskStore(REGION_NAME);
-        assertFalse(ds.forceCompaction());
-      }
-    };
-
-    vm0.invoke(compactVM);
-    vm1.invoke(compactVM);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        DiskStore diskStore = getCache().findDiskStore(regionName);
+        assertThat(diskStore.forceCompaction()).isFalse();
+      });
+    }
   }
 
   @Test
   public void testCloseDuringRegionOperation() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     createPersistentRegion(vm0);
     createPersistentRegion(vm1);
 
     // Try to make sure there are some operations in flight while closing the cache
-    SerializableCallable createData0 = new SerializableCallable() {
 
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-
-        int i = 0;
-        while (true) {
-          try {
-            region.put(0, i);
-            i++;
-          } catch (RegionDestroyedException e) {
-            break;
-          } catch (CacheClosedException e) {
-            break;
-          }
+    AsyncInvocation<Integer> createDataInVM0 = vm0.invokeAsync(() -> {
+      Region<Integer, Integer> region = getCache().getRegion(regionName);
+      int i = 0;
+      while (true) {
+        try {
+          region.put(0, i);
+          i++;
+        } catch (CacheClosedException | RegionDestroyedException e) {
+          break;
         }
-        return i - 1;
       }
-    };
+      return i - 1;
+    });
 
-    SerializableCallable createData1 = new SerializableCallable() {
-
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-
-        int i = 0;
-        while (true) {
-          try {
-            region.put(1, i);
-            i++;
-          } catch (RegionDestroyedException e) {
-            break;
-          } catch (CacheClosedException e) {
-            break;
-          }
+    AsyncInvocation<Integer> createDataInVM1 = vm1.invokeAsync(() -> {
+      Region<Integer, Integer> region = getCache().getRegion(regionName);
+      int i = 0;
+      while (true) {
+        try {
+          region.put(1, i);
+          i++;
+        } catch (CacheClosedException | RegionDestroyedException e) {
+          break;
         }
-        return i - 1;
       }
-    };
-
-    AsyncInvocation asyncCreate0 = vm0.invokeAsync(createData0);
-    AsyncInvocation asyncCreate1 = vm1.invokeAsync(createData1);
+      return i - 1;
+    });
 
     Thread.sleep(500);
 
-    AsyncInvocation close0 = closeCacheAsync(vm0);
-    AsyncInvocation close1 = closeCacheAsync(vm1);
+    AsyncInvocation closeCacheInVM0 = closeCacheAsync(vm0);
+    AsyncInvocation closeCacheInVM1 = closeCacheAsync(vm1);
 
     // wait for the close to finish
-    close0.getResult();
-    close1.getResult();
+    closeCacheInVM0.await();
+    closeCacheInVM1.await();
 
-    Integer lastSuccessfulInt0 = (Integer) asyncCreate0.getResult();
-    Integer lastSuccessfulInt1 = (Integer) asyncCreate1.getResult();
-    System.err
-        .println("Cache was closed on 0->" + lastSuccessfulInt0 + ",1->" + lastSuccessfulInt1);
+    int lastSuccessfulCreateInVM0 = createDataInVM0.get();
+    int lastSuccessfulCreateInVM1 = createDataInVM1.get();
 
-    AsyncInvocation create1 = createPersistentRegionAsync(vm0);
-    AsyncInvocation create2 = createPersistentRegionAsync(vm1);
+    AsyncInvocation createPersistentRegionInVM0 = createPersistentRegionAsync(vm0);
+    AsyncInvocation createPersistentRegionInVM1 = createPersistentRegionAsync(vm1);
 
-    create1.getResult();
-    create2.getResult();
+    createPersistentRegionInVM0.await();
+    createPersistentRegionInVM1.await();
 
-    checkConcurrentCloseValue(vm0, vm1, 0, lastSuccessfulInt0);
-    checkConcurrentCloseValue(vm0, vm1, 1, lastSuccessfulInt1);
+    checkConcurrentCloseValue(vm0, vm1, 0, lastSuccessfulCreateInVM0);
+    checkConcurrentCloseValue(vm0, vm1, 1, lastSuccessfulCreateInVM1);
   }
 
   @Ignore("TODO: Disabled due to bug #52240")
   @Test
   public void testCloseDuringRegionOperationWithTX() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    createInternalPersistentRegionAsync(vm0).getResult();
-    createInternalPersistentRegionAsync(vm1).getResult();
-    createInternalPersistentRegionAsync(vm2).getResult();
+    createInternalPersistentRegionAsync(vm0).await();
+    createInternalPersistentRegionAsync(vm1).await();
+    createInternalPersistentRegionAsync(vm2).await();
 
-
-    AsyncInvocation asyncCreate0 = createDataAsyncTX(vm0, 0);
-    AsyncInvocation asyncCreate1 = createDataAsyncTX(vm0, 1);
-    AsyncInvocation asyncCreate2 = createDataAsyncTX(vm0, 2);
+    AsyncInvocation<Integer> createDataInVM0 = createDataAsyncTX(vm0, 0);
+    AsyncInvocation<Integer> createDataInVM1 = createDataAsyncTX(vm0, 1);
+    AsyncInvocation<Integer> createDataInVM2 = createDataAsyncTX(vm0, 2);
 
     Thread.sleep(500);
 
-    AsyncInvocation close0 = closeCacheAsync(vm0);
-    AsyncInvocation close1 = closeCacheAsync(vm1);
-    AsyncInvocation close2 = closeCacheAsync(vm2);
+    AsyncInvocation closeCacheInVM0 = closeCacheAsync(vm0);
+    AsyncInvocation closeCacheInVM1 = closeCacheAsync(vm1);
+    AsyncInvocation closeCacheInVM2 = closeCacheAsync(vm2);
 
     // wait for the close to finish
-    close0.getResult();
-    close1.getResult();
-    close2.getResult();
+    closeCacheInVM0.await();
+    closeCacheInVM1.await();
+    closeCacheInVM2.await();
 
-    Integer lastSuccessfulInt0 = (Integer) asyncCreate0.getResult();
-    Integer lastSuccessfulInt1 = (Integer) asyncCreate1.getResult();
-    Integer lastSuccessfulInt2 = (Integer) asyncCreate2.getResult();
-    System.err.println("Cache was closed on 0->" + lastSuccessfulInt0 + ",1->" + lastSuccessfulInt1
-        + ",2->" + lastSuccessfulInt2);
+    int lastPutInVM0 = createDataInVM0.getResult();
+    int lastPutInVM1 = createDataInVM1.getResult();
+    int lastPutInVM2 = createDataInVM2.getResult();
 
-    AsyncInvocation create0 = createInternalPersistentRegionAsync(vm0);
-    AsyncInvocation create1 = createInternalPersistentRegionAsync(vm1);
-    AsyncInvocation create2 = createInternalPersistentRegionAsync(vm2);
+    AsyncInvocation createPersistentRegionInVM0 = createInternalPersistentRegionAsync(vm0);
+    AsyncInvocation createPersistentRegionInVM1 = createInternalPersistentRegionAsync(vm1);
+    AsyncInvocation createPersistentRegionInVM2 = createInternalPersistentRegionAsync(vm2);
 
-    create0.getResult();
-    create1.getResult();
-    create2.getResult();
+    createPersistentRegionInVM0.await();
+    createPersistentRegionInVM1.await();
+    createPersistentRegionInVM2.await();
 
-    checkConcurrentCloseValue(vm0, vm1, 0, lastSuccessfulInt0);
-    checkConcurrentCloseValue(vm0, vm1, 1, lastSuccessfulInt1);
-    checkConcurrentCloseValue(vm0, vm1, 2, lastSuccessfulInt2);
+    checkConcurrentCloseValue(vm0, vm1, 0, lastPutInVM0);
+    checkConcurrentCloseValue(vm0, vm1, 1, lastPutInVM1);
+    checkConcurrentCloseValue(vm0, vm1, 2, lastPutInVM2);
   }
 
   /**
@@ -1622,36 +1194,22 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
    */
   @Test
   public void testRecoverAfterConflict() throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
     createPersistentRegion(vm0);
     putAnEntry(vm0);
-    LogWriterUtils.getLogWriter().info("closing region in vm0");
     closeCache(vm0);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
     createPersistentRegion(vm1);
     putAnEntry(vm1);
 
-    LogWriterUtils.getLogWriter().info("Creating region in VM0");
-    IgnoredException ex =
-        addIgnoredException("ConflictingPersistentDataException", vm0);
-    try {
+    try (IgnoredException e = addIgnoredException(ConflictingPersistentDataException.class)) {
       // this should cause a conflict
-      createPersistentRegion(vm0);
-      fail("Should have received a ConflictingPersistentDataException");
-    } catch (RuntimeException e) {
-      if (!(e.getCause() instanceof ConflictingPersistentDataException)) {
-        throw e;
-      }
-    } finally {
-      ex.remove();
+      Throwable thrown = catchThrowable(() -> createPersistentRegion(vm0));
+      assertThat(thrown).hasRootCauseInstanceOf(ConflictingPersistentDataException.class);
     }
 
-    LogWriterUtils.getLogWriter().info("closing region in vm1");
     closeCache(vm1);
 
     // This should work now
@@ -1659,196 +1217,143 @@ public class PersistentRecoveryOrderDUnitTest extends PersistentReplicatedTestBa
 
     updateTheEntry(vm0);
 
-    ex = addIgnoredException("ConflictingPersistentDataException", vm1);
     // Now make sure vm1 gets a conflict
-    LogWriterUtils.getLogWriter().info("Creating region in VM1");
-    try {
+    try (IgnoredException e = addIgnoredException(ConflictingPersistentDataException.class)) {
       // this should cause a conflict
-      createPersistentRegion(vm1);
-      fail("Should have received a ConflictingPersistentDataException");
-    } catch (RuntimeException e) {
-      if (!(e.getCause() instanceof ConflictingPersistentDataException)) {
-        throw e;
-      }
-    } finally {
-      ex.remove();
+      Throwable thrown = catchThrowable(() -> createPersistentRegion(vm1));
+      assertThat(thrown).hasRootCauseInstanceOf(ConflictingPersistentDataException.class);
     }
   }
 
-  private static final AtomicBoolean sawRequestImageMessage = new AtomicBoolean(false);
+  private AsyncInvocation createPersistentRegionAsync(VM vm, boolean diskSynchronous) {
+    return vm.invokeAsync(() -> {
+      File dir = getDiskDirForVM(vm);
+      dir.mkdirs();
 
-  private AsyncInvocation createPersistentRegionAsync(final VM vm, final boolean diskSynchronous) {
-    SerializableRunnable createRegion = new SerializableRunnable("Create persistent region") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DiskStoreFactory dsf = cache.createDiskStoreFactory();
-        File dir = getDiskDirForVM(vm);
-        dir.mkdirs();
-        dsf.setDiskDirs(new File[] {dir});
-        dsf.setMaxOplogSize(1);
-        DiskStore ds = dsf.create(REGION_NAME);
-        RegionFactory rf = new RegionFactory();
-        rf.setDiskStoreName(ds.getName());
-        rf.setDiskSynchronous(diskSynchronous);
-        rf.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-        rf.setScope(Scope.DISTRIBUTED_ACK);
-        rf.create(REGION_NAME);
-      }
-    };
-    return vm.invokeAsync(createRegion);
+      DiskStoreFactory diskStoreFactory = getCache().createDiskStoreFactory();
+      diskStoreFactory.setDiskDirs(new File[] {dir});
+      diskStoreFactory.setMaxOplogSize(1);
+
+      DiskStore diskStore = diskStoreFactory.create(regionName);
+
+      RegionFactory regionFactory = new RegionFactory();
+      regionFactory.setDiskStoreName(diskStore.getName());
+      regionFactory.setDiskSynchronous(diskSynchronous);
+      regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+      regionFactory.setScope(Scope.DISTRIBUTED_ACK);
+
+      regionFactory.create(regionName);
+    });
   }
 
-  private void assertSameRVV(RegionVersionVector rvv1, RegionVersionVector rvv2) {
-    if (!rvv1.sameAs(rvv2)) {
-      fail("Expected " + rvv1 + " but was " + rvv2);
-    }
+  private void assertSameRVV(RegionVersionVector expectedRVV, RegionVersionVector actualRVV) {
+    assertThat(expectedRVV.sameAs(actualRVV))
+        .as("Expected " + expectedRVV + " but was " + actualRVV)
+        .isTrue();
   }
 
-  private AsyncInvocation createDataAsyncTX(VM vm1, final int member) {
-    SerializableCallable createData1 = new SerializableCallable() {
-
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-
-        int i = 0;
-        TXManagerImpl txManager = (TXManagerImpl) cache.getCacheTransactionManager();
-        while (true) {
-          try {
-            txManager.begin();
-            region.put(member, i);
-            txManager.commit();
-            i++;
-          } catch (RegionDestroyedException e) {
-            break;
-          } catch (CacheClosedException e) {
-            break;
-          } catch (IllegalArgumentException e) {
-            if (!e.getMessage().contains("Invalid txLockId")) {
-              throw e;
-            }
-            break;
-          } catch (LockServiceDestroyedException e) {
-            break;
+  private AsyncInvocation<Integer> createDataAsyncTX(VM vm, int member) {
+    return vm.invokeAsync(() -> {
+      Region<Integer, Integer> region = getCache().getRegion(regionName);
+      CacheTransactionManager txManager = getCache().getCacheTransactionManager();
+      int i = 0;
+      while (true) {
+        try {
+          txManager.begin();
+          region.put(member, i);
+          txManager.commit();
+          i++;
+        } catch (CacheClosedException | LockServiceDestroyedException
+            | RegionDestroyedException e) {
+          break;
+        } catch (IllegalArgumentException e) {
+          if (!e.getMessage().contains("Invalid txLockId")) {
+            throw e;
           }
+          break;
         }
-        return i - 1;
       }
-    };
-    AsyncInvocation asyncCreate1 = vm1.invokeAsync(createData1);
-    return asyncCreate1;
+      return i - 1;
+    });
   }
 
-  private void checkConcurrentCloseValue(VM vm0, VM vm1, final int key, int lastSuccessfulInt) {
-    SerializableCallable getValue = new SerializableCallable() {
+  private void checkConcurrentCloseValue(VM vm0, VM vm1, int key, int lastSuccessfulInt) {
+    int valueInVM0 = vm0.invoke(() -> doRegionGet(key));
+    int valueInVM1 = vm1.invoke(() -> doRegionGet(key));
 
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        int value = (Integer) region.get(key);
-        return value;
-      }
-    };
+    assertThat(valueInVM1).isEqualTo(valueInVM0);
+    assertThat(valueInVM0 == lastSuccessfulInt || valueInVM0 == lastSuccessfulInt + 1)
+        .as("value = " + valueInVM0 + ", lastSuccessfulInt=" + lastSuccessfulInt)
+        .isTrue();
+  }
 
-    int vm1Value = (Integer) vm0.invoke(getValue);
-    int vm2Value = (Integer) vm1.invoke(getValue);
-    assertEquals(vm1Value, vm2Value);
-    assertTrue("value = " + vm1Value + ", lastSuccessfulInt=" + lastSuccessfulInt,
-        vm1Value == lastSuccessfulInt || vm1Value == lastSuccessfulInt + 1);
+  private int doRegionGet(int key) {
+    Region<Integer, Integer> region = getCache().getRegion(regionName);
+    return region.get(key);
   }
 
   private void checkForEntry(VM vm) {
-    SerializableRunnable checkForEntry = new SerializableRunnable("check for the entry") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        assertEquals("C", region.get("A"));
-      }
-    };
-    vm.invoke(checkForEntry);
+    vm.invoke(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      assertThat(region.get("A")).isEqualTo("C");
+    });
   }
 
-  protected void updateTheEntry(VM vm1) {
-    updateTheEntry(vm1, "C");
+  private void updateTheEntry(VM vm) {
+    updateTheEntry(vm, "C");
   }
 
-  protected void updateTheEntry(VM vm1, final String value) {
-    vm1.invoke(new SerializableRunnable("change the entry") {
+  private void updateTheEntry(VM vm, String value) {
+    vm.invoke(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      region.put("A", value);
+    });
+  }
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        region.put("A", value);
+  private void putAnEntry(VM vm) {
+    vm.invoke(() -> {
+      Region<String, String> region = getCache().getRegion(regionName);
+      region.put("A", "B");
+    });
+  }
+
+  private void checkForRecoveryStat(VM vm, boolean localRecovery) {
+    vm.invoke(() -> {
+      InternalRegion region = (InternalRegion) getCache().getRegion(regionName);
+      DiskRegionStats diskRegionStats = region.getDiskRegion().getStats();
+
+      if (localRecovery) {
+        assertThat(diskRegionStats.getLocalInitializations()).isEqualTo(1);
+        assertThat(diskRegionStats.getRemoteInitializations()).isEqualTo(0);
+      } else {
+        assertThat(diskRegionStats.getLocalInitializations()).isEqualTo(0);
+        assertThat(diskRegionStats.getRemoteInitializations()).isEqualTo(1);
       }
     });
   }
 
-  protected void putAnEntry(VM vm0) {
-    vm0.invoke(new SerializableRunnable("Put an entry") {
+  private AsyncInvocation createInternalPersistentRegionAsync(VM vm) {
+    return vm.invokeAsync(() -> {
+      File dir = getDiskDirForVM(vm);
+      dir.mkdirs();
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(REGION_NAME);
-        region.put("A", "B");
-      }
+      DiskStoreFactory diskStoreFactory = getCache().createDiskStoreFactory();
+      diskStoreFactory.setDiskDirs(new File[] {dir});
+      diskStoreFactory.setMaxOplogSize(1);
+
+      DiskStore diskStore = diskStoreFactory.create(regionName);
+
+      InternalRegionArguments internalRegionArguments = new InternalRegionArguments();
+      internalRegionArguments.setIsUsedForMetaRegion(true);
+      internalRegionArguments.setMetaRegionWithTransactions(true);
+
+      AttributesFactory attributesFactory = new AttributesFactory();
+      attributesFactory.setDiskStoreName(diskStore.getName());
+      attributesFactory.setDiskSynchronous(true);
+      attributesFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+      attributesFactory.setScope(Scope.DISTRIBUTED_ACK);
+
+      getCache().createVMRegion(regionName, attributesFactory.create(), internalRegionArguments);
     });
-  }
-
-  private void checkForRecoveryStat(VM vm, final boolean localRecovery) {
-    vm.invoke(new SerializableRunnable("check disk region stat") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DistributedRegion region = (DistributedRegion) cache.getRegion(REGION_NAME);
-        DiskRegionStats stats = region.getDiskRegion().getStats();
-        if (localRecovery) {
-          assertEquals(1, stats.getLocalInitializations());
-          assertEquals(0, stats.getRemoteInitializations());
-        } else {
-          assertEquals(0, stats.getLocalInitializations());
-          assertEquals(1, stats.getRemoteInitializations());
-        }
-
-      }
-    });
-  }
-
-  protected AsyncInvocation createInternalPersistentRegionAsync(final VM vm) {
-    SerializableRunnable createRegion = new SerializableRunnable("Create persistent region") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DiskStoreFactory dsf = cache.createDiskStoreFactory();
-        File dir = getDiskDirForVM(vm);
-        dir.mkdirs();
-        dsf.setDiskDirs(new File[] {dir});
-        dsf.setMaxOplogSize(1);
-        DiskStore ds = dsf.create(REGION_NAME);
-        InternalRegionArguments internalArgs = new InternalRegionArguments();
-        internalArgs.setIsUsedForMetaRegion(true);
-        internalArgs.setMetaRegionWithTransactions(true);
-        AttributesFactory rf = new AttributesFactory();
-        rf.setDiskStoreName(ds.getName());
-        rf.setDiskSynchronous(true);
-        rf.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-        rf.setScope(Scope.DISTRIBUTED_ACK);
-        try {
-          ((GemFireCacheImpl) cache).createVMRegion(REGION_NAME, rf.create(), internalArgs);
-        } catch (ClassNotFoundException e) {
-          Assert.fail("error", e);
-        } catch (IOException e) {
-          Assert.fail("error", e);
-        }
-      }
-    };
-    return vm.invokeAsync(createRegion);
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderOldConfigDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderOldConfigDUnitTest.java
@@ -18,39 +18,36 @@ import java.io.File;
 
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskWriteAttributesFactory;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.test.dunit.AsyncInvocation;
-import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 
-@Category({PersistenceTest.class})
+@Category(PersistenceTest.class)
 public class PersistentRecoveryOrderOldConfigDUnitTest extends PersistentRecoveryOrderDUnitTest {
 
   @Override
-  protected AsyncInvocation createPersistentRegionAsync(final VM vm) {
-    SerializableRunnable createRegion = new SerializableRunnable("Create persistent region") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        File dir = getDiskDirForVM(vm);
-        dir.mkdirs();
-        RegionFactory rf = new RegionFactory();
-        // rf.setDiskSynchronous(true);
-        rf.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-        rf.setScope(Scope.DISTRIBUTED_ACK);
-        rf.setDiskDirs(new File[] {dir});
-        DiskWriteAttributesFactory dwf = new DiskWriteAttributesFactory();
-        dwf.setMaxOplogSize(1);
-        dwf.setSynchronous(true);
-        rf.setDiskWriteAttributes(dwf.create());
-        rf.create(REGION_NAME);
-      }
-    };
-    return vm.invokeAsync(createRegion);
+  AsyncInvocation createPersistentRegionAsync(VM vm) {
+    return vm.invokeAsync(() -> {
+      getCache();
+
+      File dir = getDiskDirForVM(vm);
+      dir.mkdirs();
+
+      DiskWriteAttributesFactory diskWriteAttributesFactory = new DiskWriteAttributesFactory();
+      diskWriteAttributesFactory.setMaxOplogSize(1);
+      diskWriteAttributesFactory.setSynchronous(true);
+
+      RegionFactory regionFactory = new RegionFactory();
+      regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+      regionFactory.setScope(Scope.DISTRIBUTED_ACK);
+      regionFactory.setDiskDirs(new File[] {dir});
+      regionFactory.setDiskWriteAttributes(diskWriteAttributesFactory.create());
+
+      regionFactory.create(regionName);
+    });
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -41,6 +41,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.eviction.EvictionController;
 import org.apache.geode.internal.cache.persistence.DiskExceptionHandler;
+import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
@@ -66,7 +67,7 @@ import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
  */
 @SuppressWarnings("rawtypes")
 public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryContext,
-    RegionAttributes, HasDiskRegion, RegionMapOwner, DiskExceptionHandler {
+    RegionAttributes, HasDiskRegion, RegionMapOwner, DiskExceptionHandler, DiskRecoveryStore {
 
   @Override
   CachePerfStats getCachePerfStats();
@@ -428,4 +429,8 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
   }
 
   Map<Object, Object> getEntryUserAttributes();
+
+  int getTombstoneCount();
+
+  Region.Entry getEntry(Object key, boolean allowTombstones);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -1828,6 +1828,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   }
 
   /** internally we often need to get an entry whether it is a tombstone or not */
+  @Override
   public Region.Entry getEntry(Object key, boolean allowTombstones) {
     return getDataView().getEntry(getKeyInfo(key), this, allowTombstones);
   }
@@ -3351,6 +3352,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     cachePerfStats.incEntryCount(-delta);
   }
 
+  @Override
   public int getTombstoneCount() {
     return tombstoneCount.get();
   }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/AsyncInvocation.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/AsyncInvocation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.test.dunit;
 
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -46,7 +48,7 @@ import org.apache.geode.SystemFailure;
  */
 public class AsyncInvocation<V> implements Future<V> {
 
-  private static final long DEFAULT_JOIN_MILLIS = 60 * 1000;
+  private static final long DEFAULT_JOIN_MILLIS = getTimeout().getValueInMS();
 
   private final Thread thread;
 


### PR DESCRIPTION
* Fix all future await times to use GeodeAwaitility timeout
* Fix testRevokeAHostBeforeInitialization dependency on etc hosts
* Fix testCrashDuringPreparePersistentId flakiness caused by using
wrong await timeouts

Co-authored-by: Michael Oleske <moleske@pivotal.io>
