### PR TITLE
GEODE-6696: EntryEvenImpl.offHeapLock created only if off-heap in use

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/ConnectionProxyJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/ConnectionProxyJUnitTest.java
@@ -171,7 +171,7 @@ public class ConnectionProxyJUnitTest {
     long t1 = 0;
     try {
       t1 = System.currentTimeMillis();
-      EntryEventImpl event = new EntryEventImpl((Object) null);
+      EntryEventImpl event = new EntryEventImpl((Object) null, false);
       try {
         event.setEventId(new EventID(new byte[] {1}, 1, 1));
         PutOp.execute(conn, proxy, testRegion.getFullPath(), "key1", "val1", event, null, false);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/ClientStatsManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/ClientStatsManager.java
@@ -85,9 +85,15 @@ public class ClientStatsManager {
       ServerRegionProxy regionProxy =
           new ServerRegionProxy(ClientHealthMonitoringRegion.ADMIN_REGION_NAME, pool);
 
+      boolean isOffHeap;
+      if (ds.getOffHeapStore() != null) {
+        isOffHeap = true;
+      } else {
+        isOffHeap = false;
+      }
       EventID eventId = new EventID(ds);
       @Released
-      EntryEventImpl event = new EntryEventImpl((Object) null);
+      EntryEventImpl event = new EntryEventImpl((Object) null, isOffHeap);
       try {
         event.setEventId(eventId);
         regionProxy.putForMetaRegion(ds.getDistributedMember(), stats, null, event, null);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
@@ -51,6 +51,7 @@ import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.TransactionId;
 import org.apache.geode.cache.client.internal.ServerRegionProxy;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.entries.DiskEntry.RecoveredEntry;
@@ -1209,6 +1210,13 @@ public class AbstractRegionMapTest {
       when(owner.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
       when(owner.getScope()).thenReturn(Scope.LOCAL);
       when(owner.isInitialized()).thenReturn(true);
+
+      InternalCache cache = mock(InternalCache.class);
+      InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+      when(owner.getCache()).thenReturn(cache);
+      when(cache.getDistributedSystem()).thenReturn(ids);
+      when(ids.getOffHeapStore()).thenReturn(null);
+
       doThrow(EntryNotFoundException.class).when(owner).checkEntryNotFound(any());
       initialize(owner, new Attributes(), null, false);
       if (map != null) {
@@ -1243,6 +1251,13 @@ public class AbstractRegionMapTest {
 
     private static LocalRegion createOwner(boolean withConcurrencyChecks) {
       LocalRegion owner = mock(LocalRegion.class);
+
+      InternalCache cache = mock(InternalCache.class);
+      InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+      when(owner.getCache()).thenReturn(cache);
+      when(cache.getDistributedSystem()).thenReturn(ids);
+      when(ids.getOffHeapStore()).thenReturn(null);
+
       CachePerfStats cachePerfStats = mock(CachePerfStats.class);
       when(owner.getCachePerfStats()).thenReturn(cachePerfStats);
       when(owner.getEvictionAttributes()).thenReturn(evictionAttributes);
@@ -1286,14 +1301,21 @@ public class AbstractRegionMapTest {
         owner = mock(DistributedRegion.class);
         when(owner.isInitialized()).thenReturn(false);
       }
+
+      InternalCache cache = mock(InternalCache.class);
+      InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+
       KeyInfo keyInfo = mock(KeyInfo.class);
       when(keyInfo.getKey()).thenReturn(KEY);
       when(owner.getKeyInfo(eq(KEY), any(), any())).thenReturn(keyInfo);
       when(owner.getMyId()).thenReturn(mock(InternalDistributedMember.class));
-      when(owner.getCache()).thenReturn(mock(InternalCache.class));
+      when(owner.getCache()).thenReturn(cache);
       when(owner.isAllEvents()).thenReturn(true);
       when(owner.shouldNotifyBridgeClients()).thenReturn(true);
       when(owner.lockWhenRegionIsInitializing()).thenCallRealMethod();
+
+      when(cache.getDistributedSystem()).thenReturn(ids);
+      when(ids.getOffHeapStore()).thenReturn(null);
       initialize(owner, new Attributes(), null, false);
     }
 
@@ -1311,6 +1333,12 @@ public class AbstractRegionMapTest {
     TXRmtEvent txRmtEvent = mock(TXRmtEvent.class);
     EventID eventId = mock(EventID.class);
     Object newValue = "value";
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(arm._getOwner().getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
 
     arm.txApplyPut(Operation.UPDATE, KEY, newValue, false, txId, txRmtEvent, eventId, null,
         pendingCallbacks, null, null, null, null, 1);
@@ -1331,6 +1359,12 @@ public class AbstractRegionMapTest {
     EventID eventId = mock(EventID.class);
     TXEntryState txEntryState = mock(TXEntryState.class);
     Object newValue = "value";
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(arm._getOwner().getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
 
     arm.txApplyPut(Operation.UPDATE, KEY, newValue, false, txId, null, eventId, null,
         pendingCallbacks, null, null, txEntryState, null, 1);
@@ -1386,6 +1420,12 @@ public class AbstractRegionMapTest {
     TXId txId = mock(TXId.class, RETURNS_DEEP_STUBS);
     EventID eventId = mock(EventID.class);
     TXRmtEvent txRmtEvent = mock(TXRmtEvent.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(arm._getOwner().getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
 
     arm.txApplyPut(Operation.UPDATE, KEY, "", false, txId, txRmtEvent, eventId, null,
         new ArrayList<>(), null, null, null, null, 1);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTxApplyDestroyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTxApplyDestroyTest.java
@@ -47,6 +47,7 @@ import org.apache.geode.cache.DiskAccessException;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.query.internal.index.IndexManager;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.TXEntryState.DistTxThinEntryState;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
@@ -1602,10 +1603,15 @@ public class AbstractRegionMapTxApplyDestroyTest {
   }
 
   private void setupLocalRegion() {
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
     when(owner.getCachePerfStats()).thenReturn(cachePerfStats);
-    when(owner.getCache()).thenReturn(mock(InternalCache.class));
+    when(owner.getCache()).thenReturn(cache);
     when(owner.getMyId()).thenReturn(myId);
     when(owner.getKeyInfo(any(), any(), any())).thenReturn(keyInfo);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
   }
 
   private void doTxApplyDestroy() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventImplTest.java
@@ -34,10 +34,12 @@ import org.junit.Test;
 
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.SerializedCacheValue;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.EntryEventImpl.NewValueImporter;
 import org.apache.geode.internal.cache.EntryEventImpl.OldValueImporter;
 import org.apache.geode.internal.cache.versions.VersionTag;
+import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.offheap.StoredObject;
 
 public class EntryEventImplTest {
@@ -59,6 +61,13 @@ public class EntryEventImplTest {
     doReturn(expectedRegionName).when(region).getFullPath();
     doReturn(keyInfo).when(region).getKeyInfo(any(), any(), any());
 
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
+
     // create entry event for the region
     EntryEventImpl e = createEntryEvent(region, value);
 
@@ -75,6 +84,14 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithUnserializedStoredObject() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject newValue = mock(StoredObject.class);
     byte[] newValueBytes = new byte[] {1, 2, 3};
     when(newValue.getValueAsHeapByteArray()).thenReturn(newValueBytes);
@@ -89,6 +106,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportNewValueWithByteArray() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     byte[] newValue = new byte[] {1, 2, 3};
     NewValueImporter nvImporter = mock(NewValueImporter.class);
     EntryEventImpl e = createEntryEvent(region, newValue);
@@ -101,6 +125,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportNewValueWithStringIgnoresNewValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     String newValue = "newValue";
     NewValueImporter nvImporter = mock(NewValueImporter.class);
     when(nvImporter.prefersNewSerialized()).thenReturn(true);
@@ -116,6 +147,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportNewValueWithByteArrayCachedDeserializable() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     byte[] newValueBytes = new byte[] {1, 2, 3};
     when(newValue.getValue()).thenReturn(newValueBytes);
@@ -130,6 +168,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportNewValueWithStringCachedDeserializable() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     Object newValueObj = "newValueObj";
     when(newValue.getValue()).thenReturn(newValueObj);
@@ -147,6 +192,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportNewValueWithStringCachedDeserializablePrefersNewValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     Object newValueObj = "newValueObj";
     when(newValue.getValue()).thenReturn(newValueObj);
@@ -164,6 +216,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportNewValueWithStringCachedDeserializablePrefersCachedSerializedNewValue() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     Object newValueObj = "newValueObj";
     when(newValue.getValue()).thenReturn(newValueObj);
@@ -182,6 +241,14 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithSerializedStoredObjectAndImporterPrefersSerialized() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject newValue = mock(StoredObject.class);
     when(newValue.isSerialized()).thenReturn(true);
     byte[] newValueBytes = new byte[] {1, 2, 3};
@@ -199,6 +266,14 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithSerializedStoredObject() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject newValue = mock(StoredObject.class);
     when(newValue.isSerialized()).thenReturn(true);
     Object newValueDeserialized = "newValueDeserialized";
@@ -215,6 +290,14 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithSerializedStoredObjectAndUnretainedNewReferenceOk() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject newValue = mock(StoredObject.class);
     when(newValue.isSerialized()).thenReturn(true);
     Object newValueDeserialized = "newValueDeserialized";
@@ -232,6 +315,14 @@ public class EntryEventImplTest {
   public void verifyExportOldValueWithUnserializedStoredObject() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject oldValue = mock(StoredObject.class);
     byte[] oldValueBytes = new byte[] {1, 2, 3};
     when(oldValue.getValueAsHeapByteArray()).thenReturn(oldValueBytes);
@@ -247,6 +338,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportOldValueWithByteArray() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     byte[] oldValue = new byte[] {1, 2, 3};
     OldValueImporter ovImporter = mock(OldValueImporter.class);
     EntryEventImpl e = createEntryEvent(region, null);
@@ -260,6 +358,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportOldValueWithStringIgnoresOldValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     String oldValue = "oldValue";
     OldValueImporter ovImporter = mock(OldValueImporter.class);
     when(ovImporter.prefersOldSerialized()).thenReturn(true);
@@ -276,6 +381,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportOldValuePrefersOldValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     OldValueImporter ovImporter = mock(OldValueImporter.class);
     when(ovImporter.prefersOldSerialized()).thenReturn(true);
     EntryEventImpl e = createEntryEvent(region, null);
@@ -290,6 +402,13 @@ public class EntryEventImplTest {
   @Test
   public void verifyExportOldValueWithCacheDeserializableByteArray() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     CachedDeserializable oldValue = mock(CachedDeserializable.class);
     byte[] oldValueBytes = new byte[] {1, 2, 3};
     when(oldValue.getValue()).thenReturn(oldValueBytes);
@@ -307,6 +426,13 @@ public class EntryEventImplTest {
     LocalRegion region = mock(LocalRegion.class);
     CachedDeserializable oldValue = mock(CachedDeserializable.class);
     Object oldValueObj = "oldValueObj";
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     when(oldValue.getValue()).thenReturn(oldValueObj);
     OldValueImporter ovImporter = mock(OldValueImporter.class);
     EntryEventImpl e = createEntryEvent(region, null);
@@ -322,6 +448,13 @@ public class EntryEventImplTest {
     LocalRegion region = mock(LocalRegion.class);
     CachedDeserializable oldValue = mock(CachedDeserializable.class);
     Object oldValueObj = "oldValueObj";
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     when(oldValue.getValue()).thenReturn(oldValueObj);
     OldValueImporter ovImporter = mock(OldValueImporter.class);
     when(ovImporter.isCachedDeserializableValueOk()).thenReturn(true);
@@ -337,6 +470,14 @@ public class EntryEventImplTest {
   public void verifyExportOldValueWithSerializedStoredObjectAndImporterPrefersSerialized() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject oldValue = mock(StoredObject.class);
     when(oldValue.isSerialized()).thenReturn(true);
     byte[] oldValueBytes = new byte[] {1, 2, 3};
@@ -355,6 +496,14 @@ public class EntryEventImplTest {
   public void verifyExportOldValueWithSerializedStoredObject() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject oldValue = mock(StoredObject.class);
     when(oldValue.isSerialized()).thenReturn(true);
     Object oldValueDeserialized = "newValueDeserialized";
@@ -372,6 +521,14 @@ public class EntryEventImplTest {
   public void verifyExportOldValueWithSerializedStoredObjectAndUnretainedOldReferenceOk() {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject oldValue = mock(StoredObject.class);
     when(oldValue.isSerialized()).thenReturn(true);
     Object oldValueDeserialized = "oldValueDeserialized";
@@ -389,6 +546,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueUnforcedWithRemoveTokenChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -399,6 +563,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueForcedWithRemoveTokenChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -409,6 +580,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueUnforcedWithInvalidTokenNullsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -419,6 +597,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueForcedWithInvalidTokenNullsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -429,6 +614,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueUnforcedWithNullChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -439,6 +631,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueForcedWithNullChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -449,6 +648,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueForcedWithNotAvailableTokenSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -459,6 +665,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueUnforcedWithNotAvailableTokenSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -469,6 +682,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldUnforcedValueSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -479,6 +699,13 @@ public class EntryEventImplTest {
   @Test
   public void setOldValueForcedSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
     e.basicSetOldValue(UNINITIALIZED);
@@ -508,6 +735,14 @@ public class EntryEventImplTest {
   public void verifyExternalReadMethodsBlockedByRelease() throws InterruptedException {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getOffHeap()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     StoredObject newValue = mock(StoredObject.class);
     when(newValue.hasRefCount()).thenReturn(true);
     when(newValue.isSerialized()).thenReturn(true);
@@ -670,6 +905,13 @@ public class EntryEventImplTest {
     long timestamp = System.currentTimeMillis();
     LocalRegion region = mock(LocalRegion.class);
     when(region.cacheTimeMillis()).thenReturn(timestamp);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     assertThat(e.getEventTime(0l)).isEqualTo(timestamp);
   }
@@ -679,6 +921,13 @@ public class EntryEventImplTest {
     long timestamp = System.currentTimeMillis();
     LocalRegion region = mock(LocalRegion.class);
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
     tag.setVersionTimeStamp(timestamp);
@@ -694,6 +943,13 @@ public class EntryEventImplTest {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
     when(region.cacheTimeMillis()).thenReturn(timestamp);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
     tag.setVersionTimeStamp(timestampPlus1);
@@ -708,6 +964,13 @@ public class EntryEventImplTest {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getConcurrencyChecksEnabled()).thenReturn(false);
     when(region.cacheTimeMillis()).thenReturn(timestamp);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
     tag.setVersionTimeStamp(timestamp + 1000l);
@@ -720,6 +983,13 @@ public class EntryEventImplTest {
     long timestamp = System.currentTimeMillis();
     LocalRegion region = mock(LocalRegion.class);
     when(region.getConcurrencyChecksEnabled()).thenReturn(false);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
     tag.setVersionTimeStamp(timestamp + 1000l);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessorTest.java
@@ -38,6 +38,7 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionTag;
+import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.offheap.StoredObject;
 
 public class SearchLoadAndWriteProcessorTest {
@@ -61,6 +62,14 @@ public class SearchLoadAndWriteProcessorTest {
     KeyInfo keyInfo = new KeyInfo(key, value, cbArg);
     when(lr.getKeyInfo(any(), any(), any())).thenReturn(keyInfo);
     processor.region = lr;
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    MemoryAllocator mem = mock(MemoryAllocator.class);
+    when(lr.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(mem);
+
     EntryEventImpl event =
         EntryEventImpl.create(lr, Operation.REPLACE, key, value, cbArg, false, null);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/event/DistributedEventTrackerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/event/DistributedEventTrackerTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.EntryEventImpl;
 import org.apache.geode.internal.cache.EventID;
@@ -45,6 +46,7 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.ha.ThreadIdentifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.versions.VersionTag;
+
 
 public class DistributedEventTrackerTest {
 
@@ -61,6 +63,12 @@ public class DistributedEventTrackerTest {
     when(region.getAttributes()).thenReturn(regionAttributes);
     when(regionAttributes.getDataPolicy()).thenReturn(mock(DataPolicy.class));
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
 
     member = mock(DistributedMember.class);
     eventTracker = new DistributedEventTracker(region.getCache(), mock(CancelCriterion.class),

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessageTest.java
@@ -31,10 +31,12 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.DistributedPutAllOperation;
 import org.apache.geode.internal.cache.EventID;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalDataView;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionDataStore;
@@ -85,6 +87,12 @@ public class PutAllPRMessageTest {
     when(bucketRegion.waitUntilLocked(keys)).thenReturn(true);
     when(bucketRegion.doLockForPrimary(false)).thenThrow(new PrimaryBucketException());
 
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(bucketRegion.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     message.doLocalPutAll(partitionedRegion, mock(InternalDistributedMember.class), 1);
 
     verify(bucketRegion).removeAndNotifyKeys(eq(keys));
@@ -97,6 +105,12 @@ public class PutAllPRMessageTest {
     message.addEntry(entryData);
     doReturn(keys).when(message).getKeysToBeLocked();
     when(bucketRegion.waitUntilLocked(keys)).thenThrow(regionDestroyedException);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(bucketRegion.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
 
     message.doLocalPutAll(partitionedRegion, mock(InternalDistributedMember.class), 1);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessageTest.java
@@ -31,10 +31,12 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.DistributedRemoveAllOperation;
 import org.apache.geode.internal.cache.EventID;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalDataView;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionDataStore;
@@ -98,6 +100,12 @@ public class RemoveAllPRMessageTest {
     when(bucketRegion.waitUntilLocked(keys)).thenReturn(true);
     when(bucketRegion.doLockForPrimary(false)).thenThrow(new PrimaryBucketException());
 
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(bucketRegion.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     message.doLocalRemoveAll(partitionedRegion, mock(InternalDistributedMember.class), true);
 
     verify(bucketRegion).removeAndNotifyKeys(eq(keys));
@@ -110,6 +118,12 @@ public class RemoveAllPRMessageTest {
     doReturn(keys).when(message).getKeysToBeLocked();
     RegionDestroyedException regionDestroyedException = new RegionDestroyedException("", "");
     when(bucketRegion.waitUntilLocked(keys)).thenThrow(regionDestroyedException);
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(bucketRegion.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
 
     message.doLocalRemoveAll(partitionedRegion, mock(InternalDistributedMember.class), true);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderEventProcessorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderEventProcessorJUnitTest.java
@@ -25,7 +25,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.cache.Operation;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySenderEventProcessor;
@@ -67,6 +69,13 @@ public class ParallelGatewaySenderEventProcessorJUnitTest {
     List<GatewaySenderEventImpl> originalEvents = new ArrayList<>();
     LocalRegion lr = mock(LocalRegion.class);
     when(lr.getFullPath()).thenReturn("/dataStoreRegion");
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(lr.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     Object lastUpdateValue = "Object_13964_5";
     long lastUpdateSequenceId = 104, lastUpdateShadowKey = 28161;
     originalEvents.add(ParallelGatewaySenderHelper.createGatewaySenderEvent(lr, Operation.CREATE,
@@ -120,6 +129,13 @@ public class ParallelGatewaySenderEventProcessorJUnitTest {
     List<GatewaySenderEventImpl> originalEvents = new ArrayList<>();
     LocalRegion lr = mock(LocalRegion.class);
     when(lr.getFullPath()).thenReturn("/dataStoreRegion");
+
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(lr.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+
     originalEvents.add(ParallelGatewaySenderHelper.createGatewaySenderEvent(lr, Operation.CREATE,
         "Object_13964", "Object_13964", 100, 27709));
     originalEvents.add(ParallelGatewaySenderHelper.createGatewaySenderEvent(lr, Operation.CREATE,


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [*] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [*] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [*] Is your initial contribution a single, squashed commit?

- [*] Does `gradlew build` run cleanly?

- [*] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
