### PR TITLE
GEODE-6673: remove unneeded HashSet creations

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
@@ -390,7 +390,7 @@ public abstract class DistributedCacheOperation {
 
       Set cachelessNodes = Collections.emptySet();
       Set adviseCacheServers;
-      Set<InternalDistributedMember> cachelessNodesWithNoCacheServer = new HashSet<>();
+      Set<InternalDistributedMember> cachelessNodesWithNoCacheServer = Collections.emptySet();
       if (region.getDistributionConfig().getDeltaPropagation() && this.supportsDeltaPropagation()) {
         cachelessNodes = region.getCacheDistributionAdvisor().adviseEmptys();
         if (!cachelessNodes.isEmpty()) {
@@ -405,8 +405,7 @@ public abstract class DistributedCacheOperation {
           recipients.removeAll(list);
           cachelessNodes.addAll(list);
         }
-
-        cachelessNodesWithNoCacheServer.addAll(cachelessNodes);
+        cachelessNodesWithNoCacheServer = new HashSet<>(cachelessNodes);
         adviseCacheServers = region.getCacheDistributionAdvisor().adviseCacheServers();
         cachelessNodesWithNoCacheServer.removeAll(adviseCacheServers);
       }
@@ -595,7 +594,7 @@ public abstract class DistributedCacheOperation {
             }
           }
 
-          if (cachelessNodesWithNoCacheServer.size() > 0) {
+          if (!cachelessNodesWithNoCacheServer.isEmpty()) {
             msg.resetRecipients();
             msg.setRecipients(cachelessNodesWithNoCacheServer);
             msg.setSendDelta(false);
@@ -608,17 +607,16 @@ public abstract class DistributedCacheOperation {
                 failures = newFailures;
               }
             }
+            // Add it back for size calculation ahead
+            cachelessNodes.addAll(cachelessNodesWithNoCacheServer);
           }
-          // Add it back for size calculation ahead
-          cachelessNodes.addAll(cachelessNodesWithNoCacheServer);
         }
 
         if (failures != null && !failures.isEmpty() && logger.isDebugEnabled()) {
           logger.debug("Failed sending ({}) to {} while processing event:{}", msg, failures, event);
         }
 
-        Set<InternalDistributedMember> adjunctRecipientsWithNoCacheServer =
-            new HashSet<InternalDistributedMember>();
+        Set<InternalDistributedMember> adjunctRecipientsWithNoCacheServer = Collections.emptySet();
         // send partitioned region listener notification messages now
         if (!adjunctRecipients.isEmpty()) {
           if (cachelessNodes.size() > 0) {
@@ -630,8 +628,7 @@ public abstract class DistributedCacheOperation {
               recipients.addAll(cachelessNodes);
             }
           }
-
-          adjunctRecipientsWithNoCacheServer.addAll(adjunctRecipients);
+          adjunctRecipientsWithNoCacheServer = new HashSet<>(adjunctRecipients);
           adviseCacheServers = ((Bucket) region).getPartitionedRegion()
               .getCacheDistributionAdvisor().adviseCacheServers();
           adjunctRecipientsWithNoCacheServer.removeAll(adviseCacheServers);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
@@ -405,9 +405,11 @@ public abstract class DistributedCacheOperation {
           recipients.removeAll(list);
           cachelessNodes.addAll(list);
         }
-        cachelessNodesWithNoCacheServer = new HashSet<>(cachelessNodes);
-        adviseCacheServers = region.getCacheDistributionAdvisor().adviseCacheServers();
-        cachelessNodesWithNoCacheServer.removeAll(adviseCacheServers);
+        if (!cachelessNodes.isEmpty()) {
+          cachelessNodesWithNoCacheServer = new HashSet<>(cachelessNodes);
+          adviseCacheServers = region.getCacheDistributionAdvisor().adviseCacheServers();
+          cachelessNodesWithNoCacheServer.removeAll(adviseCacheServers);
+        }
       }
 
       if (recipients.isEmpty() && adjunctRecipients.isEmpty() && needsOldValueInCacheOp.isEmpty()


### PR DESCRIPTION
DistributedCacheOperation._distribute is now careful to only create a HashSet
if it will not be empty.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
