### PR TITLE
Stop running pmd as part of build, except in concourse

### DIFF
--- a/ci/scripts/execute_build.sh
+++ b/ci/scripts/execute_build.sh
@@ -98,7 +98,7 @@ GRADLE_ARGS="\
     ${GRADLE_GLOBAL_ARGS} \
     -Pversion=${FULL_PRODUCT_VERSION} \
     -PbuildId=${BUILD_ID} \
-    build install javadoc spotlessCheck rat checkPom resolveDependencies -x test"
+    build install javadoc spotlessCheck rat checkPom resolveDependencies pmdMain -x test"
 
 EXEC_COMMAND="mkdir -p tmp && cd geode && ${SET_JAVA_HOME} && ./gradlew ${GRADLE_ARGS}"
 echo "${EXEC_COMMAND}"

--- a/gradle/pmd.gradle
+++ b/gradle/pmd.gradle
@@ -19,6 +19,7 @@ pmd {
   sourceSets = [sourceSets.main]
   ruleSetFiles = files("${project.projectDir}/../static-analysis/pmd-rules/src/main/resources/geodepmd.xml")
   ruleSets = []
+  consoleOutput = true
 }
 dependencies {
   pmd  project(":static-analysis:pmd-rules")

--- a/gradle/pmd.gradle
+++ b/gradle/pmd.gradle
@@ -16,7 +16,7 @@
  */
 apply plugin: 'pmd'
 pmd {
-  sourceSets = [sourceSets.main]
+  sourceSets = []
   ruleSetFiles = files("${project.projectDir}/../static-analysis/pmd-rules/src/main/resources/geodepmd.xml")
   ruleSets = []
   consoleOutput = true


### PR DESCRIPTION
Removing PMD as a dependency of check. Instead, we'll just directly run it in the build job in concourse. This prevents users from having to wait for this job to finish during their build runs.

Also, making sure that PMD output goes to the console, so it shows up in concourse.