### PR TITLE
GEODE-6803: be able to configure pdx using management rest api

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
@@ -132,7 +132,7 @@ public class ListIndexManagementDUnitTest {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     assertThatThrownBy(() -> cms.get(index)).isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Id is required");
+        .hasMessageContaining("unable to construct the uri ");
   }
 
   @Test
@@ -140,7 +140,7 @@ public class ListIndexManagementDUnitTest {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setName("index1");
     assertThatThrownBy(() -> cms.get(index)).isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("regionName is required");
+        .hasMessageContaining("unable to construct the uri ");
   }
 
   @Test

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/MemberManagementServiceDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/MemberManagementServiceDunitTest.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
 import org.apache.geode.management.configuration.MemberConfig;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
+import org.apache.geode.management.configuration.RuntimeMemberConfig;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 
@@ -54,10 +54,10 @@ public class MemberManagementServiceDunitTest {
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
-    assertThat(result.getResult(RuntimeCacheElement.class).size()).isEqualTo(2);
+    assertThat(result.getResult(CacheElement.class).size()).isEqualTo(2);
 
-    MemberConfig memberConfig =
-        (MemberConfig) CacheElement.findElement(result.getResult(RuntimeCacheElement.class),
+    RuntimeMemberConfig memberConfig =
+        CacheElement.findElement(result.getResult(RuntimeMemberConfig.class),
             "locator-0");
     assertThat(memberConfig.isCoordinator()).isTrue();
     assertThat(memberConfig.isLocator()).isTrue();
@@ -72,9 +72,9 @@ public class MemberManagementServiceDunitTest {
     ClusterManagementResult result = cmsClient.list(config);
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
-    assertThat(result.getResult(RuntimeCacheElement.class).size()).isEqualTo(1);
+    assertThat(result.getResult(CacheElement.class).size()).isEqualTo(1);
 
-    MemberConfig memberConfig = (MemberConfig) result.getResult(RuntimeCacheElement.class).get(0);
+    RuntimeMemberConfig memberConfig = result.getResult(RuntimeMemberConfig.class).get(0);
     assertThat(memberConfig.isCoordinator()).isTrue();
     assertThat(memberConfig.isLocator()).isTrue();
     assertThat(memberConfig.getPort()).isEqualTo(locator.getPort());
@@ -88,6 +88,6 @@ public class MemberManagementServiceDunitTest {
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode())
         .isEqualTo(ClusterManagementResult.StatusCode.OK);
-    assertThat(result.getResult(RuntimeCacheElement.class).size()).isEqualTo(0);
+    assertThat(result.getResult(CacheElement.class).size()).isEqualTo(0);
   }
 }

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -714,10 +714,11 @@ javadoc/org/apache/geode/management/client/ClusterManagementServiceBuilder.html
 javadoc/org/apache/geode/management/client/package-frame.html
 javadoc/org/apache/geode/management/client/package-summary.html
 javadoc/org/apache/geode/management/client/package-tree.html
-javadoc/org/apache/geode/management/configuration/MemberConfig.CacheServerConfig.html
 javadoc/org/apache/geode/management/configuration/MemberConfig.html
-javadoc/org/apache/geode/management/configuration/RuntimeCacheElement.html
+javadoc/org/apache/geode/management/configuration/MultiGroupCacheElement.html
 javadoc/org/apache/geode/management/configuration/RuntimeIndex.html
+javadoc/org/apache/geode/management/configuration/RuntimeMemberConfig.CacheServerConfig.html
+javadoc/org/apache/geode/management/configuration/RuntimeMemberConfig.html
 javadoc/org/apache/geode/management/configuration/RuntimeRegionConfig.html
 javadoc/org/apache/geode/management/configuration/package-frame.html
 javadoc/org/apache/geode/management/configuration/package-summary.html

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/UpdateCacheFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/UpdateCacheFunction.java
@@ -46,6 +46,12 @@ public class UpdateCacheFunction extends CliFunction<List> {
     Cache cache = context.getCache();
 
     ConfigurationRealizer realizer = realizers.get(cacheElement.getClass());
+
+    if (realizer == null) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.OK,
+          "Server needs to be restarted for this configuration change to be realized.");
+    }
+
     switch (operation) {
       case CREATE:
         realizer.create(cacheElement, cache);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/ConfigurationManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/ConfigurationManager.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.CacheElement;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
 
 /**
  * Defines the behavior to mutate a configuration change into a pre-existing cache config from a
@@ -38,5 +37,5 @@ public interface ConfigurationManager<T extends CacheElement> {
 
   void delete(T config, CacheConfig existing);
 
-  <R extends RuntimeCacheElement> List<R> list(T filterConfig, CacheConfig existing);
+  List<? extends T> list(T filterConfig, CacheConfig existing);
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/MemberConfigManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/MemberConfigManager.java
@@ -36,6 +36,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.configuration.MemberConfig;
+import org.apache.geode.management.configuration.RuntimeMemberConfig;
 import org.apache.geode.management.internal.cli.domain.CacheServerInfo;
 import org.apache.geode.management.internal.cli.domain.MemberInformation;
 import org.apache.geode.management.internal.cli.functions.GetMemberInformationFunction;
@@ -64,7 +65,7 @@ public class MemberConfigManager implements ConfigurationManager<MemberConfig> {
   }
 
   @Override
-  public List<MemberConfig> list(MemberConfig filter, CacheConfig existing) {
+  public List<RuntimeMemberConfig> list(MemberConfig filter, CacheConfig existing) {
     Set<DistributedMember> distributedMembers = getDistributedMembers(filter);
     if (distributedMembers.size() == 0) {
       return Collections.emptyList();
@@ -97,15 +98,15 @@ public class MemberConfigManager implements ConfigurationManager<MemberConfig> {
   }
 
   @VisibleForTesting
-  List<MemberConfig> generateMemberConfigs(ArrayList<MemberInformation> memberInformation) {
+  List<RuntimeMemberConfig> generateMemberConfigs(ArrayList<MemberInformation> memberInformation) {
     final String coordinatorId = getCoordinatorId();
     return memberInformation.stream().map(
         memberInfo -> generateMemberConfig(coordinatorId, memberInfo)).collect(Collectors.toList());
   }
 
   @VisibleForTesting
-  MemberConfig generateMemberConfig(String coordinatorId, MemberInformation memberInfo) {
-    MemberConfig member = new MemberConfig();
+  RuntimeMemberConfig generateMemberConfig(String coordinatorId, MemberInformation memberInfo) {
+    RuntimeMemberConfig member = new RuntimeMemberConfig();
     member.setId(memberInfo.getName());
     member.setHost(memberInfo.getHost());
     member.setPid(memberInfo.getProcessId());
@@ -119,7 +120,8 @@ public class MemberConfigManager implements ConfigurationManager<MemberConfig> {
 
     if (memberInfo.isServer()) {
       for (CacheServerInfo info : memberInfo.getCacheServeInfo()) {
-        MemberConfig.CacheServerConfig cacheServerConfig = new MemberConfig.CacheServerConfig();
+        RuntimeMemberConfig.CacheServerConfig cacheServerConfig =
+            new RuntimeMemberConfig.CacheServerConfig();
         cacheServerConfig.setPort(info.getPort());
         cacheServerConfig.setMaxConnections(info.getMaxConnections());
         cacheServerConfig.setMaxThreads(info.getMaxThreads());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/PdxManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/PdxManager.java
@@ -13,24 +13,32 @@
  * the License.
  */
 
-package org.apache.geode.management.configuration;
+package org.apache.geode.management.internal.configuration.mutators;
 
-import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlTransient;
+import org.apache.geode.cache.configuration.CacheConfig;
+import org.apache.geode.cache.configuration.PdxType;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+public class PdxManager implements ConfigurationManager<PdxType> {
+  @Override
+  public void add(PdxType config, CacheConfig existing) {
+    existing.setPdx(config);
+  }
 
-import org.apache.geode.lang.Identifiable;
+  @Override
+  public void update(PdxType config, CacheConfig existing) {
+    existing.setPdx(config);
+  }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
-public interface RuntimeCacheElement extends Identifiable<String>, Serializable {
-  @XmlTransient
-  List<String> getGroups();
+  @Override
+  public void delete(PdxType config, CacheConfig existing) {
 
-  @XmlTransient
-  @JsonIgnore
-  String getGroup();
+  }
+
+  @Override
+  public List<PdxType> list(PdxType filterConfig, CacheConfig existing) {
+    return Collections.singletonList(existing.getPdx());
+  }
 }

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -132,6 +132,7 @@ org/apache/geode/cache/configuration/JndiBindingsType$JndiBinding,false,blocking
 org/apache/geode/cache/configuration/JndiBindingsType$JndiBinding$ConfigProperty,false,configPropertyName:java/lang/String,configPropertyType:java/lang/String,configPropertyValue:java/lang/String
 org/apache/geode/cache/configuration/ObjectType,false,declarable:org/apache/geode/cache/configuration/DeclarableType,string:java/lang/String
 org/apache/geode/cache/configuration/ParameterType,false,name:java/lang/String
+org/apache/geode/cache/configuration/PdxType,false
 org/apache/geode/cache/configuration/RegionAttributesDataPolicy,false,value:java/lang/String
 org/apache/geode/cache/configuration/RegionAttributesIndexUpdateType,false,value:java/lang/String
 org/apache/geode/cache/configuration/RegionAttributesMirrorType,false,value:java/lang/String

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/ClusterManagementResultTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/ClusterManagementResultTest.java
@@ -24,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.management.api.ClusterManagementResult;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
 import org.apache.geode.util.internal.GeodeJsonMapper;
 
 public class ClusterManagementResultTest {
@@ -112,6 +112,6 @@ public class ClusterManagementResultTest {
     String json = "{\"statusCode\":\"OK\"}";
     ClusterManagementResult result =
         GeodeJsonMapper.getMapper().readValue(json, ClusterManagementResult.class);
-    assertThat(result.getResult(RuntimeCacheElement.class)).isNotNull().isEmpty();
+    assertThat(result.getResult(CacheElement.class)).isNotNull().isEmpty();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.management.internal.api;
 
-import static org.apache.geode.test.junit.assertions.ClusterManagementResultAssert.assertManagementResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -113,11 +112,11 @@ public class LocatorClusterManagementServiceTest {
   @Test
   public void create_validatorIsCalledCorrectly() throws Exception {
     doReturn(Collections.emptySet()).when(service).findMembers(anyString());
-    assertManagementResult(service.create(regionConfig))
-        .failed().hasStatusCode(ClusterManagementResult.StatusCode.ERROR)
-        .containsStatusMessage("No members found in group");
+    doNothing().when(persistenceService).updateCacheConfig(any(), any());
+    service.create(regionConfig);
     verify(cacheElementValidator).validate(CacheElementOperation.CREATE, regionConfig);
     verify(regionValidator).validate(CacheElementOperation.CREATE, regionConfig);
+    verify(regionValidator).exists(eq(regionConfig.getId()), any());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/mutators/MemberConfigManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/mutators/MemberConfigManagerTest.java
@@ -31,6 +31,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.configuration.MemberConfig;
+import org.apache.geode.management.configuration.RuntimeMemberConfig;
 import org.apache.geode.management.internal.cli.domain.CacheServerInfo;
 import org.apache.geode.management.internal.cli.domain.MemberInformation;
 
@@ -138,7 +139,7 @@ public class MemberConfigManagerTest {
     memberInformation.setLogFilePath(somePath);
     memberInformation.setWorkingDirPath(somePath);
 
-    MemberConfig memberConfig =
+    RuntimeMemberConfig memberConfig =
         memberConfigManager.generateMemberConfig("coordinatorId", memberInformation);
     assertThat(memberConfig.getId()).isEqualTo(someName);
     assertThat(memberConfig.getHost()).isEqualTo(someHost);
@@ -171,12 +172,12 @@ public class MemberConfigManagerTest {
     memberInformation.setId(memberId);
 
     String coordinatorId = "coordinatorId";
-    MemberConfig memberConfig =
+    RuntimeMemberConfig memberConfig =
         memberConfigManager.generateMemberConfig(coordinatorId, memberInformation);
 
     assertThat(memberConfig.isLocator()).isFalse();
     assertThat(memberConfig.isCoordinator()).isFalse();
-    MemberConfig.CacheServerConfig cacheServerConfig = memberConfig.getCacheServers().get(0);
+    RuntimeMemberConfig.CacheServerConfig cacheServerConfig = memberConfig.getCacheServers().get(0);
     assertThat(cacheServerConfig).isNotNull();
     assertThat(cacheServerConfig.getPort()).isEqualTo(somePort);
     assertThat(cacheServerConfig.getMaxConnections()).isEqualTo(someConnectionNumber);
@@ -193,7 +194,7 @@ public class MemberConfigManagerTest {
     memberInformation.setId(memberId);
 
     String coordinatorId = "coordinatorId";
-    MemberConfig memberConfig =
+    RuntimeMemberConfig memberConfig =
         memberConfigManager.generateMemberConfig(coordinatorId, memberInformation);
     assertThat(memberConfig.getPort()).isEqualTo(someLocatorPort);
     assertThat(memberConfig.isLocator()).isTrue();
@@ -207,7 +208,7 @@ public class MemberConfigManagerTest {
     String coordinatorId = "coordinatorId";
     memberInformation.setId(coordinatorId);
 
-    MemberConfig memberConfig =
+    RuntimeMemberConfig memberConfig =
         memberConfigManager.generateMemberConfig(coordinatorId, memberInformation);
     assertThat(memberConfig.isCoordinator()).isTrue();
   }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/ClusterManagementResultAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/ClusterManagementResultAssert.java
@@ -21,9 +21,9 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.MapAssert;
 
+import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.Status;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
 
 public class ClusterManagementResultAssert
     extends AbstractAssert<ClusterManagementResultAssert, ClusterManagementResult> {
@@ -56,12 +56,20 @@ public class ClusterManagementResultAssert
     return assertThat(actual.getMemberStatuses());
   }
 
-  public ListAssert<RuntimeCacheElement> hasListResult() {
-    return assertThat(actual.getResult(RuntimeCacheElement.class));
+  public ListAssert<CacheElement> hasListResult() {
+    return assertThat(actual.getResult(CacheElement.class));
+  }
+
+  public <T extends CacheElement> T getResult(int index, Class<T> clazz) {
+    return getActual().getResult(clazz).get(index);
   }
 
   public static ClusterManagementResultAssert assertManagementResult(
       ClusterManagementResult result) {
     return new ClusterManagementResultAssert(result, ClusterManagementResultAssert.class);
+  }
+
+  public ClusterManagementResult getActual() {
+    return actual;
   }
 }

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/PdxType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/PdxType.java
@@ -24,7 +24,10 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import org.apache.geode.annotations.Experimental;
+import org.apache.geode.management.api.RestfulEndpoint;
 
 
 /**
@@ -72,8 +75,7 @@ import org.apache.geode.annotations.Experimental;
 @XmlType(name = "pdx-type", namespace = "http://geode.apache.org/schema/cache",
     propOrder = {"pdxSerializer"})
 @Experimental
-public class PdxType {
-
+public class PdxType extends CacheElement implements RestfulEndpoint {
   @XmlElement(name = "pdx-serializer", namespace = "http://geode.apache.org/schema/cache")
   protected DeclarableType pdxSerializer;
   @XmlAttribute(name = "read-serialized")
@@ -195,4 +197,28 @@ public class PdxType {
     this.diskStoreName = value;
   }
 
+  public static final String PDX_ID = "PDX";
+  public static final String PDX_ENDPOINT = "/configurations/pdx";
+
+  @Override
+  @JsonIgnore
+  public String getId() {
+    return PDX_ID;
+  }
+
+  @Override
+  public String getEndpoint() {
+    return PDX_ENDPOINT;
+  }
+
+  @Override
+  public String getUri() {
+    return PDX_ENDPOINT;
+  }
+
+  public void setGroup(String group) {
+    if (group != null) {
+      throw new IllegalArgumentException("Pdx can only be configured in cluster level.");
+    }
+  }
 }

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
@@ -205,6 +205,14 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
     return REGION_CONFIG_ENDPOINT;
   }
 
+  @Override
+  public String getUri() {
+    if (StringUtils.isBlank(getId())) {
+      return null;
+    }
+    return REGION_CONFIG_ENDPOINT + "/" + getId();
+  }
+
   public RegionAttributesType getRegionAttributes() {
     return regionAttributes;
   }
@@ -719,6 +727,10 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
 
     public void setRegionName(String regionName) {
       this.regionName = regionName;
+      if (StringUtils.isBlank(regionName)) {
+        return;
+      }
+
       if (fromClause == null) {
         fromClause = "/" + regionName;
       } else if (!fromClause.contains(regionName)) {
@@ -736,9 +748,17 @@ public class RegionConfig extends CacheElement implements RestfulEndpoint {
     @Override
     public String getEndpoint() {
       if (StringUtils.isBlank(regionName)) {
-        throw new IllegalArgumentException("regionName is required.");
+        return null;
       }
       return RegionConfig.REGION_CONFIG_ENDPOINT + "/" + regionName + "/indexes";
+    }
+
+    @Override
+    public String getUri() {
+      if (getEndpoint() == null || StringUtils.isBlank(getId())) {
+        return null;
+      }
+      return getEndpoint() + "/" + getId();
     }
   }
 

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.geode.annotations.Experimental;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
+import org.apache.geode.cache.configuration.CacheElement;
 
 @Experimental
 public class ClusterManagementResult {
@@ -65,7 +65,7 @@ public class ClusterManagementResult {
   // Override the mapper setting so that we always show result
   @JsonInclude
   @JsonProperty
-  private List<? extends RuntimeCacheElement> result = new ArrayList<>();
+  private List<? extends CacheElement> result = new ArrayList<>();
 
   public ClusterManagementResult() {}
 
@@ -115,11 +115,11 @@ public class ClusterManagementResult {
     return statusCode;
   }
 
-  public <R extends RuntimeCacheElement> List<R> getResult(Class<R> clazz) {
+  public <R extends CacheElement> List<R> getResult(Class<R> clazz) {
     return result.stream().map(clazz::cast).collect(Collectors.toList());
   }
 
-  public void setResult(List<? extends RuntimeCacheElement> result) {
+  public void setResult(List<? extends CacheElement> result) {
     this.result = result;
   }
 }

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
@@ -60,7 +60,7 @@ public interface ClusterManagementService {
    */
   ClusterManagementResult update(CacheElement config);
 
-  ClusterManagementResult list(CacheElement config);
+  <T extends CacheElement> ClusterManagementResult list(T config);
 
   ClusterManagementResult get(CacheElement config);
 

--- a/geode-management/src/main/java/org/apache/geode/management/api/RestfulEndpoint.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/RestfulEndpoint.java
@@ -20,11 +20,23 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public interface RestfulEndpoint {
 
   /**
-   * this needs to return the uri portion after the /geode-management/v2
+   * this needs to return the uri portion after the /geode-management/v2 that points to the
+   * list of entities
    *
    * @return e.g. /regions
    */
   @JsonIgnore
   // @ApiModelProperty(hidden = true)
   String getEndpoint();
+
+  /**
+   * this needs to return the uri portion after the /geode-management/v2 that points to a single
+   * entity. If the id is not available for the object, this will return null
+   *
+   * @return e.g. /regions/regionA
+   */
+  String getUri();
+
+  // exists for json serialization purpose
+  default void setUri(String uri) {};
 }

--- a/geode-management/src/main/java/org/apache/geode/management/configuration/MultiGroupCacheElement.java
+++ b/geode-management/src/main/java/org/apache/geode/management/configuration/MultiGroupCacheElement.java
@@ -15,40 +15,18 @@
 
 package org.apache.geode.management.configuration;
 
-import org.apache.commons.lang3.StringUtils;
+import java.util.List;
 
-import org.apache.geode.annotations.Experimental;
-import org.apache.geode.cache.configuration.CacheElement;
-import org.apache.geode.management.api.RestfulEndpoint;
+import javax.xml.bind.annotation.XmlTransient;
 
-@Experimental
-public class MemberConfig extends CacheElement implements RestfulEndpoint {
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
-  public static final String MEMBER_CONFIG_ENDPOINT = "/members";
+public interface MultiGroupCacheElement {
+  @XmlTransient
+  List<String> getGroups();
 
-  private String id;
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  @Override
-  public String getId() {
-    return id;
-  }
-
-  @Override
-  public String getEndpoint() {
-    return MEMBER_CONFIG_ENDPOINT;
-  }
-
-  @Override
-  public String getUri() {
-    if (StringUtils.isBlank(getId())) {
-      throw new IllegalArgumentException("Member Id is requied.");
-    }
-    return MEMBER_CONFIG_ENDPOINT + "/" + getId();
-  }
-
-
+  // this is needed to hide "group" attribute in json serialization
+  @XmlTransient
+  @JsonIgnore
+  String getGroup();
 }

--- a/geode-management/src/main/java/org/apache/geode/management/configuration/RuntimeMemberConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/management/configuration/RuntimeMemberConfig.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import org.apache.geode.annotations.Experimental;
+
+@Experimental
+public class RuntimeMemberConfig extends MemberConfig implements MultiGroupCacheElement {
+  private boolean isLocator;
+  private boolean isCoordinator;
+  private String host;
+  private String status;
+  private int pid;
+  // Only relevant for locators - will be suppressed if null
+  private Integer port;
+  // Only relevant for servers - will be suppressed if empty
+  private List<CacheServerConfig> cacheServers = new ArrayList<>();
+  private long maxHeap;
+  private long initialHeap;
+  private long usedHeap;
+  private String logFile;
+  private String workingDirectory;
+  private int clientConnections;
+
+  public static class CacheServerConfig {
+    private int port;
+    private int maxConnections;
+    private int maxThreads;
+
+    public CacheServerConfig() {}
+
+    public int getPort() {
+      return port;
+    }
+
+    public void setPort(int port) {
+      this.port = port;
+    }
+
+    public int getMaxConnections() {
+      return maxConnections;
+    }
+
+    public void setMaxConnections(int maxConnections) {
+      this.maxConnections = maxConnections;
+    }
+
+    public int getMaxThreads() {
+      return maxThreads;
+    }
+
+    public void setMaxThreads(int maxThreads) {
+      this.maxThreads = maxThreads;
+    }
+  }
+
+  public boolean isLocator() {
+    return isLocator;
+  }
+
+  public void setLocator(boolean locator) {
+    isLocator = locator;
+  }
+
+  public boolean isCoordinator() {
+    return isCoordinator;
+  }
+
+  public void setCoordinator(boolean coordinator) {
+    isCoordinator = coordinator;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public int getPid() {
+    return pid;
+  }
+
+  public void setPid(int pid) {
+    this.pid = pid;
+  }
+
+  @JsonInclude(value = JsonInclude.Include.NON_NULL)
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  @JsonInclude(value = JsonInclude.Include.NON_EMPTY)
+  public List<CacheServerConfig> getCacheServers() {
+    return cacheServers;
+  }
+
+  public void addCacheServer(CacheServerConfig cacheServer) {
+    cacheServers.add(cacheServer);
+  }
+
+  public List<String> getGroups() {
+    return groups;
+  }
+
+  public void setGroups(List<String> groups) {
+    this.groups = groups;
+  }
+
+  public long getMaxHeap() {
+    return maxHeap;
+  }
+
+  public void setMaxHeap(long maxHeap) {
+    this.maxHeap = maxHeap;
+  }
+
+  public long getInitialHeap() {
+    return initialHeap;
+  }
+
+  public void setInitialHeap(long initialHeap) {
+    this.initialHeap = initialHeap;
+  }
+
+  public long getUsedHeap() {
+    return usedHeap;
+  }
+
+  public void setUsedHeap(long usedHeap) {
+    this.usedHeap = usedHeap;
+  }
+
+  public String getLogFile() {
+    return logFile;
+  }
+
+  public void setLogFile(String logFile) {
+    this.logFile = logFile;
+  }
+
+  public String getWorkingDirectory() {
+    return workingDirectory;
+  }
+
+  public void setWorkingDirectory(String workingDirectory) {
+    this.workingDirectory = workingDirectory;
+  }
+
+  public int getClientConnections() {
+    return clientConnections;
+  }
+
+  public void setClientConnections(int clientConnections) {
+    this.clientConnections = clientConnections;
+  }
+}

--- a/geode-management/src/main/java/org/apache/geode/management/configuration/RuntimeRegionConfig.java
+++ b/geode-management/src/main/java/org/apache/geode/management/configuration/RuntimeRegionConfig.java
@@ -26,7 +26,7 @@ import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.configuration.RegionConfig;
 
 @Experimental
-public class RuntimeRegionConfig extends RegionConfig implements RuntimeCacheElement {
+public class RuntimeRegionConfig extends RegionConfig implements MultiGroupCacheElement {
   private long entryCount;
 
   public RuntimeRegionConfig() {}

--- a/geode-management/src/test/java/org/apache/geode/cache/configuration/CacheElementJsonMappingTest.java
+++ b/geode-management/src/test/java/org/apache/geode/cache/configuration/CacheElementJsonMappingTest.java
@@ -26,20 +26,20 @@ import org.junit.Test;
 
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.configuration.MemberConfig;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
 import org.apache.geode.management.configuration.RuntimeIndex;
+import org.apache.geode.management.configuration.RuntimeMemberConfig;
 import org.apache.geode.management.configuration.RuntimeRegionConfig;
 import org.apache.geode.util.internal.GeodeJsonMapper;
 
 public class CacheElementJsonMappingTest {
   private static ObjectMapper mapper = GeodeJsonMapper.getMapper();
 
-  private static MemberConfig member;
+  private static RuntimeMemberConfig member;
   private static RuntimeRegionConfig region;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
-    member = new MemberConfig();
+    member = new RuntimeMemberConfig();
     member.setId("server");
     member.setPid(123);
 
@@ -82,7 +82,7 @@ public class CacheElementJsonMappingTest {
   @Test
   public void serializeResult() throws Exception {
     ClusterManagementResult result = new ClusterManagementResult();
-    List<RuntimeCacheElement> elements = new ArrayList<>();
+    List<CacheElement> elements = new ArrayList<>();
     elements.add(region);
     elements.add(member);
     result.setResult(elements);
@@ -91,10 +91,10 @@ public class CacheElementJsonMappingTest {
     System.out.println(json);
 
     ClusterManagementResult result1 = mapper.readValue(json, ClusterManagementResult.class);
-    assertThat(result1.getResult(RuntimeCacheElement.class)).hasSize(2);
-    assertThat(result1.getResult(RuntimeCacheElement.class).get(0))
+    assertThat(result1.getResult(CacheElement.class)).hasSize(2);
+    assertThat(result1.getResult(CacheElement.class).get(0))
         .isInstanceOf(RegionConfig.class);
-    assertThat(result1.getResult(RuntimeCacheElement.class).get(1))
+    assertThat(result1.getResult(CacheElement.class).get(1))
         .isInstanceOf(MemberConfig.class);
   }
 
@@ -159,6 +159,7 @@ public class CacheElementJsonMappingTest {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setName("index1");
     index.setFromClause("/region1 r");
+    index.setRegionName("region1");
     index.setExpression("id");
     config.getIndexes().add(index);
     RuntimeRegionConfig runtimeConfig = new RuntimeRegionConfig(config);

--- a/geode-management/src/test/java/org/apache/geode/cache/configuration/CacheElementTest.java
+++ b/geode-management/src/test/java/org/apache/geode/cache/configuration/CacheElementTest.java
@@ -22,14 +22,14 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.apache.geode.management.configuration.RuntimeCacheElement;
+import org.apache.geode.management.configuration.MultiGroupCacheElement;
 import org.apache.geode.management.configuration.RuntimeRegionConfig;
 import org.apache.geode.util.internal.GeodeJsonMapper;
 
 public class CacheElementTest {
 
   private CacheElement element;
-  private RuntimeCacheElement runtime;
+  private MultiGroupCacheElement runtime;
 
   private static ObjectMapper mapper;
   private String json;

--- a/geode-management/src/test/java/org/apache/geode/cache/configuration/PdxTypeTest.java
+++ b/geode-management/src/test/java/org/apache/geode/cache/configuration/PdxTypeTest.java
@@ -13,21 +13,18 @@
  * the License.
  */
 
-package org.apache.geode.management.configuration;
+package org.apache.geode.cache.configuration;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.geode.cache.configuration.RegionConfig;
+import org.junit.Test;
 
-public class RuntimeIndex extends RegionConfig.Index implements MultiGroupCacheElement {
-  @Override
-  public List<String> getGroups() {
-    return groups;
-  }
+public class PdxTypeTest {
 
-  public RuntimeIndex() {};
-
-  public RuntimeIndex(RegionConfig.Index index) {
-    super(index);
+  @Test
+  public void setGroup() throws Exception {
+    PdxType type = new PdxType();
+    assertThatThrownBy(() -> type.setGroup("test"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/geode-web-management/src/commonTest/java/org/apache/geode/management/internal/rest/LocatorWebContext.java
+++ b/geode-web-management/src/commonTest/java/org/apache/geode/management/internal/rest/LocatorWebContext.java
@@ -17,6 +17,8 @@ package org.apache.geode.management.internal.rest;
 
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
+import java.util.Properties;
+
 import org.springframework.test.web.client.MockMvcClientHttpRequestFactory;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.RequestBuilder;
@@ -54,6 +56,13 @@ public class LocatorWebContext {
 
   public GeodeComponent getLocator() {
     return (GeodeComponent) webApplicationContext.getServletContext().getAttribute("locator");
+  }
+
+  public void login(String username, String password) {
+    Properties properties = new Properties();
+    properties.setProperty("security-username", username);
+    properties.setProperty("security-password", password);
+    getLocator().getSecurityService().login(properties);
   }
 
   public MockMvcClientHttpRequestFactory getRequestFactory() {

--- a/geode-web-management/src/commonTest/java/org/apache/geode/management/internal/rest/SecuredLocatorContextLoader.java
+++ b/geode-web-management/src/commonTest/java/org/apache/geode/management/internal/rest/SecuredLocatorContextLoader.java
@@ -20,7 +20,7 @@ import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
 
-public class LocatorWithSecurityManagerContextLoader extends BaseLocatorContextLoader {
+public class SecuredLocatorContextLoader extends BaseLocatorContextLoader {
 
   private final LocatorStarterRule locator =
       new LocatorStarterRule().withSecurityManager(SimpleSecurityManager.class).withAutoStart();

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ConfigurePDXDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ConfigurePDXDUnitTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.client;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.cache.configuration.PdxType;
+import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementService;
+import org.apache.geode.management.api.Status;
+import org.apache.geode.management.internal.rest.LocatorWebContext;
+import org.apache.geode.management.internal.rest.PlainLocatorContextLoader;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/geode-management-servlet.xml"},
+    loader = PlainLocatorContextLoader.class)
+@WebAppConfiguration
+public class ConfigurePDXDUnitTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule(1);
+
+  private ClusterManagementService client;
+  private LocatorWebContext webContext;
+
+  @Before
+  public void before() {
+    cluster.setSkipLocalDistributedSystemCleanup(true);
+    webContext = new LocatorWebContext(webApplicationContext);
+    client = ClusterManagementServiceBuilder.buildWithRequestFactory()
+        .setRequestFactory(webContext.getRequestFactory()).build();
+    cluster.startServerVM(1, webContext.getLocator().getPort());
+  }
+
+  @Test
+  public void configurePdx() {
+    PdxType pdxType = new PdxType();
+    ClusterManagementResult result = client.create(pdxType);
+
+    assertThat(result.isSuccessful()).isTrue();
+    assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
+
+    List<PdxType> list = result.getResult(PdxType.class);
+    assertThat(list.size()).isEqualTo(1);
+    PdxType pdxResult = list.get(0);
+    assertThat(pdxResult.getGroup()).isNull();
+    assertThat(pdxResult.getUri()).isEqualTo(PdxType.PDX_ENDPOINT);
+
+    Status status = result.getMemberStatuses().get("server-1");
+    assertThat(status.getMessage())
+        .contains("Server needs to be restarted for this configuration change to be realized");
+  }
+}

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/MemberManagementServiceDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/MemberManagementServiceDUnitTest.java
@@ -39,7 +39,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.configuration.MemberConfig;
-import org.apache.geode.management.configuration.RuntimeCacheElement;
+import org.apache.geode.management.configuration.RuntimeMemberConfig;
 import org.apache.geode.management.internal.rest.LocatorLauncherContextLoader;
 import org.apache.geode.management.internal.rest.LocatorWebContext;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -77,11 +77,11 @@ public class MemberManagementServiceDUnitTest {
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
 
-    List<MemberConfig> members = result.getResult(MemberConfig.class);
+    List<RuntimeMemberConfig> members = result.getResult(RuntimeMemberConfig.class);
     assertThat(members.size()).isEqualTo(2);
     assertThat(members.stream().map(MemberConfig::getId).collect(Collectors.toList()))
         .containsExactlyInAnyOrder("locator-0", "server-1");
-    for (MemberConfig oneMember : members) {
+    for (RuntimeMemberConfig oneMember : members) {
       if (oneMember.isLocator()) {
         assertThat(oneMember.getPort())
             .as("port for locator member should not be null").isNotNull().isGreaterThan(0);
@@ -121,10 +121,10 @@ public class MemberManagementServiceDUnitTest {
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
 
-    List<MemberConfig> members = result.getResult(MemberConfig.class);
+    List<RuntimeMemberConfig> members = result.getResult(RuntimeMemberConfig.class);
     assertThat(members.size()).isEqualTo(1);
 
-    MemberConfig memberConfig = members.get(0);
+    RuntimeMemberConfig memberConfig = members.get(0);
     assertThat(memberConfig.getInitialHeap()).isGreaterThan(0);
     assertThat(memberConfig.getMaxHeap()).isGreaterThan(0);
     assertThat(memberConfig.getStatus()).isEqualTo("online");
@@ -140,7 +140,7 @@ public class MemberManagementServiceDUnitTest {
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode())
         .isEqualTo(ClusterManagementResult.StatusCode.OK);
-    assertThat(result.getResult(RuntimeCacheElement.class).size()).isEqualTo(0);
+    assertThat(result.getResult(MemberConfig.class).size()).isEqualTo(0);
   }
 
   @Test

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/PdxManagementTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/PdxManagementTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.cache.configuration.PdxType;
+import org.apache.geode.util.internal.GeodeJsonMapper;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/geode-management-servlet.xml"},
+    loader = SecuredLocatorContextLoader.class)
+@WebAppConfiguration
+public class PdxManagementTest {
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  // needs to be used together with any BaseLocatorContextLoader
+  private LocatorWebContext context;
+
+  private ObjectMapper mapper = GeodeJsonMapper.getMapper();
+
+  @Before
+  public void before() {
+    context = new LocatorWebContext(webApplicationContext);
+  }
+
+  @Test
+  public void success() throws Exception {
+    PdxType pdx = new PdxType();
+    pdx.setReadSerialized(true);
+    context.perform(post("/v2/configurations/pdx")
+        .with(httpBasic("clusterManage", "clusterManage"))
+        .content(mapper.writeValueAsString(pdx)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.memberStatuses").doesNotExist())
+        .andExpect(
+            jsonPath("$.statusMessage", containsString("Successfully updated config for cluster")))
+        .andExpect(jsonPath("$.statusCode", is("OK")))
+        .andExpect(jsonPath("$.result[0].readSerialized", is(true)))
+        .andExpect(jsonPath("$.result[0].uri", is("/configurations/pdx")));
+  }
+
+  @Test
+  public void unauthorized() throws Exception {
+    PdxType pdx = new PdxType();
+    pdx.setReadSerialized(true);
+    context.perform(post("/v2/configurations/pdx")
+        .with(httpBasic("clusterRead", "clusterRead"))
+        .content(mapper.writeValueAsString(pdx)))
+        .andExpect(status().isForbidden());
+  }
+}

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
@@ -64,10 +64,10 @@ public class RegionManagementIntegrationTest {
     regionConfig.setName("customers");
     regionConfig.setType(RegionType.REPLICATE);
 
+    // if run multiple times, this could either be OK or ENTITY_EXISTS
     assertManagementResult(client.create(regionConfig))
-        .failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ERROR)
-        .containsStatusMessage("No members found in group 'cluster' to create cache element");
+        .hasStatusCode(ClusterManagementResult.StatusCode.OK,
+            ClusterManagementResult.StatusCode.ENTITY_EXISTS);
   }
 
   @Test

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/PdxManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/PdxManagementController.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest.controllers;
+
+import static org.apache.geode.cache.configuration.PdxType.PDX_ENDPOINT;
+import static org.apache.geode.management.internal.rest.controllers.AbstractManagementController.MANAGEMENT_API_VERSION;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import org.apache.geode.cache.configuration.PdxType;
+import org.apache.geode.management.api.ClusterManagementResult;
+
+@Controller("pdxManagement")
+@RequestMapping(MANAGEMENT_API_VERSION)
+public class PdxManagementController extends AbstractManagementController {
+
+  @ApiOperation(value = "configure PDX")
+  @ApiResponses({@ApiResponse(code = 200, message = "OK."),
+      @ApiResponse(code = 401, message = "Invalid Username or Password."),
+      @ApiResponse(code = 403, message = "Insufficient privileges for operation."),
+      @ApiResponse(code = 500, message = "GemFire throws an error or exception.")})
+  @PreAuthorize("@securityService.authorize('CLUSTER', 'MANAGE')")
+  @RequestMapping(method = RequestMethod.POST, value = PDX_ENDPOINT)
+  public ResponseEntity<ClusterManagementResult> configurePdx(
+      @RequestBody PdxType pdxType) {
+    ClusterManagementResult result = clusterManagementService.create(pdxType);
+    return new ResponseEntity<>(result,
+        result.isSuccessful() ? HttpStatus.CREATED : HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}


### PR DESCRIPTION
* add RestEndPoint.getUri for single config object uri for HATOS, make it part of the json response
* rename RuntimeCacheElement to MultiGroupCacheElement since the only usage of it is to support multi group.
* make MultiGroupCacheElement a suplimental interface and list does not have to return MultiGroupCacheElement
* do not require servers to be present in order to create a cache element
* when realizer is not present, assuming the servers needs to be bounced in order for the config change to take effect

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
