### PR TITLE
GEODE-6707 gfsh export logs will now export rolled over gc logs

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterFileIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterFileIntegrationTest.java
@@ -134,4 +134,18 @@ public class LogExporterFileIntegrationTest {
     assertThat(logExporter.findStatFiles(workingDir.toPath())).contains(statFile.toPath());
     assertThat(logExporter.findStatFiles(workingDir.toPath())).doesNotContain(notALogFile.toPath());
   }
+
+  @Test
+  // GEODE-6707 - Rolled over GC logs end with names like ".log.1"
+  public void findLogsWhichContainsTheWordLog() throws Exception {
+    File gcLogFile = new File(workingDir, "gc.log");
+    FileUtils.writeStringToFile(gcLogFile, "some gc log line");
+
+    File gcRolledOverLogFile = new File(workingDir, "gc.log.1");
+    FileUtils.writeStringToFile(gcRolledOverLogFile, "some gc log line");
+
+    assertThat(logExporter.findLogFiles(workingDir.toPath())).contains(gcLogFile.toPath());
+    assertThat(logExporter.findLogFiles(workingDir.toPath()))
+        .contains(gcRolledOverLogFile.toPath());
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/LogExporter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/LogExporter.java
@@ -169,7 +169,7 @@ public class LogExporter {
   }
 
   List<Path> findLogFiles(Path workingDir) throws IOException {
-    Predicate<Path> logFileSelector = (Path file) -> file.toString().toLowerCase().endsWith(".log");
+    Predicate<Path> logFileSelector = (Path file) -> file.toString().toLowerCase().contains(".log");
     return findFiles(workingDir, logFileSelector);
   }
 


### PR DESCRIPTION
- Currently only files ending in .log are exported.
- GC logs are of the format gc.log.current, gc.log.1 which will now
  be exported if they reside in the same dir as server logs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
