### PR TITLE
GEODE-6689: remove unneeded ArrayList creation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -1284,6 +1284,9 @@ public class DistributionAdvisor {
     for (Profile profile : locProfiles) {
       collection = profileCollector.collect(profile, compareTo, collection);
     }
+    if (collection == null) {
+      collection = Collections.emptyList();
+    }
     return collection;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -1277,6 +1277,16 @@ public class DistributionAdvisor {
     return result;
   }
 
+  protected <E> List<E> collectProfiles(ProfileCollector<E> profileCollector, E compareTo) {
+    initializationGate();
+    List<E> collection = null;
+    Profile[] locProfiles = profiles;
+    for (Profile profile : locProfiles) {
+      collection = profileCollector.collect(profile, compareTo, collection);
+    }
+    return collection;
+  }
+
   /** Provide recipients for profile update. */
   public Set adviseProfileUpdate() {
     return adviseGeneric();
@@ -1371,6 +1381,10 @@ public class DistributionAdvisor {
   /** Filter interface */
   protected interface Filter {
     boolean include(Profile profile);
+  }
+
+  protected interface ProfileCollector<E> {
+    List<E> collect(Profile profile, E compareTo, List<E> list);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.cache.CacheEvent;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.InterestPolicy;
@@ -1099,13 +1100,13 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
     }
   }
 
+  @MakeNotStatic("not tied to the cache lifecycle")
   private static final SameGatewaySenderIdsCollector sameGatewaySenderIdsCollector =
       new SameGatewaySenderIdsCollector();
 
   public List<Set<String>> adviseSameGatewaySenderIds(final Set<String> allGatewaySenderIds) {
     return collectProfiles(sameGatewaySenderIdsCollector, allGatewaySenderIds);
   }
-
 
   private static class SameAsyncEventQueueIdsCollector implements ProfileCollector<Set<String>> {
     @Override
@@ -1125,11 +1126,11 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
     }
   }
 
+  @MakeNotStatic("not tied to the cache lifecycle")
   private static final SameAsyncEventQueueIdsCollector sameAsyncEventQueueIdsCollector =
       new SameAsyncEventQueueIdsCollector();
 
   public List<Set<String>> adviseSameAsyncEventQueueIds(final Set<String> allAsyncEventIds) {
     return collectProfiles(sameAsyncEventQueueIdsCollector, allAsyncEventIds);
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
@@ -1081,40 +1081,61 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
     return result;
   }
 
-  public List<Set<String>> adviseSameGatewaySenderIds(final Set<String> allGatewaySenderIds) {
-    final List<Set<String>> differSenderIds = new ArrayList<>();
-    fetchProfiles(profile -> {
+  private static class SameGatewaySenderIdsCollector implements ProfileCollector<Set<String>> {
+    @Override
+    public List<Set<String>> collect(Profile profile, Set<String> allGatewaySenderIds,
+        List<Set<String>> list) {
       if (profile instanceof CacheProfile) {
         final CacheProfile cp = (CacheProfile) profile;
-        if (allGatewaySenderIds.equals(cp.gatewaySenderIds)) {
-          return true;
-        } else {
-          differSenderIds.add(allGatewaySenderIds);
-          differSenderIds.add(cp.gatewaySenderIds);
-          return false;
+        if (!allGatewaySenderIds.equals(cp.gatewaySenderIds)) {
+          if (list == null) {
+            list = new ArrayList<>();
+          }
+          list.add(allGatewaySenderIds);
+          list.add(cp.gatewaySenderIds);
         }
       }
-      return false;
-    });
-    return differSenderIds;
+      if (list == null) {
+        list = Collections.emptyList();
+      }
+      return list;
+    }
   }
 
-  public List<Set<String>> adviseSameAsyncEventQueueIds(final Set<String> allAsyncEventIds) {
-    final List<Set<String>> differAsycnQueueIds = new ArrayList<>();
-    fetchProfiles(profile -> {
+  private static final SameGatewaySenderIdsCollector sameGatewaySenderIdsCollector =
+      new SameGatewaySenderIdsCollector();
+
+  public List<Set<String>> adviseSameGatewaySenderIds(final Set<String> allGatewaySenderIds) {
+    return collectProfiles(sameGatewaySenderIdsCollector, allGatewaySenderIds);
+  }
+
+
+  private static class SameAsyncEventQueueIdsCollector implements ProfileCollector<Set<String>> {
+    @Override
+    public List<Set<String>> collect(Profile profile, Set<String> allAsyncEventIds,
+        List<Set<String>> list) {
       if (profile instanceof CacheProfile) {
         final CacheProfile cp = (CacheProfile) profile;
-        if (allAsyncEventIds.equals(cp.asyncEventQueueIds)) {
-          return true;
-        } else {
-          differAsycnQueueIds.add(allAsyncEventIds);
-          differAsycnQueueIds.add(cp.asyncEventQueueIds);
-          return false;
+        if (!allAsyncEventIds.equals(cp.asyncEventQueueIds)) {
+          if (list == null) {
+            list = new ArrayList<>();
+          }
+          list.add(allAsyncEventIds);
+          list.add(cp.asyncEventQueueIds);
         }
       }
-      return false;
-    });
-    return differAsycnQueueIds;
+      if (list == null) {
+        list = Collections.emptyList();
+      }
+      return list;
+    }
+  }
+
+  private static final SameAsyncEventQueueIdsCollector sameAsyncEventQueueIdsCollector =
+      new SameAsyncEventQueueIdsCollector();
+
+  public List<Set<String>> adviseSameAsyncEventQueueIds(final Set<String> allAsyncEventIds) {
+    return collectProfiles(sameAsyncEventQueueIdsCollector, allAsyncEventIds);
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
@@ -1095,9 +1095,6 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
           list.add(cp.gatewaySenderIds);
         }
       }
-      if (list == null) {
-        list = Collections.emptyList();
-      }
       return list;
     }
   }
@@ -1123,9 +1120,6 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
           list.add(allAsyncEventIds);
           list.add(cp.asyncEventQueueIds);
         }
-      }
-      if (list == null) {
-        list = Collections.emptyList();
       }
       return list;
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
@@ -146,6 +146,9 @@ public class JmxManagerAdvisor extends DistributionAdvisor {
       Profile profile = locProfiles[i];
       collection = profileCollector.collect(profile, compareTo, collection);
     }
+    if (collection == null) {
+      collection = Collections.emptyList();
+    }
     return collection;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisor.java
@@ -110,8 +110,7 @@ public class JmxManagerAdvisor extends DistributionAdvisor {
     initializationGate();
     List result = null;
     {
-      JmxManagerAdvisee advisee = (JmxManagerAdvisee) getAdvisee();
-      Profile myp = advisee.getMyMostRecentProfile();
+      Profile myp = getMyMostRecentProfile();
       if (f == null || f.include(myp)) {
         if (result == null) {
           result = new ArrayList();
@@ -136,6 +135,25 @@ public class JmxManagerAdvisor extends DistributionAdvisor {
     }
     return result;
   }
+
+  @Override
+  protected <E> List<E> collectProfiles(ProfileCollector<E> profileCollector, E compareTo) {
+    initializationGate();
+    List<E> collection = null;
+    collection = profileCollector.collect(getMyMostRecentProfile(), compareTo, collection);
+    Profile[] locProfiles = this.profiles; // grab current profiles
+    for (int i = 0; i < locProfiles.length; i++) {
+      Profile profile = locProfiles[i];
+      collection = profileCollector.collect(profile, compareTo, collection);
+    }
+    return collection;
+  }
+
+  private Profile getMyMostRecentProfile() {
+    JmxManagerAdvisee advisee = (JmxManagerAdvisee) getAdvisee();
+    return advisee.getMyMostRecentProfile();
+  }
+
 
   /**
    * Message used to push event updates to remote VMs

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CacheDistributionAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CacheDistributionAdvisorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+
+import org.apache.geode.distributed.internal.DistributionAdvisor;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.CacheDistributionAdvisor.CacheProfile;
+
+/**
+ * Unit test for CacheDistributionAdvisor
+ */
+public class CacheDistributionAdvisorTest {
+
+  @Test
+  public void adviseSameGatewaySenderIdsReturnsInputAndNonMatchingProfileIds() {
+    CacheDistributionAdvisor advisor = createCacheDistributionAdvisor();
+    CacheProfile profile = new CacheProfile();
+    advisor.putProfile(profile, true);
+    Set<String> input = Collections.emptySet();
+
+    List<Set<String>> result = advisor.adviseSameGatewaySenderIds(input);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void adviseSameGatewaySenderIdsReturnsEmptySetGivenOneProfileThatMatchesInput() {
+    CacheDistributionAdvisor advisor = createCacheDistributionAdvisor();
+    CacheProfile profile = new CacheProfile();
+    Set<String> profileIds = new HashSet<>();
+    profileIds.add("profileId1");
+    profile.gatewaySenderIds = profileIds;
+    advisor.putProfile(profile, true);
+    Set<String> input = new HashSet<>();
+    input.add("inputId1");
+
+    List<Set<String>> result = advisor.adviseSameGatewaySenderIds(input);
+
+    assertThat(result).containsExactly(input, profileIds);
+  }
+
+  @Test
+  public void adviseSameGatewaySenderIdsReturnsInputAndNonMatchingProfileIdsGivenMultipleProfiles() {
+    Set<String> input = new HashSet<>();
+    input.add("inputId1");
+    CacheDistributionAdvisor advisor = createCacheDistributionAdvisor();
+    InternalDistributedMember memberId1 = mock(InternalDistributedMember.class);
+    CacheProfile profile = new CacheProfile(memberId1, 0);
+    Set<String> profileIds = new HashSet<>();
+    profileIds.add("profileId1");
+    profile.gatewaySenderIds = profileIds;
+    advisor.putProfile(profile, true);
+    InternalDistributedMember memberId2 = mock(InternalDistributedMember.class);
+    CacheProfile notInResult = new CacheProfile(memberId2, 0);
+    notInResult.gatewaySenderIds = input;
+    advisor.putProfile(notInResult, true);
+    InternalDistributedMember memberId3 = mock(InternalDistributedMember.class);
+    CacheProfile profile2 = new CacheProfile(memberId3, 0);
+    Set<String> profileIds2 = new HashSet<>();
+    profileIds.add("profileId2");
+    profile2.gatewaySenderIds = profileIds2;
+    advisor.putProfile(profile2, true);
+
+    List<Set<String>> result = advisor.adviseSameGatewaySenderIds(input);
+
+    assertThat(result).containsExactly(input, profileIds, input, profileIds2);
+  }
+
+  @Test
+  public void adviseSameAsyncEventQueueIdsReturnsInputAndNonMatchingProfileIds() {
+    CacheDistributionAdvisor advisor = createCacheDistributionAdvisor();
+    CacheProfile profile = new CacheProfile();
+    advisor.putProfile(profile, true);
+    Set<String> input = Collections.emptySet();
+
+    List<Set<String>> result = advisor.adviseSameAsyncEventQueueIds(input);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void adviseSameAsyncEventQueueIdsReturnsEmptySetGivenOneProfileThatMatchesInput() {
+    CacheDistributionAdvisor advisor = createCacheDistributionAdvisor();
+    CacheProfile profile = new CacheProfile();
+    Set<String> profileIds = new HashSet<>();
+    profileIds.add("profileId1");
+    profile.asyncEventQueueIds = profileIds;
+    advisor.putProfile(profile, true);
+    Set<String> input = new HashSet<>();
+    input.add("inputId1");
+
+    List<Set<String>> result = advisor.adviseSameAsyncEventQueueIds(input);
+
+    assertThat(result).containsExactly(input, profileIds);
+  }
+
+  @Test
+  public void adviseSameAsyncEventQueueIdsReturnsInputAndNonMatchingProfileIdsGivenMultipleProfiles() {
+    Set<String> input = new HashSet<>();
+    input.add("inputId1");
+    CacheDistributionAdvisor advisor = createCacheDistributionAdvisor();
+    InternalDistributedMember memberId1 = mock(InternalDistributedMember.class);
+    CacheProfile profile = new CacheProfile(memberId1, 0);
+    Set<String> profileIds = new HashSet<>();
+    profileIds.add("profileId1");
+    profile.asyncEventQueueIds = profileIds;
+    advisor.putProfile(profile, true);
+    InternalDistributedMember memberId2 = mock(InternalDistributedMember.class);
+    CacheProfile notInResult = new CacheProfile(memberId2, 0);
+    notInResult.asyncEventQueueIds = input;
+    advisor.putProfile(notInResult, true);
+    InternalDistributedMember memberId3 = mock(InternalDistributedMember.class);
+    CacheProfile profile2 = new CacheProfile(memberId3, 0);
+    Set<String> profileIds2 = new HashSet<>();
+    profileIds.add("profileId2");
+    profile2.asyncEventQueueIds = profileIds2;
+    advisor.putProfile(profile2, true);
+
+    List<Set<String>> result = advisor.adviseSameAsyncEventQueueIds(input);
+
+    assertThat(result).containsExactly(input, profileIds, input, profileIds2);
+  }
+
+  private CacheDistributionAdvisor createCacheDistributionAdvisor() {
+    DistributionAdvisor advisor = mock(DistributionAdvisor.class);
+    CacheDistributionAdvisee advisee = mock(CacheDistributionAdvisee.class);
+    when(advisee.getDistributionAdvisor()).thenReturn(advisor);
+    DistributionManager distributionManager = mock(DistributionManager.class);
+    when(advisee.getDistributionManager()).thenReturn(distributionManager);
+    return CacheDistributionAdvisor.createCacheDistributionAdvisor(advisee);
+  }
+}


### PR DESCRIPTION
Not only did adviseSameAsyncEventQueueIds and adviseSameGatewaySenderIds allocate and return an ArrayList every time they were called, but they also called fetchProfiles which would also create an ArrayList that was never used.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
