### PR TITLE
GEODE-6674: only create StringBuilder if needed

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
@@ -69,7 +69,6 @@ public class Put65 extends BaseCommand {
       final SecurityService securityService, long p_start)
       throws IOException, InterruptedException {
     long start = p_start;
-    final StringBuilder errMessage = new StringBuilder();
     final CacheServerStats stats = serverConnection.getCacheServerStats();
 
     // requiresResponse = true;
@@ -159,6 +158,7 @@ public class Put65 extends BaseCommand {
 
     // Process the put request
     if (key == null || regionName == null) {
+      final StringBuilder errMessage = new StringBuilder();
       if (key == null) {
         final String putMsg = " The input key for the put request is null";
         if (isDebugEnabled) {
@@ -193,8 +193,7 @@ public class Put65 extends BaseCommand {
       if (isDebugEnabled) {
         logger.debug("{}:{}", serverConnection.getName(), putMsg);
       }
-      errMessage.append(putMsg);
-      writeErrorResponse(clientMessage, MessageType.PUT_DATA_ERROR, errMessage.toString(),
+      writeErrorResponse(clientMessage, MessageType.PUT_DATA_ERROR, putMsg,
           serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put65Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put65Test.java
@@ -169,6 +169,32 @@ public class Put65Test {
   }
 
   @Test
+  public void noRegionNameShouldFail() throws Exception {
+    when(this.securityService.isClientSecurityRequired()).thenReturn(false);
+    when(this.regionNamePart.getString()).thenReturn(null);
+
+    this.put65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(this.errorResponseMessage).addStringPart(argument.capture());
+    assertThat(argument.getValue()).contains("The input region name for the put request is null");
+    verify(this.errorResponseMessage).send(this.serverConnection);
+  }
+
+  @Test
+  public void noKeyShouldFail() throws Exception {
+    when(this.securityService.isClientSecurityRequired()).thenReturn(false);
+    when(this.keyPart.getStringOrObject()).thenReturn(null);
+
+    this.put65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    verify(this.errorResponseMessage).addStringPart(argument.capture());
+    assertThat(argument.getValue()).contains("The input key for the put request is null");
+    verify(this.errorResponseMessage).send(this.serverConnection);
+  }
+
+  @Test
   public void integratedSecurityShouldSucceedIfAuthorized() throws Exception {
     when(this.securityService.isClientSecurityRequired()).thenReturn(true);
     when(this.securityService.isIntegratedSecurity()).thenReturn(true);


### PR DESCRIPTION
The StringBuilder creation is now only done when key or region is null.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
