### PR TITLE
GEODE-6883: Removing some dependencies on core from membership

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -51,6 +51,7 @@ import org.apache.geode.distributed.internal.membership.DistributedMembershipLis
 import org.apache.geode.distributed.internal.membership.MemberFactory;
 import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.distributed.internal.membership.NetView;
+import org.apache.geode.distributed.internal.membership.adapter.auth.GMSAuthenticator;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
@@ -162,7 +163,9 @@ public class GMSLocatorRecoveryIntegrationTest {
 
     // start the membership manager
     membershipManager = MemberFactory.newMembershipManager(mockListener, mockSystem, transport,
-        mockDmStats, SecurityServiceFactory.create());
+        mockDmStats, SecurityServiceFactory.create(),
+        new GMSAuthenticator(mockSystem.getSecurityProperties(), mockSystem.getSecurityService(),
+            mockSystem.getSecurityLogWriter(), mockSystem.getInternalLogWriter()));
 
     GMSLocator gmsLocator = new GMSLocator(localHost,
         membershipManager.getLocalMember().getHost() + "[" + port + "]", true, true,

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -53,7 +53,6 @@ import org.mockito.internal.verification.Times;
 import org.mockito.verification.Timeout;
 
 import org.apache.geode.SystemConnectException;
-import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -937,7 +936,8 @@ public class GMSJoinLeaveJUnitTest {
     assertTrue(gmsJoinLeave.isCoordinator());
     // wait for suspect processing
 
-    verify(healthMonitor, timeout(10000).atLeast(1)).checkIfAvailable(isA(DistributedMember.class),
+    verify(healthMonitor, timeout(10000).atLeast(1)).checkIfAvailable(
+        isA(InternalDistributedMember.class),
         isA(String.class), isA(Boolean.class));
     // verify(messenger, atLeast(1)).send(isA(RemoveMemberMessage.class));
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
@@ -535,14 +535,8 @@ public class JGroupsMessengerJUnitTest {
         -1, 0);
 
     // configure an incoming message handler for JoinRequestMessage
-    final DistributionMessage[] messageReceived = new DistributionMessage[1];
-    MessageHandler handler = new MessageHandler() {
-      @Override
-      public void processMessage(DistributionMessage m) {
-        messageReceived[0] = m;
-      }
-    };
-    messenger.addHandler(JoinRequestMessage.class, handler);
+    final JoinRequestMessage[] messageReceived = new JoinRequestMessage[1];
+    messenger.addHandler(JoinRequestMessage.class, message -> messageReceived[0] = message);
 
     // configure the outgoing message interceptor
     interceptor.unicastSentDataMessages = 0;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -67,6 +67,8 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.MemberFactory;
 import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.distributed.internal.membership.NetView;
+import org.apache.geode.distributed.internal.membership.adapter.auth.GMSAuthenticator;
+import org.apache.geode.distributed.internal.membership.gms.messages.ViewAckMessage;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.NanoTimer;
 import org.apache.geode.internal.OSProcess;
@@ -242,7 +244,7 @@ public class ClusterDistributionManager implements DistributionManager {
   /**
    * Executor for view related messages
    *
-   * @see org.apache.geode.distributed.internal.membership.gms.messages.ViewAckMessage
+   * @see ViewAckMessage
    */
   public static final int VIEW_EXECUTOR = 79;
 
@@ -417,7 +419,7 @@ public class ClusterDistributionManager implements DistributionManager {
   /**
    * Message processing executor for view messages
    *
-   * @see org.apache.geode.distributed.internal.membership.gms.messages.ViewAckMessage
+   * @see ViewAckMessage
    */
   private ExecutorService viewThread;
 
@@ -779,7 +781,9 @@ public class ClusterDistributionManager implements DistributionManager {
 
       DMListener l = new DMListener(this);
       membershipManager = MemberFactory.newMembershipManager(l, system, transport,
-          stats, system.getSecurityService());
+          stats, system.getSecurityService(),
+          new GMSAuthenticator(system.getSecurityProperties(), system.getSecurityService(),
+              system.getSecurityLogWriter(), system.getInternalLogWriter()));
 
       sb.append(System.currentTimeMillis() - start);
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyProcessor21.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyProcessor21.java
@@ -1068,7 +1068,7 @@ public class ReplyProcessor21 implements MembershipListener {
     // Increment the stat
     getDistributionManager().getStats().incReplyTimeouts();
 
-    final Set suspectMembers;
+    final Set<InternalDistributedMember> suspectMembers;
     if (suspectThem || severeAlert) {
       suspectMembers = new HashSet();
     } else {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
@@ -93,8 +93,8 @@ public class MemberFactory {
       DMStats stats,
       SecurityService securityService,
       final Authenticator authenticator) {
-    return services.newMembershipManager(listener, system, transport, stats, securityService,
-        authenticator);
+    return services.newMembershipManager(listener, transport, stats,
+        authenticator, system.getConfig());
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
@@ -23,6 +23,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.gms.GMSMemberFactory;
 import org.apache.geode.distributed.internal.membership.gms.NetLocator;
+import org.apache.geode.distributed.internal.membership.gms.interfaces.Authenticator;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.security.SecurityService;
 
@@ -30,7 +31,7 @@ import org.apache.geode.internal.security.SecurityService;
  * Create a new Member based on the given inputs. TODO: need to implement a real factory
  * implementation based on gemfire.properties
  *
- * @see org.apache.geode.distributed.internal.membership.NetMember
+ * @see NetMember
  */
 public class MemberFactory {
 
@@ -90,8 +91,10 @@ public class MemberFactory {
       InternalDistributedSystem system,
       RemoteTransportConfig transport,
       DMStats stats,
-      SecurityService securityService) {
-    return services.newMembershipManager(listener, system, transport, stats, securityService);
+      SecurityService securityService,
+      final Authenticator authenticator) {
+    return services.newMembershipManager(listener, system, transport, stats, securityService,
+        authenticator);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
@@ -18,12 +18,11 @@ import java.io.File;
 import java.net.InetAddress;
 
 import org.apache.geode.distributed.internal.DMStats;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.gms.NetLocator;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Authenticator;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
-import org.apache.geode.internal.security.SecurityService;
 
 /**
  * This is the SPI for a provider of membership services.
@@ -77,11 +76,10 @@ public interface MemberServices {
    * @return a MembershipManager
    */
   MembershipManager newMembershipManager(DistributedMembershipListener listener,
-      InternalDistributedSystem system,
       RemoteTransportConfig transport,
       DMStats stats,
-      SecurityService securityService,
-      final Authenticator authenticator);
+      final Authenticator authenticator,
+      DistributionConfig config);
 
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
@@ -21,13 +21,14 @@ import org.apache.geode.distributed.internal.DMStats;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.gms.NetLocator;
+import org.apache.geode.distributed.internal.membership.gms.interfaces.Authenticator;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.security.SecurityService;
 
 /**
  * This is the SPI for a provider of membership services.
  *
- * @see org.apache.geode.distributed.internal.membership.NetMember
+ * @see NetMember
  */
 public interface MemberServices {
 
@@ -79,7 +80,8 @@ public interface MemberServices {
       InternalDistributedSystem system,
       RemoteTransportConfig transport,
       DMStats stats,
-      SecurityService securityService);
+      SecurityService securityService,
+      final Authenticator authenticator);
 
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MembershipManager.java
@@ -238,20 +238,20 @@ public interface MembershipManager {
    * @param reason why the check is being done (must not be blank/null)
    * @return true if the member checks out
    */
-  boolean verifyMember(DistributedMember mbr, String reason);
+  boolean verifyMember(InternalDistributedMember mbr, String reason);
 
 
   /**
    * Initiate SUSPECT processing for the given members. This may be done if the members have not
    * been responsive. If they fail SUSPECT processing, they will be removed from membership.
    */
-  void suspectMembers(Set members, String reason);
+  void suspectMembers(Set<InternalDistributedMember> members, String reason);
 
   /**
    * Initiate SUSPECT processing for the given member. This may be done if the member has not been
    * responsive. If it fails SUSPECT processing, it will be removed from membership.
    */
-  void suspectMember(DistributedMember member, String reason);
+  void suspectMember(InternalDistributedMember member, String reason);
 
   /**
    * if the manager initiated shutdown, this will return the cause of abnormal termination of

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/package-info.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/package-info.java
@@ -12,15 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.distributed.internal.membership.gms.interfaces;
-
-
 /**
- * MessageHandler processes a message received by Messenger. Handlers are registered with Messenger
- * to consume specific classes of message.
+ * Implements the bridge between the geode-core module and the membership module.
+ *
+ * Classes in this package stay inside geode-core but implement interfaces from both core
+ * and membership.
  */
-public interface MessageHandler<T> {
-
-  void processMessage(T m);
-
-}
+package org.apache.geode.distributed.internal.membership.adapter;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
@@ -21,8 +21,8 @@ import java.net.UnknownHostException;
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.SystemConnectException;
 import org.apache.geode.distributed.internal.DMStats;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionException;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.DistributedMembershipListener;
 import org.apache.geode.distributed.internal.membership.MemberAttributes;
@@ -34,7 +34,6 @@ import org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.net.SocketCreator;
-import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.tcp.ConnectionException;
 import org.apache.geode.security.GemFireSecurityException;
 
@@ -99,12 +98,10 @@ public class GMSMemberFactory implements MemberServices {
 
   @Override
   public MembershipManager newMembershipManager(DistributedMembershipListener listener,
-      InternalDistributedSystem system,
       RemoteTransportConfig transport, DMStats stats,
-      SecurityService securityService,
-      final Authenticator authenticator) throws DistributionException {
-    Services services = new Services(listener, system, transport, stats, securityService,
-        authenticator);
+      final Authenticator authenticator,
+      DistributionConfig config) throws DistributionException {
+    Services services = new Services(listener, transport, stats, authenticator, config);
     try {
       services.init();
       services.start();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
@@ -29,6 +29,7 @@ import org.apache.geode.distributed.internal.membership.MemberAttributes;
 import org.apache.geode.distributed.internal.membership.MemberServices;
 import org.apache.geode.distributed.internal.membership.MembershipManager;
 import org.apache.geode.distributed.internal.membership.NetMember;
+import org.apache.geode.distributed.internal.membership.gms.interfaces.Authenticator;
 import org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
@@ -40,7 +41,7 @@ import org.apache.geode.security.GemFireSecurityException;
 /**
  * Create a new Member based on the given inputs.
  *
- * @see org.apache.geode.distributed.internal.membership.NetMember
+ * @see NetMember
  */
 public class GMSMemberFactory implements MemberServices {
 
@@ -100,8 +101,10 @@ public class GMSMemberFactory implements MemberServices {
   public MembershipManager newMembershipManager(DistributedMembershipListener listener,
       InternalDistributedSystem system,
       RemoteTransportConfig transport, DMStats stats,
-      SecurityService securityService) throws DistributionException {
-    Services services = new Services(listener, system, transport, stats, securityService);
+      SecurityService securityService,
+      final Authenticator authenticator) throws DistributionException {
+    Services services = new Services(listener, system, transport, stats, securityService,
+        authenticator);
     try {
       services.init();
       services.start();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -88,7 +88,8 @@ import org.apache.geode.internal.security.SecurableCommunicationChannel;
  * suspect processing for any member. First is checks whether the member is responding or not. Then
  * it informs probable coordinators to remove that member from view.
  * <p>
- * It has {@link #checkIfAvailable(DistributedMember, String, boolean)} api to see if that member is
+ * It has {@link HealthMonitor#checkIfAvailable(InternalDistributedMember, String, boolean)} api to
+ * see if that member is
  * alive. Then based on removal flag it initiates the suspect processing for that member.
  */
 @SuppressWarnings({"SynchronizationOnLocalVariableOrMethodParameter", "NullableProblems"})
@@ -647,9 +648,10 @@ public class GMSHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public boolean checkIfAvailable(DistributedMember mbr, String reason, boolean initiateRemoval) {
+  public boolean checkIfAvailable(InternalDistributedMember mbr, String reason,
+      boolean initiateRemoval) {
     return inlineCheckIfAvailable(localAddress, currentView, initiateRemoval,
-        (InternalDistributedMember) mbr, reason);
+        mbr, reason);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Authenticator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Authenticator.java
@@ -17,12 +17,24 @@ package org.apache.geode.distributed.internal.membership.gms.interfaces;
 import java.util.Properties;
 
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.security.AuthenticationFailedException;
 
-public interface Authenticator extends Service {
+public interface Authenticator {
 
-  String authenticate(InternalDistributedMember m, Properties credentials)
-      throws AuthenticationFailedException;
+  /**
+   * Authenticate peer member
+   *
+   * @param member the member to be authenticated
+   * @param credentials the credentials used in authentication
+   * @return null if authentication succeed (including no authenticator case), otherwise, return
+   *         failure message
+   */
+  String authenticate(InternalDistributedMember member, Properties credentials);
 
-  Properties getCredentials(InternalDistributedMember m);
+  /**
+   * Get credential object for the given GemFire distributed member.
+   *
+   * @param member the target distributed member
+   * @return the credentials
+   */
+  Properties getCredentials(InternalDistributedMember member);
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -40,7 +40,7 @@ public interface HealthMonitor extends Service {
    * @param reason the reason this check is being performed
    * @param initiateRemoval if the member should be removed if it is not available
    */
-  boolean checkIfAvailable(DistributedMember mbr, String reason, boolean initiateRemoval);
+  boolean checkIfAvailable(InternalDistributedMember mbr, String reason, boolean initiateRemoval);
 
   /**
    * Invoked by the Manager, this notifies the HealthMonitor that a ShutdownMessage has been

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
@@ -27,7 +27,7 @@ import org.apache.geode.distributed.internal.membership.NetView;
  * Manager presents the GMS services to the outside world and handles startup/shutdown race
  * conditions. It is also the default MessageHandler
  */
-public interface Manager extends Service, MessageHandler {
+public interface Manager extends Service, MessageHandler<DistributionMessage> {
 
   /**
    * After all services have been started this is used to join the distributed system

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Messenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Messenger.java
@@ -27,7 +27,7 @@ public interface Messenger extends Service {
   /**
    * adds a handler for the given class/interface of messages
    */
-  void addHandler(Class c, MessageHandler h);
+  <T> void addHandler(Class<T> c, MessageHandler<T> h);
 
   /**
    * sends an asynchronous message when the membership view may not have been established. Returns

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -578,7 +578,7 @@ public class JGroupsMessenger implements Messenger {
   public void beHealthy() {}
 
   @Override
-  public void addHandler(Class c, MessageHandler h) {
+  public <T> void addHandler(Class<T> c, MessageHandler<T> h) {
     handlers.put(c, h);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
@@ -1647,14 +1647,14 @@ public class GMSMembershipManager implements MembershipManager, Manager {
   }
 
   @Override
-  public void suspectMembers(Set members, String reason) {
-    for (final Object member : members) {
-      verifyMember((DistributedMember) member, reason);
+  public void suspectMembers(Set<InternalDistributedMember> members, String reason) {
+    for (final InternalDistributedMember member : members) {
+      verifyMember(member, reason);
     }
   }
 
   @Override
-  public void suspectMember(DistributedMember mbr, String reason) {
+  public void suspectMember(InternalDistributedMember mbr, String reason) {
     if (!this.shutdownInProgress && !this.shutdownMembers.containsKey(mbr)) {
       verifyMember(mbr, reason);
     }
@@ -1672,7 +1672,7 @@ public class GMSMembershipManager implements MembershipManager, Manager {
    * @return true if the member checks out
    */
   @Override
-  public boolean verifyMember(DistributedMember mbr, String reason) {
+  public boolean verifyMember(InternalDistributedMember mbr, String reason) {
     return mbr != null && memberExists(mbr)
         && this.services.getHealthMonitor().checkIfAvailable(mbr, reason, false);
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
@@ -265,7 +265,7 @@ public class GMSMembershipManager implements MembershipManager, Manager {
   /**
    * This is the listener that accepts our membership events
    */
-  private final org.apache.geode.distributed.internal.membership.DistributedMembershipListener listener;
+  private final DistributedMembershipListener listener;
 
   /**
    * Membership failure listeners - for testing

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -3144,7 +3144,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
                 DLockRemoteToken remoteToken = ((DLockService) getLockService()).queryLock(key);
                 lockHolder = remoteToken.getLessee();
                 if (lockHolder != null) {
-                  dm.getMembershipManager().suspectMember(lockHolder,
+                  dm.getMembershipManager().suspectMember((InternalDistributedMember) lockHolder,
                       "Has not released a global region entry lock in over "
                           + ackWaitThreshold / 1000 + " seconds");
                 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -6797,7 +6797,7 @@ public class PartitionedRegion extends LocalRegion
                 DLockRemoteToken remoteToken = this.lockService.queryLock(this.lockName);
                 lockHolder = remoteToken.getLessee();
                 if (lockHolder != null) {
-                  dm.getMembershipManager().suspectMember(lockHolder,
+                  dm.getMembershipManager().suspectMember((InternalDistributedMember) lockHolder,
                       "Has not released a partitioned region lock in over "
                           + ackWaitThreshold / 1000 + " sec");
                 }
@@ -6884,7 +6884,7 @@ public class PartitionedRegion extends LocalRegion
                 DLockRemoteToken remoteToken = this.lockService.queryLock(key);
                 lockHolder = remoteToken.getLessee();
                 if (lockHolder != null) {
-                  dm.getMembershipManager().suspectMember(lockHolder,
+                  dm.getMembershipManager().suspectMember((InternalDistributedMember) lockHolder,
                       "Has not released a global region entry lock in over "
                           + ackWaitThreshold / 1000 + " sec");
                 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Handshake.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Handshake.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.LogWriter;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.cache.client.PoolFactory;
 import org.apache.geode.cache.client.ServerRefusedConnectionException;
@@ -390,8 +391,8 @@ public abstract class Handshake {
   }
 
   public static Properties getCredentials(String authInitMethod, Properties securityProperties,
-      DistributedMember server, boolean isPeer, InternalLogWriter logWriter,
-      InternalLogWriter securityLogWriter) throws AuthenticationRequiredException {
+      DistributedMember server, boolean isPeer, LogWriter logWriter,
+      LogWriter securityLogWriter) throws AuthenticationRequiredException {
 
     Properties credentials = null;
     // if no authInit, Try to extract the credentials directly from securityProps

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -923,7 +923,7 @@ public class Connection implements Runnable {
               logger.warn("Unable to form a TCP/IP connection to {} in over {} seconds",
                   remoteAddr, (ackTimeout) / 1000);
             }
-            mgr.suspectMember(remoteAddr,
+            mgr.suspectMember((InternalDistributedMember) remoteAddr,
                 "Unable to form a TCP/IP connection in a reasonable amount of time");
             suspected = true;
           }
@@ -934,7 +934,7 @@ public class Connection implements Runnable {
           }
         } else if (!suspected && (startTime > 0) && (ackTimeout > 0)
             && (startTime + ackTimeout < now)) {
-          mgr.suspectMember(remoteAddr,
+          mgr.suspectMember((InternalDistributedMember) remoteAddr,
               "Unable to form a TCP/IP connection in a reasonable amount of time");
           suspected = true;
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
@@ -1227,7 +1227,7 @@ public class ConnectionTable {
           } else if (!suspected) {
             logger.warn("Unable to form a TCP/IP connection to %s in over %s seconds",
                 this.id, (ackTimeout) / 1000);
-            ((GMSMembershipManager) mgr).suspectMember(targetMember,
+            ((GMSMembershipManager) mgr).suspectMember((InternalDistributedMember) targetMember,
                 "Unable to form a TCP/IP connection in a reasonable amount of time");
             suspected = true;
           }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/AbstractGMSAuthenticatorTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/AbstractGMSAuthenticatorTestCase.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.distributed.internal.membership.gms.auth;
+package org.apache.geode.distributed.internal.membership.adapter.auth;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -22,7 +22,6 @@ import java.util.Properties;
 
 import org.apache.shiro.subject.Subject;
 import org.junit.Before;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -57,7 +56,6 @@ public abstract class AbstractGMSAuthenticatorTestCase {
   @Mock
   private DistributionConfig distributionConfig;
 
-  @InjectMocks
   protected GMSAuthenticator authenticator;
 
 
@@ -68,6 +66,8 @@ public abstract class AbstractGMSAuthenticatorTestCase {
 
     this.props = new Properties();
     this.securityProps = new Properties();
+    this.authenticator = new GMSAuthenticator(securityProps, securityService, mock(LogWriter.class),
+        mock(LogWriter.class));
 
     when(this.securityService.isIntegratedSecurity()).thenReturn(isIntegratedSecurity());
     when(this.securityService.isPeerSecurityRequired()).thenReturn(true);
@@ -77,8 +77,6 @@ public abstract class AbstractGMSAuthenticatorTestCase {
     when(this.services.getSecurityLogWriter()).thenReturn(mock(InternalLogWriter.class));
     when(this.services.getConfig()).thenReturn(this.serviceConfig);
     when(this.services.getSecurityService()).thenReturn(this.securityService);
-
-    this.authenticator.init(this.services);
   }
 
   protected abstract boolean isIntegratedSecurity();

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/AbstractGMSAuthenticatorTestCase.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/AbstractGMSAuthenticatorTestCase.java
@@ -30,7 +30,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.gms.ServiceConfig;
 import org.apache.geode.distributed.internal.membership.gms.Services;
-import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.security.AuthInitialize;
 import org.apache.geode.security.AuthenticationFailedException;
@@ -74,9 +73,7 @@ public abstract class AbstractGMSAuthenticatorTestCase {
     when(this.securityService.login(this.securityProps)).thenReturn(this.subject);
     when(this.distributionConfig.getSecurityProps()).thenReturn(this.securityProps);
     when(this.serviceConfig.getDistributionConfig()).thenReturn(this.distributionConfig);
-    when(this.services.getSecurityLogWriter()).thenReturn(mock(InternalLogWriter.class));
     when(this.services.getConfig()).thenReturn(this.serviceConfig);
-    when(this.services.getSecurityService()).thenReturn(this.securityService);
   }
 
   protected abstract boolean isIntegratedSecurity();

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/GMSAuthenticatorWithAuthenticatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/GMSAuthenticatorWithAuthenticatorTest.java
@@ -12,66 +12,64 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.distributed.internal.membership.gms.auth;
+package org.apache.geode.distributed.internal.membership.adapter.auth;
 
-import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_PEER_AUTHENTICATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_PEER_AUTH_INIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.when;
 
 import java.util.Properties;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.security.GemFireSecurityException;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
 /**
- * Unit tests GMSAuthenticator using new integrated security.
+ * Unit tests GMSAuthenticator using old security.
  */
 @Category({SecurityTest.class})
-public class GMSAuthenticatorWithSecurityManagerTest extends AbstractGMSAuthenticatorTestCase {
+public class GMSAuthenticatorWithAuthenticatorTest extends AbstractGMSAuthenticatorTestCase {
 
   @Override
   protected boolean isIntegratedSecurity() {
-    return true;
+    return false;
   }
 
   @Test
-  public void nullManagerShouldReturnNull() throws Exception {
-    assertThat(this.securityProps).doesNotContainKey(SECURITY_MANAGER);
+  public void nullAuthenticatorShouldReturnNull() throws Exception {
+    assertThat(this.securityProps).doesNotContainKey(SECURITY_PEER_AUTHENTICATOR);
     String result =
         this.authenticator.authenticate(this.member, this.securityProps, this.securityProps);
-    assertThat(result).isNull();
+    // assertThat(result).isNull(); NOTE: old security used to return null
+    assertThat(result).contains("Security check failed");
   }
 
   @Test
   public void emptyAuthenticatorShouldReturnNull() throws Exception {
-    this.securityProps.setProperty(SECURITY_MANAGER, "");
+    this.securityProps.setProperty(SECURITY_PEER_AUTHENTICATOR, "");
     String result =
         this.authenticator.authenticate(this.member, this.securityProps, this.securityProps);
-    assertThat(result).isNull();
+    // assertThat(result).isNull(); NOTE: old security used to return null
+    assertThat(result).contains("Security check failed");
   }
 
   @Test
   public void shouldGetSecurityPropsFromDistributionConfig() throws Exception {
     this.securityProps.setProperty(SECURITY_PEER_AUTH_INIT, "dummy1");
-    this.securityProps.setProperty(SECURITY_MANAGER, "dummy2");
+    this.securityProps.setProperty(SECURITY_PEER_AUTHENTICATOR, "dummy2");
 
     Properties secProps = this.authenticator.getSecurityProps();
 
     assertThat(secProps.size()).isEqualTo(2);
     assertThat(secProps.getProperty(SECURITY_PEER_AUTH_INIT)).isEqualTo("dummy1");
-    assertThat(secProps.getProperty(SECURITY_MANAGER)).isEqualTo("dummy2");
+    assertThat(secProps.getProperty(SECURITY_PEER_AUTHENTICATOR)).isEqualTo("dummy2");
   }
 
   @Test
   public void usesPeerAuthInitToGetCredentials() throws Exception {
     this.props.setProperty(SECURITY_PEER_AUTH_INIT, SpyAuthInit.class.getName() + ".create");
-    this.props.setProperty(SECURITY_MANAGER, "dummy");
 
     SpyAuthInit auth = new SpyAuthInit();
     assertThat(auth.isClosed()).isFalse();
@@ -81,7 +79,7 @@ public class GMSAuthenticatorWithSecurityManagerTest extends AbstractGMSAuthenti
 
     assertThat(credentials).isEqualTo(this.props);
     assertThat(auth.isClosed()).isTrue();
-    assertThat(SpyAuthInit.getCreateCount() == 1).isTrue();
+    assertThat(SpyAuthInit.getCreateCount()).isEqualTo(1);
   }
 
   @Test
@@ -102,7 +100,7 @@ public class GMSAuthenticatorWithSecurityManagerTest extends AbstractGMSAuthenti
     String authInit = getClass().getName() + "$NotExistAuth.create";
     this.props.setProperty(SECURITY_PEER_AUTH_INIT, authInit);
     assertThatThrownBy(() -> this.authenticator.getCredentials(this.member, this.props))
-        .hasMessageContaining("Instance could not be obtained");
+        .hasMessageContaining("Instance could not be obtained from");
   }
 
   @Test
@@ -118,7 +116,7 @@ public class GMSAuthenticatorWithSecurityManagerTest extends AbstractGMSAuthenti
     this.props.setProperty(SECURITY_PEER_AUTH_INIT,
         AuthInitGetCredentialsAndInitThrow.class.getName() + ".create");
     assertThatThrownBy(() -> this.authenticator.getCredentials(this.member, this.props))
-        .hasMessage("expected init error");
+        .hasMessageContaining("expected init error");
   }
 
   @Test
@@ -126,36 +124,78 @@ public class GMSAuthenticatorWithSecurityManagerTest extends AbstractGMSAuthenti
     this.props.setProperty(SECURITY_PEER_AUTH_INIT,
         AuthInitGetCredentialsThrows.class.getName() + ".create");
     assertThatThrownBy(() -> this.authenticator.getCredentials(this.member, this.props))
-        .hasMessage("expected get credential error");
+        .hasMessageContaining("expected get credential error");
   }
 
   @Test
   public void authenticateShouldReturnNullIfSuccessful() throws Exception {
-    this.props.setProperty(SECURITY_MANAGER, "dummy");
+    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
+        SpyAuthenticator.class.getName() + ".create");
+
+    SpyAuthenticator auth = new SpyAuthenticator();
+    assertThat(auth.isClosed()).isFalse();
+
+    SpyAuthenticator.setAuthenticator(auth);
     String result = this.authenticator.authenticate(this.member, this.props, this.props);
+
     assertThat(result).isNull();
+    assertThat(auth.isClosed()).isTrue();
+    assertThat(SpyAuthenticator.getCreateCount() == 1).isTrue();
   }
 
   @Test
-  public void authenticateShouldReturnNullIfNoSecurityManager() throws Exception {
+  public void authenticateShouldReturnNullIfPeerAuthenticatorIsNull() throws Exception {
     String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    assertThat(result).isNull();
+    // assertThat(result).isNull(); // NOTE: old security used to return null
+    assertThat(result).contains("Security check failed. Instance could not be obtained from null");
   }
 
   @Test
-  public void authenticateShouldReturnFailureMessageIfLoginThrows() throws Exception {
-    when(this.securityService.login(any(Properties.class)))
-        .thenThrow(new GemFireSecurityException("dummy"));
-    this.props.setProperty(SECURITY_MANAGER, "dummy");
+  public void authenticateShouldReturnNullIfPeerAuthenticatorIsEmpty() throws Exception {
+    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR, "");
     String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    assertThat(result).startsWith("Security check failed. dummy");
+    // assertThat(result).isNull(); // NOTE: old security used to return null
+    assertThat(result).contains("Security check failed. Instance could not be obtained from");
+  }
+
+  @Test
+  public void authenticateShouldReturnFailureMessageIfPeerAuthenticatorDoesNotExist()
+      throws Exception {
+    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
+        getClass().getName() + "$NotExistAuth.create");
+    String result = this.authenticator.authenticate(this.member, this.props, this.props);
+    assertThat(result).startsWith("Security check failed. Instance could not be obtained from");
+  }
+
+  @Test
+  public void authenticateShouldReturnFailureMessageIfAuthenticateReturnsNull() throws Exception {
+    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
+        AuthenticatorReturnsNulls.class.getName() + ".create");
+    String result = this.authenticator.authenticate(this.member, this.props, this.props);
+    assertThat(result).startsWith("Security check failed. Instance could not be obtained");
   }
 
   @Test
   public void authenticateShouldReturnFailureMessageIfNullCredentials() throws Exception {
-    this.props.setProperty(SECURITY_MANAGER, "dummy");
+    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
+        AuthenticatorReturnsNulls.class.getName() + ".create");
     String result = this.authenticator.authenticate(this.member, null, this.props);
     assertThat(result).startsWith("Failed to find credentials from");
   }
 
+  @Test
+  public void authenticateShouldReturnFailureMessageIfAuthenticateInitThrows() throws Exception {
+    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
+        AuthenticatorInitThrows.class.getName() + ".create");
+    String result = this.authenticator.authenticate(this.member, this.props, this.props);
+    assertThat(result).startsWith("Security check failed. expected init error");
+  }
+
+  @Test
+  public void authenticateShouldReturnFailureMessageIfAuthenticateThrows() throws Exception {
+    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
+        AuthenticatorAuthenticateThrows.class.getName() + ".create");
+    String result = this.authenticator.authenticate(this.member, this.props, this.props);
+    assertThat(result).startsWith("Security check failed. expected authenticate error");
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/GMSAuthenticatorWithSecurityManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/adapter/auth/GMSAuthenticatorWithSecurityManagerTest.java
@@ -12,64 +12,66 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.distributed.internal.membership.gms.auth;
+package org.apache.geode.distributed.internal.membership.adapter.auth;
 
-import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_PEER_AUTHENTICATOR;
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_PEER_AUTH_INIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
 
 import java.util.Properties;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.security.GemFireSecurityException;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
 /**
- * Unit tests GMSAuthenticator using old security.
+ * Unit tests GMSAuthenticator using new integrated security.
  */
 @Category({SecurityTest.class})
-public class GMSAuthenticatorWithAuthenticatorTest extends AbstractGMSAuthenticatorTestCase {
+public class GMSAuthenticatorWithSecurityManagerTest extends AbstractGMSAuthenticatorTestCase {
 
   @Override
   protected boolean isIntegratedSecurity() {
-    return false;
+    return true;
   }
 
   @Test
-  public void nullAuthenticatorShouldReturnNull() throws Exception {
-    assertThat(this.securityProps).doesNotContainKey(SECURITY_PEER_AUTHENTICATOR);
+  public void nullManagerShouldReturnNull() throws Exception {
+    assertThat(this.securityProps).doesNotContainKey(SECURITY_MANAGER);
     String result =
         this.authenticator.authenticate(this.member, this.securityProps, this.securityProps);
-    // assertThat(result).isNull(); NOTE: old security used to return null
-    assertThat(result).contains("Security check failed");
+    assertThat(result).isNull();
   }
 
   @Test
   public void emptyAuthenticatorShouldReturnNull() throws Exception {
-    this.securityProps.setProperty(SECURITY_PEER_AUTHENTICATOR, "");
+    this.securityProps.setProperty(SECURITY_MANAGER, "");
     String result =
         this.authenticator.authenticate(this.member, this.securityProps, this.securityProps);
-    // assertThat(result).isNull(); NOTE: old security used to return null
-    assertThat(result).contains("Security check failed");
+    assertThat(result).isNull();
   }
 
   @Test
   public void shouldGetSecurityPropsFromDistributionConfig() throws Exception {
     this.securityProps.setProperty(SECURITY_PEER_AUTH_INIT, "dummy1");
-    this.securityProps.setProperty(SECURITY_PEER_AUTHENTICATOR, "dummy2");
+    this.securityProps.setProperty(SECURITY_MANAGER, "dummy2");
 
     Properties secProps = this.authenticator.getSecurityProps();
 
     assertThat(secProps.size()).isEqualTo(2);
     assertThat(secProps.getProperty(SECURITY_PEER_AUTH_INIT)).isEqualTo("dummy1");
-    assertThat(secProps.getProperty(SECURITY_PEER_AUTHENTICATOR)).isEqualTo("dummy2");
+    assertThat(secProps.getProperty(SECURITY_MANAGER)).isEqualTo("dummy2");
   }
 
   @Test
   public void usesPeerAuthInitToGetCredentials() throws Exception {
     this.props.setProperty(SECURITY_PEER_AUTH_INIT, SpyAuthInit.class.getName() + ".create");
+    this.props.setProperty(SECURITY_MANAGER, "dummy");
 
     SpyAuthInit auth = new SpyAuthInit();
     assertThat(auth.isClosed()).isFalse();
@@ -79,7 +81,7 @@ public class GMSAuthenticatorWithAuthenticatorTest extends AbstractGMSAuthentica
 
     assertThat(credentials).isEqualTo(this.props);
     assertThat(auth.isClosed()).isTrue();
-    assertThat(SpyAuthInit.getCreateCount()).isEqualTo(1);
+    assertThat(SpyAuthInit.getCreateCount() == 1).isTrue();
   }
 
   @Test
@@ -100,7 +102,7 @@ public class GMSAuthenticatorWithAuthenticatorTest extends AbstractGMSAuthentica
     String authInit = getClass().getName() + "$NotExistAuth.create";
     this.props.setProperty(SECURITY_PEER_AUTH_INIT, authInit);
     assertThatThrownBy(() -> this.authenticator.getCredentials(this.member, this.props))
-        .hasMessageContaining("Instance could not be obtained from");
+        .hasMessageContaining("Instance could not be obtained");
   }
 
   @Test
@@ -116,7 +118,7 @@ public class GMSAuthenticatorWithAuthenticatorTest extends AbstractGMSAuthentica
     this.props.setProperty(SECURITY_PEER_AUTH_INIT,
         AuthInitGetCredentialsAndInitThrow.class.getName() + ".create");
     assertThatThrownBy(() -> this.authenticator.getCredentials(this.member, this.props))
-        .hasMessageContaining("expected init error");
+        .hasMessage("expected init error");
   }
 
   @Test
@@ -124,78 +126,36 @@ public class GMSAuthenticatorWithAuthenticatorTest extends AbstractGMSAuthentica
     this.props.setProperty(SECURITY_PEER_AUTH_INIT,
         AuthInitGetCredentialsThrows.class.getName() + ".create");
     assertThatThrownBy(() -> this.authenticator.getCredentials(this.member, this.props))
-        .hasMessageContaining("expected get credential error");
+        .hasMessage("expected get credential error");
   }
 
   @Test
   public void authenticateShouldReturnNullIfSuccessful() throws Exception {
-    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
-        SpyAuthenticator.class.getName() + ".create");
-
-    SpyAuthenticator auth = new SpyAuthenticator();
-    assertThat(auth.isClosed()).isFalse();
-
-    SpyAuthenticator.setAuthenticator(auth);
+    this.props.setProperty(SECURITY_MANAGER, "dummy");
     String result = this.authenticator.authenticate(this.member, this.props, this.props);
-
     assertThat(result).isNull();
-    assertThat(auth.isClosed()).isTrue();
-    assertThat(SpyAuthenticator.getCreateCount() == 1).isTrue();
   }
 
   @Test
-  public void authenticateShouldReturnNullIfPeerAuthenticatorIsNull() throws Exception {
+  public void authenticateShouldReturnNullIfNoSecurityManager() throws Exception {
     String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    // assertThat(result).isNull(); // NOTE: old security used to return null
-    assertThat(result).contains("Security check failed. Instance could not be obtained from null");
+    assertThat(result).isNull();
   }
 
   @Test
-  public void authenticateShouldReturnNullIfPeerAuthenticatorIsEmpty() throws Exception {
-    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR, "");
+  public void authenticateShouldReturnFailureMessageIfLoginThrows() throws Exception {
+    when(this.securityService.login(any(Properties.class)))
+        .thenThrow(new GemFireSecurityException("dummy"));
+    this.props.setProperty(SECURITY_MANAGER, "dummy");
     String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    // assertThat(result).isNull(); // NOTE: old security used to return null
-    assertThat(result).contains("Security check failed. Instance could not be obtained from");
-  }
-
-  @Test
-  public void authenticateShouldReturnFailureMessageIfPeerAuthenticatorDoesNotExist()
-      throws Exception {
-    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
-        getClass().getName() + "$NotExistAuth.create");
-    String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    assertThat(result).startsWith("Security check failed. Instance could not be obtained from");
-  }
-
-  @Test
-  public void authenticateShouldReturnFailureMessageIfAuthenticateReturnsNull() throws Exception {
-    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
-        AuthenticatorReturnsNulls.class.getName() + ".create");
-    String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    assertThat(result).startsWith("Security check failed. Instance could not be obtained");
+    assertThat(result).startsWith("Security check failed. dummy");
   }
 
   @Test
   public void authenticateShouldReturnFailureMessageIfNullCredentials() throws Exception {
-    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
-        AuthenticatorReturnsNulls.class.getName() + ".create");
+    this.props.setProperty(SECURITY_MANAGER, "dummy");
     String result = this.authenticator.authenticate(this.member, null, this.props);
     assertThat(result).startsWith("Failed to find credentials from");
   }
 
-  @Test
-  public void authenticateShouldReturnFailureMessageIfAuthenticateInitThrows() throws Exception {
-    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
-        AuthenticatorInitThrows.class.getName() + ".create");
-    String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    assertThat(result).startsWith("Security check failed. expected init error");
-  }
-
-  @Test
-  public void authenticateShouldReturnFailureMessageIfAuthenticateThrows() throws Exception {
-    this.props.setProperty(SECURITY_PEER_AUTHENTICATOR,
-        AuthenticatorAuthenticateThrows.class.getName() + ".create");
-    String result = this.authenticator.authenticate(this.member, this.props, this.props);
-    assertThat(result).startsWith("Security check failed. expected authenticate error");
-  }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipManagerHelper.java
+++ b/geode-dunit/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipManagerHelper.java
@@ -24,6 +24,7 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.MembershipManager;
+import org.apache.geode.distributed.internal.membership.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Manager;
 import org.apache.geode.distributed.internal.membership.gms.mgr.GMSMembershipManager;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
@@ -77,14 +78,12 @@ public class MembershipManagerHelper {
   }
 
   /** register a test hook with the manager */
-  public static void addTestHook(DistributedSystem sys,
-      org.apache.geode.distributed.internal.membership.MembershipTestHook hook) {
+  public static void addTestHook(DistributedSystem sys, MembershipTestHook hook) {
     getMembershipManager(sys).registerTestHook(hook);
   }
 
   /** remove a registered test hook */
-  public static void removeTestHook(DistributedSystem sys,
-      org.apache.geode.distributed.internal.membership.MembershipTestHook hook) {
+  public static void removeTestHook(DistributedSystem sys, MembershipTestHook hook) {
     getMembershipManager(sys).unregisterTestHook(hook);
   }
 


### PR DESCRIPTION
* Removing some direct dependencies on classes outside of membership.
* Replaced the pattern having each Service implement MessageHandler and
  have a single processMessage method with a switch statement. Instead
  we install individual MessageHandlers for each message.
* Removed GMSAuthenticator from Services. Instead we inject the
  Authenticator when we create a MembershipManager.

Key-Gripped-By: Bill Burcham <bburcham@pivotal.io>
Co-Authored-By: Bill Burcham <bburcham@pivotal.io>
Co-Authored-By: Ernest Burghardt <eburghardt@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
