### PR TITLE
GEODE-6803: Make CacheElement an interface and have RuntimeCacheEleme…

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -286,6 +286,7 @@ javadoc/org/apache/geode/cache/client/SubscriptionNotEnabledException.html
 javadoc/org/apache/geode/cache/client/package-frame.html
 javadoc/org/apache/geode/cache/client/package-summary.html
 javadoc/org/apache/geode/cache/client/package-tree.html
+javadoc/org/apache/geode/cache/configuration/AbstractCacheElement.html
 javadoc/org/apache/geode/cache/configuration/CacheConfig.AsyncEventQueue.html
 javadoc/org/apache/geode/cache/configuration/CacheConfig.CacheServer.html
 javadoc/org/apache/geode/cache/configuration/CacheConfig.GatewayHub.Gateway.GatewayEndpoint.html

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/configuration/RegionMapping.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/configuration/RegionMapping.java
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.XmlType;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.annotations.Experimental;
-import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.cache.configuration.AbstractCacheElement;
 import org.apache.geode.cache.configuration.XSDRootElement;
 
 /**
@@ -40,7 +40,7 @@ import org.apache.geode.cache.configuration.XSDRootElement;
 @XmlRootElement(name = "mapping", namespace = "http://geode.apache.org/schema/jdbc")
 @XSDRootElement(namespace = "http://geode.apache.org/schema/jdbc",
     schemaLocation = "http://geode.apache.org/schema/jdbc/jdbc-1.0.xsd")
-public class RegionMapping extends CacheElement {
+public class RegionMapping extends AbstractCacheElement {
 
   @XmlElement(name = "field-mapping", namespace = "http://geode.apache.org/schema/jdbc")
   protected final List<FieldMapping> fieldMappings = new ArrayList<>();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -185,8 +185,7 @@ public class LocatorClusterManagementService implements ClusterManagementService
     List<RuntimeCacheElement> resultList = new ArrayList<>();
 
     // get a list of all the resultList from all groups that satisfy the filter criteria (all
-    // filters
-    // have been applied except the group)
+    // filters have been applied except the group)
     for (String group : persistenceService.getGroups()) {
       CacheConfig currentPersistedConfig = persistenceService.getCacheConfig(group, true);
       List<RuntimeCacheElement> listInGroup = manager.list(filter, currentPersistedConfig);

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -121,7 +121,7 @@ org/apache/geode/cache/client/internal/ContainsKeyOp$MODE,false
 org/apache/geode/cache/client/internal/TXSynchronizationOp$CompletionType,false
 org/apache/geode/cache/client/internal/pooling/ConnectionDestroyedException,true,-6918516787578041316
 org/apache/geode/cache/configuration/CacheConfig$AsyncEventQueue,false,asyncEventListener:org/apache/geode/cache/configuration/DeclarableType,batchSize:java/lang/String,batchTimeInterval:java/lang/String,diskStoreName:java/lang/String,diskSynchronous:java/lang/Boolean,dispatcherThreads:java/lang/String,enableBatchConflation:java/lang/Boolean,forwardExpirationDestroy:java/lang/Boolean,gatewayEventFilters:java/util/List,gatewayEventSubstitutionFilter:org/apache/geode/cache/configuration/DeclarableType,id:java/lang/String,maximumQueueMemory:java/lang/String,orderPolicy:java/lang/String,parallel:java/lang/Boolean,persistent:java/lang/Boolean
-org/apache/geode/cache/configuration/CacheElement,false,group:java/lang/String
+org/apache/geode/cache/configuration/AbstractCacheElement,false,group:java/lang/String
 org/apache/geode/cache/configuration/ClassNameType,false,className:java/lang/String
 org/apache/geode/cache/configuration/DeclarableType,false,parameters:java/util/List
 org/apache/geode/cache/configuration/DiskDirsType,false,diskDirs:java/util/List

--- a/geode-core/src/test/java/org/apache/geode/cache/configuration/RegionConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/configuration/RegionConfigTest.java
@@ -257,4 +257,17 @@ public class RegionConfigTest {
     assertThatThrownBy(() -> validator.validate(config))
         .isInstanceOf(IllegalArgumentException.class);
   }
+
+  @Test
+  public void regionWithGroup() throws Exception {
+    RegionConfig regionConfig = new RegionConfig();
+    regionConfig.setName("test");
+    regionConfig.setType("REPLICATE");
+    regionConfig.setGroup("group");
+
+    CacheConfig cacheConfig = new CacheConfig();
+    cacheConfig.getRegions().add(regionConfig);
+    String xml = service.marshall(cacheConfig);
+    assertThat(xml).doesNotContain("group");
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/config/JAXBServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/config/JAXBServiceTest.java
@@ -31,8 +31,8 @@ import javax.xml.bind.annotation.XmlType;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.cache.configuration.AbstractCacheElement;
 import org.apache.geode.cache.configuration.CacheConfig;
-import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.configuration.RegionType;
 
@@ -226,7 +226,7 @@ public class JAXBServiceTest {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlType(name = "", propOrder = {"id", "value"})
   @XmlRootElement(name = "custom-one", namespace = "http://geode.apache.org/schema/CustomOne")
-  public static class ElementOne extends CacheElement {
+  public static class ElementOne extends AbstractCacheElement {
     @XmlElement(name = "id", namespace = "http://geode.apache.org/schema/CustomOne")
     private String id;
     @XmlElement(name = "value", namespace = "http://geode.apache.org/schema/CustomOne")
@@ -259,7 +259,7 @@ public class JAXBServiceTest {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlType(name = "", propOrder = {"id", "value"})
   @XmlRootElement(name = "custom-two", namespace = "http://geode.apache.org/schema/CustomTwo")
-  public static class ElementTwo extends CacheElement {
+  public static class ElementTwo extends AbstractCacheElement {
     @XmlElement(name = "id", namespace = "http://geode.apache.org/schema/CustomTwo")
     private String id;
     @XmlElement(name = "value", namespace = "http://geode.apache.org/schema/CustomTwo")

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/configuration/Index.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/management/configuration/Index.java
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.cache.configuration.AbstractCacheElement;
 import org.apache.geode.cache.configuration.DeclarableType;
 import org.apache.geode.cache.configuration.XSDRootElement;
 
@@ -71,7 +71,7 @@ import org.apache.geode.cache.configuration.XSDRootElement;
 @XmlRootElement(name = "index", namespace = "http://geode.apache.org/schema/lucene")
 @XSDRootElement(namespace = "http://geode.apache.org/schema/lucene",
     schemaLocation = "http://geode.apache.org/schema/lucene/lucene-1.0.xsd")
-public class Index extends CacheElement {
+public class Index extends AbstractCacheElement {
   @XmlElement(namespace = "http://geode.apache.org/schema/lucene", required = true)
   protected List<Index.Field> field;
   @XmlElement(namespace = "http://geode.apache.org/schema/lucene")

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/AbstractCacheElement.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/AbstractCacheElement.java
@@ -20,6 +20,8 @@ package org.apache.geode.cache.configuration;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.bind.annotation.XmlTransient;
+
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.annotations.Experimental;
@@ -32,6 +34,7 @@ public abstract class AbstractCacheElement implements CacheElement {
    * this returns a non-null value
    * for cluster level element, it will return "cluster" for sure.
    */
+  @XmlTransient
   public String getConfigGroup() {
     String group = getGroup();
     if (StringUtils.isBlank(group)) {
@@ -44,6 +47,7 @@ public abstract class AbstractCacheElement implements CacheElement {
    * this returns the first group set by the user
    * if no group is set, this returns null
    */
+  @XmlTransient
   public String getGroup() {
     if (groups.size() == 0) {
       return null;

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/AbstractCacheElement.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/AbstractCacheElement.java
@@ -15,28 +15,48 @@
  * limitations under the License.
  */
 
-package org.apache.geode.management.internal.configuration.mutators;
+package org.apache.geode.cache.configuration;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.apache.geode.annotations.Experimental;
-import org.apache.geode.cache.configuration.CacheConfig;
-import org.apache.geode.cache.configuration.CacheElement;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
 
-/**
- * Defines the behavior to mutate a configuration change into a pre-existing cache config from a
- * locator
- * {@link org.apache.geode.distributed.ConfigurationPersistenceService}. Created with an object of
- * type {@link CacheElement}, which represents the configuration change.
- */
 @Experimental
-public interface ConfigurationManager<T extends CacheElement> {
-  void add(T config, CacheConfig existing);
+public abstract class AbstractCacheElement implements CacheElement {
+  protected List<String> groups = new ArrayList<>();
 
-  void update(T config, CacheConfig existing);
+  /**
+   * this returns a non-null value
+   * for cluster level element, it will return "cluster" for sure.
+   */
+  public String getConfigGroup() {
+    String group = getGroup();
+    if (StringUtils.isBlank(group)) {
+      return "cluster";
+    }
+    return group;
+  }
 
-  void delete(T config, CacheConfig existing);
+  /**
+   * this returns the first group set by the user
+   * if no group is set, this returns null
+   */
+  public String getGroup() {
+    if (groups.size() == 0) {
+      return null;
+    }
+    return groups.get(0);
+  }
 
-  List<? extends RuntimeCacheElement> list(T filterConfig, CacheConfig existing);
+  public void setGroup(String group) {
+    groups.clear();
+
+    if (StringUtils.isBlank(group)) {
+      return;
+    }
+    groups.add(group);
+  }
 }

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
@@ -1108,7 +1108,7 @@ public class CacheConfig {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlType(name = "",
       propOrder = {"gatewayEventFilters", "gatewayEventSubstitutionFilter", "asyncEventListener"})
-  public static class AsyncEventQueue extends CacheElement {
+  public static class AsyncEventQueue extends AbstractCacheElement {
 
     @XmlElement(name = "gateway-event-filter", namespace = "http://geode.apache.org/schema/cache")
     protected List<DeclarableType> gatewayEventFilters;

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/CacheElement.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/CacheElement.java
@@ -1,24 +1,21 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package org.apache.geode.cache.configuration;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlTransient;
@@ -26,25 +23,20 @@ import javax.xml.bind.annotation.XmlTransient;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import org.apache.commons.lang3.StringUtils;
 
-import org.apache.geode.annotations.Experimental;
 import org.apache.geode.lang.Identifiable;
 
-@Experimental
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
-public abstract class CacheElement implements Identifiable<String>, Serializable {
-  protected List<String> groups = new ArrayList<>();
-
-  public static <T extends Identifiable> boolean exists(List<T> list, String id) {
+public interface CacheElement extends Identifiable<String>, Serializable {
+  static <T extends Identifiable> boolean exists(List<T> list, String id) {
     return list.stream().anyMatch(o -> o.getId().equals(id));
   }
 
-  public static <T extends Identifiable> T findElement(List<T> list, String id) {
+  static <T extends Identifiable> T findElement(List<T> list, String id) {
     return list.stream().filter(o -> o.getId().equals(id)).findFirst().orElse(null);
   }
 
-  public static <T extends Identifiable> void removeElement(List<T> list, String id) {
+  static <T extends Identifiable> void removeElement(List<T> list, String id) {
     list.removeIf(t -> t.getId().equals(id));
   }
 
@@ -54,33 +46,15 @@ public abstract class CacheElement implements Identifiable<String>, Serializable
    */
   @XmlTransient
   @JsonIgnore
-  public String getConfigGroup() {
-    String group = getGroup();
-    if (StringUtils.isBlank(group)) {
-      return "cluster";
-    }
-    return group;
-  }
+  String getConfigGroup();
 
   /**
    * this returns the first group set by the user
    * if no group is set, this returns null
    */
   @XmlTransient
-  public String getGroup() {
-    if (groups.size() == 0) {
-      return null;
-    }
-    return groups.get(0);
-  }
+  String getGroup();
 
   @JsonSetter
-  public void setGroup(String group) {
-    groups.clear();
-
-    if (StringUtils.isBlank(group)) {
-      return;
-    }
-    groups.add(group);
-  }
+  void setGroup(String group);
 }

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/DiskStoreType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/DiskStoreType.java
@@ -70,7 +70,7 @@ import org.apache.geode.annotations.Experimental;
 @XmlType(name = "disk-store-type", namespace = "http://geode.apache.org/schema/cache",
     propOrder = {"diskDirs"})
 @Experimental
-public class DiskStoreType extends CacheElement {
+public class DiskStoreType extends AbstractCacheElement {
 
   @XmlElement(name = "disk-dirs", namespace = "http://geode.apache.org/schema/cache")
   protected DiskDirsType diskDirs;

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/JndiBindingsType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/JndiBindingsType.java
@@ -202,7 +202,7 @@ public class JndiBindingsType {
   @XmlAccessorType(XmlAccessType.FIELD)
   @XmlType(name = "", propOrder = {"configProperties"})
   @Experimental
-  public static class JndiBinding extends CacheElement {
+  public static class JndiBinding extends AbstractCacheElement {
 
     @XmlElement(name = "config-property", namespace = "http://geode.apache.org/schema/cache")
     protected List<ConfigProperty> configProperties;
@@ -628,7 +628,7 @@ public class JndiBindingsType {
     @XmlAccessorType(XmlAccessType.FIELD)
     @XmlType(name = "",
         propOrder = {"configPropertyName", "configPropertyType", "configPropertyValue"})
-    public static class ConfigProperty extends CacheElement {
+    public static class ConfigProperty extends AbstractCacheElement {
 
       @XmlElement(name = "config-property-name", namespace = "http://geode.apache.org/schema/cache",
           required = true)

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
@@ -155,7 +155,7 @@ import org.apache.geode.management.api.RestfulEndpoint;
 @XmlType(name = "region-type", namespace = "http://geode.apache.org/schema/cache",
     propOrder = {"regionAttributes", "indexes", "entries", "regionElements", "regions"})
 @Experimental
-public class RegionConfig extends CacheElement implements RestfulEndpoint {
+public class RegionConfig extends AbstractCacheElement implements RestfulEndpoint {
 
   public static final String REGION_CONFIG_ENDPOINT = "/regions";
 
@@ -521,7 +521,7 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
    *
    */
   @XmlAccessorType(XmlAccessType.FIELD)
-  public static class Index extends CacheElement implements RestfulEndpoint {
+  public static class Index extends AbstractCacheElement implements RestfulEndpoint {
     @XmlAttribute(name = "name", required = true)
     protected String name;
     @XmlAttribute(name = "expression")

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.geode.annotations.Experimental;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
+import org.apache.geode.cache.configuration.CacheElement;
 
 @Experimental
 public class ClusterManagementResult {
@@ -62,7 +62,7 @@ public class ClusterManagementResult {
   private String statusMessage;
 
   @JsonProperty
-  private List<? extends RuntimeCacheElement> result = new ArrayList<>();
+  private List<? extends CacheElement> result = new ArrayList<>();
 
   public ClusterManagementResult() {}
 
@@ -112,11 +112,11 @@ public class ClusterManagementResult {
     return statusCode;
   }
 
-  public <R extends RuntimeCacheElement> List<R> getResult(Class<R> clazz) {
+  public <R extends CacheElement> List<R> getResult(Class<R> clazz) {
     return result.stream().map(clazz::cast).collect(Collectors.toList());
   }
 
-  public void setResult(List<? extends RuntimeCacheElement> result) {
+  public void setResult(List<? extends CacheElement> result) {
     this.result = result;
   }
 }

--- a/geode-management/src/main/java/org/apache/geode/management/configuration/MemberConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/management/configuration/MemberConfig.java
@@ -21,11 +21,12 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import org.apache.geode.annotations.Experimental;
-import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.cache.configuration.AbstractCacheElement;
 import org.apache.geode.management.api.RestfulEndpoint;
 
 @Experimental
-public class MemberConfig extends CacheElement implements RuntimeCacheElement, RestfulEndpoint {
+public class MemberConfig extends AbstractCacheElement
+    implements RuntimeCacheElement, RestfulEndpoint {
 
   private static final long serialVersionUID = -6262538068604902018L;
 

--- a/geode-management/src/main/java/org/apache/geode/management/configuration/RuntimeCacheElement.java
+++ b/geode-management/src/main/java/org/apache/geode/management/configuration/RuntimeCacheElement.java
@@ -15,18 +15,15 @@
 
 package org.apache.geode.management.configuration;
 
-import java.io.Serializable;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlTransient;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-import org.apache.geode.lang.Identifiable;
+import org.apache.geode.cache.configuration.CacheElement;
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
-public interface RuntimeCacheElement extends Identifiable<String>, Serializable {
+public interface RuntimeCacheElement extends CacheElement {
   @XmlTransient
   List<String> getGroups();
 


### PR DESCRIPTION
…nt should extends CacheElement

Basically our old `CacheElement` is the new `AbstractCacheElement` and the new `CacheElement` is just an interface.


Thank you for submitting a contribution to Apache Geode.
In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
