### PR TITLE
split Windows tests into Core and non-Core

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -149,6 +149,16 @@ tests:
   ARTIFACT_SLUG: windows-integrationtestfiles
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: integrationTest
+  GRADLE_TASK_OPTIONS: "-x geode-core:integrationTest"
+  execute_test_timeout: 6h
+  PARALLEL_DUNIT: "false"
+  PARALLEL_GRADLE: "false"
+- name: "WindowsCoreIntegration"
+  CPUS: "16"
+  RAM: "64"
+  ARTIFACT_SLUG: windows-coreintegrationtestfiles
+  DUNIT_PARALLEL_FORKS: "0"
+  GRADLE_TASK: geode-core:integrationTest
   execute_test_timeout: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"


### PR DESCRIPTION
this divides the longest (5 hour) Windows tests into two jobs to shorten the feedback cycle on a commit.  if favorably received, we could go further in this direction by splitting into even more jobs, and/or we could exclude tests that don't exercise platform-sensitive functionality.