### PR TITLE
Make windows tests gating

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -28,18 +28,10 @@
   - get: geode
     trigger: true
     passed:
-    {%- if test.name.startswith("Windows") %}
-    {{- all_gating_jobs() | indent(4) -}}
-    {% else %}
     - Build
-    {%- endif %}
   - get: geode-build-version
     passed:
-    {%- if test.name.startswith("Windows") %}
-    {{- all_gating_jobs() | indent(4) -}}
-    {% else %}
     - Build
-    {%- endif %}
 {% endmacro %}
 
 {%- macro deep_merge(a, b): %}
@@ -90,7 +82,7 @@ GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 {%- endmacro %}
 
 {% macro all_gating_jobs() %}
-{%- for test in (tests) if not test.name=="StressNew" and not test.name.startswith("Windows") -%}
+{%- for test in (tests) if not test.name=="StressNew" -%}
   {%- for java_test_version in (java_test_versions) %}
 - {{test.name}}Test{{java_test_version.name}}
   {%- endfor -%}


### PR DESCRIPTION
per discussion on the dev list, this change promotes Windows tests to the same level as Linux tests (all now fire at the same time, all are now visible on the main pipeline view, and all must now pass for a commit to move to the next stage of the pipeline).

dev list consensus was that even though Windows tests currently take a little longer and are still a little flakier than we would like, Windows _is_ a supported platform and these changes will encourage better upkeep.