### PR TITLE
GEODE-6839: Fix Flaky JoinQueriesIntegrationTest

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/JoinQueriesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/JoinQueriesIntegrationTest.java
@@ -351,15 +351,7 @@ public class JoinQueriesIntegrationTest {
     Region<String, Object> validationIssueXRefRegion = cache.<String, Object>createRegionFactory()
         .setDataPolicy(DataPolicy.REPLICATE).create("OrderValidationIssueXRef");
 
-    // Create Indexes
-    cache.getQueryService().createIndex("order_orderID", "orderId", "/Order", null);
-    cache.getQueryService().createIndex("validationIssue_issueID", "issueId", "/ValidationIssue",
-        null);
-    cache.getQueryService().createIndex("orderValidationIssueXRef_referenceOrderId",
-        "referenceOrderId", "/OrderValidationIssueXRef", null);
-    cache.getQueryService().createIndex("orderValidationIssueXRef_referenceIssueId",
-        "referenceIssueId", "/OrderValidationIssueXRef", null);
-
+    // Populate Regions
     if (!usePdx) {
       populateTripleJointRegionsWithSerializables(matches, extraEntitiesPerRegion, orderRegion,
           validationIssueRegion, validationIssueXRefRegion);
@@ -368,6 +360,15 @@ public class JoinQueriesIntegrationTest {
           orderRegion,
           validationIssueRegion, validationIssueXRefRegion);
     }
+
+    // Create Indexes
+    cache.getQueryService().createIndex("order_orderID", "orderId", "/Order", null);
+    cache.getQueryService().createIndex("validationIssue_issueID", "issueId", "/ValidationIssue",
+        null);
+    cache.getQueryService().createIndex("orderValidationIssueXRef_referenceOrderId",
+        "referenceOrderId", "/OrderValidationIssueXRef", null);
+    cache.getQueryService().createIndex("orderValidationIssueXRef_referenceIssueId",
+        "referenceIssueId", "/OrderValidationIssueXRef", null);
 
     SelectResults baseResultsWithIndexes =
         (SelectResults) queryService.newQuery(queryString).execute();


### PR DESCRIPTION
Index creation within the test is now done after region population
finishes, basically avoiding any race conditions that might arise
between adding entries to an index and query execution.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
