### PR TITLE
GEODE-6719 : Handling default disktore request from AppServers.

### DIFF
--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -51,7 +51,7 @@ dependencies {
   testCompile('org.apache.bcel:bcel')
   testCompile('junit:junit')
   testCompile('org.assertj:assertj-core')
-
+  testCompile('org.mockito:mockito-core')
   integrationTestCompile('junit:junit')
 
   integrationTestRuntime('org.apache.tomcat:coyote:' + DependencyConstraints.get('tomcat6.version'))

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/util/RegionHelper.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/util/RegionHelper.java
@@ -118,7 +118,7 @@ public class RegionHelper {
     }
   }
 
-  private static RegionAttributes getRegionAttributes(Cache cache,
+  public static RegionAttributes getRegionAttributes(Cache cache,
       RegionConfiguration configuration) {
     // Create the requested attributes
     RegionAttributes baseRequestedAttributes =

--- a/extensions/geode-modules/src/test/java/org/apache/geode/modules/util/CreateRegionFunctionJUnitTest.java
+++ b/extensions/geode-modules/src/test/java/org/apache/geode/modules/util/CreateRegionFunctionJUnitTest.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.modules.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.CacheListener;
+import org.apache.geode.cache.CacheLoader;
+import org.apache.geode.cache.CacheWriter;
+import org.apache.geode.cache.CustomExpiry;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.DiskWriteAttributes;
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.MembershipAttributes;
+import org.apache.geode.cache.MirrorType;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.SubscriptionAttributes;
+import org.apache.geode.compression.Compressor;
+import org.apache.geode.internal.cache.EvictionAttributesImpl;
+
+public class CreateRegionFunctionJUnitTest {
+
+  RegionAttributes getRegionAttributesWithModifiedDiskDirSize(final int diskDirSize) {
+    return new RegionAttributes() {
+      @Override
+      public CacheLoader getCacheLoader() {
+        return null;
+      }
+
+      @Override
+      public CacheWriter getCacheWriter() {
+        return null;
+      }
+
+      @Override
+      public Class getKeyConstraint() {
+        return null;
+      }
+
+      @Override
+      public Class getValueConstraint() {
+        return null;
+      }
+
+      @Override
+      public ExpirationAttributes getRegionTimeToLive() {
+        return new ExpirationAttributes();
+      }
+
+      @Override
+      public ExpirationAttributes getRegionIdleTimeout() {
+        return new ExpirationAttributes();
+      }
+
+      @Override
+      public ExpirationAttributes getEntryTimeToLive() {
+        return new ExpirationAttributes();
+      }
+
+      @Override
+      public ExpirationAttributes getEntryIdleTimeout() {
+        return new ExpirationAttributes();
+      }
+
+      @Override
+      public CustomExpiry getCustomEntryTimeToLive() {
+        return null;
+      }
+
+      @Override
+      public CustomExpiry getCustomEntryIdleTimeout() {
+        return null;
+      }
+
+      @Override
+      public boolean getIgnoreJTA() {
+        return false;
+      }
+
+      @Override
+      public MirrorType getMirrorType() {
+        return null;
+      }
+
+      @Override
+      public DataPolicy getDataPolicy() {
+        return DataPolicy.NORMAL;
+      }
+
+      @Override
+      public Scope getScope() {
+        return null;
+      }
+
+      @Override
+      public EvictionAttributes getEvictionAttributes() {
+        return new EvictionAttributesImpl().setAction(EvictionAction.OVERFLOW_TO_DISK);
+      }
+
+      @Override
+      public CacheListener getCacheListener() {
+        return null;
+      }
+
+      @Override
+      public CacheListener[] getCacheListeners() {
+        return new CacheListener[0];
+      }
+
+      @Override
+      public int getInitialCapacity() {
+        return 0;
+      }
+
+      @Override
+      public float getLoadFactor() {
+        return 0;
+      }
+
+      @Override
+      public boolean isLockGrantor() {
+        return false;
+      }
+
+      @Override
+      public boolean getMulticastEnabled() {
+        return false;
+      }
+
+      @Override
+      public int getConcurrencyLevel() {
+        return 0;
+      }
+
+      @Override
+      public boolean getPersistBackup() {
+        return false;
+      }
+
+      @Override
+      public DiskWriteAttributes getDiskWriteAttributes() {
+        return null;
+      }
+
+      @Override
+      public File[] getDiskDirs() {
+        return new File[0];
+      }
+
+      @Override
+      public boolean getIndexMaintenanceSynchronous() {
+        return false;
+      }
+
+      @Override
+      public PartitionAttributes getPartitionAttributes() {
+        return null;
+      }
+
+      @Override
+      public MembershipAttributes getMembershipAttributes() {
+        return new MembershipAttributes();
+      }
+
+      @Override
+      public SubscriptionAttributes getSubscriptionAttributes() {
+        return null;
+      }
+
+      @Override
+      public boolean getStatisticsEnabled() {
+        return false;
+      }
+
+      @Override
+      public boolean getEarlyAck() {
+        return false;
+      }
+
+      @Override
+      public boolean getPublisher() {
+        return false;
+      }
+
+      @Override
+      public boolean getEnableConflation() {
+        return false;
+      }
+
+      @Override
+      public boolean getEnableBridgeConflation() {
+        return false;
+      }
+
+      @Override
+      public boolean getEnableSubscriptionConflation() {
+        return false;
+      }
+
+      @Override
+      public boolean getEnableAsyncConflation() {
+        return false;
+      }
+
+      @Override
+      public int[] getDiskDirSizes() {
+        return new int[] {diskDirSize};
+      }
+
+      @Override
+      public String getPoolName() {
+        return null;
+      }
+
+      @Override
+      public boolean getCloningEnabled() {
+        return false;
+      }
+
+      @Override
+      public String getDiskStoreName() {
+        return null;
+      }
+
+      @Override
+      public boolean isDiskSynchronous() {
+        return false;
+      }
+
+      @Override
+      public Set<String> getGatewaySenderIds() {
+        return new HashSet<String>();
+      }
+
+      @Override
+      public Set<String> getAsyncEventQueueIds() {
+        return new HashSet<String>();
+      }
+
+      @Override
+      public boolean getConcurrencyChecksEnabled() {
+        return false;
+      }
+
+      @Override
+      public Compressor getCompressor() {
+        return null;
+      }
+
+      @Override
+      public boolean getOffHeap() {
+        return false;
+      }
+    };
+  }
+
+  @Test
+  public void whenDiskStoreNamesForBothAreNullAndDiskPropertiesAreDifferentThenRegionComparisonMustBeSuccessful() {
+    CreateRegionFunction createRegionFunction = mock(CreateRegionFunction.class);
+    doCallRealMethod().when(createRegionFunction).compareRegionAttributes(any(), any());
+    RegionAttributes existingRegionAttributes = getRegionAttributesWithModifiedDiskDirSize(1);
+    RegionAttributes requestedRegionAttributes = getRegionAttributesWithModifiedDiskDirSize(2);
+    createRegionFunction.compareRegionAttributes(existingRegionAttributes,
+        requestedRegionAttributes);
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/RegionAttributesCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/RegionAttributesCreation.java
@@ -379,6 +379,7 @@ public class RegionAttributesCreation extends UserSpecifiedRegionAttributes
    * Returns whether or not this <code>RegionAttributesCreation</code> is equivalent to another
    * <code>RegionAttributes</code>.
    */
+
   public boolean sameAs(RegionAttributes other) {
     if (!equal(this.cacheListeners, Arrays.asList(other.getCacheListeners()))) {
       throw new RuntimeException(


### PR DESCRIPTION
   * If the existing region was using the DEFAULT diskstore but it was not explicitly linked to the
   * region using setDiskStore or disk-store-name tags. diskStoreName is set as null. This is
   * interpreted by Geode as use the DEFAULT diskstore.
   * This link between the existing region and a diskstore may happen because the diskstore is
   * named as DEFAULT.
   * The user may change the default location of the DEFAULT diskstore but the AppServer always
   * requests it be at the default location.
   * This comparison with always used to fail and the AppServer could not start up.
   * The goal of this method is that if both existing region and requested region are using the
   * DEFAULT diskstore, the existing regions take precedence and the requested ones are ignored.
   * This is current behavior which can be seen in
   * {@link RegionAttributesCreation#sameAs(RegionAttributes)}
   * The logic is to intercept the configurations for the regions and only if the both the regions
   * have diskStoreName set to null, meaning both should use the DEFAULT diskstore, the diskstore
   * names are sent as DEFAULT in the configuration and send to geode-core for comparison for rest
   * of the region attributes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
