### PR TITLE
GEODE-6808: Restore JSON backward compatibility

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseDataExportTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseDataExportTest.java
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.categories.PulseTest;
 import org.apache.geode.test.junit.rules.GeodeHttpClientRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
-@Category({PulseTest.class})
+@Category(PulseTest.class)
 public class PulseDataExportTest {
 
   @Rule
@@ -41,8 +41,8 @@ public class PulseDataExportTest {
   public GeodeHttpClientRule client = new GeodeHttpClientRule(server::getHttpPort);
 
   @Before
-  public void before() throws Exception {
-    Region region = server.getCache().getRegion("regionA");
+  public void before() {
+    Region<String, String> region = server.getCache().getRegion("regionA");
     region.put("key1", "value1");
     region.put("key2", "value2");
     region.put("key3", "value3");
@@ -57,6 +57,6 @@ public class PulseDataExportTest {
             .hasStatusCode(200)
             .hasResponseBody()
             .isEqualToIgnoringWhitespace(
-                "{\"result\":[\"value1\",\"value2\",\"value3\"]}");
+                "{\"result\":[[\"java.lang.String\",\"value1\"],[\"java.lang.String\",\"value2\"],[\"java.lang.String\",\"value3\"]]}");
   }
 }

--- a/geode-assembly/src/uiTest/java/org/apache/geode/tools/pulse/ui/PulseAcceptanceTestBase.java
+++ b/geode-assembly/src/uiTest/java/org/apache/geode/tools/pulse/ui/PulseAcceptanceTestBase.java
@@ -68,20 +68,20 @@ public abstract class PulseAcceptanceTestBase {
     searchByXPathAndClick("//a[text()='Cluster View']");
   }
 
-  protected void searchByLinkAndClick(String linkText) {
+  private void searchByLinkAndClick(String linkText) {
     WebElement element = new WebDriverWait(getWebDriver(), 2)
         .until(ExpectedConditions.elementToBeClickable(By.linkText(linkText)));
     assertNotNull(element);
     element.click();
   }
 
-  protected void searchByIdAndClick(String id) {
+  private void searchByIdAndClick(String id) {
     WebElement element = getWebDriver().findElement(By.id(id));
     assertNotNull(element);
     element.click();
   }
 
-  protected void searchByXPathAndClick(String xpath) {
+  private void searchByXPathAndClick(String xpath) {
     WebElement element = getWebDriver().findElement(By.xpath(xpath));
     assertNotNull(element);
     element.click();
@@ -140,51 +140,51 @@ public abstract class PulseAcceptanceTestBase {
     // table contains header row so actual members is one less than the tr elements.
     assertThat(actualMembers.length).isEqualTo(elements.size() - 1);
 
-    for (int i = 0; i < actualMembers.length; i++) {
+    for (Cluster.Member actualMember : actualMembers) {
       // reset from member view as we are looping
       searchByXPathAndClick("//a[text()='Cluster View']");
       searchByIdAndClick("default_grid_button");
       String displayedMemberId =
           getWebDriver().findElement(By.xpath("//table[@id='memberList']/tbody/tr[contains(@id, '"
-              + actualMembers[i].getName() + "')]/td")).getText();
-      assertThat(actualMembers[i].getId()).contains(displayedMemberId);
+              + actualMember.getName() + "')]/td")).getText();
+      assertThat(actualMember.getId()).contains(displayedMemberId);
 
       String displayedMemberName =
           getWebDriver().findElement(By.xpath("//table[@id='memberList']/tbody/tr[contains(@id, '"
-              + actualMembers[i].getName() + "')]/td[2]")).getText();
-      assertThat(actualMembers[i].getName()).isEqualTo(displayedMemberName);
+              + actualMember.getName() + "')]/td[2]")).getText();
+      assertThat(actualMember.getName()).isEqualTo(displayedMemberName);
 
       String displayedMemberHost =
           getWebDriver().findElement(By.xpath("//table[@id='memberList']/tbody/tr[contains(@id, '"
-              + actualMembers[i].getName() + "')]/td[3]")).getText();
-      assertThat(actualMembers[i].getHost()).isEqualTo(displayedMemberHost);
+              + actualMember.getName() + "')]/td[3]")).getText();
+      assertThat(actualMember.getHost()).isEqualTo(displayedMemberHost);
 
       // now click the grid row to go to member view and assert details displayed
       searchByXPathAndClick("//table[@id='memberList']/tbody/tr[contains(@id, '"
-          + actualMembers[i].getName() + "')]/td");
+          + actualMember.getName() + "')]/td");
 
       String displayedRegionCount =
           getWebDriver().findElement(By.id(MEMBER_VIEW_REGION_ID)).getText();
-      assertThat(String.valueOf(actualMembers[i].getTotalRegionCount()))
+      assertThat(String.valueOf(actualMember.getTotalRegionCount()))
           .isEqualTo(displayedRegionCount);
 
       String displaySocketCount =
           getWebDriver().findElement(By.id(MEMBER_VIEW_SOCKETS_ID)).getText();
-      if (actualMembers[i].getTotalFileDescriptorOpen() < 0)
+      if (actualMember.getTotalFileDescriptorOpen() < 0)
         assertThat("NA").isEqualTo(displaySocketCount);
       else
-        assertThat(String.valueOf(actualMembers[i].getTotalFileDescriptorOpen()))
+        assertThat(String.valueOf(actualMember.getTotalFileDescriptorOpen()))
             .isEqualTo(displaySocketCount);
 
       String displayedJVMPauses =
           getWebDriver().findElement(By.id(MEMBER_VIEW_JVMPAUSES_ID)).getText();
-      assertThat(String.valueOf(actualMembers[i].getPreviousJVMPauseCount()))
+      assertThat(String.valueOf(actualMember.getPreviousJVMPauseCount()))
           .isEqualTo(displayedJVMPauses);
     }
   }
 
   @Test
-  public void testDropDownList() throws InterruptedException {
+  public void testDropDownList() {
     searchByIdAndClick("default_grid_button");
     searchByXPathAndClick("//table[@id='memberList']/tbody/tr[contains(@id, 'locator')]/td");
     searchByIdAndClick("memberName");
@@ -313,7 +313,7 @@ public abstract class PulseAcceptanceTestBase {
     }
   }
 
-  public void testTreeMapPopUpData(String gridIcon) {
+  private void testTreeMapPopUpData(String gridIcon) {
     for (String member : getCluster().getMembersHMap().keySet()) {
       searchByLinkAndClick(CLUSTER_VIEW_LABEL);
       if (gridIcon.equals(SERVER_GROUP_GRID_ID)) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/SingleHopQuarterPartitionResolver.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/SingleHopQuarterPartitionResolver.java
@@ -32,7 +32,7 @@ import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.internal.cache.xmlcache.Declarable2;
 
 public class SingleHopQuarterPartitionResolver
-    implements FixedPartitionResolver, Declarable2, DataSerializable {
+    implements FixedPartitionResolver<Date, Object>, Declarable2, DataSerializable {
   private Properties resolveProps;
   Object[][] months = new Object[12][12];
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/QueryDataDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/QueryDataDUnitTest.java
@@ -32,8 +32,6 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 import javax.management.ObjectName;
 
@@ -169,7 +167,7 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   @Test
-  public void testQueryOnPartitionedRegion() throws Exception {
+  public void testQueryOnPartitionedRegion() {
     managerVM.invoke(testName.getMethodName(), () -> {
       DistributedSystemMXBean distributedSystemMXBean =
           managementTestRule.getSystemManagementService().getDistributedSystemMXBean();
@@ -197,7 +195,7 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   @Test
-  public void testQueryOnReplicatedRegion() throws Exception {
+  public void testQueryOnReplicatedRegion() {
     managerVM.invoke(testName.getMethodName(), () -> {
       DistributedSystemMXBean distributedSystemMXBean =
           managementTestRule.getSystemManagementService().getDistributedSystemMXBean();
@@ -213,7 +211,7 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   @Test
-  public void testMemberWise() throws Exception {
+  public void testMemberWise() {
     managerVM.invoke(testName.getMethodName(), () -> {
       DistributedSystemMXBean distributedSystemMXBean =
           managementTestRule.getSystemManagementService().getDistributedSystemMXBean();
@@ -227,7 +225,7 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   @Test
-  public void testLimitForQuery() throws Exception {
+  public void testLimitForQuery() {
     memberVMs[0].invoke("putBigInstances", () -> putBigInstances(REPLICATE_REGION_NAME4));
 
     managerVM.invoke(testName.getMethodName(), () -> {
@@ -283,7 +281,7 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   @Test
-  public void testErrors() throws Exception {
+  public void testErrors() {
     managerVM.invoke(testName.getMethodName(), () -> {
       DistributedSystemMXBean distributedSystemMXBean =
           managementTestRule.getSystemManagementService().getDistributedSystemMXBean();
@@ -327,7 +325,7 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   @Test
-  public void testNormalRegions() throws Exception {
+  public void testNormalRegions() {
     managerVM.invoke(testName.getMethodName(), () -> {
       DistributedSystemMXBean distributedSystemMXBean =
           managementTestRule.getSystemManagementService().getDistributedSystemMXBean();
@@ -367,14 +365,15 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   @Test
-  public void testRegionsLocalDataSet() throws Exception {
+  public void testRegionsLocalDataSet() {
     String partitionedRegionName = testName.getMethodName() + "_PARTITIONED_REGION";
 
     String[] values1 = new String[] {"val1", "val2", "val3"};
     String[] values2 = new String[] {"val4", "val5", "val6"};
 
     memberVMs[0].invoke(testName.getMethodName() + " Create Region", () -> {
-      PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+      PartitionAttributesFactory<Date, Object> partitionAttributesFactory =
+          new PartitionAttributesFactory<>();
       partitionAttributesFactory.setRedundantCopies(2).setTotalNumBuckets(12);
 
       List<FixedPartitionAttributes> fixedPartitionAttributesList = createFixedPartitionList(1);
@@ -383,10 +382,10 @@ public class QueryDataDUnitTest implements Serializable {
       }
       partitionAttributesFactory.setPartitionResolver(new SingleHopQuarterPartitionResolver());
 
-      RegionFactory regionFactory =
-          managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
+      RegionFactory<Date, Object> regionFactory =
+          managementTestRule.getCache().<Date, Object>createRegionFactory(RegionShortcut.PARTITION)
               .setPartitionAttributes(partitionAttributesFactory.create());
-      Region region = regionFactory.create(partitionedRegionName);
+      Region<Date, Object> region = regionFactory.create(partitionedRegionName);
 
       for (int i = 0; i < values1.length; i++) {
         region.put(getDate(2013, 1, i + 5), values1[i]);
@@ -394,7 +393,8 @@ public class QueryDataDUnitTest implements Serializable {
     });
 
     memberVMs[1].invoke(testName.getMethodName() + " Create Region", () -> {
-      PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+      PartitionAttributesFactory<Date, Object> partitionAttributesFactory =
+          new PartitionAttributesFactory<>();
       partitionAttributesFactory.setRedundantCopies(2).setTotalNumBuckets(12);
 
       List<FixedPartitionAttributes> fixedPartitionAttributesList = createFixedPartitionList(2);
@@ -403,10 +403,10 @@ public class QueryDataDUnitTest implements Serializable {
       }
       partitionAttributesFactory.setPartitionResolver(new SingleHopQuarterPartitionResolver());
 
-      RegionFactory regionFactory =
-          managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
+      RegionFactory<Date, Object> regionFactory =
+          managementTestRule.getCache().<Date, Object>createRegionFactory(RegionShortcut.PARTITION)
               .setPartitionAttributes(partitionAttributesFactory.create());
-      Region region = regionFactory.create(partitionedRegionName);
+      Region<Date, Object> region = regionFactory.create(partitionedRegionName);
 
       for (int i = 0; i < values2.length; i++) {
         region.put(getDate(2013, 5, i + 5), values2[i]);
@@ -414,15 +414,16 @@ public class QueryDataDUnitTest implements Serializable {
     });
 
     memberVMs[2].invoke(testName.getMethodName() + " Create Region", () -> {
-      PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+      PartitionAttributesFactory<Date, Object> partitionAttributesFactory =
+          new PartitionAttributesFactory<>();
       partitionAttributesFactory.setRedundantCopies(2).setTotalNumBuckets(12);
 
       List<FixedPartitionAttributes> fixedPartitionAttributesList = createFixedPartitionList(3);
       fixedPartitionAttributesList.forEach(partitionAttributesFactory::addFixedPartitionAttributes);
       partitionAttributesFactory.setPartitionResolver(new SingleHopQuarterPartitionResolver());
 
-      RegionFactory regionFactory =
-          managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
+      RegionFactory<Date, Object> regionFactory =
+          managementTestRule.getCache().<Date, Object>createRegionFactory(RegionShortcut.PARTITION)
               .setPartitionAttributes(partitionAttributesFactory.create());
       regionFactory.create(partitionedRegionName);
     });
@@ -482,9 +483,9 @@ public class QueryDataDUnitTest implements Serializable {
 
   private void putDataInRegion(final String regionName, final Object[] portfolio, final int from,
       final int to) {
-    Region region = managementTestRule.getCache().getRegion(regionName);
+    Region<Integer, Object> region = managementTestRule.getCache().getRegion(regionName);
     for (int i = from; i < to; i++) {
-      region.put(new Integer(i), portfolio[i]);
+      region.put(i, portfolio[i]);
     }
   }
 
@@ -521,8 +522,8 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   private void putPdxInstances(final String regionName) throws CacheException {
-    InternalCache cache = (InternalCache) managementTestRule.getCache();
-    Region region = cache.getRegion(regionName);
+    InternalCache cache = managementTestRule.getCache();
+    Region<String, PdxInstance> region = cache.getRegion(regionName);
 
     PdxInstanceFactory pdxInstanceFactory =
         PdxInstanceFactoryImpl.newCreator("Portfolio", false, cache);
@@ -555,7 +556,7 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   private void putBigInstances(final String regionName) {
-    Region region = managementTestRule.getCache().getRegion(regionName);
+    Region<String, List<String>> region = managementTestRule.getCache().getRegion(regionName);
 
     for (int i = 0; i < 1200; i++) {
       List<String> bigCollection = new ArrayList<>();
@@ -577,29 +578,37 @@ public class QueryDataDUnitTest implements Serializable {
   }
 
   private void createColocatedPR() {
-    PartitionResolver testKeyBasedResolver = new TestPartitionResolver();
+    PartitionResolver<Integer, Object> testKeyBasedResolver = new TestPartitionResolver();
     managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
-        .setPartitionAttributes(new PartitionAttributesFactory().setTotalNumBuckets(NUM_OF_BUCKETS)
-            .setPartitionResolver(testKeyBasedResolver).create())
+        .setPartitionAttributes(
+            new PartitionAttributesFactory<Integer, Object>().setTotalNumBuckets(NUM_OF_BUCKETS)
+                .setPartitionResolver(testKeyBasedResolver).create())
         .create(PARTITIONED_REGION_NAME1);
     managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
-        .setPartitionAttributes(new PartitionAttributesFactory().setTotalNumBuckets(NUM_OF_BUCKETS)
-            .setPartitionResolver(testKeyBasedResolver).setColocatedWith(PARTITIONED_REGION_NAME1)
-            .create())
+        .setPartitionAttributes(
+            new PartitionAttributesFactory<Integer, Object>().setTotalNumBuckets(NUM_OF_BUCKETS)
+                .setPartitionResolver(testKeyBasedResolver)
+                .setColocatedWith(PARTITIONED_REGION_NAME1)
+                .create())
         .create(PARTITIONED_REGION_NAME2);
     managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
-        .setPartitionAttributes(new PartitionAttributesFactory().setTotalNumBuckets(NUM_OF_BUCKETS)
-            .setPartitionResolver(testKeyBasedResolver).setColocatedWith(PARTITIONED_REGION_NAME2)
-            .create())
+        .setPartitionAttributes(
+            new PartitionAttributesFactory<Integer, Object>().setTotalNumBuckets(NUM_OF_BUCKETS)
+                .setPartitionResolver(testKeyBasedResolver)
+                .setColocatedWith(PARTITIONED_REGION_NAME2)
+                .create())
         .create(PARTITIONED_REGION_NAME3);
     managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
-        .setPartitionAttributes(new PartitionAttributesFactory().setTotalNumBuckets(NUM_OF_BUCKETS)
-            .setPartitionResolver(testKeyBasedResolver).create())
+        .setPartitionAttributes(
+            new PartitionAttributesFactory<Integer, Object>().setTotalNumBuckets(NUM_OF_BUCKETS)
+                .setPartitionResolver(testKeyBasedResolver).create())
         .create(PARTITIONED_REGION_NAME4); // not collocated
     managementTestRule.getCache().createRegionFactory(RegionShortcut.PARTITION)
-        .setPartitionAttributes(new PartitionAttributesFactory().setTotalNumBuckets(NUM_OF_BUCKETS)
-            .setPartitionResolver(testKeyBasedResolver).setColocatedWith(PARTITIONED_REGION_NAME4)
-            .create())
+        .setPartitionAttributes(
+            new PartitionAttributesFactory<Integer, Object>().setTotalNumBuckets(NUM_OF_BUCKETS)
+                .setPartitionResolver(testKeyBasedResolver)
+                .setColocatedWith(PARTITIONED_REGION_NAME4)
+                .create())
         .create(PARTITIONED_REGION_NAME5); // collocated with 4
   }
 
@@ -607,24 +616,23 @@ public class QueryDataDUnitTest implements Serializable {
     managementTestRule.getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
   }
 
-  private void createRegionsInNodes()
-      throws InterruptedException, TimeoutException, ExecutionException {
+  private void createRegionsInNodes() {
     // Create local Region on servers
-    memberVMs[0].invoke(() -> createLocalRegion());
+    memberVMs[0].invoke(this::createLocalRegion);
 
     // Create ReplicatedRegion on servers
-    memberVMs[0].invoke(() -> createReplicatedRegion());
-    memberVMs[1].invoke(() -> createReplicatedRegion());
-    memberVMs[2].invoke(() -> createReplicatedRegion());
+    memberVMs[0].invoke(this::createReplicatedRegion);
+    memberVMs[1].invoke(this::createReplicatedRegion);
+    memberVMs[2].invoke(this::createReplicatedRegion);
 
     memberVMs[1].invoke(() -> createDistributedRegion(REPLICATE_REGION_NAME2));
     memberVMs[0].invoke(() -> createDistributedRegion(REPLICATE_REGION_NAME3));
     memberVMs[0].invoke(() -> createDistributedRegion(REPLICATE_REGION_NAME4));
 
     // Create two co-located PartitionedRegions On Servers.
-    memberVMs[0].invoke(() -> createColocatedPR());
-    memberVMs[1].invoke(() -> createColocatedPR());
-    memberVMs[2].invoke(() -> createColocatedPR());
+    memberVMs[0].invoke(this::createColocatedPR);
+    memberVMs[1].invoke(this::createColocatedPR);
+    memberVMs[2].invoke(this::createColocatedPR);
 
     managerVM.invoke("Wait for all Region Proxies to get replicated", () -> {
       awaitDistributedRegionMXBean("/" + PARTITIONED_REGION_NAME1, 3);
@@ -639,9 +647,12 @@ public class QueryDataDUnitTest implements Serializable {
     });
   }
 
+  @SuppressWarnings("unchecked")
   private List<String> getLocalDataSet(final String region) {
     PartitionedRegion partitionedRegion =
         PartitionedRegionHelper.getPartitionedRegion(region, managementTestRule.getCache());
+    assertThat(partitionedRegion).isNotNull();
+
     Set<BucketRegion> localPrimaryBucketRegions =
         partitionedRegion.getDataStore().getAllLocalPrimaryBucketRegions();
 
@@ -716,7 +727,7 @@ public class QueryDataDUnitTest implements Serializable {
     return service.getDistributedRegionMXBean(name);
   }
 
-  private static class TestPartitionResolver implements PartitionResolver {
+  private static class TestPartitionResolver implements PartitionResolver<Integer, Object> {
 
     @Override
     public void close() {}

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/DataQueryEngineIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/DataQueryEngineIntegrationTest.java
@@ -46,7 +46,7 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 /**
  * Functional integration tests for {@link DataQueryEngine}.
  */
-@Category({GfshTest.class})
+@Category(GfshTest.class)
 public class DataQueryEngineIntegrationTest {
 
   private static final String REGION_NAME = "exampleRegion";
@@ -98,10 +98,9 @@ public class DataQueryEngineIntegrationTest {
     region.put("order1", order);
 
     String expectedResult =
-        "{\"result\":[[\"org.apache.geode.management.model.Order\",{\"id\":\"test\",\"items\":[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_1\",\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"1\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_2\",\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"2\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_3\",\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"3\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_4\",\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"4\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_5\",\"order\":\"duplicate org.apache.geode.management.model.Order\"}]}]}]]}";
-    Object result = queryEngine.queryForJsonResult(QUERY_1, 0, queryResultSetLimit,
-        queryCollectionsDepth);
-    String queryResult = (String) result;
+        "{\"result\":[[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"test\"],\"items\":[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_1\"],\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"1\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_2\"],\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"2\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_3\"],\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"3\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_4\"],\"order\":\"duplicate org.apache.geode.management.model.Order\"}],\"4\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_5\"],\"order\":\"duplicate org.apache.geode.management.model.Order\"}]}]}]]}";
+    String queryResult =
+        queryEngine.queryForJsonResult(QUERY_1, 0, queryResultSetLimit, queryCollectionsDepth);
 
     assertThat(queryResult).isEqualToIgnoringWhitespace(expectedResult);
     // If not correct JSON format this will throw a JSONException
@@ -131,7 +130,7 @@ public class DataQueryEngineIntegrationTest {
         queryCollectionsDepth);
 
     String expectedResult =
-        "{\"result\":[[\"org.apache.geode.management.model.Order\",{\"id\":\"test\",\"items\":[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_1\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_1\",\"items\":[\"java.util.ArrayList\",{}]}]}],\"1\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_2\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_2\",\"items\":[\"java.util.ArrayList\",{}]}]}],\"2\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_3\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_3\",\"items\":[\"java.util.ArrayList\",{}]}]}],\"3\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_4\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_4\",\"items\":[\"java.util.ArrayList\",{}]}]}],\"4\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_5\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_5\",\"items\":[\"java.util.ArrayList\",{}]}]}]}]}]]}";
+        "{\"result\":[[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"test\"],\"items\":[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_1\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_1\"],\"items\":[\"java.util.ArrayList\",{}]}]}],\"1\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_2\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_2\"],\"items\":[\"java.util.ArrayList\",{}]}]}],\"2\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_3\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_3\"],\"items\":[\"java.util.ArrayList\",{}]}]}],\"3\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_4\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_4\"],\"items\":[\"java.util.ArrayList\",{}]}]}],\"4\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_5\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_5\"],\"items\":[\"java.util.ArrayList\",{}]}]}]}]}]]}";
     assertThat(queryResult).isEqualToIgnoringWhitespace(expectedResult);
 
     // If not correct JSON format this will throw a JSONException
@@ -161,7 +160,7 @@ public class DataQueryEngineIntegrationTest {
     String queryResult = queryEngine.queryForJsonResult(QUERY_1, 0, queryResultSetLimit,
         queryCollectionsDepth);
     String expectedResult =
-        "{\"result\":[[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_TEST\",\"items\":[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_1\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_1\",\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_2\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_2\",\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_3\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_3\",\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_4\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_4\",\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":\"Book\",\"itemId\":\"ID_5\",\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":\"ORDER_ID_5\",\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}]}]}]}],\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}],\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}],\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}],\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]]}";
+        "{\"result\":[[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_TEST\"],\"items\":[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_1\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_1\"],\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_2\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_2\"],\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_3\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_3\"],\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_4\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_4\"],\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"Book\"],\"itemId\":[\"java.lang.String\",\"ID_5\"],\"order\":[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"ORDER_ID_5\"],\"items\":[\"java.util.ArrayList\",{\"0\":\"duplicate org.apache.geode.management.model.Item\",\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}]}]}]}],\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}],\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}],\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]}],\"1\":\"duplicate org.apache.geode.management.model.Item\",\"2\":\"duplicate org.apache.geode.management.model.Item\",\"3\":\"duplicate org.apache.geode.management.model.Item\",\"4\":\"duplicate org.apache.geode.management.model.Item\"}]}]]}";
     assertThat(queryResult).isEqualToIgnoringWhitespace(expectedResult);
 
     // If not correct JSON format this will throw a JSONException
@@ -277,7 +276,7 @@ public class DataQueryEngineIntegrationTest {
     String queryResult = queryEngine.queryForJsonResult(QUERY_1, 0, queryResultSetLimit,
         queryCollectionsDepth);
     String expectedResult =
-        "{\"result\":[[\"org.apache.geode.management.model.SubOrder\",{\"id\":\"null1\",\"items\":[\"java.util.ArrayList\",{}]}]]}";
+        "{\"result\":[[\"org.apache.geode.management.model.SubOrder\",{\"id\":[\"java.lang.String\",\"null1\"],\"items\":[\"java.util.ArrayList\",{}]}]]}";
     assertThat(queryResult).isEqualToIgnoringWhitespace(expectedResult);
 
     // If not correct JSON format this will throw a JSONException
@@ -287,7 +286,7 @@ public class DataQueryEngineIntegrationTest {
   @Test
   public void testNestedPDXObject() throws Exception {
     PdxInstanceFactory factory = PdxInstanceFactoryImpl.newCreator("Portfolio", false,
-        (InternalCache) region.getCache());
+        (InternalCache) region.getRegionService());
 
     factory.writeInt("ID", 111);
     factory.writeString("status", "active");
@@ -300,7 +299,7 @@ public class DataQueryEngineIntegrationTest {
     String queryResult = queryEngine.queryForJsonResult(QUERY_1, 0, queryResultSetLimit,
         queryCollectionsDepth);
     String expectedResult =
-        "{\"result\":[[\"org.apache.geode.pdx.internal.PdxInstanceImpl\",{\"ID\":111,\"status\":\"active\",\"secId\":\"IBM\"}]]}";
+        "{\"result\":[[\"org.apache.geode.pdx.PdxInstance\",{\"ID\":[\"java.lang.Integer\",111],\"status\":[\"java.lang.String\",\"active\"],\"secId\":[\"java.lang.String\",\"IBM\"]}]]}";
     assertThat(queryResult).isEqualToIgnoringWhitespace(expectedResult);
 
     // If not correct JSON format this will throw a JSONException
@@ -318,7 +317,7 @@ public class DataQueryEngineIntegrationTest {
     String queryResult = queryEngine.queryForJsonResult(QUERY_1, 0, queryResultSetLimit,
         queryCollectionsDepth);
     String expectedResult =
-        "{\"result\":[[\"[Lorg.apache.geode.management.model.SubOrder;\",[[\"org.apache.geode.management.model.SubOrder\",{\"id\":\"null1\",\"items\":[\"java.util.ArrayList\",{}]}],null]]]}";
+        "{\"result\":[[\"org.apache.geode.management.model.SubOrder[]\",[{\"id\":[\"java.lang.String\",\"null1\"],\"items\":[\"java.util.ArrayList\",{}]},null]]]}";
     assertThat(queryResult).isEqualToIgnoringWhitespace(expectedResult);
 
     // If not correct JSON format this will throw a JSONException
@@ -336,7 +335,7 @@ public class DataQueryEngineIntegrationTest {
     String queryResult = queryEngine.queryForJsonResult(QUERY_1, 0, queryResultSetLimit,
         queryCollectionsDepth);
     String expectedResult =
-        "{\"result\":[[\"[Lorg.apache.geode.management.model.SubOrder;\",[[\"org.apache.geode.management.model.SubOrder\",{\"id\":\"null1\",\"items\":[\"java.util.ArrayList\",{}]}],null]]]}";
+        "{\"result\":[[\"org.apache.geode.management.model.SubOrder[]\",[{\"id\":[\"java.lang.String\",\"null1\"],\"items\":[\"java.util.ArrayList\",{}]},null]]]}";
     assertThat(queryResult).isEqualToIgnoringWhitespace(expectedResult);
 
     // If not correct JSON format this will throw a JSONException

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/json/QueryResultFormatterPdxIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/json/QueryResultFormatterPdxIntegrationTest.java
@@ -48,11 +48,9 @@ public class QueryResultFormatterPdxIntegrationTest {
   private void checkResult(QueryResultFormatter queryResultFormatter, String expectedJsonString)
       throws IOException {
     String jsonString = queryResultFormatter.toString();
-    System.out.println("queryResultFormatter.toString=" + jsonString);
     assertThat(jsonString).isEqualTo(expectedJsonString);
 
     JsonNode jsonObject = new ObjectMapper().readTree(jsonString);
-    System.out.println("jsonObject=" + jsonObject);
     assertThat(jsonObject.get(RESULT)).isNotNull();
   }
 

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -71,6 +71,7 @@ org/apache/geode/internal/util/concurrent/StoppableReadWriteLock
 org/apache/geode/management/internal/cli/commands/ShowMetricsCommand$Category
 org/apache/geode/management/internal/cli/exceptions/UserErrorException
 org/apache/geode/management/internal/cli/json/AbstractJSONFormatter$PreventReserializationModule
+org/apache/geode/management/internal/cli/json/QueryResultFormatter$TypeSerializationEnforcerModule
 org/apache/geode/security/ResourcePermission
 org/apache/geode/security/ResourcePermission$Operation
 org/apache/geode/security/ResourcePermission$Resource

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/JsonUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/JsonUtil.java
@@ -36,8 +36,8 @@ public class JsonUtil {
         || klass.isAssignableFrom(Float.class) || klass.isAssignableFrom(float.class)
         || klass.isAssignableFrom(Double.class) || klass.isAssignableFrom(double.class)
         || klass.isAssignableFrom(Boolean.class) || klass.isAssignableFrom(boolean.class)
-        || klass.isAssignableFrom(String.class) || klass.isAssignableFrom(Character.class)
-        || klass.isAssignableFrom(char.class);
+        || klass.isAssignableFrom(Character.class) || klass.isAssignableFrom(char.class)
+        || klass.isAssignableFrom(String.class);
   }
 
   public static List<String> toStringList(JsonNode jsonArray) {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/json/QueryResultFormatterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/json/QueryResultFormatterTest.java
@@ -41,11 +41,9 @@ public class QueryResultFormatterTest {
   private void checkResult(final QueryResultFormatter queryResultFormatter,
       String expectedJsonString) throws Exception {
     String jsonString = queryResultFormatter.toString();
-    System.out.println("queryResultFormatter.toString=" + jsonString);
     assertThat(jsonString).isEqualTo(expectedJsonString);
 
     JsonNode jsonObject = new ObjectMapper().readTree(jsonString);
-    System.out.println("jsonObject=" + jsonObject);
     assertThat(jsonObject.get(RESULT)).isNotNull();
   }
 
@@ -207,7 +205,7 @@ public class QueryResultFormatterTest {
     CollectionHolder arrayHolder = new CollectionHolder();
     QueryResultFormatter arrayHolderResult = new QueryResultFormatter(100).add(RESULT, arrayHolder);
     checkResult(arrayHolderResult,
-        "{\"result\":[[\"org.apache.geode.cache.query.data.CollectionHolder\",{\"arr\":[\"java.lang.String[]\",[\"0\",\"1\",\"2\",\"3\",\"4\",\"SUN\",\"IBM\",\"YHOO\",\"GOOG\",\"MSFT\"]]}]]}");;
+        "{\"result\":[[\"org.apache.geode.cache.query.data.CollectionHolder\",{\"arr\":[\"java.lang.String[]\",[\"0\",\"1\",\"2\",\"3\",\"4\",\"SUN\",\"IBM\",\"YHOO\",\"GOOG\",\"MSFT\"]]}]]}");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/json/QueryResultFormatterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/json/QueryResultFormatterTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,19 +30,184 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 
+import org.apache.geode.cache.query.data.CollectionHolder;
+import org.apache.geode.management.model.Item;
+import org.apache.geode.management.model.Order;
+import org.apache.geode.management.model.SubOrder;
 
 public class QueryResultFormatterTest {
-
   private static final String RESULT = "result";
 
+  private void checkResult(final QueryResultFormatter queryResultFormatter,
+      String expectedJsonString) throws Exception {
+    String jsonString = queryResultFormatter.toString();
+    System.out.println("queryResultFormatter.toString=" + jsonString);
+    assertThat(jsonString).isEqualTo(expectedJsonString);
+
+    JsonNode jsonObject = new ObjectMapper().readTree(jsonString);
+    System.out.println("jsonObject=" + jsonObject);
+    assertThat(jsonObject.get(RESULT)).isNotNull();
+  }
+
   @Test
-  public void canBeMocked() throws Exception {
+  public void canBeMocked() {
     QueryResultFormatter mockQueryResultFormatter = mock(QueryResultFormatter.class);
     Object value = new Object();
 
     mockQueryResultFormatter.add("key", value);
-
     verify(mockQueryResultFormatter, times(1)).add("key", value);
+  }
+
+  @Test
+  public void testPrimitives() throws Exception {
+    String expectedByteString = "{\"result\":[[\"java.lang.Byte\",1]]}";
+    QueryResultFormatter byteResult = new QueryResultFormatter(100).add(RESULT, (byte) 1);
+    QueryResultFormatter boxedByteResult = new QueryResultFormatter(100).add(RESULT, new Byte("1"));
+    checkResult(byteResult, expectedByteString);
+    checkResult(boxedByteResult, expectedByteString);
+
+    String expectedShortString = "{\"result\":[[\"java.lang.Short\",1]]}";
+    QueryResultFormatter shortResult = new QueryResultFormatter(100).add(RESULT, (short) 1);
+    QueryResultFormatter boxedShortResult =
+        new QueryResultFormatter(100).add(RESULT, new Short("1"));
+    checkResult(shortResult, expectedShortString);
+    checkResult(boxedShortResult, expectedShortString);
+
+    String expectedIntegerString = "{\"result\":[[\"java.lang.Integer\",1]]}";
+    QueryResultFormatter integerResult = new QueryResultFormatter(100).add(RESULT, 1);
+    QueryResultFormatter boxedIntegerResult =
+        new QueryResultFormatter(100).add(RESULT, new Integer("1"));
+    checkResult(integerResult, expectedIntegerString);
+    checkResult(boxedIntegerResult, expectedIntegerString);
+
+    String expectedLongString = "{\"result\":[[\"java.lang.Long\",25]]}";
+    QueryResultFormatter longResult = new QueryResultFormatter(100).add(RESULT, 25L);
+    QueryResultFormatter boxedLongResult =
+        new QueryResultFormatter(100).add(RESULT, new Long("25"));
+    checkResult(longResult, expectedLongString);
+    checkResult(boxedLongResult, expectedLongString);
+
+    String expectedFloatString = "{\"result\":[[\"java.lang.Float\",26.0]]}";
+    QueryResultFormatter floatResult = new QueryResultFormatter(100).add(RESULT, 26f);
+    QueryResultFormatter boxedFloatResult =
+        new QueryResultFormatter(100).add(RESULT, new Float("26.0"));
+    checkResult(floatResult, expectedFloatString);
+    checkResult(boxedFloatResult, expectedFloatString);
+
+    String expectedDoubleString = "{\"result\":[[\"java.lang.Double\",30.0]]}";
+    QueryResultFormatter doubleResult = new QueryResultFormatter(100).add(RESULT, 30d);
+    QueryResultFormatter boxedDoubleResult =
+        new QueryResultFormatter(100).add(RESULT, new Double("30.0"));
+    checkResult(doubleResult, expectedDoubleString);
+    checkResult(boxedDoubleResult, expectedDoubleString);
+
+    String expectedBooleanString = "{\"result\":[[\"java.lang.Boolean\",true]]}";
+    QueryResultFormatter booleanResult = new QueryResultFormatter(100).add(RESULT, true);
+    QueryResultFormatter boxedBooleanResult =
+        new QueryResultFormatter(100).add(RESULT, Boolean.TRUE);
+    checkResult(booleanResult, expectedBooleanString);
+    checkResult(boxedBooleanResult, expectedBooleanString);
+
+    String expectedCharString = "{\"result\":[[\"java.lang.Character\",\"a\"]]}";
+    QueryResultFormatter charResult = new QueryResultFormatter(100).add(RESULT, 'a');
+    QueryResultFormatter boxedCharResult =
+        new QueryResultFormatter(100).add(RESULT, new Character('a'));
+    checkResult(charResult, expectedCharString);
+    checkResult(boxedCharResult, expectedCharString);
+
+    QueryResultFormatter stringResult = new QueryResultFormatter(100).add(RESULT, "String");
+    checkResult(stringResult, "{\"result\":[[\"java.lang.String\",\"String\"]]}");
+
+    QueryResultFormatter javaDateResult =
+        new QueryResultFormatter(100).add(RESULT, new java.util.Date(0));
+    checkResult(javaDateResult,
+        "{\"result\":[[\"java.util.Date\",\"1970-01-01T00:00:00.000+0000\"]]}");
+
+    QueryResultFormatter sqlDateResult =
+        new QueryResultFormatter(100).add(RESULT, new java.sql.Date(0));
+    checkResult(sqlDateResult,
+        "{\"result\":[[\"java.sql.Date\",\"1970-01-01T00:00:00.000+0000\"]]}");
+  }
+
+  @Test
+  public void testCustomBeans() throws Exception {
+    Object object = new Object();
+    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, object);
+    checkResult(queryResultFormatter, "{\"result\":[[\"java.lang.Object\",{}]]}");
+
+    Order order = new Order();
+    order.setId("order1");
+    Collection<Item> items = new ArrayList<>();
+    items.add(new Item(order, "item1", "itemDescription1"));
+    order.setItems(items);
+    QueryResultFormatter orderResult = new QueryResultFormatter(100).add(RESULT, order);
+    checkResult(orderResult,
+        "{\"result\":[[\"org.apache.geode.management.model.Order\",{\"id\":[\"java.lang.String\",\"order1\"],\"items\":[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.model.Item\",{\"itemDescription\":[\"java.lang.String\",\"itemDescription1\"],\"itemId\":[\"java.lang.String\",\"item1\"],\"order\":\"duplicate org.apache.geode.management.model.Order\"}]}]}]]}");
+  }
+
+  @Test
+  public void testBigDecimal() throws Exception {
+    BigDecimal dc = new BigDecimal(20);
+
+    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, dc);
+    checkResult(queryResultFormatter, "{\"result\":[[\"java.math.BigDecimal\",20]]}");
+  }
+
+  @Test
+  public void testArrayWithPrimitives() throws Exception {
+    Byte[] byteArray = new Byte[] {0, 1, 2};
+    QueryResultFormatter byteArrayResult = new QueryResultFormatter(100).add(RESULT, byteArray);
+    checkResult(byteArrayResult, "{\"result\":[[\"java.lang.Byte[]\",[0,1,2]]]}");
+
+    Short[] shortArray = new Short[] {0, 1, 2};
+    QueryResultFormatter shortArrayResult = new QueryResultFormatter(100).add(RESULT, shortArray);
+    checkResult(shortArrayResult, "{\"result\":[[\"java.lang.Short[]\",[0,1,2]]]}");
+
+    Integer[] integerArray = new Integer[] {0, 1, 2};
+    QueryResultFormatter integerArrayResult =
+        new QueryResultFormatter(100).add(RESULT, integerArray);
+    checkResult(integerArrayResult, "{\"result\":[[\"java.lang.Integer[]\",[0,1,2]]]}");
+
+    Long[] longArray = new Long[] {0L, 1L, 2L};
+    QueryResultFormatter longArrayResult = new QueryResultFormatter(100).add(RESULT, longArray);
+    checkResult(longArrayResult, "{\"result\":[[\"java.lang.Long[]\",[0,1,2]]]}");
+
+    Float[] floatArray = new Float[] {0f, 1f, 2f};
+    QueryResultFormatter floatArrayResult = new QueryResultFormatter(100).add(RESULT, floatArray);
+    checkResult(floatArrayResult, "{\"result\":[[\"java.lang.Float[]\",[0.0,1.0,2.0]]]}");
+
+    Double[] doubleArray = new Double[] {0d, 1d, 2d};
+    QueryResultFormatter doubleArrayResult = new QueryResultFormatter(100).add(RESULT, doubleArray);
+    checkResult(doubleArrayResult, "{\"result\":[[\"java.lang.Double[]\",[0.0,1.0,2.0]]]}");
+
+    Boolean[] booleanArray = new Boolean[] {true, false};
+    QueryResultFormatter booleanArrayResult =
+        new QueryResultFormatter(100).add(RESULT, booleanArray);
+    checkResult(booleanArrayResult, "{\"result\":[[\"java.lang.Boolean[]\",[true,false]]]}");
+
+    Character[] charArray = new Character[] {'a', 'b'};
+    QueryResultFormatter charArrayResult = new QueryResultFormatter(100).add(RESULT, charArray);
+    checkResult(charArrayResult, "{\"result\":[[\"java.lang.Character[]\",[\"a\",\"b\"]]]}");
+
+    String[] stringArray = new String[] {"string_1", "string_2"};
+    QueryResultFormatter stringArrayResult = new QueryResultFormatter(100).add(RESULT, stringArray);
+    checkResult(stringArrayResult,
+        "{\"result\":[[\"java.lang.String[]\",[\"string_1\",\"string_2\"]]]}");
+  }
+
+  @Test
+  public void testArrayWithCustomBeans() throws Exception {
+    SubOrder[] subOrderArray = new SubOrder[2];
+    subOrderArray[0] = new SubOrder();
+    QueryResultFormatter subOrderArrayResult =
+        new QueryResultFormatter(100).add(RESULT, subOrderArray);
+    checkResult(subOrderArrayResult,
+        "{\"result\":[[\"org.apache.geode.management.model.SubOrder[]\",[{\"id\":[\"java.lang.String\",\"null1\"],\"items\":[\"java.util.ArrayList\",{}]},null]]]}");
+
+    CollectionHolder arrayHolder = new CollectionHolder();
+    QueryResultFormatter arrayHolderResult = new QueryResultFormatter(100).add(RESULT, arrayHolder);
+    checkResult(arrayHolderResult,
+        "{\"result\":[[\"org.apache.geode.cache.query.data.CollectionHolder\",{\"arr\":[\"java.lang.String[]\",[\"0\",\"1\",\"2\",\"3\",\"4\",\"SUN\",\"IBM\",\"YHOO\",\"GOOG\",\"MSFT\"]]}]]}");;
   }
 
   @Test
@@ -52,63 +218,8 @@ public class QueryResultFormatterTest {
     list.add("THREE");
 
     QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, list);
-
-    checkResult(queryResultFormatter);
-  }
-
-  @Test
-  public void testArray() throws Exception {
-    int[] intArray = new int[3];
-    for (int i = 0; i < 3; i++) {
-      intArray[i] = i;
-    }
-
-    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, intArray);
-
-    checkResult(queryResultFormatter);
-  }
-
-  @Test
-  public void testBigList() throws Exception {
-    List<String> list = new ArrayList<>();
-    for (int i = 0; i < 1000; i++) {
-      list.add("BIG_COLL_" + i);
-    }
-
-    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, list);
-
-    checkResult(queryResultFormatter);
-  }
-
-  @Test
-  public void testEnumContainer() throws Exception {
-    EnumContainer enumContainer = new EnumContainer(Currency.DIME);
-
-    QueryResultFormatter queryResultFormatter =
-        new QueryResultFormatter(100).add(RESULT, enumContainer);
-
-    checkResult(queryResultFormatter);
-  }
-
-  @Test
-  public void testEnum() throws Exception {
-    QueryResultFormatter queryResultFormatter =
-        new QueryResultFormatter(100).add(RESULT, Currency.DIME);
-
-    checkResult(queryResultFormatter);
-  }
-
-  @Test
-  public void testEnumList() throws Exception {
-    List<Currency> list = new ArrayList();
-    list.add(Currency.DIME);
-    list.add(Currency.NICKLE);
-    list.add(Currency.QUARTER);
-    list.add(Currency.NICKLE);
-
-    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, list);
-
-    checkResult(queryResultFormatter);
+    checkResult(queryResultFormatter,
+        "{\"result\":[[\"java.util.ArrayList\",{\"0\":[\"java.lang.String\",\"ONE\"],\"1\":[\"java.lang.String\",\"TWO\"],\"2\":[\"java.lang.String\",\"THREE\"]}]]}");
   }
 
   @Test
@@ -120,34 +231,50 @@ public class QueryResultFormatterTest {
     map.put("4", "FOUR");
 
     QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, map);
-
-    checkResult(queryResultFormatter);
+    checkResult(queryResultFormatter,
+        "{\"result\":[[\"java.util.HashMap\",{\"1\":[\"java.lang.String\",\"ONE\"],\"2\":[\"java.lang.String\",\"TWO\"],\"3\":[\"java.lang.String\",\"THREE\"],\"4\":[\"java.lang.String\",\"FOUR\"]}]]}");
   }
 
   @Test
-  public void testBigDecimal() throws Exception {
-    BigDecimal dc = new BigDecimal(20);
+  public void testBigList() throws Exception {
+    List<String> list = new ArrayList<>();
+    for (int i = 0; i < 1000; i++) {
+      list.add("BIG_COLL_" + i);
+    }
 
-    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, dc);
-
-    checkResult(queryResultFormatter);
+    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, list);
+    checkResult(queryResultFormatter,
+        "{\"result\":[[\"java.util.ArrayList\",{\"0\":[\"java.lang.String\",\"BIG_COLL_0\"],\"1\":[\"java.lang.String\",\"BIG_COLL_1\"],\"2\":[\"java.lang.String\",\"BIG_COLL_2\"],\"3\":[\"java.lang.String\",\"BIG_COLL_3\"],\"4\":[\"java.lang.String\",\"BIG_COLL_4\"],\"5\":[\"java.lang.String\",\"BIG_COLL_5\"],\"6\":[\"java.lang.String\",\"BIG_COLL_6\"],\"7\":[\"java.lang.String\",\"BIG_COLL_7\"],\"8\":[\"java.lang.String\",\"BIG_COLL_8\"],\"9\":[\"java.lang.String\",\"BIG_COLL_9\"],\"10\":[\"java.lang.String\",\"BIG_COLL_10\"],\"11\":[\"java.lang.String\",\"BIG_COLL_11\"],\"12\":[\"java.lang.String\",\"BIG_COLL_12\"],\"13\":[\"java.lang.String\",\"BIG_COLL_13\"],\"14\":[\"java.lang.String\",\"BIG_COLL_14\"],\"15\":[\"java.lang.String\",\"BIG_COLL_15\"],\"16\":[\"java.lang.String\",\"BIG_COLL_16\"],\"17\":[\"java.lang.String\",\"BIG_COLL_17\"],\"18\":[\"java.lang.String\",\"BIG_COLL_18\"],\"19\":[\"java.lang.String\",\"BIG_COLL_19\"],\"20\":[\"java.lang.String\",\"BIG_COLL_20\"],\"21\":[\"java.lang.String\",\"BIG_COLL_21\"],\"22\":[\"java.lang.String\",\"BIG_COLL_22\"],\"23\":[\"java.lang.String\",\"BIG_COLL_23\"],\"24\":[\"java.lang.String\",\"BIG_COLL_24\"],\"25\":[\"java.lang.String\",\"BIG_COLL_25\"],\"26\":[\"java.lang.String\",\"BIG_COLL_26\"],\"27\":[\"java.lang.String\",\"BIG_COLL_27\"],\"28\":[\"java.lang.String\",\"BIG_COLL_28\"],\"29\":[\"java.lang.String\",\"BIG_COLL_29\"],\"30\":[\"java.lang.String\",\"BIG_COLL_30\"],\"31\":[\"java.lang.String\",\"BIG_COLL_31\"],\"32\":[\"java.lang.String\",\"BIG_COLL_32\"],\"33\":[\"java.lang.String\",\"BIG_COLL_33\"],\"34\":[\"java.lang.String\",\"BIG_COLL_34\"],\"35\":[\"java.lang.String\",\"BIG_COLL_35\"],\"36\":[\"java.lang.String\",\"BIG_COLL_36\"],\"37\":[\"java.lang.String\",\"BIG_COLL_37\"],\"38\":[\"java.lang.String\",\"BIG_COLL_38\"],\"39\":[\"java.lang.String\",\"BIG_COLL_39\"],\"40\":[\"java.lang.String\",\"BIG_COLL_40\"],\"41\":[\"java.lang.String\",\"BIG_COLL_41\"],\"42\":[\"java.lang.String\",\"BIG_COLL_42\"],\"43\":[\"java.lang.String\",\"BIG_COLL_43\"],\"44\":[\"java.lang.String\",\"BIG_COLL_44\"],\"45\":[\"java.lang.String\",\"BIG_COLL_45\"],\"46\":[\"java.lang.String\",\"BIG_COLL_46\"],\"47\":[\"java.lang.String\",\"BIG_COLL_47\"],\"48\":[\"java.lang.String\",\"BIG_COLL_48\"],\"49\":[\"java.lang.String\",\"BIG_COLL_49\"],\"50\":[\"java.lang.String\",\"BIG_COLL_50\"],\"51\":[\"java.lang.String\",\"BIG_COLL_51\"],\"52\":[\"java.lang.String\",\"BIG_COLL_52\"],\"53\":[\"java.lang.String\",\"BIG_COLL_53\"],\"54\":[\"java.lang.String\",\"BIG_COLL_54\"],\"55\":[\"java.lang.String\",\"BIG_COLL_55\"],\"56\":[\"java.lang.String\",\"BIG_COLL_56\"],\"57\":[\"java.lang.String\",\"BIG_COLL_57\"],\"58\":[\"java.lang.String\",\"BIG_COLL_58\"],\"59\":[\"java.lang.String\",\"BIG_COLL_59\"],\"60\":[\"java.lang.String\",\"BIG_COLL_60\"],\"61\":[\"java.lang.String\",\"BIG_COLL_61\"],\"62\":[\"java.lang.String\",\"BIG_COLL_62\"],\"63\":[\"java.lang.String\",\"BIG_COLL_63\"],\"64\":[\"java.lang.String\",\"BIG_COLL_64\"],\"65\":[\"java.lang.String\",\"BIG_COLL_65\"],\"66\":[\"java.lang.String\",\"BIG_COLL_66\"],\"67\":[\"java.lang.String\",\"BIG_COLL_67\"],\"68\":[\"java.lang.String\",\"BIG_COLL_68\"],\"69\":[\"java.lang.String\",\"BIG_COLL_69\"],\"70\":[\"java.lang.String\",\"BIG_COLL_70\"],\"71\":[\"java.lang.String\",\"BIG_COLL_71\"],\"72\":[\"java.lang.String\",\"BIG_COLL_72\"],\"73\":[\"java.lang.String\",\"BIG_COLL_73\"],\"74\":[\"java.lang.String\",\"BIG_COLL_74\"],\"75\":[\"java.lang.String\",\"BIG_COLL_75\"],\"76\":[\"java.lang.String\",\"BIG_COLL_76\"],\"77\":[\"java.lang.String\",\"BIG_COLL_77\"],\"78\":[\"java.lang.String\",\"BIG_COLL_78\"],\"79\":[\"java.lang.String\",\"BIG_COLL_79\"],\"80\":[\"java.lang.String\",\"BIG_COLL_80\"],\"81\":[\"java.lang.String\",\"BIG_COLL_81\"],\"82\":[\"java.lang.String\",\"BIG_COLL_82\"],\"83\":[\"java.lang.String\",\"BIG_COLL_83\"],\"84\":[\"java.lang.String\",\"BIG_COLL_84\"],\"85\":[\"java.lang.String\",\"BIG_COLL_85\"],\"86\":[\"java.lang.String\",\"BIG_COLL_86\"],\"87\":[\"java.lang.String\",\"BIG_COLL_87\"],\"88\":[\"java.lang.String\",\"BIG_COLL_88\"],\"89\":[\"java.lang.String\",\"BIG_COLL_89\"],\"90\":[\"java.lang.String\",\"BIG_COLL_90\"],\"91\":[\"java.lang.String\",\"BIG_COLL_91\"],\"92\":[\"java.lang.String\",\"BIG_COLL_92\"],\"93\":[\"java.lang.String\",\"BIG_COLL_93\"],\"94\":[\"java.lang.String\",\"BIG_COLL_94\"],\"95\":[\"java.lang.String\",\"BIG_COLL_95\"],\"96\":[\"java.lang.String\",\"BIG_COLL_96\"],\"97\":[\"java.lang.String\",\"BIG_COLL_97\"],\"98\":[\"java.lang.String\",\"BIG_COLL_98\"],\"99\":[\"java.lang.String\",\"BIG_COLL_99\"]}]]}");
   }
 
   @Test
-  public void testObjects() throws Exception {
-    Object object = new Object();
-
-    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100);
-    queryResultFormatter.add(RESULT, object);
-    checkResult(queryResultFormatter);
+  public void testEnum() throws Exception {
+    QueryResultFormatter queryResultFormatter =
+        new QueryResultFormatter(100).add(RESULT, Currency.DIME);
+    checkResult(queryResultFormatter,
+        "{\"result\":[[\"org.apache.geode.management.internal.cli.json.QueryResultFormatterTest.Currency\",\"DIME\"]]}");
   }
 
-  private void checkResult(final QueryResultFormatter queryResultFormatter) throws Exception {
-    String jsonString = queryResultFormatter.toString();
-    System.out.println("queryResultFormatter.toString=" + jsonString);
-    JsonNode jsonObject = new ObjectMapper().readTree(jsonString);
-    System.out.println("jsonObject=" + jsonObject);
-    assertThat(jsonObject.get(RESULT)).isNotNull();
+  @Test
+  public void testEnumList() throws Exception {
+    List<Currency> list = new ArrayList<>();
+    list.add(Currency.DIME);
+    list.add(Currency.NICKLE);
+    list.add(Currency.QUARTER);
+    list.add(Currency.NICKLE);
+
+    QueryResultFormatter queryResultFormatter = new QueryResultFormatter(100).add(RESULT, list);
+    checkResult(queryResultFormatter,
+        "{\"result\":[[\"java.util.ArrayList\",{\"0\":[\"org.apache.geode.management.internal.cli.json.QueryResultFormatterTest.Currency\",\"DIME\"],\"1\":[\"org.apache.geode.management.internal.cli.json.QueryResultFormatterTest.Currency\",\"NICKLE\"],\"2\":[\"org.apache.geode.management.internal.cli.json.QueryResultFormatterTest.Currency\",\"QUARTER\"],\"3\":[\"org.apache.geode.management.internal.cli.json.QueryResultFormatterTest.Currency\",\"NICKLE\"]}]]}");
+  }
+
+  @Test
+  public void testEnumContainer() throws Exception {
+    EnumContainer enumContainer = new EnumContainer(Currency.DIME);
+    QueryResultFormatter queryResultFormatter =
+        new QueryResultFormatter(100).add(RESULT, enumContainer);
+    checkResult(queryResultFormatter,
+        "{\"result\":[[\"org.apache.geode.management.internal.cli.json.QueryResultFormatterTest.EnumContainer\",{}]]}");
   }
 
   private enum Currency {
@@ -155,7 +282,6 @@ public class QueryResultFormatterTest {
   }
 
   private static class EnumContainer {
-
     private final Currency currency;
 
     EnumContainer(final Currency currency) {


### PR DESCRIPTION
Reverted some of the changes made when deleting the in-house JSON
implementation (`TypedJson`) to the jackson library
(`QueryResultFormatter`) to restore the backward compatibility.

- Added new unit tests.
- Added tests to verify the actual JSON document generated.
- Everything is serialized as JSON array with 2 elements: type & value.
- Internal class names are hidden in the JSON document, public
  interfaces are included instead.
- Beans and primitive types only use the standard format when they are
  not being serialized as part of an array, in which case the type is
  ignored as it's already been serialized as 'ArrayElementType[]'.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
