### PR TITLE
GEODE-6823 Hang in ElderInitProcessor.init()

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -968,7 +968,7 @@ public class ClusterDistributionManager implements DistributionManager {
       throw err;
     } catch (Throwable t) {
       SystemFailure.checkFailure();
-      if (isCloseInProgress()) {
+      if (shouldInhibitMembershipWarnings()) {
         logger.debug("Caught unusual exception during shutdown: {}", t.getMessage(), t);
       } else {
         logger.warn("Task failed with exception", t);
@@ -1975,18 +1975,18 @@ public class ClusterDistributionManager implements DistributionManager {
     }
   }
 
-  /**
-   * Returns true if this DM or the DistributedSystem owned by it is closing or is closed.
-   */
-  boolean isCloseInProgress() {
-    if (closeInProgress) {
+  private boolean shouldInhibitMembershipWarnings() {
+    if (isCloseInProgress()) {
       return true;
     }
     InternalDistributedSystem ds = getSystem();
     return ds != null && ds.isDisconnecting();
   }
 
-  public boolean isShutdownStarted() {
+  /**
+   * Returns true if this distribution manager has initiated shutdown
+   */
+  public boolean isCloseInProgress() {
     return closeInProgress;
   }
 
@@ -2051,7 +2051,7 @@ public class ClusterDistributionManager implements DistributionManager {
               membershipEventQueue.take();
           handleMemberEvent(ev);
         } catch (InterruptedException e) {
-          if (isCloseInProgress()) {
+          if (shouldInhibitMembershipWarnings()) {
             if (logger.isTraceEnabled()) {
               logger.trace("MemberEventInvoker: InterruptedException during shutdown");
             }
@@ -2062,7 +2062,7 @@ public class ClusterDistributionManager implements DistributionManager {
         } catch (DistributedSystemDisconnectedException e) {
           break;
         } catch (CancelException e) {
-          if (isCloseInProgress()) {
+          if (shouldInhibitMembershipWarnings()) {
             if (logger.isTraceEnabled()) {
               logger.trace("MemberEventInvoker: cancelled");
             }
@@ -2653,7 +2653,7 @@ public class ClusterDistributionManager implements DistributionManager {
         stats.incNodes(-1);
       }
       String msg;
-      if (p_crashed && !isCloseInProgress()) {
+      if (p_crashed && !shouldInhibitMembershipWarnings()) {
         msg =
             "Member at {} unexpectedly left the distributed cache: {}";
         addMemberEvent(new MemberCrashedEvent(theId, p_reason));
@@ -2881,7 +2881,7 @@ public class ClusterDistributionManager implements DistributionManager {
   }
 
   @Override
-  public ElderState getElderState(boolean waitToBecomeElder) {
+  public ElderState getElderState(boolean waitToBecomeElder) throws InterruptedException {
     return clusterElderManager.getElderState(waitToBecomeElder);
   }
 
@@ -2890,7 +2890,8 @@ public class ClusterDistributionManager implements DistributionManager {
    *
    * @return true if newElder is the elder; false if it is no longer a member or we are the elder.
    */
-  public boolean waitForElder(final InternalDistributedMember desiredElder) {
+  public boolean waitForElder(final InternalDistributedMember desiredElder)
+      throws InterruptedException {
 
     return clusterElderManager.waitForElder(desiredElder);
   }
@@ -3476,7 +3477,7 @@ public class ClusterDistributionManager implements DistributionManager {
         try {
           handleEvent(manager, listener);
         } catch (CancelException e) {
-          if (manager.isCloseInProgress()) {
+          if (manager.shouldInhibitMembershipWarnings()) {
             if (logger.isTraceEnabled()) {
               logger.trace("MemberEventInvoker: cancelled");
             }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionManager.java
@@ -166,7 +166,7 @@ public interface DistributionManager extends ReplySender {
    * @throws IllegalStateException if elder try lock fails
    * @since GemFire 4.0
    */
-  ElderState getElderState(boolean force);
+  ElderState getElderState(boolean force) throws InterruptedException;
 
   /**
    * Returns the membership port of the underlying distribution manager used for communication.

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/ElderInitProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/ElderInitProcessor.java
@@ -169,21 +169,27 @@ public class ElderInitProcessor extends ReplyProcessor21 {
       ArrayList grantorVersions = new ArrayList(); // grantor versions
       ArrayList grantorSerialNumbers = new ArrayList(); // serial numbers of grantor svcs
       ArrayList nonGrantors = new ArrayList(); // svc names non-grantor for
-      if (dm.waitForElder(this.getSender())) {
-        GrantorRequestProcessor.readyForElderRecovery(dm.getSystem(), this.getSender(), null);
-        DLockService.recoverRmtElder(grantors, grantorVersions, grantorSerialNumbers, nonGrantors);
-        reply(dm, grantors, grantorVersions, grantorSerialNumbers, nonGrantors);
-      } else if (dm.getOtherNormalDistributionManagerIds().isEmpty()) {
-        // Either we're alone (and received a message from an unknown member) or else we haven't
-        // yet processed a view. In either case, we clearly don't have any grantors,
-        // so we return empty lists.
+      try {
+        if (dm.waitForElder(this.getSender())) {
+          GrantorRequestProcessor.readyForElderRecovery(dm.getSystem(), this.getSender(), null);
+          DLockService
+              .recoverRmtElder(grantors, grantorVersions, grantorSerialNumbers, nonGrantors);
+          reply(dm, grantors, grantorVersions, grantorSerialNumbers, nonGrantors);
+        } else if (dm.getOtherNormalDistributionManagerIds().isEmpty()) {
+          // Either we're alone (and received a message from an unknown member) or else we haven't
+          // yet processed a view. In either case, we clearly don't have any grantors,
+          // so we return empty lists.
 
-        logger.info(LogMarker.DLS_MARKER,
-            "{}: returning empty lists because I know of no other members.",
-            this);
-        reply(dm, grantors, grantorVersions, grantorSerialNumbers, nonGrantors);
-      } else {
-        logger.info(LogMarker.DLS_MARKER, "{}: disregarding request from departed member.", this);
+          logger.info(LogMarker.DLS_MARKER,
+              "{}: returning empty lists because I know of no other members.",
+              this);
+          reply(dm, grantors, grantorVersions, grantorSerialNumbers, nonGrantors);
+        } else {
+          logger.info(LogMarker.DLS_MARKER, "{}: disregarding request from departed member.", this);
+        }
+      } catch (InterruptedException e) {
+        // shutting down
+        logger.info("Elder initialization interrupted - will not send a reply");
       }
     }
 
@@ -207,7 +213,7 @@ public class ElderInitProcessor extends ReplyProcessor21 {
     @Override
     public String toString() {
       StringBuffer buff = new StringBuffer();
-      buff.append("ElderInitMessage (processorId='").append(this.processorId).append(")");
+      buff.append("ElderInitMessage (processorId=").append(this.processorId).append(")");
       return buff.toString();
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/GrantorRequestProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/GrantorRequestProcessor.java
@@ -497,11 +497,12 @@ public class GrantorRequestProcessor extends ReplyProcessor21 {
 
     protected void basicProcess(final DistributionManager dm) {
       // we should be in the elder
-      ElderState es = null;
+      final ElderState es;
       try {
-        dm.getElderState(true);
+        es = dm.getElderState(true);
       } catch (InterruptedException e) {
         logger.info("Interrupted while processing {}", this);
+        return;
       }
       switch (this.opCode) {
         case GET_OP:

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/GrantorRequestProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/GrantorRequestProcessor.java
@@ -209,7 +209,8 @@ public class GrantorRequestProcessor extends ReplyProcessor21 {
    * Sets currentElder to the memberId of the current elder if elder is remote; null if elder is in
    * our vm.
    */
-  private static ElderState startElderCall(InternalDistributedSystem sys, DLockService dls) {
+  private static ElderState startElderCall(InternalDistributedSystem sys, DLockService dls)
+      throws InterruptedException {
     InternalDistributedMember elder;
     ElderState es = null;
 
@@ -328,7 +329,12 @@ public class GrantorRequestProcessor extends ReplyProcessor21 {
     try {
       do {
         tryNewElder = false;
-        final ElderState es = startElderCall(system, service);
+        ElderState es = null;
+        try {
+          es = startElderCall(system, service);
+        } catch (InterruptedException e) {
+          interrupted = true;
+        }
         dm.throwIfDistributionStopped();
         try {
           if (es != null) {
@@ -491,7 +497,12 @@ public class GrantorRequestProcessor extends ReplyProcessor21 {
 
     protected void basicProcess(final DistributionManager dm) {
       // we should be in the elder
-      ElderState es = dm.getElderState(true);
+      ElderState es = null;
+      try {
+        dm.getElderState(true);
+      } catch (InterruptedException e) {
+        logger.info("Interrupted while processing {}", this);
+      }
       switch (this.opCode) {
         case GET_OP:
           replyGrantorInfo(dm, es.getGrantor(this.serviceName, getSender(), this.dlsSerialNumber));

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
@@ -2620,7 +2620,7 @@ public class GMSMembershipManager implements MembershipManager, Manager {
   @Override
   public boolean isShutdownStarted() {
     ClusterDistributionManager dm = listener.getDM();
-    return shutdownInProgress || (dm != null && dm.isShutdownStarted());
+    return shutdownInProgress || (dm != null && dm.isCloseInProgress());
   }
 
   @Override


### PR DESCRIPTION
This corrects elder init processing to use the isCloseInProgress to
check for shutdown.  A coding error during refactoring caused it to check the
isCloseInProgress() method, which did more than just return the value of
the isCloseInProgress variable and was incorrectly reporting a close in progress
during startup operations.

I've renamed the old isCloseInProgress() method to avoid similar coding
errors in the future and added a new implementation that merely returns
the value of the field, as you'd expect it to do.

While writing tests I found that the ClusterElderManagerTest was leaving
blocked threads behind because the waitForElder() method in
ClusterElderManager was not interruptable.  I've changed that method to
be interruptable.  We don't interrupt message-processing threads so this
should be a safe change.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
