### PR TITLE
DISCUSSION: Add TimeUnit to timeout properties and parameters on public API.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplClientQueueDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplClientQueueDistributedTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.VM.getAllVMs;
 import static org.apache.geode.test.dunit.VM.getHostName;
@@ -202,7 +203,7 @@ public class AcceptorImplClientQueueDistributedTest implements Serializable {
       clientCacheFactory.setPoolRetryAttempts(0);
       clientCacheFactory.setPoolMinConnections(1);
       clientCacheFactory.setPoolMaxConnections(1);
-      clientCacheFactory.setPoolSocketConnectTimeout(5000);
+      clientCacheFactory.setPoolSocketConnectTimeout(5000, MILLISECONDS);
       clientCacheFactory.addPoolServer(hostName, vm1_port);
       ClientCache cache = clientCacheFactory.set("mcast-port", "0").create();
       ClientRegionFactory<Integer, Integer> clientRegionFactory =

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/ClientCacheFactoryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/ClientCacheFactoryJUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.cache.client;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
@@ -160,7 +161,7 @@ public class ClientCacheFactoryJUnitTest {
     dsProps.setProperty(MCAST_PORT, "0");
     DistributedSystem.connect(dsProps);
     Pool p = PoolManager.createFactory().addServer(InetAddress.getLocalHost().getHostName(), 7777)
-        .setSocketConnectTimeout(1400).create("singlePool");
+        .setSocketConnectTimeout(0, MILLISECONDS).create("singlePool");
 
     this.clientCache = new ClientCacheFactory().create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
@@ -180,7 +181,7 @@ public class ClientCacheFactoryJUnitTest {
     // however we should be to to create it by configuring a pool
     Pool pool = PoolManager.createFactory()
         .addServer(InetAddress.getLocalHost().getHostName(), CacheServer.DEFAULT_PORT)
-        .setMultiuserAuthentication(true).setSocketConnectTimeout(2345).create("pool1");
+        .setMultiuserAuthentication(true).setSocketConnectTimeout(5, MILLISECONDS).create("pool1");
     RegionService cc = this.clientCache.createAuthenticatedView(suProps, pool.getName());
     ProxyCache pc = (ProxyCache) cc;
     UserAttributes ua = pc.getUserAttributes();
@@ -200,9 +201,9 @@ public class ClientCacheFactoryJUnitTest {
     dsProps.setProperty(MCAST_PORT, "0");
     DistributedSystem.connect(dsProps);
     PoolManager.createFactory().addServer(InetAddress.getLocalHost().getHostName(), 7777)
-        .setSocketConnectTimeout(2500).create("p7");
+        .setSocketConnectTimeout(0, MILLISECONDS).create("p7");
     PoolManager.createFactory().addServer(InetAddress.getLocalHost().getHostName(), 6666)
-        .setSocketConnectTimeout(5200).create("p6");
+        .setSocketConnectTimeout(0, MILLISECONDS).create("p6");
 
     this.clientCache = new ClientCacheFactory().create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
@@ -238,7 +239,8 @@ public class ClientCacheFactoryJUnitTest {
   @Test
   public void test004SetMethod() {
     this.clientCache =
-        new ClientCacheFactory().set(LOG_LEVEL, "severe").setPoolSocketConnectTimeout(0).create();
+        new ClientCacheFactory().set(LOG_LEVEL, "severe")
+            .setPoolSocketConnectTimeout(0, MILLISECONDS).create();
     GemFireCacheImpl gfc = (GemFireCacheImpl) this.clientCache;
     assertThat(gfc.isClient()).isTrue();
 
@@ -248,8 +250,9 @@ public class ClientCacheFactoryJUnitTest {
     assertThat(dsProps.getProperty(LOG_LEVEL)).isEqualTo("severe");
     assertThat(this.clientCache.getDefaultPool().getSocketConnectTimeout()).isEqualTo(0);
 
-    assertThatThrownBy(() -> new ClientCacheFactory().setPoolSocketConnectTimeout(-1).create())
-        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(
+        () -> new ClientCacheFactory().setPoolSocketConnectTimeout(-1, MILLISECONDS).create())
+            .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import junit.framework.Assert;
 import org.junit.After;
@@ -494,7 +495,7 @@ public class AutoConnectionSourceImplJUnitTest {
     }
 
     @Override
-    public int getSocketConnectTimeout() {
+    public long getSocketConnectTimeout(TimeUnit timeUnit) {
       return 0;
     }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/ConnectionPoolImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/ConnectionPoolImplJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.client.internal;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
@@ -134,7 +135,7 @@ public class ConnectionPoolImplJUnitTest {
     int socketTimeout = 123123;
 
     PoolFactory cpf = PoolManager.createFactory();
-    cpf.addServer("localhost", port).setSocketConnectTimeout(socketTimeout)
+    cpf.addServer("localhost", port).setSocketConnectTimeout(socketTimeout, MILLISECONDS)
         .setReadTimeout(readTimeout).setThreadLocalConnections(true);
 
     PoolImpl pool = (PoolImpl) cpf.create("myfriendlypool");

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.Before;
@@ -378,7 +379,7 @@ public class QueueManagerJUnitTest {
     public void destroy(boolean keepAlive) {}
 
     @Override
-    public int getSocketConnectTimeout() {
+    public long getSocketConnectTimeout(TimeUnit timeUnit) {
       return 0;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/ClientCacheFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/ClientCacheFactory.java
@@ -15,10 +15,12 @@
 
 package org.apache.geode.cache.client;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheWriterException;
@@ -292,9 +294,26 @@ public class ClientCacheFactory {
    * @return a reference to <code>this</code>
    * @throws IllegalArgumentException if <code>socketConnectTimeout</code> is less than or equal to
    *         <code>-1</code>.
+   * @deprecated Use {@link #setPoolSocketConnectTimeout(long, TimeUnit)}
    */
+  @Deprecated
   public ClientCacheFactory setPoolSocketConnectTimeout(int socketConnectTimeout) {
-    getPoolFactory().setSocketConnectTimeout(socketConnectTimeout);
+    return setPoolSocketConnectTimeout(socketConnectTimeout, MILLISECONDS);
+  }
+
+  /**
+   * Sets the socket connect timeout for this pool. The duration specified as socket
+   * timeout when the client connects to the servers/locators. A timeout of zero is interpreted as
+   * an infinite timeout. The connection will then block until established or an error occurs.
+   *
+   * @param socketConnectTimeout timeout in {@code timeUnit} when the client connects to the servers
+   * @param timeUnit Unit of {@code socketConnectTimeout}
+   * @return a reference to {@code this}
+   * @throws IllegalArgumentException if {@code socketConnectTimeout} is less than 0.
+   */
+  public ClientCacheFactory setPoolSocketConnectTimeout(long socketConnectTimeout,
+      TimeUnit timeUnit) {
+    getPoolFactory().setSocketConnectTimeout(socketConnectTimeout, timeUnit);
     return this;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/Pool.java
@@ -15,7 +15,10 @@
 
 package org.apache.geode.cache.client;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.query.QueryService;
@@ -64,8 +67,19 @@ public interface Pool {
    * Returns the socket connect timeout of this pool.
    *
    * @see PoolFactory#setSocketConnectTimeout(int)
+   * @deprecated Use {@link #getSocketConnectTimeout(TimeUnit)}
    */
-  int getSocketConnectTimeout();
+  @Deprecated
+  default int getSocketConnectTimeout() {
+    return (int) getSocketConnectTimeout(MILLISECONDS);
+  }
+
+  /**
+   * Returns the socket connect timeout of this pool in the given {@link TimeUnit}.
+   *
+   * @see PoolFactory#setSocketConnectTimeout(long, TimeUnit)
+   */
+  long getSocketConnectTimeout(TimeUnit timeUnit);
 
   /**
    * Returns the connection timeout of this pool.

--- a/geode-core/src/main/java/org/apache/geode/cache/client/PoolFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/PoolFactory.java
@@ -15,6 +15,10 @@
 
 package org.apache.geode.cache.client;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.util.concurrent.TimeUnit;
+
 import org.apache.geode.cache.InterestResultPolicy;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.CqAttributes;
@@ -220,8 +224,24 @@ public interface PoolFactory {
    * @return a reference to <code>this</code>
    * @throws IllegalArgumentException if <code>socketConnectTimeout</code> is less than or equal to
    *         <code>-1</code>.
+   * @deprecated Use {@link #setSocketConnectTimeout(long, TimeUnit)}
    */
-  PoolFactory setSocketConnectTimeout(int socketConnectTimeout);
+  @Deprecated
+  default PoolFactory setSocketConnectTimeout(int socketConnectTimeout) {
+    return setSocketConnectTimeout(socketConnectTimeout, MILLISECONDS);
+  }
+
+  /**
+   * Sets the socket connect timeout for this pool. The duration specified as socket
+   * timeout when the client connects to the servers/locators. A timeout of zero is interpreted as
+   * an infinite timeout. The connection will then block until established or an error occurs.
+   *
+   * @param socketConnectTimeout timeout in {@code timeUnit} when the client connects to the servers
+   * @param timeUnit Unit of {@code socketConnectTimeout}
+   * @return a reference to {@code this}
+   * @throws IllegalArgumentException if {@code socketConnectTimeout} is less than 0.
+   */
+  PoolFactory setSocketConnectTimeout(long socketConnectTimeout, TimeUnit timeUnit);
 
   /**
    * Sets the free connection timeout for this pool. If the pool has a max connections setting,

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.client.internal;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.net.InetSocketAddress;
@@ -197,7 +198,7 @@ public class PoolImpl implements InternalPool {
     this.cache = cache;
     this.threadMonitoring = threadMonitoring;
 
-    socketConnectTimeout = attributes.getSocketConnectTimeout();
+    socketConnectTimeout = (int) attributes.getSocketConnectTimeout(MILLISECONDS);
     freeConnectionTimeout = attributes.getFreeConnectionTimeout();
     loadConditioningInterval = attributes.getLoadConditioningInterval();
     socketBufferSize = attributes.getSocketBufferSize();
@@ -344,7 +345,7 @@ public class PoolImpl implements InternalPool {
 
     if (statisticInterval > 0 && distributedSystem.getConfig().getStatisticSamplingEnabled()) {
       backgroundProcessor.scheduleWithFixedDelay(new PublishClientStatsTask(), statisticInterval,
-          statisticInterval, TimeUnit.MILLISECONDS);
+          statisticInterval, MILLISECONDS);
     }
     // LOG: changed from config to info
     logger.info("Pool {} started with multiuser-authentication={}",
@@ -377,8 +378,8 @@ public class PoolImpl implements InternalPool {
   }
 
   @Override
-  public int getSocketConnectTimeout() {
-    return socketConnectTimeout;
+  public long getSocketConnectTimeout(TimeUnit timeUnit) {
+    return timeUnit.convert(socketConnectTimeout, MILLISECONDS);
   }
 
   @Override
@@ -579,7 +580,7 @@ public class PoolImpl implements InternalPool {
       try {
         if (backgroundProcessor != null) {
           backgroundProcessor.shutdown();
-          if (!backgroundProcessor.awaitTermination(SHUTDOWN_TIMEOUT, TimeUnit.MILLISECONDS)) {
+          if (!backgroundProcessor.awaitTermination(SHUTDOWN_TIMEOUT, MILLISECONDS)) {
             logger.warn("Timeout waiting for background tasks to complete.");
           }
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -405,7 +407,7 @@ public class CacheXmlParser extends CacheXml implements ContentHandler {
     }
     v = atts.getValue(SOCKET_CONNECT_TIMEOUT);
     if (v != null) {
-      f.setSocketConnectTimeout(parseInt(v));
+      f.setSocketConnectTimeout(parseInt(v), MILLISECONDS);
     }
     v = atts.getValue(FREE_CONNECTION_TIMEOUT);
     if (v != null) {


### PR DESCRIPTION
I am using this PR as an example of a proposal to deprecate current timeout APIs with new APIs that take `TimeUnit`.

Current APIs leave an ambiguity when coding as to what the unit of time is. You must consult the documentation to determine the time unit. Many of the APIs like this documentation. Making things worse there isn't consistency throughout the API, some are in seconds, others milliseconds. Adding `TimeUnit` to these APIs removes the ambiguity since the caller dictates the time unit.

It also produces more readable code. Consider `setSocketConnectTimeout(86400000)` vs. `setSocketConnectTimeout(1, DAYS)`.

The goal would be to slowly add `TimeUnit` to all public APIs, and deprecate the original, as we are working in an area of code.

A similar task has already been completed in [geode-native](http://github.com/apache/geode-native).
