### PR TITLE
GEODE-6763: Send GatewayReceiver events received to Micrometer

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.metrics;
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import org.apache.commons.io.IOUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.test.compiler.ClassBuilder;
+import org.apache.geode.test.junit.categories.MetricsTest;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+
+@Category(MetricsTest.class)
+public class GatewayReceiverMetricsTest {
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private static final String SENDER_LOCATOR_NAME = "sender-locator";
+  private static final String RECEIVER_LOCATOR_NAME = "receiver-locator";
+  private static final String SENDER_SERVER_NAME = "sender-server";
+  private static final String RECEIVER_SERVER_NAME = "receiver-server";
+  private static final String REGION_NAME = "region";
+  private static final String GFSH_COMMAND_SEPARATOR = " ";
+  private String senderLocatorFolder;
+  private String receiverLocatorFolder;
+  private String senderServerFolder;
+  private String receiverServerFolder;
+  private int receiverLocatorPort;
+  private int senderLocatorPort;
+
+  @Before
+  public void startClusters() throws IOException {
+    int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(8);
+
+    receiverLocatorPort = ports[0];
+    senderLocatorPort = ports[1];
+    int senderServerPort = ports[2];
+    int receiverServerPort = ports[3];
+    int senderLocatorJmxPort = ports[4];
+    int receiverLocatorJmxPort = ports[5];
+    int senderLocatorHttpPort = ports[6];
+    int receiverLocatorHttpPort = ports[7];
+
+    int senderSystemId = 2;
+    int receiverSystemId = 1;
+
+    senderLocatorFolder = newFolder(SENDER_LOCATOR_NAME);
+    receiverLocatorFolder = newFolder(RECEIVER_LOCATOR_NAME);
+    senderServerFolder = newFolder(SENDER_SERVER_NAME);
+    receiverServerFolder = newFolder(RECEIVER_SERVER_NAME);
+
+    String startSenderLocatorCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "start locator",
+        "--name=" + SENDER_LOCATOR_NAME,
+        "--dir=" + senderLocatorFolder,
+        "--port=" + senderLocatorPort,
+        "--locators=localhost[" + senderLocatorPort + "]",
+        "--J=-Dgemfire.remote-locators=localhost[" + receiverLocatorPort + "]",
+        "--J=-Dgemfire.distributed-system-id=" + senderSystemId,
+        "--J=-Dgemfire.jmx-manager-start=true",
+        "--J=-Dgemfire.jmx-manager-http-port=" + senderLocatorHttpPort,
+        "--J=-Dgemfire.jmx-manager-port=" + senderLocatorJmxPort);
+
+    String startReceiverLocatorCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "start locator",
+        "--name=" + RECEIVER_LOCATOR_NAME,
+        "--dir=" + receiverLocatorFolder,
+        "--port=" + receiverLocatorPort,
+        "--locators=localhost[" + receiverLocatorPort + "]",
+        "--J=-Dgemfire.remote-locators=localhost[" + senderLocatorPort + "]",
+        "--J=-Dgemfire.distributed-system-id=" + receiverSystemId,
+        "--J=-Dgemfire.jmx-manager-start=true ",
+        "--J=-Dgemfire.jmx-manager-http-port=" + receiverLocatorHttpPort,
+        "--J=-Dgemfire.jmx-manager-port=" + receiverLocatorJmxPort);
+
+    String startSenderServerCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "start server",
+        "--name=" + SENDER_SERVER_NAME,
+        "--dir=" + senderServerFolder,
+        "--locators=localhost[" + senderLocatorPort + "]",
+        "--server-port=" + senderServerPort,
+        "--J=-Dgemfire.distributed-system-id=" + senderSystemId);
+
+    String metricsPublishingServiceJarPath =
+        newJarForMetricsPublishingServiceClass(SimpleMetricsPublishingService.class,
+            "metrics-publishing-service.jar");
+
+    String startReceiverServerCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "start server",
+        "--name=" + RECEIVER_SERVER_NAME,
+        "--dir=" + receiverServerFolder,
+        "--locators=localhost[" + receiverLocatorPort + "]",
+        "--server-port=" + receiverServerPort,
+        "--classpath=" + metricsPublishingServiceJarPath,
+        "--J=-Dgemfire.distributed-system-id=" + receiverSystemId);
+
+    gfshRule.execute(startSenderLocatorCommand, startReceiverLocatorCommand,
+        startSenderServerCommand, startReceiverServerCommand);
+
+    String gatewaySenderId = "gs";
+
+    String connectToSenderLocatorCommand = "connect --locator=localhost[" + senderLocatorPort + "]";
+
+    String startGatewaySenderCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "create gateway-sender",
+        "--id=" + gatewaySenderId,
+        "--parallel=false",
+        "--remote-distributed-system-id=" + receiverSystemId);
+
+    String createSenderRegionCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "create region",
+        "--name=" + REGION_NAME,
+        "--type=" + RegionShortcut.REPLICATE.name(),
+        "--gateway-sender-id=" + gatewaySenderId);
+
+    gfshRule.execute(connectToSenderLocatorCommand, startGatewaySenderCommand);
+
+    // There is a bug in the GFSH create gateway-sender command where it returns before the system
+    // has recognized the creation status: GEODE-6777. We can remove the following when that bug is
+    // fixed.
+    try {
+      Thread.sleep(1000);
+    } catch (InterruptedException e) {
+      // Don't care
+    }
+
+    gfshRule.execute(connectToSenderLocatorCommand, createSenderRegionCommand);
+
+    String connectToReceiverLocatorCommand =
+        "connect --locator=localhost[" + receiverLocatorPort + "]";
+    String startGatewayReceiverCommand = "create gateway-receiver";
+    String createReceiverRegionCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "create region",
+        "--name=" + REGION_NAME,
+        "--type=" + RegionShortcut.REPLICATE.name());
+
+    gfshRule.execute(connectToReceiverLocatorCommand, startGatewayReceiverCommand,
+        createReceiverRegionCommand);
+
+    // Deploy function to members
+    String functionJarPath =
+        newJarForFunctionClass(GetEventsReceivedCountFunction.class, "function.jar");
+    String deployCommand = "deploy --jar=" + functionJarPath;
+    String listFunctionsCommand = "list functions";
+
+    gfshRule.execute(connectToReceiverLocatorCommand, deployCommand, listFunctionsCommand);
+  }
+
+  @After
+  public void stopClusters() {
+    String stopReceiverServerCommand = "stop server --dir=" + receiverServerFolder;
+    String stopSenderServerCommand = "stop server --dir=" + senderServerFolder;
+    String stopReceiverLocatorCommand = "stop locator --dir=" + receiverLocatorFolder;
+    String stopSenderLocatorCommand = "stop locator --dir=" + senderLocatorFolder;
+
+    gfshRule.execute(stopReceiverServerCommand, stopSenderServerCommand, stopReceiverLocatorCommand,
+        stopSenderLocatorCommand);
+  }
+
+  @Test
+  public void whenPerformingOperations_thenGatewayReceiverEventsReceivedIncreases() {
+    // TODO: perform put
+    // TODO: perform all ops that can go through a gateway
+
+    // TODO: assert that eventsReceived in receiver reflects number of puts
+    // and all ops
+
+    String connectToSenderLocatorCommand = "connect --locator=localhost[" + senderLocatorPort + "]";
+
+    String doPutCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "put",
+        "--region=" + REGION_NAME,
+        "--key=foo",
+        "--value=bar");
+
+    String doRemoveCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "remove",
+        "--region=" + REGION_NAME,
+        "--key=foo");
+
+    String doCreateRegionCommand = String.join(GFSH_COMMAND_SEPARATOR,
+        "create region",
+        "--name=blah",
+        "--type=" + RegionShortcut.REPLICATE.name());
+
+    gfshRule.execute(connectToSenderLocatorCommand, doPutCommand, doRemoveCommand,
+        doCreateRegionCommand);
+
+    String connectToReceiverLocatorCommand =
+        "connect --locator=localhost[" + receiverLocatorPort + "]";
+    String executeFunctionCommand = "execute function --id=" + GetEventsReceivedCountFunction.ID;
+
+    Collection<String> gatewayEventsExpectedToReceive =
+        Arrays.asList(doPutCommand, doRemoveCommand);
+
+    await().untilAsserted(() -> {
+      String output =
+          gfshRule.execute(connectToReceiverLocatorCommand, executeFunctionCommand).getOutputText();
+
+      assertThat(output.trim())
+          .as("Returned count of events received.")
+          .endsWith("[" + gatewayEventsExpectedToReceive.size() + ".0]");
+    });
+  }
+
+  private String newFolder(String folderName) throws IOException {
+    return temporaryFolder.newFolder(folderName).getAbsolutePath();
+  }
+
+  private String newJarForFunctionClass(Class clazz, String jarName) throws IOException {
+    File jar = temporaryFolder.newFile(jarName);
+    new ClassBuilder().writeJarFromClass(clazz, jar);
+    return jar.getAbsolutePath();
+  }
+
+  private String newJarForMetricsPublishingServiceClass(Class clazz, String jarName)
+      throws IOException {
+    File jar = temporaryFolder.newFile(jarName);
+
+    String className = clazz.getName();
+    String classAsPath = className.replace('.', '/') + ".class";
+    InputStream stream = clazz.getClassLoader().getResourceAsStream(classAsPath);
+    byte[] bytes = IOUtils.toByteArray(stream);
+    try (FileOutputStream out = new FileOutputStream(jar)) {
+      JarOutputStream jarOutputStream = new JarOutputStream(out);
+
+      // Add the class file to the JAR file
+      JarEntry classEntry = new JarEntry(classAsPath);
+      classEntry.setTime(System.currentTimeMillis());
+      jarOutputStream.putNextEntry(classEntry);
+      jarOutputStream.write(bytes);
+      jarOutputStream.closeEntry();
+
+      String metaInfPath = "META-INF/services/org.apache.geode.metrics.MetricsPublishingService";
+
+      JarEntry metaInfEntry = new JarEntry(metaInfPath);
+      metaInfEntry.setTime(System.currentTimeMillis());
+      jarOutputStream.putNextEntry(metaInfEntry);
+      jarOutputStream.write(className.getBytes());
+      jarOutputStream.closeEntry();
+
+      jarOutputStream.close();
+    }
+
+    return jar.getAbsolutePath();
+  }
+
+  public static class GetEventsReceivedCountFunction implements Function<Void> {
+    static final String ID = "GetEventsReceivedCountFunction";
+
+    @Override
+    public void execute(FunctionContext<Void> context) {
+      FunctionCounter eventsReceivedCounter = SimpleMetricsPublishingService.getRegistry()
+          .find("cache.gatewayreceiver.events.received")
+          .functionCounter();
+
+      Object result = eventsReceivedCounter == null
+          ? "Meter not found."
+          : eventsReceivedCounter.count();
+
+      context.getResultSender().lastResult(result);
+    }
+
+    @Override
+    public String getId() {
+      return ID;
+    }
+  }
+}

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
@@ -197,12 +197,6 @@ public class GatewayReceiverMetricsTest {
 
   @Test
   public void whenPerformingOperations_thenGatewayReceiverEventsReceivedIncreases() {
-    // TODO: perform put
-    // TODO: perform all ops that can go through a gateway
-
-    // TODO: assert that eventsReceived in receiver reflects number of puts
-    // and all ops
-
     String connectToSenderLocatorCommand = "connect --locator=localhost[" + senderLocatorPort + "]";
 
     String doPutCommand = String.join(GFSH_COMMAND_SEPARATOR,

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/SimpleMetricsPublishingService.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/SimpleMetricsPublishingService.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+public class SimpleMetricsPublishingService implements MetricsPublishingService {
+
+  private static final MeterRegistry registry = new SimpleMeterRegistry();
+
+  private volatile MetricsSession session;
+
+  public static MeterRegistry getRegistry() {
+    return registry;
+  }
+
+  @Override
+  public void start(MetricsSession session) {
+    this.session = session;
+
+    // add your registry as a sub-registry to the cache's composite registry
+    session.addSubregistry(registry);
+  }
+
+  @Override
+  public void stop() {
+    // clean up any resources used by your meter registry
+    session.removeSubregistry(registry);
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayReceiverStatsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayReceiverStatsIntegrationTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Properties;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +70,9 @@ public class GatewayReceiverStatsIntegrationTest {
     new CacheFactory().create();
 
     StatisticsFactory statisticsFactory = system.getStatisticsManager();
-    receiverStats = createGatewayReceiverStats(statisticsFactory, "Test Sock Name");
+    SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    receiverStats = createGatewayReceiverStats(statisticsFactory, "Test Sock Name",
+        meterRegistry);
 
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     InternalCacheServer receiverServer = mock(InternalCacheServer.class);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -56,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
@@ -597,7 +598,9 @@ public class AcceptorImpl implements Acceptor, Runnable {
       StatisticsFactory statisticsFactory =
           internalCache.getInternalDistributedSystem().getStatisticsManager();
       if (isGatewayReceiver()) {
-        stats = GatewayReceiverStats.createGatewayReceiverStats(statisticsFactory, sockName);
+        MeterRegistry meterRegistry = internalCache.getMeterRegistry();
+        stats = GatewayReceiverStats.createGatewayReceiverStats(statisticsFactory, sockName,
+            meterRegistry);
       } else {
         stats = new CacheServerStats(statisticsFactory, sockName);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.internal.cache.wan;
 
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.distributed.internal.DistributionStats;
@@ -28,73 +31,120 @@ public class GatewayReceiverStats extends CacheServerStats {
   // /** Name of the events queued statistic */
   // private static final String FAILOVER_BATCHES_RECEIVED = "failoverBatchesReceived";
 
-  /** Name of the events not queued because conflated statistic */
+  /**
+   * Name of the events not queued because conflated statistic
+   */
   private static final String DUPLICATE_BATCHES_RECEIVED = "duplicateBatchesReceived";
 
-  /** Name of the event queue time statistic */
+  /**
+   * Name of the event queue time statistic
+   */
   private static final String OUT_OF_ORDER_BATCHES_RECEIVED = "outoforderBatchesReceived";
 
-  /** Name of the event queue size statistic */
+  /**
+   * Name of the event queue size statistic
+   */
   private static final String EARLY_ACKS = "earlyAcks";
 
-  /** Name of the events distributed statistic */
+  /**
+   * Name of the events distributed statistic
+   */
   private static final String EVENTS_RECEIVED = "eventsReceived";
 
-  /** Name of the events exceeding alert threshold statistic */
+  /**
+   * Name of the events exceeding alert threshold statistic
+   */
   private static final String CREAT_REQUESTS = "createRequests";
 
-  /** Name of the batch distribution time statistic */
+  /**
+   * Name of the batch distribution time statistic
+   */
   private static final String UPDATE_REQUESTS = "updateRequest";
 
-  /** Name of the batches distributed statistic */
+  /**
+   * Name of the batches distributed statistic
+   */
   private static final String DESTROY_REQUESTS = "destroyRequest";
 
-  /** Name of the batches redistributed statistic */
+  /**
+   * Name of the batches redistributed statistic
+   */
   private static final String UNKNOWN_OPERATIONS_RECEIVED = "unknowsOperationsReceived";
 
-  /** Name of the unprocessed events added by primary statistic */
+  /**
+   * Name of the unprocessed events added by primary statistic
+   */
   private static final String EXCEPTIONS_OCCURRED = "exceptionsOccurred";
 
-  /** Name of the events retried */
+  /**
+   * Name of the events retried
+   */
   private static final String EVENTS_RETRIED = "eventsRetried";
+  private final MeterRegistry meterRegistry;
 
   // /** Id of the events queued statistic */
   // private int failoverBatchesReceivedId;
 
-  /** Id of the events not queued because conflated statistic */
+  /**
+   * Id of the events not queued because conflated statistic
+   */
   private int duplicateBatchesReceivedId;
 
-  /** Id of the event queue time statistic */
+  /**
+   * Id of the event queue time statistic
+   */
   private int outoforderBatchesReceivedId;
 
-  /** Id of the event queue size statistic */
+  /**
+   * Id of the event queue size statistic
+   */
   private int earlyAcksId;
 
-  /** Id of the events distributed statistic */
+  /**
+   * Id of the events distributed statistic
+   */
   private int eventsReceivedId;
+  private final FunctionCounter eventsReceivedCounter;
+  private static final String EVENTS_RECEIVED_COUNTER_NAME =
+      "cache.gatewayreceiver.events.received";
+  private static final String EVENTS_RECEIVED_COUNTER_DESCRIPTION =
+      "total number events across the batched received by this GatewayReceiver";
+  private static final String EVENTS_RECEIVED_COUNTER_UNITS = "operations";
 
-  /** Id of the events exceeding alert threshold statistic */
+  /**
+   * Id of the events exceeding alert threshold statistic
+   */
   private int createRequestId;
 
-  /** Id of the batch distribution time statistic */
+  /**
+   * Id of the batch distribution time statistic
+   */
   private int updateRequestId;
 
-  /** Id of the batches distributed statistic */
+  /**
+   * Id of the batches distributed statistic
+   */
   private int destroyRequestId;
 
-  /** Id of the batches redistributed statistic */
+  /**
+   * Id of the batches redistributed statistic
+   */
   private int unknowsOperationsReceivedId;
 
-  /** Id of the unprocessed events added by primary statistic */
+  /**
+   * Id of the unprocessed events added by primary statistic
+   */
   private int exceptionsOccurredId;
 
-  /** Id of the events retried statistic */
+  /**
+   * Id of the events retried statistic
+   */
   private int eventsRetriedId;
 
   // ///////////////////// Constructors ///////////////////////
 
   public static GatewayReceiverStats createGatewayReceiverStats(StatisticsFactory f,
-      String ownerName) {
+      String ownerName, MeterRegistry meterRegistry) {
     StatisticDescriptor[] descriptors = new StatisticDescriptor[] {
         f.createIntCounter(DUPLICATE_BATCHES_RECEIVED,
             "number of batches which have already been seen by this GatewayReceiver",
@@ -104,8 +154,8 @@ public class GatewayReceiverStats extends CacheServerStats {
         f.createIntCounter(EARLY_ACKS, "number of early acknowledgements sent to gatewaySenders",
             "operations"),
         f.createIntCounter(EVENTS_RECEIVED,
-            "total number events across the batched received by this GatewayReceiver",
-            "operations"),
+            EVENTS_RECEIVED_COUNTER_DESCRIPTION,
+            EVENTS_RECEIVED_COUNTER_UNITS),
         f.createIntCounter(CREAT_REQUESTS,
             "total number of create operations received by this GatewayReceiver", "operations"),
         f.createIntCounter(UPDATE_REQUESTS,
@@ -118,12 +168,12 @@ public class GatewayReceiverStats extends CacheServerStats {
             "number of exceptions occurred while porcessing the batches", "operations"),
         f.createIntCounter(EVENTS_RETRIED,
             "total number events retried by this GatewayReceiver due to exceptions", "operations")};
-    return new GatewayReceiverStats(f, ownerName, typeName, descriptors);
+    return new GatewayReceiverStats(f, ownerName, typeName, descriptors, meterRegistry);
 
   }
 
   public GatewayReceiverStats(StatisticsFactory f, String ownerName, String typeName,
-      StatisticDescriptor[] descriptiors) {
+      StatisticDescriptor[] descriptiors, MeterRegistry meterRegistry) {
     super(f, ownerName, typeName, descriptiors);
     // Initialize id fields
     // failoverBatchesReceivedId = statType.nameToId(FAILOVER_BATCHES_RECEIVED);
@@ -137,6 +187,13 @@ public class GatewayReceiverStats extends CacheServerStats {
     unknowsOperationsReceivedId = statType.nameToId(UNKNOWN_OPERATIONS_RECEIVED);
     exceptionsOccurredId = statType.nameToId(EXCEPTIONS_OCCURRED);
     eventsRetriedId = statType.nameToId(EVENTS_RETRIED);
+
+    this.meterRegistry = meterRegistry;
+    eventsReceivedCounter = FunctionCounter.builder(EVENTS_RECEIVED_COUNTER_NAME, stats,
+        s -> s.getInt(eventsReceivedId))
+        .description(EVENTS_RECEIVED_COUNTER_DESCRIPTION)
+        .baseUnit(EVENTS_RECEIVED_COUNTER_UNITS)
+        .register(meterRegistry);
   }
 
   // /////////////////// Instance Methods /////////////////////
@@ -271,4 +328,9 @@ public class GatewayReceiverStats extends CacheServerStats {
     return DistributionStats.getStatTime();
   }
 
+  @Override
+  public void close() {
+    meterRegistry.remove(eventsReceivedCounter);
+    super.close();
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
@@ -32,6 +32,7 @@ import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.Properties;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -107,6 +108,7 @@ public class AcceptorImplTest {
     when(system.getStatisticsManager()).thenReturn(statisticsManager);
     when(statisticsManager.createType(any(), any(), any())).thenReturn(mock(StatisticsType.class));
     when(statisticsManager.createAtomicStatistics(any(), any())).thenReturn(mock(Statistics.class));
+    when(cache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
 
     Acceptor acceptor = new AcceptorImpl(0, null, false, DEFAULT_SOCKET_BUFFER_SIZE,
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverStatsTest.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.wan;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.Statistics;
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.StatisticsType;
+
+public class GatewayReceiverStatsTest {
+
+  private static final String EVENTS_RECEIVED_COUNTER_NAME =
+      "cache.gatewayreceiver.events.received";
+  private static final String EVENTS_RECEIVED_STAT_NAME = "eventsReceived";
+
+  private StatisticsType statisticsType;
+  private Statistics statistics;
+  private MeterRegistry registry;
+  private String ownerName;
+  private StatisticsFactory factory;
+
+  @Before
+  public void setup() {
+    ownerName = getClass().getSimpleName();
+
+    statisticsType = mock(StatisticsType.class);
+    factory = mock(StatisticsFactory.class);
+    statistics = mock(Statistics.class);
+
+    when(factory.createType(any(), any(), any()))
+        .thenReturn(statisticsType);
+    when(factory.createAtomicStatistics(any(), any()))
+        .thenReturn(statistics);
+
+    registry = new CompositeMeterRegistry();
+
+  }
+
+  @Test
+  public void incEventsReceived_incrementsTheEventsReceivedStat() {
+    int eventsReceivedStatId = 33;
+
+    when(statisticsType.nameToId(EVENTS_RECEIVED_STAT_NAME))
+        .thenReturn(eventsReceivedStatId);
+
+    GatewayReceiverStats gatewayReceiverStats =
+        GatewayReceiverStats.createGatewayReceiverStats(factory, ownerName, registry);
+
+    int delta = 99;
+
+    gatewayReceiverStats.incEventsReceived(delta);
+
+    verify(statistics).incInt(eventsReceivedStatId, delta);
+
+    gatewayReceiverStats.close();
+  }
+
+  @Test
+  public void eventsReceivedMeter_getsValueFromEventsReceivedStat() {
+    int eventsReceivedId = 543;
+    when(statisticsType.nameToId(EVENTS_RECEIVED_STAT_NAME))
+        .thenReturn(eventsReceivedId);
+
+    int statValue = 22;
+    when(statistics.getInt(eventsReceivedId))
+        .thenReturn(statValue);
+
+    GatewayReceiverStats gatewayReceiverStats =
+        GatewayReceiverStats.createGatewayReceiverStats(factory, ownerName, registry);
+
+    FunctionCounter eventsReceivedCounter = registry
+        .find(EVENTS_RECEIVED_COUNTER_NAME)
+        .functionCounter();
+
+    assertThat(eventsReceivedCounter)
+        .as("events received counter")
+        .isNotNull();
+
+    assertThat(eventsReceivedCounter.count())
+        .as("events received count")
+        .isEqualTo(statValue);
+
+    gatewayReceiverStats.close();
+  }
+
+  @Test
+  public void eventsReceivedMeter_descriptionMatchesEventsReceivedStat() {
+    GatewayReceiverStats gatewayReceiverStats =
+        GatewayReceiverStats.createGatewayReceiverStats(factory, ownerName, registry);
+
+    ArgumentCaptor<String> descriptionCaptor = ArgumentCaptor.forClass(String.class);
+    verify(factory)
+        .createIntCounter(eq(EVENTS_RECEIVED_STAT_NAME), descriptionCaptor.capture(), any());
+
+    assertThat(meterNamed(EVENTS_RECEIVED_COUNTER_NAME))
+        .as("events received counter")
+        .isNotNull();
+
+    assertThat(meterNamed(EVENTS_RECEIVED_COUNTER_NAME).getId().getDescription())
+        .as("meter description")
+        .isEqualTo(descriptionCaptor.getValue());
+
+    gatewayReceiverStats.close();
+  }
+
+  @Test
+  public void eventsReceivedMeter_unitsMatchesEventsReceivedStat() {
+    GatewayReceiverStats gatewayReceiverStats =
+        GatewayReceiverStats.createGatewayReceiverStats(factory, ownerName, registry);
+
+    ArgumentCaptor<String> unitsCaptor = ArgumentCaptor.forClass(String.class);
+    verify(factory).createIntCounter(eq(EVENTS_RECEIVED_STAT_NAME), any(), unitsCaptor.capture());
+
+    assertThat(meterNamed(EVENTS_RECEIVED_COUNTER_NAME))
+        .as("events received counter")
+        .isNotNull();
+
+    assertThat(meterNamed(EVENTS_RECEIVED_COUNTER_NAME).getId().getBaseUnit())
+        .as("meter base unit")
+        .isEqualTo(unitsCaptor.getValue());
+
+    gatewayReceiverStats.close();
+  }
+
+  @Test
+  public void close_removesItsOwnMetersFromTheRegistry() {
+    int eventsReceivedId = 543;
+    when(statisticsType.nameToId(EVENTS_RECEIVED_STAT_NAME))
+        .thenReturn(eventsReceivedId);
+
+    GatewayReceiverStats gatewayReceiverStats =
+        GatewayReceiverStats.createGatewayReceiverStats(factory, ownerName, registry);
+
+    assertThat(meterNamed(EVENTS_RECEIVED_COUNTER_NAME))
+        .as("events received counter before closing the stats")
+        .isNotNull();
+
+    gatewayReceiverStats.close();
+
+    assertThat(meterNamed(EVENTS_RECEIVED_COUNTER_NAME))
+        .as("events received counter after closing the stats")
+        .isNull();
+  }
+
+  @Test
+  public void close_doesNotRemoveMetersItDoesNotOwn() {
+    int eventsReceivedId = 543;
+    when(statisticsType.nameToId(EVENTS_RECEIVED_STAT_NAME))
+        .thenReturn(eventsReceivedId);
+
+    GatewayReceiverStats gatewayReceiverStats =
+        GatewayReceiverStats.createGatewayReceiverStats(factory, ownerName, registry);
+
+    String foreignMeterName = "some.meter.not.created.by.the.gateway.receiver.stats";
+
+    Timer.builder(foreignMeterName)
+        .register(registry);
+
+    gatewayReceiverStats.close();
+
+    assertThat(meterNamed(foreignMeterName))
+        .as("foreign meter after closing the stats")
+        .isNotNull();
+  }
+
+  private Meter meterNamed(String meterName) {
+    return registry
+        .find(meterName)
+        .meter();
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/categories/MetricsTest.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/categories/MetricsTest.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.test.junit.categories;
+
+public interface MetricsTest {
+}


### PR DESCRIPTION
Updated GatewayReceiverStats to add a
cache.gatewayreceiver.events.received meter to the registry.

The meter is a FunctionCounter that retrieves its value from the
"eventsReceived" stat.

Co-Authored-By: Aaron Lindsey <alindsey@pivotal.io>
Co-Authored-By: Michael Oleske <moleske@pivotal.io>
Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?
