### PR TITLE
GEODE-6750: Clean up Swagger UI model for Manageability REST API

### DIFF
--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
@@ -348,7 +348,6 @@ public class RegionAttributesType implements Serializable {
 
   @XmlElement(name = "key-constraint", namespace = "http://geode.apache.org/schema/cache")
   protected String keyConstraint;
-
   @XmlElement(name = "value-constraint", namespace = "http://geode.apache.org/schema/cache")
   protected String valueConstraint;
   @XmlElement(name = "region-time-to-live", namespace = "http://geode.apache.org/schema/cache")
@@ -1499,7 +1498,7 @@ public class RegionAttributesType implements Serializable {
     this.offHeap = value;
   }
 
-  @ApiModelProperty(hidden=true)
+  @ApiModelProperty(hidden = true)
   public void setLruHeapPercentageEvictionAction(EnumActionDestroyOverflow action) {
     if (evictionAttributes == null) {
       evictionAttributes = new EvictionAttributes();
@@ -2807,7 +2806,6 @@ public class RegionAttributesType implements Serializable {
      * {@link String }
      *
      */
-    @ApiModelProperty(hidden = true)
     public String getLocalMaxMemory() {
       return localMaxMemory;
     }

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
@@ -348,6 +348,7 @@ public class RegionAttributesType implements Serializable {
 
   @XmlElement(name = "key-constraint", namespace = "http://geode.apache.org/schema/cache")
   protected String keyConstraint;
+
   @XmlElement(name = "value-constraint", namespace = "http://geode.apache.org/schema/cache")
   protected String valueConstraint;
   @XmlElement(name = "region-time-to-live", namespace = "http://geode.apache.org/schema/cache")

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
@@ -33,6 +33,8 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.annotations.Experimental;
@@ -996,6 +998,7 @@ public class RegionAttributesType implements Serializable {
   /**
    * turn the comma separated ids into a set of id
    */
+  @JsonIgnore
   public Set<String> getGatewaySenderIdsAsSet() {
     if (gatewaySenderIds == null) {
       return null;
@@ -1030,6 +1033,7 @@ public class RegionAttributesType implements Serializable {
   /**
    * turn the comma separated id into a set of ids
    */
+  @JsonIgnore
   public Set<String> getAsyncEventQueueIdsAsSet() {
     if (asyncEventQueueIds == null) {
       return null;
@@ -1494,6 +1498,7 @@ public class RegionAttributesType implements Serializable {
     this.offHeap = value;
   }
 
+  @ApiModelProperty(hidden=true)
   public void setLruHeapPercentageEvictionAction(EnumActionDestroyOverflow action) {
     if (evictionAttributes == null) {
       evictionAttributes = new EvictionAttributes();
@@ -1504,6 +1509,7 @@ public class RegionAttributesType implements Serializable {
     evictionAttributes.setLruHeapPercentage(lruHeapPercentage);
   }
 
+  @ApiModelProperty(hidden=true)
   public void setInterestPolicy(String interestPolicy) {
     if (subscriptionAttributes == null) {
       subscriptionAttributes = new SubscriptionAttributes();
@@ -1511,6 +1517,7 @@ public class RegionAttributesType implements Serializable {
     subscriptionAttributes.setInterestPolicy(interestPolicy);
   }
 
+  @ApiModelProperty(hidden=true)
   public void setRedundantCopy(String copies) {
     if (partitionAttributes == null) {
       partitionAttributes = new PartitionAttributes();
@@ -1518,6 +1525,7 @@ public class RegionAttributesType implements Serializable {
     partitionAttributes.setRedundantCopies(copies);
   }
 
+  @ApiModelProperty(hidden=true)
   public void setLocalMaxMemory(String maxMemory) {
     if (partitionAttributes == null) {
       partitionAttributes = new PartitionAttributes();
@@ -2798,6 +2806,7 @@ public class RegionAttributesType implements Serializable {
      * {@link String }
      *
      */
+    @ApiModelProperty(hidden=true)
     public String getLocalMaxMemory() {
       return localMaxMemory;
     }

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionAttributesType.java
@@ -1509,7 +1509,7 @@ public class RegionAttributesType implements Serializable {
     evictionAttributes.setLruHeapPercentage(lruHeapPercentage);
   }
 
-  @ApiModelProperty(hidden=true)
+  @ApiModelProperty(hidden = true)
   public void setInterestPolicy(String interestPolicy) {
     if (subscriptionAttributes == null) {
       subscriptionAttributes = new SubscriptionAttributes();
@@ -1517,7 +1517,7 @@ public class RegionAttributesType implements Serializable {
     subscriptionAttributes.setInterestPolicy(interestPolicy);
   }
 
-  @ApiModelProperty(hidden=true)
+  @ApiModelProperty(hidden = true)
   public void setRedundantCopy(String copies) {
     if (partitionAttributes == null) {
       partitionAttributes = new PartitionAttributes();
@@ -1525,7 +1525,7 @@ public class RegionAttributesType implements Serializable {
     partitionAttributes.setRedundantCopies(copies);
   }
 
-  @ApiModelProperty(hidden=true)
+  @ApiModelProperty(hidden = true)
   public void setLocalMaxMemory(String maxMemory) {
     if (partitionAttributes == null) {
       partitionAttributes = new PartitionAttributes();
@@ -2806,7 +2806,7 @@ public class RegionAttributesType implements Serializable {
      * {@link String }
      *
      */
-    @ApiModelProperty(hidden=true)
+    @ApiModelProperty(hidden = true)
     public String getLocalMaxMemory() {
       return localMaxMemory;
     }

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
@@ -162,8 +162,6 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
 
   @XmlElement(name = "region-attributes", namespace = "http://geode.apache.org/schema/cache")
   protected RegionAttributesType regionAttributes;
-
-  @ApiModelProperty(hidden = true)
   @XmlElement(name = "index", namespace = "http://geode.apache.org/schema/cache")
   protected List<Index> indexes;
 

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
@@ -32,7 +32,6 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.StringUtils;
 
@@ -164,7 +163,7 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
   @XmlElement(name = "region-attributes", namespace = "http://geode.apache.org/schema/cache")
   protected RegionAttributesType regionAttributes;
 
-  @ApiModelProperty(hidden=true)
+  @ApiModelProperty(hidden = true)
   @XmlElement(name = "index", namespace = "http://geode.apache.org/schema/cache")
   protected List<Index> indexes;
 

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
@@ -32,6 +32,8 @@ import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiModelProperty;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.annotations.Experimental;
@@ -161,16 +163,25 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
 
   @XmlElement(name = "region-attributes", namespace = "http://geode.apache.org/schema/cache")
   protected RegionAttributesType regionAttributes;
+
+  @ApiModelProperty(hidden=true)
   @XmlElement(name = "index", namespace = "http://geode.apache.org/schema/cache")
   protected List<Index> indexes;
+
+  @ApiModelProperty(hidden = true)
   @XmlElement(name = "entry", namespace = "http://geode.apache.org/schema/cache")
   protected List<Entry> entries;
+
   @XmlAnyElement(lax = true)
   protected List<CacheElement> regionElements;
+
+  @ApiModelProperty(hidden = true)
   @XmlElement(name = "region", namespace = "http://geode.apache.org/schema/cache")
   protected List<RegionConfig> regions;
+
   @XmlAttribute(name = "name", required = true)
   protected String name;
+
   @XmlAttribute(name = "refid")
   protected String type;
 
@@ -252,6 +263,7 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
    * Currently, users can not create regions with custom region elements using management v2 api.
    * this cache element list will be ignored when creating the region
    */
+  @ApiModelProperty(hidden = true)
   public List<CacheElement> getCustomRegionElements() {
     if (regionElements == null) {
       regionElements = new ArrayList<>();

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.geode.annotations.Experimental;
@@ -61,6 +62,8 @@ public class ClusterManagementResult {
   private StatusCode statusCode = StatusCode.OK;
   private String statusMessage;
 
+  // Override the mapper setting so that we always show result
+  @JsonInclude
   @JsonProperty
   private List<? extends RuntimeCacheElement> result = new ArrayList<>();
 

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GeneralManagementServiceRestIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GeneralManagementServiceRestIntegrationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/geode-management-servlet.xml"},
+    loader = LocatorLauncherContextLoader.class)
+@WebAppConfiguration
+public class GeneralManagementServiceRestIntegrationTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule(1);
+
+  private LocatorWebContext webContext;
+
+  @Before
+  public void before() {
+    webContext = new LocatorWebContext(webApplicationContext);
+
+    cluster.setSkipLocalDistributedSystemCleanup(true);
+    cluster.startServerVM(1, webContext.getLocator().getPort());
+  }
+
+  @Test
+  public void noResultsShowsEmptyResultsListAndNoStatuses() throws Exception {
+    webContext.perform(get("/v2/regions"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result").isArray())
+        .andExpect(jsonPath("$.memberStatuses").doesNotExist());
+  }
+}


### PR DESCRIPTION
- Add a bunch of @ApiModelProperty annotations to hide most of
  RegionConfig and RegionAttributesType fields.

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
