### PR TITLE
GEODE-6702: optimize equals by not calling compareTo

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.InternalGemFireError;
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.cache.UnsupportedVersionException;
 import org.apache.geode.cache.client.ServerConnectivityException;
@@ -1227,6 +1228,15 @@ public class InternalDistributedMember implements DistributedMember, Externaliza
     return dsfidVersions;
   }
 
+  @VisibleForTesting
+  void setUniqueTag(String tag) {
+    uniqueTag = tag;
+  }
+
+  @VisibleForTesting
+  void setIsPartial(boolean value) {
+    isPartial = value;
+  }
 
   public static class InternalDistributedMemberWrapper {
     InternalDistributedMember mbr;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -638,7 +638,68 @@ public class InternalDistributedMember implements DistributedMember, Externaliza
     if ((obj == null) || !(obj instanceof InternalDistributedMember)) {
       return false;
     }
-    return compareTo((InternalDistributedMember) obj) == 0;
+    InternalDistributedMember other = (InternalDistributedMember) obj;
+
+    int myPort = getPort();
+    int otherPort = other.getPort();
+    if (myPort != otherPort) {
+      return false;
+    }
+
+    InetAddress myAddr = getInetAddress();
+    InetAddress otherAddr = other.getInetAddress();
+    // Discard null cases
+    if (myAddr == null && otherAddr == null) {
+      return true;
+    } else if (myAddr == null) {
+      return false;
+    } else if (otherAddr == null) {
+      return false;
+    } else if (!myAddr.equals(otherAddr)) {
+      return false;
+    }
+
+    if (!isPartial() && !other.isPartial()) {
+      String myName = getName();
+      String otherName = other.getName();
+      if (myName == null && otherName == null) {
+        // could be equal
+      } else if (myName == null) {
+        return false;
+      } else if (otherName == null) {
+        return false;
+      } else if (!myName.equals(otherName)) {
+        return false;
+      }
+    }
+
+    if (this.uniqueTag == null && other.uniqueTag == null) {
+      // not loners, so look at P2P view ID
+      int thisViewId = getVmViewId();
+      int otherViewId = other.getVmViewId();
+      if (thisViewId >= 0 && otherViewId >= 0) {
+        if (thisViewId != otherViewId) {
+          return false;
+        } // else they're the same, so continue
+      }
+    } else if (this.uniqueTag == null) {
+      return false;
+    } else if (other.uniqueTag == null) {
+      return false;
+    } else if (!this.uniqueTag.equals(other.uniqueTag)) {
+      return false;
+    }
+
+    if (this.netMbr != null && other.netMbr != null) {
+      if (0 != this.netMbr.compareAdditionalData(other.netMbr)) {
+        return false;
+      }
+    }
+
+    // purposely avoid checking roles
+    // @todo Add durableClientAttributes to equals
+
+    return true;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.geode.DataSerializer;
@@ -648,27 +649,14 @@ public class InternalDistributedMember implements DistributedMember, Externaliza
 
     InetAddress myAddr = getInetAddress();
     InetAddress otherAddr = other.getInetAddress();
-    // Discard null cases
     if (myAddr == null && otherAddr == null) {
       return true;
-    } else if (myAddr == null) {
-      return false;
-    } else if (otherAddr == null) {
-      return false;
-    } else if (!myAddr.equals(otherAddr)) {
+    } else if (!Objects.equals(myAddr, otherAddr)) {
       return false;
     }
 
     if (!isPartial() && !other.isPartial()) {
-      String myName = getName();
-      String otherName = other.getName();
-      if (myName == null && otherName == null) {
-        // could be equal
-      } else if (myName == null) {
-        return false;
-      } else if (otherName == null) {
-        return false;
-      } else if (!myName.equals(otherName)) {
+      if (!Objects.equals(getName(), other.getName())) {
         return false;
       }
     }
@@ -682,11 +670,7 @@ public class InternalDistributedMember implements DistributedMember, Externaliza
           return false;
         } // else they're the same, so continue
       }
-    } else if (this.uniqueTag == null) {
-      return false;
-    } else if (other.uniqueTag == null) {
-      return false;
-    } else if (!this.uniqueTag.equals(other.uniqueTag)) {
+    } else if (!Objects.equals(this.uniqueTag, other.uniqueTag)) {
       return false;
     }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/InternalDistributedMemberTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/InternalDistributedMemberTest.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.membership;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.MembershipTest;
+
+/**
+ * Unit test for InternalDistributedMember
+ */
+@Category({MembershipTest.class})
+public class InternalDistributedMemberTest {
+
+  @Test
+  public void equalsReturnsTrueForSameMember() {
+    InternalDistributedMember member = new InternalDistributedMember("", 34567);
+
+    boolean result = member.equals(member);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void equalsReturnsFalseForNull() {
+    InternalDistributedMember member = new InternalDistributedMember("", 34567);
+
+    boolean result = member.equals(null);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsFalseForNonInternalDistributedMember() {
+    InternalDistributedMember member = new InternalDistributedMember("", 34567);
+
+    boolean result = member.equals(new Object());
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsFalseIfPortsDiffer() {
+    InternalDistributedMember member = new InternalDistributedMember("", 34567);
+    InternalDistributedMember other = new InternalDistributedMember("", 34568);
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsTrueIfNullInetAddress() throws UnknownHostException {
+    InetAddress localHost = InetAddress.getLocalHost();
+    NetMember netMember1 = mock(NetMember.class);
+    when(netMember1.getInetAddress()).thenReturn(localHost).thenReturn(null);
+    NetMember netMember2 = mock(NetMember.class);
+    when(netMember2.getInetAddress()).thenReturn(localHost).thenReturn(null);
+    InternalDistributedMember member = new InternalDistributedMember(netMember1);
+    InternalDistributedMember other = new InternalDistributedMember(netMember2);
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void equalsReturnsFalseIfInetAddressDiffer() throws UnknownHostException {
+    InetAddress host1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    InetAddress host2 = InetAddress.getByAddress(new byte[] {127, 0, 0, 2});
+    NetMember netMember1 = mock(NetMember.class);
+    when(netMember1.getInetAddress()).thenReturn(host1);
+    NetMember netMember2 = mock(NetMember.class);
+    when(netMember2.getInetAddress()).thenReturn(host2);
+    InternalDistributedMember member = new InternalDistributedMember(netMember1);
+    InternalDistributedMember other = new InternalDistributedMember(netMember2);
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsFalseIfGetViewIdDiffer() throws UnknownHostException {
+    InetAddress host1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    NetMember netMember1 = mock(NetMember.class);
+    when(netMember1.getInetAddress()).thenReturn(host1);
+    NetMember netMember2 = mock(NetMember.class);
+    when(netMember2.getInetAddress()).thenReturn(host1);
+    when(netMember1.getVmViewId()).thenReturn(1);
+    when(netMember2.getVmViewId()).thenReturn(2);
+    InternalDistributedMember member = new InternalDistributedMember(netMember1);
+    InternalDistributedMember other = new InternalDistributedMember(netMember2);
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsFalseIfUniqueTagsDiffer() throws UnknownHostException {
+    InetAddress host1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    NetMember netMember1 = mock(NetMember.class);
+    when(netMember1.getInetAddress()).thenReturn(host1);
+    NetMember netMember2 = mock(NetMember.class);
+    when(netMember2.getInetAddress()).thenReturn(host1);
+    InternalDistributedMember member = new InternalDistributedMember(netMember1);
+    member.setUniqueTag("tag1");
+    InternalDistributedMember other = new InternalDistributedMember(netMember2);
+    other.setUniqueTag("tag2");
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsFalseIfNotPartialAndNamesDiffer() throws UnknownHostException {
+    InetAddress host1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    NetMember netMember1 = mock(NetMember.class);
+    when(netMember1.getInetAddress()).thenReturn(host1);
+    when(netMember1.getName()).thenReturn("name1");
+    NetMember netMember2 = mock(NetMember.class);
+    when(netMember2.getInetAddress()).thenReturn(host1);
+    when(netMember2.getName()).thenReturn("name2");
+    InternalDistributedMember member = new InternalDistributedMember(netMember1);
+    member.setIsPartial(false);
+    InternalDistributedMember other = new InternalDistributedMember(netMember2);
+    other.setIsPartial(false);
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsFalseIfCompareAdditionalDataDiffer() throws UnknownHostException {
+    InetAddress host1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    NetMember netMember1 = mock(NetMember.class);
+    when(netMember1.getInetAddress()).thenReturn(host1);
+    NetMember netMember2 = mock(NetMember.class);
+    when(netMember2.getInetAddress()).thenReturn(host1);
+    when(netMember1.compareAdditionalData(netMember2)).thenReturn(1);
+    when(netMember2.compareAdditionalData(netMember1)).thenReturn(-1);
+    InternalDistributedMember member = new InternalDistributedMember(netMember1);
+    InternalDistributedMember other = new InternalDistributedMember(netMember2);
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void equalsReturnsTrueForTwoMembersOnSamePort() {
+    InternalDistributedMember member = new InternalDistributedMember("", 34567);
+    InternalDistributedMember other = new InternalDistributedMember("", 34567);
+
+    boolean result = member.equals(other);
+
+    assertThat(result).isTrue();
+  }
+
+}


### PR DESCRIPTION
The compareTo implementation needs to get the InetAddress as a byte array
which causes to byte array allocations.
By changing InternalDistributedMember.equals to not call compareTo InetAddress.equals
can be used instead which prevents the byte array allocations.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
