### PR TITLE
GEODE-6730: optimize check for sender id differences

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -183,6 +183,8 @@ public class DistributionAdvisor {
    */
   private ConcurrentMap<ProfileListener, Boolean> profileListeners = new ConcurrentHashMap<>();
 
+  private volatile InitializationListener initializationListener;
+
   /**
    * The resource getting advise from this.
    */
@@ -424,6 +426,17 @@ public class DistributionAdvisor {
     membershipListeners.putIfAbsent(listener, Boolean.TRUE);
   }
 
+  public interface InitializationListener {
+    /**
+     * Called after this DistributionAdvisor has been initialized.
+     */
+    void initialized();
+  }
+
+  public void setInitializationListener(InitializationListener listener) {
+    this.initializationListener = listener;
+  }
+
   public boolean addProfileChangeListener(ProfileListener listener) {
     return null == profileListeners.putIfAbsent(listener, Boolean.TRUE);
   }
@@ -453,10 +466,21 @@ public class DistributionAdvisor {
     if (initialized) {
       return false;
     }
-    synchronized (initializeLock) {
-      if (!initialized) {
-        exchangeProfiles();
-        return true;
+    boolean exchangedProfiles = false;
+    try {
+      synchronized (initializeLock) {
+        if (!initialized) {
+          exchangedProfiles = true;
+          exchangeProfiles();
+          return true;
+        }
+      }
+    } finally {
+      if (exchangedProfiles) {
+        if (this.initializationListener != null) {
+          // this needs to be done outside the initializeLock
+          this.initializationListener.initialized();
+        }
       }
     }
     return false;
@@ -475,7 +499,7 @@ public class DistributionAdvisor {
    *
    * @since GemFire 5.7
    */
-  protected boolean pollIsInitialized() {
+  public boolean pollIsInitialized() {
     return initialized;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -701,7 +701,8 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
     return this.asyncEventQueueIds;
   }
 
-  Set<String> getVisibleAsyncEventQueueIds() {
+  @Override
+  public Set<String> getVisibleAsyncEventQueueIds() {
     return this.visibleAsyncEventQueueIds;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -2418,4 +2418,19 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     return entries.clear(rvv, this);
   }
 
+  @Override
+  SenderIdMonitor createSenderIdMonitor() {
+    // bucket regions do not need to monitor sender ids
+    return null;
+  }
+
+  @Override
+  void updateSenderIdMonitor() {
+    // nothing needed on a bucket region
+  }
+
+  @Override
+  void checkSameSenderIdsAvailableOnAllNodes() {
+    // nothing needed on a bucket region
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheDistributionAdvisor.java
@@ -1080,41 +1080,4 @@ public class CacheDistributionAdvisor extends DistributionAdvisor {
     }
     return result;
   }
-
-  public List<Set<String>> adviseSameGatewaySenderIds(final Set<String> allGatewaySenderIds) {
-    final List<Set<String>> differSenderIds = new ArrayList<>();
-    fetchProfiles(profile -> {
-      if (profile instanceof CacheProfile) {
-        final CacheProfile cp = (CacheProfile) profile;
-        if (allGatewaySenderIds.equals(cp.gatewaySenderIds)) {
-          return true;
-        } else {
-          differSenderIds.add(allGatewaySenderIds);
-          differSenderIds.add(cp.gatewaySenderIds);
-          return false;
-        }
-      }
-      return false;
-    });
-    return differSenderIds;
-  }
-
-  public List<Set<String>> adviseSameAsyncEventQueueIds(final Set<String> allAsyncEventIds) {
-    final List<Set<String>> differAsycnQueueIds = new ArrayList<>();
-    fetchProfiles(profile -> {
-      if (profile instanceof CacheProfile) {
-        final CacheProfile cp = (CacheProfile) profile;
-        if (allAsyncEventIds.equals(cp.asyncEventQueueIds)) {
-          return true;
-        } else {
-          differAsycnQueueIds.add(allAsyncEventIds);
-          differAsycnQueueIds.add(cp.asyncEventQueueIds);
-          return false;
-        }
-      }
-      return false;
-    });
-    return differAsycnQueueIds;
-  }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2690,9 +2690,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   }
 
   SenderIdMonitor createSenderIdMonitor() {
-    SenderIdMonitor senderIdMonitor = new SenderIdMonitor(this, this.distAdvisor);
-    this.distAdvisor.addProfileChangeListener(senderIdMonitor);
-    return senderIdMonitor;
+    return SenderIdMonitor.createSenderIdMonitor(this, this.distAdvisor);
   }
 
   void updateSenderIdMonitor() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -141,7 +141,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   private final Object dlockMonitor = new Object();
 
   final CacheDistributionAdvisor distAdvisor;
-  final SenderIdMonitor senderIdMonitor;
+  private final SenderIdMonitor senderIdMonitor;
 
   /**
    * GuardedBy {@link #dlockMonitor}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -433,4 +433,7 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
   int getTombstoneCount();
 
   Region.Entry getEntry(Object key, boolean allowTombstones);
+
+  Set<String> getVisibleAsyncEventQueueIds();
+
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1283,9 +1283,7 @@ public class PartitionedRegion extends LocalRegion
   }
 
   private SenderIdMonitor createSenderIdMonitor() {
-    SenderIdMonitor senderIdMonitor = new SenderIdMonitor(this, this.distAdvisor);
-    this.distAdvisor.addProfileChangeListener(senderIdMonitor);
-    return senderIdMonitor;
+    return SenderIdMonitor.createSenderIdMonitor(this, this.distAdvisor);
   }
 
   private void updateSenderIdMonitor() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SenderIdMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SenderIdMonitor.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.geode.distributed.internal.DistributionAdvisor.Profile;
+import org.apache.geode.distributed.internal.ProfileListener;
+import org.apache.geode.internal.cache.CacheDistributionAdvisor.CacheProfile;
+import org.apache.geode.internal.cache.wan.GatewaySenderConfigurationException;
+
+public class SenderIdMonitor implements ProfileListener {
+  private final InternalRegion region;
+  private final CacheDistributionAdvisor advisor;
+  private volatile Set<String> illegalGatewaySenderIds = null;
+  private volatile Set<String> illegalAsyncEventQueueIds = null;
+
+  public SenderIdMonitor(InternalRegion region, CacheDistributionAdvisor advisor) {
+    this.region = region;
+    this.advisor = advisor;
+  }
+
+  @Override
+  public void profileCreated(Profile profile) {
+    update();
+  }
+
+  @Override
+  public void profileUpdated(Profile profile) {
+    update();
+  }
+
+  @Override
+  public void profileRemoved(Profile profile, boolean destroyed) {
+    update();
+  }
+
+  /**
+   * Needs to be called if this region's gateways or asyncEventIds change.
+   */
+  public void update() {
+    final Set<String> gatewaySenderIds = region.getGatewaySenderIds();
+    final Set<String> visibleAsyncEventQueueIds = region.getVisibleAsyncEventQueueIds();
+    final AtomicBoolean foundIllegalState = new AtomicBoolean();
+    this.advisor.accept((advisor, profile, idx, count, aggregate) -> {
+      if (profile instanceof CacheProfile) {
+        final CacheProfile cp = (CacheProfile) profile;
+        if (!gatewaySenderIds.equals(cp.gatewaySenderIds)) {
+          foundIllegalState.set(true);
+          illegalGatewaySenderIds = cp.gatewaySenderIds;
+        }
+        if (!visibleAsyncEventQueueIds.equals(cp.asyncEventQueueIds)) {
+          foundIllegalState.set(true);
+          illegalAsyncEventQueueIds = cp.asyncEventQueueIds;
+        }
+      }
+      return true;
+    }, null);
+    if (!foundIllegalState.get()) {
+      illegalGatewaySenderIds = null;
+      illegalAsyncEventQueueIds = null;
+    }
+  }
+
+  public void checkSenderIds() {
+    if (illegalGatewaySenderIds != null) {
+      throw new GatewaySenderConfigurationException(
+          String.format(
+              "Region %s has %s gateway sender IDs. Another cache has same region with %s gateway sender IDs. For region across all members, gateway sender ids should be same.",
+              region.getName(), region.getGatewaySenderIds(), illegalGatewaySenderIds));
+    }
+    if (illegalAsyncEventQueueIds != null) {
+      throw new GatewaySenderConfigurationException(
+          String.format(
+              "Region %s has %s AsyncEvent queue IDs. Another cache has same region with %s AsyncEvent queue IDs. For region across all members, AsyncEvent queue IDs should be same.",
+              region.getName(), region.getVisibleAsyncEventQueueIds(), illegalAsyncEventQueueIds));
+
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SenderIdMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SenderIdMonitor.java
@@ -28,9 +28,16 @@ public class SenderIdMonitor implements ProfileListener {
   private volatile Set<String> illegalGatewaySenderIds = null;
   private volatile Set<String> illegalAsyncEventQueueIds = null;
 
-  public SenderIdMonitor(InternalRegion region, CacheDistributionAdvisor advisor) {
+  private SenderIdMonitor(InternalRegion region, CacheDistributionAdvisor advisor) {
     this.region = region;
     this.advisor = advisor;
+  }
+
+  public static SenderIdMonitor createSenderIdMonitor(InternalRegion region,
+      CacheDistributionAdvisor advisor) {
+    SenderIdMonitor senderIdMonitor = new SenderIdMonitor(region, advisor);
+    advisor.addProfileChangeListener(senderIdMonitor);
+    return senderIdMonitor;
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/SenderIdMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/SenderIdMonitorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import org.apache.geode.distributed.internal.DistributionAdvisor;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.internal.cache.CacheDistributionAdvisor.CacheProfile;
+
+public class SenderIdMonitorTest {
+  private InternalRegion region = mock(InternalRegion.class);
+  private CacheDistributionAdvisor advisor = createCacheDistributionAdvisor(region);
+  private SenderIdMonitor senderIdMonitor = SenderIdMonitor.createSenderIdMonitor(region, advisor);
+
+  @Test
+  public void checkPassesByDefault() {
+    senderIdMonitor.checkSenderIds();
+  }
+
+  @Test
+  public void checkPassesOnRegionWithNoIdsAndAdvisorWithNoProfiles() {
+    senderIdMonitor.update();
+    senderIdMonitor.checkSenderIds();
+  }
+
+  @Test
+  public void checkPassesOnRegionWithGatewayIdsAndAdvisorWithNoProfiles() {
+    when(region.getGatewaySenderIds()).thenReturn(Collections.singleton("gatewayId"));
+    senderIdMonitor.update();
+    senderIdMonitor.checkSenderIds();
+  }
+
+  @Test
+  public void checkPassesOnRegionWithAsyncEventQueueIdsAndAdvisorWithNoProfiles() {
+    when(region.getVisibleAsyncEventQueueIds())
+        .thenReturn(Collections.singleton("AsyncEventQueueId"));
+    senderIdMonitor.update();
+    senderIdMonitor.checkSenderIds();
+  }
+
+  @Test
+  public void checkFailsWithRegionAndProfileWithDifferentGatewayIds() {
+    when(region.getGatewaySenderIds()).thenReturn(Collections.singleton("gatewayId"));
+    CacheProfile profile = new CacheProfile();
+    profile.gatewaySenderIds = Collections.singleton("profileGatewayId");
+    advisor.putProfile(profile, true);
+
+    Throwable t = catchThrowable(() -> senderIdMonitor.checkSenderIds());
+
+    assertThat(t).hasMessage(
+        "Region null has [gatewayId] gateway sender IDs. Another cache has same region with [profileGatewayId] gateway sender IDs. For region across all members, gateway sender ids should be same.");
+  }
+
+  @Test
+  public void checkPassesWithRegionAndProfileWithDifferentGatewayIdsThatBecomeEqual() {
+    when(region.getGatewaySenderIds()).thenReturn(Collections.singleton("gatewayId"));
+    CacheProfile profile = new CacheProfile();
+    profile.gatewaySenderIds = Collections.singleton("profileGatewayId");
+    advisor.putProfile(profile, true);
+    when(region.getGatewaySenderIds()).thenReturn(Collections.singleton("profileGatewayId"));
+    senderIdMonitor.update();
+    senderIdMonitor.checkSenderIds();
+  }
+
+  @Test
+  public void checkFailsWithRegionAndProfileWithDifferentAsyncEventQueueIds() {
+    when(region.getVisibleAsyncEventQueueIds())
+        .thenReturn(Collections.singleton("AsyncEventQueueId"));
+    CacheProfile profile = new CacheProfile();
+    profile.asyncEventQueueIds = Collections.singleton("profileAsyncEventQueueId");
+    advisor.putProfile(profile, true);
+
+    Throwable t = catchThrowable(() -> senderIdMonitor.checkSenderIds());
+
+    assertThat(t).hasMessage(
+        "Region null has [AsyncEventQueueId] AsyncEvent queue IDs. Another cache has same region with [profileAsyncEventQueueId] AsyncEvent queue IDs. For region across all members, AsyncEvent queue IDs should be same.");
+  }
+
+  @Test
+  public void checkPassesWithRegionAndProfileWithDifferentAsyncEventQueueIdsThatBecomeEqual() {
+    when(region.getVisibleAsyncEventQueueIds())
+        .thenReturn(Collections.singleton("AsyncEventQueueId"));
+    CacheProfile profile = new CacheProfile();
+    profile.asyncEventQueueIds = Collections.singleton("profileAsyncEventQueueId");
+    advisor.putProfile(profile, true);
+    when(region.getVisibleAsyncEventQueueIds())
+        .thenReturn(Collections.singleton("profileAsyncEventQueueId"));
+    senderIdMonitor.update();
+    senderIdMonitor.checkSenderIds();
+  }
+
+  private CacheDistributionAdvisor createCacheDistributionAdvisor(InternalRegion region) {
+    DistributionAdvisor advisor = mock(DistributionAdvisor.class);
+    CacheDistributionAdvisee advisee = mock(CacheDistributionAdvisee.class);
+    when(advisee.getDistributionAdvisor()).thenReturn(advisor);
+    DistributionManager distributionManager = mock(DistributionManager.class);
+    when(advisee.getDistributionManager()).thenReturn(distributionManager);
+    CacheDistributionAdvisor result =
+        CacheDistributionAdvisor.createCacheDistributionAdvisor(advisee);
+    result.initializationGate();
+    return result;
+  }
+
+}


### PR DESCRIPTION
Instead of every region write operation scanning the profiles and doing set comparisions to detect if any of the gateway or async event queue ids on a region are configured differently, now this check is done whenever the profiles or our local sender ids change. The region write operations now just check two volatiles to see if they are non-null.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
