### PR TITLE
GEODE-6825: Add workingDirectory field to GMSLocator

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -34,8 +34,10 @@ import java.net.InetAddress;
 import java.util.List;
 import java.util.Properties;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.distributed.ConfigurationProperties;
@@ -68,6 +70,9 @@ import org.apache.geode.internal.security.SecurityServiceFactory;
 
 @Category({MembershipJUnitTest.class})
 public class MembershipJUnitTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   /**
    * This test creates a locator with a colocated membership manager and then creates a second
@@ -126,7 +131,7 @@ public class MembershipJUnitTest {
       // this locator will hook itself up with the first MembershipManager
       // to be created
       l = InternalLocator.startLocator(port, new File(""), null, null, localHost, false,
-          new Properties(), null);
+          new Properties(), null, temporaryFolder.getRoot());
 
       // create configuration objects
       Properties nonDefault = new Properties();
@@ -270,7 +275,8 @@ public class MembershipJUnitTest {
       p.setProperty(ConfigurationProperties.SECURITY_UDP_DHALGO, "AES:128");
       // this locator will hook itself up with the first MembershipManager
       // to be created
-      l = InternalLocator.startLocator(port, new File(""), null, null, localHost, false, p, null);
+      l = InternalLocator.startLocator(port, new File(""), null, null, localHost, false, p, null,
+          temporaryFolder.getRoot());
 
       // create configuration objects
       Properties nonDefault = new Properties();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.distributed.internal.membership.gms.locator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.distributed.internal.LocatorStats;
+import org.apache.geode.distributed.internal.membership.NetView;
+import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+
+public class GMSLocatorIntegrationTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private TcpServer tcpServer;
+  private NetView view;
+  private GMSLocator gmsLocator;
+
+  @Before
+  public void setUp() {
+    tcpServer = mock(TcpServer.class);
+    view = new NetView();
+    gmsLocator =
+        new GMSLocator(null, null, false, false, new LocatorStats(), "", temporaryFolder.getRoot());
+  }
+
+  @Test
+  public void viewFileIsNullByDefault() {
+    assertThat(gmsLocator.getViewFile()).isNull();
+  }
+
+  @Test
+  public void initDefinesViewFileInSpecifiedDirectory() {
+    gmsLocator.init(tcpServer);
+
+    assertThat(gmsLocator.getViewFile()).isNotNull();
+  }
+
+  @Test
+  public void installViewCreatesViewFileInSpecifiedDirectory() {
+    gmsLocator.init(tcpServer);
+
+    gmsLocator.installView(view);
+
+    assertThat(gmsLocator.getViewFile()).exists();
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -59,7 +59,7 @@ import org.apache.geode.internal.security.SecurityServiceFactory;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
 @Category({MembershipTest.class})
-public class GMSLocatorRecoveryJUnitTest {
+public class GMSLocatorRecoveryIntegrationTest {
 
   private File tempStateFile;
   private GMSLocator locator;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -17,31 +17,31 @@ package org.apache.geode.distributed.internal.membership.gms.locator;
 import static org.apache.geode.distributed.ConfigurationProperties.BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_TCP;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
-import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
-import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
-import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.apache.geode.distributed.internal.ClusterDistributionManager.NORMAL_DM_TYPE;
+import static org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator.LOCATOR_FILE_STAMP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.net.InetAddress;
 import java.util.Properties;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.InternalGemFireException;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DMStats;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
@@ -58,36 +58,135 @@ import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityServiceFactory;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
-@Category({MembershipTest.class})
+@Category(MembershipTest.class)
 public class GMSLocatorRecoveryIntegrationTest {
 
-  private File tempStateFile;
-  private GMSLocator locator;
-  private File dir;
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public TestName testName = new TestName();
+
+  private File stateFile;
+  private GMSLocator gmsLocator;
+  private MembershipManager membershipManager;
+  private Locator locator;
 
   @Before
   public void setUp() throws Exception {
-    this.tempStateFile = new File("GMSLocatorJUnitTest_locator.dat");
-    if (this.tempStateFile.exists()) {
-      this.tempStateFile.delete();
-    }
-    this.locator = new GMSLocator(null, null, false, false, new LocatorStats(), "");
-    locator.setViewFile(tempStateFile);
+    stateFile = new File(temporaryFolder.getRoot(), getClass().getSimpleName() + "_locator.dat");
+
+    gmsLocator = new GMSLocator(null, null, false, false, new LocatorStats(), "");
+    gmsLocator.setViewFile(stateFile);
   }
 
   @After
   public void tearDown() throws Exception {
-    if (this.tempStateFile.exists()) {
-      this.tempStateFile.delete();
+    if (membershipManager != null) {
+      membershipManager.disconnect(false);
     }
-
-    if (dir != null) {
-      FileUtils.deleteQuietly(dir);
+    if (locator != null) {
+      locator.stop();
     }
   }
 
+  @Test
+  public void testRecoverFromFileWithNonExistFile() {
+    assertThat(stateFile).doesNotExist();
+
+    assertThat(gmsLocator.recoverFromFile(stateFile)).isFalse();
+  }
+
+  @Test
+  public void testRecoverFromFileWithNormalFile() throws Exception {
+    NetView view = new NetView();
+    populateStateFile(stateFile, LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL, view);
+
+    assertThat(gmsLocator.recoverFromFile(stateFile)).isTrue();
+  }
+
+  @Test
+  public void testRecoverFromFileWithWrongFileStamp() throws Exception {
+    // add 1 to file stamp to make it invalid
+    populateStateFile(stateFile, LOCATOR_FILE_STAMP + 1, Version.CURRENT_ORDINAL, 1);
+
+    assertThat(gmsLocator.recoverFromFile(stateFile)).isFalse();
+  }
+
+  @Test
+  public void testRecoverFromFileWithWrongOrdinal() throws Exception {
+    // add 1 to ordinal to make it wrong
+    populateStateFile(stateFile, LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL + 1, 1);
+
+    Throwable thrown = catchThrowable(() -> gmsLocator.recoverFromFile(stateFile));
+
+    assertThat(thrown)
+        .isInstanceOf(InternalGemFireException.class);
+  }
+
+  @Test
+  public void testRecoverFromFileWithInvalidViewObject() throws Exception {
+    populateStateFile(stateFile, LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL, 1);
+
+    Throwable thrown = catchThrowable(() -> gmsLocator.recoverFromFile(stateFile));
+
+    assertThat(thrown)
+        .isInstanceOf(InternalGemFireException.class)
+        .hasMessageStartingWith("Unable to recover previous membership view from");
+  }
+
+  @Test
+  public void testRecoverFromOther() throws Exception {
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
+    InetAddress localHost = SocketCreator.getLocalHost();
+
+    // this locator will hook itself up with the first MembershipManager to be created
+    locator = InternalLocator.startLocator(port, null, null, null, localHost, false,
+        new Properties(), null);
+
+    // create configuration objects
+    Properties nonDefault = new Properties();
+    nonDefault.setProperty(BIND_ADDRESS, localHost.getHostAddress());
+    nonDefault.setProperty(DISABLE_TCP, "true");
+    nonDefault.setProperty(LOCATORS, localHost.getHostAddress() + '[' + port + ']');
+
+    DistributionConfigImpl config = new DistributionConfigImpl(nonDefault);
+    RemoteTransportConfig transport = new RemoteTransportConfig(config, NORMAL_DM_TYPE);
+
+    DistributedMembershipListener mockListener = mock(DistributedMembershipListener.class);
+    InternalDistributedSystem mockSystem = mock(InternalDistributedSystem.class);
+    DMStats mockDmStats = mock(DMStats.class);
+
+    when(mockSystem.getConfig()).thenReturn(config);
+
+    // start the membership manager
+    membershipManager = MemberFactory.newMembershipManager(mockListener, mockSystem, transport,
+        mockDmStats, SecurityServiceFactory.create());
+
+    GMSLocator gmsLocator = new GMSLocator(localHost,
+        membershipManager.getLocalMember().getHost() + "[" + port + "]", true, true,
+        new LocatorStats(), "");
+    gmsLocator.setViewFile(new File(temporaryFolder.getRoot(), "locator2.dat"));
+    gmsLocator.init(null);
+
+    assertThat(gmsLocator.getMembers()).contains(membershipManager.getLocalMember());
+  }
+
+  @Test
+  public void testViewFileNotFound() throws Exception {
+    populateStateFile(stateFile, LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL, new NetView());
+    assertThat(stateFile).exists();
+
+    File dir = temporaryFolder.newFolder(testName.getMethodName());
+    File viewFileInNewDirectory = new File(dir, stateFile.getName());
+    assertThat(viewFileInNewDirectory).doesNotExist();
+
+    File locatorViewFile = gmsLocator.setViewFile(viewFileInNewDirectory);
+    assertThat(gmsLocator.recoverFromFile(locatorViewFile)).isFalse();
+  }
+
   private void populateStateFile(File file, int fileStamp, int ordinal, Object object)
-      throws Exception {
+      throws IOException {
     try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(file))) {
       oos.writeInt(fileStamp);
       oos.writeInt(ordinal);
@@ -95,125 +194,4 @@ public class GMSLocatorRecoveryIntegrationTest {
       oos.flush();
     }
   }
-
-  @Test
-  public void testRecoverFromFileWithNonExistFile() throws Exception {
-    this.tempStateFile.delete();
-    assertFalse(this.tempStateFile.exists());
-    assertFalse(this.locator.recoverFromFile(this.tempStateFile));
-  }
-
-  @Test
-  public void testRecoverFromFileWithNormalFile() throws Exception {
-    NetView view = new NetView();
-    populateStateFile(this.tempStateFile, GMSLocator.LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL,
-        view);
-    assertTrue(this.locator.recoverFromFile(this.tempStateFile));
-  }
-
-  @Test
-  public void testRecoverFromFileWithWrongFileStamp() throws Exception {
-    // add 1 to file stamp to make it invalid
-    populateStateFile(this.tempStateFile, GMSLocator.LOCATOR_FILE_STAMP + 1,
-        Version.CURRENT_ORDINAL, 1);
-    assertFalse(this.locator.recoverFromFile(this.tempStateFile));
-  }
-
-  @Test
-  public void testRecoverFromFileWithWrongOrdinal() throws Exception {
-    // add 1 to ordinal to make it wrong
-    populateStateFile(this.tempStateFile, GMSLocator.LOCATOR_FILE_STAMP,
-        Version.CURRENT_ORDINAL + 1, 1);
-    try {
-      this.locator.recoverFromFile(this.tempStateFile);
-      fail("expected an InternalGemFireException to be thrown");
-    } catch (InternalGemFireException e) {
-      // success
-    }
-  }
-
-  @Test
-  public void testRecoverFromFileWithInvalidViewObject() throws Exception {
-    populateStateFile(this.tempStateFile, GMSLocator.LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL,
-        1);
-    try {
-      this.locator.recoverFromFile(this.tempStateFile);
-      fail("should catch InternalGemFileException");
-    } catch (InternalGemFireException e) {
-      assertTrue(e.getMessage().startsWith("Unable to recover previous membership view from"));
-    }
-  }
-
-  @Test
-  public void testRecoverFromOther() throws Exception {
-
-    MembershipManager m1 = null, m2 = null;
-    Locator l = null;
-
-    try {
-
-      // boot up a locator
-      int port = AvailablePortHelper.getRandomAvailableTCPPort();
-      InetAddress localHost = SocketCreator.getLocalHost();
-
-      // this locator will hook itself up with the first MembershipManager
-      // to be created
-      // l = Locator.startLocator(port, new File(""), localHost);
-      l = InternalLocator.startLocator(port, new File(""), null, null, localHost, false,
-          new Properties(), null);
-
-      // create configuration objects
-      Properties nonDefault = new Properties();
-      nonDefault.put(DISABLE_TCP, "true");
-      nonDefault.put(MCAST_PORT, "0");
-      nonDefault.put(LOG_FILE, "");
-      nonDefault.put(LOG_LEVEL, "fine");
-      nonDefault.put(LOCATORS, localHost.getHostAddress() + '[' + port + ']');
-      nonDefault.put(BIND_ADDRESS, localHost.getHostAddress());
-      DistributionConfigImpl config = new DistributionConfigImpl(nonDefault);
-      RemoteTransportConfig transport =
-          new RemoteTransportConfig(config, ClusterDistributionManager.NORMAL_DM_TYPE);
-
-      // start the first membership manager
-      DistributedMembershipListener listener1 = mock(DistributedMembershipListener.class);
-      InternalDistributedSystem mockSystem = mock(InternalDistributedSystem.class);
-      when(mockSystem.getConfig()).thenReturn(config);
-      DMStats stats1 = mock(DMStats.class);
-      m1 = MemberFactory.newMembershipManager(listener1, mockSystem, transport, stats1,
-          SecurityServiceFactory.create());
-
-      GMSLocator l2 = new GMSLocator(SocketCreator.getLocalHost(),
-          m1.getLocalMember().getHost() + "[" + port + "]", true, true, new LocatorStats(), "");
-      l2.setViewFile(new File("l2.dat"));
-      l2.init(null);
-
-      assertTrue("expected view to contain " + m1.getLocalMember() + ": " + l2.getMembers(),
-          l2.getMembers().contains(m1.getLocalMember()));
-    } finally {
-      if (m1 != null) {
-        m1.disconnect(false);
-      }
-      if (l != null) {
-        l.stop();
-      }
-    }
-  }
-
-  @Test
-  public void testViewFileNotFound() throws Exception {
-    NetView view = new NetView();
-    populateStateFile(this.tempStateFile, GMSLocator.LOCATOR_FILE_STAMP, Version.CURRENT_ORDINAL,
-        view);
-    assertTrue(this.tempStateFile.exists());
-
-    dir = new File("testViewFileFoundWhenUserDirModified");
-    dir.mkdir();
-    File viewFileInNewDirectory = new File(dir, tempStateFile.getName());
-
-    assertFalse(viewFileInNewDirectory.exists());
-    File locatorViewFile = locator.setViewFile(viewFileInNewDirectory);
-    assertFalse(locator.recoverFromFile(locatorViewFile));
-  }
-
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -76,7 +76,8 @@ public class GMSLocatorRecoveryIntegrationTest {
   public void setUp() throws Exception {
     stateFile = new File(temporaryFolder.getRoot(), getClass().getSimpleName() + "_locator.dat");
 
-    gmsLocator = new GMSLocator(null, null, false, false, new LocatorStats(), "");
+    gmsLocator = new GMSLocator(null, null, false, false, new LocatorStats(), "",
+        temporaryFolder.getRoot());
     gmsLocator.setViewFile(stateFile);
   }
 
@@ -142,7 +143,7 @@ public class GMSLocatorRecoveryIntegrationTest {
 
     // this locator will hook itself up with the first MembershipManager to be created
     locator = InternalLocator.startLocator(port, null, null, null, localHost, false,
-        new Properties(), null);
+        new Properties(), null, temporaryFolder.getRoot());
 
     // create configuration objects
     Properties nonDefault = new Properties();
@@ -165,7 +166,7 @@ public class GMSLocatorRecoveryIntegrationTest {
 
     GMSLocator gmsLocator = new GMSLocator(localHost,
         membershipManager.getLocalMember().getHost() + "[" + port + "]", true, true,
-        new LocatorStats(), "");
+        new LocatorStats(), "", temporaryFolder.getRoot());
     gmsLocator.setViewFile(new File(temporaryFolder.getRoot(), "locator2.dat"));
     gmsLocator.init(null);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithLocatorIntegrationTest.java
@@ -89,7 +89,8 @@ public class LoggingWithLocatorIntegrationTest {
   public void startLocatorDefaultLoggingConfig() throws Exception {
     Properties config = new Properties();
 
-    locator = InternalLocator.startLocator(port, null, null, null, null, false, config, null);
+    locator = InternalLocator.startLocator(port, null, null, null, null, false, config, null,
+        temporaryFolder.getRoot());
 
     LogConfig logConfig = locator.getLogConfig();
 
@@ -107,7 +108,8 @@ public class LoggingWithLocatorIntegrationTest {
   public void startLocatorDefaultLoggingConfigWithLogFile() throws Exception {
     Properties config = new Properties();
 
-    locator = InternalLocator.startLocator(port, logFile, null, null, null, false, config, null);
+    locator = InternalLocator.startLocator(port, logFile, null, null, null, false, config, null,
+        temporaryFolder.getRoot());
 
     LogConfig logConfig = locator.getLogConfig();
 
@@ -164,7 +166,8 @@ public class LoggingWithLocatorIntegrationTest {
     config.setProperty(LOG_FILE, logFile.getAbsolutePath());
     config.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
 
-    locator = InternalLocator.startLocator(port, null, null, null, null, false, config, null);
+    locator = InternalLocator.startLocator(port, null, null, null, null, false, config, null,
+        temporaryFolder.getRoot());
     Logger logger = LogService.getLogger();
 
     // assert that logging goes to logFile

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -673,7 +673,8 @@ public class LocatorLauncher extends AbstractLauncher<String> {
 
         try {
           this.locator = InternalLocator.startLocator(getPort(), getLogFile(), null, null,
-              getBindAddress(), true, getDistributedSystemProperties(), getHostnameForClients());
+              getBindAddress(), true, getDistributedSystemProperties(), getHostnameForClients(),
+              new File(workingDirectory));
         } finally {
           ProcessLauncherContext.remove();
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -14,9 +14,12 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
 import static org.apache.geode.distributed.ConfigurationProperties.BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.internal.admin.remote.DistributionLocatorId.asDistributionLocatorIds;
 
 import java.io.File;
 import java.io.IOException;
@@ -24,7 +27,6 @@ import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
@@ -35,14 +37,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.annotations.internal.MakeNotStatic;
-import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.cache.client.internal.locator.ClientConnectionRequest;
 import org.apache.geode.cache.client.internal.locator.ClientReplacementRequest;
 import org.apache.geode.cache.client.internal.locator.GetAllServersRequest;
@@ -54,14 +54,12 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.LockServiceDestroyedException;
 import org.apache.geode.distributed.internal.InternalDistributedSystem.ConnectListener;
-import org.apache.geode.distributed.internal.InternalDistributedSystem.DisconnectListener;
 import org.apache.geode.distributed.internal.membership.MemberFactory;
 import org.apache.geode.distributed.internal.membership.QuorumChecker;
 import org.apache.geode.distributed.internal.membership.gms.NetLocator;
 import org.apache.geode.distributed.internal.membership.gms.locator.PeerLocatorRequest;
 import org.apache.geode.distributed.internal.tcpserver.LocatorCancelException;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
-import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
@@ -98,12 +96,15 @@ import org.apache.geode.management.internal.configuration.messages.SharedConfigu
 /**
  * Provides the implementation of a distribution {@code Locator} as well as internal-only
  * functionality.
+ *
  * <p>
  * This class has APIs that perform essentially three layers of services. At the bottom layer is the
  * JGroups location service. On top of that you can start a distributed system. And then on top of
  * that you can start server location services.
+ *
  * <p>
  * Server Location Service DistributedSystem Peer Location Service
+ *
  * <p>
  * The startLocator() methods provide a way to start all three services in one call. Otherwise, the
  * services can be started independently {@code  locator = createLocator();
@@ -128,90 +129,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * system property name for forcing locators to be preferred as coordinators
    */
   public static final String LOCATORS_PREFERRED_AS_COORDINATORS =
-      DistributionConfig.GEMFIRE_PREFIX + "disable-floating-coordinator";
-
-  /**
-   * The tcp server responding to locator requests
-   */
-  private final TcpServer server;
-
-  /**
-   * @since GemFire 5.7
-   */
-  private final PrimaryHandler handler;
-
-  /**
-   * The distributed system owned by this locator, if any. Note that if a ds already exists because
-   * the locator is being colocated in a normal member this field will be null.
-   */
-  private InternalDistributedSystem myDs;
-  /**
-   * The cache owned by this locator, if any. Note that if a cache already exists because the
-   * locator is being colocated in a normal member this field will be null.
-   */
-  private InternalCache myCache;
-
-  /**
-   * product use logging
-   */
-  private ProductUseLog productUseLog;
-
-  private boolean peerLocator;
-
-  private ServerLocator serverLocator;
-
-  protected volatile LocatorStats stats;
-
-  private Properties env;
-
-  /**
-   * the TcpHandler used for peer location
-   */
-  private NetLocator locatorImpl;
-
-  private DistributionConfigImpl config;
-
-  private final LocatorMembershipListener locatorListener;
-
-  private WanLocatorDiscoverer locatorDiscoverer;
-
-  /**
-   * whether the locator was stopped during forced-disconnect processing but a reconnect will occur
-   */
-  private volatile boolean stoppedForReconnect;
-
-  private volatile boolean reconnected;
-
-  /**
-   * whether the locator was stopped during forced-disconnect processing
-   */
-  private volatile boolean forcedDisconnect;
-
-  private final AtomicBoolean shutdownHandled = new AtomicBoolean(false);
-
-  private InternalConfigurationPersistenceService configurationPersistenceService;
-
-  private volatile boolean isSharedConfigurationStarted = false;
-
-  private volatile Thread restartThread;
-  private LocatorClusterManagementService clusterManagementService;
-
-  private final LoggingSession loggingSession;
-
-  private final Set<LogConfigListener> logConfigListeners = new HashSet<>();
-
-  public boolean isSharedConfigurationEnabled() {
-    return this.config.getEnableClusterConfiguration();
-  }
-
-  private boolean loadFromSharedConfigDir() {
-    return this.config.getLoadClusterConfigFromDir();
-  }
-
-  public boolean isSharedConfigurationRunning() {
-    return this.configurationPersistenceService != null
-        && this.configurationPersistenceService.getStatus() == SharedConfigurationStatus.RUNNING;
-  }
+      GEMFIRE_PREFIX + "disable-floating-coordinator";
 
   /**
    * the locator hosted by this JVM. As of 7.0 it is a singleton.
@@ -223,15 +141,70 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
 
   private static final Object locatorLock = new Object();
 
-  // TODO: getLocator() overrides static method of a superclass
+  /**
+   * The tcp server responding to locator requests
+   */
+  private final TcpServer server;
+
+  /**
+   * @since GemFire 5.7
+   */
+  private final PrimaryHandler handler;
+  private final LocatorMembershipListener locatorListener;
+  private final AtomicBoolean shutdownHandled = new AtomicBoolean(false);
+  private final LoggingSession loggingSession;
+  private final Set<LogConfigListener> logConfigListeners = new HashSet<>();
+
+  private final LocatorStats locatorStats;
+
+  /**
+   * whether the locator was stopped during forced-disconnect processing but a reconnect will occur
+   */
+  private volatile boolean stoppedForReconnect;
+  private volatile boolean reconnected;
+
+  /**
+   * whether the locator was stopped during forced-disconnect processing
+   */
+  private volatile boolean forcedDisconnect;
+  private volatile boolean isSharedConfigurationStarted;
+  private volatile Thread restartThread;
+
+  /**
+   * The distributed system owned by this locator, if any. Note that if a ds already exists because
+   * the locator is being colocated in a normal member this field will be null.
+   */
+  private InternalDistributedSystem internalDistributedSystem;
+
+  /**
+   * The cache owned by this locator, if any. Note that if a cache already exists because the
+   * locator is being colocated in a normal member this field will be null.
+   */
+  private InternalCache internalCache;
+
+  /**
+   * product use logging
+   */
+  private ProductUseLog productUseLog;
+  private boolean peerLocator;
+  private ServerLocator serverLocator;
+  private Properties env;
+
+  /**
+   * the TcpHandler used for peer location
+   */
+  private NetLocator netLocator;
+  private DistributionConfigImpl distributionConfig;
+  private WanLocatorDiscoverer locatorDiscoverer;
+  private InternalConfigurationPersistenceService configurationPersistenceService;
+  private LocatorClusterManagementService clusterManagementService;
+
   public static InternalLocator getLocator() {
-    // synchronize in order to fix #46336 (race condition in createLocator)
     synchronized (locatorLock) {
       return locator;
     }
   }
 
-  // TODO: hasLocator() overrides static method of a superclass
   public static boolean hasLocator() {
     synchronized (locatorLock) {
       return locator != null;
@@ -251,10 +224,6 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     }
   }
 
-  public LocatorMembershipListener getlocatorMembershipListener() {
-    return this.locatorListener;
-  }
-
   /**
    * Create a locator that listens on a given port. This locator will not have peer or server
    * location services available until they are started by calling startServerLocation or
@@ -264,17 +233,15 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @param loggingSession the LoggingSession to use, may be a NullLoggingSession which does
    *        nothing
    * @param logFile the file that log messages should be written to
-   * @param logger a log writer that should be used (logFile parameter is ignored)
-   * @param securityLogger the logger to be used for security related log messages
+   * @param logWriter a log writer that should be used (logFile parameter is ignored)
+   * @param securityLogWriter the logWriter to be used for security related log messages
    * @param distributedSystemProperties optional properties to configure the distributed system
    *        (e.g., mcast addr/port, other locators)
    * @param startDistributedSystem if true then this locator will also start its own ds
    */
   public static InternalLocator createLocator(int port, LoggingSession loggingSession, File logFile,
-      InternalLogWriter logger,
-      InternalLogWriter securityLogger,
-      InetAddress bindAddress, String hostnameForClients,
-      Properties distributedSystemProperties,
+      InternalLogWriter logWriter, InternalLogWriter securityLogWriter, InetAddress bindAddress,
+      String hostnameForClients, Properties distributedSystemProperties,
       boolean startDistributedSystem) {
     synchronized (locatorLock) {
       if (hasLocator()) {
@@ -282,7 +249,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
             "A locator can not be created because one already exists in this JVM.");
       }
       InternalLocator locator =
-          new InternalLocator(port, loggingSession, logFile, logger, securityLogger, bindAddress,
+          new InternalLocator(port, loggingSession, logFile, logWriter, securityLogWriter,
+              bindAddress,
               hostnameForClients, distributedSystemProperties, null, startDistributedSystem);
       InternalLocator.locator = locator;
       return locator;
@@ -302,24 +270,23 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
 
   /**
    * Creates a distribution locator that runs in this VM on the given port and bind address.
+   *
    * <p>
    * This is for internal use only as it does not create a distributed system unless told to do so.
    *
    * @param port the tcp/ip port to listen on
    * @param logFile the file that log messages should be written to
-   * @param logger a log writer that should be used (logFile parameter is ignored)
-   * @param securityLogger the logger to be used for security related log messages
+   * @param logWriter a log writer that should be used (logFile parameter is ignored)
+   * @param securityLogWriter the logWriter to be used for security related log messages
    * @param startDistributedSystem if true, a distributed system is started
-   * @param dsProperties optional properties to configure the distributed system (e.g., mcast
+   * @param distributedSystemProperties optional properties to configure the distributed system
+   *        (e.g., mcast
    *        addr/port, other locators)
    * @param hostnameForClients the name to give to clients for connecting to this locator
    */
-  public static InternalLocator startLocator(int port, File logFile, InternalLogWriter logger,
-      InternalLogWriter securityLogger,
-      InetAddress bindAddress,
-      boolean startDistributedSystem,
-      Properties dsProperties, String hostnameForClients)
-      throws IOException {
+  public static InternalLocator startLocator(int port, File logFile, InternalLogWriter logWriter,
+      InternalLogWriter securityLogWriter, InetAddress bindAddress, boolean startDistributedSystem,
+      Properties distributedSystemProperties, String hostnameForClients) throws IOException {
     System.setProperty(FORCE_LOCATOR_DM_TYPE, "true");
     InternalLocator newLocator = null;
 
@@ -330,8 +297,9 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       LoggingSession loggingSession =
           startDistributedSystem ? NullLoggingSession.create() : LoggingSession.create();
 
-      newLocator = createLocator(port, loggingSession, logFile, logger, securityLogger, bindAddress,
-          hostnameForClients, dsProperties, startDistributedSystem);
+      newLocator =
+          createLocator(port, loggingSession, logFile, logWriter, securityLogWriter, bindAddress,
+              hostnameForClients, distributedSystemProperties, startDistributedSystem);
 
       loggingSession.createSession(newLocator);
       loggingSession.startSession();
@@ -348,20 +316,21 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
             throw e;
           }
 
-          final InternalDistributedSystem ids = newLocator.myDs;
-          if (ids != null) {
-            ids.getDistributionManager().addHostedLocators(ids.getDistributedMember(),
+          InternalDistributedSystem system = newLocator.internalDistributedSystem;
+          if (system != null) {
+            system.getDistributionManager().addHostedLocators(system.getDistributedMember(),
                 getLocatorStrings(), newLocator.isSharedConfigurationEnabled());
           }
         }
-      } catch (final LocatorCancelException lce) {
+      } catch (LocatorCancelException e) {
         newLocator.stop();
-        throw lce;
+        throw e;
       }
-      InternalDistributedSystem sys = InternalDistributedSystem.getConnectedInstance();
-      if (sys != null) {
+
+      InternalDistributedSystem system = InternalDistributedSystem.getConnectedInstance();
+      if (system != null) {
         try {
-          newLocator.startServerLocation(sys);
+          newLocator.startServerLocation(system);
         } catch (RuntimeException e) {
           newLocator.stop();
           throw e;
@@ -373,19 +342,18 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       return newLocator;
 
     } finally {
-      System.getProperties().remove(FORCE_LOCATOR_DM_TYPE);
+      System.clearProperty(FORCE_LOCATOR_DM_TYPE);
 
       if (!startedLocator) {
         removeLocator(newLocator);
       }
     }
-
   }
 
-  /***
+  /**
    * Determines if this VM is a locator which must ignore a shutdown.
    *
-   * @return true if this VM is a locator which should ignore a shutdown , false if it is a normal
+   * @return true if this VM is a locator which should ignore a shutdown, false if it is a normal
    *         member.
    */
   public static boolean isDedicatedLocator() {
@@ -394,20 +362,21 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       return false;
     }
 
-    InternalDistributedSystem ids = internalLocator.myDs;
-    if (ids == null) {
+    InternalDistributedSystem system = internalLocator.internalDistributedSystem;
+    if (system == null) {
       return false;
     }
-    DistributionManager dm = ids.getDistributionManager();
-    if (dm.isLoner()) {
+    DistributionManager distributionManager = system.getDistributionManager();
+    if (distributionManager.isLoner()) {
       return false;
     }
-    ClusterDistributionManager distMgr = (ClusterDistributionManager) ids.getDistributionManager();
-    return distMgr.getDMType() == ClusterDistributionManager.LOCATOR_DM_TYPE;
+    ClusterDistributionManager clusterDistributionManager =
+        (ClusterDistributionManager) system.getDistributionManager();
+    return clusterDistributionManager.getDMType() == ClusterDistributionManager.LOCATOR_DM_TYPE;
   }
 
   /**
-   * Creates a new {@code Locator} with the given port, log file, logger, and bind address.
+   * Creates a new {@code Locator} with the given port, log file, logWriter, and bind address.
    *
    * @param port the tcp/ip port to listen on
    * @param logFile the file that log messages should be written to
@@ -416,104 +385,127 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @param hostnameForClients the name to give to clients for connecting to this locator
    * @param distributedSystemProperties optional properties to configure the distributed system
    *        (e.g., mcast addr/port, other locators)
-   * @param cfg the config if being called from a distributed system; otherwise null.
+   * @param distributionConfig the config if being called from a distributed system; otherwise null.
    * @param startDistributedSystem if true locator will start its own distributed system
    */
   private InternalLocator(int port, LoggingSession loggingSession, File logFile,
-      InternalLogWriter logWriter, InternalLogWriter securityLogWriter,
-      InetAddress bindAddress, String hostnameForClients,
-      Properties distributedSystemProperties,
-      DistributionConfigImpl cfg, boolean startDistributedSystem) {
-
+      InternalLogWriter logWriter, InternalLogWriter securityLogWriter, InetAddress bindAddress,
+      String hostnameForClients, Properties distributedSystemProperties,
+      DistributionConfigImpl distributionConfig, boolean startDistributedSystem) {
     // TODO: the following three assignments are already done in superclass
     this.logFile = logFile;
     this.bindAddress = bindAddress;
     this.hostnameForClients = hostnameForClients;
 
-    this.config = cfg;
+    this.distributionConfig = distributionConfig;
 
-    this.env = new Properties();
+    env = new Properties();
 
     // set bind-address explicitly only if not wildcard and let any explicit
-    // value in distributedSystemProperties take precedence (#46870)
+    // value in distributedSystemProperties take precedence
     if (bindAddress != null && !bindAddress.isAnyLocalAddress()) {
-      this.env.setProperty(BIND_ADDRESS, bindAddress.getHostAddress());
+      env.setProperty(BIND_ADDRESS, bindAddress.getHostAddress());
     }
 
     if (distributedSystemProperties != null) {
-      this.env.putAll(distributedSystemProperties);
+      env.putAll(distributedSystemProperties);
     }
-    this.env.setProperty(CACHE_XML_FILE, "");
+    env.setProperty(CACHE_XML_FILE, "");
 
     // create a DC so that all of the lookup rules, gemfire.properties, etc,
     // are considered and we have a config object we can trust
-    if (this.config == null) {
-      this.config = new DistributionConfigImpl(this.env);
-      this.env.clear();
-      this.env.putAll(this.config.getProps());
+    if (this.distributionConfig == null) {
+      this.distributionConfig = new DistributionConfigImpl(env);
+      env.clear();
+      env.putAll(this.distributionConfig.getProps());
     }
 
-    final boolean hasLogFileButConfigDoesNot = this.logFile != null && this.config.getLogFile()
-        .toString().equals(DistributionConfig.DEFAULT_LOG_FILE.toString());
+    boolean hasLogFileButConfigDoesNot =
+        this.logFile != null && this.distributionConfig.getLogFile()
+            .toString().equals(DistributionConfig.DEFAULT_LOG_FILE.toString());
     if (logWriter == null && hasLogFileButConfigDoesNot) {
       // LOG: this is(was) a hack for when logFile and config don't match -- if config specifies a
       // different log-file things will break!
-      this.config.unsafeSetLogFile(this.logFile);
+      this.distributionConfig.unsafeSetLogFile(this.logFile);
     }
 
     if (loggingSession == null) {
       throw new Error("LoggingSession must not be null");
-    } else {
-      this.loggingSession = loggingSession;
     }
+    this.loggingSession = loggingSession;
 
     // LOG: create LogWriters for GemFireTracer (or use whatever was passed in)
     if (logWriter == null) {
-      logWriter = LogWriterFactory.createLogWriterLogger(this.config, false);
+      LogWriterFactory.createLogWriterLogger(this.distributionConfig, false);
       if (logger.isDebugEnabled()) {
         logger.debug("LogWriter for locator is created.");
       }
     }
 
     if (securityLogWriter == null) {
-      securityLogWriter = LogWriterFactory.createLogWriterLogger(this.config, true);
+      securityLogWriter = LogWriterFactory.createLogWriterLogger(this.distributionConfig, true);
       securityLogWriter.fine("SecurityLogWriter for locator is created.");
     }
 
-    SocketCreatorFactory.setDistributionConfig(this.config);
+    SocketCreatorFactory.setDistributionConfig(this.distributionConfig);
 
-    this.locatorListener = WANServiceProvider.createLocatorMembershipListener();
-    if (this.locatorListener != null) {
+    locatorListener = WANServiceProvider.createLocatorMembershipListener();
+    if (locatorListener != null) {
       // We defer setting the port until the handler is init'd - that way we'll have an actual port
       // in the case where we're starting with port = 0.
-      this.locatorListener.setConfig(getConfig());
+      locatorListener.setConfig(getConfig());
     }
-    this.handler = new PrimaryHandler(this, locatorListener);
+    handler = new PrimaryHandler(this, locatorListener);
 
-    this.stats = new LocatorStats();
+    locatorStats = new LocatorStats();
 
-    this.server = new TcpServerFactory().makeTcpServer(port, this.bindAddress, null, this.config,
-        this.handler, new DelayedPoolStatHelper(), this.toString(), this);
+    server = new TcpServerFactory().makeTcpServer(port, this.bindAddress, null,
+        this.distributionConfig, handler, new DelayedPoolStatHelper(), toString(), this);
+  }
+
+  public boolean isSharedConfigurationEnabled() {
+    return distributionConfig.getEnableClusterConfiguration();
+  }
+
+  private boolean loadFromSharedConfigDir() {
+    return distributionConfig.getLoadClusterConfigFromDir();
+  }
+
+  public boolean isSharedConfigurationRunning() {
+    return configurationPersistenceService != null
+        && configurationPersistenceService.getStatus() == SharedConfigurationStatus.RUNNING;
+  }
+
+  public LocatorMembershipListener getLocatorMembershipListener() {
+    return locatorListener;
+  }
+
+  /**
+   * @deprecated Please use {@link #getLocatorMembershipListener()} instead.
+   */
+  @Deprecated
+  public LocatorMembershipListener getlocatorMembershipListener() {
+    return getLocatorMembershipListener();
   }
 
   private void startTcpServer() throws IOException {
     logger.info("Starting {}", this);
-    this.server.start();
+    server.start();
   }
 
   public InternalConfigurationPersistenceService getConfigurationPersistenceService() {
-    return this.configurationPersistenceService;
+    return configurationPersistenceService;
   }
 
   public DistributionConfigImpl getConfig() {
-    return this.config;
+    return distributionConfig;
   }
 
   public InternalCache getCache() {
-    if (myCache == null) {
+    if (internalCache == null) {
       return GemFireCacheImpl.getInstance();
     }
-    return myCache;
+    return internalCache;
   }
 
   /**
@@ -526,37 +518,37 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
   int startPeerLocation() throws IOException {
     if (isPeerLocator()) {
       throw new IllegalStateException(
-          String.format("Peer location is already running for %s",
-              this));
+          String.format("Peer location is already running for %s", this));
     }
     logger.info("Starting peer location for {}", this);
 
-    String locatorsProp = this.config.getLocators();
+    String locatorsConfigValue = distributionConfig.getLocators();
 
     // check for settings that would require only locators to hold the
     // coordinator - e.g., security and network-partition detection
     boolean locatorsAreCoordinators;
-    boolean networkPartitionDetectionEnabled = this.config.getEnableNetworkPartitionDetection();
-    String securityUDPDHAlgo = this.config.getSecurityUDPDHAlgo();
+    boolean networkPartitionDetectionEnabled =
+        distributionConfig.getEnableNetworkPartitionDetection();
+    String securityUDPDHAlgo = distributionConfig.getSecurityUDPDHAlgo();
     if (networkPartitionDetectionEnabled) {
       locatorsAreCoordinators = true;
     } else {
       // check if security is enabled
-      String prop = this.config.getSecurityPeerAuthInit();
+      String prop = distributionConfig.getSecurityPeerAuthInit();
       locatorsAreCoordinators = prop != null && !prop.isEmpty();
       if (!locatorsAreCoordinators) {
         locatorsAreCoordinators = Boolean.getBoolean(LOCATORS_PREFERRED_AS_COORDINATORS);
       }
     }
 
-    this.locatorImpl = MemberFactory.newLocatorHandler(this.bindAddress, locatorsProp,
-        locatorsAreCoordinators, networkPartitionDetectionEnabled, this.stats, securityUDPDHAlgo);
-    this.handler.addHandler(PeerLocatorRequest.class, this.locatorImpl);
-    this.peerLocator = true;
-    if (!this.server.isAlive()) {
+    netLocator = MemberFactory.newLocatorHandler(bindAddress, locatorsConfigValue,
+        locatorsAreCoordinators, networkPartitionDetectionEnabled, locatorStats, securityUDPDHAlgo);
+    handler.addHandler(PeerLocatorRequest.class, netLocator);
+    peerLocator = true;
+    if (!server.isAlive()) {
       startTcpServer();
     }
-    int boundPort = this.server.getPort();
+    int boundPort = server.getPort();
     File productUseFile = new File("locator" + boundPort + "views.log");
     productUseLog = new ProductUseLog(productUseFile);
 
@@ -567,24 +559,21 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @return the TcpHandler for peer to peer discovery
    */
   public NetLocator getLocatorHandler() {
-    return this.locatorImpl;
+    return netLocator;
   }
 
   /**
    * For backward-compatibility we retain this method
-   * <p>
-   * TODO: parameters peerLocator and serverLocator and b1 are never used
    *
    * @deprecated use a form of the method that does not have peerLocator/serverLocator parameters
    */
   @Deprecated
   public static InternalLocator startLocator(int locatorPort, File logFile,
-      InternalLogWriter logger, InternalLogWriter logger1,
-      InetAddress addr,
-      Properties dsProperties, boolean peerLocator,
-      boolean serverLocator, String s, boolean b1)
-      throws IOException {
-    return startLocator(locatorPort, logFile, logger, logger1, addr, true, dsProperties, s);
+      InternalLogWriter logWriter, InternalLogWriter securityLogWriter, InetAddress bindAddress,
+      Properties distributedSystemProperties, boolean peerLocator, boolean serverLocator,
+      String hostnameForClients, boolean b1) throws IOException {
+    return startLocator(locatorPort, logFile, logWriter, securityLogWriter, bindAddress, true,
+        distributedSystemProperties, hostnameForClients);
   }
 
   /**
@@ -603,80 +592,73 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     } else {
 
       StringBuilder sb = new StringBuilder(100);
-      if (this.bindAddress != null) {
-        sb.append(this.bindAddress.getHostAddress());
+      if (bindAddress != null) {
+        sb.append(bindAddress.getHostAddress());
       } else {
         sb.append(SocketCreator.getLocalHost().getHostAddress());
       }
       sb.append('[').append(getPort()).append(']');
       String thisLocator = sb.toString();
 
-      if (this.peerLocator) {
+      if (peerLocator) {
         // append this locator to the locators list from the config properties
-        // this.logger.config("ensuring that this locator is in the locators list");
         boolean setLocatorsProp = false;
-        String locatorsProp = this.config.getLocators();
-        if (StringUtils.isNotBlank(locatorsProp)) {
-          if (!locatorsProp.contains(thisLocator)) {
-            locatorsProp = locatorsProp + ',' + thisLocator;
+        String locatorsConfigValue = distributionConfig.getLocators();
+        if (StringUtils.isNotBlank(locatorsConfigValue)) {
+          if (!locatorsConfigValue.contains(thisLocator)) {
+            locatorsConfigValue = locatorsConfigValue + ',' + thisLocator;
             setLocatorsProp = true;
           }
         } else {
-          locatorsProp = thisLocator;
+          locatorsConfigValue = thisLocator;
           setLocatorsProp = true;
         }
         if (setLocatorsProp) {
           Properties updateEnv = new Properties();
-          updateEnv.setProperty(LOCATORS, locatorsProp);
-          this.config.setApiProps(updateEnv);
-          // fix for bug 41248
-          String propName = DistributionConfig.GEMFIRE_PREFIX + LOCATORS;
-          if (System.getProperty(propName) != null) {
-            System.setProperty(propName, locatorsProp);
+          updateEnv.setProperty(LOCATORS, locatorsConfigValue);
+          distributionConfig.setApiProps(updateEnv);
+          String locatorsPropertyName = GEMFIRE_PREFIX + LOCATORS;
+          if (System.getProperty(locatorsPropertyName) != null) {
+            System.setProperty(locatorsPropertyName, locatorsConfigValue);
           }
         }
-        // No longer default mcast-port to zero. See 46277.
+        // No longer default mcast-port to zero.
       }
 
-      Properties connectEnv = new Properties();
+      Properties distributedSystemProperties = new Properties();
       // LogWriterAppender is now shared via that class
       // using a DistributionConfig earlier in this method
-      connectEnv.put(DistributionConfig.DS_CONFIG_NAME, this.config);
+      distributedSystemProperties.put(DistributionConfig.DS_CONFIG_NAME, distributionConfig);
 
       logger.info("Starting distributed system");
 
-      this.myDs = (InternalDistributedSystem) DistributedSystem.connect(connectEnv);
+      internalDistributedSystem =
+          (InternalDistributedSystem) DistributedSystem.connect(distributedSystemProperties);
 
-      if (this.peerLocator) {
-        this.locatorImpl.setMembershipManager(this.myDs.getDM().getMembershipManager());
+      if (peerLocator) {
+        netLocator.setMembershipManager(internalDistributedSystem.getDM().getMembershipManager());
       }
 
-      this.myDs.addDisconnectListener(new DisconnectListener() {
-        @Override
-        public void onDisconnect(InternalDistributedSystem sys) {
-          stop(false, false, false);
-        }
-      });
+      internalDistributedSystem.addDisconnectListener(sys -> stop(false, false, false));
 
-      startCache(myDs);
+      startCache(internalDistributedSystem);
 
-      logger.info("Locator started on {}",
-          thisLocator);
+      logger.info("Locator started on {}", thisLocator);
 
-      myDs.setDependentLocator(this);
+      internalDistributedSystem.setDependentLocator(this);
     }
   }
 
-  private void startCache(DistributedSystem ds) {
+  private void startCache(DistributedSystem system) {
     InternalCache internalCache = GemFireCacheImpl.getInstance();
     if (internalCache == null) {
       logger.info("Creating cache for locator.");
-      this.myCache = new InternalCacheBuilder(ds.getProperties())
-          .create((InternalDistributedSystem) ds);
-      internalCache = this.myCache;
+      this.internalCache = new InternalCacheBuilder(system.getProperties())
+          .create((InternalDistributedSystem) system);
+      internalCache = this.internalCache;
     } else {
       logger.info("Using existing cache for locator.");
-      ((InternalDistributedSystem) ds).handleResourceEvent(ResourceEvent.LOCATOR_START, this);
+      ((InternalDistributedSystem) system).handleResourceEvent(ResourceEvent.LOCATOR_START, this);
     }
     startJmxManagerLocationService(internalCache);
 
@@ -686,47 +668,45 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
   private void startClusterManagementService() {
     startConfigurationPersistenceService();
 
-    if (myCache == null) {
+    if (internalCache == null) {
       return;
     }
 
-    clusterManagementService =
-        new LocatorClusterManagementService(locator.myCache,
-            locator.configurationPersistenceService);
+    clusterManagementService = new LocatorClusterManagementService(locator.internalCache,
+        locator.configurationPersistenceService);
 
     // start management rest service
     AgentUtil agentUtil = new AgentUtil(GemFireVersion.getGemFireVersion());
+
     // Find the V2 Management rest WAR file
-    final String gemfireManagementWar = agentUtil.findWarLocation("geode-web-management");
+    String gemfireManagementWar = agentUtil.findWarLocation("geode-web-management");
     if (gemfireManagementWar == null) {
       logger.info(
           "Unable to find GemFire V2 Management REST API WAR file; the Management REST Interface for Geode will not be accessible.");
       return;
     }
 
-    Pair<String, Object> securityServiceAttr =
+    Pair<String, Object> securityServiceAttribute =
         new ImmutablePair<>(HttpService.SECURITY_SERVICE_SERVLET_CONTEXT_PARAM,
-            myCache.getSecurityService());
-    Pair<String, Object> cmServiceAttr =
+            internalCache.getSecurityService());
+    Pair<String, Object> clusterManagementServiceAttribute =
         new ImmutablePair<>(HttpService.CLUSTER_MANAGEMENT_SERVICE_CONTEXT_PARAM,
             clusterManagementService);
 
     if (Boolean.getBoolean(ClusterManagementService.FEATURE_FLAG)) {
-      logger.info(
-          "System Property " + ClusterManagementService.FEATURE_FLAG
-              + "=true Geode Management API is enabled.");
-      myCache.getHttpService().ifPresent(x -> {
+      logger.info("System Property {}=true Geode Management API is enabled.",
+          ClusterManagementService.FEATURE_FLAG);
+      internalCache.getHttpService().ifPresent(x -> {
         try {
-          x.addWebApplication("/management", gemfireManagementWar, securityServiceAttr,
-              cmServiceAttr);
+          x.addWebApplication("/management", gemfireManagementWar, securityServiceAttribute,
+              clusterManagementServiceAttribute);
         } catch (Throwable e) {
           logger.warn("Unable to start management service: {}", e.getMessage());
         }
       });
     } else {
-      logger.info(
-          "System Property " + ClusterManagementService.FEATURE_FLAG
-              + "=false Geode Management API is disabled.");
+      logger.info("System Property {}=false Geode Management API is disabled.",
+          ClusterManagementService.FEATURE_FLAG);
     }
   }
 
@@ -738,20 +718,22 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @since GemFire 5.7
    */
   void endStartLocator(InternalDistributedSystem distributedSystem) {
-    this.env = null;
+    env = null;
+
     if (distributedSystem == null) {
       distributedSystem = InternalDistributedSystem.getConnectedInstance();
     }
+
     if (distributedSystem != null) {
       onConnect(distributedSystem);
     } else {
       InternalDistributedSystem.addConnectListener(this);
     }
 
-    this.locatorDiscoverer = WANServiceProvider.createLocatorDiscoverer();
-    if (this.locatorDiscoverer != null) {
-      this.locatorDiscoverer.discover(getPort(), this.config, this.locatorListener,
-          this.hostnameForClients);
+    locatorDiscoverer = WANServiceProvider.createLocatorDiscoverer();
+    if (locatorDiscoverer != null) {
+      locatorDiscoverer.discover(getPort(), distributionConfig, locatorListener,
+          hostnameForClients);
     }
   }
 
@@ -766,8 +748,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
   void startServerLocation(InternalDistributedSystem distributedSystem) throws IOException {
     if (isServerLocator()) {
       throw new IllegalStateException(
-          String.format("Server location is already running for %s",
-              this));
+          String.format("Server location is already running for %s", this));
     }
     logger.info("Starting server location for {}", this);
 
@@ -779,22 +760,21 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       }
     }
 
-    ServerLocator serverLocator =
-        new ServerLocator(getPort(), this.bindAddress, this.hostnameForClients, this.logFile,
-            this.productUseLog, getConfig().getName(), distributedSystem, this.stats);
-    this.handler.addHandler(LocatorListRequest.class, serverLocator);
-    this.handler.addHandler(ClientConnectionRequest.class, serverLocator);
-    this.handler.addHandler(QueueConnectionRequest.class, serverLocator);
-    this.handler.addHandler(ClientReplacementRequest.class, serverLocator);
-    this.handler.addHandler(GetAllServersRequest.class, serverLocator);
-    this.handler.addHandler(LocatorStatusRequest.class, serverLocator);
+    ServerLocator serverLocator = new ServerLocator(getPort(), bindAddress, hostnameForClients,
+        logFile, productUseLog, getConfig().getName(), distributedSystem, locatorStats);
+    handler.addHandler(LocatorListRequest.class, serverLocator);
+    handler.addHandler(ClientConnectionRequest.class, serverLocator);
+    handler.addHandler(QueueConnectionRequest.class, serverLocator);
+    handler.addHandler(ClientReplacementRequest.class, serverLocator);
+    handler.addHandler(GetAllServersRequest.class, serverLocator);
+    handler.addHandler(LocatorStatusRequest.class, serverLocator);
     this.serverLocator = serverLocator;
-    if (!this.server.isAlive()) {
+    if (!server.isAlive()) {
       startTcpServer();
     }
     // the product use is not guaranteed to be initialized until the server is started, so
     // the last thing we do is tell it to start logging
-    this.productUseLog.monitorUse(distributedSystem);
+    productUseLog.monitorUse(distributedSystem);
   }
 
   /**
@@ -812,22 +792,23 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @param waitForDisconnect - wait up to 60 seconds for the locator to completely stop
    */
   public void stop(boolean forcedDisconnect, boolean stopForReconnect, boolean waitForDisconnect) {
-    final boolean isDebugEnabled = logger.isDebugEnabled();
+    boolean isDebugEnabled = logger.isDebugEnabled();
 
-    this.stoppedForReconnect = stopForReconnect;
+    stoppedForReconnect = stopForReconnect;
     this.forcedDisconnect = forcedDisconnect;
 
-    if (this.server.isShuttingDown()) {
+    if (server.isShuttingDown()) {
       // fix for bug 46156
       // If we are already shutting down don't do all of this again.
       // But, give the server a bit of time to shut down so a new
       // locator can be created, if desired, when this method returns
       if (!stopForReconnect && waitForDisconnect) {
         long endOfWait = System.currentTimeMillis() + 60000;
-        if (isDebugEnabled && this.server.isAlive()) {
+        if (isDebugEnabled && server.isAlive()) {
           logger.debug("sleeping to wait for the locator server to shut down...");
         }
-        while (this.server.isAlive() && System.currentTimeMillis() < endOfWait) {
+
+        while (server.isAlive() && System.currentTimeMillis() < endOfWait) {
           try {
             Thread.sleep(500);
           } catch (InterruptedException ignored) {
@@ -835,8 +816,9 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
             return;
           }
         }
+
         if (isDebugEnabled) {
-          if (this.server.isAlive()) {
+          if (server.isAlive()) {
             logger.debug(
                 "60 seconds have elapsed waiting for the locator server to shut down - terminating wait and returning");
           } else {
@@ -847,27 +829,28 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       return;
     }
 
-    if (this.locatorDiscoverer != null) {
-      this.locatorDiscoverer.stop();
-      this.locatorDiscoverer = null;
+    if (locatorDiscoverer != null) {
+      locatorDiscoverer.stop();
+      locatorDiscoverer = null;
     }
 
-    if (this.server.isAlive()) {
+    if (server.isAlive()) {
       logger.info("Stopping {}", this);
       try {
-        new TcpClient().stop(this.bindAddress, getPort());
+        new TcpClient().stop(bindAddress, getPort());
       } catch (ConnectException ignore) {
         // must not be running
       }
+
       boolean interrupted = Thread.interrupted();
       try {
         // TcpServer up to SHUTDOWN_WAIT_TIME for its executor pool to shut down.
         // We wait 2 * SHUTDOWN_WAIT_TIME here to account for that shutdown, and then our own.
-        this.server.join(TcpServer.SHUTDOWN_WAIT_TIME * 2);
+        server.join(TcpServer.SHUTDOWN_WAIT_TIME * 2);
 
       } catch (InterruptedException ex) {
         interrupted = true;
-        logger.warn("Interrupted while stopping " + this, ex);
+        logger.warn("Interrupted while stopping {}", this, ex);
 
         // Continue running -- doing our best to stop everything...
       } finally {
@@ -876,7 +859,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
         }
       }
 
-      if (this.server.isAlive()) {
+      if (server.isAlive()) {
         logger.fatal("Could not stop {} in 60 seconds", this);
       }
     }
@@ -886,8 +869,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     handleShutdown();
     logger.info("{} is stopped", this);
 
-    if (this.stoppedForReconnect) {
-      if (this.myDs != null) {
+    if (stoppedForReconnect) {
+      if (internalDistributedSystem != null) {
         launchRestartThread();
       }
     }
@@ -897,42 +880,43 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * answers whether this locator is currently stopped
    */
   public boolean isStopped() {
-    return this.server == null || !this.server.isAlive();
+    return server == null || !server.isAlive();
   }
 
-  private void handleShutdown() {
-    if (!this.shutdownHandled.compareAndSet(false, true)) {
-      return; // already shutdown
+  void handleShutdown() {
+    if (!shutdownHandled.compareAndSet(false, true)) {
+      // already shutdown
+      return;
     }
-    if (this.productUseLog != null) {
-      this.productUseLog.close();
+    if (productUseLog != null) {
+      productUseLog.close();
     }
-    if (this.myDs != null) {
-      this.myDs.setDependentLocator(null);
+    if (internalDistributedSystem != null) {
+      internalDistributedSystem.setDependentLocator(null);
     }
 
-    if (this.myCache != null && !this.stoppedForReconnect && !this.forcedDisconnect) {
+    if (internalCache != null && !stoppedForReconnect && !forcedDisconnect) {
       logger.info("Closing locator's cache");
       try {
-        this.myCache.close();
+        internalCache.close();
       } catch (RuntimeException ex) {
         logger.info("Could not close locator's cache because: {}", ex.getMessage(), ex);
       }
     }
 
-    if (this.stats != null) {
-      this.stats.close();
+    if (locatorStats != null) {
+      locatorStats.close();
     }
 
-    if (this.locatorListener != null) {
-      this.locatorListener.clearLocatorInfo();
+    if (locatorListener != null) {
+      locatorListener.clearLocatorInfo();
     }
 
-    this.isSharedConfigurationStarted = false;
-    if (this.myDs != null && !this.forcedDisconnect) {
-      if (this.myDs.isConnected()) {
+    isSharedConfigurationStarted = false;
+    if (internalDistributedSystem != null && !forcedDisconnect) {
+      if (internalDistributedSystem.isConnected()) {
         logger.info("Disconnecting distributed system for {}", this);
-        this.myDs.disconnect();
+        internalDistributedSystem.disconnect();
       }
     }
   }
@@ -945,17 +929,17 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
   public void waitToStop() throws InterruptedException {
     boolean restarted;
     do {
-      DistributedSystem ds = this.myDs;
+      DistributedSystem system = internalDistributedSystem;
       restarted = false;
-      this.server.join();
-      if (this.stoppedForReconnect) {
+      server.join();
+      if (stoppedForReconnect) {
         logger.info("waiting for distributed system to disconnect...");
-        while (ds.isConnected()) {
+        while (system.isConnected()) {
           Thread.sleep(5000);
         }
         logger.info("waiting for distributed system to reconnect...");
         try {
-          restarted = ds.waitUntilReconnected(-1, TimeUnit.SECONDS);
+          restarted = system.waitUntilReconnected(-1, TimeUnit.SECONDS);
         } catch (CancelException e) {
           // reconnect attempt failed
         }
@@ -980,7 +964,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    */
   private void launchRestartThread() {
     String threadName = "Location services restart thread";
-    this.restartThread = new LoggingThread(threadName, () -> {
+    restartThread = new LoggingThread(threadName, () -> {
       boolean restarted = false;
       try {
         restarted = attemptReconnect();
@@ -995,9 +979,9 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
         }
         reconnected = restarted;
       }
-      InternalLocator.this.restartThread = null;
+      restartThread = null;
     });
-    this.restartThread.start();
+    restartThread.start();
   }
 
   public boolean isReconnected() {
@@ -1015,126 +999,141 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    */
   private boolean attemptReconnect() throws InterruptedException, IOException {
     boolean restarted = false;
-    if (this.stoppedForReconnect) {
+    if (stoppedForReconnect) {
       logger.info("attempting to restart locator");
       boolean tcpServerStarted = false;
-      InternalDistributedSystem ds = this.myDs;
-      long waitTime = ds.getConfig().getMaxWaitTimeForReconnect() / 2;
-      QuorumChecker checker = null;
-      while (ds.getReconnectedSystem() == null && !ds.isReconnectCancelled()) {
-        if (checker == null) {
-          checker = this.myDs.getQuorumChecker();
-          if (checker != null) {
-            logger.info("The distributed system returned this quorum checker: {}", checker);
+      InternalDistributedSystem system = internalDistributedSystem;
+      long waitTime = system.getConfig().getMaxWaitTimeForReconnect() / 2;
+      QuorumChecker quorumChecker = null;
+
+      while (system.getReconnectedSystem() == null && !system.isReconnectCancelled()) {
+        if (quorumChecker == null) {
+          quorumChecker = internalDistributedSystem.getQuorumChecker();
+          if (quorumChecker != null) {
+            logger.info("The distributed system returned this quorum checker: {}", quorumChecker);
           }
         }
-        if (checker != null && !tcpServerStarted) {
-          boolean start = checker.checkForQuorum(3L * this.myDs.getConfig().getMemberTimeout());
+
+        if (quorumChecker != null && !tcpServerStarted) {
+          boolean start = quorumChecker
+              .checkForQuorum(3L * internalDistributedSystem.getConfig().getMemberTimeout());
           if (start) {
-            // start up peer location. server location is started after the DS finishes
-            // reconnecting
+            // start up peer location. server location is started after the DS finishes reconnecting
             logger.info("starting peer location");
-            if (this.locatorListener != null) {
-              this.locatorListener.clearLocatorInfo();
+            if (locatorListener != null) {
+              locatorListener.clearLocatorInfo();
             }
-            this.stoppedForReconnect = false;
-            this.myDs = null;
-            this.myCache = null;
-            restartWithoutDS();
+            stoppedForReconnect = false;
+            internalDistributedSystem = null;
+            internalCache = null;
+            restartWithoutSystem();
             tcpServerStarted = true;
             setLocator(this);
           }
         }
+
         try {
-          ds.waitUntilReconnected(waitTime, TimeUnit.MILLISECONDS);
+          system.waitUntilReconnected(waitTime, TimeUnit.MILLISECONDS);
         } catch (CancelException e) {
           logger.info("Attempt to reconnect failed and further attempts have been terminated");
-          this.stoppedForReconnect = false;
+          stoppedForReconnect = false;
           return false;
         }
       }
-      InternalDistributedSystem newSystem = (InternalDistributedSystem) ds.getReconnectedSystem();
+
+      InternalDistributedSystem newSystem =
+          (InternalDistributedSystem) system.getReconnectedSystem();
       if (newSystem != null) {
         if (!tcpServerStarted) {
-          if (this.locatorListener != null) {
-            this.locatorListener.clearLocatorInfo();
+          if (locatorListener != null) {
+            locatorListener.clearLocatorInfo();
           }
-          this.stoppedForReconnect = false;
+          stoppedForReconnect = false;
         }
+
         try {
-          restartWithDS(newSystem, GemFireCacheImpl.getInstance());
+          restartWithSystem(newSystem, GemFireCacheImpl.getInstance());
         } catch (CancelException e) {
-          this.stoppedForReconnect = true;
+          stoppedForReconnect = true;
           return false;
         }
+
         setLocator(this);
         restarted = true;
       }
     }
+
     logger.info("restart thread exiting.  Service was {}restarted", restarted ? "" : "not ");
     return restarted;
   }
 
-  private void restartWithoutDS() throws IOException {
+  private void restartWithoutSystem() throws IOException {
     synchronized (locatorLock) {
       if (locator != this && hasLocator()) {
         throw new IllegalStateException(
             "A locator can not be created because one already exists in this JVM.");
       }
-      this.myDs = null;
-      this.myCache = null;
+      internalDistributedSystem = null;
+      internalCache = null;
+
       logger.info("Locator restart: initializing TcpServer peer location services");
-      this.server.restarting(null, null, null);
-      if (this.productUseLog.isClosed()) {
-        this.productUseLog.reopen();
+      server.restarting(null, null, null);
+
+      if (productUseLog.isClosed()) {
+        productUseLog.reopen();
       }
-      if (!this.server.isAlive()) {
+
+      if (!server.isAlive()) {
         logger.info("Locator restart: starting TcpServer");
         startTcpServer();
       }
     }
   }
 
-  private void restartWithDS(InternalDistributedSystem newSystem, InternalCache newCache)
+  private void restartWithSystem(InternalDistributedSystem newSystem, InternalCache newCache)
       throws IOException {
-
     synchronized (locatorLock) {
       if (locator != this && hasLocator()) {
         throw new IllegalStateException(
             "A locator can not be created because one already exists in this JVM.");
       }
-      this.myDs = newSystem;
-      this.myCache = newCache;
-      this.myDs.setDependentLocator(this);
+      internalDistributedSystem = newSystem;
+      internalCache = newCache;
+      internalDistributedSystem.setDependentLocator(this);
       logger.info("Locator restart: initializing TcpServer");
 
       try {
-        this.server.restarting(newSystem, newCache, this.configurationPersistenceService);
+        server.restarting(newSystem, newCache, configurationPersistenceService);
       } catch (CancelException e) {
-        this.myDs = null;
-        this.myCache = null;
+        internalDistributedSystem = null;
+        internalCache = null;
         logger.info("Locator restart: attempt to restart location services failed", e);
         throw e;
       }
-      if (this.productUseLog.isClosed()) {
-        this.productUseLog.reopen();
+
+      if (productUseLog.isClosed()) {
+        productUseLog.reopen();
       }
-      this.productUseLog.monitorUse(newSystem);
+
+      productUseLog.monitorUse(newSystem);
+
       if (isSharedConfigurationEnabled()) {
-        this.configurationPersistenceService =
+        configurationPersistenceService =
             new InternalConfigurationPersistenceService(newCache);
         startClusterManagementService();
       }
-      if (!this.server.isAlive()) {
+
+      if (!server.isAlive()) {
         logger.info("Locator restart: starting TcpServer");
         startTcpServer();
       }
+
       logger.info("Locator restart: initializing JMX manager");
       startJmxManagerLocationService(newCache);
-      endStartLocator(this.myDs);
+      endStartLocator(internalDistributedSystem);
       logger.info("Locator restart completed");
     }
-    this.server.restartCompleted(newSystem);
+    server.restartCompleted(newSystem);
   }
 
   public ClusterManagementService getClusterManagementService() {
@@ -1143,21 +1142,21 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
 
   @Override
   public DistributedSystem getDistributedSystem() {
-    if (myDs == null) {
+    if (internalDistributedSystem == null) {
       return InternalDistributedSystem.getAnyInstance();
     }
 
-    return myDs;
+    return internalDistributedSystem;
   }
 
   @Override
   public boolean isPeerLocator() {
-    return this.peerLocator;
+    return peerLocator;
   }
 
   @Override
   public boolean isServerLocator() {
-    return this.serverLocator != null;
+    return serverLocator != null;
   }
 
   /**
@@ -1165,7 +1164,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * locator.
    */
   public ServerLocator getServerLocatorAdvisee() {
-    return this.serverLocator;
+    return serverLocator;
   }
 
   /**
@@ -1176,20 +1175,20 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    */
   @Override
   public Integer getPort() {
-    if (this.server != null) {
-      return this.server.getPort();
+    if (server != null) {
+      return server.getPort();
     }
     return null;
   }
 
   @Override
   public LogConfig getLogConfig() {
-    return config;
+    return distributionConfig;
   }
 
   @Override
   public StatisticsConfig getStatisticsConfig() {
-    return config;
+    return distributionConfig;
   }
 
   @Override
@@ -1202,190 +1201,28 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     logConfigListeners.remove(logConfigListener);
   }
 
-  /**
-   * Apparently nothing provides RuntimeDistributionConfigImpl behavior in a stand-alone locator
-   * (without DS), so there are currently no callers of {@code logConfigChanged()}. Keep it?
-   */
-  @SuppressWarnings("unused")
-  void logConfigChanged() {
-    for (LogConfigListener listener : logConfigListeners) {
-      listener.configChanged();
-    }
-  }
-
-  class FetchSharedConfigStatus implements Callable<SharedConfigurationStatusResponse> {
-
-    static final int SLEEPTIME = 1000;
-    static final byte MAX_RETRIES = 5;
-
-    @Override
-    public SharedConfigurationStatusResponse call() throws InterruptedException {
-      final InternalLocator locator = InternalLocator.this;
-
-      SharedConfigurationStatusResponse response;
-      if (locator.configurationPersistenceService != null) {
-        response = locator.configurationPersistenceService.createStatusResponse();
-      } else {
-        response = new SharedConfigurationStatusResponse();
-        response.setStatus(SharedConfigurationStatus.UNDETERMINED);
-      }
-      return response;
-    }
-  }
-
   public SharedConfigurationStatusResponse getSharedConfigurationStatus() {
-    ExecutorService es = this.myCache.getDistributionManager().getWaitingThreadPool();
+    ExecutorService waitingPoolExecutor =
+        internalCache.getDistributionManager().getWaitingThreadPool();
     Future<SharedConfigurationStatusResponse> statusFuture =
-        es.submit(new FetchSharedConfigStatus());
+        waitingPoolExecutor.submit(new FetchSharedConfigStatus());
     SharedConfigurationStatusResponse response;
 
     try {
       response = statusFuture.get(5, TimeUnit.SECONDS);
     } catch (Exception e) {
-      logger.info("Exception occurred while fetching the status {}",
-          ExceptionUtils.getStackTrace(e));
+      logger.info("Exception occurred while fetching the status {}", getStackTrace(e));
       response = new SharedConfigurationStatusResponse();
       response.setStatus(SharedConfigurationStatus.UNDETERMINED);
     }
     return response;
   }
 
-  public static class PrimaryHandler implements TcpHandler {
-
-    private volatile HashMap<Class, TcpHandler> handlerMapping = new HashMap<>();
-    private volatile HashSet<TcpHandler> allHandlers = new HashSet<>();
-    private TcpServer tcpServer;
-    private final LocatorMembershipListener locatorListener;
-    private final InternalLocator internalLocator;
-
-    PrimaryHandler(InternalLocator locator, LocatorMembershipListener listener) {
-      this.locatorListener = listener;
-      this.internalLocator = locator;
-    }
-
-    // this method is synchronized to make sure that no new handlers are added while
-    // initialization is taking place.
-    @Override
-    public synchronized void init(TcpServer tcpServer) {
-      if (this.locatorListener != null) {
-        // This is deferred until now as the initial requested port could have been 0
-        this.locatorListener.setPort(this.internalLocator.getPort());
-      }
-      this.tcpServer = tcpServer;
-      for (TcpHandler handler : this.allHandlers) {
-        handler.init(tcpServer);
-      }
-    }
-
-    @Override
-    public void restarting(DistributedSystem ds, GemFireCache cache,
-        InternalConfigurationPersistenceService sharedConfig) {
-      if (ds != null) {
-        for (TcpHandler handler : this.allHandlers) {
-          handler.restarting(ds, cache, sharedConfig);
-        }
-      }
-    }
-
-    @Override
-    public void restartCompleted(DistributedSystem ds) {
-      if (ds != null) {
-        for (TcpHandler handler : this.allHandlers) {
-          handler.restartCompleted(ds);
-        }
-      }
-    }
-
-    @Override
-    public Object processRequest(Object request) throws IOException {
-      long giveup = 0;
-      while (giveup == 0 || System.currentTimeMillis() < giveup) {
-        TcpHandler handler;
-        if (request instanceof PeerLocatorRequest) {
-          handler = this.handlerMapping.get(PeerLocatorRequest.class);
-        } else {
-          handler = this.handlerMapping.get(request.getClass());
-        }
-
-        if (handler != null) {
-          return handler.processRequest(request);
-        } else {
-          if (this.locatorListener != null) {
-            return this.locatorListener.handleRequest(request);
-          } else {
-            // either there is a configuration problem or the locator is still starting up
-            if (giveup == 0) {
-              int locatorWaitTime = this.internalLocator.getConfig().getLocatorWaitTime();
-              if (locatorWaitTime <= 0) {
-                // always retry some number of times
-                locatorWaitTime = 30;
-              }
-              giveup = System.currentTimeMillis() + locatorWaitTime * 1000L;
-              try {
-                Thread.sleep(1000);
-              } catch (InterruptedException ignored) {
-                // running in an executor - no need to set the interrupted flag on the thread
-                return null;
-              }
-            }
-          }
-        }
-      } // while
-      logger.info(
-          "Received a location request of class {} but the handler for this is "
-              + "either not enabled or is not ready to process requests",
-          request.getClass().getSimpleName());
-      return null;
-    }
-
-    @Override
-    public void shutDown() {
-      try {
-        for (TcpHandler handler : this.allHandlers) {
-          handler.shutDown();
-        }
-      } finally {
-        this.internalLocator.handleShutdown();
-      }
-    }
-
-    synchronized boolean isHandled(Class clazz) {
-      return this.handlerMapping.containsKey(clazz);
-    }
-
-    public synchronized void addHandler(Class clazz, TcpHandler handler) {
-      HashMap<Class, TcpHandler> tmpHandlerMapping = new HashMap<>(this.handlerMapping);
-      HashSet<TcpHandler> tmpAllHandlers = new HashSet<>(this.allHandlers);
-      tmpHandlerMapping.put(clazz, handler);
-      if (tmpAllHandlers.add(handler) && this.tcpServer != null) {
-        handler.init(this.tcpServer);
-      }
-      this.handlerMapping = tmpHandlerMapping;
-      this.allHandlers = tmpAllHandlers;
-    }
-
-    @Override
-    public void endRequest(Object request, long startTime) {
-      TcpHandler handler = this.handlerMapping.get(request.getClass());
-      if (handler != null) {
-        handler.endRequest(request, startTime);
-      }
-    }
-
-    @Override
-    public void endResponse(Object request, long startTime) {
-      TcpHandler handler = this.handlerMapping.get(request.getClass());
-      if (handler != null) {
-        handler.endResponse(request, startTime);
-      }
-    }
-  }
-
   @Override
   public void onConnect(InternalDistributedSystem sys) {
     try {
-      this.stats.hookupStats(sys,
-          SocketCreator.getLocalHost().getCanonicalHostName() + '-' + this.server.getBindAddress());
+      locatorStats.hookupStats(sys,
+          SocketCreator.getLocalHost().getCanonicalHostName() + '-' + server.getBindAddress());
     } catch (UnknownHostException e) {
       logger.warn(e);
     }
@@ -1400,46 +1237,26 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
   public static Collection<String> getLocatorStrings() {
     Collection<String> locatorStrings;
     try {
-      Collection<DistributionLocatorId> locatorIds =
-          DistributionLocatorId.asDistributionLocatorIds(getLocators());
+      Collection<DistributionLocatorId> locatorIds = asDistributionLocatorIds(getLocators());
       locatorStrings = DistributionLocatorId.asStrings(locatorIds);
     } catch (UnknownHostException ignored) {
       locatorStrings = null;
     }
     if (locatorStrings == null || locatorStrings.isEmpty()) {
       return null;
-    } else {
-      return locatorStrings;
     }
-  }
-
-  /**
-   * A helper object so that the TcpServer can record its stats to the proper place. Stats are only
-   * recorded if a distributed system is started.
-   */
-  protected class DelayedPoolStatHelper implements PoolStatHelper {
-    @Override
-    public void startJob() {
-      stats.incRequestInProgress(1);
-
-    }
-
-    @Override
-    public void endJob() {
-      stats.incRequestInProgress(-1);
-    }
+    return locatorStrings;
   }
 
   private void startConfigurationPersistenceService() {
-
     installRequestHandlers();
 
-    if (!config.getEnableClusterConfiguration()) {
+    if (!distributionConfig.getEnableClusterConfiguration()) {
       logger.info("Cluster configuration service is disabled");
       return;
     }
 
-    if (!config.getJmxManager()) {
+    if (!distributionConfig.getJmxManager()) {
       throw new IllegalStateException(
           "Cannot start cluster configuration without jmx-manager=true");
     }
@@ -1450,16 +1267,16 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     }
 
     if (!isDedicatedLocator()) {
-      logger.info("Cluster configuration service not enabled as it is only supported "
-          + "in dedicated locators");
+      logger.info(
+          "Cluster configuration service not enabled as it is only supported in dedicated locators");
       return;
     }
 
     try {
       if (locator.configurationPersistenceService == null) {
-        // locator.configurationPersistenceService will already be created in case of auto-reconnect
+        // configurationPersistenceService will already be created in case of auto-reconnect
         locator.configurationPersistenceService =
-            new InternalConfigurationPersistenceService(locator.myCache);
+            new InternalConfigurationPersistenceService(locator.internalCache);
       }
       locator.configurationPersistenceService
           .initSharedConfiguration(locator.loadFromSharedConfigDir());
@@ -1477,29 +1294,63 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
 
   public void startJmxManagerLocationService(InternalCache internalCache) {
     if (internalCache.getJmxManagerAdvisor() != null) {
-      if (!this.handler.isHandled(JmxManagerLocatorRequest.class)) {
-        this.handler.addHandler(JmxManagerLocatorRequest.class,
+      if (!handler.isHandled(JmxManagerLocatorRequest.class)) {
+        handler.addHandler(JmxManagerLocatorRequest.class,
             new JmxManagerLocator(internalCache));
       }
     }
   }
 
   private void installRequestHandlers() {
-    if (!this.handler.isHandled(SharedConfigurationStatusRequest.class)) {
-      this.handler.addHandler(SharedConfigurationStatusRequest.class,
+    if (!handler.isHandled(SharedConfigurationStatusRequest.class)) {
+      handler.addHandler(SharedConfigurationStatusRequest.class,
           new SharedConfigurationStatusRequestHandler());
       logger.info("SharedConfigStatusRequestHandler installed");
     }
 
-    if (!this.handler.isHandled(ClusterManagementServiceInfoRequest.class)) {
-      this.handler.addHandler(ClusterManagementServiceInfoRequest.class,
+    if (!handler.isHandled(ClusterManagementServiceInfoRequest.class)) {
+      handler.addHandler(ClusterManagementServiceInfoRequest.class,
           new ClusterManagementServiceInfoRequestHandler());
       logger.info("ClusterManagementServiceInfoRequestHandler installed");
     }
   }
 
   public boolean hasHandlerForClass(Class messageClass) {
-    return this.handler.isHandled(messageClass);
+    return handler.isHandled(messageClass);
   }
 
+  class FetchSharedConfigStatus implements Callable<SharedConfigurationStatusResponse> {
+
+    @Override
+    public SharedConfigurationStatusResponse call() throws InterruptedException {
+      InternalLocator locator = InternalLocator.this;
+
+      SharedConfigurationStatusResponse response;
+      if (locator.configurationPersistenceService != null) {
+        response = locator.configurationPersistenceService.createStatusResponse();
+      } else {
+        response = new SharedConfigurationStatusResponse();
+        response.setStatus(SharedConfigurationStatus.UNDETERMINED);
+      }
+      return response;
+    }
+  }
+
+  /**
+   * A helper object so that the TcpServer can record its stats to the proper place. Stats are only
+   * recorded if a distributed system is started.
+   */
+  protected class DelayedPoolStatHelper implements PoolStatHelper {
+
+    @Override
+    public void startJob() {
+      locatorStats.incRequestInProgress(1);
+
+    }
+
+    @Override
+    public void endJob() {
+      locatorStats.incRequestInProgress(-1);
+    }
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/PrimaryHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/PrimaryHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.cache.client.internal.locator.wan.LocatorMembershipListener;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.membership.gms.locator.PeerLocatorRequest;
+import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
+import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+import org.apache.geode.internal.logging.LogService;
+
+public class PrimaryHandler implements TcpHandler {
+  private static final Logger logger = LogService.getLogger();
+
+  private final LocatorMembershipListener locatorListener;
+  private final InternalLocator internalLocator;
+
+  private volatile Map<Class, TcpHandler> handlerMapping = new HashMap<>();
+  private volatile Set<TcpHandler> allHandlers = new HashSet<>();
+
+  private TcpServer tcpServer;
+
+  PrimaryHandler(InternalLocator locator, LocatorMembershipListener listener) {
+    locatorListener = listener;
+    internalLocator = locator;
+  }
+
+  // this method is synchronized to make sure that no new handlers are added while
+  // initialization is taking place.
+  @Override
+  public synchronized void init(TcpServer tcpServer) {
+    if (locatorListener != null) {
+      // This is deferred until now as the initial requested port could have been 0
+      locatorListener.setPort(internalLocator.getPort());
+    }
+    this.tcpServer = tcpServer;
+    for (TcpHandler handler : allHandlers) {
+      handler.init(tcpServer);
+    }
+  }
+
+  @Override
+  public void restarting(DistributedSystem ds, GemFireCache cache,
+      InternalConfigurationPersistenceService sharedConfig) {
+    if (ds != null) {
+      for (TcpHandler handler : allHandlers) {
+        handler.restarting(ds, cache, sharedConfig);
+      }
+    }
+  }
+
+  @Override
+  public void restartCompleted(DistributedSystem ds) {
+    if (ds != null) {
+      for (TcpHandler handler : allHandlers) {
+        handler.restartCompleted(ds);
+      }
+    }
+  }
+
+  @Override
+  public Object processRequest(Object request) throws IOException {
+    long giveup = 0;
+    while (giveup == 0 || System.currentTimeMillis() < giveup) {
+      TcpHandler handler;
+      if (request instanceof PeerLocatorRequest) {
+        handler = handlerMapping.get(PeerLocatorRequest.class);
+      } else {
+        handler = handlerMapping.get(request.getClass());
+      }
+
+      if (handler != null) {
+        return handler.processRequest(request);
+      }
+
+      if (locatorListener != null) {
+        return locatorListener.handleRequest(request);
+      }
+
+      // either there is a configuration problem or the locator is still starting up
+      if (giveup == 0) {
+        int locatorWaitTime = internalLocator.getConfig().getLocatorWaitTime();
+        if (locatorWaitTime <= 0) {
+          // always retry some number of times
+          locatorWaitTime = 30;
+        }
+        giveup = System.currentTimeMillis() + locatorWaitTime * 1000L;
+        try {
+          Thread.sleep(1000);
+        } catch (InterruptedException ignored) {
+          // running in an executor - no need to set the interrupted flag on the thread
+          return null;
+        }
+      }
+    }
+    logger.info(
+        "Received a location request of class {} but the handler for this is either not enabled or is not ready to process requests",
+        request.getClass().getSimpleName());
+    return null;
+  }
+
+  @Override
+  public void shutDown() {
+    try {
+      for (TcpHandler handler : allHandlers) {
+        handler.shutDown();
+      }
+    } finally {
+      internalLocator.handleShutdown();
+    }
+  }
+
+  synchronized boolean isHandled(Class clazz) {
+    return handlerMapping.containsKey(clazz);
+  }
+
+  public synchronized void addHandler(Class clazz, TcpHandler handler) {
+    Map<Class, TcpHandler> tmpHandlerMapping = new HashMap<>(handlerMapping);
+    Set<TcpHandler> tmpAllHandlers = new HashSet<>(allHandlers);
+    tmpHandlerMapping.put(clazz, handler);
+    if (tmpAllHandlers.add(handler) && tcpServer != null) {
+      handler.init(tcpServer);
+    }
+    handlerMapping = tmpHandlerMapping;
+    allHandlers = tmpAllHandlers;
+  }
+
+  @Override
+  public void endRequest(Object request, long startTime) {
+    TcpHandler handler = handlerMapping.get(request.getClass());
+    if (handler != null) {
+      handler.endRequest(request, startTime);
+    }
+  }
+
+  @Override
+  public void endResponse(Object request, long startTime) {
+    TcpHandler handler = handlerMapping.get(request.getClass());
+    if (handler != null) {
+      handler.endResponse(request, startTime);
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal.membership;
 
+import java.io.File;
 import java.net.InetAddress;
 
 import org.apache.geode.annotations.Immutable;
@@ -99,9 +100,9 @@ public class MemberFactory {
    */
   public static NetLocator newLocatorHandler(InetAddress bindAddress, String locatorString,
       boolean usePreferredCoordinators, boolean networkPartitionDetectionEnabled,
-      LocatorStats stats, String securityUDPDHAlgo) {
+      LocatorStats stats, String securityUDPDHAlgo, File workingDirectory) {
     return services.newLocatorHandler(bindAddress, locatorString, usePreferredCoordinators,
-        networkPartitionDetectionEnabled, stats, securityUDPDHAlgo);
+        networkPartitionDetectionEnabled, stats, securityUDPDHAlgo, workingDirectory);
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal.membership;
 
+import java.io.File;
 import java.net.InetAddress;
 
 import org.apache.geode.distributed.internal.DMStats;
@@ -87,5 +88,5 @@ public interface MemberServices {
    */
   NetLocator newLocatorHandler(InetAddress bindAddress, String locatorString,
       boolean usePreferredCoordinators, boolean networkPartitionDetectionEnabled,
-      LocatorStats stats, String securityUDPDHAlgo);
+      LocatorStats stats, String securityUDPDHAlgo, File workingDirectory);
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal.membership.gms;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -120,10 +121,10 @@ public class GMSMemberFactory implements MemberServices {
   @Override
   public NetLocator newLocatorHandler(InetAddress bindAddress, String locatorString,
       boolean usePreferredCoordinators, boolean networkPartitionDetectionEnabled,
-      LocatorStats stats, String securityUDPDHAlgo) {
+      LocatorStats stats, String securityUDPDHAlgo, File workingDirectory) {
 
     return new GMSLocator(bindAddress, locatorString, usePreferredCoordinators,
-        networkPartitionDetectionEnabled, stats, securityUDPDHAlgo);
+        networkPartitionDetectionEnabled, stats, securityUDPDHAlgo, workingDirectory);
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -61,7 +62,7 @@ import org.apache.geode.internal.logging.LogService;
 
 public class GMSLocator implements Locator, NetLocator {
 
-  /* package */ static final int LOCATOR_FILE_STAMP = 0x7b8cf741;
+  static final int LOCATOR_FILE_STAMP = 0x7b8cf741;
 
   private static final Logger logger = LogService.getLogger();
 
@@ -70,44 +71,46 @@ public class GMSLocator implements Locator, NetLocator {
   private final String securityUDPDHAlgo;
   private final String locatorString;
   private final List<HostAddress> locators;
-  private Services services;
-  private final LocatorStats stats;
-  private InternalDistributedMember localAddress;
-
+  private final LocatorStats locatorStats;
   private final Set<InternalDistributedMember> registrants = new HashSet<>();
-  private Map<InternalDistributedMemberWrapper, byte[]> registerMbrVsPK = new ConcurrentHashMap<>();
+  private final Map<InternalDistributedMemberWrapper, byte[]> publicKeys =
+      new ConcurrentHashMap<>();
+
+  private volatile boolean isCoordinator;
+
+  private Services services;
+  private InternalDistributedMember localAddress;
 
   /**
    * The current membership view, or one recovered from disk. This is a copy-on-write variable.
    */
-  private transient NetView view;
+  private NetView view;
 
-  private transient NetView recoveredView;
+  private NetView recoveredView;
 
   private File viewFile;
-
-  private volatile boolean isCoordinator;
 
   /**
    * @param bindAddress network address that TcpServer will bind to
    * @param locatorString location of other locators (bootstrapping, failover)
    * @param usePreferredCoordinators true if the membership coordinator should be a Locator
    * @param networkPartitionDetectionEnabled true if network partition detection is enabled
-   * @param stats the locator statistics object
+   * @param locatorStats the locator statistics object
    * @param securityUDPDHAlgo DF algorithm
    */
   public GMSLocator(InetAddress bindAddress, String locatorString, boolean usePreferredCoordinators,
-      boolean networkPartitionDetectionEnabled, LocatorStats stats, String securityUDPDHAlgo) {
+      boolean networkPartitionDetectionEnabled, LocatorStats locatorStats,
+      String securityUDPDHAlgo) {
     this.usePreferredCoordinators = usePreferredCoordinators;
     this.networkPartitionDetectionEnabled = networkPartitionDetectionEnabled;
     this.securityUDPDHAlgo = securityUDPDHAlgo;
     this.locatorString = locatorString;
-    if (this.locatorString == null || this.locatorString.length() == 0) {
-      this.locators = new ArrayList<>(0);
+    if (this.locatorString == null || this.locatorString.isEmpty()) {
+      locators = new ArrayList<>(0);
     } else {
-      this.locators = GMSUtil.parseLocators(locatorString, bindAddress);
+      locators = GMSUtil.parseLocators(locatorString, bindAddress);
     }
-    this.stats = stats;
+    this.locatorStats = locatorStats;
   }
 
   @Override
@@ -115,7 +118,7 @@ public class GMSLocator implements Locator, NetLocator {
     if (services == null || services.isStopped()) {
       services = ((GMSMembershipManager) mgr).getServices();
       localAddress = services.getMessenger().getMemberID();
-      assert localAddress != null : "member address should have been established";
+      Objects.requireNonNull(localAddress, "member address should have been established");
       logger.info("Peer locator is connecting to local membership services with ID {}",
           localAddress);
       services.setLocator(this);
@@ -136,12 +139,12 @@ public class GMSLocator implements Locator, NetLocator {
           if (recoveredView != null) {
             recoveredView.remove(localAddress);
           }
-          synchronized (this.registrants) {
-            this.registrants.add(localAddress);
+          synchronized (registrants) {
+            registrants.add(localAddress);
           }
         }
       }
-      this.notifyAll();
+      notifyAll();
       return true;
     }
     return false;
@@ -149,15 +152,14 @@ public class GMSLocator implements Locator, NetLocator {
 
   @VisibleForTesting
   File setViewFile(File file) {
-    this.viewFile = file.getAbsoluteFile();
-    return this.viewFile;
+    viewFile = file.getAbsoluteFile();
+    return viewFile;
   }
 
   @Override
   public void init(TcpServer server) throws InternalGemFireException {
-    if (this.viewFile == null) {
-      // GEODE-4180, use absolute paths
-      this.viewFile = new File("locator" + server.getPort() + "view.dat").getAbsoluteFile();
+    if (viewFile == null) {
+      viewFile = new File("locator" + server.getPort() + "view.dat").getAbsoluteFile();
     }
     logger.info(
         "GemFire peer location service starting.  Other locators: {}  Locators preferred as coordinators: {}  Network partition detection enabled: {}  View persistence file: {}",
@@ -167,28 +169,26 @@ public class GMSLocator implements Locator, NetLocator {
 
   @Override
   public void installView(NetView view) {
-    synchronized (this.registrants) {
+    synchronized (registrants) {
       registrants.clear();
     }
-    logger.info("Peer locator received new membership view: " + view);
+    logger.info("Peer locator received new membership view: {}", view);
     this.view = view;
-    this.recoveredView = null;
+    recoveredView = null;
     saveView(view);
   }
 
   @Override
   public void setIsCoordinator(boolean isCoordinator) {
     if (isCoordinator) {
-      logger.info("Location services has received notification that this node is becoming"
-          + " membership coordinator");
+      logger.info(
+          "Location services has received notification that this node is becoming membership coordinator");
     }
     this.isCoordinator = isCoordinator;
   }
 
   @Override
   public Object processRequest(Object request) {
-    Object response = null;
-
     if (logger.isDebugEnabled()) {
       logger.debug("Peer locator processing {}", request);
     }
@@ -197,6 +197,7 @@ public class GMSLocator implements Locator, NetLocator {
       localAddress = services.getMessenger().getMemberID();
     }
 
+    Object response = null;
     if (request instanceof GetViewRequest) {
       if (view != null) {
         response = new GetViewResponse(view);
@@ -220,11 +221,11 @@ public class GMSLocator implements Locator, NetLocator {
 
     if (services == null) {
       if (findRequest.getMyPublicKey() != null) {
-        registerMbrVsPK.put(new InternalDistributedMemberWrapper(findRequest.getMemberID()),
+        publicKeys.put(new InternalDistributedMemberWrapper(findRequest.getMemberID()),
             findRequest.getMyPublicKey());
       }
-      logger.debug("Rejecting a request to find the coordinator - membership services are"
-          + " still initializing");
+      logger.debug(
+          "Rejecting a request to find the coordinator - membership services are still initializing");
       return null;
     }
 
@@ -235,8 +236,6 @@ public class GMSLocator implements Locator, NetLocator {
     services.getMessenger().setPublicKey(findRequest.getMyPublicKey(),
         findRequest.getMemberID());
 
-    InternalDistributedMember coordinator = null;
-
     // at this level we want to return the coordinator known to membership services,
     // which may be more up-to-date than the one known by the membership manager
     if (view == null) {
@@ -246,10 +245,9 @@ public class GMSLocator implements Locator, NetLocator {
       }
     }
 
-    boolean fromView = false;
-    NetView v = this.view;
-    if (v == null) {
-      v = this.recoveredView;
+    NetView responseView = view;
+    if (responseView == null) {
+      responseView = recoveredView;
     }
 
     synchronized (registrants) {
@@ -259,24 +257,26 @@ public class GMSLocator implements Locator, NetLocator {
       }
     }
 
-    if (v != null) {
+    InternalDistributedMember coordinator = null;
+    boolean fromView = false;
+    if (responseView != null) {
       // if the ID of the requester matches an entry in the membership view then remove
       // that entry - it's obviously an old member since the ID has been reused
       InternalDistributedMember requestingMemberID = findRequest.getMemberID();
-      for (InternalDistributedMember id : v.getMembers()) {
+      for (InternalDistributedMember id : responseView.getMembers()) {
         if (requestingMemberID.compareTo(id, false) == 0) {
-          NetView newView = new NetView(v, v.getViewId());
+          NetView newView = new NetView(responseView, responseView.getViewId());
           newView.remove(id);
-          v = newView;
+          responseView = newView;
           break;
         }
       }
 
-      if (v.getViewId() > findRequest.getLastViewId()) {
+      if (responseView.getViewId() > findRequest.getLastViewId()) {
         // ignore the requests rejectedCoordinators if the view has changed
-        coordinator = v.getCoordinator(Collections.emptyList());
+        coordinator = responseView.getCoordinator(Collections.emptyList());
       } else {
-        coordinator = v.getCoordinator(findRequest.getRejectedCoordinators());
+        coordinator = responseView.getCoordinator(findRequest.getRejectedCoordinators());
       }
       logger.info("Peer locator: coordinator from view is {}", coordinator);
       fromView = true;
@@ -306,23 +306,23 @@ public class GMSLocator implements Locator, NetLocator {
     synchronized (registrants) {
       if (isCoordinator) {
         coordinator = localAddress;
-        if (v != null && localAddress != null && !localAddress.equals(v.getCoordinator())) {
-          v = null;
+        if (responseView != null && localAddress != null
+            && !localAddress.equals(responseView.getCoordinator())) {
+          responseView = null;
           fromView = false;
         }
       }
 
       byte[] coordinatorPublicKey = null;
-      if (v != null) {
-        coordinatorPublicKey = (byte[]) v.getPublicKey(coordinator);
+      if (responseView != null) {
+        coordinatorPublicKey = (byte[]) responseView.getPublicKey(coordinator);
       }
       if (coordinatorPublicKey == null) {
         coordinatorPublicKey = services.getMessenger().getPublicKey(coordinator);
       }
 
-      return new FindCoordinatorResponse(coordinator, localAddress, fromView, v,
-          new HashSet<>(registrants),
-          this.networkPartitionDetectionEnabled, this.usePreferredCoordinators,
+      return new FindCoordinatorResponse(coordinator, localAddress, fromView, responseView,
+          new HashSet<>(registrants), networkPartitionDetectionEnabled, usePreferredCoordinators,
           coordinatorPublicKey);
     }
   }
@@ -332,60 +332,48 @@ public class GMSLocator implements Locator, NetLocator {
       return;
     }
     if (!viewFile.delete() && viewFile.exists()) {
-      logger.warn("Peer locator is unable to delete persistent membership information in "
-          + viewFile.getAbsolutePath());
+      logger.warn("Peer locator is unable to delete persistent membership information in {}",
+          viewFile.getAbsolutePath());
     }
-    try {
-      ObjectOutputStream oos = null;
-      try {
-        oos = new ObjectOutputStream(new FileOutputStream(viewFile));
-        oos.writeInt(LOCATOR_FILE_STAMP);
-        oos.writeInt(Version.CURRENT_ORDINAL);
-        DataSerializer.writeObject(view, oos);
-      } finally {
-        if (oos != null) {
-          oos.flush();
-          oos.close();
-        }
-      }
+    try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(viewFile))) {
+      oos.writeInt(LOCATOR_FILE_STAMP);
+      oos.writeInt(Version.CURRENT_ORDINAL);
+      DataSerializer.writeObject(view, oos);
     } catch (Exception e) {
       logger.warn(
           "Peer locator encountered an error writing current membership to disk.  Disabling persistence.  Care should be taken when bouncing this locator as it will not be able to recover knowledge of the running distributed system",
           e);
-      this.viewFile = null;
+      viewFile = null;
     }
   }
 
-
   @Override
   public void endRequest(Object request, long startTime) {
-    stats.endLocatorRequest(startTime);
+    locatorStats.endLocatorRequest(startTime);
   }
 
   @Override
   public void endResponse(Object request, long startTime) {
-    stats.endLocatorResponse(startTime);
+    locatorStats.endLocatorResponse(startTime);
   }
 
-  public byte[] getPublicKey(InternalDistributedMember mbr) {
-    return registerMbrVsPK.get(new InternalDistributedMemberWrapper(mbr));
+  public byte[] getPublicKey(InternalDistributedMember member) {
+    return publicKeys.get(new InternalDistributedMemberWrapper(member));
   }
 
   @Override
   public void shutDown() {
     // nothing to do for GMSLocator
-    registerMbrVsPK.clear();
+    publicKeys.clear();
   }
 
-
-  // test hook
+  @VisibleForTesting
   public List<InternalDistributedMember> getMembers() {
     if (view != null) {
       return new ArrayList<>(view.getMembers());
-    } else {
-      synchronized (registrants) {
-        return new ArrayList<>(registrants);
-      }
+    }
+    synchronized (registrants) {
+      return new ArrayList<>(registrants);
     }
   }
 
@@ -402,59 +390,59 @@ public class GMSLocator implements Locator, NetLocator {
   }
 
   private boolean recoverFromOtherLocators() {
-    for (HostAddress other : this.locators) {
+    for (HostAddress other : locators) {
       if (recover(other.getSocketInetAddress())) {
-        logger.info("Peer locator recovered state from " + other);
+        logger.info("Peer locator recovered state from {}", other);
         return true;
       }
-    } // for
+    }
     return false;
   }
 
   private boolean recover(InetSocketAddress other) {
     try {
-      logger.info("Peer locator attempting to recover from " + other);
+      logger.info("Peer locator attempting to recover from {}", other);
       TcpClient client = new TcpClient();
       Object response = client.requestToServer(other.getAddress(), other.getPort(),
           new GetViewRequest(), 20000, true);
       if (response instanceof GetViewResponse) {
-        this.view = ((GetViewResponse) response).getView();
+        view = ((GetViewResponse) response).getView();
         logger.info("Peer locator recovered initial membership of {}", view);
         return true;
       }
-    } catch (IOException | ClassNotFoundException ex) {
+    } catch (IOException | ClassNotFoundException e) {
       logger.debug("Peer locator could not recover membership view from {}: {}", other,
-          ex.getMessage());
+          e.getMessage());
     }
     logger.info("Peer locator was unable to recover state from this locator");
     return false;
   }
 
-  /* package */ boolean recoverFromFile(File file) throws InternalGemFireException {
+  boolean recoverFromFile(File file) throws InternalGemFireException {
     if (!file.exists()) {
-      logger.info("recovery file not found: " + file.getAbsolutePath());
+      logger.info("recovery file not found: {}", file.getAbsolutePath());
       return false;
     }
 
-    logger.info("Peer locator recovering from " + file.getAbsolutePath());
+    logger.info("Peer locator recovering from {}", file.getAbsolutePath());
     try (ObjectInput ois = new ObjectInputStream(new FileInputStream(file))) {
       if (ois.readInt() != LOCATOR_FILE_STAMP) {
         return false;
       }
 
-      ObjectInput ois2 = ois;
-      int version = ois2.readInt();
+      ObjectInput input = ois;
+      int version = input.readInt();
       if (version != Version.CURRENT_ORDINAL) {
         Version geodeVersion = Version.fromOrdinalNoThrow((short) version, false);
         logger.info("Peer locator found that persistent view was written with {}", geodeVersion);
-        ois2 = new VersionedObjectInput(ois2, geodeVersion);
+        input = new VersionedObjectInput(input, geodeVersion);
       }
 
-      Object o = DataSerializer.readObject(ois2);
-      recoveredView = (NetView) o;
-      recoveredView.setViewId(-1); // this is not a valid view so it shouldn't have a usable Id
+      recoveredView = DataSerializer.readObject(input);
+      // this is not a valid view so it shouldn't have a usable Id
+      recoveredView.setViewId(-1);
       List<InternalDistributedMember> members = new ArrayList<>(recoveredView.getMembers());
-      // GEODE-3052 - remove locators from the view. Since we couldn't recover from an existing
+      // Remove locators from the view. Since we couldn't recover from an existing
       // locator we know that all of the locators in the view are defunct
       for (InternalDistributedMember member : members) {
         if (member.getVmKind() == ClusterDistributionManager.LOCATOR_DM_TYPE) {
@@ -462,19 +450,18 @@ public class GMSLocator implements Locator, NetLocator {
         }
       }
 
-      logger.info("Peer locator recovered membership is " + recoveredView);
+      logger.info("Peer locator recovered membership is {}", recoveredView);
       return true;
 
     } catch (Exception e) {
-      String msg =
+      String message =
           String.format("Unable to recover previous membership view from %s", file.toString());
-      logger.warn(msg, e);
+      logger.warn(message, e);
       if (!file.delete() && file.exists()) {
-        logger.warn("Peer locator was unable to recover from or delete " + file);
-        this.viewFile = null;
+        logger.warn("Peer locator was unable to recover from or delete {}", file);
+        viewFile = null;
       }
-      throw new InternalGemFireException(msg, e);
+      throw new InternalGemFireException(message, e);
     }
   }
-
 }

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/wan/MyDistributedSystemListener.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/wan/MyDistributedSystemListener.java
@@ -40,7 +40,7 @@ public class MyDistributedSystemListener implements DistributedSystemListener {
     List<Locator> locatorsConfigured = Locator.getLocators();
     Locator locator = locatorsConfigured.get(0);
     Map<Integer, Set<DistributionLocatorId>> allSiteMetaData =
-        ((InternalLocator) locator).getlocatorMembershipListener().getAllLocatorsInfo();
+        ((InternalLocator) locator).getLocatorMembershipListener().getAllLocatorsInfo();
     System.out.println("Added : allSiteMetaData : " + allSiteMetaData);
   }
 
@@ -50,7 +50,7 @@ public class MyDistributedSystemListener implements DistributedSystemListener {
     List<Locator> locatorsConfigured = Locator.getLocators();
     Locator locator = locatorsConfigured.get(0);
     Map<Integer, Set<DistributionLocatorId>> allSiteMetaData =
-        ((InternalLocator) locator).getlocatorMembershipListener().getAllLocatorsInfo();
+        ((InternalLocator) locator).getLocatorMembershipListener().getAllLocatorsInfo();
     System.out.println("Removed : allSiteMetaData : " + allSiteMetaData);
   }
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -2992,7 +2992,7 @@ public class WANTestBase extends DistributedTestCase {
     Locator locator = locatorsConfigured.get(0);
     await().untilAsserted(() -> {
       Map<Integer, Set<DistributionLocatorId>> allSiteMetaData =
-          ((InternalLocator) locator).getlocatorMembershipListener().getAllLocatorsInfo();
+          ((InternalLocator) locator).getLocatorMembershipListener().getAllLocatorsInfo();
       for (Map.Entry<Integer, Set<InetSocketAddress>> entry : dsIdToLocatorAddresses.entrySet()) {
         Set<DistributionLocatorId> foundLocatorIds = allSiteMetaData.get(entry.getKey());
         Set<InetSocketAddress> expectedLocators = entry.getValue();
@@ -3011,7 +3011,7 @@ public class WANTestBase extends DistributedTestCase {
             () -> assertEquals("System is not initialized", true, (getSystemStatic() != null)));
     List<Locator> locatorsConfigured = Locator.getLocators();
     Locator locator = locatorsConfigured.get(0);
-    LocatorMembershipListener listener = ((InternalLocator) locator).getlocatorMembershipListener();
+    LocatorMembershipListener listener = ((InternalLocator) locator).getLocatorMembershipListener();
     if (listener == null) {
       fail(
           "No locator membership listener available. WAN is likely not enabled. Is this test in the WAN project?");
@@ -3047,7 +3047,7 @@ public class WANTestBase extends DistributedTestCase {
     Locator locator = locatorsConfigured.get(0);
     if (remoteLocators != null) {
       // Add fake remote locators to the locators map
-      ((InternalLocator) locator).getlocatorMembershipListener().getAllServerLocatorsInfo()
+      ((InternalLocator) locator).getLocatorMembershipListener().getAllServerLocatorsInfo()
           .put(remoteDsId, remoteLocators);
     }
   }


### PR DESCRIPTION
Add workingDirectory parameter to the following:
* InternalLocator.startLocator
* MemberFactory.newLocatorHandler
* GMSMemberFactory.newLocatorHandler

Update some tests to use TemporaryFolder for Locator workingDirectory. Note: All of the LocatorLauncher tests are already setting workingDirectory on the launcher -- this PR updates the LocatorLauncher code to set the workingDirectory on the locator, so those tests automatically benefit from having the locator view file moved to a TemporaryFolder.

The purpose of GEODE-6825 is to better facilitate specifying where a Locator will create files, including the locator state file, so that tests can move those files to a JUnit TemporaryFolder.

This PR is divided into multiple commits to facilitate review (5. is the actual fix for GEODE-6825):

1) [Cleanup GMSLocator](https://github.com/apache/geode/pull/3692/commits/1749f81c69fac67a4c7c131905c0ab48e87f6d60)
```
commit 1749f81c69fac67a4c7c131905c0ab48e87f6d60
Author: Kirk Lund <klund@apache.org>
Date:   Mon Jun 10 09:57:22 2019 -0700

    GEODE-6825: Cleanup GMSLocator
    
    General cleanup of code and fixup of IDE warnings.
    
    * Remove unnecessary uses of this
    * Remove use of transient from non-serializable class
    * Make field(s) final
    * Use more descriptive var names
    * Change assert to non-assert null-check
    * Use @VisibleForTesting annoation
    * Remove Jira ticket numbers
    * Make log4j statements use log4j parameters
    * Declare vars closer to where they are used
    * Use try-with-resource instead of try-finally
    * Minor reformatting changes
```
2) [Rename GMSLocatorRecoveryIntegrationTest](https://github.com/apache/geode/pull/3692/commits/425db89a147877dd6cdbab091c95f71fba3e6c98)
```
commit 425db89a147877dd6cdbab091c95f71fba3e6c98
Author: Kirk Lund <klund@apache.org>
Date:   Mon Jun 10 10:09:16 2019 -0700

    GEODE-6825: Rename GMSLocatorRecoveryIntegrationTest
    
    Rename GMSLocatorRecoveryJUnitTest to GMSLocatorRecoveryIntegrationTest
```
3) [Cleanup GMSLocatorRecoveryIntegrationTest](https://github.com/apache/geode/pull/3692/commits/c6745e4bfc795d213b3454ba0e5d10063a5d716e)
```
commit c6745e4bfc795d213b3454ba0e5d10063a5d716e
Author: Kirk Lund <klund@apache.org>
Date:   Mon Jun 10 10:57:47 2019 -0700

    GEODE-6825: Cleanup GMSLocatorRecoveryIntegrationTest
    
    General cleanup of code and fixup of IDE warnings.
    
    * Use TemporaryFolder rule for all files and dirs
    * Remove unnecessary uses of this
    * Move test tear down to tearDown
    * Convert from JUnit assertions to AssertJ
    * Use more descriptive var names
    * Remove unused vars
    * Use Properties.setProperty instead of Map.put
    * Remove commented-out code
```
4) [Cleanup InternalLocator](https://github.com/apache/geode/pull/3692/commits/d84225f1ca623052e862b5508c5e9ba21494de76)
```
commit d84225f1ca623052e862b5508c5e9ba21494de76
Author: Kirk Lund <klund@apache.org>
Date:   Mon Jun 10 12:28:19 2019 -0700

    GEODE-6825: Cleanup InternalLocator
    
    General cleanup of code and fixup of IDE warnings.
    
    * Minor formatting changes
    * Reorder fields: static, final, volatile, mutable
    * Rename some fields and vars with more descriptive names
    * Change locatorStats field to private final
    * Rename LogWriter method parameters
    * Remove unnecessary uses of final from local vars
    * Remove unnecessary uses of this
    * Change getProperties().remove to clearProperty
    * Deprecate getlocatorMembershipListener in favor of
      getLocatorMembershipListener
    * Extract PrimaryHandler inner class to top level class
    * Move non-static inner classes to bottom of outer class
    * Make log4j statements use log4j parameters
    * Remove old bug system references
```
5) [Add workingDirectory field to GMSLocator](https://github.com/apache/geode/pull/3692/commits/9b05d9fda84e01a9f676e9e36f2c6f146b5b591c) (the actual fix for GEODE-6825)
```
commit 9b05d9fda84e01a9f676e9e36f2c6f146b5b591c (HEAD -> GEODE-6825-GMSLocator-workingDirectory, kirklund-fork/GEODE-6825-GMSLocator-workingDirectory)
Author: Kirk Lund <klund@apache.org>
Date:   Mon Jun 10 13:23:47 2019 -0700

    GEODE-6825: Add workingDirectory field to GMSLocator
    
    Add workingDirectory parameter to the following:
    * InternalLocator.startLocator
    * MemberFactory.newLocatorHandler
    * GMSMemberFactory.newLocatorHandler
    
    Update some tests to use TemporaryFolder for Locator workingDirectory.
```