### PR TITLE
GEODE-6759: Prevent Deleting Pool Still in Use and Fix NPE in Function Execution

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testMultiplePools.cache.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testMultiplePools.cache.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance with the License. You may obtain a
+  ~ copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License
+  ~ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  ~ or implied. See the License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<client-cache
+    xmlns="http://geode.apache.org/schema/cache"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+    version="1.0">
+
+	<pool name="poolOne" subscription-enabled="true">
+		<server host="127.0.0.1" port="11211"/>
+	</pool>
+
+	<pool name="poolTwo" subscription-enabled="true">
+		<server host="127.0.0.1" port="11222"/>
+	</pool>
+
+	<region name="regionOne" refid="PROXY">
+		<region-attributes pool-name="poolOne"/>
+	</region>
+
+	<region name="regionTwo" refid="PROXY">
+		<region-attributes pool-name="poolTwo"/>
+	</region>
+</client-cache>

--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testRegionWithNonExistingPool.cache.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testRegionWithNonExistingPool.cache.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance with the License. You may obtain a
+  ~ copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License
+  ~ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  ~ or implied. See the License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<client-cache
+    xmlns="http://geode.apache.org/schema/cache"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd"
+    version="1.0">
+
+	<pool name="poolOne" subscription-enabled="true">
+		<server host="127.0.0.1" port="11211"/>
+	</pool>
+
+	<region name="region" refid="PROXY">
+		<region-attributes pool-name="nonExistingPool"/>
+	</region>
+</client-cache>

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolManagerImpl.java
@@ -166,6 +166,13 @@ public class PoolManagerImpl {
    * @return true if pool unregistered from cache; false if someone else already did it
    */
   public boolean unregister(Pool pool) {
+    // Continue only if the pool is not currently being used by any region and/or service.
+    int attachCount = ((PoolImpl) pool).getAttachCount();
+    if (attachCount > 0) {
+      throw new IllegalStateException(String.format(
+          "Pool could not be destroyed because it is still in use by %s regions", attachCount));
+    }
+
     synchronized (poolLock) {
       Map<String, Pool> copy = new HashMap<>(pools);
       String name = pool.getName();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PoolManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PoolManagerTest.java
@@ -26,17 +26,19 @@ import org.junit.Test;
 import org.apache.geode.cache.client.internal.PoolImpl;
 
 public class PoolManagerTest {
+  private PoolImpl pool;
   private PoolManagerImpl poolManager;
 
   @Before
   public void setUp() {
+    pool = mock(PoolImpl.class);
     poolManager = spy(new PoolManagerImpl(true));
+
     assertThat(poolManager.getMap()).isEmpty();
   }
 
   @Test
   public void unregisterShouldThrowExceptionWhenPoolHasRegionsStillAssociated() {
-    PoolImpl pool = mock(PoolImpl.class);
     when(pool.getAttachCount()).thenReturn(2);
 
     assertThatThrownBy(() -> poolManager.unregister(pool)).isInstanceOf(IllegalStateException.class)
@@ -45,7 +47,6 @@ public class PoolManagerTest {
 
   @Test
   public void unregisterShouldReturnFalseWhenThePoolIsNotPartOfTheManagedPools() {
-    PoolImpl pool = mock(PoolImpl.class);
     when(pool.getAttachCount()).thenReturn(0);
 
     assertThat(poolManager.unregister(pool)).isFalse();
@@ -53,7 +54,6 @@ public class PoolManagerTest {
 
   @Test
   public void unregisterShouldReturnTrueWhenThePoolIsSuccessfullyRemovedFromTheManagedPools() {
-    PoolImpl pool = mock(PoolImpl.class);
     when(pool.getAttachCount()).thenReturn(0);
     poolManager.register(pool);
     assertThat(poolManager.getMap()).isNotEmpty();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PoolManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PoolManagerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.client.internal.PoolImpl;
+
+public class PoolManagerTest {
+  private PoolManagerImpl poolManager;
+
+  @Before
+  public void setUp() {
+    poolManager = spy(new PoolManagerImpl(true));
+    assertThat(poolManager.getMap()).isEmpty();
+  }
+
+  @Test
+  public void unregisterShouldThrowExceptionWhenPoolHasRegionsStillAssociated() {
+    PoolImpl pool = mock(PoolImpl.class);
+    when(pool.getAttachCount()).thenReturn(2);
+
+    assertThatThrownBy(() -> poolManager.unregister(pool)).isInstanceOf(IllegalStateException.class)
+        .hasMessage("Pool could not be destroyed because it is still in use by 2 regions");
+  }
+
+  @Test
+  public void unregisterShouldReturnFalseWhenThePoolIsNotPartOfTheManagedPools() {
+    PoolImpl pool = mock(PoolImpl.class);
+    when(pool.getAttachCount()).thenReturn(0);
+
+    assertThat(poolManager.unregister(pool)).isFalse();
+  }
+
+  @Test
+  public void unregisterShouldReturnTrueWhenThePoolIsSuccessfullyRemovedFromTheManagedPools() {
+    PoolImpl pool = mock(PoolImpl.class);
+    when(pool.getAttachCount()).thenReturn(0);
+    poolManager.register(pool);
+    assertThat(poolManager.getMap()).isNotEmpty();
+
+    assertThat(poolManager.unregister(pool)).isTrue();
+    assertThat(poolManager.getMap()).isEmpty();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.execute;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.execute.FunctionException;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.PartitionedRegion;
+
+public class InternalFunctionExecutionServiceTest {
+  private InternalFunctionExecutionServiceImpl functionExecutionService;
+
+  @Before
+  public void setUp() {
+    functionExecutionService = spy(new InternalFunctionExecutionServiceImpl());
+  }
+
+  @Test
+  public void onRegionShouldThrowExceptionWhenRegionIsNull() {
+    assertThatThrownBy(() -> functionExecutionService.onRegion(null))
+        .isInstanceOf(FunctionException.class)
+        .hasMessage("Region instance passed is null");
+  }
+
+  @Test
+  public void onRegionShouldThrowExceptionWhenThePoolAssociatedWithTheRegionCanNotBeFound() {
+    when(functionExecutionService.findPool(any())).thenReturn(null);
+
+    Region mockRegion = mock(Region.class);
+    RegionAttributes mockAttributes = mock(RegionAttributes.class);
+    when(mockAttributes.getPoolName()).thenReturn("testPool");
+    when(mockRegion.getAttributes()).thenReturn(mockAttributes);
+
+
+    assertThatThrownBy(() -> functionExecutionService.onRegion(mockRegion))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Could not find a pool named testPool.");
+  }
+
+  @Test
+  public void onRegionShouldThrowExceptionWhenMultiUserAuthenticationIsSetForNonProxyRegions() {
+    Pool mockPool = mock(Pool.class);
+    when(mockPool.getMultiuserAuthentication()).thenReturn(true);
+    when(functionExecutionService.findPool(any())).thenReturn(mockPool);
+
+    Region mockRegion = mock(Region.class);
+    RegionAttributes mockAttributes = mock(RegionAttributes.class);
+    when(mockAttributes.getPoolName()).thenReturn("testPool");
+    when(mockRegion.getAttributes()).thenReturn(mockAttributes);
+
+    assertThatThrownBy(() -> functionExecutionService.onRegion(mockRegion))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void onRegionShouldReturnClientExecutorImplementationForClientRegions() {
+    LocalRegion mockRegion = mock(LocalRegion.class);
+    when(mockRegion.hasServerProxy()).thenReturn(true);
+    RegionAttributes mockAttributes = mock(RegionAttributes.class);
+    when(mockAttributes.getPoolName()).thenReturn(null);
+    when(mockRegion.getAttributes()).thenReturn(mockAttributes);
+
+    assertThat(functionExecutionService.onRegion(mockRegion))
+        .isInstanceOf(ServerRegionFunctionExecutor.class);
+  }
+
+  @Test
+  public void onRegionShouldReturnPartitionExecutorImplementationForPartitionedRegions() {
+    PartitionedRegion mockRegion = mock(PartitionedRegion.class);
+    RegionAttributes mockAttributes = mock(RegionAttributes.class);
+    when(mockAttributes.getPoolName()).thenReturn(null);
+    when(mockRegion.getAttributes()).thenReturn(mockAttributes);
+
+    assertThat(functionExecutionService.onRegion(mockRegion))
+        .isInstanceOf(PartitionedRegionFunctionExecutor.class);
+  }
+}


### PR DESCRIPTION
GEODE-6759: Avoid Deleting Pools Still in Use

- Fixed minor warnings.
- Added unit and integration tests.
- Replaced the usage of `junit.Assert` by `assertj`.
- PoolManagerImpl now checks whether the pool is being used or not
  before unregistering it.
- InternalFunctionExecutionServiceImpl now throws a meaningul
  exception if the pool can not be found instead of NPE.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
