### PR TITLE
GEODE-6862: Create LogConsumerTest

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/Patterns.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/Patterns.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.test.greplogs;
+
+import static java.util.regex.Pattern.compile;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public enum Patterns {
+
+  /** IgnoredException add or remove statement */
+  IGNORED_EXCEPTION(compile("<ExpectedException action=(add|remove)>(.*)</ExpectedException>")),
+  /** Log statement */
+  LOG_STATEMENT(compile("^\\[(?:fatal|error|warn|info|debug|trace|severe|warning|fine|finer|finest)")),
+  /** Blank line */
+  BLANK(compile("^\\s*$")),
+  /** WARN or less specific log level */
+  WARN_OR_LESS_LOG_LEVEL(compile("^\\[(?:warn|warning|info|debug|trace|fine|finer|finest)")),
+  /** ERROR or more specific log level */
+  ERROR_OR_MORE_LOG_LEVEL(compile("^\\[(?:fatal|error|severe)")),
+  /** "Caused by" literal */
+  CAUSED_BY(compile("Caused by")),
+  /** Short name of error ? */
+  ERROR_SHORT_NAME(compile("^\\[[^\\]]+\\](.*)$", Pattern.MULTILINE | Pattern.DOTALL)),
+  /** "debug.*Wrote exception:" literal */
+  DEBUG_WROTE_EXCEPTION(compile("\\[debug.*Wrote exception:")),
+  /** Hydra rmi warning statement */
+  RMI_WARNING(compile("^WARNING: Failed to .*java.rmi.ConnectException: Connection refused to host: .*; nested exception is:")),
+  /** "java.lang.Error" literal */
+  JAVA_LANG_ERROR(compile("^java\\.lang\\.\\S+Error$")),
+  /** "Exception:" literal */
+  EXCEPTION(compile("Exception:")),
+  /** "Exception:" matcher 2 */
+  EXCEPTION_2(compile("( [\\w\\.]+Exception: (([\\S]+ ){0,6}))")),
+  /** "Exception:" matcher 3 */
+  EXCEPTION_3(compile("( [\\w\\.]+Exception)$")),
+  /** "Exception:" matcher 4 */
+  EXCEPTION_4(compile("^([^:]+: (([\\w\"]+ ){0,6}))")),
+  /** Misformatted i18n message */
+  MISFORMATTED_I18N_MESSAGE(compile("[^\\d]\\{\\d+\\}")),
+  /** RegionVersionVector bit set message */
+  RVV_BIT_SET_MESSAGE(compile("RegionVersionVector.+bsv\\d+.+bs=\\{\\d+\\}"));
+
+  private final Pattern pattern;
+
+  Patterns(Pattern pattern) {
+    this.pattern = pattern;
+  }
+
+  Matcher matcher(CharSequence input) {
+    return pattern.matcher(input);
+  }
+}

--- a/geode-dunit/src/test/java/org/apache/geode/test/greplogs/LogConsumerTest.java
+++ b/geode-dunit/src/test/java/org/apache/geode/test/greplogs/LogConsumerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.test.greplogs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+
+public class LogConsumerTest {
+
+  @Rule
+  public TestName testName = new TestName();
+
+  private LogConsumer logConsumer;
+
+  @Before
+  public void setUp() {
+    boolean allowSkipLogMessages = false;
+    List<Pattern> expectedStrings = Collections.emptyList();
+    String logFileName = getClass().getSimpleName() + "_" + testName.getMethodName();
+    int repeatLimit = 2;
+
+    logConsumer = new LogConsumer(allowSkipLogMessages, expectedStrings, logFileName, repeatLimit);
+  }
+
+  @Test
+  public void consumeReturnsNullIfLineIsOk() {
+    StringBuilder value = logConsumer.consume("ok");
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void consumeReturnsNullIfLineIsEmpty() {
+    StringBuilder value = logConsumer.consume("");
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void consumeThrowsNullPointerExceptionIfLineIsNull() {
+    Throwable thrown = catchThrowable(() -> logConsumer.consume(null));
+
+    assertThat(thrown)
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void closeReturnsNullIfLineIsOk() {
+    logConsumer.consume("ok");
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void closeReturnsNullIfLineIsEmpty() {
+    logConsumer.consume("");
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void closeReturnsNullIfLineContainsInfoLogStatementWithException() {
+    logConsumer.consume("[info 019/06/13 14:41:05.750 PDT <main> tid=0x1] " +
+        NullPointerException.class.getName());
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void closeReturnsLineIfLineContainsErrorLogStatement() {
+    String line = "[error 019/06/13 14:41:05.750 PDT <main> tid=0x1] message";
+    logConsumer.consume(line);
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).contains(line);
+  }
+
+  @Test
+  public void closeReturnsNullIfLineContainsWarningLogStatement() {
+    logConsumer.consume("[warning 2019/06/13 14:41:05.750 PDT <main> tid=0x1] message");
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void closeReturnsLineIfLineContainsFatalLogStatement() {
+    String line = "[fatal 2019/06/13 14:41:05.750 PDT <main> tid=0x1] message";
+    logConsumer.consume(line);
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).contains(line);
+  }
+
+  @Test
+  public void closeReturnsLineIfLineContainsSevereLogStatement() {
+    String line = "[severe 2019/06/13 14:41:05.750 PDT <main> tid=0x1] message";
+    logConsumer.consume(line);
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).contains(line);
+  }
+}


### PR DESCRIPTION
Second commit includes some cleanup of LogConsumer and extracts
new Patterns enum.

Note: this does not complete GEODE-6862, but it does create the unit
test and Naba is investigating a possible LogConsumer bug so I want to
share this and hopefully merge what I have so far as a starting point
for testing. Hopefully we can add a regression test that reproduces the
problem that Naba is looking into.