### PR TITLE
GEODE-6853: Do not request region sync during message processing.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -1918,9 +1918,9 @@ public class InitialImageOperation {
         InternalDistributedMember lostMember, VersionSource lostVersionSource) {
       if (region.setRegionSynchronizedWithIfNotScheduled(lostVersionSource)) {
         // if region synchronization has not been scheduled or performed,
-        // we do synchronization with others right away as we received the synchronization request
+        // we do synchronization with no delay as we received the synchronization request
         // indicating timed task has been triggered on other nodes
-        region.synchronizeForLostMember(lostMember, lostVersionSource);
+        region.scheduleSynchronizeForLostMember(lostMember, lostVersionSource, 0);
       }
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InitialImageOperationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InitialImageOperationTest.java
@@ -77,12 +77,12 @@ public class InitialImageOperationTest {
   }
 
   @Test
-  public void synchronizeForLostMemberIsInvokedIfRegionHasNotScheduledOrDoneSynchronization() {
+  public void scheduleSynchronizeForLostMemberIsInvokedIfRegionHasNotScheduledOrDoneSynchronization() {
     when(distributedRegion.setRegionSynchronizedWithIfNotScheduled(versionSource)).thenReturn(true);
 
     message.synchronizeIfNotScheduled(distributedRegion, lostMember, versionSource);
 
-    verify(distributedRegion).synchronizeForLostMember(lostMember, versionSource);
+    verify(distributedRegion).scheduleSynchronizeForLostMember(lostMember, versionSource, 0);
   }
 
   @Test
@@ -92,6 +92,7 @@ public class InitialImageOperationTest {
 
     message.synchronizeIfNotScheduled(distributedRegion, lostMember, versionSource);
 
-    verify(distributedRegion, never()).synchronizeForLostMember(lostMember, versionSource);
+    verify(distributedRegion, never()).scheduleSynchronizeForLostMember(lostMember, versionSource,
+        0);
   }
 }


### PR DESCRIPTION
 * Move schedule region synchronize task to DistributedRegion.
 * Use the time task to request region sync with no delay when processing region sync message.
