### PR TITLE
GEODE-6720: Add FastLogger benchmarks

### DIFF
--- a/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerDisabledLevelBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerDisabledLevelBenchmark.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.logging.log4j.Level.INFO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,8 +36,8 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-@Measurement(iterations = 1, time = 1, timeUnit = SECONDS)
-@Warmup(iterations = 1, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = MINUTES)
+@Warmup(iterations = 1, time = 1, timeUnit = MINUTES)
 @Fork(1)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(SECONDS)

--- a/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerDisabledLevelBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerDisabledLevelBenchmark.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.logging.log4j;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.logging.log4j.Level.INFO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Measurement(iterations = 1, time = 1, timeUnit = SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = SECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(SECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings("unused")
+public class FastLoggerDisabledLevelBenchmark {
+
+  private Logger logger;
+  private FastLogger fastLogger;
+
+  private String message;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    logger = LogManager.getLogger();
+    fastLogger = new FastLogger(LogManager.getLogger());
+
+    FastLogger.setDelegating(false);
+
+    org.apache.logging.log4j.core.Logger coreLogger =
+        (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
+    LoggerContext context = coreLogger.getContext();
+
+    Configuration configuration = context.getConfiguration();
+    LoggerConfig loggerConfig = configuration.getLoggerConfig(coreLogger.getName());
+
+    loggerConfig.removeAppender("STDOUT");
+    loggerConfig.setLevel(INFO);
+
+    context.updateLoggers();
+
+    assertThat(logger.getLevel()).isEqualTo(INFO);
+
+    message = "message";
+  }
+
+  @Benchmark
+  public void logger_debugLogStatement_isDebugEnabled_benchmark_01() {
+    if (logger.isDebugEnabled()) {
+      logger.debug(message);
+    }
+  }
+
+  @Benchmark
+  public void fastLogger_debugLogStatement_isDebugEnabled_benchmark_01() {
+    if (fastLogger.isDebugEnabled()) {
+      fastLogger.debug(message);
+    }
+  }
+
+  @Benchmark
+  public void logger_debugLogStatement_benchmark_02() {
+    logger.debug(message);
+  }
+
+  @Benchmark
+  public void fastLogger_debugLogStatement_benchmark_02() {
+    fastLogger.debug(message);
+  }
+
+  @Benchmark
+  public void logger_debugLogStatement_lambda_benchmark_03() {
+    logger.debug(() -> message);
+  }
+
+  @Benchmark
+  public void fastLogger_debugLogStatement_lambda_benchmark_03() {
+    fastLogger.debug(() -> message);
+  }
+}

--- a/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerEnabledLevelBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerEnabledLevelBenchmark.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.logging.log4j.Level.INFO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,8 +36,8 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-@Measurement(iterations = 1, time = 1, timeUnit = SECONDS)
-@Warmup(iterations = 1, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = MINUTES)
+@Warmup(iterations = 1, time = 1, timeUnit = MINUTES)
 @Fork(1)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(SECONDS)

--- a/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerEnabledLevelBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerEnabledLevelBenchmark.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.logging.log4j;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.logging.log4j.Level.INFO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Measurement(iterations = 1, time = 1, timeUnit = SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = SECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(SECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings("unused")
+public class FastLoggerEnabledLevelBenchmark {
+
+  private Logger logger;
+  private FastLogger fastLogger;
+
+  private String message;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    logger = LogManager.getLogger();
+    fastLogger = new FastLogger(LogManager.getLogger());
+
+    FastLogger.setDelegating(false);
+
+    org.apache.logging.log4j.core.Logger coreLogger =
+        (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
+    LoggerContext context = coreLogger.getContext();
+
+    Configuration configuration = context.getConfiguration();
+    LoggerConfig loggerConfig = configuration.getLoggerConfig(coreLogger.getName());
+
+    loggerConfig.removeAppender("STDOUT");
+    loggerConfig.setLevel(INFO);
+
+    context.updateLoggers();
+
+    assertThat(logger.getLevel()).isEqualTo(INFO);
+
+    message = "message";
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_benchmark_01() {
+    logger.info(message);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_benchmark_01() {
+    fastLogger.info(message);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_lambda_benchmark_02() {
+    logger.info(() -> message);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_lambda_benchmark_02() {
+    fastLogger.info(() -> message);
+  }
+}

--- a/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerParameterTypeBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerParameterTypeBenchmark.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.logging.log4j;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.logging.log4j.Level.INFO;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,8 +39,8 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
-@Measurement(iterations = 1, time = 1, timeUnit = SECONDS)
-@Warmup(iterations = 1, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 1, time = 1, timeUnit = MINUTES)
+@Warmup(iterations = 1, time = 1, timeUnit = MINUTES)
 @Fork(1)
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(SECONDS)

--- a/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerParameterTypeBenchmark.java
+++ b/geode-core/src/jmh/java/org/apache/geode/internal/logging/log4j/FastLoggerParameterTypeBenchmark.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.logging.log4j;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.logging.log4j.Level.INFO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@Measurement(iterations = 1, time = 1, timeUnit = SECONDS)
+@Warmup(iterations = 1, time = 1, timeUnit = SECONDS)
+@Fork(1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(SECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings("unused")
+public class FastLoggerParameterTypeBenchmark {
+
+  private Logger logger;
+  private FastLogger fastLogger;
+
+  private String messageForConcat;
+  private String messageForParams;
+  private String string1;
+  private String string2;
+  private Map<String, String> map1;
+  private Map<String, String> map2;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    logger = LogManager.getLogger();
+    fastLogger = new FastLogger(LogManager.getLogger());
+
+    FastLogger.setDelegating(false);
+
+    org.apache.logging.log4j.core.Logger coreLogger =
+        (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
+    LoggerContext context = coreLogger.getContext();
+
+    Configuration configuration = context.getConfiguration();
+    LoggerConfig loggerConfig = configuration.getLoggerConfig(coreLogger.getName());
+
+    loggerConfig.removeAppender("STDOUT");
+    loggerConfig.setLevel(INFO);
+
+    context.updateLoggers();
+
+    assertThat(logger.getLevel()).isEqualTo(INFO);
+
+    messageForConcat = "message: ";
+    messageForParams = "message: {}, {}";
+    string1 = "string1";
+    string2 = "string2";
+    map1 = new HashMap<>();
+    map2 = new HashMap<>();
+    for (int i = 1; i <= 100; i++) {
+      map1.put("key" + i, "value" + i);
+    }
+    for (int i = 1; i <= 100; i++) {
+      map2.put("key" + i, "value" + i);
+    }
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_stringConcat_benchmark_01() {
+    logger.info(messageForConcat + string1 + ", " + string2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_stringConcat_benchmark_01() {
+    fastLogger.info(messageForConcat + string1 + ", " + string2);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_complexConcat_benchmark_02() {
+    logger.info(messageForConcat + map1 + ", " + map2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_complexConcat_benchmark_02() {
+    fastLogger.info(messageForConcat + map1 + ", " + map2);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_lambda_stringConcat_benchmark_03() {
+    logger.info(() -> messageForConcat + string1 + ", " + string2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_lambda_stringConcat_benchmark_03() {
+    fastLogger.info(() -> messageForConcat + string1 + ", " + string2);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_lambda_complexConcat_benchmark_04() {
+    logger.info(() -> messageForConcat + map1 + ", " + map2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_lambda_complexConcat_benchmark_04() {
+    fastLogger.info(() -> messageForConcat + map1 + ", " + map2);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_params_benchmark_05() {
+    logger.info(messageForParams, string1, string2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_params_benchmark_05() {
+    fastLogger.info(messageForParams, string1, string2);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_complexParams_benchmark_06() {
+    logger.info(messageForParams, map1, map2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_complexParams_benchmark_06() {
+    fastLogger.info(messageForParams, map1, map2);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_lambda_params_benchmark_07() {
+    logger.info(messageForParams, () -> string1, () -> string2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_lambda_params_benchmark_07() {
+    fastLogger.info(messageForParams, () -> string1, () -> string2);
+  }
+
+  @Benchmark
+  public void logger_infoLogStatement_lambda_complexParams_benchmark_08() {
+    logger.info(messageForParams, () -> map1, () -> map2);
+  }
+
+  @Benchmark
+  public void fastLogger_infoLogStatement_lambda_complexParams_benchmark_08() {
+    fastLogger.info(messageForParams, () -> map1, () -> map2);
+  }
+}


### PR DESCRIPTION
I'd like to merge these FastLogger benchmarks to develop:
* **FastLoggerDisabledLevelBenchmark** compares FastLogger vs Logger for log statements at a disabled level (ie, debug level when current log level is info).
* **FastLoggerEnabledLevelBenchmark** compares FastLogger vs Logger for log statements at an enabled level (ie, info level when current log level is info).
* **FastLoggerParameterTypeBenchmark** compares FastLogger vs Logger for various types of parameters at an enabled level (ie, info level when current log level is info).

Please review: @demery-pivotal @mhansonp @aaronlindsey @moleske @pivotal-jbarrett 

You can run a single JMH Benchmark class using:
```
$ ./gradlew geode-core:jmh -Pinclude=".*FastLoggerDisabledLevelBenchmark.*"
```
The numbers fluctuate from run-to-run, but _fastLogger_debugLogStatement_isDebugEnabled_benchmark_01_ consistently out-performs _logger_debugLogStatement_isDebugEnabled_benchmark_01_.

Sample run results:
```
Benchmark                                                                                   Mode  Cnt           Score   Error  Units

FastLoggerDisabledLevelBenchmark.fastLogger_debugLogStatement_isDebugEnabled_benchmark_01  thrpt       1807689366.083          ops/s
FastLoggerDisabledLevelBenchmark.logger_debugLogStatement_isDebugEnabled_benchmark_01      thrpt        619325332.223          ops/s
FastLoggerDisabledLevelBenchmark.fastLogger_debugLogStatement_benchmark_02                 thrpt        448305344.988          ops/s
FastLoggerDisabledLevelBenchmark.logger_debugLogStatement_benchmark_02                     thrpt        530355280.629          ops/s
FastLoggerDisabledLevelBenchmark.fastLogger_debugLogStatement_lambda_benchmark_03          thrpt        498633100.474          ops/s
FastLoggerDisabledLevelBenchmark.logger_debugLogStatement_lambda_benchmark_03              thrpt        627625938.074          ops/s
```
```
Benchmark                                                                         Mode  Cnt        Score   Error  Units

FastLoggerEnabledLevelBenchmark.fastLogger_infoLogStatement_benchmark_01         thrpt       3491924.597          ops/s
FastLoggerEnabledLevelBenchmark.logger_infoLogStatement_benchmark_01             thrpt       3407224.481          ops/s
FastLoggerEnabledLevelBenchmark.fastLogger_infoLogStatement_lambda_benchmark_02  thrpt       3057080.066          ops/s
FastLoggerEnabledLevelBenchmark.logger_infoLogStatement_lambda_benchmark_02      thrpt       3114615.700          ops/s
```
```
Benchmark                                                                                        Mode  Cnt        Score   Error  Units

FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_stringConcat_benchmark_01          thrpt       3110811.106          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_stringConcat_benchmark_01              thrpt       3020759.569          ops/s
FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_complexConcat_benchmark_02         thrpt         61516.196          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_complexConcat_benchmark_02             thrpt         61287.729          ops/s
FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_lambda_stringConcat_benchmark_03   thrpt       2710364.613          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_lambda_stringConcat_benchmark_03       thrpt       2667739.878          ops/s
FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_lambda_complexConcat_benchmark_04  thrpt         64283.010          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_lambda_complexConcat_benchmark_04      thrpt         60132.630          ops/s
FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_params_benchmark_05                thrpt       2944026.000          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_params_benchmark_05                    thrpt       2736174.880          ops/s
FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_complexParams_benchmark_06         thrpt       2926546.641          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_complexParams_benchmark_06             thrpt       2884928.362          ops/s
FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_lambda_params_benchmark_07         thrpt       2491212.879          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_lambda_params_benchmark_07             thrpt       2428997.756          ops/s
FastLoggerParameterTypeBenchmark.fastLogger_infoLogStatement_lambda_complexParams_benchmark_08  thrpt       2324345.545          ops/s
FastLoggerParameterTypeBenchmark.logger_infoLogStatement_lambda_complexParams_benchmark_08      thrpt       2275429.973          ops/s
```