### PR TITLE
GEODE-6664 CI failure: org.apache.geode.ClusterCommunicationsDUnitTes…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -308,18 +308,17 @@ public class NioSslEngine implements NioFilter {
     }
   }
 
-  /*
-   * NioSslEngine doesn't need to ensure capacity in network buffers because they
-   * are fixed in size by the SslContext. The size recommended by the context is
-   * big enough for the SslEngine to do its work.
-   */
   @Override
   public ByteBuffer ensureWrappedCapacity(int amount, ByteBuffer wrappedBuffer,
       Buffers.BufferType bufferType, DMStats stats) {
-    if (wrappedBuffer == null) {
-      wrappedBuffer = Buffers.acquireBuffer(bufferType, amount, stats);
+    ByteBuffer buffer = wrappedBuffer;
+    int requiredSize = engine.getSession().getPacketBufferSize();
+    if (buffer == null) {
+      buffer = Buffers.acquireBuffer(bufferType, requiredSize, stats);
+    } else if (buffer.capacity() < requiredSize) {
+      buffer = Buffers.expandWriteBufferIfNeeded(bufferType, buffer, requiredSize, stats);
     }
-    return wrappedBuffer;
+    return buffer;
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
@@ -373,11 +373,19 @@ public class NioSslEngineTest {
   }
 
   @Test
-  public void ensureWrappedCapacity() {
-    ByteBuffer buffer = ByteBuffer.allocate(10);
+  public void ensureWrappedCapacityOfSmallMessage() {
+    ByteBuffer buffer = ByteBuffer.allocate(netBufferSize);
     assertThat(
         nioSslEngine.ensureWrappedCapacity(10, buffer, Buffers.BufferType.UNTRACKED, mockStats))
             .isEqualTo(buffer);
+  }
+
+  @Test
+  public void ensureWrappedCapacityWithNoBuffer() {
+    assertThat(
+        nioSslEngine.ensureWrappedCapacity(10, null, Buffers.BufferType.UNTRACKED, mockStats)
+            .capacity())
+                .isEqualTo(netBufferSize);
   }
 
   @Test


### PR DESCRIPTION
…t.receiveBigResponse

Ensure that the encrypted buffer is at least as big as the
SSLSession's packet buffer size.  That's required for proper decryption
of incoming packets.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
