### PR TITLE
GEODE-6643: Fix intermittent failure of GfshCommandIntegrationTest on Windows

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GfshCommandIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GfshCommandIntegrationTest.java
@@ -62,7 +62,7 @@ public class GfshCommandIntegrationTest {
     gfsh.executeAndAssertThat(
         "start locator --properties-file=unknown --J=-Dgemfire.security-password=bob")
         .statusIsError();
-    gfsh.executeAndAssertThat("connect --password=secret").statusIsError();
+    gfsh.executeAndAssertThat("connect --jmx-manager=localhost[999] --password=secret").statusIsError();
 
     List<LogEvent> logEvents = listAppender.getEvents();
     assertThat(logEvents.size()).as("There should be exactly 2 log events").isEqualTo(2);
@@ -71,7 +71,7 @@ public class GfshCommandIntegrationTest {
     assertThat(logEvents.get(0).getMessage().getFormattedMessage()).isEqualTo(
         "Executing command: start locator --properties-file=unknown --J=-Dgemfire.security-password=********");
     assertThat(logEvents.get(1).getMessage().getFormattedMessage())
-        .isEqualTo("Executing command: connect --password=********");
+        .isEqualTo("Executing command: connect --jmx-manager=localhost[999] --password=********");
 
     logger.removeAppender(listAppender);
   }


### PR DESCRIPTION

- Honestly this is just a workaround as it's more likely that some
  lingering, existing process is causing this to fail.

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
