### PR TITLE
GEODE-6693: run concurrency tests for longer

### DIFF
--- a/geode-concurrency-test/build.gradle
+++ b/geode-concurrency-test/build.gradle
@@ -23,10 +23,10 @@ dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compile('junit:junit')
   compile('org.apache.logging.log4j:log4j-api')
-  testCompile('org.assertj:assertj-core')
+  integrationTestCompile('org.assertj:assertj-core')
 }
 
-test {
+integrationTest {
   // Some tests have inner tests that should be ignored
   exclude "**/*\$*.class"
 }

--- a/geode-concurrency-test/src/integrationTest/java/org/apache/geode/test/concurrency/ConcurrentTestRunnerTest.java
+++ b/geode-concurrency-test/src/integrationTest/java/org/apache/geode/test/concurrency/ConcurrentTestRunnerTest.java
@@ -30,7 +30,7 @@ public class ConcurrentTestRunnerTest {
   public void confirmThatInParallelRunsConcurrently() {
     // We only need FailingTest to fail once for the following
     // assertion to pass. ConcurrentTestRunner runs FailingTest
-    // 1000 times by default. It will stop running it once it
+    // 2000 times by default. It will stop running it once it
     // sees it fail, which is what we want to see because it
     // confirms that running inParallel actually runs concurrently.
     assertThat(JUnitCore.runClasses(CheckForConcurrency.class).wasSuccessful()).isFalse();

--- a/geode-concurrency-test/src/main/java/org/apache/geode/test/concurrency/loop/LoopRunner.java
+++ b/geode-concurrency-test/src/main/java/org/apache/geode/test/concurrency/loop/LoopRunner.java
@@ -35,7 +35,7 @@ import org.apache.geode.test.concurrency.Runner;
  * Simple runner that just runs the test in a loop
  */
 public class LoopRunner implements Runner {
-  private static final int DEFAULT_COUNT = 1000;
+  private static final int DEFAULT_COUNT = 2000;
 
   @Override
   public List<Throwable> runTestMethod(Method child) {


### PR DESCRIPTION
Run the concurrency test runner for longer by default to increase the
chance of catching issues, and move runner's tests to the integration
level since they are non-deterministic.

Signed-off-by: Jacob Barrett <jbarrett@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
