### PR TITLE
GEODE-6694: Use volatile access to read current state of BucketAdvisor

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
@@ -115,7 +115,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    * The current state of this BucketAdvisor which tracks which member is primary and whether or not
    * this member is hosting a real Bucket.
    */
-  private byte primaryState = NO_PRIMARY_NOT_HOSTING;
+  private volatile byte primaryState = NO_PRIMARY_NOT_HOSTING;
 
   /**
    * This delegate handles all volunteering for primary status. Lazily created. Protected by
@@ -917,9 +917,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    * @return true if this advisor has been closed
    */
   protected boolean isClosed() {
-    synchronized (this) {
-      return primaryState == CLOSED;
-    }
+    return primaryState == CLOSED;
   }
 
   /**
@@ -928,9 +926,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    * @return true if this member is currently marked as primary
    */
   public boolean isPrimary() {
-    synchronized (this) {
-      return primaryState == IS_PRIMARY_HOSTING;
-    }
+    return primaryState == IS_PRIMARY_HOSTING;
   }
 
   /**
@@ -939,9 +935,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    * @return true if this member is currently volunteering for primary
    */
   private boolean isVolunteering() {
-    synchronized (this) {
-      return primaryState == VOLUNTEERING_HOSTING;
-    }
+    return primaryState == VOLUNTEERING_HOSTING;
   }
 
   /**
@@ -962,11 +956,10 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    * @return true if this member is currently hosting real bucket
    */
   public boolean isHosting() {
-    synchronized (this) {
-      return primaryState == NO_PRIMARY_HOSTING || primaryState == OTHER_PRIMARY_HOSTING
-          || primaryState == VOLUNTEERING_HOSTING || primaryState == BECOMING_HOSTING
-          || primaryState == IS_PRIMARY_HOSTING;
-    }
+    final byte primaryState = this.primaryState;
+    return primaryState == NO_PRIMARY_HOSTING || primaryState == OTHER_PRIMARY_HOSTING
+        || primaryState == VOLUNTEERING_HOSTING || primaryState == BECOMING_HOSTING
+        || primaryState == IS_PRIMARY_HOSTING;
   }
 
   /**
@@ -1601,10 +1594,9 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    * Returns true if the a primary is known.
    */
   private boolean hasPrimary() {
-    synchronized (this) {
-      return primaryState == OTHER_PRIMARY_NOT_HOSTING
-          || primaryState == OTHER_PRIMARY_HOSTING || primaryState == IS_PRIMARY_HOSTING;
-    }
+    final byte primaryState = this.primaryState;
+    return primaryState == OTHER_PRIMARY_NOT_HOSTING || primaryState == OTHER_PRIMARY_HOSTING
+        || primaryState == IS_PRIMARY_HOSTING;
   }
 
   @Override


### PR DESCRIPTION
Since that value can change immediately after we exit these methods,
unless we already have the monitor, we can safely read the current value
with the same staleness guarantee when exiting the method. Lock still
acquired for composite checks and updating the value.

This change measures a 17% increase in throughput in PartitionedFunctionExecutionBenchmark.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
