### PR TITLE
GEODE-6765: Gfsh list* commands do not return error when no results found

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommandDUnitTest.java
@@ -51,9 +51,6 @@ public class ListAsyncEventQueuesCommandDUnitTest {
 
   @Test
   public void list() {
-    gfsh.executeAndAssertThat("list async-event-queue").statusIsSuccess()
-        .containsOutput(CliStrings.LIST_ASYNC_EVENT_QUEUES__NO_QUEUES_FOUND_MESSAGE);
-
     gfsh.executeAndAssertThat("create async-event-queue --id=queue1 --group=group1 --listener="
         + MyAsyncEventListener.class.getName()).statusIsSuccess();
 
@@ -78,5 +75,14 @@ public class ListAsyncEventQueuesCommandDUnitTest {
         .tableHasRowWithValues("Member", "ID", "server-1", "queue")
         .tableHasRowWithValues("Member", "ID", "server-2", "queue");
 
+    gfsh.executeAndAssertThat("destroy async-event-queue --id=queue").statusIsSuccess();
+    gfsh.executeAndAssertThat("destroy async-event-queue --id=queue1").statusIsSuccess();
+    gfsh.executeAndAssertThat("destroy async-event-queue --id=queue2").statusIsSuccess();
+  }
+
+  @Test
+  public void ensureNoResultIsSuccess() {
+    gfsh.executeAndAssertThat("list async-event-queue").statusIsSuccess()
+        .containsOutput(CliStrings.LIST_ASYNC_EVENT_QUEUES__NO_QUEUES_FOUND_MESSAGE);
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ListRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ListRegionDUnitTest.java
@@ -123,6 +123,13 @@ public class ListRegionDUnitTest {
         REGION2, REGION3, SUBREGION1A);
   }
 
+  @Test
+  public void listNoMembersIsSuccess() {
+    CommandStringBuilder csb = new CommandStringBuilder(LIST_REGION);
+    csb.addOption(GROUP, "unknown");
+    gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
+  }
+
   private static void createLocalRegion(final String regionName) {
     final Cache cache = CacheFactory.getAnyInstance();
     // Create the data region

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/CliUtil.java
@@ -551,7 +551,7 @@ public class CliUtil {
           null, workingDir);
       p.waitFor();
     } catch (IOException | InterruptedException e) {
-      Gfsh.printlnErr(e.getMessage());
+      Gfsh.println(e.getMessage());
     } finally {
       if (file != null)
         file.delete();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesCommand.java
@@ -48,7 +48,7 @@ public class ListAsyncEventQueuesCommand extends GfshCommand {
   public ResultModel listAsyncEventQueues() {
     Set<DistributedMember> targetMembers = getAllNormalMembers();
     if (targetMembers.isEmpty()) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      return ResultModel.createInfo(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
 
     // Each (successful) member returns a list of AsyncEventQueueDetails.

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListClientCommand.java
@@ -51,7 +51,7 @@ public class ListClientCommand extends GfshCommand {
     ObjectName[] cacheServers = service.getDistributedSystemMXBean().listCacheServerObjectNames();
 
     if (cacheServers.length == 0) {
-      return ResultModel.createError(
+      return ResultModel.createInfo(
           CliStrings.format(CliStrings.LIST_CLIENT_COULD_NOT_RETRIEVE_SERVER_LIST));
     }
 
@@ -81,7 +81,7 @@ public class ListClientCommand extends GfshCommand {
     }
 
     if (clientServerMap.size() == 0) {
-      return ResultModel.createError(
+      return ResultModel.createInfo(
           CliStrings.format(CliStrings.LIST_COULD_NOT_RETRIEVE_CLIENT_LIST));
     }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDeployedCommand.java
@@ -51,7 +51,7 @@ public class ListDeployedCommand extends GfshCommand {
 
     Set<DistributedMember> targetMembers = findMembers(group, null);
     if (targetMembers.isEmpty()) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      return ResultModel.createInfo(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
 
     ResultModel result = new ResultModel();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListDurableClientCQsCommand.java
@@ -56,7 +56,7 @@ public class ListDurableClientCQsCommand extends GfshCommand {
     Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
     if (targetMembers.isEmpty()) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      return ResultModel.createInfo(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
 
     final ResultCollector<?, ?> rc =
@@ -72,7 +72,7 @@ public class ListDurableClientCQsCommand extends GfshCommand {
         table.accumulate("Status", oneResult.getStatus());
         table.accumulate("CQ Name", oneResult.getStatusMessage());
 
-        if (!oneResult.isSuccessful()) {
+        if (!(oneResult.isSuccessful() || oneResult.isIgnorableFailure())) {
           result.setStatus(Result.Status.ERROR);
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListFunctionCommand.java
@@ -53,7 +53,7 @@ public class ListFunctionCommand extends GfshCommand {
     Set<DistributedMember> targetMembers = findMembers(groups, members);
 
     if (targetMembers.isEmpty()) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      return ResultModel.createInfo(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
 
     List<CliFunctionResult> results = executeAndGetFunctionResult(this.listFunctionFunction,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListGatewayCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListGatewayCommand.java
@@ -62,7 +62,7 @@ public class ListGatewayCommand extends GfshCommand {
     Set<DistributedMember> dsMembers = findMembers(onGroup, onMember);
 
     if (dsMembers.isEmpty()) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      return ResultModel.createInfo(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
 
     Map<String, Map<String, GatewaySenderMXBean>> gatewaySenderBeans = new TreeMap<>();
@@ -104,7 +104,7 @@ public class ListGatewayCommand extends GfshCommand {
       }
     }
     if (gatewaySenderBeans.isEmpty() && gatewayReceiverBeans.isEmpty()) {
-      return ResultModel.createError(CliStrings.GATEWAYS_ARE_NOT_AVAILABLE_IN_CLUSTER);
+      return ResultModel.createInfo(CliStrings.GATEWAYS_ARE_NOT_AVAILABLE_IN_CLUSTER);
     }
 
     accumulateListGatewayResult(result, gatewaySenderBeans, gatewayReceiverBeans);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/ListRegionCommand.java
@@ -63,7 +63,7 @@ public class ListRegionCommand extends GfshCommand {
     Set<DistributedMember> targetMembers = findMembers(group, memberNameOrId);
 
     if (targetMembers.isEmpty()) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      return ResultModel.createInfo(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
     }
 
     TabularResultModel resultData = result.addTable("regionInfo");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ListDurableCqNamesFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/ListDurableCqNamesFunction.java
@@ -68,28 +68,28 @@ public class ListDurableCqNamesFunction implements InternalFunction {
     try {
       CacheClientNotifier ccn = CacheClientNotifier.getInstance();
       if (ccn == null) {
-        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.ERROR,
+        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.IGNORABLE,
             CliStrings.NO_CLIENT_FOUND));
         return results;
       }
 
       CacheClientProxy ccp = ccn.getClientProxy(durableClientId);
       if (ccp == null) {
-        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.ERROR,
+        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.IGNORABLE,
             CliStrings.format(CliStrings.NO_CLIENT_FOUND_WITH_CLIENT_ID, durableClientId)));
         return results;
       }
 
       CqService cqService = ccp.getCache().getCqService();
       if (cqService == null || !cqService.isRunning()) {
-        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.ERROR,
+        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.IGNORABLE,
             CliStrings.LIST_DURABLE_CQS__NO__CQS__REGISTERED));
         return results;
       }
 
       List<String> durableCqNames = cqService.getAllDurableClientCqs(ccp.getProxyID());
       if (durableCqNames == null || durableCqNames.isEmpty()) {
-        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.ERROR,
+        results.add(new CliFunctionResult(memberNameOrId, CliFunctionResult.StatusState.IGNORABLE,
             CliStrings
                 .format(CliStrings.LIST_DURABLE_CQS__NO__CQS__FOR__CLIENT, durableClientId)));
         return results;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -272,15 +272,15 @@ public class Gfsh extends JLineShell {
     gfshout.println();
   }
 
-  public static <T> void println(T toPrint) {
+  public static void println(Object toPrint) {
     gfshout.println(toPrint);
   }
 
-  public static <T> void print(T toPrint) {
+  public static void print(Object toPrint) {
     gfshout.print(toPrint);
   }
 
-  public static <T> void printlnErr(T toPrint) {
+  public static void printlnErr(Object toPrint) {
     gfsherr.println(toPrint);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/ListAsyncEventQueuesTest.java
@@ -66,7 +66,7 @@ public class ListAsyncEventQueuesTest {
     doReturn(Collections.emptySet()).when(command).getAllNormalMembers();
 
     // Command should succeed with one row of data
-    gfsh.executeAndAssertThat(command, COMMAND).statusIsError()
+    gfsh.executeAndAssertThat(command, COMMAND).statusIsSuccess()
         .containsOutput(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
   }
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DurableClientCommandsDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DurableClientCommandsDUnitTest.java
@@ -135,10 +135,10 @@ public class DurableClientCommandsDUnitTest {
     csb.addOption(CliStrings.LIST_DURABLE_CQS__DURABLECLIENTID, CLIENT_NAME);
     String commandString = csb.toString();
 
-    gfsh.executeAndAssertThat(commandString).statusIsError()
+    gfsh.executeAndAssertThat(commandString).statusIsSuccess()
         .hasTableSection()
-        .hasColumn("CQ Name")
-        .containsExactlyInAnyOrder(
+        .hasColumn("Status").containsExactlyInAnyOrder("IGNORED", "IGNORED")
+        .hasColumn("CQ Name").containsExactlyInAnyOrder(
             CliStrings.format(CliStrings.NO_CLIENT_FOUND_WITH_CLIENT_ID, CLIENT_NAME),
             CliStrings.format(CliStrings.NO_CLIENT_FOUND_WITH_CLIENT_ID, CLIENT_NAME));
   }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DurableClientCommandsDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DurableClientCommandsDUnitTest.java
@@ -121,8 +121,9 @@ public class DurableClientCommandsDUnitTest {
     csb.addOption(CliStrings.LIST_DURABLE_CQS__DURABLECLIENTID, CLIENT_NAME);
     commandString = csb.toString();
 
-    gfsh.executeAndAssertThat(commandString).statusIsError()
+    gfsh.executeAndAssertThat(commandString).statusIsSuccess()
         .hasTableSection()
+        .hasColumn("Status").containsExactly("IGNORED", "IGNORED")
         .hasColumn("CQ Name")
         .containsExactlyInAnyOrder(
             CliStrings.format(CliStrings.LIST_DURABLE_CQS__NO__CQS__FOR__CLIENT, CLIENT_NAME),
@@ -151,8 +152,9 @@ public class DurableClientCommandsDUnitTest {
     csb.addOption(CliStrings.LIST_DURABLE_CQS__DURABLECLIENTID, CLIENT_NAME);
     String commandString = csb.toString();
 
-    gfsh.executeAndAssertThat(commandString).statusIsError()
+    gfsh.executeAndAssertThat(commandString).statusIsSuccess()
         .hasTableSection()
+        .hasColumn("Status").containsExactlyInAnyOrder("IGNORED", "OK", "OK", "OK")
         .hasColumn("CQ Name")
         .containsExactlyInAnyOrder("cq1", "cq2", "cq3", "No client found with client-id : dc1");
 

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/CommandResultAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/CommandResultAssert.java
@@ -281,7 +281,9 @@ public class CommandResultAssert
   // convenience method to get the first table section. if more than one table section
   // use the sectionName to get it
   public TabularResultModelAssert hasTableSection() {
-    return new TabularResultModelAssert(getResultModel().getTableSections().get(0));
+    List<TabularResultModel> table = getResultModel().getTableSections();
+    assertThat(table.size()).isGreaterThan(0);
+    return new TabularResultModelAssert(table.get(0));
   }
 
   public TabularResultModelAssert hasTableSection(String sectionName) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewaySenderCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewaySenderCommandDUnitTest.java
@@ -82,7 +82,7 @@ public class DestroyGatewaySenderCommandDUnitTest {
 
     locatorSite1.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(0);
 
-    gfsh.executeAndAssertThat("list gateways").statusIsError()
+    gfsh.executeAndAssertThat("list gateways").statusIsSuccess()
         .containsOutput("GatewaySenders or GatewayReceivers are not available in cluster");
   }
 
@@ -100,7 +100,7 @@ public class DestroyGatewaySenderCommandDUnitTest {
 
     locatorSite1.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(0);
 
-    gfsh.executeAndAssertThat("list gateways").statusIsError()
+    gfsh.executeAndAssertThat("list gateways").statusIsSuccess()
         .containsOutput("GatewaySenders or GatewayReceivers are not available in cluster");
   }
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/ListGatewaysCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/ListGatewaysCommandDUnitTest.java
@@ -89,7 +89,7 @@ public class ListGatewaysCommandDUnitTest implements Serializable {
     locatorSite1.invoke(() -> validateMemberMXBeanProxy(getMember(server3.getVM())));
 
     String command = CliStrings.LIST_GATEWAY;
-    gfsh.executeAndAssertThat(command).statusIsError();
+    gfsh.executeAndAssertThat(command).statusIsSuccess();
   }
 
   @Test

--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
@@ -54,7 +54,7 @@ public class CommandOverHttpTest {
   @Test
   public void testListClient() throws Exception {
     gfshRule.executeAndAssertThat("list clients")
-        .statusIsError()
+        .statusIsSuccess()
         .hasInfoSection().hasOutput()
         .isEqualTo("No clients were retrieved for cache-servers.");
   }


### PR DESCRIPTION
- This also includes not returning an error when no members are found to
  execute against.

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
