### PR TITLE
GEODE-6802: Execute region synchronization on newly joined member.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -265,6 +265,14 @@ public class DistributionAdvisor {
     if (isDebugEnabled) {
       logger.debug("da.syncForCrashedMember will sync region in cache's timer for region: {}", dr);
     }
+    CacheProfile cacheProfile = (CacheProfile) profile;
+    PersistentMemberID persistentId = getPersistentID(cacheProfile);
+    VersionSource lostVersionID;
+    if (persistentId != null) {
+      lostVersionID = persistentId.getVersionMember();
+    } else {
+      lostVersionID = id;
+    }
     // schedule the synchronization for execution in the future based on the client health monitor
     // interval. This allows client caches to retry an operation that might otherwise be recovered
     // through the sync operation. Without associated event information this could cause the
@@ -289,11 +297,9 @@ public class DistributionAdvisor {
             }
           }
         }
-        CacheProfile cp = (CacheProfile) profile;
-        PersistentMemberID persistentId = cp.persistentID;
         if (dr.getDataPolicy().withPersistence() && persistentId == null) {
           // Fix for 46704. The lost member may be a replicate
-          // or an empty accessor. We don't need to to a synchronization
+          // or an empty accessor. We don't need to do a synchronization
           // in that case, because those members send their writes to
           // a persistent member.
           if (isDebugEnabled) {
@@ -303,17 +309,16 @@ public class DistributionAdvisor {
           }
           return;
         }
-
-
-        VersionSource lostVersionID;
-        if (persistentId != null) {
-          lostVersionID = persistentId.getVersionMember();
-        } else {
-          lostVersionID = id;
-        }
         dr.synchronizeForLostMember(id, lostVersionID);
       }
     }, delay);
+    if (dr.getConcurrencyChecksEnabled()) {
+      dr.setRegionSynchronizeScheduled(lostVersionID);
+    }
+  }
+
+  private PersistentMemberID getPersistentID(CacheProfile cp) {
+    return cp.persistentID;
   }
 
   /** find the region for a delta-gii operation (synch) */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -117,6 +117,7 @@ import org.apache.geode.internal.cache.tx.RemoteFetchVersionMessage.FetchVersion
 import org.apache.geode.internal.cache.tx.RemoteInvalidateMessage;
 import org.apache.geode.internal.cache.tx.RemotePutMessage;
 import org.apache.geode.internal.cache.versions.ConcurrentCacheModificationException;
+import org.apache.geode.internal.cache.versions.RegionVersionHolder;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionTag;
@@ -1296,6 +1297,24 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
       InternalDistributedMember lostMember) {
     InitialImageOperation op = new InitialImageOperation(this, entries);
     op.synchronizeWith(target, versionMember, lostMember);
+  }
+
+
+  public void setRegionSynchronizeScheduled(VersionSource lostMemberVersionID) {
+    RegionVersionHolder regionVersionHolder =
+        getVersionVector().getHolderForMember(lostMemberVersionID);
+    if (regionVersionHolder != null) {
+      regionVersionHolder.setRegionSynchronizeScheduled();
+    }
+  }
+
+  public boolean setRegionSynchronizedWithIfNotScheduled(VersionSource lostMemberVersionID) {
+    RegionVersionHolder regionVersionHolder =
+        getVersionVector().getHolderForMember(lostMemberVersionID);
+    if (regionVersionHolder != null) {
+      return regionVersionHolder.setRegionSynchronizeScheduledOrDoneIfNot();
+    }
+    return false;
   }
 
   /** remove any partial entries received in a failed GII */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -1300,6 +1300,12 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   }
 
 
+  /**
+   * This is invoked by syncForCrashedMember when scheduling region synchronization
+   * triggered by member departed event. It sets the regionSynchronizeScheduledOrDone
+   * flag in region version holder to true. This indicates that no additional region sync for
+   * the lost member is needed, when it receives requests for region sync for the lost member.
+   */
   public void setRegionSynchronizeScheduled(VersionSource lostMemberVersionID) {
     RegionVersionHolder regionVersionHolder =
         getVersionVector().getHolderForMember(lostMemberVersionID);
@@ -1308,6 +1314,11 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     }
   }
 
+  /**
+   * This method checks region version holder to see if regionSynchronizeScheduledOrDone is
+   * set to true for the lost member. If it is not, the regionSynchronizeScheduledOrDone variable
+   * is set to true and returns true. If it is already set to true, do nothing and returns false.
+   */
   public boolean setRegionSynchronizedWithIfNotScheduled(VersionSource lostMemberVersionID) {
     RegionVersionHolder regionVersionHolder =
         getVersionVector().getHolderForMember(lostMemberVersionID);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -1904,6 +1904,16 @@ public class InitialImageOperation {
           null, null);
     }
 
+    /**
+     * If there is no region sync scheduled after checking region version holder holding the
+     * lost member. Region sync requests are sent to members hosting the region.
+     * This is only executed when processing region sync requests from other members hosting the
+     * region.
+     * Region sync is triggered by a member departed event. If this member exists during the
+     * event, region sync would be scheduled. This method is only handles the case when
+     * node is recently joining the cluster or restarted, and does not get the member departed
+     * event.
+     */
     void synchronizeIfNotScheduled(DistributedRegion region,
         InternalDistributedMember lostMember, VersionSource lostVersionSource) {
       if (region.setRegionSynchronizedWithIfNotScheduled(lostVersionSource)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -808,6 +808,7 @@ public class InitialImageOperation {
   boolean processChunk(List entries, InternalDistributedMember sender, Version remoteVersion)
       throws IOException, ClassNotFoundException {
     final boolean isDebugEnabled = logger.isDebugEnabled();
+    final boolean isTraceEnabled = logger.isTraceEnabled();
 
     // one volatile read of test flag
     int slow = slowImageProcessing;
@@ -895,8 +896,8 @@ public class InitialImageOperation {
         if (diskRegion != null) {
           // verify if entry from GII is the same as the one from recovery
           RegionEntry regionEntry = this.entries.getEntry(entry.key);
-          if (isDebugEnabled) {
-            logger.debug("processChunk:entry={},tag={},re={}", entry, tag, regionEntry);
+          if (isTraceEnabled) {
+            logger.trace("processChunk:entry={},tag={},re={}", entry, tag, regionEntry);
           }
           // re will be null if the gii chunk gives us a create
           if (regionEntry != null) {
@@ -973,8 +974,8 @@ public class InitialImageOperation {
             if (tag != null) {
               tag.replaceNullIDs(sender);
             }
-            if (isDebugEnabled) {
-              logger.debug(
+            if (isTraceEnabled) {
+              logger.trace(
                   "processChunk:initialImagePut:key={},lastModified={},tmpValue={},wasRecovered={},tag={}",
                   entry.key, lastModified, tmpValue, wasRecovered, tag);
             }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskStoreID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DiskStoreID.java
@@ -146,4 +146,9 @@ public class DiskStoreID implements VersionSource<DiskStoreID>, Serializable {
     return Long.toHexString(mostSig).substring(8);
   }
 
+  @Override
+  public boolean isDiskStoreId() {
+    return true;
+  }
+
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionHolder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionHolder.java
@@ -63,6 +63,8 @@ public class RegionVersionHolder<T> implements Cloneable, DataSerializable {
   private List<RVVException> exceptions;
   boolean isDepartedMember;
 
+  private transient boolean regionSynchronizeScheduledOrDone;
+
   // non final for tests
   @MutableForTesting
   public static int BIT_SET_WIDTH = 64 * 16; // should be a multiple of 4 64-bit longs
@@ -140,8 +142,6 @@ public class RegionVersionHolder<T> implements Cloneable, DataSerializable {
     return getExceptions().toString();
   }
 
-
-  /* test only method */
   public void setVersion(long ver) {
     this.version = ver;
   }
@@ -383,7 +383,7 @@ public class RegionVersionHolder<T> implements Cloneable, DataSerializable {
   /**
    * Add an exception that is older than this.bitSetVersion.
    */
-  protected synchronized void addException(long previousVersion, long nextVersion) {
+  synchronized void addException(long previousVersion, long nextVersion) {
     if (this.exceptions == null) {
       this.exceptions = new LinkedList<RVVException>();
     }
@@ -791,4 +791,19 @@ public class RegionVersionHolder<T> implements Cloneable, DataSerializable {
     return canon;
   }
 
+  private synchronized boolean isRegionSynchronizeScheduledOrDone() {
+    return regionSynchronizeScheduledOrDone;
+  }
+
+  public synchronized void setRegionSynchronizeScheduled() {
+    regionSynchronizeScheduledOrDone = true;
+  }
+
+  public synchronized boolean setRegionSynchronizeScheduledOrDoneIfNot() {
+    if (!isRegionSynchronizeScheduledOrDone()) {
+      regionSynchronizeScheduledOrDone = true;
+      return true;
+    }
+    return false;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionSource.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/VersionSource.java
@@ -31,4 +31,8 @@ import org.apache.geode.internal.DataSerializableFixedID;
 public interface VersionSource<T> extends DataSerializableFixedID, Comparable<T> {
 
   void writeEssentialData(DataOutput out) throws IOException;
+
+  default boolean isDiskStoreId() {
+    return false;
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.versions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import org.apache.geode.internal.cache.persistence.DiskStoreID;
+
+public class RegionVersionHolderTest {
+  @Test
+  public void setRegionSynchronizeScheduledCanSetSyncScheduledOrDone() {
+    DiskStoreID server = new DiskStoreID(0, 0);
+    RegionVersionHolder holder = new RegionVersionHolder(server);
+
+    holder.setRegionSynchronizeScheduled();
+    assertThat(holder.setRegionSynchronizeScheduledOrDoneIfNot()).isFalse();
+  }
+
+  @Test
+  public void setRegionSynchronizeScheduledOrDoneIfNotReturnsTrueIfSyncScheduledNotSet() {
+    DiskStoreID server = new DiskStoreID(0, 0);
+    RegionVersionHolder holder = new RegionVersionHolder(server);
+
+    assertThat(holder.setRegionSynchronizeScheduledOrDoneIfNot()).isTrue();
+    assertThat(holder.setRegionSynchronizeScheduledOrDoneIfNot()).isFalse();
+  }
+}


### PR DESCRIPTION
 * Region sync will be invoked to avoid data inconsistency on a newly joined/restarted member
   if it received a region synchronization request from other members due to timed task.
 * Use a flag in RegionVersionHolder to ensure only one such call is executed.
 * Make sure RVV exception is filled for persistent member requesting region sync. (This may
   leads to CommitConflictException on some transactions on persistent regions due to this
   region sync operation. But it should be rare and is acceptable compared to data inconsistency
   issue.)
