### PR TITLE
GEODE-6771: Have ProcessWrapper implement Consumer

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DeprecatedCacheServerLauncherIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DeprecatedCacheServerLauncherIntegrationTest.java
@@ -446,6 +446,7 @@ public class DeprecatedCacheServerLauncherIntegrationTest {
       throws InterruptedException, TimeoutException {
     ProcessWrapper processWrapper = new ProcessWrapper.Builder()
         .mainClass(CacheServerLauncher.class).mainArguments(args).build();
+    processWrapper.setConsumer(c -> logger.info(c));
     processWrapper.execute();
     if (regex != null) {
       processWrapper.waitForOutputToMatch(regex, 2 * 60 * 1000);

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/ProcessLogger.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/ProcessLogger.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -62,6 +63,8 @@ public class ProcessLogger {
   }
 
   private static LoggerContext createLoggerContext() {
+    LogManager.shutdown();
+
     ConfigurationBuilder<BuiltConfiguration> builder =
         ConfigurationBuilderFactory.newConfigurationBuilder();
     builder.setStatusLevel(Level.ERROR);

--- a/geode-junit/src/main/java/org/apache/geode/test/process/ProcessStreamReader.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/process/ProcessStreamReader.java
@@ -18,8 +18,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.List;
-import java.util.Queue;
+import java.util.function.Consumer;
 
 /**
  * Reads the output from a process stream and stores it for test validation.
@@ -34,17 +33,15 @@ public class ProcessStreamReader extends Thread {
 
   private final String command;
   private final BufferedReader reader;
-  private final Queue<String> lineBuffer;
-  private final List<String> allLines;
+  private final Consumer<String> consumer;
 
   private int lineCount = 0;
 
   public ProcessStreamReader(final String command, final InputStream stream,
-      final Queue<String> lineBuffer, final List<String> allLines) {
+      final Consumer<String> consumer) {
     this.command = command;
     this.reader = new BufferedReader(new InputStreamReader(stream));
-    this.lineBuffer = lineBuffer;
-    this.allLines = allLines;
+    this.consumer = consumer;
   }
 
   @Override
@@ -59,8 +56,7 @@ public class ProcessStreamReader extends Thread {
       String line;
       while ((line = this.reader.readLine()) != null) {
         this.lineCount++;
-        this.lineBuffer.offer(line);
-        this.allLines.add(line);
+        consumer.accept(line);
       }
 
       // EOF


### PR DESCRIPTION
- Log all stdout/stderr from DeprecatedCacheServerLauncherIntegrationTest
  java invocations.
- Ensure LogManager is initialized correctly in ProcessLogger
- Clean up manifest jars created by ProcessWrapper

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
