### PR TITLE
GEODE-6764: Fix tests broken and flaky on Windows

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTC
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableUDPPort;
 import static org.apache.geode.internal.AvailablePortHelper.initializeUniquePortRange;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -42,6 +43,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.internal.AvailablePort.Keeper;
+import org.apache.geode.internal.lang.SystemUtils;
 
 @RunWith(JUnitParamsRunner.class)
 public class AvailablePortHelperIntegrationTest {
@@ -266,6 +268,10 @@ public class AvailablePortHelperIntegrationTest {
   @Parameters({"true", "false"})
   public void initializeUniquePortRange_willReturnSamePortsForSameRange(
       final boolean useMembershipPortRange) {
+    assumeTrue(
+        "Windows has ports scattered throughout the range that makes this test difficult to pass consistently",
+        SystemUtils.isWindows());
+
     for (int i = 0; i < 100; ++i) {
       initializeUniquePortRange(i);
       int[] testPorts = getRandomAvailableTCPPorts(3, useMembershipPortRange);
@@ -278,6 +284,10 @@ public class AvailablePortHelperIntegrationTest {
   @Parameters({"true", "false"})
   public void initializeUniquePortRange_willReturnUniquePortsForUniqueRanges(
       final boolean useMembershipPortRange) {
+    assumeTrue(
+        "Windows has ports scattered throughout the range that makes this test difficult to pass consistently",
+        SystemUtils.isWindows());
+
     Set<Integer> ports = new HashSet<>();
 
     for (int i = 0; i < 100; ++i) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -24,7 +24,7 @@ import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTC
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableUDPPort;
 import static org.apache.geode.internal.AvailablePortHelper.initializeUniquePortRange;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -268,7 +268,7 @@ public class AvailablePortHelperIntegrationTest {
   @Parameters({"true", "false"})
   public void initializeUniquePortRange_willReturnSamePortsForSameRange(
       final boolean useMembershipPortRange) {
-    assumeTrue(
+    assumeFalse(
         "Windows has ports scattered throughout the range that makes this test difficult to pass consistently",
         SystemUtils.isWindows());
 
@@ -284,7 +284,7 @@ public class AvailablePortHelperIntegrationTest {
   @Parameters({"true", "false"})
   public void initializeUniquePortRange_willReturnUniquePortsForUniqueRanges(
       final boolean useMembershipPortRange) {
-    assumeTrue(
+    assumeFalse(
         "Windows has ports scattered throughout the range that makes this test difficult to pass consistently",
         SystemUtils.isWindows());
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandTest.java
@@ -44,6 +44,6 @@ public class ExportConfigCommandTest {
   public void incorrectDirectoryShowsError() throws Exception {
     String wrongDir = temp.newFile().getAbsolutePath();
     gfsh.executeAndAssertThat(command, "export config --dir=" + wrongDir).statusIsError()
-        .containsOutput(wrongDir.replace("\\", "\\\\") + " is not a directory");
+        .containsOutput(wrongDir + " is not a directory");
   }
 }


### PR DESCRIPTION
- ExportConfigCommandTest was broken by refactorings around removing
  LegacyCommandResult.
- AvailablePortHelperIntegrationTest has always been flaky on Windows.
  By default, Windows uses a bunch more ports than Linux, so some of
  these tests just don't work reliably as larger port ranges are not
  open and available on Windows.

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
