### PR TITLE
GEODE-6672: persist the diskstore dir correctly in cluster configuration

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -44,7 +44,6 @@ import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.DiskDirType;
-import org.apache.geode.cache.configuration.DiskDirsType;
 import org.apache.geode.cache.configuration.DiskStoreType;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
@@ -522,8 +521,7 @@ public class DiskStoreCommandsDUnitTest implements Serializable {
     List<DiskStoreType> diskStores = config.getDiskStores();
     assertThat(diskStores.size()).isEqualTo(1);
     DiskStoreType diskStore = diskStores.get(0);
-    DiskDirsType diskDirsType = diskStore.getDiskDirs();
-    List<DiskDirType> diskDirs = diskDirsType.getDiskDirs();
+    List<DiskDirType> diskDirs = diskStore.getDiskDirs();
     assertThat(diskDirs.size()).isEqualTo(1);
     DiskDirType diskDir = diskDirs.get(0);
     assertThat(diskDir.getContent()).isEqualTo(absoluteDirectoryName);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -16,6 +16,7 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -24,7 +25,6 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.DiskDirType;
-import org.apache.geode.cache.configuration.DiskDirsType;
 import org.apache.geode.cache.configuration.DiskStoreType;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.DiskStoreAttributes;
@@ -129,18 +129,15 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
     diskStoreType
         .setCompactionThreshold(Integer.toString(diskStoreAttributes.getCompactionThreshold()));
 
-    DiskDirsType diskDirsType = new DiskDirsType();
-    List<DiskDirType> diskDirs = diskDirsType.getDiskDirs();
+    List<DiskDirType> diskDirs = new ArrayList<>();
     for (int i = 0; i < diskStoreAttributes.getDiskDirs().length; i++) {
       DiskDirType diskDir = new DiskDirType();
       File diskDirFile = diskStoreAttributes.getDiskDirs()[i];
-      diskDir.setContent(
-          diskDirFile.isAbsolute() ? diskDirFile.getAbsolutePath() : diskDirFile.getName());
+      diskDir.setContent(diskDirFile.toString());
       diskDir.setDirSize(Integer.toString(diskStoreAttributes.getDiskDirSizes()[i]));
-
       diskDirs.add(diskDir);
     }
-    diskStoreType.setDiskDirs(diskDirsType);
+    diskStoreType.setDiskDirs(diskDirs);
     diskStoreType.setDiskUsageCriticalPercentage(
         Integer.toString((int) diskStoreAttributes.getDiskUsageCriticalPercentage()));
     diskStoreType.setDiskUsageWarningPercentage(

--- a/geode-core/src/test/java/org/apache/geode/cache/configuration/RegionConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/configuration/RegionConfigTest.java
@@ -176,4 +176,66 @@ public class RegionConfigTest {
     System.out.println(newXml);
     assertThat(newXml).contains("from-clause=");
   }
+
+  @Test
+  public void diskDirTypeInXml() throws Exception {
+    CacheConfig cacheConfig = new CacheConfig();
+    DiskStoreType diskStore = new DiskStoreType();
+    diskStore.setName("diskStore");
+    DiskDirType dir1 = new DiskDirType();
+    DiskDirType dir2 = new DiskDirType();
+    dir1.setContent("./data/persist");
+    dir2.setContent("/data/persist");
+
+    diskStore.getDiskDirs().add(dir1);
+    diskStore.getDiskDirs().add(dir2);
+
+    cacheConfig.getDiskStores().add(diskStore);
+
+    String xml = service.marshall(cacheConfig);
+    System.out.println(xml);
+
+    String diskStoreXml = "<disk-store name=\"diskStore\">\n"
+        + "        <disk-dirs>\n"
+        + "            <disk-dir>./data/persist</disk-dir>\n"
+        + "            <disk-dir>/data/persist</disk-dir>\n"
+        + "        </disk-dirs>\n"
+        + "    </disk-store>";
+    assertThat(xml).contains(diskStoreXml);
+
+    DiskStoreType parsedDiskStore = service.unMarshall(diskStoreXml, DiskStoreType.class);
+    assertThat(parsedDiskStore.getDiskDirs()).hasSize(2);
+
+    cacheConfig.getDiskStores().clear();
+    cacheConfig.getDiskStores().add(parsedDiskStore);
+
+    String xml2 = service.marshall(cacheConfig);
+    System.out.println(xml2);
+    assertThat(xml).contains(diskStoreXml);
+  }
+
+  @Test
+  public void diskDirTypeInJson() throws Exception {
+    DiskStoreType diskStore = new DiskStoreType();
+    diskStore.setName("diskStore");
+    DiskDirType dir1 = new DiskDirType();
+    DiskDirType dir2 = new DiskDirType();
+    dir1.setContent("./data/persist");
+    dir2.setContent("/data/persist");
+
+    diskStore.getDiskDirs().add(dir1);
+    diskStore.getDiskDirs().add(dir2);
+
+    ObjectMapper mapper = GeodeJsonMapper.getMapper();
+    String json = mapper.writeValueAsString(diskStore);
+    System.out.println(json);
+
+    String goldenJson =
+        "\"diskDirs\":[{\"content\":\"./data/persist\"},{\"content\":\"/data/persist\"}]";
+    assertThat(json).contains(goldenJson);
+
+    DiskStoreType newDiskStore = mapper.readValue(json, DiskStoreType.class);
+    assertThat(newDiskStore.getDiskDirs()).hasSize(2);
+
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.apache.geode.cache.configuration.DiskDirType;
+import org.apache.geode.cache.configuration.DiskStoreType;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
+import org.apache.geode.test.junit.rules.GfshParserRule;
+
+public class CreateDiskStoreCommandTest {
+
+  @ClassRule
+  public static GfshParserRule gfsh = new GfshParserRule();
+
+  private CreateDiskStoreCommand command;
+
+  @Before
+  public void before() throws Exception {
+    command = spy(CreateDiskStoreCommand.class);
+  }
+
+  @Test
+  public void dirWithRelativePath() throws Exception {
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command).findMembers(any(),
+        any());
+    doReturn(Collections.singletonList(mock(CliFunctionResult.class))).when(command)
+        .executeAndGetFunctionResult(any(), any(), any());
+    ResultModel resultModel =
+        gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=./data/persist")
+            .getResultModel();
+    DiskStoreType diskStoreType = (DiskStoreType) resultModel.getConfigObject();
+
+    DiskDirType diskDirType = diskStoreType.getDiskDirs().get(0);
+    assertThat(diskDirType.getContent()).isEqualTo("./data/persist");
+  }
+
+  @Test
+  public void dirWithAbsolutePath() throws Exception {
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command).findMembers(any(),
+        any());
+    doReturn(Collections.singletonList(mock(CliFunctionResult.class))).when(command)
+        .executeAndGetFunctionResult(any(), any(), any());
+    ResultModel resultModel =
+        gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=/data/persist")
+            .getResultModel();
+    DiskStoreType diskStoreType = (DiskStoreType) resultModel.getConfigObject();
+
+    DiskDirType diskDirType = diskStoreType.getDiskDirs().get(0);
+    assertThat(diskDirType.getContent()).isEqualTo("/data/persist");
+  }
+}

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/DiskStoreType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/DiskStoreType.java
@@ -18,11 +18,15 @@
 
 package org.apache.geode.cache.configuration;
 
+import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.geode.annotations.Experimental;
 
@@ -92,30 +96,9 @@ public class DiskStoreType extends CacheElement {
   protected String diskUsageCriticalPercentage;
 
   @Override
+  @JsonProperty(value = "name")
   public String getId() {
     return getName();
-  }
-
-  /**
-   * Gets the value of the diskDirs property.
-   *
-   * possible object is
-   * {@link DiskDirsType }
-   *
-   */
-  public DiskDirsType getDiskDirs() {
-    return diskDirs;
-  }
-
-  /**
-   * Sets the value of the diskDirs property.
-   *
-   * allowed object is
-   * {@link DiskDirsType }
-   *
-   */
-  public void setDiskDirs(DiskDirsType value) {
-    this.diskDirs = value;
   }
 
   /**
@@ -127,6 +110,18 @@ public class DiskStoreType extends CacheElement {
    */
   public String getName() {
     return name;
+  }
+
+  public List<DiskDirType> getDiskDirs() {
+    if (diskDirs == null) {
+      diskDirs = new DiskDirsType();
+    }
+    return diskDirs.getDiskDirs();
+  }
+
+  public void setDiskDirs(List<DiskDirType> diskDirs) {
+    getDiskDirs().clear();
+    getDiskDirs().addAll(diskDirs);
   }
 
   /**


### PR DESCRIPTION
Co-authored-by: Jens Deppe <jdeppe@pivotal.io>

* also make the diskstore config api easier to navigate without affecting xml and json serialization

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
