### PR TITLE
PoC: Stats supplied by meters

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/metrics/MeterSubregistryReconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/metrics/MeterSubregistryReconnectDistributedTest.java
@@ -143,7 +143,7 @@ public class MeterSubregistryReconnectDistributedTest implements Serializable {
       InternalCache cache = system.getCache();
       CompositeMeterRegistry compositeMeterRegistry =
           (CompositeMeterRegistry) cache.getMeterRegistry();
-      assertThat(compositeMeterRegistry.getRegistries()).containsOnly(addedSubregistry);
+      assertThat(compositeMeterRegistry.getRegistries()).contains(addedSubregistry);
     });
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/CacheFactoryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/CacheFactoryIntegrationTest.java
@@ -45,7 +45,7 @@ public class CacheFactoryIntegrationTest {
         .create();
 
     assertThat(getCacheMeterRegistry(cache).getRegistries())
-        .containsExactly(theMeterRegistry);
+        .contains(theMeterRegistry);
   }
 
   @Test
@@ -61,7 +61,7 @@ public class CacheFactoryIntegrationTest {
         .create();
 
     assertThat(getCacheMeterRegistry(cache).getRegistries())
-        .containsExactlyInAnyOrder(firstMeterRegistry, secondMeterRegistry, thirdMeterRegistry);
+        .contains(firstMeterRegistry, secondMeterRegistry, thirdMeterRegistry);
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
@@ -47,6 +47,7 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.metrics.CacheLifecycleMetricsSession;
 import org.apache.geode.internal.metrics.CacheMeterRegistryFactory;
 import org.apache.geode.internal.metrics.CompositeMeterRegistryFactory;
+import org.apache.geode.internal.statistics.StatisticsManager;
 import org.apache.geode.pdx.PdxSerializer;
 import org.apache.geode.pdx.internal.TypeRegistry;
 import org.apache.geode.security.AuthenticationFailedException;
@@ -200,9 +201,10 @@ public class InternalCacheBuilder {
             int systemId = internalDistributedSystem.getConfig().getDistributedSystemId();
             String memberName = internalDistributedSystem.getName();
             String hostName = internalDistributedSystem.getDistributedMember().getHost();
+            StatisticsManager statisticsManager = internalDistributedSystem.getStatisticsManager();
 
             CompositeMeterRegistry compositeMeterRegistry = compositeMeterRegistryFactory
-                .create(systemId, memberName, hostName);
+                .create(systemId, memberName, hostName, statisticsManager.getMeterWhitelist());
 
             for (MeterRegistry meterSubregistry : meterSubregistries) {
               compositeMeterRegistry.add(meterSubregistry);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/Acceptor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/Acceptor.java
@@ -25,6 +25,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor;
 import org.apache.geode.internal.cache.tier.sockets.CommBufferPool;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
+import org.apache.geode.internal.cache.wan.GatewayReceiverMeters;
 
 /**
  * Defines the message listener/acceptor interface which is the GemFire cache server. Multiple
@@ -105,4 +106,6 @@ public interface Acceptor extends CommBufferPool {
   void unregisterServerConnection(ServerConnection serverConnection);
 
   void decClientServerConnectionCount();
+
+  GatewayReceiverMeters gatewayReceiverMetrics();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
@@ -94,7 +94,8 @@ public class GatewayReceiverCommand extends BaseCommand {
     // Retrieve the number of events
     Part numberOfEventsPart = clientMessage.getPart(0);
     int numberOfEvents = numberOfEventsPart.getInt();
-    stats.incEventsReceived(numberOfEvents);
+    serverConnection.getAcceptor().gatewayReceiverMetrics()
+        .eventsReceivedCounter().increment(numberOfEvents);
 
     // Retrieve the batch id
     Part batchIdPart = clientMessage.getPart(1);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverMeters.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverMeters.java
@@ -1,0 +1,50 @@
+package org.apache.geode.internal.cache.wan;
+
+import static java.lang.String.format;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import org.apache.geode.Statistics;
+
+public class GatewayReceiverMeters {
+  private static final Set<String> meterWhitelist = new HashSet<String>() {
+    {
+      add("cache.gatewayreceiver.events.received");
+    }
+  };
+
+  private final Counter eventsReceivedCounter;
+
+  public GatewayReceiverMeters(MeterRegistry meterRegistry, GatewayReceiverStats stats) {
+    eventsReceivedCounter = createIntCounter(meterRegistry, "cache.gatewayreceiver.events.received",
+        stats.getStats(), stats.getEventsReceivedId());
+  }
+
+  public static Set<String> whitelist() {
+    return meterWhitelist;
+  }
+
+  private Counter createIntCounter(MeterRegistry registry, String name, Statistics stats,
+      int statId) {
+    if (!meterWhitelist.contains(name)) {
+      throw new IllegalStateException(
+          format("Meter name '%s' is not whitelisted in %s", name, getClass().getSimpleName()));
+    }
+    Counter counter = Counter.builder(name)
+        .description(stats.getType().getDescription())
+        .register(registry);
+
+    // NOTE: This will convert the double count to an int, which will roll from MAX_INT to MIN_INT.
+    stats.setIntSupplier(statId, () -> (int) counter.count());
+
+    return counter;
+  }
+
+  public Counter eventsReceivedCounter() {
+    return eventsReceivedCounter;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverMeters.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverMeters.java
@@ -52,7 +52,8 @@ public class GatewayReceiverMeters {
       int statId) {
     if (!meterWhitelist.contains(meterName)) {
       throw new IllegalStateException(
-          format("Meter name '%s' is not whitelisted in %s", meterName, getClass().getSimpleName()));
+          format("Meter name '%s' is not whitelisted in %s", meterName,
+              getClass().getSimpleName()));
     }
     Counter counter = Counter.builder(meterName)
         .description(stats.getType().getDescription())

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverMeters.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverMeters.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.geode.internal.cache.wan;
 
 import static java.lang.String.format;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
@@ -139,18 +139,9 @@ public class GatewayReceiverStats extends CacheServerStats {
     eventsRetriedId = statType.nameToId(EVENTS_RETRIED);
   }
 
-  // /////////////////// Instance Methods /////////////////////
-
-  // /**
-  // * Increments the number of failover batches received by 1.
-  // */
-  // public void incFailoverBatchesReceived() {
-  // this.stats.incInt(failoverBatchesReceivedId, 1);
-  // }
-  //
-  // public int getFailoverBatchesReceived() {
-  // return this.stats.getInt(failoverBatchesReceivedId);
-  // }
+  int getEventsReceivedId() {
+    return eventsReceivedId;
+  }
 
   /**
    * Increments the number of duplicate batches received by 1.
@@ -183,17 +174,6 @@ public class GatewayReceiverStats extends CacheServerStats {
 
   public int getEarlyAcks() {
     return this.stats.getInt(earlyAcksId);
-  }
-
-  /**
-   * Increments the number of events received by 1.
-   */
-  public void incEventsReceived(int delta) {
-    this.stats.incInt(eventsReceivedId, delta);
-  }
-
-  public int getEventsReceived() {
-    return this.stats.getInt(eventsReceivedId);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
@@ -30,10 +30,6 @@ public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory 
     CompositeMeterRegistry registry = new CompositeMeterRegistry();
     MeterRegistry whitelistedRegistry = new SimpleMeterRegistry();
 
-    // meter name
-    // whether to wire it to a stat
-    // how to wire it to a stat
-
     MeterFilter acceptOnlyStatMeters =
         MeterFilter.denyUnless(id -> meterWhitelist.contains(id.getName()));
     whitelistedRegistry.config().meterFilter(acceptOnlyStatMeters);

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
@@ -14,15 +14,31 @@
  */
 package org.apache.geode.internal.metrics;
 
+import java.util.Set;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory {
 
   @Override
-  public CompositeMeterRegistry create(int systemId, String memberName, String hostName) {
+  public CompositeMeterRegistry create(int systemId, String memberName, String hostName,
+      Set<String> meterWhitelist) {
     CompositeMeterRegistry registry = new CompositeMeterRegistry();
+    MeterRegistry whitelistedRegistry = new SimpleMeterRegistry();
+
+    // meter name
+    // whether to wire it to a stat
+    // how to wire it to a stat
+
+    MeterFilter acceptOnlyStatMeters =
+        MeterFilter.denyUnless(id -> meterWhitelist.contains(id.getName()));
+    whitelistedRegistry.config().meterFilter(acceptOnlyStatMeters);
+
+    registry.add(whitelistedRegistry);
 
     MeterRegistry.Config registryConfig = registry.config();
     registryConfig.commonTags("cluster.id", String.valueOf(systemId));

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.metrics;
 
+import java.util.Set;
+
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 /**
@@ -21,5 +23,6 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
  */
 public interface CompositeMeterRegistryFactory {
 
-  CompositeMeterRegistry create(int systemId, String memberName, String hostName);
+  CompositeMeterRegistry create(int systemId, String memberName, String hostName,
+      Set<String> meterWhitelist);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/GemFireStatSampler.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/GemFireStatSampler.java
@@ -37,7 +37,6 @@ import org.apache.geode.internal.admin.remote.StatListenerMessage;
 import org.apache.geode.internal.logging.LogFile;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.log4j.LogMarker;
-import org.apache.geode.internal.statistics.platform.OsStatisticsFactory;
 import org.apache.geode.internal.statistics.platform.ProcessStats;
 
 /**
@@ -60,7 +59,6 @@ public class GemFireStatSampler extends HostStatSampler {
 
   private final long systemId;
   private final StatisticsConfig statisticsConfig;
-  private final StatisticsManager statisticsManager;
   private final DistributionManager distributionManager;
 
   private int nextListenerId = 1;
@@ -88,10 +86,9 @@ public class GemFireStatSampler extends HostStatSampler {
       StatisticsManager statisticsManager,
       DistributionManager distributionManager,
       long systemId) {
-    super(cancelCriterion, statSamplerStats, logFile);
+    super(statisticsManager, cancelCriterion, statSamplerStats, logFile);
     this.systemId = systemId;
     this.statisticsConfig = statisticsConfig;
-    this.statisticsManager = statisticsManager;
     this.distributionManager = distributionManager;
   }
 
@@ -252,16 +249,6 @@ public class GemFireStatSampler extends HostStatSampler {
   @Override
   public boolean isSamplingEnabled() {
     return statisticsConfig.getStatisticSamplingEnabled();
-  }
-
-  @Override
-  protected StatisticsManager getStatisticsManager() {
-    return statisticsManager;
-  }
-
-  @Override
-  protected OsStatisticsFactory getOsStatisticsFactory() {
-    return statisticsManager;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/LocalStatisticsFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/LocalStatisticsFactory.java
@@ -14,6 +14,10 @@
  */
 package org.apache.geode.internal.statistics;
 
+import static java.util.Collections.emptySet;
+
+import java.util.Set;
+
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelCriterion;
@@ -93,5 +97,10 @@ public class LocalStatisticsFactory extends AbstractStatisticsFactory
       return new DummyStatisticsImpl(type, textId, numericId);
     }
     return super.createAtomicStatistics(type, textId, numericId);
+  }
+
+  @Override
+  public Set<String> getMeterWhitelist() {
+    return emptySet();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/SimpleStatSampler.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/SimpleStatSampler.java
@@ -54,15 +54,12 @@ public class SimpleStatSampler extends HostStatSampler {
   private final int sampleRate =
       Integer.getInteger(SAMPLE_RATE_PROPERTY, DEFAULT_SAMPLE_RATE).intValue();
 
-  private final StatisticsManager sm;
-
   public SimpleStatSampler(CancelCriterion stopper, StatisticsManager sm) {
     this(stopper, sm, new NanoTimer());
   }
 
   public SimpleStatSampler(CancelCriterion stopper, StatisticsManager sm, NanoTimer timer) {
-    super(stopper, new StatSamplerStats(sm, 0), timer);
-    this.sm = sm;
+    super(sm, stopper, new StatSamplerStats(sm, 0), timer);
     logger.info(LogMarker.STATISTICS_MARKER, "stats.sample-rate={}", getSampleRate());
   }
 
@@ -102,11 +99,6 @@ public class SimpleStatSampler extends HostStatSampler {
   @Override
   public String getProductDescription() {
     return "Unknown product";
-  }
-
-  @Override
-  protected StatisticsManager getStatisticsManager() {
-    return this.sm;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsImpl.java
@@ -537,7 +537,7 @@ public abstract class StatisticsImpl implements Statistics {
    *
    * @return the number of callback errors that occurred while sampling stats
    */
-  int invokeSuppliers() {
+  public int invokeSuppliers() {
     int errors = 0;
     for (Map.Entry<Integer, IntSupplier> entry : intSuppliers.entrySet()) {
       try {

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsManager.java
@@ -16,6 +16,7 @@
 package org.apache.geode.internal.statistics;
 
 import java.util.List;
+import java.util.Set;
 
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
@@ -76,4 +77,6 @@ public interface StatisticsManager extends StatisticsFactory, OsStatisticsFactor
    * Returns an array of all the current statistic resource instances.
    */
   Statistics[] getStatistics();
+
+  Set<String> getMeterWhitelist();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsRegistry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsRegistry.java
@@ -16,8 +16,10 @@ package org.apache.geode.internal.statistics;
 
 import java.io.IOException;
 import java.io.Reader;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntSupplier;
@@ -28,6 +30,7 @@ import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
+import org.apache.geode.internal.cache.wan.GatewayReceiverMeters;
 import org.apache.geode.internal.process.ProcessUtils;
 
 /**
@@ -44,6 +47,7 @@ public class StatisticsRegistry implements StatisticsManager {
   private final long startTime;
   private final List<Statistics> instances = new CopyOnWriteArrayList<>();
   private final AtomicLong nextUniqueId = new AtomicLong(1);
+  private final Set<String> meterWhitelist;
 
   private int modificationCount;
 
@@ -104,6 +108,13 @@ public class StatisticsRegistry implements StatisticsManager {
     this.osStatisticsFactory = osStatisticsFactory;
     this.atomicStatisticsFactory = atomicStatisticsFactory;
     this.pidSupplier = pidSupplier;
+    meterWhitelist = createMeterWhitelist();
+  }
+
+  private static Set<String> createMeterWhitelist() {
+    Set<String> meterWhitelist = new HashSet<>();
+    meterWhitelist.addAll(GatewayReceiverMeters.whitelist());
+    return meterWhitelist;
   }
 
   @Override
@@ -134,6 +145,11 @@ public class StatisticsRegistry implements StatisticsManager {
   @Override
   public Statistics[] getStatistics() {
     return getStatsList().toArray(new Statistics[0]);
+  }
+
+  @Override
+  public Set<String> getMeterWhitelist() {
+    return meterWhitelist;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StripedStatisticsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StripedStatisticsImpl.java
@@ -38,12 +38,16 @@ public class StripedStatisticsImpl extends StatisticsImpl {
     StatisticsTypeImpl realType = (StatisticsTypeImpl) type;
 
     this.intAdders =
-        Stream.generate(LongAdder::new).limit(realType.getIntStatCount()).toArray(LongAdder[]::new);
+        Stream.generate(LongAdder::new)
+            .limit(realType.getIntStatCount())
+            .toArray(LongAdder[]::new);
     this.longAdders =
-        Stream.generate(LongAdder::new).limit(realType.getLongStatCount())
+        Stream.generate(LongAdder::new)
+            .limit(realType.getLongStatCount())
             .toArray(LongAdder[]::new);
     this.doubleAdders =
-        Stream.generate(DoubleAdder::new).limit(realType.getDoubleStatCount())
+        Stream.generate(DoubleAdder::new)
+            .limit(realType.getDoubleStatCount())
             .toArray(DoubleAdder[]::new);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.util.Collections.emptySet;
 import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS_PROPERTY;
 import static org.apache.geode.internal.cache.InternalCacheBuilderAllowsMultipleSystemsTest.CacheState.CLOSED;
 import static org.apache.geode.internal.cache.InternalCacheBuilderAllowsMultipleSystemsTest.CacheState.OPEN;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.util.Collections;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -48,6 +50,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalCacheConstructor;
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalDistributedSystemConstructor;
 import org.apache.geode.internal.metrics.CompositeMeterRegistryFactory;
+import org.apache.geode.internal.statistics.StatisticsManager;
 
 /**
  * Unit tests for {@link InternalCacheBuilder} when
@@ -426,11 +429,15 @@ public class InternalCacheBuilderAllowsMultipleSystemsTest {
     InternalDistributedSystem system = mock(InternalDistributedSystem.class, mockName);
     DistributionConfig distributionConfig = mock(DistributionConfig.class);
     InternalDistributedMember distributedMember = mock(InternalDistributedMember.class);
+    StatisticsManager statisticsManager = mock(StatisticsManager.class);
+
     when(distributionConfig.getDistributedSystemId()).thenReturn(systemId);
     when(distributedMember.getHost()).thenReturn(hostName);
     when(system.getConfig()).thenReturn(distributionConfig);
     when(system.getDistributedMember()).thenReturn(distributedMember);
     when(system.getName()).thenReturn(memberName);
+    when(statisticsManager.getMeterWhitelist()).thenReturn(emptySet());
+    when(system.getStatisticsManager()).thenReturn(statisticsManager);
     return system;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderAllowsMultipleSystemsTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.util.Collections;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.function.Supplier;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
@@ -50,6 +50,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalCacheConstructor;
 import org.apache.geode.internal.cache.InternalCacheBuilder.InternalDistributedSystemConstructor;
 import org.apache.geode.internal.metrics.CompositeMeterRegistryFactory;
+import org.apache.geode.internal.statistics.StatisticsManager;
 
 /**
  * Unit tests for {@link InternalCacheBuilder}.
@@ -167,7 +168,7 @@ public class InternalCacheBuilderTest {
         .create();
 
     verify(theCompositeMeterRegistryFactory)
-        .create(eq(theSystemId), eq(theMemberName), eq(theHostName));
+        .create(eq(theSystemId), eq(theMemberName), eq(theHostName), any());
   }
 
   @Test
@@ -178,7 +179,7 @@ public class InternalCacheBuilderTest {
     CompositeMeterRegistry theCompositeMeterRegistry = new CompositeMeterRegistry();
     CompositeMeterRegistryFactory theCompositeMeterRegistryFactory =
         mock(CompositeMeterRegistryFactory.class);
-    when(theCompositeMeterRegistryFactory.create(anyInt(), any(), any()))
+    when(theCompositeMeterRegistryFactory.create(anyInt(), any(), any(), any()))
         .thenReturn(theCompositeMeterRegistry);
 
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
@@ -626,7 +627,7 @@ public class InternalCacheBuilderTest {
     MeterRegistry theMeterRegistry = new SimpleMeterRegistry();
 
     CompositeMeterRegistry theCompositeMeterRegistry = new CompositeMeterRegistry();
-    when(compositeMeterRegistryFactory.create(anyInt(), any(), any()))
+    when(compositeMeterRegistryFactory.create(anyInt(), any(), any(), any()))
         .thenReturn(theCompositeMeterRegistry);
 
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
@@ -659,11 +660,14 @@ public class InternalCacheBuilderTest {
     InternalDistributedSystem system = mock(InternalDistributedSystem.class, mockName);
     DistributionConfig distributionConfig = mock(DistributionConfig.class);
     InternalDistributedMember distributedMember = mock(InternalDistributedMember.class);
+    StatisticsManager statisticsManager = mock(StatisticsManager.class);
+
     when(distributionConfig.getDistributedSystemId()).thenReturn(systemId);
     when(distributedMember.getHost()).thenReturn(hostName);
     when(system.getConfig()).thenReturn(distributionConfig);
     when(system.getDistributedMember()).thenReturn(distributedMember);
     when(system.getName()).thenReturn(memberName);
+    when(system.getStatisticsManager()).thenReturn(statisticsManager);
     return system;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
@@ -32,6 +32,7 @@ import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.Properties;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -81,6 +82,7 @@ public class AcceptorImplTest {
 
     when(cache.getDistributedSystem()).thenReturn(system);
     when(cache.getInternalDistributedSystem()).thenReturn(system);
+    when(cache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
     when(serverSocket.getLocalSocketAddress()).thenReturn(mock(SocketAddress.class));
     when(socketCreator.createServerSocket(anyInt(), anyInt(), isNull(), anyList(), anyInt()))
         .thenReturn(serverSocket);
@@ -104,9 +106,14 @@ public class AcceptorImplTest {
   @Test
   public void constructorWithGatewayReceiverCreatesAcceptorImplForGatewayReceiver()
       throws Exception {
+    StatisticsType statisticsType = mock(StatisticsType.class);
+    when(statisticsType.getDescription()).thenReturn("some-description");
+    Statistics statistics = mock(Statistics.class);
+    when(statistics.getType()).thenReturn(statisticsType);
+    
     when(system.getStatisticsManager()).thenReturn(statisticsManager);
-    when(statisticsManager.createType(any(), any(), any())).thenReturn(mock(StatisticsType.class));
-    when(statisticsManager.createAtomicStatistics(any(), any())).thenReturn(mock(Statistics.class));
+    when(statisticsManager.createType(any(), any(), any())).thenReturn(statisticsType);
+    when(statisticsManager.createAtomicStatistics(any(), any())).thenReturn(statistics);
 
     Acceptor acceptor = new AcceptorImpl(0, null, false, DEFAULT_SOCKET_BUFFER_SIZE,
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
@@ -77,13 +77,11 @@ public class AcceptorImplTest {
     securityService = mock(SecurityService.class);
     system = mock(InternalDistributedSystem.class);
     statisticsManager = mock(StatisticsManager.class);
-
     ServerSocket serverSocket = mock(ServerSocket.class);
+    when(serverSocket.getLocalSocketAddress()).thenReturn(mock(SocketAddress.class));
 
     when(cache.getDistributedSystem()).thenReturn(system);
     when(cache.getInternalDistributedSystem()).thenReturn(system);
-    when(cache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
-    when(serverSocket.getLocalSocketAddress()).thenReturn(mock(SocketAddress.class));
     when(socketCreator.createServerSocket(anyInt(), anyInt(), isNull(), anyList(), anyInt()))
         .thenReturn(serverSocket);
     when(system.getConfig()).thenReturn(mock(DistributionConfig.class));
@@ -106,11 +104,12 @@ public class AcceptorImplTest {
   @Test
   public void constructorWithGatewayReceiverCreatesAcceptorImplForGatewayReceiver()
       throws Exception {
+    when(cache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
     StatisticsType statisticsType = mock(StatisticsType.class);
     when(statisticsType.getDescription()).thenReturn("some-description");
     Statistics statistics = mock(Statistics.class);
     when(statistics.getType()).thenReturn(statisticsType);
-    
+
     when(system.getStatisticsManager()).thenReturn(statisticsManager);
     when(statisticsManager.createType(any(), any(), any())).thenReturn(statisticsType);
     when(statisticsManager.createAtomicStatistics(any(), any())).thenReturn(statistics);

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/CallbackSamplerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/CallbackSamplerTest.java
@@ -19,46 +19,41 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 import java.util.Arrays;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
-import org.apache.geode.CancelCriterion;
 
 /**
  * Unit tests for {@link CallbackSampler}.
  */
-@RunWith(MockitoJUnitRunner.class)
+
 public class CallbackSamplerTest {
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(STRICT_STUBS);
 
   @Mock
-  CancelCriterion cancelCriterion;
-  @Mock
   StatSamplerStats statSamplerStats;
+
   @Mock
   StatisticsManager statisticsManager;
-  @Mock
-  ScheduledExecutorService executorService;
 
   private CallbackSampler sampler;
 
   @Before
   public void createSampler() {
-    sampler = new CallbackSampler(cancelCriterion, statSamplerStats);
+    sampler = new CallbackSampler(statisticsManager, statSamplerStats);
   }
 
   @Test
   public void taskShouldSampleStatistics() {
-    Runnable sampleTask = invokeStartAndGetTask();
-
     StatisticsImpl stats1 = mock(StatisticsImpl.class);
     StatisticsImpl stats2 = mock(StatisticsImpl.class);
     when(stats1.invokeSuppliers()).thenReturn(3);
@@ -66,33 +61,12 @@ public class CallbackSamplerTest {
     when(stats1.getSupplierCount()).thenReturn(7);
     when(stats2.getSupplierCount()).thenReturn(8);
     when(statisticsManager.getStatsList()).thenReturn(Arrays.asList(stats1, stats2));
-    sampleTask.run();
+
+    sampler.sampleCallbacks();
+
     verify(statSamplerStats).setSampleCallbacks(eq(15));
     verify(statSamplerStats).incSampleCallbackErrors(5);
     verify(statSamplerStats).incSampleCallbackDuration(anyLong());
-  }
-
-  @Test
-  public void stopShouldStopExecutor() {
-    sampler.start(executorService, statisticsManager, 1, TimeUnit.MILLISECONDS);
-    sampler.stop();
-    verify(executorService).shutdown();
-  }
-
-  @Test
-  public void cancelCriterionShouldStopExecutor() {
-    Runnable sampleTask = invokeStartAndGetTask();
-    when(cancelCriterion.isCancelInProgress()).thenReturn(Boolean.TRUE);
-    sampleTask.run();
-    verify(executorService).shutdown();
-  }
-
-  private Runnable invokeStartAndGetTask() {
-    sampler.start(executorService, statisticsManager, 1, TimeUnit.MILLISECONDS);
-    ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
-    verify(executorService).scheduleAtFixedRate(runnableCaptor.capture(), eq(1L), eq(1L),
-        eq(TimeUnit.MILLISECONDS));
-    return runnableCaptor.getValue();
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/HostStatSamplerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/HostStatSamplerTest.java
@@ -95,13 +95,11 @@ public class HostStatSamplerTest {
 
   private static class TestableHostStatSampler extends HostStatSampler {
 
-    private final StatisticsManager statisticsManager;
     private final long systemId;
 
     TestableHostStatSampler(CancelCriterion stopper, StatSamplerStats samplerStats, NanoTimer timer,
         LogFile logFile, StatisticsManager statisticsManager, long systemId) {
-      super(stopper, samplerStats, timer, logFile);
-      this.statisticsManager = statisticsManager;
+      super(statisticsManager, stopper, samplerStats, timer, logFile);
       this.systemId = systemId;
     }
 
@@ -118,11 +116,6 @@ public class HostStatSamplerTest {
     @Override
     public boolean isSamplingEnabled() {
       return false;
-    }
-
-    @Override
-    protected StatisticsManager getStatisticsManager() {
-      return statisticsManager;
     }
 
     @Override

--- a/geode-junit/src/main/java/org/apache/geode/internal/statistics/TestStatisticsManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/statistics/TestStatisticsManager.java
@@ -14,6 +14,10 @@
  */
 package org.apache.geode.internal.statistics;
 
+import static java.util.Collections.emptySet;
+
+import java.util.Set;
+
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.internal.statistics.platform.OsStatisticsFactory;
@@ -32,5 +36,10 @@ public class TestStatisticsManager extends AbstractStatisticsFactory
   public Statistics createOsStatistics(final StatisticsType type, final String textId,
       final long numericId, final int osStatFlags) {
     return null;
+  }
+
+  @Override
+  public Set<String> getMeterWhitelist() {
+    return emptySet();
   }
 }


### PR DESCRIPTION
This is a _proof of concept,_ intended to provoke feedback about the approach. We will not merge this code into Geode as is. Whether this PoC or some other approach is accepted, we will test-drive a real implementation and submit a PR for that.

# Goals for this PoC

Demonstrate a way to:
- Minimize the number of places in the code that have to know how to arrange for a given stat and meter to report the same values.
  - Minimize how much the registry must know about stats.
  - Minimize how much the stats must know about registries and meters.
  - Minimize the number of places that know how to construct a given meter.
  - Minimize the number of places that know how to associate a given stat with a meter.
- Minimize the intrusiveness of instrumentation.
- For performance, configure the cache’s meter registry to store values only for meters that supply stats, and to create no-op meters for all other meters.
- Remove the relevant meters and stats when the measured thing (e.g. region) is removed.

# Design Choices

**Introduce the `XMeters` pattern.** For each instrumented class X, create an XMeters class that creates all meters for X, and encapsulates all knowledge of the associations between stats and meters. In particular, an XMeters class:

- Constructs all meters for X and its instances.
- Knows which stats and meters represent the same measurement.
- When applicable, arranges for a given stat's value to be supplied from the relevant meter.
- Exposes each meter via a method (for each X to use to instrument its code).
- Reports the set of meter names that require real meters in the cache's meter registry. That is, the names of the meters that supply values for stats.

**Changes to `StatisticsRegistry`.** The statistics registry creates a global set of meter names that require real meters in the cache's meter registry. It creates the set by aggregating the names from each `XMeters`.

**The Storage Registry.** The `CacheMeterRegistryFactory` adds a `SimpleMeterRegistry` to the `CompositeMeterRegistry`. It adds a filter to the simple registry that accepts only meters whose names are reported by the `StatisticsRegistry`'s as requiring real meters. If the filter accepts a meter name, the registry creates a real meter that accumulates values. If the filter denies a meter name, the registry creates a no-op meter.

**Instrumented Code.**  Each instrumented object constructs (or perhaps injects) an XMeters instance, and uses the instances meters for its instrumentation.

# Example: Events Received by a Gateway Receiver

We used "gateway receiver events received" as our one example, because currently that is the only measurement that we record as both a meter and a stat.

We created a `GatewayReceiverMeters` class and used it to instrument the _events received_ meter. `GatewayReceiverMeters` creates the meter and arranges for it to supply the associated stat.

Given that our main goal was to demonstrate how to associate the meter and the stat _while minimizing the amount of code that knows about the association,_ we stopped when we had demonstrated that.

# Limitations

This approach uses only meter _names_ to decide which kind of meter (real vs no-op) to create. In a comment on this PR, Jake raises a concern that this PoC does not address: That for some meters, we may want to base the decision on the value of a tag.

The `GatewayReceiverMeters` currently fails our "remove the meters when you're done with them" goal.

# Opportunities Beyond this PoC

Adopting the _XMeters pattern_ allows us to migrate all instrumentation for a particular class from stats to meters, while continuing to publish existing measurements to GFS files. Once any given instrument is created and configured in an XMeters object, and instrumented as a meter, we can change the details of where and how each measurement is reported without affecting the instrumented code.

- If we want to publish a given measurement through _both GFS files and Micrometer:_ Create a meter in the registry, and arrange for the meter to supply the stat value, as in our `GatewayReceiverMeters` example.
- If we want to publish a measurement _only through GFS_ files and _not through Micrometer:_ Don't use the cache's meter registry to create the meter. Instead, construct the meter directly. Then connect the meter to the stat.
- If we want to publish a measurement _only through Micrometer_ and _not through GFS files:_ Create a meter in the registry, and don't connect it to a stat.
- If we want to decide where to publish a measurement based on details of the instrumented object, the XMeters class can take the object as a parameter, and choose which of the above configurations to apply

All of these choices can be encapsulated in the relevant XMeters class.