### PR TITLE
GEODE-6683: Set java SSL properties when Pulse runs in non-embedded mode

### DIFF
--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/PulseAppListenerTest.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/PulseAppListenerTest.java
@@ -45,6 +45,8 @@ public class PulseAppListenerTest {
 
   @Before
   public void setUp() {
+    System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_EMBEDDED, "true");
+
     repository = Repository.get();
     appListener = new PulseAppListener();
 
@@ -56,7 +58,6 @@ public class PulseAppListenerTest {
 
   @Test
   public void embeddedModeDefaultPropertiesRepositoryInitializationTest() {
-    System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_EMBEDDED, "true");
     appListener.contextInitialized(contextEvent);
 
     Assert.assertEquals(false, repository.getJmxUseLocator());
@@ -69,7 +70,6 @@ public class PulseAppListenerTest {
 
   @Test
   public void embeddedModeNonDefaultPropertiesRepositoryInitializationTest() {
-    System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_EMBEDDED, "true");
     System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_PORT, "9999");
     System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_HOST, "nonDefaultBindAddress");
     System.setProperty(PulseConstants.SYSTEM_PROPERTY_PULSE_USESSL_MANAGER,

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/PulseAppListenerUnitTest.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/PulseAppListenerUnitTest.java
@@ -1,0 +1,146 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.tools.pulse.internal;
+
+import static java.util.Collections.emptyEnumeration;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Enumeration;
+import java.util.Properties;
+import java.util.ResourceBundle;
+import java.util.function.Function;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import org.apache.geode.tools.pulse.internal.data.Repository;
+
+public class PulseAppListenerUnitTest {
+
+  @Rule
+  public MockitoRule rule = MockitoJUnit.rule();
+
+  private PulseAppListener subject;
+
+  @Mock
+  private ServletContextEvent contextEvent;
+
+  @Mock
+  private ServletContext servletContext;
+
+  @Mock
+  private Repository repository;
+
+  @Mock
+  private Function<String, Properties> loadProperties;
+
+  private ResourceBundle resourceBundle;
+
+  @Before
+  public void setUp() {
+    when(loadProperties.apply(eq("GemFireVersion.properties"))).thenReturn(new Properties());
+  }
+
+  @Test
+  public void contextInitialized_isEmbeddedModeWithoutSslProperties_doesNotSetSslProperties() {
+    resourceBundle = new StubResourceBundle();
+
+    when(contextEvent.getServletContext()).thenReturn(servletContext);
+    when(repository.getResourceBundle()).thenReturn(resourceBundle);
+
+    subject = new PulseAppListener(true, repository, loadProperties);
+
+    subject.contextInitialized(contextEvent);
+
+    verify(repository, never()).setJavaSslProperties(any());
+  }
+
+  @Test
+  public void contextInitialized_isEmbeddedModeWithSslProperties_setsProvidedSslProperties() {
+    resourceBundle = new StubResourceBundle();
+
+    Properties sslProperties = new Properties();
+
+    when(contextEvent.getServletContext()).thenReturn(servletContext);
+    when(repository.getResourceBundle()).thenReturn(resourceBundle);
+    when(servletContext.getAttribute("org.apache.geode.sslConfig")).thenReturn(sslProperties);
+
+    subject = new PulseAppListener(true, repository, loadProperties);
+
+    subject.contextInitialized(contextEvent);
+
+    verify(repository).setJavaSslProperties(sslProperties);
+  }
+
+  @Test
+  public void contextInitialized_isNonEmbeddedModeWithoutSslProperties_doesNotSetSslProperties() {
+    resourceBundle = new StubResourceBundle();
+
+    when(repository.getResourceBundle()).thenReturn(resourceBundle);
+    when(loadProperties.apply(anyString())).thenReturn(new Properties());
+
+    subject = new PulseAppListener(false, repository, loadProperties);
+
+    subject.contextInitialized(contextEvent);
+
+    verify(repository, never()).setJavaSslProperties(any());
+  }
+
+  @Test
+  public void contextInitialized_isNonEmbeddedModeWithSslProperties_setsProvidedSslProperties() {
+    resourceBundle = new StubResourceBundle();
+
+    Properties sslProperties = new Properties();
+    sslProperties.put("foo", "bar");
+
+    when(repository.getResourceBundle()).thenReturn(resourceBundle);
+    when(loadProperties.apply(eq("pulse.properties"))).thenReturn(new Properties());
+    when(loadProperties.apply(eq("pulsesecurity.properties"))).thenReturn(sslProperties);
+
+    subject = new PulseAppListener(false, repository, loadProperties);
+
+    subject.contextInitialized(contextEvent);
+
+    verify(repository).setJavaSslProperties(sslProperties);
+  }
+
+  class StubResourceBundle extends ResourceBundle {
+
+    @Override
+    protected Object handleGetObject(String key) {
+      return "the same string";
+    }
+
+    @Override
+    public Enumeration<String> getKeys() {
+      return emptyEnumeration();
+    }
+  }
+}

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/PulseAppListenerUnitTest.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/PulseAppListenerUnitTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.ResourceBundle;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -59,13 +59,13 @@ public class PulseAppListenerUnitTest {
   private Repository repository;
 
   @Mock
-  private Function<String, Properties> loadProperties;
+  private BiFunction<String, ResourceBundle, Properties> loadProperties;
 
   private ResourceBundle resourceBundle;
 
   @Before
   public void setUp() {
-    when(loadProperties.apply(eq("GemFireVersion.properties"))).thenReturn(new Properties());
+    when(loadProperties.apply(eq("GemFireVersion.properties"), any())).thenReturn(new Properties());
   }
 
   @Test
@@ -104,7 +104,7 @@ public class PulseAppListenerUnitTest {
     resourceBundle = new StubResourceBundle();
 
     when(repository.getResourceBundle()).thenReturn(resourceBundle);
-    when(loadProperties.apply(anyString())).thenReturn(new Properties());
+    when(loadProperties.apply(anyString(), any())).thenReturn(new Properties());
 
     subject = new PulseAppListener(false, repository, loadProperties);
 
@@ -121,8 +121,8 @@ public class PulseAppListenerUnitTest {
     sslProperties.put("foo", "bar");
 
     when(repository.getResourceBundle()).thenReturn(resourceBundle);
-    when(loadProperties.apply(eq("pulse.properties"))).thenReturn(new Properties());
-    when(loadProperties.apply(eq("pulsesecurity.properties"))).thenReturn(sslProperties);
+    when(loadProperties.apply(eq("pulse.properties"), any())).thenReturn(new Properties());
+    when(loadProperties.apply(eq("pulsesecurity.properties"), any())).thenReturn(sslProperties);
 
     subject = new PulseAppListener(false, repository, loadProperties);
 


### PR DESCRIPTION
Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Michael Oleske <moleske@pivotal.io>
Co-authored-by: Mark Hanson <mhanson@pivotal.io>

The change that fixes the NPE from GEODE-6683 is adding the line `repository.setJavaSslProperties(pulseSecurityProperties);` in PulseAppListener.java. The other changes are refactoring to do TDD for this change.

Please review: @kirklund @demery-pivotal @mhansonp @moleske

---

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
