### PR TITLE
GEODE-6724 split brain formed on concurrent locator startup

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
@@ -86,6 +86,9 @@ public class GMSUtil {
         int startIdx = str.indexOf('[') + 1;
         int endIdx = str.indexOf(']');
         port = Integer.parseInt(str.substring(startIdx, endIdx));
+        if (port <= 0) {
+          continue;
+        }
         InetSocketAddress isa = new InetSocketAddress(host, port);
 
         if (checkLoopback) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -279,13 +279,13 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
 
     public String toString() {
       StringBuffer sb = new StringBuffer(200);
-      sb.append("SearchState(locatorsContacted=").append(locatorsContacted)
+      sb.append("locatorsContacted=").append(locatorsContacted)
           .append("; findInViewResponses=").append(joinedMembersContacted)
           .append("; alreadyTried=").append(alreadyTried).append("; registrants=")
           .append(registrants).append("; possibleCoordinator=").append(possibleCoordinator)
           .append("; viewId=").append(viewId).append("; hasContactedAJoinedLocator=")
           .append(hasContactedAJoinedLocator).append("; view=").append(view).append("; responses=")
-          .append(responses).append(")");
+          .append(responses);
       return sb.toString();
     }
   }
@@ -323,6 +323,7 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
       long startTime = System.currentTimeMillis();
       long locatorGiveUpTime = startTime + locatorWaitTime;
       long giveupTime = startTime + timeout;
+      int minimumRetriesBeforeBecomingCoordinator = locators.size() * 2;
 
       for (int tries = 0; !this.isJoined && !this.isStopping; tries++) {
         logger.debug("searching for the membership coordinator");
@@ -333,8 +334,11 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
           logger.info("found possible coordinator {}", state.possibleCoordinator);
           if (localAddress.getNetMember().preferredForCoordinator()
               && state.possibleCoordinator.equals(this.localAddress)) {
+            // if we haven't contacted a member of a cluster maybe this node should
+            // become the coordinator.
             if (state.joinedMembersContacted <= 0 &&
-                (tries > 2 || System.currentTimeMillis() < giveupTime)) {
+                (tries >= minimumRetriesBeforeBecomingCoordinator ||
+                    state.locatorsContacted >= locators.size())) {
               synchronized (viewInstallationLock) {
                 becomeCoordinator();
               }
@@ -376,10 +380,11 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
               logger.debug("sleeping for {} before making another attempt to find the coordinator",
                   retrySleep);
               Thread.sleep(retrySleep);
-            }
+            } /* else { */
             // since we were given a coordinator that couldn't be used we should keep trying
             tries = 0;
             giveupTime = System.currentTimeMillis() + timeout;
+            // }
           }
         } catch (InterruptedException e) {
           logger.debug("retry sleep interrupted - giving up on joining the distributed system");

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -380,11 +380,11 @@ public class GMSJoinLeave implements JoinLeave, MessageHandler {
               logger.debug("sleeping for {} before making another attempt to find the coordinator",
                   retrySleep);
               Thread.sleep(retrySleep);
-            } /* else { */
-            // since we were given a coordinator that couldn't be used we should keep trying
-            tries = 0;
-            giveupTime = System.currentTimeMillis() + timeout;
-            // }
+            } else {
+              // since we were given a coordinator that couldn't be used we should keep trying
+              tries = 0;
+              giveupTime = System.currentTimeMillis() + timeout;
+            }
           }
         } catch (InterruptedException e) {
           logger.debug("retry sleep interrupted - giving up on joining the distributed system");


### PR DESCRIPTION
Ensure that either all locators have been contacted or a decent
number of attempts to join have occurred before allowing a member to
start its own cluster.

If all locators have been contacted we ought to have a sufficient
registration pool to choose a membership coordinator during concurrent
startup.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
