### PR TITLE
GEODE-5731: Add tests for hostname-for-clients

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandIntegrationTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
@@ -44,7 +43,7 @@ public class StartLocatorCommandIntegrationTest {
   private StartLocatorCommand spy;
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     spy = Mockito.spy(StartLocatorCommand.class);
     doReturn(mock(Gfsh.class)).when(spy).getGfsh();
   }
@@ -88,5 +87,18 @@ public class StartLocatorCommandIntegrationTest {
 
     String[] lines = commandLines.getValue();
     assertThat(lines[12]).isEqualTo("--bind-address=127.0.0.1");
+  }
+
+  @Test
+  public void startLocatorRespectsHostnameForClients() throws Exception {
+    doReturn(mock(Process.class)).when(spy).getProcess(any(), any());
+    String startLocatorCommand = new CommandStringBuilder("start locator")
+        .addOption("hostname-for-clients", FAKE_HOSTNAME).toString();
+
+    commandRule.executeAndAssertThat(spy, startLocatorCommand);
+    ArgumentCaptor<String[]> commandLines = ArgumentCaptor.forClass(String[].class);
+    verify(spy).getProcess(any(), commandLines.capture());
+    String[] lines = commandLines.getValue();
+    assertThat(lines).containsOnlyOnce("--hostname-for-clients=" + FAKE_HOSTNAME);
   }
 }

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartServerCommandIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartServerCommandIntegrationTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_HOSTNAME_FOR_CLIENTS;
@@ -44,14 +43,14 @@ public class StartServerCommandIntegrationTest {
   private StartServerCommand spy;
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     spy = Mockito.spy(StartServerCommand.class);
     doReturn(mock(Gfsh.class)).when(spy).getGfsh();
   }
 
   @Test
   public void startServerWorksWithNoOptions() throws Exception {
-    commandRule.executeCommandWithInstance(spy, "start server");
+    commandRule.executeAndAssertThat(spy, "start server");
 
     ArgumentCaptor<Properties> gemfirePropertiesCaptor = ArgumentCaptor.forClass(Properties.class);
     verify(spy).createStartServerCommandLine(any(), any(), any(), gemfirePropertiesCaptor.capture(),
@@ -67,7 +66,7 @@ public class StartServerCommandIntegrationTest {
     String startServerCommand = new CommandStringBuilder("start server")
         .addOption(JMX_MANAGER_HOSTNAME_FOR_CLIENTS, FAKE_HOSTNAME).toString();
 
-    commandRule.executeCommandWithInstance(spy, startServerCommand);
+    commandRule.executeAndAssertThat(spy, startServerCommand);
 
     ArgumentCaptor<Properties> gemfirePropertiesCaptor = ArgumentCaptor.forClass(Properties.class);
     verify(spy).createStartServerCommandLine(any(), any(), any(), gemfirePropertiesCaptor.capture(),
@@ -78,4 +77,15 @@ public class StartServerCommandIntegrationTest {
     assertThat(gemfireProperties.get(JMX_MANAGER_HOSTNAME_FOR_CLIENTS)).isEqualTo(FAKE_HOSTNAME);
   }
 
+  @Test
+  public void startServerRespectsHostnameForClients() throws Exception {
+    String startServerCommand = new CommandStringBuilder("start server")
+        .addOption("hostname-for-clients", FAKE_HOSTNAME).toString();
+
+    commandRule.executeAndAssertThat(spy, startServerCommand);
+    ArgumentCaptor<String[]> commandLines = ArgumentCaptor.forClass(String[].class);
+    verify(spy).getProcess(any(), commandLines.capture());
+    String[] lines = commandLines.getValue();
+    assertThat(lines).containsOnlyOnce("--hostname-for-clients=" + FAKE_HOSTNAME);
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -28,6 +28,7 @@ import javax.management.MalformedObjectNameException;
 import javax.net.ssl.SSLException;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
@@ -36,10 +37,8 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.internal.OSProcess;
-import org.apache.geode.internal.lang.StringUtils;
 import org.apache.geode.internal.lang.SystemUtils;
 import org.apache.geode.internal.process.ProcessStreamReader;
-import org.apache.geode.internal.process.ProcessType;
 import org.apache.geode.internal.util.IOUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -181,10 +180,6 @@ public class StartLocatorCommand extends OfflineGfshCommand {
               gemfireSecurityPropertiesFile.getAbsolutePath()));
     }
 
-    File locatorPidFile = new File(workingDirectory, ProcessType.LOCATOR.getPidFileName());
-
-    final int oldPid = StartMemberUtils.readPid(locatorPidFile);
-
     Properties gemfireProperties = new Properties();
 
     StartMemberUtils.setPropertyIfNotNull(gemfireProperties, ConfigurationProperties.GROUPS, group);
@@ -239,7 +234,7 @@ public class StartLocatorCommand extends OfflineGfshCommand {
     ProcessStreamReader.InputListener inputListener = line -> {
       message.append(line);
       if (readingMode == ProcessStreamReader.ReadingMode.BLOCKING) {
-        message.append(StringUtils.LINE_SEPARATOR);
+        message.append(SystemUtils.getLineSeparator());
       }
     };
 
@@ -514,7 +509,7 @@ public class StartLocatorCommand extends OfflineGfshCommand {
       commandLine.add("--redirect-output");
     }
 
-    return commandLine.toArray(new String[commandLine.size()]);
+    return commandLine.toArray(new String[] {});
   }
 
   String getLocatorClasspath(final boolean includeSystemClasspath, final String userClasspath) {
@@ -528,7 +523,7 @@ public class StartLocatorCommand extends OfflineGfshCommand {
     }
 
     return StartMemberUtils.toClasspath(includeSystemClasspath,
-        jarFilePathnames.toArray(new String[jarFilePathnames.size()]), userClasspath);
+        jarFilePathnames.toArray(new String[] {}), userClasspath);
   }
 
   private String[] getExtensionsJars() {
@@ -537,7 +532,7 @@ public class StartLocatorCommand extends OfflineGfshCommand {
 
     if (extensionsJars != null) {
       // assume `extensions` directory does not contain any subdirectories. It only contains jars.
-      return Arrays.stream(extensionsJars).filter(file -> file.isFile()).map(
+      return Arrays.stream(extensionsJars).filter(File::isFile).map(
           file -> IOUtils.appendToPath(StartMemberUtils.GEODE_HOME, "extensions", file.getName()))
           .toArray(String[]::new);
     } else {


### PR DESCRIPTION
- Fixed minor warnings.
- Added some tests to check that the `hostname-for-clients` flag is
  propagated across the stack while starting locators and servers.
- Replaced usage of class `org.apache.geode.internal.lang.StringUtils`
  (deprecated) by `org.apache.commons.lang3.StringUtils`.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
