### PR TITLE
GEODE-6670: remove getCacheServers allocation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -397,6 +397,11 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
    * outnumber the mutative operations such as add, remove.
    */
   private final List<InternalCacheServer> allCacheServers = new CopyOnWriteArrayList<>();
+  /**
+   * Unmodifiable view of "allCacheServers".
+   */
+  private final List<CacheServer> unmodifiableAllCacheServers =
+      Collections.unmodifiableList(allCacheServers);
 
   /**
    * Controls updates to the list of all gateway senders
@@ -3957,7 +3962,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   @Override
   public List<CacheServer> getCacheServers() {
-    return Collections.unmodifiableList(allCacheServers);
+    return this.unmodifiableAllCacheServers;
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -554,6 +554,14 @@ public class GemFireCacheImplTest {
     assertThat(value).isFalse();
   }
 
+  @Test
+  public void getCacheServersIsCanonical() {
+    gemFireCacheImpl = createGemFireCacheImpl();
+    List<CacheServer> list1 = gemFireCacheImpl.getCacheServers();
+    List<CacheServer> list2 = gemFireCacheImpl.getCacheServers();
+    assertThat(list1).isSameAs(list2);
+  }
+
   private static GemFireCacheImpl createGemFireCacheImpl() {
     return (GemFireCacheImpl) new InternalCacheBuilder().create(Fakes.distributedSystem());
   }


### PR DESCRIPTION
getCacheServers now returns a canonical instance
instead of creating a new instance for each call.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
