### PR TITLE
GEODE-6827: Make windows not gate for Benchmark

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -89,8 +89,8 @@ GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 {%- endfor -%}
 {% endmacro %}
 
-{% macro all_gating_except_windows_jobs() %}
-{%- for test in (tests) if not test.name=="StressNew" and test.PLATFORM=="linux" -%}
+{% macro all_gating_jobs_for_benchmark() %}
+{%- for test in (tests) if not test.name=="StressNew" and not test.name.startswith("Windows") -%}
   {%- for java_test_version in (java_test_versions) %}
 - {{test.name}}Test{{java_test_version.name}}
   {%- endfor -%}
@@ -388,12 +388,12 @@ jobs:
   - aggregate:
     - get: geode
       passed:
-      {{ all_gating_except_windows_jobs() | indent(6) }}
+      {{ all_gating_jobs_for_benchmark() | indent(6) }}
       trigger: true
     - get: geode-benchmarks
     - get: geode-build-version
       passed:
-      {{ all_gating_except_windows_jobs() | indent(6) }}
+      {{ all_gating_jobs_for_benchmark() | indent(6) }}
     - put: concourse-metadata-resource
   - task: run_benchmarks
     {{- alpine_tools_config()|indent(4) }}

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -90,7 +90,7 @@ GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 {% endmacro %}
 
 {% macro all_gating_jobs_for_benchmark() %}
-{%- for test in (tests) if not test.name=="StressNew" and not test.name.startswith("Windows") -%}
+{%- for test in (tests) if not test.name=="StressNew" and test.PLATFORM=="linux" -%}
   {%- for java_test_version in (java_test_versions) %}
 - {{test.name}}Test{{java_test_version.name}}
   {%- endfor -%}
@@ -128,7 +128,7 @@ groups:
 - name: linux
   jobs:
   - {{ build_test.name }}
-  {%- for test in (tests) if not test.name.startswith("Windows") and not test.name=="StressNew" -%}
+  {%- for test in (tests) if test.PLATFORM=="linux" and not test.name=="StressNew" -%}
     {% for java_test_version in (java_test_versions) %}
   - {{test.name}}Test{{java_test_version.name}}
     {%- endfor -%}
@@ -137,7 +137,7 @@ groups:
 - name: windows
   jobs:
   - {{ build_test.name }}
-  {%- for test in (tests) if test.name.startswith("Windows") -%}
+  {%- for test in (tests) if test.PLATFORM=="linux" -%}
     {% for java_test_version in (java_test_versions) %}
   - {{test.name}}Test{{java_test_version.name}}
     {%- endfor -%}

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -89,6 +89,14 @@ GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 {%- endfor -%}
 {% endmacro %}
 
+{% macro all_gating_except_windows_jobs() %}
+{%- for test in (tests) if not test.name=="StressNew" and test.PLATFORM=="linux" -%}
+  {%- for java_test_version in (java_test_versions) %}
+- {{test.name}}Test{{java_test_version.name}}
+  {%- endfor -%}
+{%- endfor -%}
+{% endmacro %}
+
 groups:
 - name: main
   jobs:
@@ -380,12 +388,12 @@ jobs:
   - aggregate:
     - get: geode
       passed:
-      {{ all_gating_jobs() | indent(6) }}
+      {{ all_gating_except_windows_jobs() | indent(6) }}
       trigger: true
     - get: geode-benchmarks
     - get: geode-build-version
       passed:
-      {{ all_gating_jobs() | indent(6) }}
+      {{ all_gating_except_windows_jobs() | indent(6) }}
     - put: concourse-metadata-resource
   - task: run_benchmarks
     {{- alpine_tools_config()|indent(4) }}

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -574,7 +574,7 @@ jobs:
             - name: geode
             - name: instance-data-{{java_test_version.name}}
               path: instance-data
-          timeout: {{parameters.execute_test_timeout}}
+          timeout: {{parameters.EXECUTE_TEST_TIMEOUT}}
         ensure:
           do:
           - task: rsync_code_down-{{java_test_version.name}}

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -23,7 +23,7 @@ groups:
 - name: main
   jobs:
   - {{ build_test.name }}
-{%- for test in tests if not test.name.startswith("Windows") %}
+{%- for test in tests if test.PLATFORM=="linux" %}
   {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
   - {{test.name}}Test{{java_test_version.name}}
   {%- endfor %}
@@ -207,7 +207,7 @@ jobs:
         get_params: {skip_download: true}
 
 
-{% for test in tests if not test.name.startswith("Windows")%}
+{% for test in tests if test.PLATFORM=="linux"%}
   {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
 - name: {{test.name}}Test{{java_test_version.name}}
   public: true

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -144,7 +144,7 @@ jobs:
         - name: geode-ci
         - name: geode
         - name: instance-data
-      timeout: {{build_test.execute_test_timeout}}
+      timeout: {{build_test.EXECUTE_TEST_TIMEOUT}}
     on_failure:
       do:
       - put: pull-request-job-failure
@@ -293,7 +293,7 @@ jobs:
         - name: geode
         - name: geode-ci
         - name: instance-data
-      timeout: {{test.execute_test_timeout}}
+      timeout: {{test.EXECUTE_TEST_TIMEOUT}}
     on_failure:
       do:
       - put: pull-request-job-failure

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -74,9 +74,10 @@ tests:
   CALL_STACK_TIMEOUT: "1800"
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: test
-  execute_test_timeout: 10m
+  EXECUTE_TEST_TIMEOUT: 10m
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "true"
+  PLATFORM: "linux"
 - name: "Acceptance"
   CPUS: "8"
   RAM: "12"
@@ -84,9 +85,10 @@ tests:
   CALL_STACK_TIMEOUT: "1800"
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: acceptanceTest
-  execute_test_timeout: 45m
+  EXECUTE_TEST_TIMEOUT: 45m
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "linux"
 - name: "Distributed"
   CPUS: "96"
   RAM: "180"
@@ -94,8 +96,9 @@ tests:
   CALL_STACK_TIMEOUT: "7200"
   DUNIT_PARALLEL_FORKS: "24"
   GRADLE_TASK: distributedTest
-  execute_test_timeout: 2h15m
+  EXECUTE_TEST_TIMEOUT: 2h15m
   PARALLEL_DUNIT: "true"
+  PLATFORM: "linux"
 - name: "Integration"
   CPUS: "96"
   RAM: "90"
@@ -103,8 +106,9 @@ tests:
   CALL_STACK_TIMEOUT: "1500"
   DUNIT_PARALLEL_FORKS: "48"
   GRADLE_TASK: integrationTest
-  execute_test_timeout: 40m
+  EXECUTE_TEST_TIMEOUT: 40m
   PARALLEL_DUNIT: "true"
+  PLATFORM: "linux"
 - name: "Upgrade"
   CPUS: "96"
   RAM: "160"
@@ -112,8 +116,9 @@ tests:
   CALL_STACK_TIMEOUT: "3000"
   DUNIT_PARALLEL_FORKS: "48"
   GRADLE_TASK: upgradeTest
-  execute_test_timeout: 1h
+  EXECUTE_TEST_TIMEOUT: 1h
   PARALLEL_DUNIT: "true"
+  PLATFORM: "linux"
 - name: "StressNew"
   CPUS: "96"
   RAM: "210"
@@ -121,18 +126,20 @@ tests:
   CALL_STACK_TIMEOUT: "7200"
   DUNIT_PARALLEL_FORKS: "24"
   GRADLE_TASK: repeatTest
-  execute_test_timeout: 2h15m
+  EXECUTE_TEST_TIMEOUT: 2h15m
   PARALLEL_DUNIT: "true"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "linux"
 - name: "WindowsAcceptance"
   CPUS: "16"
   RAM: "64"
   ARTIFACT_SLUG: windows-acceptancetestfiles
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: :geode-assembly:acceptanceTest
-  execute_test_timeout: 6h
+  EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsGfshDistributed"
   CPUS: "16"
   RAM: "64"
@@ -140,9 +147,10 @@ tests:
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: distributedTest
   GRADLE_TASK_OPTIONS: "-PtestCategory=org.apache.geode.test.junit.categories.GfshTest"
-  execute_test_timeout: 6h
+  EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsIntegration"
   CPUS: "16"
   RAM: "64"
@@ -150,23 +158,26 @@ tests:
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: integrationTest
   GRADLE_TASK_OPTIONS: "-x geode-core:integrationTest"
-  execute_test_timeout: 6h
+  EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsCoreIntegration"
   CPUS: "16"
   RAM: "64"
   ARTIFACT_SLUG: windows-coreintegrationtestfiles
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: geode-core:integrationTest
-  execute_test_timeout: 6h
+  EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsUnit"
   CPUS: "16"
   RAM: "64"
   ARTIFACT_SLUG: windows-unittestfiles
   DUNIT_PARALLEL_FORKS: "0"
   GRADLE_TASK: test
-  execute_test_timeout: 6h
+  EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
+  PLATFORM: "windows"

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -30,7 +30,7 @@ build_test:
   # It's consumption is more like a "TEST_RESULTS_DESTINATIONS_DIRECTORY_STUB_THING.
   GRADLE_TASK: build
   PARALLEL_GRADLE: "false"
-  execute_test_timeout: 10m
+  EXECUTE_TEST_TIMEOUT: 10m
 examples_test:
   name: "TestExamples"
   CPUS: "8"
@@ -42,13 +42,13 @@ examples_test:
   # Actual gradle task is "clean runAll" but is hard-coded in execute_build_examples.sh
   # It's consumption is more like a "TEST_RESULTS_DESTINATIONS_DIRECTORY_STUB_THING.
   GRADLE_TASK: runAll
-  execute_test_timeout: 30m
+  EXECUTE_TEST_TIMEOUT: 30m
 
 publish_artifacts:
   name: "PublishArtifacts"
   CPUS: "8"
   RAM: "16"
-  execute_test_timeout: 10m
+  EXECUTE_TEST_TIMEOUT: 10m
 
 java_test_versions:
 - name: OpenJDK8

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -77,6 +77,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 10m
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "true"
+  PLATFORM: "linux"
 - name: "Acceptance"
   CPUS: "8"
   RAM: "12"
@@ -87,6 +88,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 45m
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "linux"
 - name: "Distributed"
   CPUS: "96"
   RAM: "180"
@@ -96,6 +98,7 @@ tests:
   GRADLE_TASK: distributedTest
   EXECUTE_TEST_TIMEOUT: 2h15m
   PARALLEL_DUNIT: "true"
+  PLATFORM: "linux"
 - name: "Integration"
   CPUS: "96"
   RAM: "90"
@@ -105,6 +108,7 @@ tests:
   GRADLE_TASK: integrationTest
   EXECUTE_TEST_TIMEOUT: 40m
   PARALLEL_DUNIT: "true"
+  PLATFORM: "linux"
 - name: "Upgrade"
   CPUS: "96"
   RAM: "160"
@@ -114,6 +118,7 @@ tests:
   GRADLE_TASK: upgradeTest
   EXECUTE_TEST_TIMEOUT: 1h
   PARALLEL_DUNIT: "true"
+  PLATFORM: "linux"
 - name: "StressNew"
   CPUS: "96"
   RAM: "210"
@@ -124,6 +129,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 2h15m
   PARALLEL_DUNIT: "true"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "linux"
 - name: "WindowsAcceptance"
   CPUS: "16"
   RAM: "64"
@@ -133,6 +139,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsGfshDistributed"
   CPUS: "16"
   RAM: "64"
@@ -143,6 +150,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsIntegration"
   CPUS: "16"
   RAM: "64"
@@ -153,6 +161,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsCoreIntegration"
   CPUS: "16"
   RAM: "64"
@@ -162,6 +171,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
+  PLATFORM: "windows"
 - name: "WindowsUnit"
   CPUS: "16"
   RAM: "64"
@@ -170,3 +180,4 @@ tests:
   GRADLE_TASK: test
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
+  PLATFORM: "windows"

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -77,7 +77,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 10m
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "true"
-  PLATFORM: "linux"
 - name: "Acceptance"
   CPUS: "8"
   RAM: "12"
@@ -88,7 +87,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 45m
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
-  PLATFORM: "linux"
 - name: "Distributed"
   CPUS: "96"
   RAM: "180"
@@ -98,7 +96,6 @@ tests:
   GRADLE_TASK: distributedTest
   EXECUTE_TEST_TIMEOUT: 2h15m
   PARALLEL_DUNIT: "true"
-  PLATFORM: "linux"
 - name: "Integration"
   CPUS: "96"
   RAM: "90"
@@ -108,7 +105,6 @@ tests:
   GRADLE_TASK: integrationTest
   EXECUTE_TEST_TIMEOUT: 40m
   PARALLEL_DUNIT: "true"
-  PLATFORM: "linux"
 - name: "Upgrade"
   CPUS: "96"
   RAM: "160"
@@ -118,7 +114,6 @@ tests:
   GRADLE_TASK: upgradeTest
   EXECUTE_TEST_TIMEOUT: 1h
   PARALLEL_DUNIT: "true"
-  PLATFORM: "linux"
 - name: "StressNew"
   CPUS: "96"
   RAM: "210"
@@ -129,7 +124,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 2h15m
   PARALLEL_DUNIT: "true"
   PARALLEL_GRADLE: "false"
-  PLATFORM: "linux"
 - name: "WindowsAcceptance"
   CPUS: "16"
   RAM: "64"
@@ -139,7 +133,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
-  PLATFORM: "windows"
 - name: "WindowsGfshDistributed"
   CPUS: "16"
   RAM: "64"
@@ -150,7 +143,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
-  PLATFORM: "windows"
 - name: "WindowsIntegration"
   CPUS: "16"
   RAM: "64"
@@ -161,7 +153,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
-  PLATFORM: "windows"
 - name: "WindowsCoreIntegration"
   CPUS: "16"
   RAM: "64"
@@ -171,7 +162,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
   PARALLEL_GRADLE: "false"
-  PLATFORM: "windows"
 - name: "WindowsUnit"
   CPUS: "16"
   RAM: "64"
@@ -180,4 +170,3 @@ tests:
   GRADLE_TASK: test
   EXECUTE_TEST_TIMEOUT: 6h
   PARALLEL_DUNIT: "false"
-  PLATFORM: "windows"


### PR DESCRIPTION
Make the Windows tests not gating for Benchmark job, since benchmark is
run on Linux.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
