### PR TITLE
GEODE-6732 GMSHealthMonitor reports member is not available when self…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -1314,6 +1314,7 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
       }
 
       if (!pinged && !isStopping) {
+        failed = true;
         TimeStamp ts = memberTimeStamps.get(mbr);
         if (ts == null || ts.getTime() < startTime) {
           logger.info("Availability check failed for member {}", mbr);
@@ -1325,7 +1326,6 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
             // make sure it is still suspected
             memberSuspected(localAddress, mbr, reason);
           } else {
-            failed = true;
             // if this node can survive an availability check then initiate suspicion about
             // the node that failed the availability check
             logger.info("BRUCE: invoking self-check on {}", localAddress);
@@ -1353,6 +1353,7 @@ public class GMSHealthMonitor implements HealthMonitor, MessageHandler {
           logger.info(
               "Availability check failed but detected recent message traffic for suspect member "
                   + mbr);
+          failed = false;
         }
       }
 


### PR DESCRIPTION
…-health check fails

If a self-health check fails we should give a member that's under
suspicion a break and stop suspecting it for the moment.  If it's really
not there anymore a subsequent check will happen and that will resolve
the issue.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
