### PR TITLE
GEODE-5231: Fix PersistentReplicatedTestBase subclass flakiness

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
@@ -87,6 +87,7 @@ import org.apache.geode.test.junit.categories.PersistenceTest;
 
 @Category(PersistenceTest.class)
 @RunWith(JUnitParamsRunner.class)
+@SuppressWarnings("serial")
 public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase {
 
   private static final int TEST_REPLICATED_TOMBSTONE_TIMEOUT = 1_000;
@@ -372,6 +373,8 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     VM vm1 = getVM(1);
 
     vm0.invoke(() -> {
+      getCache();
+
       PartitionAttributesFactory<String, String> partitionAttributesFactory =
           new PartitionAttributesFactory<>();
       partitionAttributesFactory.setRedundantCopies(1);
@@ -392,6 +395,8 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     // Create a cache and region, do an update to change the version no. and
     // restart the cache and region.
     vm1.invoke(() -> {
+      getCache();
+
       PartitionAttributesFactory<String, String> partitionAttributesFactory =
           new PartitionAttributesFactory<>();
       partitionAttributesFactory.setRedundantCopies(1);
@@ -700,6 +705,8 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
   }
 
   private void createRegionWithAsyncPersistence(VM vm) {
+    getCache();
+
     File dir = getDiskDirForVM(vm);
     dir.mkdirs();
 
@@ -721,6 +728,8 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
   }
 
   private InternalRegion createRegion(VM vm0) {
+    getCache();
+
     File dir = getDiskDirForVM(vm0);
     dir.mkdirs();
 
@@ -759,6 +768,8 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
   }
 
   private Region createAsyncRegionWithSmallQueue(VM vm0) {
+    getCache();
+
     File dir = getDiskDirForVM(vm0);
     dir.mkdirs();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderOldConfigDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderOldConfigDUnitTest.java
@@ -27,6 +27,7 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 
 @Category(PersistenceTest.class)
+@SuppressWarnings("serial")
 public class PersistentRecoveryOrderOldConfigDUnitTest extends PersistentRecoveryOrderDUnitTest {
 
   @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.persistence;
 
 import static org.apache.commons.io.FileUtils.deleteDirectory;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,19 +46,19 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
   private File diskDir;
 
   @Before
-  public void setUpPersistentReplicatedTestBase() throws IOException {
+  public void setUpPersistentReplicatedTestBase() {
     invokeInEveryVM(() -> regionName = getUniqueName() + "Region");
     regionName = getUniqueName() + "Region";
 
     diskDir = new File("diskDir-" + getName()).getAbsoluteFile();
-    deleteDirectory(diskDir);
+    deleteQuietly(diskDir);
     diskDir.mkdir();
     diskDir.deleteOnExit();
   }
 
   @After
-  public void tearDownPersistentReplicatedTestBase() throws IOException {
-    deleteDirectory(diskDir);
+  public void tearDownPersistentReplicatedTestBase() {
+    deleteQuietly(diskDir);
   }
 
   void waitForBlockedInitialization(VM vm) {
@@ -72,6 +73,8 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
 
   void createPersistentRegionWithoutCompaction(VM vm) {
     vm.invoke(() -> {
+      getCache();
+
       File dir = getDiskDirForVM(vm);
       dir.mkdirs();
 
@@ -143,6 +146,8 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
 
   AsyncInvocation createPersistentRegionAsync(VM vm) {
     return vm.invokeAsync(() -> {
+      getCache();
+
       File dir = getDiskDirForVM(vm);
       dir.mkdirs();
 


### PR DESCRIPTION
Fix additional minor timing issues related to these tickets:
GEODE-1703 GEODE-4267 GEODE-4378 GEODE-5231 GEODE-6375 GEODE-6615

I found a few more places where awaiting the disconnect that was invoked within a DistributionObserver would be a good idea. I also changed the deleteDirectory in setUp and tearDown to deleteQuietly. And I made sure getCache() is invoked before creating disk dirs to be used to create a diskStore for that cache. I think the await is the primary fix that'll prevent problems but the other two may help.