### PR TITLE
GEODE-6767: Make sure that we don't lose metadata when altering a PR

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionAttributesMutatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionAttributesMutatorDUnitTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.internal.cache.partitioned;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionAttributesMutatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionAttributesMutatorDUnitTest.java
@@ -1,0 +1,120 @@
+package org.apache.geode.internal.cache.partitioned;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.control.RebalanceResults;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
+
+public class PartitionedRegionAttributesMutatorDUnitTest extends CacheTestCase {
+
+  public static final int NUM_BUCKETS = 13;
+  public static final int NUM_VMS = 3;
+  private static final String COLOCATED = "colocated";
+  private static final String BASE = "base";
+
+  /**
+   * This is a regression test for GEODE-6767 that we can still rebalance after altering certain
+   * partitioned region attributes.
+   *
+   * Altering the region attributes changes metadata in the __PR region. If that metadata is
+   * corrupted, rebalance may end up reducing redundancy due to the fact that
+   * isColocationComplete=false
+   * in the metadata.
+   */
+  @Test
+  public void canStillRebalanceAfterAlteringEntryTimeToLive() {
+    VM vm0 = VM.getVM(0);
+    IntStream.range(0, NUM_VMS).forEach(this::createRegionsOnVM);
+
+    vm0.invoke(this::createAllBuckets);
+
+    // Alter the region
+    vm0.invoke(this::alterRegion);
+
+    // Move data.
+    vm0.invoke(this::moveBuckets);
+
+    // Check redundancy of all regions
+    vm0.invoke(this::checkRedundancyLevel);
+  }
+
+  private void alterRegion() {
+    Cache cache = getCache();
+    PartitionedRegion region = (PartitionedRegion) cache.getRegion(COLOCATED);
+    region.getAttributesMutator().setEntryTimeToLive(new ExpirationAttributes(1000));
+  }
+
+  private void checkRedundancyLevel() {
+    Cache cache = getCache();
+    PartitionedRegion region = (PartitionedRegion) cache.getRegion(COLOCATED);
+    assertThat(region.getPrStats().getLowRedundancyBucketCount()).isEqualTo(0);
+  }
+
+  private void moveBuckets() throws InterruptedException {
+    // Move some data, to force a rebalance
+    Region<Object, Object> base = getCache().getRegion(BASE);
+    Set<DistributedMember> allMembersForKey =
+        PartitionRegionHelper.getAllMembersForKey(base, 0);
+
+    Iterator<DistributedMember> memberIterator = allMembersForKey.iterator();
+    DistributedMember member1 = memberIterator.next();
+    DistributedMember member2 = memberIterator.next();
+
+    RebalanceResults results = PartitionRegionHelper.moveData(base, member1, member2, 100);
+    assertThat(results.getTotalBucketTransfersCompleted()).isGreaterThan(1);
+  }
+
+  private void createAllBuckets() {
+    Cache cache = getCache();
+    PartitionRegionHelper.assignBucketsToPartitions(cache.getRegion(BASE));
+  }
+
+  private void createRegionsOnVM(int i) {
+    VM.getVM(i).invoke(() -> {
+      createRegions();
+    });
+  }
+
+  private void createRegions() {
+    Cache cache = getCache();
+    {
+      PartitionAttributes attributes = new PartitionAttributesFactory<>()
+          .setRedundantCopies(1)
+          .setTotalNumBuckets(NUM_BUCKETS)
+          .create();
+
+      cache.createRegionFactory(RegionShortcut.PARTITION_REDUNDANT)
+          .setStatisticsEnabled(true)
+          .setPartitionAttributes(attributes)
+          .create(BASE);
+    }
+
+    PartitionAttributes attributes = new PartitionAttributesFactory<>()
+        .setColocatedWith(BASE)
+        .setRedundantCopies(1)
+        .setTotalNumBuckets(NUM_BUCKETS)
+        .create();
+
+    cache.createRegionFactory(RegionShortcut.PARTITION_REDUNDANT)
+        .setStatisticsEnabled(true)
+        .setPartitionAttributes(attributes)
+        .create(COLOCATED);
+  }
+
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -27,12 +28,14 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.apache.geode.CopyHelper;
 import org.apache.geode.cache.CacheLoader;
 import org.apache.geode.cache.CacheLoaderException;
 import org.apache.geode.cache.CacheWriter;
@@ -48,6 +51,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionEvent;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.partitioned.PartitionedRegionObserverAdapter;
 import org.apache.geode.internal.cache.partitioned.PartitionedRegionObserverHolder;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -87,14 +91,18 @@ public class PartitionedRegionAttributesMutatorTest {
       CompletableFuture<Void> createBucket =
           CompletableFuture.runAsync(() -> PartitionRegionHelper.assignBucketsToPartitions(pr));
       bucketCreated.await();
-      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig beforeConfig = getConfig(pr);
       pr.getAttributesMutator().setCacheLoader(loader);
       mutationMade.countDown();
       createBucket.get(DEFAULT_WAIT_DURATION, DEFAULT_WAIT_UNIT);
       getAllBucketRegions(pr).forEach(region -> assertEquals(loader, region.getCacheLoader()));
-      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig afterConfig = getConfig(pr);
       verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
+  }
+
+  private static PartitionRegionConfig getConfig(PartitionedRegion pr) {
+    return CopyHelper.copy(pr.getPRRoot().get(pr.getRegionIdentifier()));
   }
 
   private static void verifyMetaDataIsOk(PartitionRegionConfig beforeConfig,
@@ -103,6 +111,17 @@ public class PartitionedRegionAttributesMutatorTest {
     assertEquals(beforeConfig.isFirstDataStoreCreated(), afterConfig.isFirstDataStoreCreated());
     assertEquals(beforeConfig.getNodes(), afterConfig.getNodes());
     assertEquals(beforeConfig.getColocatedWith(), afterConfig.getColocatedWith());
+
+    List<InternalDistributedMember> beforeMembers = getMembers(beforeConfig);
+    List<InternalDistributedMember> afterMembers = getMembers(beforeConfig);
+    assertEquals(beforeMembers, afterMembers);
+  }
+
+  private static List<InternalDistributedMember> getMembers(PartitionRegionConfig beforeConfig) {
+    return beforeConfig.getNodes()
+        .stream()
+        .map(Node::getMemberId)
+        .collect(Collectors.toList());
   }
 
   @Test
@@ -111,11 +130,11 @@ public class PartitionedRegionAttributesMutatorTest {
     server.invoke(() -> {
       PartitionedRegion pr = createRegionSpy();
       CacheLoader loader = createTestCacheLoader();
-      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig beforeConfig = getConfig(pr);
       pr.getAttributesMutator().setCacheLoader(loader);
       verify(pr).updatePRNodeInformation();
       verify(pr, times(1)).updatePRConfig(any(), anyBoolean());
-      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig afterConfig = getConfig(pr);
       verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
@@ -126,11 +145,11 @@ public class PartitionedRegionAttributesMutatorTest {
     server.invoke(() -> {
       PartitionedRegion pr = createRegionSpy();
       CacheWriter writer = createTestCacheWriter();
-      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig beforeConfig = getConfig(pr);
       pr.getAttributesMutator().setCacheWriter(writer);
       verify(pr).updatePRNodeInformation();
       verify(pr, times(1)).updatePRConfig(any(), anyBoolean());
-      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig afterConfig = getConfig(pr);
       verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
@@ -148,14 +167,14 @@ public class PartitionedRegionAttributesMutatorTest {
       CompletableFuture<Void> createBucket =
           CompletableFuture.runAsync(() -> PartitionRegionHelper.assignBucketsToPartitions(pr));
       bucketCreated.await();
-      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig beforeConfig = getConfig(pr);
       pr.getAttributesMutator().setCustomEntryTimeToLive(customExpiry);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(customExpiry, region.customEntryTimeToLive));
-      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig afterConfig = getConfig(pr);
       verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
@@ -173,14 +192,14 @@ public class PartitionedRegionAttributesMutatorTest {
       CompletableFuture<Void> createBucket =
           CompletableFuture.runAsync(() -> PartitionRegionHelper.assignBucketsToPartitions(pr));
       bucketCreated.await();
-      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig beforeConfig = getConfig(pr);
       pr.getAttributesMutator().setCustomEntryIdleTimeout(customExpiry);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(customExpiry, region.customEntryIdleTimeout));
-      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig afterConfig = getConfig(pr);
       verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
@@ -199,14 +218,14 @@ public class PartitionedRegionAttributesMutatorTest {
       bucketCreated.await();
       ExpirationAttributes expirationAttributes =
           new ExpirationAttributes(1000, ExpirationAction.DESTROY);
-      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig beforeConfig = getConfig(pr);
       pr.getAttributesMutator().setEntryIdleTimeout(expirationAttributes);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(expirationAttributes, region.getEntryIdleTimeout()));
-      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig afterConfig = getConfig(pr);
       verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
@@ -224,14 +243,14 @@ public class PartitionedRegionAttributesMutatorTest {
       bucketCreated.await();
       ExpirationAttributes expirationAttributes =
           new ExpirationAttributes(1000, ExpirationAction.DESTROY);
-      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig beforeConfig = getConfig(pr);
       pr.getAttributesMutator().setEntryTimeToLive(expirationAttributes);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(expirationAttributes, region.getEntryTimeToLive()));
-      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      PartitionRegionConfig afterConfig = getConfig(pr);
       verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
@@ -87,11 +87,22 @@ public class PartitionedRegionAttributesMutatorTest {
       CompletableFuture<Void> createBucket =
           CompletableFuture.runAsync(() -> PartitionRegionHelper.assignBucketsToPartitions(pr));
       bucketCreated.await();
+      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
       pr.getAttributesMutator().setCacheLoader(loader);
       mutationMade.countDown();
       createBucket.get(DEFAULT_WAIT_DURATION, DEFAULT_WAIT_UNIT);
       getAllBucketRegions(pr).forEach(region -> assertEquals(loader, region.getCacheLoader()));
+      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
+  }
+
+  private static void verifyMetaDataIsOk(PartitionRegionConfig beforeConfig,
+      PartitionRegionConfig afterConfig) {
+    assertEquals(beforeConfig.isColocationComplete(), afterConfig.isColocationComplete());
+    assertEquals(beforeConfig.isFirstDataStoreCreated(), afterConfig.isFirstDataStoreCreated());
+    assertEquals(beforeConfig.getNodes(), afterConfig.getNodes());
+    assertEquals(beforeConfig.getColocatedWith(), afterConfig.getColocatedWith());
   }
 
   @Test
@@ -100,9 +111,12 @@ public class PartitionedRegionAttributesMutatorTest {
     server.invoke(() -> {
       PartitionedRegion pr = createRegionSpy();
       CacheLoader loader = createTestCacheLoader();
+      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
       pr.getAttributesMutator().setCacheLoader(loader);
       verify(pr).updatePRNodeInformation();
       verify(pr, times(1)).updatePRConfig(any(), anyBoolean());
+      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
 
@@ -112,9 +126,12 @@ public class PartitionedRegionAttributesMutatorTest {
     server.invoke(() -> {
       PartitionedRegion pr = createRegionSpy();
       CacheWriter writer = createTestCacheWriter();
+      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
       pr.getAttributesMutator().setCacheWriter(writer);
       verify(pr).updatePRNodeInformation();
       verify(pr, times(1)).updatePRConfig(any(), anyBoolean());
+      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
 
@@ -131,12 +148,15 @@ public class PartitionedRegionAttributesMutatorTest {
       CompletableFuture<Void> createBucket =
           CompletableFuture.runAsync(() -> PartitionRegionHelper.assignBucketsToPartitions(pr));
       bucketCreated.await();
+      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
       pr.getAttributesMutator().setCustomEntryTimeToLive(customExpiry);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(customExpiry, region.customEntryTimeToLive));
+      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
 
@@ -153,12 +173,15 @@ public class PartitionedRegionAttributesMutatorTest {
       CompletableFuture<Void> createBucket =
           CompletableFuture.runAsync(() -> PartitionRegionHelper.assignBucketsToPartitions(pr));
       bucketCreated.await();
+      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
       pr.getAttributesMutator().setCustomEntryIdleTimeout(customExpiry);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(customExpiry, region.customEntryIdleTimeout));
+      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
 
@@ -176,12 +199,15 @@ public class PartitionedRegionAttributesMutatorTest {
       bucketCreated.await();
       ExpirationAttributes expirationAttributes =
           new ExpirationAttributes(1000, ExpirationAction.DESTROY);
+      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
       pr.getAttributesMutator().setEntryIdleTimeout(expirationAttributes);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(expirationAttributes, region.getEntryIdleTimeout()));
+      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
 
@@ -198,12 +224,15 @@ public class PartitionedRegionAttributesMutatorTest {
       bucketCreated.await();
       ExpirationAttributes expirationAttributes =
           new ExpirationAttributes(1000, ExpirationAction.DESTROY);
+      PartitionRegionConfig beforeConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
       pr.getAttributesMutator().setEntryTimeToLive(expirationAttributes);
       mutationMade.countDown();
       createBucket.get();
 
       getAllBucketRegions(pr)
           .forEach(region -> assertEquals(expirationAttributes, region.getEntryTimeToLive()));
+      PartitionRegionConfig afterConfig = pr.getPRRoot().get(pr.getRegionIdentifier());
+      verifyMetaDataIsOk(beforeConfig, afterConfig);
     });
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionAttributesMutatorTest.java
@@ -113,7 +113,7 @@ public class PartitionedRegionAttributesMutatorTest {
     assertEquals(beforeConfig.getColocatedWith(), afterConfig.getColocatedWith());
 
     List<InternalDistributedMember> beforeMembers = getMembers(beforeConfig);
-    List<InternalDistributedMember> afterMembers = getMembers(beforeConfig);
+    List<InternalDistributedMember> afterMembers = getMembers(afterConfig);
     assertEquals(beforeMembers, afterMembers);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionRegionConfig.java
@@ -324,6 +324,14 @@ public class PartitionRegionConfig extends ExternalizableDSFID implements Versio
     partitionedRegion.executeColocationCallbacks();
   }
 
+  public void setEntryIdleTimeout(ExpirationAttributes idleTimeout) {
+    this.entryIdleTimeout = idleTimeout;
+  }
+
+  public void setEntryTimeToLive(ExpirationAttributes timeToLive) {
+    this.entryTimeToLive = timeToLive;
+  }
+
   public boolean isGreaterNodeListVersion(final PartitionRegionConfig other) {
     return this.nodes.isNewerThan(other.nodes);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1619,7 +1619,16 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
-  public void updatePRConfig(PartitionRegionConfig prConfig, boolean putOnlyIfUpdated) {
+  /**
+   *
+   * Set the global PartitionedRegionConfig metadata for this region.
+   *
+   * This method should *only* be called while holding the partitioned region lock. For code
+   * that is mutating the config, use
+   * {@link #updatePartitionRegionConfig(PartitionRegionConfigModifier)}
+   * instead.
+   */
+  void updatePRConfig(PartitionRegionConfig prConfig, boolean putOnlyIfUpdated) {
     final PartitionedRegion colocatedRegion = ColocationHelper.getColocatedRegion(this);
     RegionLock colocatedLock = null;
     boolean colocatedLockAcquired = false;
@@ -9197,17 +9206,8 @@ public class PartitionedRegion extends LocalRegion
     PartitionRegionHelper.assignBucketsToPartitions(this);
     dataStore.lockBucketCreationAndVisit(
         (bucketId, r) -> r.getAttributesMutator().setEntryTimeToLive(timeToLive));
-    updatePRConfig(getPRConfigWithLatestExpirationAttributes(), false);
+    updatePartitionRegionConfig(config -> config.setEntryTimeToLive(timeToLive));
     return attr;
-  }
-
-  private PartitionRegionConfig getPRConfigWithLatestExpirationAttributes() {
-    PartitionRegionConfig prConfig = getPRRoot().get(getRegionIdentifier());
-
-    return new PartitionRegionConfig(prConfig.getPRId(), prConfig.getFullPath(),
-        prConfig.getPartitionAttrs(), prConfig.getScope(), prConfig.getEvictionAttributes(),
-        this.getRegionIdleTimeout(), this.getRegionTimeToLive(), this.getEntryIdleTimeout(),
-        this.getEntryTimeToLive(), prConfig.getGatewaySenderIds());
   }
 
   /**
@@ -9248,7 +9248,8 @@ public class PartitionedRegion extends LocalRegion
     // Set to Bucket regions as well
     dataStore.lockBucketCreationAndVisit(
         (bucketId, r) -> r.getAttributesMutator().setEntryIdleTimeout(idleTimeout));
-    updatePRConfig(getPRConfigWithLatestExpirationAttributes(), false);
+
+    updatePartitionRegionConfig(config -> config.setEntryIdleTimeout(idleTimeout));
     return attr;
   }
 


### PR DESCRIPTION
The methods on a PR to alter the time-to-live and idle-time were losing
some of the metadata in the PartitionRegionConfig, including the
isColocationComplete flag. This causes issues with rebalancing and
bucket creation.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
