### PR TITLE
GEODE-6321: This is race caused by not enough SLOP time (it could use…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/ScheduledThreadPoolExecutorWithKeepAliveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/ScheduledThreadPoolExecutorWithKeepAliveJUnitTest.java
@@ -212,11 +212,15 @@ public class ScheduledThreadPoolExecutorWithKeepAliveJUnitTest {
     ex.schedule(new Runnable() {
       @Override
       public void run() {
-        // The testShutdown2 will test only with sleep, no deley
-        // let testShutdown to test only with delay
-        System.out.println("Finished scheduled task");
+        try {
+          // change to sleep 3 seconds, the same as testShutdown2, to avoid not enough SLOP time
+          Thread.sleep(3000);
+          System.out.println("Finished scheduled task");
+        } catch (InterruptedException e) {
+          fail("interrupted");
+        }
       }
-    }, 4, TimeUnit.SECONDS);
+    }, 2, TimeUnit.SECONDS);
     long start = System.nanoTime();
     ex.shutdown();
     assertTrue(ex.awaitTermination(10, TimeUnit.SECONDS));


### PR DESCRIPTION
… up to 300ms). The next test testShutdown2 used 3 seconds sleep,

but verify at least run for 2 seconds. Apply the same design to resolve the race.
The logic is already verified in assertTrue(ex.awaitTermination())

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
