### PR TITLE
GEODE-6887: Add LegacyStatCounter and LegacyStatTimer

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
-import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Counter;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -272,9 +272,9 @@ public class GatewayReceiverMetricsTest {
 
     @Override
     public void execute(FunctionContext<Void> context) {
-      FunctionCounter eventsReceivedCounter = SimpleMetricsPublishingService.getRegistry()
+      Counter eventsReceivedCounter = SimpleMetricsPublishingService.getRegistry()
           .find("cache.gatewayreceiver.events.received")
-          .functionCounter();
+          .counter();
 
       Object result = eventsReceivedCounter == null
           ? "Meter not found."

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
@@ -14,13 +14,14 @@
  */
 package org.apache.geode.internal.cache.wan;
 
-import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.distributed.internal.DistributionStats;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
+import org.apache.geode.internal.statistics.meters.LegacyStatCounter;
 
 public class GatewayReceiverStats extends CacheServerStats {
 
@@ -104,7 +105,7 @@ public class GatewayReceiverStats extends CacheServerStats {
    * Id of the events distributed statistic
    */
   private int eventsReceivedId;
-  private final FunctionCounter eventsReceivedCounter;
+  private final Counter eventsReceivedCounter;
   private static final String EVENTS_RECEIVED_COUNTER_NAME =
       "cache.gatewayreceiver.events.received";
   private static final String EVENTS_RECEIVED_COUNTER_DESCRIPTION =
@@ -189,8 +190,8 @@ public class GatewayReceiverStats extends CacheServerStats {
     eventsRetriedId = statType.nameToId(EVENTS_RETRIED);
 
     this.meterRegistry = meterRegistry;
-    eventsReceivedCounter = FunctionCounter.builder(EVENTS_RECEIVED_COUNTER_NAME, stats,
-        s -> s.getInt(eventsReceivedId))
+    eventsReceivedCounter = LegacyStatCounter.builder(EVENTS_RECEIVED_COUNTER_NAME)
+        .intStatistic(stats, eventsReceivedId)
         .description(EVENTS_RECEIVED_COUNTER_DESCRIPTION)
         .baseUnit(EVENTS_RECEIVED_COUNTER_UNITS)
         .register(meterRegistry);
@@ -246,11 +247,11 @@ public class GatewayReceiverStats extends CacheServerStats {
    * Increments the number of events received by 1.
    */
   public void incEventsReceived(int delta) {
-    this.stats.incInt(eventsReceivedId, delta);
+    eventsReceivedCounter.increment(delta);
   }
 
   public int getEventsReceived() {
-    return this.stats.getInt(eventsReceivedId);
+    return (int) eventsReceivedCounter.count();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/DoubleStatisticBinding.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/DoubleStatisticBinding.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import org.apache.geode.Statistics;
+
+/**
+ * Increments and reads a {@code double} stat.
+ */
+public class DoubleStatisticBinding implements StatisticBinding {
+  private final Statistics statistics;
+  private final int statId;
+
+  public DoubleStatisticBinding(Statistics statistics, int statId) {
+    this.statistics = statistics;
+    this.statId = statId;
+  }
+
+  @Override
+  public void add(double amount) {
+    statistics.incDouble(statId, amount);
+  }
+
+  @Override
+  public double doubleValue() {
+    return statistics.getDouble(statId);
+  }
+
+  @Override
+  public long longValue() {
+    return (long) statistics.getDouble(statId);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/IntStatisticBinding.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/IntStatisticBinding.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import org.apache.geode.Statistics;
+
+/**
+ * Increments and reads an {@code int} stat.
+ */
+public class IntStatisticBinding implements StatisticBinding {
+  private final Statistics statistics;
+  private final int statId;
+
+  public IntStatisticBinding(Statistics statistics, int statId) {
+    this.statistics = statistics;
+    this.statId = statId;
+  }
+
+  @Override
+  public void add(double amount) {
+    statistics.incInt(statId, (int) amount);
+  }
+
+  @Override
+  public double doubleValue() {
+    return (double) statistics.getInt(statId);
+  }
+
+  @Override
+  public long longValue() {
+    return 0;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/LegacyStatCounter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/LegacyStatCounter.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+import org.apache.geode.Statistics;
+
+/**
+ * Wraps a {@code Counter} to increment and read an associated stat as well as incrementing the
+ * counter.
+ */
+public class LegacyStatCounter implements Counter {
+  private final Counter underlyingCounter;
+  private final StatisticBinding statisticBinding;
+
+  /**
+   * Creates a {@code LegacyStatCounter} that wraps the given counter to add the ability
+   * to increment and read an associated stat.
+   *
+   * @param underlyingCounter the counter to wrap
+   * @param statisticBinding associates the {@code LegacyStatCounter} with a stat
+   */
+  private LegacyStatCounter(Counter underlyingCounter,
+      StatisticBinding statisticBinding) {
+    this.underlyingCounter = underlyingCounter;
+    this.statisticBinding = statisticBinding;
+  }
+
+  /**
+   * Increments both the underlying counter and the associated stat by the given amount.
+   */
+  @Override
+  public void increment(double amount) {
+    underlyingCounter.increment(amount);
+    statisticBinding.add(amount);
+  }
+
+  /**
+   * Returns the value of the associated stat.
+   */
+  @Override
+  public double count() {
+    return statisticBinding.doubleValue();
+  }
+
+  /**
+   * Returns the ID of the underlying counter.
+   */
+  @Override
+  public Id getId() {
+    return underlyingCounter.getId();
+  }
+
+  /**
+   * Returns a builder that can associate a stat with the eventual {@code LegacyStatCounter}. To
+   * associate the counter with a stat, call one of
+   * {@link Builder#doubleStatistic(Statistics, int)} or
+   * {@link Builder#longStatistic(Statistics, int)}.
+   */
+  public static Builder builder(String name) {
+    return new Builder(name);
+  }
+
+  public static class Builder {
+    private final Counter.Builder builder;
+    private StatisticBinding statisticBinding = StatisticBinding.noOp();
+
+    private Builder(String name) {
+      builder = Counter.builder(name);
+    }
+
+    /**
+     * Prepares to associate the eventual {@code LegacyStatCounter} with the specified {@code
+     * double} stat. The given {@code Statistics} and {@code statId} must identify a {@code
+     * double} stat.
+     */
+    public Builder doubleStatistic(Statistics statistics, int statId) {
+      statisticBinding = new DoubleStatisticBinding(statistics, statId);
+      return this;
+    }
+
+    /**
+     * Prepares to associate the eventual {@code LegacyStatCounter} with the specified {@code
+     * int} stat. The given {@code Statistics} and {@code statId} must identify an {@code int}
+     * stat.
+     */
+    public Builder intStatistic(Statistics statistics, int statId) {
+      statisticBinding = new IntStatisticBinding(statistics, statId);
+      return this;
+    }
+
+    /**
+     * Prepares to associate the eventual {@code LegacyStatCounter} with the specified {@code
+     * long} stat. The given {@code Statistics} and {@code statId} must identify a {@code long}
+     * stat.
+     */
+    public Builder longStatistic(Statistics statistics, int statId) {
+      statisticBinding = new LongStatisticBinding(statistics, statId);
+      return this;
+    }
+
+    public Builder baseUnit(String unit) {
+      builder.baseUnit(unit);
+      return this;
+    }
+
+    public Builder description(String description) {
+      builder.description(description);
+      return this;
+    }
+
+    public Builder tag(String name, String value) {
+      builder.tag(name, value);
+      return this;
+    }
+
+    public Builder tags(String... tags) {
+      builder.tags(tags);
+      return this;
+    }
+
+    public Builder tags(Iterable<Tag> tags) {
+      builder.tags(tags);
+      return this;
+    }
+
+    /**
+     * Registers a {@code Counter} with the given registry, and returns a {@code LegacyStatCounter}
+     * that wraps the counter to increment and read the associated stat. Note that the returned
+     * {@code LegacyStatCounter} is not registered with the registry, but it has the same ID, so
+     * it can be used to remove the registered counter from the registry.
+     */
+    public LegacyStatCounter register(MeterRegistry registry) {
+      Counter underlyingCounter = builder.register(registry);
+      return new LegacyStatCounter(underlyingCounter, statisticBinding);
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/LegacyStatTimer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/LegacyStatTimer.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+
+import org.apache.geode.Statistics;
+
+/**
+ * Wraps a {@code Timer} to increment and read associated stats as well as updating the
+ * timer.
+ */
+public class LegacyStatTimer implements Timer {
+  private final Clock clock;
+  private final Timer underlyingTimer;
+  private final StatisticBinding countStatisticBinding;
+  private final StatisticBinding timeStatisticBinding;
+
+  /**
+   * Creates a {@code LegacyStatTimer} that wraps the given timer to add the ability
+   * to increment and read associated stats.
+   *
+   * @param clock the clock to use to determine the current time
+   * @param underlyingTimer the timer to wrap
+   * @param countStatisticBinding associates the timer's count with a stat
+   * @param timeStatisticBinding associates the timer's total time with a stat
+   */
+  private LegacyStatTimer(Clock clock, Timer underlyingTimer,
+      StatisticBinding countStatisticBinding,
+      StatisticBinding timeStatisticBinding) {
+    this.clock = clock;
+    this.underlyingTimer = underlyingTimer;
+    this.countStatisticBinding = countStatisticBinding;
+    this.timeStatisticBinding = timeStatisticBinding;
+  }
+
+  /**
+   * Returns the ID of the underlying timer.
+   */
+  @Override
+  public Id getId() {
+    return underlyingTimer.getId();
+  }
+
+  /**
+   * Returns the base time unit of the underlying timer.
+   */
+  @Override
+  public TimeUnit baseTimeUnit() {
+    return underlyingTimer.baseTimeUnit();
+  }
+
+  /**
+   * Records the event to both the underlying timer and the associated stats.
+   */
+  @Override
+  public void record(long amount, TimeUnit unit) {
+    underlyingTimer.record(amount, unit);
+    countStatisticBinding.add(1);
+    timeStatisticBinding.add(NANOSECONDS.convert(amount, unit));
+  }
+
+  /**
+   * Executes the given supplier, records its duration, and returns the supplied value.
+   */
+  @Override
+  public <T> T record(Supplier<T> supplier) {
+    final long s = clock.monotonicTime();
+    try {
+      return supplier.get();
+    } finally {
+      final long e = clock.monotonicTime();
+      record(e - s, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  /**
+   * Executes the given callable, records its duration, and returns the supplied value.
+   */
+  @Override
+  public <T> T recordCallable(Callable<T> callable) throws Exception {
+    final long s = clock.monotonicTime();
+    try {
+      return callable.call();
+    } finally {
+      final long e = clock.monotonicTime();
+      record(e - s, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  /**
+   * Executes the given runnable and records its duration.
+   */
+  @Override
+  public void record(Runnable runnable) {
+    final long s = clock.monotonicTime();
+    try {
+      runnable.run();
+    } finally {
+      final long e = clock.monotonicTime();
+      record(e - s, TimeUnit.NANOSECONDS);
+    }
+  }
+
+  /**
+   * Returns the value of the associated count stat.
+   */
+  @Override
+  public long count() {
+    return countStatisticBinding.longValue();
+  }
+
+  /**
+   * Returns the value of the associated time stat, converted to the given time unit.
+   */
+  @Override
+  public double totalTime(TimeUnit unit) {
+    return unit.convert(timeStatisticBinding.longValue(), NANOSECONDS);
+  }
+
+  /**
+   * This method is not supported in this implementation.
+   */
+  @Override
+  public double max(TimeUnit unit) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * This method is not supported in this implementation.
+   */
+  @Override
+  public HistogramSnapshot takeSnapshot() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns a builder that can associate a pair of stats with the eventual {@code
+   * LegacyStatTimer}. To associate the timer's count with a stat, call one of
+   * {@link Builder#doubleCountStatistic(Statistics, int)} or
+   * {@link Builder#longCountStatistic(Statistics, int)}. To associate the
+   * timer's total time with a stat, call one of
+   * {@link Builder#doubleTimeStatistic(Statistics, int)} or
+   * {@link Builder#longTimeStatistic(Statistics, int)}.
+   */
+  public static Builder builder(String name) {
+    return new Builder(name);
+  }
+
+  public static class Builder {
+    private final Timer.Builder builder;
+    private StatisticBinding countStatisticBinding = StatisticBinding.noOp();
+    private StatisticBinding timeStatisticBinding = StatisticBinding.noOp();
+
+    private Builder(String name) {
+      builder = Timer.builder(name);
+    }
+
+    public Builder description(String description) {
+      builder.description((description));
+      return this;
+    }
+
+    /**
+     * Prepares to associate the eventual {@code LegacyStatTimer}'s count with the specified
+     * {@code double} stat. The given {@code Statistics} and {@code statId} must identify a
+     * {@code double} stat.
+     */
+    public Builder doubleCountStatistic(Statistics statistics, int statId) {
+      countStatisticBinding = new DoubleStatisticBinding(statistics, statId);
+      return this;
+    }
+
+    /**
+     * Prepares to associate the eventual {@code LegacyStatTimer}'s count with the specified
+     * {@code long} stat. The given {@code Statistics} and {@code statId} must identify a {@code
+     * long} stat.
+     */
+    public Builder longCountStatistic(Statistics statistics, int statId) {
+      countStatisticBinding = new LongStatisticBinding(statistics, statId);
+      return this;
+    }
+
+    /**
+     * Prepares to associate the eventual {@code LegacyStatTimer}'s total time with the specified
+     * {@code double} stat. The given {@code Statistics} and {@code statId} must identify a
+     * {@code double} stat.
+     */
+    public Builder doubleTimeStatistic(Statistics statistics, int statId) {
+      timeStatisticBinding = new DoubleStatisticBinding(statistics, statId);
+      return this;
+    }
+
+    /**
+     * Prepares to associate the eventual {@code LegacyStatTimer}'s total time with the specified
+     * {@code long} stat. The given {@code Statistics} and {@code statId} must identify a {@code
+     * long} stat.
+     */
+    public Builder longTimeStatistic(Statistics statistics, int statId) {
+      timeStatisticBinding = new LongStatisticBinding(statistics, statId);
+      return this;
+    }
+
+    public Builder tags(Iterable<Tag> tags) {
+      builder.tags(tags);
+      return this;
+    }
+
+    public Builder tag(String name, String value) {
+      builder.tag(name, value);
+      return this;
+    }
+
+    public Builder tags(String... tags) {
+      builder.tags(tags);
+      return this;
+    }
+
+    /**
+     * Registers a {@code Timer} with the given registry, and returns a {@code LegacyStatTimer}
+     * that wraps the timer to update and read the associated stats. Note that the returned
+     * {@code LegacyStatTimer} is not registered with the registry, but it has the same ID, so
+     * it can be used to remove the registered timer from the registry.
+     */
+    public Timer register(MeterRegistry registry) {
+      Clock clock = registry.config().clock();
+      Timer underlyingTimer = builder.register(registry);
+      return new LegacyStatTimer(clock, underlyingTimer, countStatisticBinding,
+          timeStatisticBinding);
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/LongStatisticBinding.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/LongStatisticBinding.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import org.apache.geode.Statistics;
+
+/**
+ * Increments and reads a {@code long} stat.
+ */
+public class LongStatisticBinding implements StatisticBinding {
+  private final Statistics statistics;
+  private final int statId;
+
+  public LongStatisticBinding(Statistics statistics, int statId) {
+    this.statistics = statistics;
+    this.statId = statId;
+  }
+
+  @Override
+  public void add(double amount) {
+    statistics.incLong(statId, (long) amount);
+  }
+
+  @Override
+  public double doubleValue() {
+    return (double) statistics.getLong(statId);
+  }
+
+  @Override
+  public long longValue() {
+    return statistics.getLong(statId);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/StatisticBinding.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/StatisticBinding.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+/**
+ * Reads and writes a stat.
+ */
+public interface StatisticBinding {
+  /**
+   * Adds the specified amount to the stat.
+   */
+  void add(double amount);
+
+  /**
+   * Returns the value of the stat as a {@code double}.
+   */
+  double doubleValue();
+
+  /**
+   * Returns the value of the stat as a {@code long}.
+   */
+  long longValue();
+
+  static StatisticBinding noOp() {
+    return new StatisticBinding() {
+      @Override
+      public void add(double amount) {}
+
+      @Override
+      public double doubleValue() {
+        return 0.0;
+      }
+
+      @Override
+      public long longValue() {
+        return 0L;
+      }
+    };
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/package-info.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/meters/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * Meters that wrap standard Micrometer meters with the ability to increment and read associated
+ * statistics.
+ */
+package org.apache.geode.internal.statistics.meters;

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/DoubleStatisticBindingTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/DoubleStatisticBindingTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+
+public class DoubleStatisticBindingTest {
+  private Statistics statistics = mock(Statistics.class);
+
+  @Test
+  public void add_addsAmountToStat() {
+    int statId = 27;
+    StatisticBinding binding = new DoubleStatisticBinding(statistics, statId);
+
+    binding.add(1234.8);
+
+    verify(statistics).incDouble(statId, 1234.8);
+  }
+
+  @Test
+  public void doubleValue_returnsDoubleStatValue() {
+    int statId = 27;
+    StatisticBinding binding = new DoubleStatisticBinding(statistics, statId);
+
+    when(statistics.getDouble(statId)).thenReturn(2341.9);
+
+    assertThat(binding.doubleValue())
+        .isEqualTo(2341.9);
+  }
+
+  @Test
+  public void longValue_returnsDoubleStatValueAsLong() {
+    int statId = 27;
+    StatisticBinding binding = new DoubleStatisticBinding(statistics, statId);
+
+    when(statistics.getDouble(statId)).thenReturn(2341.0);
+
+    assertThat(binding.longValue())
+        .isEqualTo(2341L);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/IntStatisticBindingTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/IntStatisticBindingTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+
+public class IntStatisticBindingTest {
+  private Statistics statistics = mock(Statistics.class);
+
+  @Test
+  public void add_incrementsTheStat() {
+    int statId = 27;
+    StatisticBinding binding = new IntStatisticBinding(statistics, statId);
+
+    binding.add(1234.0);
+
+    verify(statistics).incInt(statId, 1234);
+  }
+
+  @Test
+  public void doubleValue_returnsTheStatValue() {
+    int statId = 27;
+    StatisticBinding binding = new IntStatisticBinding(statistics, statId);
+
+    when(statistics.getInt(statId)).thenReturn(2341);
+
+    assertThat(binding.doubleValue())
+        .isEqualTo(2341.0);
+  }
+
+  @Test
+  public void longValue_returnsLongStatValue() {
+    int statId = 27;
+    StatisticBinding binding = new LongStatisticBinding(statistics, statId);
+
+    when(statistics.getLong(statId)).thenReturn(2341L);
+
+    assertThat(binding.longValue())
+        .isEqualTo(2341L);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/LegacyStatCounterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/LegacyStatCounterTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+
+public class LegacyStatCounterTest {
+  private final MeterRegistry registry = new SimpleMeterRegistry();
+
+  @Test
+  public void builder_registersACounterWithTheBuiltId() {
+    List<Tag> tagsFromList = new ArrayList<>();
+    tagsFromList.add(Tag.of("tag.one", "tag.one.value"));
+    tagsFromList.add(Tag.of("tag.two", "tag.two.value"));
+
+    LegacyStatCounter.builder("my.meter.name")
+        .tags(tagsFromList)
+        .tag("tag.three", "tag.three.value")
+        .tag("tag.four", "tag.four.value")
+        .tags("tag.five", "tag.five.value", "tag.six", "tag.six.value")
+        .description("my meter description")
+        .baseUnit("my meter base unit")
+        .register(registry);
+
+    Counter underlyingCounter = registry.find("my.meter.name").counter();
+
+    assertThat(underlyingCounter)
+        .as("underlying counter")
+        .isNotNull();
+
+    Meter.Id underlyingCounterId = underlyingCounter.getId();
+
+    assertThat(underlyingCounterId)
+        .as("underlying counter ID")
+        .isNotNull();
+
+    assertThat(underlyingCounterId.getName())
+        .as("underlying counter name")
+        .isEqualTo("my.meter.name");
+
+    assertThat(underlyingCounterId.getTags())
+        .as("underlying counter tags")
+        .containsOnly(
+            Tag.of("tag.one", "tag.one.value"),
+            Tag.of("tag.two", "tag.two.value"),
+            Tag.of("tag.three", "tag.three.value"),
+            Tag.of("tag.four", "tag.four.value"),
+            Tag.of("tag.five", "tag.five.value"),
+            Tag.of("tag.six", "tag.six.value"));
+
+    assertThat(underlyingCounterId.getDescription())
+        .as("underlying counter description")
+        .isEqualTo("my meter description");
+
+    assertThat(underlyingCounterId.getBaseUnit())
+        .as("underlying counter base unit")
+        .isEqualTo("my meter base unit");
+  }
+
+  @Test
+  public void hasSameIdAsUnderlyingCounter() {
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .register(registry);
+
+    Counter underlyingCounter = registry.find("my.meter.name").counter();
+
+    assertThat(legacyStatCounter.getId())
+        .isSameAs(underlyingCounter.getId());
+  }
+
+  @Test
+  public void increment_incrementsUnderlyingCounter() {
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .register(registry);
+
+    Counter underlyingCounter = registry.find("my.meter.name").counter();
+
+    legacyStatCounter.increment(22.9);
+
+    assertThat(underlyingCounter.count())
+        .isEqualTo(22.9);
+  }
+
+  @Test
+  public void withDoubleStat_increment_incrementsDoubleStat() {
+    Statistics statistics = mock(Statistics.class);
+    int statId = 93;
+
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .doubleStatistic(statistics, statId)
+        .register(registry);
+
+    legacyStatCounter.increment(8493.2);
+
+    verify(statistics).incDouble(statId, 8493.2);
+  }
+
+  @Test
+  public void withDoubleStat_count_readsFromDoubleStat() {
+    Statistics statistics = mock(Statistics.class);
+    int statId = 93;
+
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .doubleStatistic(statistics, statId)
+        .register(registry);
+
+    when(statistics.getDouble(statId)).thenReturn(934.7);
+
+    assertThat(legacyStatCounter.count())
+        .isEqualTo(934.7);
+  }
+
+  @Test
+  public void withIntStat_increment_incrementsIntStat() {
+    Statistics statistics = mock(Statistics.class);
+    int statId = 93;
+
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .intStatistic(statistics, statId)
+        .register(registry);
+
+    legacyStatCounter.increment(8493.0);
+
+    verify(statistics).incInt(statId, 8493);
+  }
+
+  @Test
+  public void withIntStat_count_readsFromLongStat() {
+    Statistics statistics = mock(Statistics.class);
+    int statId = 93;
+
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .intStatistic(statistics, statId)
+        .register(registry);
+
+    when(statistics.getInt(statId)).thenReturn(47282903);
+
+    assertThat(legacyStatCounter.count())
+        .isEqualTo(47282903.0);
+  }
+
+  @Test
+  public void withLongStat_increment_incrementsLongStat() {
+    Statistics statistics = mock(Statistics.class);
+    int statId = 93;
+
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .longStatistic(statistics, statId)
+        .register(registry);
+
+    legacyStatCounter.increment(8493.0);
+
+    verify(statistics).incLong(statId, 8493);
+  }
+
+  @Test
+  public void withLongStat_count_readsFromLongStat() {
+    Statistics statistics = mock(Statistics.class);
+    int statId = 93;
+
+    Counter legacyStatCounter = LegacyStatCounter.builder("my.meter.name")
+        .longStatistic(statistics, statId)
+        .register(registry);
+
+    when(statistics.getLong(statId)).thenReturn(472829034L);
+
+    assertThat(legacyStatCounter.count())
+        .isEqualTo(472829034.0);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/LegacyStatTimerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/LegacyStatTimerTest.java
@@ -1,0 +1,537 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+
+public class LegacyStatTimerTest {
+  private final MockClock clock = new MockClock();
+  private final MeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+
+  @Test
+  public void builder_registersATimerWithTheBuiltId() {
+    List<Tag> tagsFromList = new ArrayList<>();
+    tagsFromList.add(Tag.of("tag.one", "tag.one.value"));
+    tagsFromList.add(Tag.of("tag.two", "tag.two.value"));
+
+    LegacyStatTimer.builder("my.meter.name")
+        .tags(tagsFromList)
+        .tag("tag.three", "tag.three.value")
+        .tag("tag.four", "tag.four.value")
+        .tags("tag.five", "tag.five.value", "tag.six", "tag.six.value")
+        .description("my meter description")
+        .register(registry);
+
+    Timer underlyingTimer = registry.find("my.meter.name").timer();
+
+    assertThat(underlyingTimer)
+        .as("underlying timer")
+        .isNotNull();
+
+    Meter.Id underlyingTimerId = underlyingTimer.getId();
+
+    assertThat(underlyingTimerId)
+        .as("underlying timer ID")
+        .isNotNull();
+
+    assertThat(underlyingTimerId.getName())
+        .as("underlying timer name")
+        .isEqualTo("my.meter.name");
+
+    assertThat(underlyingTimerId.getTags())
+        .as("underlying timer tags")
+        .containsOnly(
+            Tag.of("tag.one", "tag.one.value"),
+            Tag.of("tag.two", "tag.two.value"),
+            Tag.of("tag.three", "tag.three.value"),
+            Tag.of("tag.four", "tag.four.value"),
+            Tag.of("tag.five", "tag.five.value"),
+            Tag.of("tag.six", "tag.six.value"));
+
+    assertThat(underlyingTimerId.getDescription())
+        .as("underlying timer description")
+        .isEqualTo("my meter description");
+  }
+
+  @Test
+  public void hasSameIdAsUnderlyingTimer() {
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .register(registry);
+
+    Timer underlyingTimer = registry.find("my.meter.name").timer();
+
+    assertThat(legacyStatTimer.getId())
+        .isSameAs(underlyingTimer.getId());
+  }
+
+  @Test
+  public void hasSameBaseTimeUnitAsUnderlyingTimer() {
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .register(registry);
+
+    Timer underlyingTimer = registry.find("my.meter.name").timer();
+
+    assertThat(legacyStatTimer.baseTimeUnit())
+        .isEqualTo(underlyingTimer.baseTimeUnit());
+  }
+
+  @Test
+  public void recordDuration_recordsToUnderlyingTimer() {
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .register(registry);
+
+    Timer underlyingTimer = registry.find("my.meter.name").timer();
+
+    legacyStatTimer.record(17, SECONDS);
+    legacyStatTimer.record(5, SECONDS);
+
+    assertThat(underlyingTimer.count())
+        .as("underlying timer count")
+        .isEqualTo(2L);
+
+    assertThat(underlyingTimer.totalTime(SECONDS))
+        .as("underlying timer total time")
+        .isEqualTo(22.0);
+  }
+
+  @Test
+  public void recordRunnable_recordsToUnderlyingTimer() {
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(543_234_234_234L);
+    Runnable timeConsumingRunnable = () -> clock.add(duration);
+
+    legacyStatTimer.record(timeConsumingRunnable);
+
+    Timer underlyingTimer = registry.find("my.meter.name").timer();
+
+    assertThat(underlyingTimer.count())
+        .as("underlying timer count")
+        .isEqualTo(1L);
+
+    assertThat(underlyingTimer.totalTime(NANOSECONDS))
+        .as("underlying timer total time")
+        .isEqualTo((double) duration.toNanos());
+  }
+
+  @Test
+  public void recordSupplier_recordsToUnderlyingTimer() {
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(543_234_234_234L);
+    Supplier<Void> timeConsumingSupplier = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.record(timeConsumingSupplier);
+
+    Timer underlyingTimer = registry.find("my.meter.name").timer();
+
+    assertThat(underlyingTimer.count())
+        .as("underlying timer count")
+        .isEqualTo(1L);
+
+    assertThat(underlyingTimer.totalTime(NANOSECONDS))
+        .as("underlying timer total time")
+        .isEqualTo((double) duration.toNanos());
+  }
+
+  @Test
+  public void recordCallable_recordsToUnderlyingTimer() throws Exception {
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(543_234_234_234L);
+    Callable<Void> timeConsumingCallable = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.recordCallable(timeConsumingCallable);
+
+    Timer underlyingTimer = registry.find("my.meter.name").timer();
+
+    assertThat(underlyingTimer.count())
+        .as("underlying timer count")
+        .isEqualTo(1L);
+
+    assertThat(underlyingTimer.totalTime(NANOSECONDS))
+        .as("underlying timer total time")
+        .isEqualTo((double) duration.toNanos());
+  }
+
+  @Test
+  public void withDoubleCountStat_recordDuration_incrementsCountStat() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    legacyStatTimer.record(17, NANOSECONDS);
+
+    verify(statistics).incDouble(countStatId, 1);
+  }
+
+  @Test
+  public void withDoubleCountStat_recordRunnable_incrementsCountStat() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(234L);
+    Runnable timeConsumingRunnable = () -> clock.add(duration);
+
+    legacyStatTimer.record(timeConsumingRunnable);
+
+    verify(statistics).incDouble(countStatId, 1);
+  }
+
+  @Test
+  public void withDoubleCountStat_recordSupplier_incrementsCountStat() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(17L);
+    Supplier<Void> timeConsumingSupplier = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.record(timeConsumingSupplier);
+
+    verify(statistics).incDouble(countStatId, 1);
+  }
+
+  @Test
+  public void withDoubleCountStat_recordCallable_incrementsCountStat() throws Exception {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(543_234_234_234L);
+    Callable<Void> timeConsumingCallable = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.recordCallable(timeConsumingCallable);
+
+    verify(statistics).incDouble(countStatId, 1);
+  }
+
+  @Test
+  public void withDoubleCountStat_count_returnsCountStatAsLong() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+    when(statistics.getDouble(countStatId)).thenReturn(92.0);
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    assertThat(legacyStatTimer.count()).isEqualTo(92);
+  }
+
+  @Test
+  public void withDoubleTimeStat_recordDuration_addsNanosToTimeStat() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    legacyStatTimer.record(17, SECONDS);
+
+    verify(statistics).incDouble(timeStatId, 17_000_000_000.0);
+  }
+
+  @Test
+  public void withDoubleTimeStat_recordRunnable_addsNanosToTimeStat() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(543_234_234_234L);
+    Runnable timeConsumingRunnable = () -> clock.add(duration);
+
+    legacyStatTimer.record(timeConsumingRunnable);
+
+    verify(statistics).incDouble(timeStatId, (double) duration.toNanos());
+  }
+
+  @Test
+  public void withDoubleTimeStat_recordSupplier_addsNanosToTimeStat() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(222L);
+    Supplier<Void> timeConsumingSupplier = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.record(timeConsumingSupplier);
+
+    verify(statistics).incDouble(timeStatId, duration.toNanos());
+  }
+
+  @Test
+  public void withDoubleTimeStat_recordCallable_addsNanosToTimeStat() throws Exception {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(222L);
+    Callable<Void> timeConsumingCallable = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.recordCallable(timeConsumingCallable);
+
+    verify(statistics).incDouble(timeStatId, duration.toNanos());
+  }
+
+  @Test
+  public void withDoubleTimeStat_totalTime_returnsTimeStatInGivenUnits() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+    when(statistics.getDouble(timeStatId)).thenReturn(92_123.0);
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .doubleTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    assertThat(legacyStatTimer.totalTime(TimeUnit.MICROSECONDS)).isEqualTo(92.0);
+  }
+
+  @Test
+  public void withLongCountStat_recordDuration_incrementsCountStat() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    legacyStatTimer.record(17, NANOSECONDS);
+
+    verify(statistics).incLong(countStatId, 1);
+  }
+
+  @Test
+  public void withLongCountStat_recordRunnable_incrementsCountStat() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(234L);
+    Runnable timeConsumingRunnable = () -> clock.add(duration);
+
+    legacyStatTimer.record(timeConsumingRunnable);
+
+    verify(statistics).incLong(countStatId, 1);
+  }
+
+  @Test
+  public void withLongCountStat_recordSupplier_incrementsCountStat() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(17L);
+    Supplier<Void> timeConsumingSupplier = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.record(timeConsumingSupplier);
+
+    verify(statistics).incLong(countStatId, 1);
+  }
+
+  @Test
+  public void withLongCountStat_recordCallable_incrementsCountStat() throws Exception {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(543_234_234_234L);
+    Callable<Void> timeConsumingCallable = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.recordCallable(timeConsumingCallable);
+
+    verify(statistics).incLong(countStatId, 1);
+  }
+
+  @Test
+  public void withLongCountStat_count_returnsCountStat() {
+    Statistics statistics = mock(Statistics.class);
+    int countStatId = 18;
+    when(statistics.getLong(countStatId)).thenReturn(123_456_789_000L);
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longCountStatistic(statistics, countStatId)
+        .register(registry);
+
+    assertThat(legacyStatTimer.count()).isEqualTo(123_456_789_000L);
+  }
+
+  @Test
+  public void withLongTimeStat_recordDuration_addsNanosToTimeStat() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    legacyStatTimer.record(17, SECONDS);
+
+    verify(statistics).incLong(timeStatId, 17_000_000_000L);
+  }
+
+  @Test
+  public void withLongTimeStat_recordRunnable_addsNanosToTimeStat() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(543_234_234_234L);
+    Runnable timeConsumingRunnable = () -> clock.add(duration);
+
+    legacyStatTimer.record(timeConsumingRunnable);
+
+    verify(statistics).incLong(timeStatId, duration.toNanos());
+  }
+
+  @Test
+  public void withLongTimeStat_recordSupplier_addsNanosToTimeStat() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(222L);
+    Supplier<Void> timeConsumingSupplier = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.record(timeConsumingSupplier);
+
+    verify(statistics).incLong(timeStatId, duration.toNanos());
+  }
+
+  @Test
+  public void withLongTimeStat_recordCallable_addsNanosToTimeStat() throws Exception {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    Duration duration = Duration.ofNanos(222L);
+    Callable<Void> timeConsumingCallable = () -> {
+      clock.add(duration);
+      return null;
+    };
+
+    legacyStatTimer.recordCallable(timeConsumingCallable);
+
+    verify(statistics).incLong(timeStatId, duration.toNanos());
+  }
+
+  @Test
+  public void withLongTimeStat_totalTime_returnsTimeStatInGivenUnits() {
+    Statistics statistics = mock(Statistics.class);
+    int timeStatId = 18;
+    when(statistics.getLong(timeStatId)).thenReturn(987_654_321_000L);
+
+    Timer legacyStatTimer = LegacyStatTimer.builder("my.meter.name")
+        .longTimeStatistic(statistics, timeStatId)
+        .register(registry);
+
+    assertThat(legacyStatTimer.totalTime(TimeUnit.MICROSECONDS)).isEqualTo(987_654_321L);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/LongStatisticBindingTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/meters/LongStatisticBindingTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.statistics.meters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+
+public class LongStatisticBindingTest {
+  private Statistics statistics = mock(Statistics.class);
+
+  @Test
+  public void add_addsAmountToStat() {
+    int statId = 27;
+    StatisticBinding binding = new LongStatisticBinding(statistics, statId);
+
+    binding.add(1234.0);
+
+    verify(statistics).incLong(statId, 1234);
+  }
+
+  @Test
+  public void doubleValue_returnsLongStatValueAsDouble() {
+    int statId = 27;
+    StatisticBinding binding = new LongStatisticBinding(statistics, statId);
+
+    when(statistics.getLong(statId)).thenReturn(2341L);
+
+    assertThat(binding.doubleValue())
+        .isEqualTo(2341.0);
+  }
+
+  @Test
+  public void longValue_returnsLongStatValue() {
+    int statId = 27;
+    StatisticBinding binding = new LongStatisticBinding(statistics, statId);
+
+    when(statistics.getLong(statId)).thenReturn(2341L);
+
+    assertThat(binding.longValue())
+        .isEqualTo(2341L);
+  }
+}


### PR DESCRIPTION
Added `LegacyStatCounter` and `LegacyStatTimer`. Updated `CacheServerStats` to use a `LegacyStatCounter` to report "events received."

For now, `LegacyStatCounter` allows binding to int stats, so that we can use it for our existing gateway receiver events received meter. After all int stats are converted to long stats (in a separate PR), we will remove the ability to bind to int stats.

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

Please review @kirklund @pivotal-jbarrett @upthewaterspout @moleske @aaronlindsey @mhansonp 