### PR TITLE
reduce PR checks to Java 11 only

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -101,7 +101,11 @@ groups:
 - name: main
   jobs:
   - {{ build_test.name }}
-  {{- all_gating_jobs() | indent(2) }}
+  {%- for test in (tests) if not test.name=="StressNew" -%}
+    {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") %}
+  - {{test.name}}Test{{java_test_version.name}}
+    {%- endfor -%}
+  {%- endfor -%}
   {%- if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
   - UpdatePassingRef
   {%- endif %}

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -101,11 +101,7 @@ groups:
 - name: main
   jobs:
   - {{ build_test.name }}
-  {%- for test in (tests) if not test.name=="StressNew" -%}
-    {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") %}
-  - {{test.name}}Test{{java_test_version.name}}
-    {%- endfor -%}
-  {%- endfor -%}
+  {{- all_gating_jobs() | indent(2) }}
   {%- if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
   - UpdatePassingRef
   {%- endif %}

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -24,7 +24,7 @@ groups:
   jobs:
   - {{ build_test.name }}
 {%- for test in tests if not test.name.startswith("Windows") %}
-  {%- for java_test_version in (java_test_versions) %}
+  {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") %}
   - {{test.name}}Test{{java_test_version.name}}
   {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
We have recognized that there are very few cases where a commit works fine on JDK11 but fails on JDK8 (since generally most development work is done on 8 and compiled on 8 to begin with).  Therefore, it is not necessary to run PR checks for both 8 and 11.  11 only will catch the most issues, and the main pipeline will still run both just to be absolutely sure.