### PR TITLE
Use Ubuntu Bionic as the test-container base

### DIFF
--- a/ci/images/test-container/Dockerfile
+++ b/ci/images/test-container/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM buildpack-deps:sid-scm
+FROM buildpack-deps:bionic-scm
 ENTRYPOINT []
 
 ARG CHROME_DRIVER_VERSION=2.35

--- a/ci/pipelines/geode-build/deploy_pipeline.sh
+++ b/ci/pipelines/geode-build/deploy_pipeline.sh
@@ -53,7 +53,7 @@ VERSION_BUCKET="concourse-${ENV_ID}-version"
 
 #echo "DEBUG INFO *****************************"
 #echo "Pipeline prefix = ${PIPELINE_PREFIX}"
-#echo "Docker image prefix = ${DOCKER_IMAGE_PREFIX}"]
+#echo "Docker image prefix = ${DOCKER_IMAGE_PREFIX}"
 pushd ${SCRIPTDIR} 2>&1 > /dev/null
 
   cat > repository.yml <<YML

--- a/ci/pipelines/images/jinja.template.yml
+++ b/ci/pipelines/images/jinja.template.yml
@@ -44,18 +44,18 @@ resources:
 - name: google-geode-builder
   type: git
   source:
-    {{ github_access() | indent(4) }}
     branch: ((geode-build-branch))
     paths:
     - ci/images/google-geode-builder
+    {{ github_access() | indent(4) }}
 
 - name: google-windows-geode-builder
   type: git
   source:
-    {{ github_access() | indent(4) }}
     branch: ((geode-build-branch))
     paths:
     - ci/images/google-windows-geode-builder
+    {{ github_access() | indent(4) }}
 
 - name: alpine-docker-image
   type: docker-image
@@ -67,10 +67,10 @@ resources:
 - name: alpine-tools-dockerfile
   type: git
   source:
-    {{ github_access() | indent(4) }}
     branch: ((geode-build-branch))
     paths:
     - ci/images/alpine-tools/*
+    {{ github_access() | indent(4) }}
 
 - name: alpine-tools-docker-image
   type: docker-image
@@ -82,10 +82,10 @@ resources:
 - name: test-container-dockerfile
   type: git
   source:
-    {{ github_access() | indent(4) }}
     branch: ((geode-build-branch))
     paths:
     - ci/images/test-container/*
+    {{ github_access() | indent(4) }}
 
 - name: test-container-docker-image
   type: docker-image


### PR DESCRIPTION
Previously used Debian `sid`, which has had openjdk-8 removed by the
maintainers.

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
