### PR TITLE
GEODE-6849: Stop using 'stats' to pull redundancy info

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
@@ -1854,13 +1854,12 @@ public class PRHARedundancyProvider {
       return null;
     }
 
-    PartitionedRegionStats prStats = pr.getPrStats();
-
     int configuredBucketCount = pr.getTotalNumberOfBuckets();
     int createdBucketCount = pr.getRegionAdvisor().getCreatedBucketsCount();
-    int lowRedundancyBucketCount = prStats.getLowRedundancyBucketCount();
+
+    int lowRedundancyBucketCount = pr.getRedundancyTracker().getLowestBucketCopies();
     int configuredRedundantCopies = pr.getRedundantCopies();
-    int actualRedundantCopies = prStats.getActualRedundantCopies();
+    int actualRedundantCopies = pr.getRedundancyTracker().getActualRedundancy();
 
     final PartitionedRegionDataStore ds = pr.getDataStore();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
@@ -1857,7 +1857,7 @@ public class PRHARedundancyProvider {
     int configuredBucketCount = pr.getTotalNumberOfBuckets();
     int createdBucketCount = pr.getRegionAdvisor().getCreatedBucketsCount();
 
-    int lowRedundancyBucketCount = pr.getRedundancyTracker().getLowestBucketCopies();
+    int lowRedundancyBucketCount = pr.getRedundancyTracker().getLowRedundancyBuckets();
     int configuredRedundantCopies = pr.getRedundantCopies();
     int actualRedundantCopies = pr.getRedundancyTracker().getActualRedundancy();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionRedundancyTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionRedundancyTracker.java
@@ -62,6 +62,10 @@ class PartitionedRegionRedundancyTracker {
     return lowestBucketCopies;
   }
 
+  int getLowRedundancyBuckets() {
+    return lowRedundancyBuckets;
+  }
+
   /**
    * Increments the count of buckets that do not meet redundancy
    */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionRedundancyTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionRedundancyTracker.java
@@ -33,6 +33,7 @@ class PartitionedRegionRedundancyTracker {
   private int lowRedundancyBuckets;
   private int noCopiesBuckets;
   private int lowestBucketCopies;
+  private volatile int actualRedundancy;
 
   /**
    * Creates a new PartitionedRegionRedundancyTracker
@@ -131,7 +132,13 @@ class PartitionedRegionRedundancyTracker {
     }
   }
 
+  public int getActualRedundancy() {
+    return actualRedundancy;
+  }
+
   void setActualRedundancy(int actualRedundancy) {
-    stats.setActualRedundantCopies(Math.max(actualRedundancy, 0));
+    int nonNegativeRedundancy = Math.max(actualRedundancy, 0);
+    this.actualRedundancy = nonNegativeRedundancy;
+    stats.setActualRedundantCopies(nonNegativeRedundancy);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStats.java
@@ -927,10 +927,6 @@ public class PartitionedRegionStats {
     this.stats.setLong(localMaxMemoryId, l);
   }
 
-  public int getActualRedundantCopies() {
-    return this.stats.getInt(actualRedundantCopiesId);
-  }
-
   public void setActualRedundantCopies(int val) {
     this.stats.setInt(actualRedundantCopiesId, val);
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
@@ -73,7 +73,7 @@ public class PRHARedundancyProviderTest {
 
     when(mockPartitionedRegion.getTotalNumberOfBuckets()).thenReturn(42);
     when(mockPartitionedRegion.getRegionAdvisor().getCreatedBucketsCount()).thenReturn(17);
-    when(mockPartitionedRegion.getRedundancyTracker().getLowestBucketCopies()).thenReturn(3);
+    when(mockPartitionedRegion.getRedundancyTracker().getLowRedundancyBuckets()).thenReturn(3);
     when(mockPartitionedRegion.getRedundantCopies()).thenReturn(12);
     when(mockPartitionedRegion.getRedundancyTracker().getActualRedundancy()).thenReturn(33);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -21,23 +22,28 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.TreeSet;
+
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.internal.cache.partitioned.InternalPRInfo;
+import org.apache.geode.internal.cache.partitioned.LoadProbe;
 import org.apache.geode.internal.cache.partitioned.PersistentBucketRecoverer;
 
 
 public class PRHARedundancyProviderTest {
   private PRHARedundancyProvider provider;
+  private PartitionedRegion mockPartitionedRegion;
 
   @Before
   public void setup() {
-    PartitionedRegion partitionedRegion = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
+    mockPartitionedRegion = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
     InternalCache cache = mock(InternalCache.class);
     DistributedRegion root = mock(DistributedRegion.class);
-    when(partitionedRegion.getCache()).thenReturn(cache);
+    when(mockPartitionedRegion.getCache()).thenReturn(cache);
     when(cache.getRegion(PartitionedRegionHelper.PR_ROOT_REGION_NAME, true)).thenReturn(root);
-    provider = spy(new PRHARedundancyProvider(partitionedRegion));
+    provider = spy(new PRHARedundancyProvider(mockPartitionedRegion));
   }
 
   @Test
@@ -57,5 +63,29 @@ public class PRHARedundancyProviderTest {
     provider.waitForPersistentBucketRecovery();
 
     verify(recoverer).await();
+  }
+
+  @Test
+  public void buildPartitionedRegionInfo_() {
+    when(mockPartitionedRegion.getRegionAdvisor().adviseDataStore()).thenReturn(new TreeSet<>());
+    when(mockPartitionedRegion.getRegionAdvisor().getProxyBucketArray())
+        .thenReturn(new ProxyBucketRegion[] {});
+
+    when(mockPartitionedRegion.getTotalNumberOfBuckets()).thenReturn(42);
+    when(mockPartitionedRegion.getRegionAdvisor().getCreatedBucketsCount()).thenReturn(17);
+    when(mockPartitionedRegion.getRedundancyTracker().getLowestBucketCopies()).thenReturn(3);
+    when(mockPartitionedRegion.getRedundantCopies()).thenReturn(12);
+    when(mockPartitionedRegion.getRedundancyTracker().getActualRedundancy()).thenReturn(33);
+
+
+    InternalPRInfo internalPRInfo =
+        provider.buildPartitionedRegionInfo(false, mock(LoadProbe.class));
+
+
+    assertThat(internalPRInfo.getConfiguredBucketCount()).isEqualTo(42);
+    assertThat(internalPRInfo.getCreatedBucketCount()).isEqualTo(17);
+    assertThat(internalPRInfo.getLowRedundancyBucketCount()).isEqualTo(3);
+    assertThat(internalPRInfo.getConfiguredRedundantCopies()).isEqualTo(12);
+    assertThat(internalPRInfo.getActualRedundantCopies()).isEqualTo(33);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
@@ -66,7 +66,7 @@ public class PRHARedundancyProviderTest {
   }
 
   @Test
-  public void buildPartitionedRegionInfo_() {
+  public void buildPartitionedRegionInfo() {
     when(mockPartitionedRegion.getRegionAdvisor().adviseDataStore()).thenReturn(new TreeSet<>());
     when(mockPartitionedRegion.getRegionAdvisor().getProxyBucketArray())
         .thenReturn(new ProxyBucketRegion[] {});

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionRedundancyTrackerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionRedundancyTrackerTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -117,8 +118,16 @@ public class PartitionedRegionRedundancyTrackerTest {
   }
 
   @Test
+  public void willSetActualRedundancyAndStoreStat() {
+    redundancyTracker.setActualRedundancy(7);
+    assertThat(redundancyTracker.getActualRedundancy()).isEqualTo(7);
+    verify(stats).setActualRedundantCopies(7);
+  }
+
+  @Test
   public void willNotSetActualRedundantCopiesStatBelowZero() {
     redundancyTracker.setActualRedundancy(-1);
-    assertEquals(0, stats.getActualRedundantCopies());
+    assertThat(redundancyTracker.getActualRedundancy()).isEqualTo(0);
+    verify(stats).setActualRedundantCopies(0);
   }
 }


### PR DESCRIPTION
stats is not a reliable source of information. Operators can disable
stats entirely and the data is not guaranteed (ala logging). Instead
pull from the 'original' sources of this data.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
