### PR TITLE
GEODE-6662 NioPlainEngine.ensureWrappedCapacity

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
@@ -76,6 +76,7 @@ public class NioPlainEngine implements NioFilter {
       buffer = Buffers.acquireBuffer(bufferType, amount, stats);
       buffer.clear();
       buffer.put(oldBuffer);
+      Buffers.releaseBuffer(bufferType, oldBuffer, stats);
       lastReadPosition = buffer.position();
       lastProcessedPosition = 0;
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/net/NioPlainEngineTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/NioPlainEngineTest.java
@@ -58,12 +58,14 @@ public class NioPlainEngineTest {
 
   @Test
   public void ensureWrappedCapacity() {
-    ByteBuffer wrappedBuffer = ByteBuffer.allocate(100);
+    ByteBuffer wrappedBuffer = Buffers.acquireReceiveBuffer(100, mockStats);
+    verify(mockStats, times(1)).incReceiverBufferSize(any(Integer.class), any(Boolean.class));
     wrappedBuffer.put(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
     nioEngine.lastReadPosition = 10;
     int requestedCapacity = 210;
     ByteBuffer result = nioEngine.ensureWrappedCapacity(requestedCapacity, wrappedBuffer,
-        Buffers.BufferType.UNTRACKED, mockStats);
+        Buffers.BufferType.TRACKED_RECEIVER, mockStats);
+    verify(mockStats, times(2)).incReceiverBufferSize(any(Integer.class), any(Boolean.class));
     assertThat(result.capacity()).isGreaterThanOrEqualTo(requestedCapacity);
     assertThat(result).isNotSameAs(wrappedBuffer);
     // make sure that data was transferred to the new buffer


### PR DESCRIPTION
Fixing a memory leak:

Return the old buffer to the Buffers pool after copying its
contents to a newly allocated buffer.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
