### PR TITLE
GEODE-6813: Build pipeline emits passing ref and build artifact

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -94,7 +94,7 @@ groups:
   jobs:
   - {{ build_test.name }}
   {{- all_gating_jobs() | indent(2) }}
-  {%- if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
+  {%- if repository.sanitized_fork == "apache" or repository.branch == "develop" %}
   - UpdatePassingRef
   {%- endif %}
   - UpdatePassingBuild
@@ -109,7 +109,7 @@ groups:
   - {{test.name}}Test{{java_test_version.name}}
     {%- endfor -%}
   {%- endfor -%}
-  {%- if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
+  {%- if repository.sanitized_fork == "apache" or repository.branch == "develop" %}
   - UpdatePassingRef
   {%- endif %}
   - UpdatePassingBuild
@@ -330,7 +330,7 @@ jobs:
               - name: instance-data
             timeout: 1h
 
-{% if repository.sanitized_fork == "apache" and repository.branch == "develop" %}
+{% if repository.sanitized_fork == "apache" or repository.branch == "develop" %}
 - name: UpdatePassingRef
   public: true
   serial: true


### PR DESCRIPTION
Make concourse more useful to developers.
* For all Apache branches, or all branches named 'develop', update the
passing SHA at the end of the pipeline
* Store the updated-ref at a `<ARTIFACT_BUCKET>/<BRANCH>` encoded location in GCS

Co-authored-by: Patrick Rhomberg <prhomberg@pivotal.io>
Co-authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
