### PR TITLE
GEODE-6783: Remove Thread.sleep() from GatewayReceiverMetricsTest @be…

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
@@ -151,18 +151,8 @@ public class GatewayReceiverMetricsTest {
         "--type=" + RegionShortcut.REPLICATE.name(),
         "--gateway-sender-id=" + gatewaySenderId);
 
-    gfshRule.execute(connectToSenderLocatorCommand, startGatewaySenderCommand);
-
-    // There is a bug in the GFSH create gateway-sender command where it returns before the system
-    // has recognized the creation status: GEODE-6777. We can remove the following when that bug is
-    // fixed.
-    try {
-      Thread.sleep(1000);
-    } catch (InterruptedException e) {
-      // Don't care
-    }
-
-    gfshRule.execute(connectToSenderLocatorCommand, createSenderRegionCommand);
+    gfshRule.execute(connectToSenderLocatorCommand, startGatewaySenderCommand,
+        createSenderRegionCommand);
 
     String connectToReceiverLocatorCommand =
         "connect --locator=localhost[" + receiverLocatorPort + "]";


### PR DESCRIPTION
…fore method

Remove Thread.sleep() from test to reduce flakiness. I ran the test 14 times locally to verify the race condition mentioned in the comment is no longer an issue.

@moleske @demery-pivotal @kirklund @mhansonp 

---

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
