### PR TITLE
GEODE-6588: Properly type Function execution related interfaces.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientFunctionTimeoutRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientFunctionTimeoutRegressionTest.java
@@ -183,14 +183,14 @@ public class ClientFunctionTimeoutRegressionTest implements Serializable {
 
     Function<Integer> function = new CheckClientReadTimeout();
     FunctionService.registerFunction(function);
-    Execution<Integer, Boolean, List<Boolean>> execution = null;
+    Execution<Integer, Boolean, List<Boolean>> execution;
 
     if (functionServiceTarget == ExecutionTarget.REGION) {
-      execution =
-          FunctionService.onRegion(clientCache.getRegion(regionName)).setArguments(timeout);
+      execution = FunctionService.onRegion(clientCache.getRegion(regionName));
     } else {
-      execution = FunctionService.onServer(clientCache.getDefaultPool()).setArguments(timeout);
+      execution = FunctionService.onServer(clientCache.getDefaultPool());
     }
+    execution = execution.setArguments(timeout);
 
     ResultCollector<Boolean, List<Boolean>> resultCollector = execution.execute(function);
 
@@ -212,7 +212,7 @@ public class ClientFunctionTimeoutRegressionTest implements Serializable {
    */
   private static class CheckClientReadTimeout implements Function<Integer> {
 
-    public CheckClientReadTimeout() {
+    CheckClientReadTimeout() {
       // nothing
     }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRFunctionExecutionDUnitTest.java
@@ -121,7 +121,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Test to validate that the function execution is successful on PR with Loner Distributed System
    */
   @Test
-  public void testFunctionExecution() throws Exception {
+  public void testFunctionExecution() {
     Properties config = getDistributedSystemProperties();
     config.setProperty(MCAST_PORT, "0");
     config.setProperty(LOCATORS, "");
@@ -141,7 +141,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
   }
 
   @Test
-  public void testHAFunctionExecution() throws Exception {
+  public void testHAFunctionExecution() {
     Region<String, Integer> region = createPartitionedRegion(regionName, 10, 0);
 
     Function<Void> function = new TestFunction<>(false, TestFunction.TEST_FUNCTION10);
@@ -160,7 +160,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Test remote execution by a pure accessor which doesn't have the function factory present.
    */
   @Test
-  public void testRemoteSingleKeyExecution_byName() throws Exception {
+  public void testRemoteSingleKeyExecution_byName() {
     VM accessor = getHost(0).getVM(2);
     VM datastore = getHost(0).getVM(3);
 
@@ -208,8 +208,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * function will send Boolean as last result. factory present.
    */
   @Test
-  public void testLocalSingleKeyExecution_byName_FunctionInvocationTargetException()
-      throws Exception {
+  public void testLocalSingleKeyExecution_byName_FunctionInvocationTargetException() {
     Region<String, Integer> region = createPartitionedRegion(regionName, 10, 0);
     region.put(STRING_KEY, 1);
 
@@ -231,8 +230,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * last result.
    */
   @Test
-  public void testRemoteSingleKeyExecution_byName_FunctionInvocationTargetException()
-      throws Exception {
+  public void testRemoteSingleKeyExecution_byName_FunctionInvocationTargetException() {
     VM accessor = getHost(0).getVM(2);
     VM datastore = getHost(0).getVM(3);
 
@@ -266,7 +264,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Test remote execution by a pure accessor which doesn't have the function factory present.
    */
   @Test
-  public void testRemoteSingleKeyExecution_byInstance() throws Exception {
+  public void testRemoteSingleKeyExecution_byInstance() {
     VM accessor = getHost(0).getVM(2);
     VM datastore = getHost(0).getVM(3);
 
@@ -314,7 +312,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Test remote execution of inline function by a pure accessor
    */
   @Test
-  public void testRemoteSingleKeyExecution_byInlineFunction() throws Exception {
+  public void testRemoteSingleKeyExecution_byInlineFunction() {
     VM accessor = getHost(0).getVM(2);
     VM datastore = getHost(0).getVM(3);
 
@@ -343,7 +341,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * present. ResultCollector = DefaultResultCollector haveResults = true;
    */
   @Test
-  public void testRemoteMultiKeyExecution_byName() throws Exception {
+  public void testRemoteMultiKeyExecution_byName() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -415,7 +413,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
   }
 
   @Test
-  public void testRemoteMultiKeyExecution_BucketMoved() throws Exception {
+  public void testRemoteMultiKeyExecution_BucketMoved() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -463,7 +461,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
   }
 
   @Test
-  public void testLocalMultiKeyExecution_BucketMoved() throws Exception {
+  public void testLocalMultiKeyExecution_BucketMoved() {
     IgnoredException.addIgnoredException("BucketMovedException");
 
     VM datastore0 = getHost(0).getVM(0);
@@ -601,7 +599,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
       }
     });
 
-    AsyncInvocation<List<Boolean>> async = accessor.invokeAsync(() -> executeFunction());
+    AsyncInvocation<List<Boolean>> async = accessor.invokeAsync(this::executeFunction);
 
     datastore0.invoke(() -> {
       Thread.sleep(3_000);
@@ -653,7 +651,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
       }
     });
 
-    AsyncInvocation<List<Boolean>> async = accessor.invokeAsync(() -> executeFunction());
+    AsyncInvocation<List<Boolean>> async = accessor.invokeAsync(this::executeFunction);
 
     datastore0.invoke(() -> {
       Thread.sleep(3000);
@@ -669,7 +667,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * DefaultResultCollector haveResults = true;
    */
   @Test
-  public void testRemoteMultiKeyExecution_byInlineFunction() throws Exception {
+  public void testRemoteMultiKeyExecution_byInlineFunction() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -720,7 +718,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * present. ResultCollector = CustomResultCollector haveResults = true;
    */
   @Test
-  public void testRemoteMultiKeyExecutionWithCollector_byName() throws Exception {
+  public void testRemoteMultiKeyExecutionWithCollector_byName() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -777,7 +775,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * present. ResultCollector = DefaultResultCollector haveResults = false;
    */
   @Test
-  public void testRemoteMultiKeyExecutionNoResult_byName() throws Exception {
+  public void testRemoteMultiKeyExecutionNoResult_byName() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -822,7 +820,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
 
       ResultCollector<Void, Void> resultCollector =
           dataSet.withFilter(keySet).setArguments(true).execute(function.getId());
-      assertThatThrownBy(() -> resultCollector.getResult()).isInstanceOf(FunctionException.class)
+      assertThatThrownBy(resultCollector::getResult).isInstanceOf(FunctionException.class)
           .hasMessageStartingWith(
               String.format("Cannot %s result as the Function#hasResult() is false",
                   "return any"));
@@ -835,7 +833,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * milliseconds expected result to be 0.(as the execution gets the timeout)
    */
   @Test
-  public void testRemoteMultiKeyExecution_timeout() throws Exception {
+  public void testRemoteMultiKeyExecution_timeout() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -891,7 +889,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * present. ResultCollector = CustomResultCollector haveResults = false;
    */
   @Test
-  public void testRemoteMultiKeyExecutionWithCollectorNoResult_byName() throws Exception {
+  public void testRemoteMultiKeyExecutionWithCollectorNoResult_byName() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -938,7 +936,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
       ResultCollector<Object, List<Object>> resultCollector =
           dataSet.withFilter(keySet).setArguments(true).execute(function.getId());
 
-      assertThatThrownBy(() -> resultCollector.getResult()).isInstanceOf(FunctionException.class)
+      assertThatThrownBy(resultCollector::getResult).isInstanceOf(FunctionException.class)
           .hasMessageStartingWith(
               String.format("Cannot %s result as the Function#hasResult() is false",
                   "return any"));
@@ -950,7 +948,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * present.
    */
   @Test
-  public void testRemoteMultiKeyExecution_byInstance() throws Exception {
+  public void testRemoteMultiKeyExecution_byInstance() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -1024,7 +1022,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Test bucketFilter functionality
    */
   @Test
-  public void testBucketFilter_1() throws Exception {
+  public void testBucketFilter_1() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -1106,7 +1104,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
   }
 
   @Test
-  public void testBucketFilterOverride() throws Exception {
+  public void testBucketFilterOverride() {
     VM accessor = getHost(0).getVM(3);
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
@@ -1162,7 +1160,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * DefaultResultCollector haveResult = true
    */
   @Test
-  public void testLocalMultiKeyExecution_byName() throws Exception {
+  public void testLocalMultiKeyExecution_byName() {
     PartitionedRegion pr = createPartitionedRegion(regionName, 10, 0);
 
     Set<String> keySet = new HashSet<>();
@@ -1210,7 +1208,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Test ability to execute a multi-key function by a local data store
    */
   @Test
-  public void testLocalMultiKeyExecution_byInstance() throws Exception {
+  public void testLocalMultiKeyExecution_byInstance() {
     PartitionedRegion pr = createPartitionedRegion(regionName, 10, 0);
 
     Set<String> keySet = new HashSet<>();
@@ -1259,7 +1257,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * works correctly such that there is not extra execution
    */
   @Test
-  public void testMultiKeyExecutionOnASingleBucket_byName() throws Exception {
+  public void testMultiKeyExecutionOnASingleBucket_byName() {
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
     VM datastore2 = getHost(0).getVM(2);
@@ -1338,7 +1336,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * works correctly such that there is not extra execution
    */
   @Test
-  public void testMultiKeyExecutionOnASingleBucket_byInstance() throws Exception {
+  public void testMultiKeyExecutionOnASingleBucket_byInstance() {
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
     VM datastore2 = getHost(0).getVM(2);
@@ -1416,7 +1414,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Ensure that the execution is happening all the PR as a whole
    */
   @Test
-  public void testExecutionOnAllNodes_byName() throws Exception {
+  public void testExecutionOnAllNodes_byName() {
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
     VM datastore2 = getHost(0).getVM(2);
@@ -1477,7 +1475,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Ensure that the execution is happening all the PR as a whole
    */
   @Test
-  public void testExecutionOnAllNodes_byInstance() throws Exception {
+  public void testExecutionOnAllNodes_byInstance() {
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
     VM datastore2 = getHost(0).getVM(2);
@@ -1537,7 +1535,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Ensure that the execution of inline function is happening all the PR as a whole
    */
   @Test
-  public void testExecutionOnAllNodes_byInlineFunction() throws Exception {
+  public void testExecutionOnAllNodes_byInlineFunction() {
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
     VM datastore2 = getHost(0).getVM(2);
@@ -1592,7 +1590,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * LocalDataSet
    */
   @Test
-  public void testExecutionOnAllNodes_LocalReadPR() throws Exception {
+  public void testExecutionOnAllNodes_LocalReadPR() {
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
     VM datastore2 = getHost(0).getVM(2);
@@ -1657,7 +1655,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * LocalDataSet
    */
   @Test
-  public void testExecutionOnMultiNodes_LocalReadPR() throws Exception {
+  public void testExecutionOnMultiNodes_LocalReadPR() {
     VM datastore0 = getHost(0).getVM(0);
     VM datastore1 = getHost(0).getVM(1);
     VM datastore2 = getHost(0).getVM(2);
@@ -1760,7 +1758,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Assert the {@link RegionFunctionContext} yields the proper objects.
    */
   @Test
-  public void testLocalDataContext() throws Exception {
+  public void testLocalDataContext() {
     VM accessor = getHost(0).getVM(1);
     VM datastore1 = getHost(0).getVM(2);
     VM datastore2 = getHost(0).getVM(3);
@@ -1843,7 +1841,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
    * Assert the {@link RegionFunctionContext} yields the proper objects.
    */
   @Test
-  public void testLocalDataContextWithColocation() throws Exception {
+  public void testLocalDataContextWithColocation() {
     VM accessor = getHost(0).getVM(1);
     VM datastore1 = getHost(0).getVM(2);
     VM datastore2 = getHost(0).getVM(3);
@@ -1973,8 +1971,9 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
       }
     };
 
+    Execution<Boolean, Boolean, List<Boolean>> execution = FunctionService.onRegion(rootRegion);
     ResultCollector<Boolean, List<Boolean>> resultCollector =
-        FunctionService.onRegion(rootRegion).withFilter(createKeySet(key1)).execute(function);
+        execution.withFilter(createKeySet(key1)).execute(function);
     assertThat(resultCollector.getResult()).hasSize(1).containsExactly(true);
   }
 
@@ -2126,9 +2125,7 @@ public class PRFunctionExecutionDUnitTest extends CacheTestCase {
 
   private Set<String> createKeySet(final String... keys) {
     Set<String> keySet = new HashSet<>();
-    for (String key : keys) {
-      keySet.add(key);
-    }
+    Collections.addAll(keySet, keys);
     return keySet;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/execute/FunctionExecutionOnLonerRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/execute/FunctionExecutionOnLonerRegressionTest.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.Properties;
 import java.util.Set;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -64,6 +65,7 @@ public class FunctionExecutionOnLonerRegressionTest {
   private Region<String, String> region;
   private Set<String> keysForGet;
   private Set<String> expectedValues;
+  private Cache cache;
 
   @Before
   public void setUp() {
@@ -76,7 +78,7 @@ public class FunctionExecutionOnLonerRegressionTest {
     DistributionManager dm = ds.getDistributionManager();
     assertThat(dm).isInstanceOf(LonerDistributionManager.class);
 
-    Cache cache = CacheFactory.create(ds);
+    cache = CacheFactory.create(ds);
 
     RegionFactory<String, String> regionFactory = cache.createRegionFactory(PARTITION);
     region = regionFactory.create("region");
@@ -92,6 +94,11 @@ public class FunctionExecutionOnLonerRegressionTest {
         expectedValues.add(value);
       }
     }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    cache.close();
   }
 
   private Properties getDistributedSystemProperties() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/execute/FunctionExecutionOnLonerRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/execute/FunctionExecutionOnLonerRegressionTest.java
@@ -104,9 +104,10 @@ public class FunctionExecutionOnLonerRegressionTest {
   }
 
   @Test
-  public void executeFunctionOnLonerShouldNotThrowClassCastException() throws Exception {
+  public void executeFunctionOnLonerShouldNotThrowClassCastException() {
     Execution<Void, Collection<String>, Collection<String>> execution =
-        FunctionService.onRegion(region).withFilter(keysForGet);
+        FunctionService.onRegion(region);
+    execution = execution.withFilter(keysForGet);
     ResultCollector<Collection<String>, Collection<String>> resultCollector =
         execution.execute(new TestFunction());
     assertThat(resultCollector.getResult())

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/Execution.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/Execution.java
@@ -26,16 +26,16 @@ import org.apache.geode.cache.LowMemoryException;
  * This interface is implemented by GemFire. To obtain an instance of it use
  * {@link FunctionService}.
  *
- * @param <IN> The type of the argument passed into the function, if any
- * @param <OUT> The type of results sent by the function
- * @param <AGG> The type of the aggregated result returned by the ResultCollector
+ * @param <ArgumentT> The type of the argument passed into the function, if any
+ * @param <ReturnT> The type of results sent by the function
+ * @param <AggregatorT> The type of the aggregated result returned by the ResultCollector
  *
  * @since GemFire 6.0
  *
  * @see FunctionService
  * @see Function
  */
-public interface Execution<IN, OUT, AGG> {
+public interface Execution<ArgumentT, ReturnT, AggregatorT> {
 
   /**
    * Specifies a data filter of routing objects for selecting the GemFire members to execute the
@@ -51,7 +51,7 @@ public interface Execution<IN, OUT, AGG> {
    *         {@link FunctionService#onRegion(org.apache.geode.cache.Region)}
    * @since GemFire 6.0
    */
-  Execution<IN, OUT, AGG> withFilter(Set<?> filter);
+  Execution<ArgumentT, ReturnT, AggregatorT> withFilter(Set<?> filter);
 
   /**
    * Specifies the user data passed to the function when it is executed. The function can retrieve
@@ -63,7 +63,7 @@ public interface Execution<IN, OUT, AGG> {
    * @since Geode 1.2
    *
    */
-  Execution<IN, OUT, AGG> setArguments(IN args);
+  Execution<ArgumentT, ReturnT, AggregatorT> setArguments(ArgumentT args);
 
   /**
    * Specifies the user data passed to the function when it is executed. The function can retrieve
@@ -76,7 +76,7 @@ public interface Execution<IN, OUT, AGG> {
    * @deprecated use {@link #setArguments(Object)} instead
    *
    */
-  Execution<IN, OUT, AGG> withArgs(IN args);
+  Execution<ArgumentT, ReturnT, AggregatorT> withArgs(ArgumentT args);
 
   /**
    * Specifies the {@link ResultCollector} that will receive the results after the function has been
@@ -88,7 +88,8 @@ public interface Execution<IN, OUT, AGG> {
    * @see ResultCollector
    * @since GemFire 6.0
    */
-  Execution<IN, OUT, AGG> withCollector(ResultCollector<OUT, AGG> rc);
+  Execution<ArgumentT, ReturnT, AggregatorT> withCollector(
+      ResultCollector<ReturnT, AggregatorT> rc);
 
   /**
    * Executes the function using its {@linkplain Function#getId() id}
@@ -104,7 +105,7 @@ public interface Execution<IN, OUT, AGG> {
    *
    * @since GemFire 6.0
    */
-  ResultCollector<OUT, AGG> execute(String functionId) throws FunctionException;
+  ResultCollector<ReturnT, AggregatorT> execute(String functionId) throws FunctionException;
 
   /**
    * Executes the function instance provided.
@@ -121,5 +122,5 @@ public interface Execution<IN, OUT, AGG> {
    *
    * @since GemFire 6.0
    */
-  ResultCollector<OUT, AGG> execute(Function function) throws FunctionException;
+  ResultCollector<ReturnT, AggregatorT> execute(Function function) throws FunctionException;
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionService.java
@@ -72,7 +72,8 @@ public class FunctionService {
    * @throws FunctionException if the region passed in is null
    * @since GemFire 6.0
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegion(Region region) {
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onRegion(
+      Region region) {
     return getFunctionExecutionService().onRegion(region);
   }
 
@@ -87,7 +88,8 @@ public class FunctionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool) {
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      Pool pool) {
     return getFunctionExecutionService().onServer(pool);
   }
 
@@ -100,7 +102,8 @@ public class FunctionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool) {
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      Pool pool) {
     return getFunctionExecutionService().onServers(pool);
   }
 
@@ -117,7 +120,8 @@ public class FunctionService {
    *         pool
    * @since GemFire 6.5
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService) {
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      RegionService regionService) {
     return getFunctionExecutionService().onServer(regionService);
   }
 
@@ -132,7 +136,8 @@ public class FunctionService {
    *         pool
    * @since GemFire 6.5
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService) {
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      RegionService regionService) {
     return getFunctionExecutionService().onServers(regionService);
   }
 
@@ -146,7 +151,7 @@ public class FunctionService {
    * @throws FunctionException if distributedMember is null
    * @since GemFire 7.0
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
       DistributedMember distributedMember) {
     return getFunctionExecutionService().onMember(distributedMember);
   }
@@ -166,7 +171,8 @@ public class FunctionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(String... groups) {
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      String... groups) {
     return getFunctionExecutionService().onMembers(groups);
   }
 
@@ -179,7 +185,7 @@ public class FunctionService {
    * @throws FunctionException if distributedMembers is null
    * @since GemFire 7.0
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
       Set<DistributedMember> distributedMembers) {
     return getFunctionExecutionService().onMembers(distributedMembers);
   }
@@ -195,7 +201,8 @@ public class FunctionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(String... groups) {
+  public static <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      String... groups) {
     return getFunctionExecutionService().onMember(groups);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionService.java
@@ -72,7 +72,7 @@ public class FunctionService {
    * @throws FunctionException if the region passed in is null
    * @since GemFire 6.0
    */
-  public static <I, O, A> Execution<I, O, A> onRegion(Region region) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegion(Region region) {
     return getFunctionExecutionService().onRegion(region);
   }
 
@@ -87,7 +87,7 @@ public class FunctionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  public static <I, O, A> Execution<I, O, A> onServer(Pool pool) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool) {
     return getFunctionExecutionService().onServer(pool);
   }
 
@@ -100,7 +100,7 @@ public class FunctionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  public static <I, O, A> Execution<I, O, A> onServers(Pool pool) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool) {
     return getFunctionExecutionService().onServers(pool);
   }
 
@@ -117,7 +117,7 @@ public class FunctionService {
    *         pool
    * @since GemFire 6.5
    */
-  public static <I, O, A> Execution<I, O, A> onServer(RegionService regionService) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService) {
     return getFunctionExecutionService().onServer(regionService);
   }
 
@@ -132,7 +132,7 @@ public class FunctionService {
    *         pool
    * @since GemFire 6.5
    */
-  public static <I, O, A> Execution<I, O, A> onServers(RegionService regionService) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService) {
     return getFunctionExecutionService().onServers(regionService);
   }
 
@@ -146,7 +146,8 @@ public class FunctionService {
    * @throws FunctionException if distributedMember is null
    * @since GemFire 7.0
    */
-  public static <I, O, A> Execution<I, O, A> onMember(DistributedMember distributedMember) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(
+      DistributedMember distributedMember) {
     return getFunctionExecutionService().onMember(distributedMember);
   }
 
@@ -165,7 +166,7 @@ public class FunctionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  public static <I, O, A> Execution<I, O, A> onMembers(String... groups) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(String... groups) {
     return getFunctionExecutionService().onMembers(groups);
   }
 
@@ -178,7 +179,8 @@ public class FunctionService {
    * @throws FunctionException if distributedMembers is null
    * @since GemFire 7.0
    */
-  public static <I, O, A> Execution<I, O, A> onMembers(Set<DistributedMember> distributedMembers) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(
+      Set<DistributedMember> distributedMembers) {
     return getFunctionExecutionService().onMembers(distributedMembers);
   }
 
@@ -193,7 +195,7 @@ public class FunctionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  public static <I, O, A> Execution<I, O, A> onMember(String... groups) {
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(String... groups) {
     return getFunctionExecutionService().onMember(groups);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/execute/FunctionService.java
@@ -72,7 +72,7 @@ public class FunctionService {
    * @throws FunctionException if the region passed in is null
    * @since GemFire 6.0
    */
-  public static Execution onRegion(Region region) {
+  public static <I, O, A> Execution<I, O, A> onRegion(Region region) {
     return getFunctionExecutionService().onRegion(region);
   }
 
@@ -87,7 +87,7 @@ public class FunctionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  public static Execution onServer(Pool pool) {
+  public static <I, O, A> Execution<I, O, A> onServer(Pool pool) {
     return getFunctionExecutionService().onServer(pool);
   }
 
@@ -100,7 +100,7 @@ public class FunctionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  public static Execution onServers(Pool pool) {
+  public static <I, O, A> Execution<I, O, A> onServers(Pool pool) {
     return getFunctionExecutionService().onServers(pool);
   }
 
@@ -117,7 +117,7 @@ public class FunctionService {
    *         pool
    * @since GemFire 6.5
    */
-  public static Execution onServer(RegionService regionService) {
+  public static <I, O, A> Execution<I, O, A> onServer(RegionService regionService) {
     return getFunctionExecutionService().onServer(regionService);
   }
 
@@ -132,7 +132,7 @@ public class FunctionService {
    *         pool
    * @since GemFire 6.5
    */
-  public static Execution onServers(RegionService regionService) {
+  public static <I, O, A> Execution<I, O, A> onServers(RegionService regionService) {
     return getFunctionExecutionService().onServers(regionService);
   }
 
@@ -146,7 +146,7 @@ public class FunctionService {
    * @throws FunctionException if distributedMember is null
    * @since GemFire 7.0
    */
-  public static Execution onMember(DistributedMember distributedMember) {
+  public static <I, O, A> Execution<I, O, A> onMember(DistributedMember distributedMember) {
     return getFunctionExecutionService().onMember(distributedMember);
   }
 
@@ -165,7 +165,7 @@ public class FunctionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  public static Execution onMembers(String... groups) {
+  public static <I, O, A> Execution<I, O, A> onMembers(String... groups) {
     return getFunctionExecutionService().onMembers(groups);
   }
 
@@ -178,7 +178,7 @@ public class FunctionService {
    * @throws FunctionException if distributedMembers is null
    * @since GemFire 7.0
    */
-  public static Execution onMembers(Set<DistributedMember> distributedMembers) {
+  public static <I, O, A> Execution<I, O, A> onMembers(Set<DistributedMember> distributedMembers) {
     return getFunctionExecutionService().onMembers(distributedMembers);
   }
 
@@ -193,7 +193,7 @@ public class FunctionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  public static Execution onMember(String... groups) {
+  public static <I, O, A> Execution<I, O, A> onMember(String... groups) {
     return getFunctionExecutionService().onMember(groups);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AbstractExecution.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AbstractExecution.java
@@ -49,7 +49,8 @@ import org.apache.geode.internal.logging.LogService;
  * @since GemFire 5.8LA
  *
  */
-public abstract class AbstractExecution<IN, OUT, AGG> implements InternalExecution<IN, OUT, AGG> {
+public abstract class AbstractExecution<ArgumentT, ReturnT, AggregatorT>
+    implements InternalExecution<ArgumentT, ReturnT, AggregatorT> {
 
   private static final Logger logger = LogService.getLogger();
 
@@ -205,7 +206,7 @@ public abstract class AbstractExecution<IN, OUT, AGG> implements InternalExecuti
     return this.filter;
   }
 
-  public AbstractExecution<IN, OUT, AGG> setIsReExecute() {
+  public AbstractExecution<ArgumentT, ReturnT, AggregatorT> setIsReExecute() {
     this.isReExecute = true;
     if (this.executionNodesListener != null) {
       this.executionNodesListener.reset();
@@ -356,7 +357,7 @@ public abstract class AbstractExecution<IN, OUT, AGG> implements InternalExecuti
   }
 
   @Override
-  public ResultCollector<OUT, AGG> execute(final String functionName) {
+  public ResultCollector<ReturnT, AggregatorT> execute(final String functionName) {
     if (functionName == null) {
       throw new FunctionException(
           "The input function for the execute function request is null");
@@ -373,7 +374,7 @@ public abstract class AbstractExecution<IN, OUT, AGG> implements InternalExecuti
   }
 
   @Override
-  public ResultCollector<OUT, AGG> execute(Function function) throws FunctionException {
+  public ResultCollector<ReturnT, AggregatorT> execute(Function function) throws FunctionException {
     if (function == null) {
       throw new FunctionException(
           "The input function for the execute function request is null");
@@ -423,7 +424,7 @@ public abstract class AbstractExecution<IN, OUT, AGG> implements InternalExecuti
     return this.ignoreDepartedMembers;
   }
 
-  protected abstract ResultCollector<OUT, AGG> executeFunction(Function fn);
+  protected abstract ResultCollector<ReturnT, AggregatorT> executeFunction(Function fn);
 
   /**
    * validates whether a function should execute in presence of transaction and HeapCritical
@@ -436,8 +437,8 @@ public abstract class AbstractExecution<IN, OUT, AGG> implements InternalExecuti
    */
   public abstract void validateExecution(Function function, Set targetMembers);
 
-  public LocalResultCollector<OUT, AGG> getLocalResultCollector(Function function,
-      final ResultCollector<OUT, AGG> rc) {
+  public LocalResultCollector<ReturnT, AggregatorT> getLocalResultCollector(Function function,
+      final ResultCollector<ReturnT, AggregatorT> rc) {
     if (rc instanceof LocalResultCollector) {
       return (LocalResultCollector) rc;
     } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DefaultResultCollector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DefaultResultCollector.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.execute;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.geode.cache.execute.Function;
@@ -32,9 +33,9 @@ import org.apache.geode.distributed.DistributedMember;
  * @since GemFire 6.0
  *
  */
-public class DefaultResultCollector implements ResultCollector {
+public class DefaultResultCollector implements ResultCollector<Object, List<Object>> {
 
-  private ArrayList<Object> resultList = new ArrayList<Object>();
+  private List<Object> resultList = new ArrayList<>();
 
   public DefaultResultCollector() {}
 
@@ -57,7 +58,7 @@ public class DefaultResultCollector implements ResultCollector {
    * @throws FunctionException if something goes wrong while retrieving the result
    */
   @Override
-  public Object getResult() throws FunctionException {
+  public List<Object> getResult() throws FunctionException {
     return this.resultList; // this is full result
   }
 
@@ -81,7 +82,7 @@ public class DefaultResultCollector implements ResultCollector {
    * @throws FunctionException if something goes wrong while retrieving the result
    */
   @Override
-  public Object getResult(long timeout, TimeUnit unit) throws FunctionException {
+  public List<Object> getResult(long timeout, TimeUnit unit) throws FunctionException {
     return this.resultList;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutor.java
@@ -45,8 +45,8 @@ import org.apache.geode.internal.cache.control.MemoryThresholds;
  * @since GemFire 5.8 LA
  *
  */
-public class DistributedRegionFunctionExecutor<IN, OUT, AGG>
-    extends AbstractExecution<IN, OUT, AGG> {
+public class DistributedRegionFunctionExecutor<ArgumentT, ReturnT, AggregatorT>
+    extends AbstractExecution<ArgumentT, ReturnT, AggregatorT> {
 
   private final LocalRegion region;
 
@@ -212,7 +212,8 @@ public class DistributedRegionFunctionExecutor<IN, OUT, AGG>
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withBucketFilter(
+      Set<Integer> bucketIDs) {
     if (bucketIDs != null && !bucketIDs.isEmpty()) {
       throw new IllegalArgumentException(
           String.format("Buckets as filter cannot be applied to a non partitioned region: %s",

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutor.java
@@ -45,7 +45,8 @@ import org.apache.geode.internal.cache.control.MemoryThresholds;
  * @since GemFire 5.8 LA
  *
  */
-public class DistributedRegionFunctionExecutor extends AbstractExecution {
+public class DistributedRegionFunctionExecutor<IN, OUT, AGG>
+    extends AbstractExecution<IN, OUT, AGG> {
 
   private final LocalRegion region;
 
@@ -58,16 +59,6 @@ public class DistributedRegionFunctionExecutor extends AbstractExecution {
               "region"));
     }
     this.region = (LocalRegion) r;
-  }
-
-  private DistributedRegionFunctionExecutor(DistributedRegionFunctionExecutor drfe) {
-    super(drfe);
-    this.region = drfe.region;
-    if (drfe.filter != null) {
-      this.filter.clear();
-      this.filter.addAll(drfe.filter);
-    }
-    this.sender = drfe.sender;
   }
 
   public DistributedRegionFunctionExecutor(DistributedRegion region, Set filter2, Object args,
@@ -221,7 +212,7 @@ public class DistributedRegionFunctionExecutor extends AbstractExecution {
   }
 
   @Override
-  public InternalExecution withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
     if (bucketIDs != null && !bucketIDs.isEmpty()) {
       throw new IllegalArgumentException(
           String.format("Buckets as filter cannot be applied to a non partitioned region: %s",
@@ -282,14 +273,12 @@ public class DistributedRegionFunctionExecutor extends AbstractExecution {
 
   @Override
   public String toString() {
-    final StringBuffer buf = new StringBuffer();
-    buf.append("[ DistributedRegionFunctionExecutor:");
-    buf.append("args=");
-    buf.append(this.args);
-    buf.append(";region=");
-    buf.append(this.region.getName());
-    buf.append("]");
-    return buf.toString();
+    return "[ DistributedRegionFunctionExecutor:"
+        + "args="
+        + this.args
+        + ";region="
+        + this.region.getName()
+        + "]";
   }
 
   /*

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionExecutionService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionExecutionService.java
@@ -50,7 +50,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if the region passed in is null
    * @since GemFire 6.0
    */
-  <I, O, A> Execution<I, O, A> onRegion(Region region);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegion(Region region);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -63,7 +63,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <I, O, A> Execution<I, O, A> onServer(Pool pool);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -74,7 +74,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <I, O, A> Execution<I, O, A> onServers(Pool pool);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -89,7 +89,7 @@ public interface FunctionExecutionService {
    *         pool
    * @since GemFire 6.5
    */
-  <I, O, A> Execution<I, O, A> onServer(RegionService regionService);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -102,7 +102,7 @@ public interface FunctionExecutionService {
    *         pool
    * @since GemFire 6.5
    */
-  <I, O, A> Execution<I, O, A> onServers(RegionService regionService);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -114,7 +114,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if distributedMember is null
    * @since GemFire 7.0
    */
-  <I, O, A> Execution<I, O, A> onMember(DistributedMember distributedMember);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedMember distributedMember);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -131,7 +131,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  <I, O, A> Execution<I, O, A> onMembers(String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -142,7 +142,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if distributedMembers is null
    * @since GemFire 7.0
    */
-  <I, O, A> Execution<I, O, A> onMembers(Set<DistributedMember> distributedMembers);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(Set<DistributedMember> distributedMembers);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -155,7 +155,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  <I, O, A> Execution<I, O, A> onMember(String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(String... groups);
 
   /**
    * Returns the {@link Function} defined by the functionId, returns null if no function is found

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionExecutionService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionExecutionService.java
@@ -50,7 +50,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if the region passed in is null
    * @since GemFire 6.0
    */
-  Execution onRegion(Region region);
+  <I, O, A> Execution<I, O, A> onRegion(Region region);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -63,7 +63,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  Execution onServer(Pool pool);
+  <I, O, A> Execution<I, O, A> onServer(Pool pool);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -74,7 +74,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  Execution onServers(Pool pool);
+  <I, O, A> Execution<I, O, A> onServers(Pool pool);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -89,7 +89,7 @@ public interface FunctionExecutionService {
    *         pool
    * @since GemFire 6.5
    */
-  Execution onServer(RegionService regionService);
+  <I, O, A> Execution<I, O, A> onServer(RegionService regionService);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -102,7 +102,7 @@ public interface FunctionExecutionService {
    *         pool
    * @since GemFire 6.5
    */
-  Execution onServers(RegionService regionService);
+  <I, O, A> Execution<I, O, A> onServers(RegionService regionService);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -114,7 +114,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if distributedMember is null
    * @since GemFire 7.0
    */
-  Execution onMember(DistributedMember distributedMember);
+  <I, O, A> Execution<I, O, A> onMember(DistributedMember distributedMember);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -131,7 +131,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  Execution onMembers(String... groups);
+  <I, O, A> Execution<I, O, A> onMembers(String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -142,7 +142,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if distributedMembers is null
    * @since GemFire 7.0
    */
-  Execution onMembers(Set<DistributedMember> distributedMembers);
+  <I, O, A> Execution<I, O, A> onMembers(Set<DistributedMember> distributedMembers);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -155,7 +155,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  Execution onMember(String... groups);
+  <I, O, A> Execution<I, O, A> onMember(String... groups);
 
   /**
    * Returns the {@link Function} defined by the functionId, returns null if no function is found

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionExecutionService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionExecutionService.java
@@ -50,7 +50,8 @@ public interface FunctionExecutionService {
    * @throws FunctionException if the region passed in is null
    * @since GemFire 6.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegion(Region region);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onRegion(
+      Region region);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -63,7 +64,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(Pool pool);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -74,7 +75,7 @@ public interface FunctionExecutionService {
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(Pool pool);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -89,7 +90,8 @@ public interface FunctionExecutionService {
    *         pool
    * @since GemFire 6.5
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      RegionService regionService);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -102,7 +104,8 @@ public interface FunctionExecutionService {
    *         pool
    * @since GemFire 6.5
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      RegionService regionService);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -114,7 +117,8 @@ public interface FunctionExecutionService {
    * @throws FunctionException if distributedMember is null
    * @since GemFire 7.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedMember distributedMember);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      DistributedMember distributedMember);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -131,7 +135,8 @@ public interface FunctionExecutionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -142,7 +147,8 @@ public interface FunctionExecutionService {
    * @throws FunctionException if distributedMembers is null
    * @since GemFire 7.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(Set<DistributedMember> distributedMembers);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      Set<DistributedMember> distributedMembers);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -155,7 +161,8 @@ public interface FunctionExecutionService {
    * @throws FunctionException if no members are found belonging to the provided groups
    * @since GemFire 7.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      String... groups);
 
   /**
    * Returns the {@link Function} defined by the functionId, returns null if no function is found

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalExecution.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalExecution.java
@@ -28,9 +28,9 @@ import org.apache.geode.cache.execute.ResultCollector;
  * @since GemFire 5.8LA
  *
  */
-public interface InternalExecution extends Execution {
+public interface InternalExecution<IN, OUT, AGG> extends Execution<IN, OUT, AGG> {
 
-  InternalExecution withMemberMappedArgument(MemberMappedArgument argument);
+  InternalExecution<IN, OUT, AGG> withMemberMappedArgument(MemberMappedArgument argument);
 
   /**
    * Specifies a filter of bucketIDs for selecting the GemFire members to execute the function on.
@@ -44,7 +44,7 @@ public interface InternalExecution extends Execution {
    *         {@link FunctionService#onRegion(org.apache.geode.cache.Region)}
    * @since Geode 1.0
    */
-  InternalExecution withBucketFilter(Set<Integer> bucketIDs);
+  InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs);
 
   /**
    * If true, function execution waits for all exceptions from target nodes <br>

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalExecution.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalExecution.java
@@ -28,9 +28,11 @@ import org.apache.geode.cache.execute.ResultCollector;
  * @since GemFire 5.8LA
  *
  */
-public interface InternalExecution<IN, OUT, AGG> extends Execution<IN, OUT, AGG> {
+public interface InternalExecution<ArgumentT, ReturnT, AggregatorT>
+    extends Execution<ArgumentT, ReturnT, AggregatorT> {
 
-  InternalExecution<IN, OUT, AGG> withMemberMappedArgument(MemberMappedArgument argument);
+  InternalExecution<ArgumentT, ReturnT, AggregatorT> withMemberMappedArgument(
+      MemberMappedArgument argument);
 
   /**
    * Specifies a filter of bucketIDs for selecting the GemFire members to execute the function on.
@@ -44,7 +46,7 @@ public interface InternalExecution<IN, OUT, AGG> extends Execution<IN, OUT, AGG>
    *         {@link FunctionService#onRegion(org.apache.geode.cache.Region)}
    * @since Geode 1.0
    */
-  InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs);
+  InternalExecution<ArgumentT, ReturnT, AggregatorT> withBucketFilter(Set<Integer> bucketIDs);
 
   /**
    * If true, function execution waits for all exceptions from target nodes <br>

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionService.java
@@ -52,7 +52,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *
    * @see MultiRegionFunctionContext
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegions(Set<Region> regions);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onRegions(
+      Set<Region> regions);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -65,7 +66,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *         pool
    * @since GemFire 6.5
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService, String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      RegionService regionService, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -80,7 +82,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *         pool
    * @since GemFire 6.5
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService, String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      RegionService regionService, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -91,7 +94,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool, String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(Pool pool,
+      String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -104,7 +108,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool, String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(Pool pool,
+      String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -118,7 +123,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @since GemFire 6.0
    *
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system,
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      DistributedSystem system,
       DistributedMember distributedMember);
 
   /**
@@ -131,7 +137,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if DistributedSystem instance passed is null
    * @since GemFire 6.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system, String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      DistributedSystem system, String... groups);
 
   /**
    * Uses {@code RANDOM_onMember} for tests.
@@ -139,7 +146,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * <p>
    * TODO: maybe merge with {@link #onMembers(DistributedSystem, String...)}
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system, String... groups);
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      DistributedSystem system, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -151,6 +159,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if DistributedSystem instance passed is null
    * @since GemFire 6.0
    */
-  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system,
+  <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      DistributedSystem system,
       Set<DistributedMember> distributedMembers);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionService.java
@@ -52,7 +52,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *
    * @see MultiRegionFunctionContext
    */
-  <I, O, A> Execution<I, O, A> onRegions(Set<Region> regions);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegions(Set<Region> regions);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -65,7 +65,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *         pool
    * @since GemFire 6.5
    */
-  <I, O, A> Execution<I, O, A> onServers(RegionService regionService, String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -80,7 +80,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *         pool
    * @since GemFire 6.5
    */
-  <I, O, A> Execution<I, O, A> onServer(RegionService regionService, String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -91,7 +91,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <I, O, A> Execution<I, O, A> onServers(Pool pool, String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -104,7 +104,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  <I, O, A> Execution<I, O, A> onServer(Pool pool, String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -118,7 +118,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @since GemFire 6.0
    *
    */
-  <I, O, A> Execution<I, O, A> onMember(DistributedSystem system,
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system,
       DistributedMember distributedMember);
 
   /**
@@ -131,7 +131,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if DistributedSystem instance passed is null
    * @since GemFire 6.0
    */
-  <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system, String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system, String... groups);
 
   /**
    * Uses {@code RANDOM_onMember} for tests.
@@ -139,7 +139,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * <p>
    * TODO: maybe merge with {@link #onMembers(DistributedSystem, String...)}
    */
-  <I, O, A> Execution<I, O, A> onMember(DistributedSystem system, String... groups);
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -151,6 +151,6 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if DistributedSystem instance passed is null
    * @since GemFire 6.0
    */
-  <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system,
+  <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system,
       Set<DistributedMember> distributedMembers);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionService.java
@@ -52,7 +52,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *
    * @see MultiRegionFunctionContext
    */
-  Execution onRegions(Set<Region> regions);
+  <I, O, A> Execution<I, O, A> onRegions(Set<Region> regions);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -65,7 +65,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *         pool
    * @since GemFire 6.5
    */
-  Execution onServers(RegionService regionService, String... groups);
+  <I, O, A> Execution<I, O, A> onServers(RegionService regionService, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -80,7 +80,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    *         pool
    * @since GemFire 6.5
    */
-  Execution onServer(RegionService regionService, String... groups);
+  <I, O, A> Execution<I, O, A> onServer(RegionService regionService, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -91,7 +91,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  Execution onServers(Pool pool, String... groups);
+  <I, O, A> Execution<I, O, A> onServers(Pool pool, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -104,7 +104,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if Pool instance passed in is null
    * @since GemFire 6.0
    */
-  Execution onServer(Pool pool, String... groups);
+  <I, O, A> Execution<I, O, A> onServer(Pool pool, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -118,7 +118,8 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @since GemFire 6.0
    *
    */
-  Execution onMember(DistributedSystem system, DistributedMember distributedMember);
+  <I, O, A> Execution<I, O, A> onMember(DistributedSystem system,
+      DistributedMember distributedMember);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -130,7 +131,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if DistributedSystem instance passed is null
    * @since GemFire 6.0
    */
-  Execution onMembers(DistributedSystem system, String... groups);
+  <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system, String... groups);
 
   /**
    * Uses {@code RANDOM_onMember} for tests.
@@ -138,7 +139,7 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * <p>
    * TODO: maybe merge with {@link #onMembers(DistributedSystem, String...)}
    */
-  Execution onMember(DistributedSystem system, String... groups);
+  <I, O, A> Execution<I, O, A> onMember(DistributedSystem system, String... groups);
 
   /**
    * Returns an {@link Execution} object that can be used to execute a data independent function on
@@ -150,5 +151,6 @@ public interface InternalFunctionExecutionService extends FunctionExecutionServi
    * @throws FunctionException if DistributedSystem instance passed is null
    * @since GemFire 6.0
    */
-  Execution onMembers(DistributedSystem system, Set<DistributedMember> distributedMembers);
+  <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system,
+      Set<DistributedMember> distributedMembers);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceImpl.java
@@ -67,42 +67,42 @@ public class InternalFunctionExecutionServiceImpl
   // FunctionExecutionService API ----------------------------------------------------------------
 
   @Override
-  public Execution onServer(Pool pool) {
+  public <I, O, A> Execution<I, O, A> onServer(Pool pool) {
     return onServer(pool, EMPTY_GROUPS);
   }
 
   @Override
-  public Execution onServers(Pool pool) {
+  public <I, O, A> Execution<I, O, A> onServers(Pool pool) {
     return onServers(pool, EMPTY_GROUPS);
   }
 
   @Override
-  public Execution onServer(RegionService regionService) {
+  public <I, O, A> Execution<I, O, A> onServer(RegionService regionService) {
     return onServer(regionService, EMPTY_GROUPS);
   }
 
   @Override
-  public Execution onServers(RegionService regionService) {
+  public <I, O, A> Execution<I, O, A> onServers(RegionService regionService) {
     return onServers(regionService, EMPTY_GROUPS);
   }
 
   @Override
-  public Execution onMember(DistributedMember distributedMember) {
+  public <I, O, A> Execution<I, O, A> onMember(DistributedMember distributedMember) {
     return onMember(getDistributedSystem(), distributedMember);
   }
 
   @Override
-  public Execution onMembers(String... groups) {
+  public <I, O, A> Execution<I, O, A> onMembers(String... groups) {
     return onMembers(getDistributedSystem(), groups);
   }
 
   @Override
-  public Execution onMembers(Set<DistributedMember> distributedMembers) {
+  public <I, O, A> Execution<I, O, A> onMembers(Set<DistributedMember> distributedMembers) {
     return onMembers(getDistributedSystem(), distributedMembers);
   }
 
   @Override
-  public Execution onMember(String... groups) {
+  public <I, O, A> Execution<I, O, A> onMember(String... groups) {
     return onMember(getDistributedSystem(), groups);
   }
 
@@ -111,7 +111,7 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public Execution onRegion(Region region) {
+  public <I, O, A> Execution<I, O, A> onRegion(Region region) {
     if (region == null) {
       throw new FunctionException("Region instance passed is null");
     }
@@ -137,12 +137,12 @@ public class InternalFunctionExecutionServiceImpl
     }
 
     if (isClientRegion(region)) {
-      return new ServerRegionFunctionExecutor(region, proxyCache);
+      return new ServerRegionFunctionExecutor<>(region, proxyCache);
     }
     if (PartitionRegionHelper.isPartitionedRegion(region)) {
-      return new PartitionedRegionFunctionExecutor(region);
+      return new PartitionedRegionFunctionExecutor<>(region);
     }
-    return new DistributedRegionFunctionExecutor(region);
+    return new DistributedRegionFunctionExecutor<>(region);
   }
 
   @Override
@@ -205,7 +205,7 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService OnServerGroups API -----------------------------------------
 
   @Override
-  public Execution onServer(Pool pool, String... groups) {
+  public <I, O, A> Execution<I, O, A> onServer(Pool pool, String... groups) {
     if (pool == null) {
       throw new FunctionException(
           String.format("%s passed is null", "Pool instance "));
@@ -215,11 +215,11 @@ public class InternalFunctionExecutionServiceImpl
       throw new UnsupportedOperationException();
     }
 
-    return new ServerFunctionExecutor(pool, false, groups);
+    return new ServerFunctionExecutor<>(pool, false, groups);
   }
 
   @Override
-  public Execution onServers(Pool pool, String... groups) {
+  public <I, O, A> Execution<I, O, A> onServers(Pool pool, String... groups) {
     if (pool == null) {
       throw new FunctionException(
           String.format("%s passed is null", "Pool instance "));
@@ -229,11 +229,11 @@ public class InternalFunctionExecutionServiceImpl
       throw new UnsupportedOperationException();
     }
 
-    return new ServerFunctionExecutor(pool, true, groups);
+    return new ServerFunctionExecutor<>(pool, true, groups);
   }
 
   @Override
-  public Execution onServer(RegionService regionService, String... groups) {
+  public <I, O, A> Execution<I, O, A> onServer(RegionService regionService, String... groups) {
     if (regionService == null) {
       throw new FunctionException(String.format("%s passed is null",
           "RegionService instance "));
@@ -249,13 +249,14 @@ public class InternalFunctionExecutionServiceImpl
       }
     } else {
       ProxyCache proxyCache = (ProxyCache) regionService;
-      return new ServerFunctionExecutor(proxyCache.getUserAttributes().getPool(), false, proxyCache,
+      return new ServerFunctionExecutor<>(proxyCache.getUserAttributes().getPool(), false,
+          proxyCache,
           groups);
     }
   }
 
   @Override
-  public Execution onServers(RegionService regionService, String... groups) {
+  public <I, O, A> Execution<I, O, A> onServers(RegionService regionService, String... groups) {
     if (regionService == null) {
       throw new FunctionException(String.format("%s passed is null",
           "RegionService instance "));
@@ -271,7 +272,8 @@ public class InternalFunctionExecutionServiceImpl
       }
     } else {
       ProxyCache proxyCache = (ProxyCache) regionService;
-      return new ServerFunctionExecutor(proxyCache.getUserAttributes().getPool(), true, proxyCache,
+      return new ServerFunctionExecutor<>(proxyCache.getUserAttributes().getPool(), true,
+          proxyCache,
           groups);
     }
   }
@@ -279,7 +281,8 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService InDistributedSystem API ------------------------------------
 
   @Override
-  public Execution onMember(DistributedSystem system, DistributedMember distributedMember) {
+  public <I, O, A> Execution<I, O, A> onMember(DistributedSystem system,
+      DistributedMember distributedMember) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
           "DistributedSystem instance "));
@@ -288,17 +291,17 @@ public class InternalFunctionExecutionServiceImpl
       throw new FunctionException(String.format("%s passed is null",
           "DistributedMember instance "));
     }
-    return new MemberFunctionExecutor(system, distributedMember);
+    return new MemberFunctionExecutor<>(system, distributedMember);
   }
 
   @Override
-  public Execution onMembers(DistributedSystem system, String... groups) {
+  public <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system, String... groups) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
           "DistributedSystem instance "));
     }
     if (groups.length == 0) {
-      return new MemberFunctionExecutor(system);
+      return new MemberFunctionExecutor<>(system);
     }
     Set<DistributedMember> members = new HashSet<>();
     for (String group : groups) {
@@ -308,11 +311,11 @@ public class InternalFunctionExecutionServiceImpl
       throw new FunctionException(String.format("No members found in group(s) %s",
           Arrays.toString(groups)));
     }
-    return new MemberFunctionExecutor(system, members);
+    return new MemberFunctionExecutor<>(system, members);
   }
 
   @Override
-  public Execution onMember(DistributedSystem system, String... groups) {
+  public <I, O, A> Execution<I, O, A> onMember(DistributedSystem system, String... groups) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
           "DistributedSystem instance "));
@@ -333,11 +336,12 @@ public class InternalFunctionExecutionServiceImpl
       throw new FunctionException(String.format("No members found in group(s) %s",
           Arrays.toString(groups)));
     }
-    return new MemberFunctionExecutor(system, members);
+    return new MemberFunctionExecutor<>(system, members);
   }
 
   @Override
-  public Execution onMembers(DistributedSystem system, Set<DistributedMember> distributedMembers) {
+  public <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system,
+      Set<DistributedMember> distributedMembers) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
           "DistributedSystem instance "));
@@ -346,13 +350,13 @@ public class InternalFunctionExecutionServiceImpl
       throw new FunctionException(String.format("%s passed is null",
           "distributedMembers set "));
     }
-    return new MemberFunctionExecutor(system, distributedMembers);
+    return new MemberFunctionExecutor<>(system, distributedMembers);
   }
 
   // InternalFunctionExecutionService OnRegions API ----------------------------------------------
 
   @Override
-  public Execution onRegions(Set<Region> regions) {
+  public <I, O, A> Execution<I, O, A> onRegions(Set<Region> regions) {
     if (regions == null) {
       throw new IllegalArgumentException(
           String.format("The input %s for the execute function request is null",
@@ -372,7 +376,7 @@ public class InternalFunctionExecutionServiceImpl
             "FunctionService#onRegions() is not supported for cache clients in client server mode");
       }
     }
-    return new MultiRegionFunctionExecutor(regions);
+    return new MultiRegionFunctionExecutor<>(regions);
   }
 
   // InternalFunctionExecutionService unregisterAllFunctions API ---------------------------------

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceImpl.java
@@ -67,42 +67,43 @@ public class InternalFunctionExecutionServiceImpl
   // FunctionExecutionService API ----------------------------------------------------------------
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServer(Pool pool) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool) {
     return onServer(pool, EMPTY_GROUPS);
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServers(Pool pool) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool) {
     return onServers(pool, EMPTY_GROUPS);
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServer(RegionService regionService) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService) {
     return onServer(regionService, EMPTY_GROUPS);
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServers(RegionService regionService) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService) {
     return onServers(regionService, EMPTY_GROUPS);
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMember(DistributedMember distributedMember) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedMember distributedMember) {
     return onMember(getDistributedSystem(), distributedMember);
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMembers(String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(String... groups) {
     return onMembers(getDistributedSystem(), groups);
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMembers(Set<DistributedMember> distributedMembers) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(
+      Set<DistributedMember> distributedMembers) {
     return onMembers(getDistributedSystem(), distributedMembers);
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMember(String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(String... groups) {
     return onMember(getDistributedSystem(), groups);
   }
 
@@ -111,7 +112,7 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onRegion(Region region) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegion(Region region) {
     if (region == null) {
       throw new FunctionException("Region instance passed is null");
     }
@@ -205,7 +206,7 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService OnServerGroups API -----------------------------------------
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServer(Pool pool, String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool, String... groups) {
     if (pool == null) {
       throw new FunctionException(
           String.format("%s passed is null", "Pool instance "));
@@ -219,7 +220,7 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServers(Pool pool, String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool, String... groups) {
     if (pool == null) {
       throw new FunctionException(
           String.format("%s passed is null", "Pool instance "));
@@ -233,7 +234,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServer(RegionService regionService, String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService,
+      String... groups) {
     if (regionService == null) {
       throw new FunctionException(String.format("%s passed is null",
           "RegionService instance "));
@@ -256,7 +258,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onServers(RegionService regionService, String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService,
+      String... groups) {
     if (regionService == null) {
       throw new FunctionException(String.format("%s passed is null",
           "RegionService instance "));
@@ -281,7 +284,7 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService InDistributedSystem API ------------------------------------
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMember(DistributedSystem system,
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system,
       DistributedMember distributedMember) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -295,7 +298,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system, String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system,
+      String... groups) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
           "DistributedSystem instance "));
@@ -315,7 +319,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMember(DistributedSystem system, String... groups) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system,
+      String... groups) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
           "DistributedSystem instance "));
@@ -340,7 +345,7 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <I, O, A> Execution<I, O, A> onMembers(DistributedSystem system,
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system,
       Set<DistributedMember> distributedMembers) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -356,7 +361,7 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService OnRegions API ----------------------------------------------
 
   @Override
-  public <I, O, A> Execution<I, O, A> onRegions(Set<Region> regions) {
+  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegions(Set<Region> regions) {
     if (regions == null) {
       throw new IllegalArgumentException(
           String.format("The input %s for the execute function request is null",

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/InternalFunctionExecutionServiceImpl.java
@@ -67,43 +67,50 @@ public class InternalFunctionExecutionServiceImpl
   // FunctionExecutionService API ----------------------------------------------------------------
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      Pool pool) {
     return onServer(pool, EMPTY_GROUPS);
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      Pool pool) {
     return onServers(pool, EMPTY_GROUPS);
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      RegionService regionService) {
     return onServer(regionService, EMPTY_GROUPS);
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      RegionService regionService) {
     return onServers(regionService, EMPTY_GROUPS);
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedMember distributedMember) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      DistributedMember distributedMember) {
     return onMember(getDistributedSystem(), distributedMember);
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(String... groups) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      String... groups) {
     return onMembers(getDistributedSystem(), groups);
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
       Set<DistributedMember> distributedMembers) {
     return onMembers(getDistributedSystem(), distributedMembers);
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(String... groups) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      String... groups) {
     return onMember(getDistributedSystem(), groups);
   }
 
@@ -112,7 +119,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegion(Region region) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onRegion(
+      Region region) {
     if (region == null) {
       throw new FunctionException("Region instance passed is null");
     }
@@ -206,7 +214,8 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService OnServerGroups API -----------------------------------------
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(Pool pool, String... groups) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      Pool pool, String... groups) {
     if (pool == null) {
       throw new FunctionException(
           String.format("%s passed is null", "Pool instance "));
@@ -220,7 +229,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(Pool pool, String... groups) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      Pool pool, String... groups) {
     if (pool == null) {
       throw new FunctionException(
           String.format("%s passed is null", "Pool instance "));
@@ -234,7 +244,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServer(RegionService regionService,
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServer(
+      RegionService regionService,
       String... groups) {
     if (regionService == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -258,7 +269,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onServers(RegionService regionService,
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onServers(
+      RegionService regionService,
       String... groups) {
     if (regionService == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -284,7 +296,8 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService InDistributedSystem API ------------------------------------
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system,
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      DistributedSystem system,
       DistributedMember distributedMember) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -298,7 +311,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system,
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      DistributedSystem system,
       String... groups) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -319,7 +333,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMember(DistributedSystem system,
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMember(
+      DistributedSystem system,
       String... groups) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -345,7 +360,8 @@ public class InternalFunctionExecutionServiceImpl
   }
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onMembers(DistributedSystem system,
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onMembers(
+      DistributedSystem system,
       Set<DistributedMember> distributedMembers) {
     if (system == null) {
       throw new FunctionException(String.format("%s passed is null",
@@ -361,7 +377,8 @@ public class InternalFunctionExecutionServiceImpl
   // InternalFunctionExecutionService OnRegions API ----------------------------------------------
 
   @Override
-  public <IN, OUT, AGG> Execution<IN, OUT, AGG> onRegions(Set<Region> regions) {
+  public <ArgumentT, ReturnT, AggregatorT> Execution<ArgumentT, ReturnT, AggregatorT> onRegions(
+      Set<Region> regions) {
     if (regions == null) {
       throw new IllegalArgumentException(
           String.format("The input %s for the execute function request is null",

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MemberFunctionExecutor.java
@@ -36,8 +36,9 @@ import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 
-public class MemberFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, OUT, AGG>
-    implements Execution<IN, OUT, AGG> {
+public class MemberFunctionExecutor<ArgumentT, ReturnT, AggregatorT>
+    extends AbstractExecution<ArgumentT, ReturnT, AggregatorT>
+    implements Execution<ArgumentT, ReturnT, AggregatorT> {
 
   protected InternalDistributedSystem ds;
 
@@ -96,7 +97,7 @@ public class MemberFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @SuppressWarnings("unchecked")
-  private ResultCollector<OUT, AGG> executeFunction(final Function function,
+  private ResultCollector<ReturnT, AggregatorT> executeFunction(final Function function,
       ResultCollector resultCollector) {
     final DistributionManager dm = this.ds.getDistributionManager();
     final Set dest = new HashSet(this.members);
@@ -110,7 +111,7 @@ public class MemberFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
 
     final InternalDistributedMember localVM =
         this.ds.getDistributionManager().getDistributionManagerId();
-    final LocalResultCollector<OUT, AGG> localRC =
+    final LocalResultCollector<ReturnT, AggregatorT> localRC =
         getLocalResultCollector(function, resultCollector);
     boolean remoteOnly = false;
     boolean localOnly = false;
@@ -184,7 +185,7 @@ public class MemberFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  protected ResultCollector<OUT, AGG> executeFunction(Function function) {
+  protected ResultCollector<ReturnT, AggregatorT> executeFunction(Function function) {
     if (function.hasResult()) {
       ResultCollector rc = this.rc;
       if (rc == null) {
@@ -198,7 +199,7 @@ public class MemberFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  public Execution<IN, OUT, AGG> setArguments(Object args) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> setArguments(Object args) {
     if (args == null) {
       throw new IllegalArgumentException(
           String.format("The input %s for the execute function request is null",
@@ -209,13 +210,13 @@ public class MemberFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
 
   // Changing the object!!
   @Override
-  public Execution<IN, OUT, AGG> withArgs(Object args) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withArgs(Object args) {
     return setArguments(args);
   }
 
   // Changing the object!!
   @Override
-  public Execution<IN, OUT, AGG> withCollector(ResultCollector rs) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withCollector(ResultCollector rs) {
     if (rs == null) {
       throw new IllegalArgumentException(
           String.format("The input %s for the execute function request is null",
@@ -225,21 +226,23 @@ public class MemberFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  public Execution<IN, OUT, AGG> withFilter(Set filter) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withFilter(Set filter) {
     throw new FunctionException(
         String.format("Cannot specify %s for data independent functions",
             "filter"));
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withBucketFilter(
+      Set<Integer> bucketIDs) {
     throw new FunctionException(
         String.format("Cannot specify %s for data independent functions",
             "bucket as filter"));
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withMemberMappedArgument(MemberMappedArgument argument) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withMemberMappedArgument(
+      MemberMappedArgument argument) {
     if (argument == null) {
       throw new IllegalArgumentException(
           String.format("The input %s for the execute function request is null",

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MultiRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MultiRegionFunctionExecutor.java
@@ -40,7 +40,8 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 
-public class MultiRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, OUT, AGG> {
+public class MultiRegionFunctionExecutor<ArgumentT, ReturnT, AggregatorT>
+    extends AbstractExecution<ArgumentT, ReturnT, AggregatorT> {
 
   private final Set<Region> regions;
 
@@ -142,7 +143,8 @@ public class MultiRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecution
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withBucketFilter(
+      Set<Integer> bucketIDs) {
     throw new FunctionException(
         String.format("Cannot specify %s for multi region function",
             "bucket as filter"));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MultiRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/MultiRegionFunctionExecutor.java
@@ -40,7 +40,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 
-public class MultiRegionFunctionExecutor extends AbstractExecution {
+public class MultiRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, OUT, AGG> {
 
   private final Set<Region> regions;
 
@@ -48,33 +48,6 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
 
   public MultiRegionFunctionExecutor(Set<Region> regions) {
     this.regions = regions;
-  }
-
-  private MultiRegionFunctionExecutor(MultiRegionFunctionExecutor drfe) {
-    super(drfe);
-    this.regions = drfe.regions;
-    if (drfe.filter != null) {
-      this.filter.clear();
-      this.filter.addAll(drfe.filter);
-    }
-    this.sender = drfe.sender;
-  }
-
-  private MultiRegionFunctionExecutor(Set<Region> regions, Set filter2, Object args,
-      MemberMappedArgument memberMappedArg, ServerToClientFunctionResultSender resultSender) {
-    if (args != null) {
-      this.args = args;
-    } else if (memberMappedArg != null) {
-      this.memberMappedArg = memberMappedArg;
-      this.isMemberMappedArgument = true;
-    }
-    this.sender = resultSender;
-    if (filter2 != null) {
-      this.filter.clear();
-      this.filter.addAll(filter2);
-    }
-    this.regions = regions;
-    this.isClientServerMode = true;
   }
 
   private MultiRegionFunctionExecutor(MultiRegionFunctionExecutor executor,
@@ -169,7 +142,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
   }
 
   @Override
-  public InternalExecution withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
     throw new FunctionException(
         String.format("Cannot specify %s for multi region function",
             "bucket as filter"));
@@ -200,7 +173,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
     final Map<InternalDistributedMember, Set<String>> memberToRegionMap =
         calculateMemberToRegionMap();
     final Set<InternalDistributedMember> dest =
-        new HashSet<InternalDistributedMember>(memberToRegionMap.keySet());
+        new HashSet<>(memberToRegionMap.keySet());
 
     if (dest.isEmpty()) {
       throw new FunctionException(
@@ -214,6 +187,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
     }
     setExecutionNodes(dest);
 
+    assert cache != null;
     final InternalDistributedMember localVM = cache.getMyId();
     final LocalResultCollector<?, ?> localResultCollector =
         getLocalResultCollector(function, resultCollector);
@@ -232,7 +206,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
       // if member is local VM
       dest.remove(localVM);
       Set<String> regionPathSet = memberToRegionMap.get(localVM);
-      Set<Region> regions = new HashSet<Region>();
+      Set<Region> regions = new HashSet<>();
       if (regionPathSet != null) {
         InternalCache cache1 = GemFireCacheImpl.getInstance();
         for (String regionPath : regionPathSet) {
@@ -242,12 +216,12 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
       final FunctionContextImpl context =
           new MultiRegionFunctionContextImpl(cache, function.getId(),
               getArgumentsForMember(localVM.getId()), resultSender, regions, this.isReExecute);
-      boolean isTx = cache.getTxManager().getTXState() == null ? false : true;
+      boolean isTx = cache.getTxManager().getTXState() != null;
       executeFunctionOnLocalNode(function, context, resultSender, dm, isTx);
     }
     if (!dest.isEmpty()) {
       HashMap<InternalDistributedMember, Object> memberArgs =
-          new HashMap<InternalDistributedMember, Object>();
+          new HashMap<>();
       for (InternalDistributedMember recip : dest) {
         memberArgs.put(recip, getArgumentsForMember(recip.getId()));
       }
@@ -261,10 +235,9 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
   }
 
   private Map<InternalDistributedMember, Set<String>> calculateMemberToRegionMap() {
-    Map<InternalDistributedMember, Set<String>> memberToRegions =
-        new HashMap<InternalDistributedMember, Set<String>>();
+    Map<InternalDistributedMember, Set<String>> memberToRegions = new HashMap<>();
     // nodes is maintained for node pruning logic
-    Set<InternalDistributedMember> nodes = new HashSet<InternalDistributedMember>();
+    Set<InternalDistributedMember> nodes = new HashSet<>();
     for (Region region : regions) {
       DataPolicy dp = region.getAttributes().getDataPolicy();
       if (region instanceof PartitionedRegion) {
@@ -276,7 +249,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
           InternalDistributedMember localVm = cache.getMyId();
           Set<String> regions = memberToRegions.get(localVm);
           if (regions == null) {
-            regions = new HashSet<String>();
+            regions = new HashSet<>();
           }
           regions.add(pr.getFullPath());
           memberToRegions.put(localVm, regions);
@@ -285,7 +258,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
           for (InternalDistributedMember member : prMembers) {
             Set<String> regions = memberToRegions.get(member);
             if (regions == null) {
-              regions = new HashSet<String>();
+              regions = new HashSet<>();
             }
             regions.add(pr.getFullPath());
             memberToRegions.put(member, regions);
@@ -305,7 +278,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
               added = true;
               Set<String> regions = memberToRegions.get(member);
               if (regions == null) {
-                regions = new HashSet<String>();
+                regions = new HashSet<>();
               }
               regions.add(dr.getFullPath());
               memberToRegions.put(member, regions);
@@ -319,7 +292,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
                 .toArray()[new Random().nextInt(replicates.size())]);
             Set<String> regions = memberToRegions.get(member);
             if (regions == null) {
-              regions = new HashSet<String>();
+              regions = new HashSet<>();
             }
             regions.add(dr.getFullPath());
             memberToRegions.put(member, regions);
@@ -330,7 +303,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
           InternalDistributedMember local = cache.getMyId();
           Set<String> regions = memberToRegions.get(local);
           if (regions == null) {
-            regions = new HashSet<String>();
+            regions = new HashSet<>();
           }
           regions.add(region.getFullPath());
           memberToRegions.put(local, regions);
@@ -341,7 +314,7 @@ public class MultiRegionFunctionExecutor extends AbstractExecution {
         InternalDistributedMember local = cache.getMyId();
         Set<String> regions = memberToRegions.get(local);
         if (regions == null) {
-          regions = new HashSet<String>();
+          regions = new HashSet<>();
         }
         regions.add(region.getFullPath());
         memberToRegions.put(local, regions);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache.execute;
 
-import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.geode.cache.Region;
@@ -29,7 +28,8 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 
-public class PartitionedRegionFunctionExecutor extends AbstractExecution {
+public class PartitionedRegionFunctionExecutor<IN, OUT, AGG>
+    extends AbstractExecution<IN, OUT, AGG> {
 
   private final PartitionedRegion pr;
 
@@ -46,21 +46,6 @@ public class PartitionedRegionFunctionExecutor extends AbstractExecution {
               "region"));
     }
     this.pr = (PartitionedRegion) r;
-  }
-
-  private PartitionedRegionFunctionExecutor(PartitionedRegionFunctionExecutor prfe) {
-    super(prfe);
-    this.pr = prfe.pr;
-    this.executeOnBucketSet = prfe.executeOnBucketSet;
-    this.isPRSingleHop = prfe.isPRSingleHop;
-    this.isReExecute = prfe.isReExecute;
-    if (prfe.filter != null) {
-      this.filter.clear();
-      this.filter.addAll(prfe.filter);
-    }
-    if (prfe.sender != null) {
-      this.sender = prfe.sender;
-    }
   }
 
   private PartitionedRegionFunctionExecutor(PartitionedRegionFunctionExecutor prfe,
@@ -249,9 +234,7 @@ public class PartitionedRegionFunctionExecutor extends AbstractExecution {
 
     bucketIDs.retainAll(actualBucketSet);
 
-    Iterator<Integer> it = bucketIDs.iterator();
-    while (it.hasNext()) {
-      int bid = it.next();
+    for (int bid : bucketIDs) {
       if (!actualBucketSet.contains(bid)) {
         throw new FunctionException("Bucket " + bid + " does not exist.");
       }
@@ -316,16 +299,14 @@ public class PartitionedRegionFunctionExecutor extends AbstractExecution {
 
   @Override
   public String toString() {
-    final StringBuffer buf = new StringBuffer();
-    buf.append("[ PartitionedRegionFunctionExecutor:");
-    buf.append("args=");
-    buf.append(this.args);
-    buf.append(";filter=");
-    buf.append(this.filter);
-    buf.append(";region=");
-    buf.append(this.pr.getName());
-    buf.append("]");
-    return buf.toString();
+    return "[ PartitionedRegionFunctionExecutor:"
+        + "args="
+        + this.args
+        + ";filter="
+        + this.filter
+        + ";region="
+        + this.pr.getName()
+        + "]";
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
@@ -28,8 +28,8 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 
-public class PartitionedRegionFunctionExecutor<IN, OUT, AGG>
-    extends AbstractExecution<IN, OUT, AGG> {
+public class PartitionedRegionFunctionExecutor<ArgumentT, ReturnT, AggregatorT>
+    extends AbstractExecution<ArgumentT, ReturnT, AggregatorT> {
 
   private final PartitionedRegion pr;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerFunctionExecutor.java
@@ -33,8 +33,9 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.cache.execute.util.SynchronizedResultCollector;
 
-public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, OUT, AGG>
-    implements Execution<IN, OUT, AGG> {
+public class ServerFunctionExecutor<ArgumentT, ReturnT, AggregatorT>
+    extends AbstractExecution<ArgumentT, ReturnT, AggregatorT>
+    implements Execution<ArgumentT, ReturnT, AggregatorT> {
 
   private PoolImpl pool;
 
@@ -81,7 +82,8 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
     this.isMemberMappedArgument = true;
   }
 
-  protected ResultCollector<OUT, AGG> executeFunction(final String functionId, boolean result,
+  protected ResultCollector<ReturnT, AggregatorT> executeFunction(final String functionId,
+      boolean result,
       boolean isHA,
       boolean optimizeForWrite) {
     try {
@@ -111,7 +113,7 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  protected ResultCollector<OUT, AGG> executeFunction(final Function function) {
+  protected ResultCollector<ReturnT, AggregatorT> executeFunction(final Function function) {
     byte hasResult = 0;
     try {
       if (proxyCache != null) {
@@ -139,7 +141,8 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
 
   }
 
-  private ResultCollector<OUT, AGG> executeOnServer(Function function, ResultCollector rc,
+  private ResultCollector<ReturnT, AggregatorT> executeOnServer(Function function,
+      ResultCollector rc,
       byte hasResult) {
     FunctionStats stats = FunctionStats.getFunctionStats(function.getId());
     try {
@@ -162,7 +165,8 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
     }
   }
 
-  private ResultCollector<OUT, AGG> executeOnServer(String functionId, ResultCollector rc,
+  private ResultCollector<ReturnT, AggregatorT> executeOnServer(String functionId,
+      ResultCollector rc,
       byte hasResult,
       boolean isHA, boolean optimizeForWrite) {
     FunctionStats stats = FunctionStats.getFunctionStats(functionId);
@@ -233,21 +237,22 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  public Execution<IN, OUT, AGG> withFilter(Set filter) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withFilter(Set filter) {
     throw new FunctionException(
         String.format("Cannot specify %s for data independent functions",
             "filter"));
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withBucketFilter(
+      Set<Integer> bucketIDs) {
     throw new FunctionException(
         String.format("Cannot specify %s for data independent functions",
             "buckets as filter"));
   }
 
   @Override
-  public Execution<IN, OUT, AGG> setArguments(Object args) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> setArguments(Object args) {
     if (args == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -257,12 +262,12 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  public Execution<IN, OUT, AGG> withArgs(Object args) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withArgs(Object args) {
     return setArguments(args);
   }
 
   @Override
-  public Execution<IN, OUT, AGG> withCollector(ResultCollector rs) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withCollector(ResultCollector rs) {
     if (rs == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -272,7 +277,8 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withMemberMappedArgument(MemberMappedArgument argument) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withMemberMappedArgument(
+      MemberMappedArgument argument) {
     if (argument == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -289,7 +295,7 @@ public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, 
   }
 
   @Override
-  public ResultCollector<OUT, AGG> execute(final String functionName) {
+  public ResultCollector<ReturnT, AggregatorT> execute(final String functionName) {
     if (functionName == null) {
       throw new FunctionException(
           "The input function for the execute function request is null");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerFunctionExecutor.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.execute;
 
+import java.util.List;
 import java.util.Set;
 
 import org.apache.geode.cache.client.Pool;
@@ -32,7 +33,8 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.cache.execute.util.SynchronizedResultCollector;
 
-public class ServerFunctionExecutor extends AbstractExecution {
+public class ServerFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, OUT, AGG>
+    implements Execution<IN, OUT, AGG> {
 
   private PoolImpl pool;
 
@@ -79,7 +81,8 @@ public class ServerFunctionExecutor extends AbstractExecution {
     this.isMemberMappedArgument = true;
   }
 
-  protected ResultCollector executeFunction(final String functionId, boolean result, boolean isHA,
+  protected ResultCollector<OUT, AGG> executeFunction(final String functionId, boolean result,
+      boolean isHA,
       boolean optimizeForWrite) {
     try {
       if (proxyCache != null) {
@@ -108,7 +111,7 @@ public class ServerFunctionExecutor extends AbstractExecution {
   }
 
   @Override
-  protected ResultCollector executeFunction(final Function function) {
+  protected ResultCollector<OUT, AGG> executeFunction(final Function function) {
     byte hasResult = 0;
     try {
       if (proxyCache != null) {
@@ -121,7 +124,7 @@ public class ServerFunctionExecutor extends AbstractExecution {
       if (function.hasResult()) { // have Results
         hasResult = 1;
         if (this.rc == null) { // Default Result Collector
-          ResultCollector defaultCollector = new DefaultResultCollector();
+          ResultCollector<Object, List<Object>> defaultCollector = new DefaultResultCollector();
           return executeOnServer(function, defaultCollector, hasResult);
         } else { // Custome Result COllector
           return executeOnServer(function, this.rc, hasResult);
@@ -136,7 +139,8 @@ public class ServerFunctionExecutor extends AbstractExecution {
 
   }
 
-  private ResultCollector executeOnServer(Function function, ResultCollector rc, byte hasResult) {
+  private ResultCollector<OUT, AGG> executeOnServer(Function function, ResultCollector rc,
+      byte hasResult) {
     FunctionStats stats = FunctionStats.getFunctionStats(function.getId());
     try {
       validateExecution(function, null);
@@ -158,7 +162,8 @@ public class ServerFunctionExecutor extends AbstractExecution {
     }
   }
 
-  private ResultCollector executeOnServer(String functionId, ResultCollector rc, byte hasResult,
+  private ResultCollector<OUT, AGG> executeOnServer(String functionId, ResultCollector rc,
+      byte hasResult,
       boolean isHA, boolean optimizeForWrite) {
     FunctionStats stats = FunctionStats.getFunctionStats(functionId);
     try {
@@ -228,52 +233,52 @@ public class ServerFunctionExecutor extends AbstractExecution {
   }
 
   @Override
-  public Execution withFilter(Set filter) {
+  public Execution<IN, OUT, AGG> withFilter(Set filter) {
     throw new FunctionException(
         String.format("Cannot specify %s for data independent functions",
             "filter"));
   }
 
   @Override
-  public InternalExecution withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
     throw new FunctionException(
         String.format("Cannot specify %s for data independent functions",
             "buckets as filter"));
   }
 
   @Override
-  public Execution setArguments(Object args) {
+  public Execution<IN, OUT, AGG> setArguments(Object args) {
     if (args == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "args"));
     }
-    return new ServerFunctionExecutor(this, args);
+    return new ServerFunctionExecutor<>(this, args);
   }
 
   @Override
-  public Execution withArgs(Object args) {
+  public Execution<IN, OUT, AGG> withArgs(Object args) {
     return setArguments(args);
   }
 
   @Override
-  public Execution withCollector(ResultCollector rs) {
+  public Execution<IN, OUT, AGG> withCollector(ResultCollector rs) {
     if (rs == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "Result Collector"));
     }
-    return new ServerFunctionExecutor(this, rs);
+    return new ServerFunctionExecutor<>(this, rs);
   }
 
   @Override
-  public InternalExecution withMemberMappedArgument(MemberMappedArgument argument) {
+  public InternalExecution<IN, OUT, AGG> withMemberMappedArgument(MemberMappedArgument argument) {
     if (argument == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "MemberMapped Args"));
     }
-    return new ServerFunctionExecutor(this, argument);
+    return new ServerFunctionExecutor<>(this, argument);
   }
 
   @Override
@@ -284,7 +289,7 @@ public class ServerFunctionExecutor extends AbstractExecution {
   }
 
   @Override
-  public ResultCollector execute(final String functionName) {
+  public ResultCollector<OUT, AGG> execute(final String functionName) {
     if (functionName == null) {
       throw new FunctionException(
           "The input function for the execute function request is null");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerRegionFunctionExecutor.java
@@ -41,7 +41,8 @@ import org.apache.geode.internal.logging.LogService;
  * @see FunctionService#onRegion(Region) *
  * @since GemFire 5.8 LA
  */
-public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, OUT, AGG> {
+public class ServerRegionFunctionExecutor<ArgumentT, ReturnT, AggregatorT>
+    extends AbstractExecution<ArgumentT, ReturnT, AggregatorT> {
   private static final Logger logger = LogService.getLogger();
 
   private final LocalRegion region;
@@ -114,7 +115,7 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
   }
 
   @Override
-  public Execution<IN, OUT, AGG> withFilter(Set fltr) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withFilter(Set fltr) {
     if (fltr == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -125,7 +126,8 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withBucketFilter(
+      Set<Integer> bucketIDs) {
     if (bucketIDs == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -135,7 +137,7 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
   }
 
   @Override
-  protected ResultCollector<OUT, AGG> executeFunction(final Function function) {
+  protected ResultCollector<ReturnT, AggregatorT> executeFunction(final Function function) {
     byte hasResult = 0;
     try {
       if (proxyCache != null) {
@@ -162,7 +164,8 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
     }
   }
 
-  protected ResultCollector<OUT, AGG> executeFunction(final String functionId, boolean resultReq,
+  protected ResultCollector<ReturnT, AggregatorT> executeFunction(final String functionId,
+      boolean resultReq,
       boolean isHA, boolean optimizeForWrite) {
     try {
       if (proxyCache != null) {
@@ -189,7 +192,8 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
     }
   }
 
-  private ResultCollector<OUT, AGG> executeOnServer(Function function, ResultCollector collector,
+  private ResultCollector<ReturnT, AggregatorT> executeOnServer(Function function,
+      ResultCollector collector,
       byte hasResult) throws FunctionException {
     ServerRegionProxy srp = getServerRegionProxy();
     FunctionStats stats = FunctionStats.getFunctionStats(function.getId(), this.region.getSystem());
@@ -297,7 +301,7 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
   }
 
   @Override
-  public Execution<IN, OUT, AGG> setArguments(Object args) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> setArguments(Object args) {
     if (args == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -307,12 +311,12 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
   }
 
   @Override
-  public Execution<IN, OUT, AGG> withArgs(Object args) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withArgs(Object args) {
     return setArguments(args);
   }
 
   @Override
-  public Execution<IN, OUT, AGG> withCollector(ResultCollector rs) {
+  public Execution<ArgumentT, ReturnT, AggregatorT> withCollector(ResultCollector rs) {
     if (rs == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -322,7 +326,8 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
   }
 
   @Override
-  public InternalExecution<IN, OUT, AGG> withMemberMappedArgument(MemberMappedArgument argument) {
+  public InternalExecution<ArgumentT, ReturnT, AggregatorT> withMemberMappedArgument(
+      MemberMappedArgument argument) {
     if (argument == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
@@ -342,7 +347,7 @@ public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecutio
   }
 
   @Override
-  public ResultCollector<OUT, AGG> execute(final String functionName) {
+  public ResultCollector<ReturnT, AggregatorT> execute(final String functionName) {
     if (functionName == null) {
       throw new FunctionException(
           "The input function for the execute function request is null");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/ServerRegionFunctionExecutor.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.execute;
 
+import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
@@ -40,7 +41,7 @@ import org.apache.geode.internal.logging.LogService;
  * @see FunctionService#onRegion(Region) *
  * @since GemFire 5.8 LA
  */
-public class ServerRegionFunctionExecutor extends AbstractExecution {
+public class ServerRegionFunctionExecutor<IN, OUT, AGG> extends AbstractExecution<IN, OUT, AGG> {
   private static final Logger logger = LogService.getLogger();
 
   private final LocalRegion region;
@@ -113,28 +114,28 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
   }
 
   @Override
-  public Execution withFilter(Set fltr) {
+  public Execution<IN, OUT, AGG> withFilter(Set fltr) {
     if (fltr == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "filter"));
     }
     this.executeOnBucketSet = false;
-    return new ServerRegionFunctionExecutor(this, fltr);
+    return new ServerRegionFunctionExecutor<>(this, fltr);
   }
 
   @Override
-  public InternalExecution withBucketFilter(Set<Integer> bucketIDs) {
+  public InternalExecution<IN, OUT, AGG> withBucketFilter(Set<Integer> bucketIDs) {
     if (bucketIDs == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "buckets as filter"));
     }
-    return new ServerRegionFunctionExecutor(this, bucketIDs, true /* execute on bucketset */);
+    return new ServerRegionFunctionExecutor<>(this, bucketIDs, true /* execute on bucketset */);
   }
 
   @Override
-  protected ResultCollector executeFunction(final Function function) {
+  protected ResultCollector<OUT, AGG> executeFunction(final Function function) {
     byte hasResult = 0;
     try {
       if (proxyCache != null) {
@@ -147,7 +148,7 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
       if (function.hasResult()) { // have Results
         hasResult = 1;
         if (this.rc == null) { // Default Result Collector
-          ResultCollector defaultCollector = new DefaultResultCollector();
+          ResultCollector<Object, List<Object>> defaultCollector = new DefaultResultCollector();
           return executeOnServer(function, defaultCollector, hasResult);
         } else { // Custome Result COllector
           return executeOnServer(function, this.rc, hasResult);
@@ -161,7 +162,7 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
     }
   }
 
-  protected ResultCollector executeFunction(final String functionId, boolean resultReq,
+  protected ResultCollector<OUT, AGG> executeFunction(final String functionId, boolean resultReq,
       boolean isHA, boolean optimizeForWrite) {
     try {
       if (proxyCache != null) {
@@ -174,7 +175,7 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
       if (resultReq) { // have Results
         hasResult = 1;
         if (this.rc == null) { // Default Result Collector
-          ResultCollector defaultCollector = new DefaultResultCollector();
+          ResultCollector<Object, List<Object>> defaultCollector = new DefaultResultCollector();
           return executeOnServer(functionId, defaultCollector, hasResult, isHA, optimizeForWrite);
         } else { // Custome Result COllector
           return executeOnServer(functionId, this.rc, hasResult, isHA, optimizeForWrite);
@@ -188,7 +189,7 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
     }
   }
 
-  private ResultCollector executeOnServer(Function function, ResultCollector collector,
+  private ResultCollector<OUT, AGG> executeOnServer(Function function, ResultCollector collector,
       byte hasResult) throws FunctionException {
     ServerRegionProxy srp = getServerRegionProxy();
     FunctionStats stats = FunctionStats.getFunctionStats(function.getId(), this.region.getSystem());
@@ -277,13 +278,10 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
       }
       return srp;
     } else {
-      StringBuilder message = new StringBuilder();
-      message.append(srp).append(": ");
-      message
-          .append(
-              "No available connection was found. Server Region Proxy is not available for this region ")
-          .append(region.getName());
-      throw new FunctionException(message.toString());
+      String message = srp + ": "
+          + "No available connection was found. Server Region Proxy is not available for this region "
+          + region.getName();
+      throw new FunctionException(message);
     }
   }
 
@@ -293,44 +291,44 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
 
   @Override
   public String toString() {
-    return new StringBuffer().append("[ ServerRegionExecutor:").append("args=").append(this.args)
-        .append(" ;filter=").append(this.filter).append(" ;region=").append(this.region.getName())
-        .append("]").toString();
+    return "[ ServerRegionExecutor:" + "args=" + this.args
+        + " ;filter=" + this.filter + " ;region=" + this.region.getName()
+        + "]";
   }
 
   @Override
-  public Execution setArguments(Object args) {
+  public Execution<IN, OUT, AGG> setArguments(Object args) {
     if (args == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "args"));
     }
-    return new ServerRegionFunctionExecutor(this, args);
+    return new ServerRegionFunctionExecutor<>(this, args);
   }
 
   @Override
-  public Execution withArgs(Object args) {
+  public Execution<IN, OUT, AGG> withArgs(Object args) {
     return setArguments(args);
   }
 
   @Override
-  public Execution withCollector(ResultCollector rs) {
+  public Execution<IN, OUT, AGG> withCollector(ResultCollector rs) {
     if (rs == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "Result Collector"));
     }
-    return new ServerRegionFunctionExecutor(this, rs);
+    return new ServerRegionFunctionExecutor<>(this, rs);
   }
 
   @Override
-  public InternalExecution withMemberMappedArgument(MemberMappedArgument argument) {
+  public InternalExecution<IN, OUT, AGG> withMemberMappedArgument(MemberMappedArgument argument) {
     if (argument == null) {
       throw new FunctionException(
           String.format("The input %s for the execute function request is null",
               "MemberMappedArgument"));
     }
-    return new ServerRegionFunctionExecutor(this, argument);
+    return new ServerRegionFunctionExecutor<>(this, argument);
   }
 
   @Override
@@ -344,7 +342,7 @@ public class ServerRegionFunctionExecutor extends AbstractExecution {
   }
 
   @Override
-  public ResultCollector execute(final String functionName) {
+  public ResultCollector<OUT, AGG> execute(final String functionName) {
     if (functionName == null) {
       throw new FunctionException(
           "The input function for the execute function request is null");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/MemberConfigManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/MemberConfigManager.java
@@ -92,9 +92,11 @@ public class MemberConfigManager implements ConfigurationManager<MemberConfig> {
 
   private ArrayList<MemberInformation> getMemberInformation(
       Set<DistributedMember> distributedMembers) {
-    Execution execution = FunctionService.onMembers(distributedMembers);
-    ResultCollector<?, ?> resultCollector = execution.execute(new GetMemberInformationFunction());
-    return (ArrayList<MemberInformation>) resultCollector.getResult();
+    Execution<DistributedMember, MemberInformation, ArrayList<MemberInformation>> execution =
+        FunctionService.onMembers(distributedMembers);
+    ResultCollector<MemberInformation, ArrayList<MemberInformation>> resultCollector =
+        execution.execute(new GetMemberInformationFunction());
+    return resultCollector.getResult();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Extensions and implementations of Execution and ResultCollector and the
classes and interfaces involved in the execution chain were lacking the
ability to apply Generic types.

Typing issues starting from MemberConfigManager.java class were fixed.

Trivial IDE warnings were fixed.

Co-authored-by: Joris Melchior <joris.melchior@gmail.com>
Co-authored-by: Peter Tran <ptran@gmail.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
