### PR TITLE
GEODE-6789 locator fails to start even though ports in membership-por…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -23,7 +23,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
-import java.net.BindException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -525,7 +524,7 @@ public class AcceptorImpl implements Acceptor, Runnable {
             serverSock.bind(new InetSocketAddress(getBindAddress(), port), backLog);
             break;
           } catch (SocketException b) {
-            if (!treatAsBindException(b) || System.currentTimeMillis() > tilt) {
+            if (System.currentTimeMillis() > tilt) {
               throw b;
             }
           }
@@ -555,7 +554,7 @@ public class AcceptorImpl implements Acceptor, Runnable {
                 this.gatewayTransportFilters, socketBufferSize);
             break;
           } catch (SocketException e) {
-            if (!treatAsBindException(e) || System.currentTimeMillis() > tilt) {
+            if (System.currentTimeMillis() > tilt) {
               throw e;
             }
           }
@@ -1816,15 +1815,6 @@ public class AcceptorImpl implements Acceptor, Runnable {
 
   public List<GatewayTransportFilter> getGatewayTransportFilters() {
     return gatewayTransportFilters;
-  }
-
-  // IBM J9 sometimes reports "listen failed" instead of BindException
-  private static boolean treatAsBindException(SocketException se) {
-    if (se instanceof BindException) {
-      return true;
-    }
-    final String msg = se.getMessage();
-    return msg != null && msg.contains("Invalid argument: listen failed");
   }
 
   static boolean isAuthenticationRequired() {

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -774,8 +774,8 @@ public class SocketCreator {
               "Unable to find a free port in the membership-port-range");
         }
       }
+      ServerSocket socket = null;
       try {
-        ServerSocket socket;
         if (useNIO) {
           ServerSocketChannel channel = ServerSocketChannel.open();
           socket = channel.socket();
@@ -788,21 +788,12 @@ public class SocketCreator {
         }
         return socket;
       } catch (java.net.SocketException ex) {
-        if (useNIO || SocketCreator.treatAsBindException(ex)) {
-          localPort++;
-        } else {
-          throw ex;
+        if (socket != null && !socket.isClosed()) {
+          socket.close();
         }
+        localPort++;
       }
     }
-  }
-
-  private static boolean treatAsBindException(SocketException se) {
-    if (se instanceof BindException) {
-      return true;
-    }
-    final String msg = se.getMessage();
-    return (msg != null && msg.contains("Invalid argument: listen failed"));
   }
 
   /**


### PR DESCRIPTION
…t-range are available

Do not rely on exception text to determine whether a bind() operation
failed.  Instead, treat all SocketAcceptions thrown by server socket
creation a failure to bind to an inet socket address.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
