### PR TITLE
GEODE-6698: optimize region name deserialization in client/server messaging

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
@@ -639,7 +639,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
       boolean withInterest = (Boolean) isInterestListPassedPart.getObject();
       boolean withCQs = (Boolean) hasCqsPart.getObject();
 
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
       key = keyPart.getStringOrObject();
       Object callbackArgument = callbackArgumentPart.getObject();
 
@@ -820,7 +820,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
       Part isInterestListPassedPart = clientMessage.getPart(partCnt++);
       Part hasCqsPart = clientMessage.getPart(partCnt++);
 
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
       key = keyPart.getStringOrObject();
 
       Object callbackArgument = callbackArgumentPart.getObject();
@@ -922,7 +922,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
         versionTag.replaceNullIDs((InternalDistributedMember) this.endpoint.getMemberId());
       }
 
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
       key = keyPart.getStringOrObject();
 
       Part isInterestListPassedPart = clientMessage.getPart(partCnt++);
@@ -1010,7 +1010,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
       int partCnt = 0;
       Part regionNamePart = clientMessage.getPart(partCnt++);
       Part callbackArgumentPart = clientMessage.getPart(partCnt++);
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
       Object callbackArgument = callbackArgumentPart.getObject();
 
       Part hasCqsPart = clientMessage.getPart(partCnt++);
@@ -1083,7 +1083,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
 
       Part hasCqsPart = clientMessage.getPart(partCnt++);
 
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
       Object callbackArgument = callbackArgumentPart.getObject();
       if (isDebugEnabled) {
         logger.debug("Clearing region: {} callbackArgument: {}", regionName, callbackArgument);
@@ -1150,7 +1150,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
 
       Part hasCqsPart = clientMessage.getPart(partCnt++);
 
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
 
       if ((Boolean) hasCqsPart.getObject()) {
         Part numCqsPart = clientMessage.getPart(partCnt++);
@@ -1347,7 +1347,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
       Part isDurablePart = clientMessage.getPart(partCnt++);
       Part receiveUpdatesAsInvalidatesPart = clientMessage.getPart(partCnt++);
 
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
       key = keyPart.getStringOrObject();
       int interestType = (Integer) interestTypePart.getObject();
       byte interestResultPolicy = (Byte) interestResultPolicyPart.getObject();
@@ -1405,7 +1405,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
       Part receiveUpdatesAsInvalidatesPart = clientMessage.getPart(partCnt++);
       // Not reading the eventId part
 
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
       key = keyPart.getStringOrObject();
       int interestType = (Integer) interestTypePart.getObject();
       boolean isDurable = (Boolean) isDurablePart.getObject();
@@ -1447,7 +1447,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
       int partIdx = 0;
 
       // see ClientTombstoneMessage.getGFE70Message
-      regionName = clientMessage.getPart(partIdx++).getString();
+      regionName = clientMessage.getPart(partIdx++).getCachedString();
       int op = clientMessage.getPart(partIdx++).getInt();
       LocalRegion region = (LocalRegion) this.cacheHelper.getRegion(regionName);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Message.java
@@ -277,7 +277,7 @@ public class Message {
     addStringPart(str, false);
   }
 
-  @MakeNotStatic
+  @MakeNotStatic("not tied to the cache lifecycle")
   private static final Map<String, byte[]> CACHED_STRINGS = new ConcurrentHashMap<>();
 
   public void addStringPart(String str, boolean enableCaching) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Part.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Part.java
@@ -176,7 +176,7 @@ public class Part {
     return CacheServerHelper.fromUTF((byte[]) this.part);
   }
 
-  @MakeNotStatic
+  @MakeNotStatic("not tied to the cache lifecycle")
   private static final Map<ByteArrayKey, String> CACHED_STRINGS = new ConcurrentHashMap<>();
 
   private static String getCachedString(byte[] serializedBytes) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Part.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Part.java
@@ -175,6 +175,34 @@ public class Part {
     return CacheServerHelper.fromUTF((byte[]) this.part);
   }
 
+  @MakeNotStatic
+  private static final Map<ByteBuffer, String> CACHED_STRINGS = new ConcurrentHashMap<>();
+
+  private static String getCachedString(byte[] serializedBytes) {
+    ByteBuffer key = ByteBuffer.wrap(serializedBytes);
+    String result = CACHED_STRINGS.get(key);
+    if (result == null) {
+      result = CacheServerHelper.fromUTF(serializedBytes);
+      CACHED_STRINGS.put(key, result);
+    }
+    return result;
+  }
+
+  /**
+   * Like getString but will also check a cache of frequently serialized strings.
+   * The result will be added to the cache if it is not already in it.
+   * NOTE: only call this for strings that are reused often (like region names).
+   */
+  public String getCachedString() {
+    if (this.part == null) {
+      return null;
+    }
+    if (!isBytes()) {
+      Assert.assertTrue(false, "expected String part to be of type BYTE, part =" + this.toString());
+    }
+    return getCachedString((byte[]) this.part);
+  }
+
   @Immutable
   private static final byte[][] BYTES = new byte[256][1];
   private static final int BYTES_OFFSET = -1 * Byte.MIN_VALUE;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ClearRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ClearRegion.java
@@ -76,7 +76,7 @@ public class ClearRegion extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     if (logger.isDebugEnabled()) {
       logger.debug(serverConnection.getName() + ": Received clear region request ("
           + clientMessage.getPayloadLength() + " bytes) from " + serverConnection.getSocketString()

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKey.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKey.java
@@ -70,7 +70,7 @@ public class ContainsKey extends BaseCommand {
     // Retrieve the data from the message parts
     regionNamePart = clientMessage.getPart(0);
     keyPart = clientMessage.getPart(1);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKey66.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKey66.java
@@ -71,7 +71,7 @@ public class ContainsKey66 extends BaseCommand {
     regionNamePart = clientMessage.getPart(0);
     keyPart = clientMessage.getPart(1);
     mode = ContainsKeyOp.MODE.values()[(clientMessage.getPart(2).getInt())];
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegion.java
@@ -52,10 +52,10 @@ public class CreateRegion extends BaseCommand {
     // start = DistributionStats.getStatTime();
     // Retrieve the data from the message parts
     Part parentRegionNamePart = clientMessage.getPart(0);
-    String parentRegionName = parentRegionNamePart.getString();
+    String parentRegionName = parentRegionNamePart.getCachedString();
 
     regionNamePart = clientMessage.getPart(1);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     if (logger.isDebugEnabled()) {
       logger.debug(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy.java
@@ -84,7 +84,7 @@ public class Destroy extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65.java
@@ -152,7 +152,7 @@ public class Destroy65 extends BaseCommand {
       return;
     }
 
-    final String regionName = regionNamePart.getString();
+    final String regionName = regionNamePart.getCachedString();
 
     if (logger.isDebugEnabled()) {
       logger.debug(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyRegion.java
@@ -87,7 +87,7 @@ public class DestroyRegion extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     if (logger.isDebugEnabled()) {
       logger.debug("{}: Received destroy region request ({} bytes) from {} for region {}",
           serverConnection.getName(), clientMessage.getPayloadLength(),

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction.java
@@ -80,7 +80,7 @@ public class ExecuteRegionFunction extends BaseCommand {
         serverConnection.setAsTrue(REQUIRES_RESPONSE);
         serverConnection.setAsTrue(REQUIRES_CHUNKED_RESPONSE);
       }
-      regionName = clientMessage.getPart(1).getString();
+      regionName = clientMessage.getPart(1).getCachedString();
       function = clientMessage.getPart(2).getStringOrObject();
       args = clientMessage.getPart(3).getObject();
       Part part = clientMessage.getPart(4);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction61.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction61.java
@@ -82,7 +82,7 @@ public class ExecuteRegionFunction61 extends BaseCommand {
         serverConnection.setAsTrue(REQUIRES_RESPONSE);
         serverConnection.setAsTrue(REQUIRES_CHUNKED_RESPONSE);
       }
-      regionName = clientMessage.getPart(1).getString();
+      regionName = clientMessage.getPart(1).getCachedString();
       function = clientMessage.getPart(2).getStringOrObject();
       args = clientMessage.getPart(3).getObject();
       Part part = clientMessage.getPart(4);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction65.java
@@ -86,7 +86,7 @@ public class ExecuteRegionFunction65 extends BaseCommand {
         serverConnection.setAsTrue(REQUIRES_RESPONSE);
         serverConnection.setAsTrue(REQUIRES_CHUNKED_RESPONSE);
       }
-      regionName = clientMessage.getPart(1).getString();
+      regionName = clientMessage.getPart(1).getCachedString();
       function = clientMessage.getPart(2).getStringOrObject();
       args = clientMessage.getPart(3).getObject();
       Part part = clientMessage.getPart(4);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction66.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunction66.java
@@ -95,7 +95,7 @@ public class ExecuteRegionFunction66 extends BaseCommand {
         serverConnection.setAsTrue(REQUIRES_RESPONSE);
         serverConnection.setAsTrue(REQUIRES_CHUNKED_RESPONSE);
       }
-      regionName = clientMessage.getPart(1).getString();
+      regionName = clientMessage.getPart(1).getCachedString();
       function = clientMessage.getPart(2).getStringOrObject();
       args = clientMessage.getPart(3).getObject();
       Part part = clientMessage.getPart(4);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunctionSingleHop.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteRegionFunctionSingleHop.java
@@ -96,7 +96,7 @@ public class ExecuteRegionFunctionSingleHop extends BaseCommand {
         serverConnection.setAsTrue(REQUIRES_RESPONSE);
         serverConnection.setAsTrue(REQUIRES_CHUNKED_RESPONSE);
       }
-      regionName = clientMessage.getPart(1).getString();
+      regionName = clientMessage.getPart(1).getCachedString();
       function = clientMessage.getPart(2).getStringOrObject();
       args = clientMessage.getPart(3).getObject();
       Part part = clientMessage.getPart(4);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
@@ -188,7 +188,7 @@ public class GatewayReceiverCommand extends BaseCommand {
 
           // Retrieve the region name from the message parts
           Part regionNamePart = clientMessage.getPart(partNumber + 2);
-          regionName = regionNamePart.getString();
+          regionName = regionNamePart.getCachedString();
           if (regionName.equals(PeerTypeRegistration.REGION_FULL_PATH)) {
             indexWithoutPDXEvent--;
             isPdxEvent = true;
@@ -541,7 +541,7 @@ public class GatewayReceiverCommand extends BaseCommand {
               try {
                 // Region name
                 regionNamePart = clientMessage.getPart(partNumber + 2);
-                regionName = regionNamePart.getString();
+                regionName = regionNamePart.getCachedString();
 
                 // Retrieve the event id from the message parts
                 eventIdPart = clientMessage.getPart(partNumber + 3);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Get70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Get70.java
@@ -90,7 +90,7 @@ public class Get70 extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll.java
@@ -57,7 +57,7 @@ public class GetAll extends BaseCommand {
 
     // Retrieve the region name from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     // Retrieve the keys array from the message parts
     keysPart = clientMessage.getPart(1);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll651.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll651.java
@@ -57,7 +57,7 @@ public class GetAll651 extends BaseCommand {
 
     // Retrieve the region name from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     // Retrieve the keys array from the message parts
     keysPart = clientMessage.getPart(1);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll70.java
@@ -64,7 +64,7 @@ public class GetAll70 extends BaseCommand {
 
     // Retrieve the region name from the message parts
     regionNamePart = clientMessage.getPart(partIdx++);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     // Retrieve the keys array from the message parts
     keysPart = clientMessage.getPart(partIdx++);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAllWithCallback.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetAllWithCallback.java
@@ -69,7 +69,7 @@ public class GetAllWithCallback extends BaseCommand {
 
     // Retrieve the region name from the message parts
     regionNamePart = clientMessage.getPart(partIdx++);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     // Retrieve the keys array from the message parts
     keysPart = clientMessage.getPart(partIdx++);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPRMetadataCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPRMetadataCommand.java
@@ -55,7 +55,7 @@ public class GetClientPRMetadataCommand extends BaseCommand {
       throws IOException, ClassNotFoundException, InterruptedException {
     String regionFullPath = null;
     CachedRegionHelper crHelper = serverConnection.getCachedRegionHelper();
-    regionFullPath = clientMessage.getPart(0).getString();
+    regionFullPath = clientMessage.getPart(0).getCachedString();
     String errMessage = "";
     if (regionFullPath == null) {
       logger.warn("The input region path for the GetClientPRMetadata request is null");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPRMetadataCommand66.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPRMetadataCommand66.java
@@ -53,7 +53,7 @@ public class GetClientPRMetadataCommand66 extends BaseCommand {
       throws IOException, ClassNotFoundException, InterruptedException {
     String regionFullPath = null;
     CachedRegionHelper crHelper = serverConnection.getCachedRegionHelper();
-    regionFullPath = clientMessage.getPart(0).getString();
+    regionFullPath = clientMessage.getPart(0).getCachedString();
     String errMessage = "";
     if (regionFullPath == null) {
       logger.warn("The input region path for the GetClientPRMetadata request is null");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommand.java
@@ -50,7 +50,7 @@ public class GetClientPartitionAttributesCommand extends BaseCommand {
       final SecurityService securityService, long start)
       throws IOException, ClassNotFoundException, InterruptedException {
     String regionFullPath = null;
-    regionFullPath = clientMessage.getPart(0).getString();
+    regionFullPath = clientMessage.getPart(0).getCachedString();
     String errMessage = "";
     if (regionFullPath == null) {
       errMessage = "The input region path for the GetClientPartitionAttributes request is null";

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommand66.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommand66.java
@@ -55,7 +55,7 @@ public class GetClientPartitionAttributesCommand66 extends BaseCommand {
       final SecurityService securityService, long start)
       throws IOException, ClassNotFoundException, InterruptedException {
     String regionFullPath = null;
-    regionFullPath = clientMessage.getPart(0).getString();
+    regionFullPath = clientMessage.getPart(0).getCachedString();
     String errMessage = "";
     if (regionFullPath == null) {
       logger.warn("The input region path for the GetClientPartitionAttributes request is null");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Invalidate.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Invalidate.java
@@ -81,7 +81,7 @@ public class Invalidate extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/KeySet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/KeySet.java
@@ -59,7 +59,7 @@ public class KeySet extends BaseCommand {
 
     // Retrieve the region name from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     ChunkedMessage chunkedResponseMsg = serverConnection.getChunkedResponseMessage();
     final boolean isDebugEnabled = logger.isDebugEnabled();
     if (isDebugEnabled) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put.java
@@ -83,7 +83,7 @@ public class Put extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     try {
       key = keyPart.getStringOrObject();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put61.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put61.java
@@ -98,7 +98,7 @@ public class Put61 extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     try {
       key = keyPart.getStringOrObject();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
@@ -145,7 +145,7 @@ public class Put65 extends BaseCommand {
       return;
     }
 
-    final String regionName = regionNamePart.getString();
+    final String regionName = regionNamePart.getCachedString();
 
     final boolean isDebugEnabled = logger.isDebugEnabled();
     if (isDebugEnabled) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutAll.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutAll.java
@@ -83,7 +83,7 @@ public class PutAll extends BaseCommand {
       // Retrieve the data from the message parts
       // part 0: region name
       regionNamePart = clientMessage.getPart(0);
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
 
       if (regionName == null) {
         String putAllMsg =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutAll70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutAll70.java
@@ -88,7 +88,7 @@ public class PutAll70 extends BaseCommand {
       // Retrieve the data from the message parts
       // part 0: region name
       regionNamePart = clientMessage.getPart(0);
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
 
       if (regionName == null) {
         String putAllMsg =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutAll80.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutAll80.java
@@ -103,7 +103,7 @@ public class PutAll80 extends BaseCommand {
       // Retrieve the data from the message parts
       // part 0: region name
       regionNamePart = clientMessage.getPart(0);
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
 
       if (regionName == null) {
         String putAllMsg =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterest.java
@@ -59,7 +59,7 @@ public class RegisterInterest extends BaseCommand {
     // start = DistributionStats.getStatTime();
     // Retrieve the data from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     InterestResultPolicy policy = null;
     // Retrieve the interest type
     int interestType = clientMessage.getPart(1).getInt();
@@ -84,7 +84,7 @@ public class RegisterInterest extends BaseCommand {
     }
     // Retrieve the key
     keyPart = clientMessage.getPart(4);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterest61.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterest61.java
@@ -76,7 +76,7 @@ public class RegisterInterest61 extends BaseCommand {
     // start = DistributionStats.getStatTime();
     // Retrieve the data from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     InterestResultPolicy policy = null;
     // Retrieve the interest type
     int interestType = clientMessage.getPart(1).getInt();
@@ -116,7 +116,7 @@ public class RegisterInterest61 extends BaseCommand {
     }
     // Retrieve the key
     keyPart = clientMessage.getPart(4);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList.java
@@ -68,7 +68,7 @@ public class RegisterInterestList extends BaseCommand {
     // start = DistributionStats.getStatTime();
     // Retrieve the data from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     // Retrieve the InterestResultPolicy
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList61.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList61.java
@@ -71,7 +71,7 @@ public class RegisterInterestList61 extends BaseCommand {
     // start = DistributionStats.getStatTime();
     // Retrieve the data from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     // Retrieve the InterestResultPolicy
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList66.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList66.java
@@ -71,7 +71,7 @@ public class RegisterInterestList66 extends BaseCommand {
 
     // Retrieve the data from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     // Retrieve the InterestResultPolicy
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RemoveAll.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/RemoveAll.java
@@ -86,7 +86,7 @@ public class RemoveAll extends BaseCommand {
       // Retrieve the data from the message parts
       // part 0: region name
       regionNamePart = clientMessage.getPart(0);
-      regionName = regionNamePart.getString();
+      regionName = regionNamePart.getCachedString();
 
       if (regionName == null) {
         String txt =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Request.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Request.java
@@ -84,7 +84,7 @@ public class Request extends BaseCommand {
         return;
       }
     }
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Size.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Size.java
@@ -65,7 +65,7 @@ public class Size extends BaseCommand {
     stats.incReadSizeRequestTime(start - oldStart);
     // Retrieve the data from the message parts
     Part regionNamePart = clientMessage.getPart(0);
-    String regionName = regionNamePart.getString();
+    String regionName = regionNamePart.getCachedString();
 
     if (regionName == null) {
       logger.warn("The input region name for the %s request is null", "size");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/UnregisterInterest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/UnregisterInterest.java
@@ -60,7 +60,7 @@ public class UnregisterInterest extends BaseCommand {
     Part isClosingPart = clientMessage.getPart(3);
     byte[] isClosingPartBytes = (byte[]) isClosingPart.getObject();
     boolean isClosing = isClosingPartBytes[0] == 0x01;
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
     try {
       key = keyPart.getStringOrObject();
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/UnregisterInterestList.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/UnregisterInterestList.java
@@ -62,7 +62,7 @@ public class UnregisterInterestList extends BaseCommand {
     // start = DistributionStats.getStatTime();
     // Retrieve the data from the message parts
     regionNamePart = clientMessage.getPart(0);
-    regionName = regionNamePart.getString();
+    regionName = regionNamePart.getCachedString();
 
     Part isClosingListPart = clientMessage.getPart(1);
     byte[] isClosingListPartBytes = (byte[]) isClosingListPart.getObject();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/PartTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/PartTest.java
@@ -45,11 +45,12 @@ public class PartTest {
   @Test
   public void getCacheStringReturnsCanonicalInstance() {
     String stringValue = "test string";
-    byte[] stringBytes = CacheServerHelper.toUTF(stringValue);
     Part part1 = new Part();
-    part1.setPartState(stringBytes, false);
+    byte[] stringBytes1 = CacheServerHelper.toUTF(stringValue);
+    part1.setPartState(stringBytes1, false);
     Part part2 = new Part();
-    part2.setPartState(stringBytes, false);
+    byte[] stringBytes2 = CacheServerHelper.toUTF(stringValue);
+    part2.setPartState(stringBytes2, false);
 
     String result1 = part1.getCachedString();
     String result2 = part2.getCachedString();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/PartTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/PartTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -38,5 +40,39 @@ public class PartTest {
     mockPart.writeTo(mockOutputStream, mockByteBuffer);
 
     verify(mockPart, times(1)).writeTo(mockOutputStream, mockByteBuffer);
+  }
+
+  @Test
+  public void getCacheStringReturnsCanonicalInstance() {
+    String stringValue = "test string";
+    byte[] stringBytes = CacheServerHelper.toUTF(stringValue);
+    Part part1 = new Part();
+    part1.setPartState(stringBytes, false);
+    Part part2 = new Part();
+    part2.setPartState(stringBytes, false);
+
+    String result1 = part1.getCachedString();
+    String result2 = part2.getCachedString();
+
+    assertThat(result1).isEqualTo(stringValue);
+    assertThat(result1).isSameAs(result2);
+  }
+
+  @Test
+  public void getCacheStringWithNullStateReturnsNull() {
+    Part part = new Part();
+
+    String result = part.getCachedString();
+
+    assertThat(result).isNull();
+  }
+
+  @Test
+  public void getCachedStringGivenPartThatIsNotBytesThrows() {
+    Part part = new Part();
+    part.setPartState(new byte[0], true);
+
+    assertThatThrownBy(() -> part.getCachedString())
+        .hasMessageContaining("expected String part to be of type BYTE, part =");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKey66Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKey66Test.java
@@ -90,7 +90,7 @@ public class ContainsKey66Test {
     when(this.serverConnection.getAuthzRequest()).thenReturn(this.authzRequest);
     when(this.serverConnection.getClientVersion()).thenReturn(Version.CURRENT);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.keyPart.getStringOrObject()).thenReturn(KEY);
     when(this.modePart.getInt()).thenReturn(0);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKeyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ContainsKeyTest.java
@@ -82,7 +82,7 @@ public class ContainsKeyTest {
     when(this.serverConnection.getErrorResponseMessage()).thenReturn(this.errorResponseMessage);
 
     Part regionNamePart = mock(Part.class);
-    when(regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     Part keyPart = mock(Part.class);
     when(keyPart.getStringOrObject()).thenReturn(KEY);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegionTest.java
@@ -87,9 +87,9 @@ public class CreateRegionTest {
 
     when(this.parentRegion.getAttributes()).thenReturn(new AttributesFactory().create());
 
-    when(this.parentRegionNamePart.getString()).thenReturn(PARENT_REGION_NAME);
+    when(this.parentRegionNamePart.getCachedString()).thenReturn(PARENT_REGION_NAME);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getAuthzRequest()).thenReturn(this.authzRequest);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65Test.java
@@ -112,7 +112,7 @@ public class Destroy65Test {
     when(this.message.getPart(eq(4))).thenReturn(this.eventPart);
     when(this.message.getPart(eq(5))).thenReturn(this.callbackArgPart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(this.cacheServerStats);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyRegionTest.java
@@ -100,7 +100,7 @@ public class DestroyRegionTest {
     when(this.message.getPart(eq(1))).thenReturn(this.eventPart);
     when(this.message.getPart(eq(2))).thenReturn(this.callbackArgPart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(this.cacheServerStats);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyTest.java
@@ -115,7 +115,7 @@ public class DestroyTest {
 
     when(this.region.containsKey(eq(REGION_NAME))).thenReturn(true);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(this.cacheServerStats);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Get70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Get70Test.java
@@ -102,7 +102,7 @@ public class Get70Test {
     when(this.message.getPart(eq(1))).thenReturn(this.keyPart);
     when(this.message.getPart(eq(2))).thenReturn(this.valuePart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(this.cacheServerStats);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll651Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll651Test.java
@@ -92,7 +92,7 @@ public class GetAll651Test {
     when(this.message.getPart(eq(0))).thenReturn(this.regionNamePart);
     when(this.message.getPart(eq(1))).thenReturn(this.keyPart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAll70Test.java
@@ -103,7 +103,7 @@ public class GetAll70Test {
 
     when(this.regionAttributes.getConcurrencyChecksEnabled()).thenReturn(true);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.requestSerializableValuesPart.getInt()).thenReturn(0);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAllTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAllTest.java
@@ -91,7 +91,7 @@ public class GetAllTest {
     when(this.message.getPart(eq(0))).thenReturn(this.regionNamePart);
     when(this.message.getPart(eq(1))).thenReturn(this.keyPart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAllWithCallbackTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetAllWithCallbackTest.java
@@ -99,7 +99,7 @@ public class GetAllWithCallbackTest {
 
     when(this.regionAttributes.getConcurrencyChecksEnabled()).thenReturn(true);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.requestSerializableValuesPart.getInt()).thenReturn(0);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommand66Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommand66Test.java
@@ -65,7 +65,7 @@ public class GetClientPartitionAttributesCommand66Test {
 
     when(this.message.getPart(eq(0))).thenReturn(this.regionNamePart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getResponseMessage()).thenReturn(this.responseMessage);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/GetClientPartitionAttributesCommandTest.java
@@ -65,7 +65,7 @@ public class GetClientPartitionAttributesCommandTest {
 
     when(this.message.getPart(eq(0))).thenReturn(this.regionNamePart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getResponseMessage()).thenReturn(this.responseMessage);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/InvalidateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/InvalidateTest.java
@@ -105,7 +105,7 @@ public class InvalidateTest {
     when(this.message.getPart(eq(2))).thenReturn(this.eventPart);
     when(this.message.getPart(eq(3))).thenReturn(this.callbackArgPart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/KeySetTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/KeySetTest.java
@@ -93,7 +93,7 @@ public class KeySetTest {
 
     when(this.message.getPart(eq(0))).thenReturn(this.regionNamePart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put61Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put61Test.java
@@ -124,7 +124,7 @@ public class Put61Test {
     when(this.message.getPart(eq(4))).thenReturn(this.eventPart);
     when(this.message.getPart(eq(5))).thenReturn(this.callbackArgsPart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put65Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put65Test.java
@@ -145,7 +145,7 @@ public class Put65Test {
     when(this.putOperationContext.getValue()).thenReturn(VALUE);
     when(this.putOperationContext.isObject()).thenReturn(true);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));
@@ -171,7 +171,7 @@ public class Put65Test {
   @Test
   public void noRegionNameShouldFail() throws Exception {
     when(this.securityService.isClientSecurityRequired()).thenReturn(false);
-    when(this.regionNamePart.getString()).thenReturn(null);
+    when(this.regionNamePart.getCachedString()).thenReturn(null);
 
     this.put65.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/PutTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/PutTest.java
@@ -122,7 +122,7 @@ public class PutTest {
     when(this.message.getPart(eq(3))).thenReturn(this.eventPart);
     when(this.message.getPart(eq(4))).thenReturn(this.callbackArgsPart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterest61Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterest61Test.java
@@ -112,7 +112,7 @@ public class RegisterInterest61Test {
 
     when(this.notifyPart.getObject()).thenReturn(DURABLE);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.registerInterestOperationContext.getKey()).thenReturn(KEY);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList61Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList61Test.java
@@ -115,7 +115,7 @@ public class RegisterInterestList61Test {
 
     when(this.numberOfKeysPart.getInt()).thenReturn(1);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.registerInterestOperationContext.getKey()).thenReturn(KEY);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList66Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestList66Test.java
@@ -122,7 +122,7 @@ public class RegisterInterestList66Test {
 
     when(this.regionDataPolicyPart.getObject()).thenReturn(DATA_POLICY);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.registerInterestOperationContext.getKey()).thenReturn(KEY);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestListTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestListTest.java
@@ -115,7 +115,7 @@ public class RegisterInterestListTest {
 
     when(this.numberOfKeysPart.getInt()).thenReturn(1);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.registerInterestOperationContext.getKey()).thenReturn(KEY);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RegisterInterestTest.java
@@ -108,7 +108,7 @@ public class RegisterInterestTest {
 
     when(this.notifyPart.getObject()).thenReturn(DURABLE);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getAuthzRequest()).thenReturn(this.authzRequest);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RemoveAllTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RemoveAllTest.java
@@ -113,7 +113,7 @@ public class RemoveAllTest {
 
     when(this.numberofKeysPart.getInt()).thenReturn(1);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(mock(CacheServerStats.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RequestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/RequestTest.java
@@ -102,7 +102,7 @@ public class RequestTest {
     when(this.message.getPart(eq(1))).thenReturn(this.keyPart);
     when(this.message.getPart(eq(2))).thenReturn(this.valuePart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(this.cacheServerStats);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/UnregisterInterestTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/UnregisterInterestTest.java
@@ -120,7 +120,7 @@ public class UnregisterInterestTest {
     when(this.message.getPart(eq(3))).thenReturn(this.isClosingPart);
     when(this.message.getPart(eq(4))).thenReturn(this.keepAlivePart);
 
-    when(this.regionNamePart.getString()).thenReturn(REGION_NAME);
+    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
     when(this.serverConnection.getCache()).thenReturn(this.cache);
     when(this.serverConnection.getCacheServerStats()).thenReturn(this.cacheServerStats);

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/MonitorCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/MonitorCQ.java
@@ -60,7 +60,7 @@ public class MonitorCQ extends BaseCQCommand {
     String regionName = null;
     if (clientMessage.getNumberOfParts() == 2) {
       // This will be enable/disable on region.
-      regionName = clientMessage.getPart(1).getString();
+      regionName = clientMessage.getPart(1).getCachedString();
       if (regionName == null) {
         // This should have been taken care at the client - remove?
         String err =


### PR DESCRIPTION
Added a static cache (like the already existing one on Message that optimizes String serialization) on Part. Changed all the messages that used to call Part.getString() to get a region name to now call Part.getCachedString().
Added unit test coverage for the new Part method.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
