### PR TITLE
GEODE-6739: Create Concourse heavy-lift workers in the current zone

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -18,6 +18,7 @@
 {% from 'shared_jinja.yml' import alpine_tools_config with context %}
 {% from 'shared_jinja.yml' import pipeline_prefix with context %}
 {% from 'shared_jinja.yml' import github_access with context %}
+{% from 'shared_jinja.yml' import init_retry with context %}
 
 ---
 
@@ -224,6 +225,7 @@ jobs:
         pre: ((semver-prerelease-token))
     - do:
       - put: concourse-metadata-resource
+      {{ init_retry()|indent(6) }}
       - task: create_instance
         {{- alpine_tools_config()|indent(8) }}
           params:
@@ -234,9 +236,13 @@ jobs:
           run:
             path: geode-ci/ci/scripts/create_instance.sh
           inputs:
+          - name: attempts-log
+            path: old
           - name: concourse-metadata-resource
           - name: geode-ci
           outputs:
+          - name: attempts-log
+            path: new
           - name: instance-data
         timeout: 15m
         attempts: 10

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -17,6 +17,7 @@
 
 {% from 'shared_jinja.yml' import alpine_tools_config with context %}
 {% from 'shared_jinja.yml' import pipeline_prefix with context %}
+{% from 'shared_jinja.yml' import init_retry with context %}
 
 groups:
 - name: main
@@ -87,6 +88,7 @@ jobs:
           get_params: {skip_download: true}
       - do:
         - put: concourse-metadata-resource
+        {{ init_retry()|indent(8) }}
         - task: create_instance
           {{- alpine_tools_config()|indent(10) }}
             params:
@@ -103,8 +105,12 @@ jobs:
             - name: concourse-metadata-resource
             - name: geode
             - name: geode-ci
+            - name: attempts-log
+              path: old
             outputs:
             - name: instance-data
+            - name: attempts-log
+              path: new
           timeout: 15m
           attempts: 100
     - task: rsync_code_up

--- a/ci/pipelines/shared/shared_jinja.yml
+++ b/ci/pipelines/shared/shared_jinja.yml
@@ -38,3 +38,13 @@ username: ((github-username))
 password: ((github-password))
 {%- endif %}
 {%- endmacro %}
+
+{%- macro init_retry() -%}
+- task: initial-output
+  {{- docker_config()|indent(2) }}
+    outputs:
+    - name: attempts-log
+    run:
+      path: touch
+      args: ['attempts-log/attempts']
+{%- endmacro %}

--- a/ci/scripts/create_instance.sh
+++ b/ci/scripts/create_instance.sh
@@ -77,7 +77,6 @@ GCP_SUBNETWORK=${GCP_SUBNETWORK##*/}
 cp old/attempts new/
 echo attempt >> new/attempts
 attempts=$(cat new/attempts | wc -l)
-echo $attempts > /tmp/retry_number
 
 if [ $attempts -eq 1 ]; then
   ZONE=${MY_ZONE}


### PR DESCRIPTION
GCP costs are incurred on data egress between zones, even the same
region. Track our `create-instance` attempts, to put the heavy lifter in
the same zone on the first attempt, and roulette only on failure

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Helena Bales <hbales@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
