### PR TITLE
GEODE-6777: Create gateway senders command should only return when DistributedSystemMXBean reflects creation status

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -226,7 +226,8 @@ public abstract class GfshCommand implements CommandMarker {
    * function that may have an unbounded runtime. The timeout is very coarse and will not account
    * for the function overrunning the given time.
    *
-   * @param function a {@link Supplier<Boolean>} function that will poll for the condition
+   * @param function a {@link Supplier Supplier&lt;Boolean&gt;} function that will poll for the
+   *        condition
    * @return true if the function returns true within the timeout period; false otherwise
    */
   public boolean poll(long timeout, TimeUnit unit, Supplier<Boolean> function) {

--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -17,6 +17,8 @@ package org.apache.geode.management.cli;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.apache.shiro.subject.Subject;
 import org.springframework.shell.core.CommandMarker;
@@ -216,5 +218,35 @@ public abstract class GfshCommand implements CommandMarker {
       Set<DistributedMember> targetMembers) {
     ResultCollector rc = executeFunction(function, args, targetMembers);
     return CliFunctionResult.cleanResults((List<?>) rc.getResult());
+  }
+
+  /**
+   * Very basic polling functionality that executes a function until it returns true or the timeout
+   * is reached. The polling call is performed on the calling thread. Do not use it with a
+   * function that may have an unbounded runtime. The timeout is very coarse and will not account
+   * for the function overrunning the given time.
+   *
+   * @param function a {@link Supplier<Boolean>} function that will poll for the condition
+   * @return true if the function returns true within the timeout period; false otherwise
+   */
+  public boolean poll(long timeout, TimeUnit unit, Supplier<Boolean> function) {
+    long startWaitTime = System.currentTimeMillis();
+    long waitTime = unit.toMillis(timeout);
+
+    do {
+      try {
+        if (function.get()) {
+          return true;
+        }
+
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return false;
+      }
+    } while (System.currentTimeMillis() - startWaitTime < waitTime);
+
+    return false;
+
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -49,7 +49,7 @@ import org.apache.geode.security.ResourcePermission;
 
 public class CreateGatewaySenderCommand extends SingleGfshCommand {
   private static final Logger logger = LogService.getLogger();
-  private static int MBEAN_CREATION_WAIT_TIME = 10000;
+  private static final int MBEAN_CREATION_WAIT_TIME = 10000;
 
   @CliCommand(value = CliStrings.CREATE_GATEWAYSENDER, help = CliStrings.CREATE_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN,

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -164,14 +164,13 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
   }
 
   /*
-   * Wait for up tp 2 seconds for the proxy MBeans to be created.
+   * Wait for up tp 3 seconds for the proxy MBeans to be created.
    */
   @VisibleForTesting
   boolean waitForGatewaySenderMBeanCreation(String id,
       Set<DistributedMember> membersToCreateGatewaySenderOn) {
     DistributedSystemMXBean dsMXBean = getManagementService().getDistributedSystemMXBean();
     long startWaitTime = System.currentTimeMillis();
-    long waitedFor;
 
     do {
       try {
@@ -185,16 +184,15 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
         // ignored
       }
 
-      waitedFor = System.currentTimeMillis() - startWaitTime;
-    } while (waitedFor < 2000);
+    } while (System.currentTimeMillis() - startWaitTime < 3000);
 
     return false;
   }
 
-  private boolean gatewaySenderBeanExists(DistributedSystemMXBean dsMXBean, String member,
+  static boolean gatewaySenderBeanExists(DistributedSystemMXBean dsMXBean, String member,
       String id) {
     try {
-      // Throw a vanilla Exception if this call does not find anything
+      // This throws a vanilla Exception if this call does not find anything
       dsMXBean.fetchGatewaySenderObjectName(member, id);
       return true;
     } catch (Exception e) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -49,6 +49,7 @@ import org.apache.geode.security.ResourcePermission;
 
 public class CreateGatewaySenderCommand extends SingleGfshCommand {
   private static final Logger logger = LogService.getLogger();
+  private static int MBEAN_CREATION_WAIT_TIME = 10000;
 
   @CliCommand(value = CliStrings.CREATE_GATEWAYSENDER, help = CliStrings.CREATE_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN,
@@ -184,7 +185,7 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
         // ignored
       }
 
-    } while (System.currentTimeMillis() - startWaitTime < 3000);
+    } while (System.currentTimeMillis() - startWaitTime < MBEAN_CREATION_WAIT_TIME);
 
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
@@ -40,6 +40,7 @@ import org.apache.geode.security.ResourcePermission;
 
 public class DestroyGatewaySenderCommand extends SingleGfshCommand {
   private static final Logger logger = LogService.getLogger();
+  private static int MBEAN_DELETION_WAIT_TIME = 10000;
 
   @CliCommand(value = CliStrings.DESTROY_GATEWAYSENDER,
       help = CliStrings.DESTROY_GATEWAYSENDER__HELP)
@@ -99,7 +100,7 @@ public class DestroyGatewaySenderCommand extends SingleGfshCommand {
         // ignored
       }
 
-    } while (System.currentTimeMillis() - startWaitTime < 3000);
+    } while (System.currentTimeMillis() - startWaitTime < MBEAN_DELETION_WAIT_TIME);
 
     return false;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommand.java
@@ -40,7 +40,7 @@ import org.apache.geode.security.ResourcePermission;
 
 public class DestroyGatewaySenderCommand extends SingleGfshCommand {
   private static final Logger logger = LogService.getLogger();
-  private static int MBEAN_DELETION_WAIT_TIME = 10000;
+  private static final int MBEAN_DELETION_WAIT_TIME = 10000;
 
   @CliCommand(value = CliStrings.DESTROY_GATEWAYSENDER,
       help = CliStrings.DESTROY_GATEWAYSENDER__HELP)

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
@@ -62,6 +62,7 @@ public class CreateGatewaySenderCommandTest {
     command = spy(CreateGatewaySenderCommand.class);
     InternalCache cache = mock(InternalCache.class);
     doReturn(cache).when(command).getCache();
+    doReturn(true).when(command).waitForGatewaySenderMBeanCreation(any(), any());
     functionResults = new ArrayList<>();
     doReturn(functionResults).when(command).executeAndGetFunctionResult(any(), any(), any());
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DestroyGatewaySenderCommandTest.java
@@ -49,6 +49,7 @@ public class DestroyGatewaySenderCommandTest {
     command = spy(DestroyGatewaySenderCommand.class);
     cache = mock(InternalCache.class);
     doReturn(cache).when(command).getCache();
+    doReturn(true).when(command).waitForGatewaySenderMBeanDeletion(any(), any());
     functionResults = new ArrayList<>();
     doReturn(functionResults).when(command).executeAndGetFunctionResult(any(), any(),
         any(Set.class));

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleAwaitDUnitTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/MemberStarterRuleAwaitDUnitTest.java
@@ -128,11 +128,4 @@ public class MemberStarterRuleAwaitDUnitTest {
                     + existingDiskStoreName);
   }
 
-  @Test
-  public void nonexistingGatewayTimeout() {
-    assertThatThrownBy(
-        () -> memberToTest.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(3))
-            .hasCauseInstanceOf(ConditionTimeoutException.class)
-            .hasStackTraceContaining("Expecting to find exactly 3 gateway sender beans");
-  }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/MemberVM.java
@@ -164,12 +164,6 @@ public class MemberVM extends VMProvider implements Member {
         .waitUntilAsyncEventQueuesAreReadyOnExactlyThisManyServers(queueId, serverCount));
   }
 
-  public void waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(
-      int expectedGatewayObjectCount) {
-    vm.invoke(() -> ClusterStartupRule.memberStarter
-        .waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(expectedGatewayObjectCount));
-  }
-
   public void waitTillCacheClientProxyHasBeenPaused() {
     vm.invoke(() -> ClusterStartupRule.memberStarter.waitTillCacheClientProxyHasBeenPaused());
   }

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -435,17 +435,6 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
     return managementService.getMBeanProxy(cacheServerMBeanName, CacheServerMXBean.class);
   }
 
-  public void waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(int exactGatewaySenderCount)
-      throws Exception {
-    DistributedSystemMXBean dsMXBean = getManagementService().getDistributedSystemMXBean();
-    String predicateDescription = String.format(
-        "Expecting to find exactly %d gateway sender beans.", exactGatewaySenderCount);
-
-    waitUntilEqual(() -> dsMXBean.listGatewaySenderObjectNames(),
-        array -> array.length, exactGatewaySenderCount, predicateDescription, WAIT_UNTIL_TIMEOUT,
-        TimeUnit.SECONDS);
-  }
-
   public void waitUntilDiskStoreIsReadyOnExactlyThisManyServers(String diskStoreName,
       int exactServerCount) throws Exception {
     final Supplier<DistributedSystemMXBean> distributedSystemMXBeanSupplier =

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -503,6 +503,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
       throws Exception {
     try {
       await(assertionConsumerDescription)
+          .atMost(timeout, unit)
           .untilAsserted(() -> assertionConsumer.accept(examiner.apply(supplier.get())));
     } catch (ConditionTimeoutException e) {
       // There is a very slight race condition here, where the above could conceivably time out,

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateDestroyGatewaySenderCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateDestroyGatewaySenderCommandDUnitTest.java
@@ -97,6 +97,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
   @Test
   public void testCreateDestroyGatewaySenderWithDefault() {
     gfsh.executeAndAssertThat(CREATE).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" created on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" created on \"" + SERVER_4 + "\"",
@@ -116,6 +117,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
 
     // destroy gateway sender and verify AEQs cleaned up
     gfsh.executeAndAssertThat(DESTROY).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" destroyed on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" destroyed on \"" + SERVER_4 + "\"",
@@ -156,6 +158,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
         + CliStrings.CREATE_GATEWAYSENDER__ORDERPOLICY + "=THREAD";
 
     gfsh.executeAndAssertThat(command).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" created on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" created on \"" + SERVER_4 + "\"",
@@ -169,6 +172,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
 
     // destroy gateway sender and verify AEQs cleaned up
     gfsh.executeAndAssertThat(DESTROY).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" destroyed on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" destroyed on \"" + SERVER_4 + "\"",
@@ -203,6 +207,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
         + "=org.apache.geode.cache30.MyGatewayEventFilter1,org.apache.geode.cache30.MyGatewayEventFilter2";
 
     gfsh.executeAndAssertThat(command).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" created on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" created on \"" + SERVER_4 + "\"",
@@ -220,6 +225,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
 
     // destroy gateway sender and verify AEQs cleaned up
     gfsh.executeAndAssertThat(DESTROY).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" destroyed on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" destroyed on \"" + SERVER_4 + "\"",
@@ -254,6 +260,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
         + "=org.apache.geode.cache30.MyGatewayTransportFilter1";
 
     gfsh.executeAndAssertThat(command).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" created on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" created on \"" + SERVER_4 + "\"",
@@ -270,6 +277,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
 
     // destroy gateway sender and verify AEQs cleaned up
     gfsh.executeAndAssertThat(DESTROY).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" destroyed on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" destroyed on \"" + SERVER_4 + "\"",
@@ -285,6 +293,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
   @Test
   public void testCreateDestroyGatewaySender_OnMember() {
     gfsh.executeAndAssertThat(CREATE + " --member=" + server1.getName()).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(1).hasColumn("Message")
         .containsOnly("GatewaySender \"ln\" created on \"" + SERVER_3 + "\"");
 
@@ -292,6 +301,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
     VMProvider.invokeInEveryMember(() -> verifySenderDoesNotExist("ln", false), server2, server3);
 
     gfsh.executeAndAssertThat(DESTROY + " --member=" + server1.getName()).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(1).hasColumn("Message")
         .containsOnly("GatewaySender \"ln\" destroyed on \"" + SERVER_3 + "\"");
 
@@ -304,6 +314,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
   @Test
   public void testCreateDestroyGatewaySender_Group() {
     gfsh.executeAndAssertThat(CREATE + " --group=senderGroup1").statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(1).hasColumn("Message")
         .containsOnly("GatewaySender \"ln\" created on \"" + SERVER_3 + "\"");
 
@@ -311,6 +322,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
     VMProvider.invokeInEveryMember(() -> verifySenderDoesNotExist("ln", false), server2, server3);
 
     gfsh.executeAndAssertThat(DESTROY + " --group=senderGroup1").statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(1).hasColumn("Message")
         .containsOnly("GatewaySender \"ln\" destroyed on \"" + SERVER_3 + "\"");
 
@@ -323,6 +335,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
   @Test
   public void testCreateDestroyParallelGatewaySender() {
     gfsh.executeAndAssertThat(CREATE + " --parallel").statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" created on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" created on \"" + SERVER_4 + "\"",
@@ -330,6 +343,7 @@ public class CreateDestroyGatewaySenderCommandDUnitTest implements Serializable 
 
     // destroy gateway sender and verify AEQs cleaned up
     gfsh.executeAndAssertThat(DESTROY).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
         .hasTableSection().hasRowSize(3).hasColumn("Message").containsOnly(
             "GatewaySender \"ln\" destroyed on \"" + SERVER_3 + "\"",
             "GatewaySender \"ln\" destroyed on \"" + SERVER_4 + "\"",

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewaySenderCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/DestroyGatewaySenderCommandDUnitTest.java
@@ -71,16 +71,18 @@ public class DestroyGatewaySenderCommandDUnitTest {
 
   @Test
   public void testCreateDestroySerialGatewaySenderWithDefault() throws Exception {
-    gfsh.executeAndAssertThat(CREATE).statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder(
-        "Message", "GatewaySender \"sender\" created on \"happyserver1\"");
-
-    locatorSite1.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+    gfsh.executeAndAssertThat(CREATE).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
+        .hasTableSection()
+        .hasColumn("Message")
+        .containsExactly("GatewaySender \"sender\" created on \"happyserver1\"");
 
     // destroy gateway sender and verify AEQs cleaned up
-    gfsh.executeAndAssertThat(DESTROY).statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder(
-        "Message", "GatewaySender \"sender\" destroyed on \"happyserver1\"");
-
-    locatorSite1.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(0);
+    gfsh.executeAndAssertThat(DESTROY).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
+        .hasTableSection()
+        .hasColumn("Message")
+        .containsExactly("GatewaySender \"sender\" destroyed on \"happyserver1\"");
 
     gfsh.executeAndAssertThat("list gateways").statusIsError()
         .containsOutput("GatewaySenders or GatewayReceivers are not available in cluster");
@@ -89,16 +91,17 @@ public class DestroyGatewaySenderCommandDUnitTest {
   @Test
   public void testCreateDestroyParallellGatewaySenderWithDefault() throws Exception {
     gfsh.executeAndAssertThat(CREATE + " --parallel").statusIsSuccess()
-        .tableHasColumnWithExactValuesInAnyOrder("Message",
-            "GatewaySender \"sender\" created on \"happyserver1\"");
-
-    locatorSite1.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+        .doesNotContainOutput("Did not complete waiting")
+        .hasTableSection()
+        .hasColumn("Message")
+        .containsExactly("GatewaySender \"sender\" created on \"happyserver1\"");
 
     // destroy gateway sender and verify AEQs cleaned up
-    gfsh.executeAndAssertThat(DESTROY).statusIsSuccess().tableHasColumnWithExactValuesInAnyOrder(
-        "Message", "GatewaySender \"sender\" destroyed on \"happyserver1\"");
-
-    locatorSite1.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(0);
+    gfsh.executeAndAssertThat(DESTROY).statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting")
+        .hasTableSection()
+        .hasColumn("Message")
+        .containsExactly("GatewaySender \"sender\" destroyed on \"happyserver1\"");
 
     gfsh.executeAndAssertThat("list gateways").statusIsError()
         .containsOutput("GatewaySenders or GatewayReceivers are not available in cluster");

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
@@ -210,8 +210,8 @@ public class AlterRegionCommandDUnitTest {
     gfsh.executeAndAssertThat(
         "create gateway-sender --parallel=true --enable-persistence=false --remote-distributed-system-id=2 --id="
             + gatewaySenderName)
-        .statusIsSuccess();
-    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+        .statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting");
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + regionName)
         .statusIsSuccess();
@@ -250,8 +250,8 @@ public class AlterRegionCommandDUnitTest {
     gfsh.executeAndAssertThat(
         "create gateway-sender --parallel=true --enable-persistence=false --remote-distributed-system-id=2 --id="
             + gatewaySenderName)
-        .statusIsSuccess();
-    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+        .statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting");
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region1Name)
         .statusIsSuccess();
@@ -305,8 +305,8 @@ public class AlterRegionCommandDUnitTest {
     gfsh.executeAndAssertThat(
         "create gateway-sender --parallel=true --enable-persistence=false --remote-distributed-system-id=2 --id="
             + gatewaySenderName)
-        .statusIsSuccess();
-    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(1);
+        .statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting");
 
     gfsh.executeAndAssertThat("create region --type=PARTITION_PERSISTENT --name=" + regionName
         + " --disk-store=diskStore").statusIsSuccess();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -87,8 +87,8 @@ public class CreateRegionCommandDUnitTest {
     gfsh.executeAndAssertThat(
         "create gateway-sender --parallel=true --remote-distributed-system-id=2 --id="
             + gatewaySenderName)
-        .statusIsSuccess();
-    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(2);
+        .statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting");
 
     gfsh.executeAndAssertThat("create region --type=REPLICATE  --name=" + regionName
         + " --gateway-sender-id=" + gatewaySenderName)
@@ -113,8 +113,8 @@ public class CreateRegionCommandDUnitTest {
     gfsh.executeAndAssertThat(
         "create gateway-sender --remote-distributed-system-id=2 --id="
             + gatewaySenderName)
-        .statusIsSuccess();
-    locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(2);
+        .statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting");
 
     gfsh.executeAndAssertThat("create region --type=REPLICATE  --name=" + regionName
         + " --gateway-sender-id=" + gatewaySenderName + "-2")
@@ -141,10 +141,9 @@ public class CreateRegionCommandDUnitTest {
 
     gfsh.executeAndAssertThat("create gateway-sender"
         + " --id=" + sender
-        + " --remote-distributed-system-id=" + remoteDS).statusIsSuccess();
-
-    // Give gateway sender time to get created
-    Thread.sleep(2000);
+        + " --remote-distributed-system-id=" + remoteDS)
+        .statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting");
 
     gfsh.executeAndAssertThat("create region"
         + " --name=" + regionName

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeRegionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeRegionDUnitTest.java
@@ -54,9 +54,10 @@ public class DescribeRegionDUnitTest {
     gfsh.executeAndAssertThat("create async-event-queue --id=queue1 --group=group1 "
         + "--listener=org.apache.geode.internal.cache.wan.MyAsyncEventListener").statusIsSuccess();
     gfsh.executeAndAssertThat("create gateway-sender --id=sender1 --remote-distributed-system-id=2")
-        .statusIsSuccess();
+        .statusIsSuccess()
+        .doesNotContainOutput("Did not complete waiting");
+
     sending_locator.waitUntilAsyncEventQueuesAreReadyOnExactlyThisManyServers("queue1", 1);
-    sending_locator.waitUntilGatewaySendersAreReadyOnExactlyThisManyServers(2);
 
     gfsh.executeAndAssertThat(
         "create region --name=region4 --type=REPLICATE --async-event-queue-id=queue1 --gateway-sender-id=sender1")


### PR DESCRIPTION

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
