### PR TITLE
GEODE-6812: Do not return null if waitToBecomeElder

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterElderManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterElderManager.java
@@ -84,11 +84,10 @@ public class ClusterElderManager {
 
   public ElderState getElderState(boolean waitToBecomeElder) throws InterruptedException {
     if (waitToBecomeElder) {
-      // This should always return true.
       waitForElder(clusterDistributionManager.getId());
     }
 
-    if (!isElder()) {
+    if (!isElder() && !waitToBecomeElder) {
       return null; // early return if this clusterDistributionManager is not the elder
     }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/ClusterElderManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/ClusterElderManagerTest.java
@@ -306,4 +306,18 @@ public class ClusterElderManagerTest {
       await().until(() -> !waitThread.isAlive());
     }
   }
+
+  @Test
+  public void getElderStateReturnsElderStateIfWaitsToBecomeElder() throws Exception {
+    Supplier<ElderState> elderStateSupplier = mock(Supplier.class);
+    ElderState elderState = mock(ElderState.class);
+    when(elderStateSupplier.get()).thenReturn(elderState);
+    ClusterElderManager clusterElderManager =
+        new ClusterElderManager(clusterDistributionManager, elderStateSupplier);
+    when(clusterDistributionManager.getId()).thenReturn(member0);
+    when(clusterDistributionManager.isCloseInProgress()).thenReturn(true);
+    when(clusterDistributionManager.getViewMembers()).thenReturn(Arrays.asList(member1));
+
+    assertThat(clusterElderManager.getElderState(true)).isEqualTo(elderState);
+  }
 }


### PR DESCRIPTION
* waitToBecomeElder could return false earlier without waiting if the node is being shutdown.
* always return an elderState when waitToBecomeElder is true.
