### PR TITLE
GEODE-6670: optimize GemFireCacheImpl.getCacheServers

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -398,6 +398,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    * This list has all the cache servers that are not gateway receivers
    */
   private final List<CacheServer> cacheServersNotGatewayReceivers = new CopyOnWriteArrayList<>();
+  private final List<CacheServer> immutableCacheServersNotGatewayReceivers =
+      Collections.unmodifiableList(cacheServersNotGatewayReceivers);
 
   /**
    * Controls updates to the list of all gateway senders
@@ -3938,7 +3940,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   @Override
   public List<CacheServer> getCacheServers() {
-    return this.cacheServersNotGatewayReceivers;
+    return this.immutableCacheServersNotGatewayReceivers;
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.NotSerializableException;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -345,6 +346,50 @@ public class GemFireCacheImplTest {
     gemFireCacheImpl = createGemFireCacheImpl();
 
     assertThat(gemFireCacheImpl.getMeterRegistry()).isInstanceOf(MeterRegistry.class);
+  }
+
+  @Test
+  public void getCacheServersResultContainsNonGatewayCacheServer() {
+    gemFireCacheImpl = createGemFireCacheImpl();
+    CacheServer addedNonGatewayServer = gemFireCacheImpl.addCacheServer(false);
+
+    List<CacheServer> result = gemFireCacheImpl.getCacheServers();
+
+    assertThat(result).contains(addedNonGatewayServer);
+  }
+
+  @Test
+  public void getCacheServersUnchangedAfterAddRemoveOfNonGatewayCacheServer() {
+    gemFireCacheImpl = createGemFireCacheImpl();
+    List<CacheServer> original = gemFireCacheImpl.getCacheServers();
+    CacheServer addedNonGatewayServer = gemFireCacheImpl.addCacheServer(false);
+
+    gemFireCacheImpl.removeCacheServer(addedNonGatewayServer);
+    List<CacheServer> result = gemFireCacheImpl.getCacheServers();
+
+    assertThat(result).isEqualTo(original);
+  }
+
+  @Test
+  public void getCacheServersUnchangedAfterAddRemoveOfGatewayCacheServer() {
+    gemFireCacheImpl = createGemFireCacheImpl();
+    List<CacheServer> original = gemFireCacheImpl.getCacheServers();
+    CacheServer addedGatewayServer = gemFireCacheImpl.addCacheServer(true);
+
+    gemFireCacheImpl.removeCacheServer(addedGatewayServer);
+    List<CacheServer> result = gemFireCacheImpl.getCacheServers();
+
+    assertThat(result).isEqualTo(original);
+  }
+
+  @Test
+  public void getCacheServersResultDoesNotContainGatewayCacheServer() {
+    gemFireCacheImpl = createGemFireCacheImpl();
+    CacheServer addedGatewayServer = gemFireCacheImpl.addCacheServer(true);
+
+    List<CacheServer> result = gemFireCacheImpl.getCacheServers();
+
+    assertThat(result).doesNotContain(addedGatewayServer);
   }
 
   private static GemFireCacheImpl createGemFireCacheImpl() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.NotSerializableException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -361,7 +362,7 @@ public class GemFireCacheImplTest {
   @Test
   public void getCacheServersUnchangedAfterAddRemoveOfNonGatewayCacheServer() {
     gemFireCacheImpl = createGemFireCacheImpl();
-    List<CacheServer> original = gemFireCacheImpl.getCacheServers();
+    List<CacheServer> original = new ArrayList<>(gemFireCacheImpl.getCacheServers());
     CacheServer addedNonGatewayServer = gemFireCacheImpl.addCacheServer(false);
 
     gemFireCacheImpl.removeCacheServer(addedNonGatewayServer);
@@ -373,7 +374,7 @@ public class GemFireCacheImplTest {
   @Test
   public void getCacheServersUnchangedAfterAddRemoveOfGatewayCacheServer() {
     gemFireCacheImpl = createGemFireCacheImpl();
-    List<CacheServer> original = gemFireCacheImpl.getCacheServers();
+    List<CacheServer> original = new ArrayList<>(gemFireCacheImpl.getCacheServers());
     CacheServer addedGatewayServer = gemFireCacheImpl.addCacheServer(true);
 
     gemFireCacheImpl.removeCacheServer(addedGatewayServer);


### PR DESCRIPTION
getCacheServers no longer allocates an ArrayList on every call.
Instead, addCacheServer and removeCacheServer, maintain another set.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
