### PR TITLE
GEODE-6786: be able to delete cache element when no members are found.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -190,11 +190,6 @@ public class LocatorClusterManagementService implements ClusterManagementService
     Set<DistributedMember> targetedMembers = new HashSet<>();
     relevantGroups.forEach(g -> targetedMembers.addAll(findMembers(g)));
 
-    if (targetedMembers.size() == 0) {
-      return new ClusterManagementResult(false,
-          "No members found to delete cache element");
-    }
-
     ClusterManagementResult result = new ClusterManagementResult();
 
     List<CliFunctionResult> functionResults = executeAndGetFunctionResult(

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidator.java
@@ -22,7 +22,7 @@ import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.management.internal.CacheElementOperation;
 
 /**
- * this is used to validate all the common attributes of CacheElement, eg. group
+ * this is used to validate all the common attributes of CacheElement, eg. name and group
  */
 public class CacheElementValidator implements ConfigurationValidator<CacheElement> {
   @Override
@@ -32,9 +32,33 @@ public class CacheElementValidator implements ConfigurationValidator<CacheElemen
       throw new IllegalArgumentException("id cannot be null or blank");
     }
 
+    switch (operation) {
+      case UPDATE:
+      case CREATE:
+        validateCreate(config);
+        break;
+      case DELETE:
+        validateDelete(config);
+        break;
+      default:
+    }
+  }
+
+  private void validateCreate(CacheElement config) {
     if ("cluster".equalsIgnoreCase(config.getGroup())) {
       throw new IllegalArgumentException(
           "'cluster' is a reserved group name. Do not use it for member groups.");
+    }
+    if (config.getGroup() != null && config.getGroup().contains(",")) {
+      throw new IllegalArgumentException(
+          "Group name should not contain comma.");
+    }
+  }
+
+  private void validateDelete(CacheElement config) {
+    if (StringUtils.isNotBlank(config.getGroup())) {
+      throw new IllegalArgumentException(
+          "group is an invalid option when deleting an element from the cache.");
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidator.java
@@ -16,7 +16,6 @@
 package org.apache.geode.management.internal.configuration.validators;
 
 
-import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.CacheElement;
@@ -41,19 +40,12 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
   @Override
   public void validate(CacheElementOperation operation, RegionConfig config)
       throws IllegalArgumentException {
-
-    if (config.getName() == null) {
-      throw new IllegalArgumentException("Name of the region has to be specified.");
-    }
-
     switch (operation) {
       case UPDATE:
       case CREATE:
         validateCreate(config);
         break;
       case DELETE:
-        validateDelete(config);
-        break;
       default:
     }
   }
@@ -81,12 +73,6 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
       cache.getSecurityService()
           .authorize(ResourcePermission.Resource.CLUSTER, ResourcePermission.Operation.WRITE,
               ResourcePermission.Target.DISK);
-    }
-  }
-
-  private void validateDelete(RegionConfig config) {
-    if (StringUtils.isNotBlank(config.getGroup())) {
-      throw new IllegalArgumentException("Group is invalid option when deleting a region");
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidatorTest.java
@@ -35,6 +35,19 @@ public class CacheElementValidatorTest {
   }
 
   @Test
+  public void blankName() throws Exception {
+    assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config)).isInstanceOf(
+        IllegalArgumentException.class)
+        .hasMessageContaining(
+            "id cannot be null or blank");
+
+    assertThatThrownBy(() -> validator.validate(CacheElementOperation.DELETE, config)).isInstanceOf(
+        IllegalArgumentException.class)
+        .hasMessageContaining(
+            "id cannot be null or blank");
+  }
+
+  @Test
   public void invalidGroup_cluster() throws Exception {
     config.setName("test");
     config.setGroup("cluster");
@@ -42,5 +55,25 @@ public class CacheElementValidatorTest {
         IllegalArgumentException.class)
         .hasMessageContaining(
             "'cluster' is a reserved group name");
+  }
+
+  @Test
+  public void invalidGroup_comma() throws Exception {
+    config.setName("test");
+    config.setGroup("group1,group2");
+    assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config)).isInstanceOf(
+        IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Group name should not contain comma");
+  }
+
+  @Test
+  public void invalidGroup_delete() throws Exception {
+    config.setName("test");
+    config.setGroup("group1");
+    assertThatThrownBy(() -> validator.validate(CacheElementOperation.DELETE, config)).isInstanceOf(
+        IllegalArgumentException.class)
+        .hasMessageContaining(
+            "group is an invalid option when deleting an element from the cache");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidatorTest.java
@@ -87,13 +87,6 @@ public class RegionConfigValidatorTest {
   }
 
   @Test
-  public void noName() {
-    assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config)).isInstanceOf(
-        IllegalArgumentException.class)
-        .hasMessageContaining("Name of the region has to be specified");
-  }
-
-  @Test
   public void invalidName1() {
     config.setName("__test");
     config.setType("REPLICATE");

--- a/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
@@ -17,6 +17,7 @@ package org.apache.geode.management.internal;
 
 
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
@@ -62,6 +63,9 @@ public class ClientClusterManagementService implements ClusterManagementService 
   @Override
   public ClusterManagementResult delete(CacheElement config) {
     String endPoint = getEndpoint(config);
+    if (StringUtils.isNotBlank(config.getGroup())) {
+      throw new IllegalArgumentException("Group is an invalid option when deleting an element.");
+    }
     return restTemplate
         .exchange(VERSION + endPoint + "/{id}?group={group}",
             HttpMethod.DELETE,


### PR DESCRIPTION
* validate group when there deleting a cache element
* group name should not have comma when creating the cache element.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
