### PR TITLE
GEODE-6822: Deploying jars only creates new classloader for the newly deployed jar

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderDeployTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderDeployTest.java
@@ -399,48 +399,6 @@ public class ClassPathLoaderDeployTest {
         ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classBName);
   }
 
-  // @Test (expected = ClassNotFoundException.class)
-  // public void parentClassRemovedShouldNoLongerAllowLoadingParentClass() throws Exception {
-  // String classAName = "classA";
-  // String classBName = "classB";
-  // String classB2Name = "classB2";
-  //
-  // String classAContents =
-  // "package jddunit.function;"
-  // + "public class "
-  // + classAName + " extends " + classBName + " { public boolean hasResult() {return true;}}";
-  //
-  // String classBContents =
-  // "package jddunit.function;"
-  // + "public class "
-  // + classBName + " { public boolean someMethod() {return true;}}";
-  //
-  // String classB2Contents =
-  // "package jddunit.function;"
-  // + "public class "
-  // + classB2Name + " { public boolean someMethod() {return false;}}";
-  //
-  // File jarB = createJarFromClassContents("JarBVersion1", classBName, "JarB.jar", classBContents);
-  // File jarA = createJarFromClassContents("JarAVersion1", classAName, "JarA.jar", classAContents,
-  // jarB.getAbsolutePath());
-  // File jarBV2 = createJarFromClassContents("JarBVersion2", classB2Name, "JarB.jar",
-  // classB2Contents);
-  //
-  // ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarB);
-  // Class classB = ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." +
-  // classBName);
-  // Object classBInstance = classB.newInstance();
-  //
-  // ClassPathLoader.getLatest().getJarDeployer().deploy("JarA.jar", jarA);
-  // Class classA = ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." +
-  // classAName);
-  // Object classAInstance = classA.newInstance();
-  //
-  // ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarBV2);
-  // Class classB2 = ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." +
-  // classBName);
-  // }
-
   @Test
   public void undeployedUnrelatedJarShouldNotAffectDeserializedObjectComparison() throws Exception {
     String classAName = "classA";

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderJUnitTest.java
@@ -15,131 +15,27 @@
 package org.apache.geode.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import org.apache.geode.cache.GemFireCache;
-import org.apache.geode.cache.execute.Execution;
-import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.ResultCollector;
-import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.test.compiler.ClassBuilder;
-import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 /**
  * Integration tests for {@link ClassPathLoader}.
  */
-public class ClassPathLoaderDeployTest {
+public class ClassPathLoaderJUnitTest {
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
-  @Rule
-  public ServerStarterRule server = new ServerStarterRule();
 
   @After
   public void resetClassPathLoader() {
     ClassPathLoader.setLatestToDefault();
-  }
-
-  @Test
-  public void testDeployWithExistingDependentJars() throws Exception {
-    ClassBuilder classBuilder = new ClassBuilder();
-    final File parentJarFile =
-        new File("JarDeployerDUnitAParent.v1.jar");
-    final File usesJarFile = new File("JarDeployerDUnitUses.v1.jar");
-    final File functionJarFile =
-        new File("JarDeployerDUnitFunction.v1.jar");
-
-    // Write out a JAR files.
-    StringBuilder stringBuilder = new StringBuilder();
-    stringBuilder.append("package jddunit.parent;");
-    stringBuilder.append("public class JarDeployerDUnitParent {");
-    stringBuilder.append("public String getValueParent() {");
-    stringBuilder.append("return \"PARENT\";}}");
-
-    byte[] jarBytes = classBuilder.createJarFromClassContent(
-        "jddunit/parent/JarDeployerDUnitParent", stringBuilder.toString());
-    FileOutputStream outStream = new FileOutputStream(parentJarFile);
-    outStream.write(jarBytes);
-    outStream.close();
-
-    stringBuilder = new StringBuilder();
-    stringBuilder.append("package jddunit.uses;");
-    stringBuilder.append("public class JarDeployerDUnitUses {");
-    stringBuilder.append("public String getValueUses() {");
-    stringBuilder.append("return \"USES\";}}");
-
-    jarBytes = classBuilder.createJarFromClassContent("jddunit/uses/JarDeployerDUnitUses",
-        stringBuilder.toString());
-    outStream = new FileOutputStream(usesJarFile);
-    outStream.write(jarBytes);
-    outStream.close();
-
-    stringBuilder = new StringBuilder();
-    stringBuilder.append("package jddunit.function;");
-    stringBuilder.append("import jddunit.parent.JarDeployerDUnitParent;");
-    stringBuilder.append("import jddunit.uses.JarDeployerDUnitUses;");
-    stringBuilder.append("import org.apache.geode.cache.execute.Function;");
-    stringBuilder.append("import org.apache.geode.cache.execute.FunctionContext;");
-    stringBuilder.append(
-        "public class JarDeployerDUnitFunction  extends JarDeployerDUnitParent implements Function {");
-    stringBuilder.append("private JarDeployerDUnitUses uses = new JarDeployerDUnitUses();");
-    stringBuilder.append("public boolean hasResult() {return true;}");
-    stringBuilder.append(
-        "public void execute(FunctionContext context) {context.getResultSender().lastResult(getValueParent() + \":\" + uses.getValueUses());}");
-    stringBuilder.append("public String getId() {return \"JarDeployerDUnitFunction\";}");
-    stringBuilder.append("public boolean optimizeForWrite() {return false;}");
-    stringBuilder.append("public boolean isHA() {return false;}}");
-
-    ClassBuilder functionClassBuilder = new ClassBuilder();
-    functionClassBuilder.addToClassPath(parentJarFile.getAbsolutePath());
-    functionClassBuilder.addToClassPath(usesJarFile.getAbsolutePath());
-    jarBytes = functionClassBuilder.createJarFromClassContent(
-        "jddunit/function/JarDeployerDUnitFunction", stringBuilder.toString());
-    outStream = new FileOutputStream(functionJarFile);
-    outStream.write(jarBytes);
-    outStream.close();
-
-    server.startServer();
-
-    GemFireCacheImpl gemFireCache = GemFireCacheImpl.getInstance();
-    DistributedSystem distributedSystem = gemFireCache.getDistributedSystem();
-    Execution execution = FunctionService.onMember(distributedSystem.getDistributedMember());
-    ResultCollector resultCollector = execution.execute("JarDeployerDUnitFunction");
-    List<String> result = (List<String>) resultCollector.getResult();
-    assertEquals("PARENT:USES", result.get(0));
-  }
-
-  @Test
-  public void deployNewVersionOfFunctionOverOldVersion() throws Exception {
-    File jarVersion1 = createVersionOfJar("Version1", "MyFunction", "MyJar.jar");
-    File jarVersion2 = createVersionOfJar("Version2", "MyFunction", "MyJar.jar");
-
-    server.startServer();
-
-    GemFireCache gemFireCache = server.getCache();
-    DistributedSystem distributedSystem = gemFireCache.getDistributedSystem();
-
-    ClassPathLoader.getLatest().getJarDeployer().deploy("MyJar.jar", jarVersion1);
-
-    assertThatClassCanBeLoaded("jddunit.function.MyFunction");
-    Execution execution = FunctionService.onMember(distributedSystem.getDistributedMember());
-
-    List<String> result = (List<String>) execution.execute("MyFunction").getResult();
-    assertThat(result.get(0)).isEqualTo("Version1");
-
-    ClassPathLoader.getLatest().getJarDeployer().deploy("MyJar.jar", jarVersion2);
-    result = (List<String>) execution.execute("MyFunction").getResult();
-    assertThat(result.get(0)).isEqualTo("Version2");
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderJUnitTest.java
@@ -163,7 +163,7 @@ public class ClassPathLoaderJUnitTest {
   }
 
   @Test
-  public void redeployingParentClassDoesNotCauseSubclassIncompatibilities() throws Exception {
+  public void redeploySubclassJarThatExtendsInterdependentJarShouldNowLoadNewSubclass() throws Exception {
     String classAName = "classA";
     String classBName = "classB";
 
@@ -173,36 +173,82 @@ public class ClassPathLoaderJUnitTest {
             + classAName + " extends " + classBName
             + " { public boolean hasResult() {return true;}}";
 
+    String classA2Contents =
+            "package jddunit.function;"
+                    + "public class "
+                    + classAName + " extends " + classBName
+                    + " { public boolean hasResult() {return false;}}";
+
     String classBContents =
         "package jddunit.function;"
             + "public class "
             + classBName + " { public boolean someMethod() {return true;}}";
 
-    String classB2Contents =
-        "package jddunit.function;"
-            + "public class "
-            + classBName + " { public boolean someMethod() {return false;}}";
 
     File jarB = createJarFromClassContents("JarBVersion1", classBName, "JarB.jar", classBContents);
     File jarA = createJarFromClassContents("JarAVersion1", classAName, "JarA.jar", classAContents,
         jarB.getAbsolutePath());
-    File jarBV2 =
-        createJarFromClassContents("JarBVersion2", classBName, "JarB.jar", classB2Contents);
+    File jarAV2 = createJarFromClassContents("JarAVersion2", classAName, "JarA.jar", classA2Contents,
+            jarB.getAbsolutePath());
 
     ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarB);
     Class classB =
         ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classBName);
-    Object classBInstance = classB.newInstance();
 
     ClassPathLoader.getLatest().getJarDeployer().deploy("JarA.jar", jarA);
     Class classA =
         ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
     Object classAInstance = classA.newInstance();
 
+    ClassPathLoader.getLatest().getJarDeployer().deploy("JarA.jar", jarAV2);
+    Class classA2 =
+        ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
+    Object classA2Instance = classA2.newInstance();
+
+    assertThat(classA2Instance).isNotInstanceOf(classA);
+  }
+
+  @Test
+  public void redeployingParentClassDoesNotCauseSubclassIncompatibilities() throws Exception {
+    String classAName = "classA";
+    String classBName = "classB";
+
+    String classAContents =
+            "package jddunit.function;"
+                    + "public class "
+                    + classAName + " extends " + classBName
+                    + " { public boolean hasResult() {return true;}}";
+
+    String classBContents =
+            "package jddunit.function;"
+                    + "public class "
+                    + classBName + " { public boolean someMethod() {return true;}}";
+
+    String classB2Contents =
+            "package jddunit.function;"
+                    + "public class "
+                    + classBName + " { public boolean someMethod() {return false;}}";
+
+    File jarB = createJarFromClassContents("JarBVersion1", classBName, "JarB.jar", classBContents);
+    File jarA = createJarFromClassContents("JarAVersion1", classAName, "JarA.jar", classAContents,
+            jarB.getAbsolutePath());
+    File jarBV2 =
+            createJarFromClassContents("JarBVersion2", classBName, "JarB.jar", classB2Contents);
+
+    ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarB);
+    Class classB =
+            ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classBName);
+    Object classBInstance = classB.newInstance();
+
+    ClassPathLoader.getLatest().getJarDeployer().deploy("JarA.jar", jarA);
+    Class classA =
+            ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
+    Object classAInstance = classA.newInstance();
+
     ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarBV2);
 
     Class classA2 =
-        ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
+            ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
     Object classA2Instance = classA2.newInstance();
 
     assertThat(classA2Instance).isInstanceOf(classAInstance.getClass());
@@ -255,7 +301,6 @@ public class ClassPathLoaderJUnitTest {
     assertThat(classA2Instance).isInstanceOf(classAInstance.getClass());
   }
 
-
   @Test(expected = ClassNotFoundException.class)
   public void redeployingJarWithRemovedClassShouldNoLongerAllowLoadingRemovedClass()
       throws Exception {
@@ -294,48 +339,6 @@ public class ClassPathLoaderJUnitTest {
     Class classB2 =
         ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classBName);
   }
-
-  // @Test (expected = ClassNotFoundException.class)
-  // public void parentClassRemovedShouldNoLongerAllowLoadingParentClass() throws Exception {
-  // String classAName = "classA";
-  // String classBName = "classB";
-  // String classB2Name = "classB2";
-  //
-  // String classAContents =
-  // "package jddunit.function;"
-  // + "public class "
-  // + classAName + " extends " + classBName + " { public boolean hasResult() {return true;}}";
-  //
-  // String classBContents =
-  // "package jddunit.function;"
-  // + "public class "
-  // + classBName + " { public boolean someMethod() {return true;}}";
-  //
-  // String classB2Contents =
-  // "package jddunit.function;"
-  // + "public class "
-  // + classB2Name + " { public boolean someMethod() {return false;}}";
-  //
-  // File jarB = createJarFromClassContents("JarBVersion1", classBName, "JarB.jar", classBContents);
-  // File jarA = createJarFromClassContents("JarAVersion1", classAName, "JarA.jar", classAContents,
-  // jarB.getAbsolutePath());
-  // File jarBV2 = createJarFromClassContents("JarBVersion2", classB2Name, "JarB.jar",
-  // classB2Contents);
-  //
-  // ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarB);
-  // Class classB = ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." +
-  // classBName);
-  // Object classBInstance = classB.newInstance();
-  //
-  // ClassPathLoader.getLatest().getJarDeployer().deploy("JarA.jar", jarA);
-  // Class classA = ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." +
-  // classAName);
-  // Object classAInstance = classA.newInstance();
-  //
-  // ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarBV2);
-  // Class classB2 = ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." +
-  // classBName);
-  // }
 
   @Test
   public void undeployedUnrelatedJarShouldNotAffectDeserializedObjectComparison() throws Exception {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/ClassPathLoaderJUnitTest.java
@@ -163,7 +163,8 @@ public class ClassPathLoaderJUnitTest {
   }
 
   @Test
-  public void redeploySubclassJarThatExtendsInterdependentJarShouldNowLoadNewSubclass() throws Exception {
+  public void redeploySubclassJarThatExtendsInterdependentJarShouldNowLoadNewSubclass()
+      throws Exception {
     String classAName = "classA";
     String classBName = "classB";
 
@@ -174,10 +175,10 @@ public class ClassPathLoaderJUnitTest {
             + " { public boolean hasResult() {return true;}}";
 
     String classA2Contents =
-            "package jddunit.function;"
-                    + "public class "
-                    + classAName + " extends " + classBName
-                    + " { public boolean hasResult() {return false;}}";
+        "package jddunit.function;"
+            + "public class "
+            + classAName + " extends " + classBName
+            + " { public boolean hasResult() {return false;}}";
 
     String classBContents =
         "package jddunit.function;"
@@ -188,7 +189,8 @@ public class ClassPathLoaderJUnitTest {
     File jarB = createJarFromClassContents("JarBVersion1", classBName, "JarB.jar", classBContents);
     File jarA = createJarFromClassContents("JarAVersion1", classAName, "JarA.jar", classAContents,
         jarB.getAbsolutePath());
-    File jarAV2 = createJarFromClassContents("JarAVersion2", classAName, "JarA.jar", classA2Contents,
+    File jarAV2 =
+        createJarFromClassContents("JarAVersion2", classAName, "JarA.jar", classA2Contents,
             jarB.getAbsolutePath());
 
     ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarB);
@@ -214,41 +216,41 @@ public class ClassPathLoaderJUnitTest {
     String classBName = "classB";
 
     String classAContents =
-            "package jddunit.function;"
-                    + "public class "
-                    + classAName + " extends " + classBName
-                    + " { public boolean hasResult() {return true;}}";
+        "package jddunit.function;"
+            + "public class "
+            + classAName + " extends " + classBName
+            + " { public boolean hasResult() {return true;}}";
 
     String classBContents =
-            "package jddunit.function;"
-                    + "public class "
-                    + classBName + " { public boolean someMethod() {return true;}}";
+        "package jddunit.function;"
+            + "public class "
+            + classBName + " { public boolean someMethod() {return true;}}";
 
     String classB2Contents =
-            "package jddunit.function;"
-                    + "public class "
-                    + classBName + " { public boolean someMethod() {return false;}}";
+        "package jddunit.function;"
+            + "public class "
+            + classBName + " { public boolean someMethod() {return false;}}";
 
     File jarB = createJarFromClassContents("JarBVersion1", classBName, "JarB.jar", classBContents);
     File jarA = createJarFromClassContents("JarAVersion1", classAName, "JarA.jar", classAContents,
-            jarB.getAbsolutePath());
+        jarB.getAbsolutePath());
     File jarBV2 =
-            createJarFromClassContents("JarBVersion2", classBName, "JarB.jar", classB2Contents);
+        createJarFromClassContents("JarBVersion2", classBName, "JarB.jar", classB2Contents);
 
     ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarB);
     Class classB =
-            ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classBName);
+        ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classBName);
     Object classBInstance = classB.newInstance();
 
     ClassPathLoader.getLatest().getJarDeployer().deploy("JarA.jar", jarA);
     Class classA =
-            ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
+        ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
     Object classAInstance = classA.newInstance();
 
     ClassPathLoader.getLatest().getJarDeployer().deploy("JarB.jar", jarBV2);
 
     Class classA2 =
-            ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
+        ClassPathLoader.getLatest().asClassLoader().loadClass("jddunit.function." + classAName);
     Object classA2Instance = classA2.newInstance();
 
     assertThat(classA2Instance).isInstanceOf(classAInstance.getClass());

--- a/geode-core/src/main/java/org/apache/geode/internal/ChildFirstClassLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/ChildFirstClassLoader.java
@@ -62,11 +62,14 @@ public class ChildFirstClassLoader extends URLClassLoader {
       }
     }
 
-
     // if we could not find it, delegate to parent
     // Note that we don't attempt to catch any ClassNotFoundException
     if (c == null) {
-      c = searchParent(name);
+      try {
+        c = searchParent(name);
+      } catch (ClassNotFoundException | NoClassDefFoundError cnfe) {
+        // ignore
+      }
     }
 
     if (resolve) {

--- a/geode-core/src/main/java/org/apache/geode/internal/ChildFirstClassLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/ChildFirstClassLoader.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal;
+
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class ChildFirstClassLoader extends URLClassLoader {
+
+  public ChildFirstClassLoader() {
+    super(new URL[] {});
+  }
+
+  public ChildFirstClassLoader(URL[] urls) {
+    super(urls);
+  }
+
+  public ChildFirstClassLoader(URL[] urls, ClassLoader parent) {
+    super(urls, parent);
+  }
+
+  @Override
+  public void addURL(URL url) {
+    super.addURL(url);
+  }
+
+  @Override
+  public Class loadClass(String name) throws ClassNotFoundException {
+    return loadClass(name, false);
+  }
+
+  /**
+   * We override the parent-first behavior established by java.lang.Classloader.
+   */
+  @Override
+  protected Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    Class c = null;
+
+    // First, check if the class has already been loaded
+    c = findLoadedClass(name);
+
+    // if not loaded, search the local (child) resources
+    if (c == null) {
+      try {
+        c = findClass(name);
+      } catch (ClassNotFoundException cnfe) {
+        // ignore
+      }
+    }
+
+
+    // if we could not find it, delegate to parent
+    // Note that we don't attempt to catch any ClassNotFoundException
+    if (c == null) {
+      c = searchParent(name);
+    }
+
+    if (resolve) {
+      resolveClass(c);
+    }
+
+    return c;
+  }
+
+  @Override
+  public URL getResource(String name) {
+    URL url = null;
+    if (url == null) {
+      url = findResource(name);
+    }
+    if (url == null) {
+      url = super.getResource(name);
+    }
+    return url;
+  }
+
+  protected Class searchParent(String name) throws ClassNotFoundException {
+    Class c;
+    if (getParent() != null) {
+      c = getParent().loadClass(name);
+    } else {
+      c = getSystemClassLoader().loadClass(name);
+    }
+    return c;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/DeployJarChildFirstClassLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DeployJarChildFirstClassLoader.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+
+public class DeployJarChildFirstClassLoader extends ChildFirstClassLoader {
+
+  private String jarName;
+  public final HashMap<String, DeployJarChildFirstClassLoader> latestJarNamesToClassLoader;
+
+
+
+  public DeployJarChildFirstClassLoader(
+      HashMap<String, DeployJarChildFirstClassLoader> latestJarNamesToClassLoader, URL[] urls,
+      String jarName, ClassLoader parent) {
+    super(urls, parent);
+    this.latestJarNamesToClassLoader = latestJarNamesToClassLoader;
+    this.jarName = jarName;
+    updateLatestJarNamesToClassLoaderMap();
+  }
+
+  private void updateLatestJarNamesToClassLoaderMap() {
+    latestJarNamesToClassLoader.put(jarName, this);
+  }
+
+
+  @Override
+  public Class loadClass(String name) throws ClassNotFoundException {
+    return loadClass(name, false);
+  }
+
+  /**
+   * We override the parent-first behavior established by java.lang.Classloader.
+   */
+  @Override
+  protected Class loadClass(String name, boolean resolve) throws ClassNotFoundException {
+    if (thisIsOld()) {
+      return searchParent(name);
+    } else {
+      System.out.println("JASON loading class:" + name + " from " + jarName + ":" + this);
+      return super.loadClass(name, resolve);
+    }
+  }
+
+  @Override
+  public URL findResource(String name) {
+    if (thisIsOld()) {
+      return null;
+    }
+    return super.findResource(name);
+  }
+
+  @Override
+  public Enumeration<URL> findResources(final String name) throws IOException {
+    if (thisIsOld()) {
+      return Collections.enumeration(Collections.EMPTY_LIST);
+    } else {
+      return super.findResources(name);
+    }
+  }
+
+  private boolean thisIsOld() {
+    System.out.println("JASON" + jarName + ":" + latestJarNamesToClassLoader.get(jarName) + "::::"
+        + this + " is this old?:" + (latestJarNamesToClassLoader.get(jarName) != this));
+    return latestJarNamesToClassLoader.get(jarName) != this;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/DeployJarChildFirstClassLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DeployJarChildFirstClassLoader.java
@@ -110,10 +110,7 @@ public class DeployJarChildFirstClassLoader extends ChildFirstClassLoader {
     }
   }
 
-  private boolean thisIsOld() {
-    new Exception(
-        "thisIsOld lookup:" + latestJarNamesToClassLoader.get(jarName) + ":" + jarName + ":" + this)
-            .printStackTrace();
+  boolean thisIsOld() {
     return latestJarNamesToClassLoader.get(jarName) != this;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/DeployedJar.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DeployedJar.java
@@ -156,7 +156,6 @@ public class DeployedJar {
     JarInputStream jarInputStream = null;
     try {
       Collection<String> functionClasses = findFunctionsInThisJar();
-
       jarInputStream = new JarInputStream(bufferedInputStream);
       JarEntry jarEntry = jarInputStream.getNextJarEntry();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/JarDeployer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/JarDeployer.java
@@ -361,11 +361,10 @@ public class JarDeployer implements Serializable {
         if (deployedJar != null) {
           logger.info("Registering new version of jar: {}", deployedJar);
           DeployedJar oldJar = this.deployedJars.put(deployedJar.getJarName(), deployedJar);
+          ClassPathLoader.getLatest().chainClassloader(deployedJar);
           newVersionToOldVersion.put(deployedJar, oldJar);
         }
       }
-
-      ClassPathLoader.getLatest().rebuildClassLoaderForDeployedJars();
 
       // Finally, unregister functions that were removed
       for (Map.Entry<DeployedJar, DeployedJar> entry : newVersionToOldVersion.entrySet()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/JarDeployer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/JarDeployer.java
@@ -484,7 +484,7 @@ public class JarDeployer implements Serializable {
         throw new IllegalArgumentException("JAR not deployed");
       }
 
-      ClassPathLoader.getLatest().rebuildClassLoaderForDeployedJars();
+      ClassPathLoader.getLatest().unloadClassloaderForJar(jarName);
 
       deployedJar.cleanUp(null);
 


### PR DESCRIPTION
This solution causes each deployed jar to create it's own class loader and chains them together.

The class loaders are now child first class loaders and If a class cannot be found, it will search all 'sibling'/other deployed jars

When a jar is redeployed (new version), we keep some meta data in a map so we no longer crawl the 'old' jar when possible and only search through the latest version of a specific jar.

Java does some caching of classes and in the undeploy scenario, we may still be able to load classes that have been "removed" from the new jar (only if it was already cached by some other class loader).  This can happen when we have inter jar dependencies.

Geode also caches classes, so whenever a redeploy occurs, the geode class cache gets wiped, and first lookups take a minor performance hit, but subsequent lookups go through geodes caching of the classes (so the for name and class lookups through chaining should have a minimal impact)

