### PR TITLE
GEODE-6863: Ignoring IllegalStateException

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
@@ -95,6 +95,9 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
 
   private final SecurityService securityService;
 
+  public static final String CACHE_SERVER_BIND_ADDRESS_NOT_AVAILABLE_EXCEPTION_MESSAGE =
+      "A cache server's bind address is only available if it has been started";
+
   private final AcceptorBuilder acceptorBuilder;
 
   private final boolean sendResourceEvents;
@@ -430,9 +433,8 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   public String getExternalAddress(boolean checkServerRunning) {
     if (checkServerRunning) {
       if (!this.isRunning()) {
-        String s = "A cache server's bind address is only available if it has been started";
         this.cache.getCancelCriterion().checkCancelInProgress(null);
-        throw new IllegalStateException(s);
+        throw new IllegalStateException(CACHE_SERVER_BIND_ADDRESS_NOT_AVAILABLE_EXCEPTION_MESSAGE);
       }
     }
     if (this.hostnameForClients == null || this.hostnameForClients.isEmpty()) {


### PR DESCRIPTION
	* Ignoring IllegalStateException if the server is no more running.
	* If the server is not running then getting external address will result in IllegalStateException.
	* The server may shut down in between isRunning and getExternalAddress calls.
	* If this happens then the server is not added to the location list of the servers hosting bucket.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
