### PR TITLE
GEODE-6889: Ensure the highest value is recorded to maxReplyWaitTime

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
@@ -1603,17 +1603,13 @@ public class DistributionStats implements DMStats {
     }
     if (initTime != 0) {
       long waitTime = System.currentTimeMillis() - initTime;
-      recordMaxReplyWaitTime(waitTime);
+      maxReplyWaitTime.recordMax(waitTime);
     }
     stats.incInt(replyWaitsInProgressId, -1);
     stats.incInt(replyWaitsCompletedId, 1);
 
     Breadcrumbs.setSendSide(null); // clear any recipient breadcrumbs set by the message
     Breadcrumbs.setProblem(null); // clear out reply-wait errors
-  }
-
-  void recordMaxReplyWaitTime(long waitTime) {
-    maxReplyWaitTime.recordMax(waitTime);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
@@ -22,6 +22,7 @@ import org.apache.geode.StatisticsFactory;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.internal.NanoTimer;
 import org.apache.geode.internal.logging.LogService;
@@ -48,8 +49,10 @@ public class DistributionStats implements DMStats {
   private static final int sentMessagesId;
   private static final int sentCommitMessagesId;
   private static final int commitWaitsId;
-  private static final int sentMessagesTimeId;
-  private static final int sentMessagesMaxTimeId;
+  @VisibleForTesting
+  static final int sentMessagesTimeId;
+  @VisibleForTesting
+  static final int sentMessagesMaxTimeId;
   private static final int broadcastMessagesId;
   private static final int broadcastMessagesTimeId;
   private static final int receivedMessagesId;
@@ -91,9 +94,11 @@ public class DistributionStats implements DMStats {
   private static final int serialQueueThrottleCountId;
   private static final int replyWaitsInProgressId;
   private static final int replyWaitsCompletedId;
-  private static final int replyWaitTimeId;
+  @VisibleForTesting
+  static final int replyWaitTimeId;
   private static final int replyTimeoutsId;
-  private static final int replyWaitMaxTimeId;
+  @VisibleForTesting
+  static final int replyWaitMaxTimeId;
   private static final int receiverConnectionsId;
   private static final int failedAcceptsId;
   private static final int failedConnectsId;
@@ -949,9 +954,7 @@ public class DistributionStats implements DMStats {
    * factory.
    */
   public DistributionStats(StatisticsFactory f, long statId) {
-    this.stats = f.createAtomicStatistics(type, "distributionStats", statId);
-    maxReplyWaitTime = new MaxLongGauge(replyWaitMaxTimeId, stats);
-    maxSentMessagesTime = new MaxLongGauge(sentMessagesMaxTimeId, stats);
+    this(f.createAtomicStatistics(type, "distributionStats", statId));
     // this.replyHandoffHistogram = new HistogramStats("ReplyHandOff", "nanoseconds", f,
     // new long[] {100000, 200000, 300000, 400000, 500000, 600000, 700000, 800000, 900000, 1000000},
     // false);
@@ -967,7 +970,6 @@ public class DistributionStats implements DMStats {
     this.stats = stats;
     maxReplyWaitTime = new MaxLongGauge(replyWaitMaxTimeId, stats);
     maxSentMessagesTime = new MaxLongGauge(sentMessagesMaxTimeId, stats);
-
     // this.replyHandoffHistogram = null;
     // this.replyWaitHistogram = null;
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
@@ -1600,8 +1600,10 @@ public class DistributionStats implements DMStats {
     if (enableClockStats) {
       stats.incLong(replyWaitTimeId, getStatTime() - startNanos);
       // this.replyWaitHistogram.endOp(delta);
-      long currentWaitTime = System.currentTimeMillis() - initTime;
-      recordMaxReplyWaitTime(currentWaitTime);
+    }
+    if (initTime != 0) {
+      long waitTime = System.currentTimeMillis() - initTime;
+      recordMaxReplyWaitTime(waitTime);
     }
     stats.incInt(replyWaitsInProgressId, -1);
     stats.incInt(replyWaitsCompletedId, 1);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/MaxLongGauge.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/MaxLongGauge.java
@@ -7,7 +7,7 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless rired y applicable law or agreed to in writing, software distributed under the License
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
@@ -18,6 +18,11 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.geode.Statistics;
 
+/**
+ * This class holds the max value of a stat inside an AtomicLong. Every time a higher value is found
+ * the class will forward the delta between the old max and the new max to the statistics class.
+ * This pattern is a lock-less alternative to calling Statistics.getLong and then updating the max.
+ */
 class MaxLongGauge {
   private final int statId;
   private final Statistics stats;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/MaxLongGauge.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/MaxLongGauge.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless rired y applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.geode.Statistics;
+
+class MaxLongGauge {
+  private final int statId;
+  private final Statistics stats;
+  private final AtomicLong max;
+
+  public MaxLongGauge(int statId, Statistics stats) {
+    this.statId = statId;
+    this.stats = stats;
+    max = new AtomicLong();
+  }
+
+  public void recordMax(long currentValue) {
+    boolean done = false;
+    while (!done) {
+      long maxValue = max.get();
+      if (currentValue <= maxValue) {
+        done = true;
+      } else {
+        done = max.compareAndSet(maxValue, currentValue);
+        if (done) {
+          stats.incLong(statId, currentValue - maxValue);
+        }
+      }
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
@@ -14,12 +14,14 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import org.apache.geode.Statistics;
 
@@ -41,14 +43,15 @@ public class DistributionStatsTest {
   }
 
   @Test
-  public void recordMaxReplyWaitTime_singleRecord() {
-    distributionStats.recordMaxReplyWaitTime(12);
+  public void recordMaxReplyWaitTime() {
+    distributionStats.endReplyWait(12000000, 12);
 
-    verify(mockStats).incLong(45, 12L);
+    verify(mockStats).incLong(eq(44), Mockito.anyLong());
+    verify(mockStats).incLong(eq(45), Mockito.anyLong());
   }
 
   @Test
-  public void incSentMessagesTime_oneMessage() {
+  public void incSentMessagesTime() {
     distributionStats.incSentMessagesTime(50000000L);
 
     verify(mockStats).incLong(3, 50000000L);

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+
+public class DistributionStatsTest {
+
+  @Test
+  public void recordMaxReplyWaitTime_singleRecord() {
+    Statistics mockStats = mock(Statistics.class);
+    DistributionStats distributionStats = new DistributionStats(mockStats);
+
+    distributionStats.recordMaxReplyWaitTime(5, 17);
+    verify(mockStats).incLong(anyInt(), eq(12L));
+  }
+
+  @Test
+  public void recordMaxReplyWaitTime_multipleRecords() {
+    Statistics mockStats = mock(Statistics.class);
+    DistributionStats distributionStats = new DistributionStats(mockStats);
+
+    distributionStats.recordMaxReplyWaitTime(5, 17);
+    verify(mockStats).incLong(anyInt(), eq(12L));
+
+    distributionStats.recordMaxReplyWaitTime(12, 25);
+    verify(mockStats).incLong(anyInt(), eq(1L));
+  }
+
+  @Test
+  public void recordMaxReplyWaitTime_recordNothing_ifMaxTimeIsNotExceeded() {
+    Statistics mockStats = mock(Statistics.class);
+    DistributionStats distributionStats = new DistributionStats(mockStats);
+
+    distributionStats.recordMaxReplyWaitTime(5, 17);
+    verify(mockStats).incLong(anyInt(), eq(12L));
+
+    distributionStats.recordMaxReplyWaitTime(12, 24);
+    verify(mockStats, times(1)).incLong(anyInt(), anyLong());
+  }
+
+  @Test
+  public void recordMaxReplyWaitTime_recordNothing_ifInitTimeIsZero() {
+    Statistics mockStats = mock(Statistics.class);
+    DistributionStats distributionStats = new DistributionStats(mockStats);
+
+    distributionStats.recordMaxReplyWaitTime(5, 17);
+    verify(mockStats).incLong(anyInt(), eq(12L));
+
+    distributionStats.recordMaxReplyWaitTime(0, 42);
+    verify(mockStats, times(1)).incLong(anyInt(), anyLong());
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
@@ -7,69 +7,112 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * Unless rired y applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
 package org.apache.geode.distributed.internal;
 
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.Statistics;
 
 public class DistributionStatsTest {
 
+  private Statistics mockStats;
+  private DistributionStats distributionStats;
+
+  @Before
+  public void setup() {
+    mockStats = mock(Statistics.class);
+    distributionStats = new DistributionStats(mockStats);
+    DistributionStats.enableClockStats = true;
+  }
+
+  @After
+  public void cleanup() {
+    DistributionStats.enableClockStats = false;
+  }
+
   @Test
   public void recordMaxReplyWaitTime_singleRecord() {
-    Statistics mockStats = mock(Statistics.class);
-    DistributionStats distributionStats = new DistributionStats(mockStats);
+    distributionStats.recordMaxReplyWaitTime(12);
 
-    distributionStats.recordMaxReplyWaitTime(5, 17);
-    verify(mockStats).incLong(anyInt(), eq(12L));
+    verify(mockStats).incLong(45, 12L);
   }
 
   @Test
   public void recordMaxReplyWaitTime_multipleRecords() {
-    Statistics mockStats = mock(Statistics.class);
-    DistributionStats distributionStats = new DistributionStats(mockStats);
+    distributionStats.recordMaxReplyWaitTime(12);
+    distributionStats.recordMaxReplyWaitTime(13);
 
-    distributionStats.recordMaxReplyWaitTime(5, 17);
-    verify(mockStats).incLong(anyInt(), eq(12L));
-
-    distributionStats.recordMaxReplyWaitTime(12, 25);
-    verify(mockStats).incLong(anyInt(), eq(1L));
+    verify(mockStats).incLong(45, 12L);
+    verify(mockStats).incLong(45, 1L);
   }
 
   @Test
   public void recordMaxReplyWaitTime_recordNothing_ifMaxTimeIsNotExceeded() {
-    Statistics mockStats = mock(Statistics.class);
-    DistributionStats distributionStats = new DistributionStats(mockStats);
+    distributionStats.recordMaxReplyWaitTime(12);
+    distributionStats.recordMaxReplyWaitTime(3);
 
-    distributionStats.recordMaxReplyWaitTime(5, 17);
-    verify(mockStats).incLong(anyInt(), eq(12L));
-
-    distributionStats.recordMaxReplyWaitTime(12, 24);
-    verify(mockStats, times(1)).incLong(anyInt(), anyLong());
+    verify(mockStats, times(1)).incLong(45, 12);
+    verifyNoMoreInteractions(mockStats);
   }
 
   @Test
-  public void recordMaxReplyWaitTime_recordNothing_ifInitTimeIsZero() {
-    Statistics mockStats = mock(Statistics.class);
-    DistributionStats distributionStats = new DistributionStats(mockStats);
+  public void recordMaxReplyWaitTime_ignoresNegativesAndZero() {
+    distributionStats.recordMaxReplyWaitTime(-12);
+    distributionStats.recordMaxReplyWaitTime(0);
 
-    distributionStats.recordMaxReplyWaitTime(5, 17);
-    verify(mockStats).incLong(anyInt(), eq(12L));
-
-    distributionStats.recordMaxReplyWaitTime(0, 42);
-    verify(mockStats, times(1)).incLong(anyInt(), anyLong());
+    verifyZeroInteractions(mockStats);
   }
 
+  @Test
+  public void incSentMessagesTime_oneMessage() {
+    distributionStats.incSentMessagesTime(50000000L);
+
+    verify(mockStats).incLong(3, 50000000L);
+    verify(mockStats).incLong(4, 50L);
+  }
+
+  @Test
+  public void incSentMessagesTime_twoMessages() {
+    distributionStats.incSentMessagesTime(50000000L);
+    distributionStats.incSentMessagesTime(80000000L);
+
+    verify(mockStats).incLong(3, 50000000L);
+    verify(mockStats).incLong(4, 50L);
+    verify(mockStats).incLong(3, 80000000L);
+    verify(mockStats).incLong(4, 30L);
+  }
+
+  @Test
+  public void incSentMessagesTime_noChangeIfMaxTimeIsNotExceeded() {
+    distributionStats.incSentMessagesTime(50000000L);
+    distributionStats.incSentMessagesTime(20000000L);
+
+    verify(mockStats).incLong(3, 50000000L);
+    verify(mockStats).incLong(4, 50L);
+    verify(mockStats).incLong(3, 20000000L);
+    verifyNoMoreInteractions(mockStats);
+  }
+
+  @Test
+  public void incSentMessagesTime_ignoresNegativesAndZeroForMaxValue() {
+    distributionStats.incSentMessagesTime(-50000000L);
+    distributionStats.incSentMessagesTime(0);
+
+    verify(mockStats).incLong(3, -50000000L);
+    verify(mockStats).incLong(3, 0L);
+    verifyNoMoreInteractions(mockStats);
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
@@ -46,15 +46,15 @@ public class DistributionStatsTest {
   public void recordMaxReplyWaitTime() {
     distributionStats.endReplyWait(12000000, 12);
 
-    verify(mockStats).incLong(eq(44), Mockito.anyLong());
-    verify(mockStats).incLong(eq(45), Mockito.anyLong());
+    verify(mockStats).incLong(eq(DistributionStats.replyWaitTimeId), Mockito.anyLong());
+    verify(mockStats).incLong(eq(DistributionStats.replyWaitMaxTimeId), Mockito.anyLong());
   }
 
   @Test
   public void incSentMessagesTime() {
     distributionStats.incSentMessagesTime(50000000L);
 
-    verify(mockStats).incLong(3, 50000000L);
-    verify(mockStats).incLong(4, 50L);
+    verify(mockStats).incLong(DistributionStats.sentMessagesTimeId, 50000000L);
+    verify(mockStats).incLong(DistributionStats.sentMessagesMaxTimeId, 50L);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
@@ -43,7 +43,7 @@ public class DistributionStatsTest {
   }
 
   @Test
-  public void recordMaxReplyWaitTime() {
+  public void endReplyWait() {
     distributionStats.endReplyWait(12000000, 12);
 
     verify(mockStats).incLong(eq(DistributionStats.replyWaitTimeId), Mockito.anyLong());

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
@@ -7,7 +7,7 @@
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless rired y applicable law or agreed to in writing, software distributed under the License
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
@@ -15,10 +15,7 @@
 package org.apache.geode.distributed.internal;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 import org.junit.After;
 import org.junit.Before;
@@ -51,68 +48,10 @@ public class DistributionStatsTest {
   }
 
   @Test
-  public void recordMaxReplyWaitTime_multipleRecords() {
-    distributionStats.recordMaxReplyWaitTime(12);
-    distributionStats.recordMaxReplyWaitTime(13);
-
-    verify(mockStats).incLong(45, 12L);
-    verify(mockStats).incLong(45, 1L);
-  }
-
-  @Test
-  public void recordMaxReplyWaitTime_recordNothing_ifMaxTimeIsNotExceeded() {
-    distributionStats.recordMaxReplyWaitTime(12);
-    distributionStats.recordMaxReplyWaitTime(3);
-
-    verify(mockStats, times(1)).incLong(45, 12);
-    verifyNoMoreInteractions(mockStats);
-  }
-
-  @Test
-  public void recordMaxReplyWaitTime_ignoresNegativesAndZero() {
-    distributionStats.recordMaxReplyWaitTime(-12);
-    distributionStats.recordMaxReplyWaitTime(0);
-
-    verifyZeroInteractions(mockStats);
-  }
-
-  @Test
   public void incSentMessagesTime_oneMessage() {
     distributionStats.incSentMessagesTime(50000000L);
 
     verify(mockStats).incLong(3, 50000000L);
     verify(mockStats).incLong(4, 50L);
-  }
-
-  @Test
-  public void incSentMessagesTime_twoMessages() {
-    distributionStats.incSentMessagesTime(50000000L);
-    distributionStats.incSentMessagesTime(80000000L);
-
-    verify(mockStats).incLong(3, 50000000L);
-    verify(mockStats).incLong(4, 50L);
-    verify(mockStats).incLong(3, 80000000L);
-    verify(mockStats).incLong(4, 30L);
-  }
-
-  @Test
-  public void incSentMessagesTime_noChangeIfMaxTimeIsNotExceeded() {
-    distributionStats.incSentMessagesTime(50000000L);
-    distributionStats.incSentMessagesTime(20000000L);
-
-    verify(mockStats).incLong(3, 50000000L);
-    verify(mockStats).incLong(4, 50L);
-    verify(mockStats).incLong(3, 20000000L);
-    verifyNoMoreInteractions(mockStats);
-  }
-
-  @Test
-  public void incSentMessagesTime_ignoresNegativesAndZeroForMaxValue() {
-    distributionStats.incSentMessagesTime(-50000000L);
-    distributionStats.incSentMessagesTime(0);
-
-    verify(mockStats).incLong(3, -50000000L);
-    verify(mockStats).incLong(3, 0L);
-    verifyNoMoreInteractions(mockStats);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeConcurrentTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeConcurrentTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.distributed.internal;
 
 import static org.apache.geode.internal.statistics.StatisticDescriptorImpl.createLongGauge;

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeConcurrentTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeConcurrentTest.java
@@ -1,0 +1,59 @@
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.internal.statistics.StatisticDescriptorImpl.createLongGauge;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.StatisticDescriptor;
+import org.apache.geode.internal.statistics.StatisticsTypeImpl;
+import org.apache.geode.internal.statistics.StripedStatisticsImpl;
+import org.apache.geode.test.concurrency.ConcurrentTestRunner;
+import org.apache.geode.test.concurrency.ParallelExecutor;
+
+@RunWith(ConcurrentTestRunner.class)
+public class MaxLongGaugeConcurrentTest {
+  private static final int PARALLEL_COUNT = 100;
+  public static final int RECORDS_PER_TASK = 20;
+
+
+  @Test
+  public void recordMax(ParallelExecutor executor)
+      throws Exception {
+    StatisticDescriptor descriptor =
+        createLongGauge("1", "", "", true);
+    StatisticDescriptor[] descriptors = {descriptor};
+    StatisticsTypeImpl statisticsType = new StatisticsTypeImpl("abc", "test",
+        descriptors);
+    StripedStatisticsImpl fakeStatistics = new StripedStatisticsImpl(
+        statisticsType,
+        "def", 12, 10,
+        null);
+
+    MaxLongGauge maxLongGauge = new MaxLongGauge(descriptor.getId(), fakeStatistics);
+    ConcurrentLinkedQueue<Long> longs = new ConcurrentLinkedQueue<>();
+
+    executor.inParallel(() -> {
+      for (int i = 0; i < RECORDS_PER_TASK; i++) {
+        long value = ThreadLocalRandom.current().nextLong();
+        maxLongGauge.recordMax(value);
+        longs.add(value);
+      }
+    }, PARALLEL_COUNT);
+    executor.execute();
+
+    long actualMax = fakeStatistics.getLong(descriptor.getId());
+    long expectedMax = getMax(longs);
+
+    assertThat(longs).hasSize(RECORDS_PER_TASK * PARALLEL_COUNT);
+    assertThat(actualMax).isEqualTo(expectedMax);
+  }
+
+  private long getMax(ConcurrentLinkedQueue<Long> longs) {
+    return Math.max(longs.parallelStream().max(Long::compareTo).get(), 0);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
@@ -49,7 +49,7 @@ public class MaxLongGaugeTest {
 
   @Test
   public void recordMax_singleRecord() {
-    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+    MaxLongGauge maxLongGauge = new MaxLongGauge(statId1, fakeStatistics);
 
     maxLongGauge.recordMax(12);
 
@@ -58,7 +58,7 @@ public class MaxLongGaugeTest {
 
   @Test
   public void recordMax_multipleRecords() {
-    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+    MaxLongGauge maxLongGauge = new MaxLongGauge(statId1, fakeStatistics);
 
     maxLongGauge.recordMax(12);
     maxLongGauge.recordMax(13);
@@ -68,7 +68,7 @@ public class MaxLongGaugeTest {
 
   @Test
   public void recordMax_recordNothing_ifMaxIsNotExceeded() {
-    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+    MaxLongGauge maxLongGauge = new MaxLongGauge(statId1, fakeStatistics);
 
     maxLongGauge.recordMax(12);
     maxLongGauge.recordMax(11);
@@ -78,7 +78,7 @@ public class MaxLongGaugeTest {
 
   @Test
   public void recordMax_ignoresNegatives() {
-    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+    MaxLongGauge maxLongGauge = new MaxLongGauge(statId1, fakeStatistics);
 
     maxLongGauge.recordMax(-12);
 
@@ -87,7 +87,7 @@ public class MaxLongGaugeTest {
 
   @Test
   public void recordMax_ignoresZero() {
-    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+    MaxLongGauge maxLongGauge = new MaxLongGauge(statId1, fakeStatistics);
 
     maxLongGauge.recordMax(0);
 
@@ -96,7 +96,7 @@ public class MaxLongGaugeTest {
 
   @Test
   public void recordMax_usesStatId() {
-    MaxLongGauge maxLongGauge = new MaxLongGauge(1, fakeStatistics);
+    MaxLongGauge maxLongGauge = new MaxLongGauge(statId2, fakeStatistics);
 
     maxLongGauge.recordMax(17);
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
@@ -25,7 +25,6 @@ import org.apache.geode.internal.statistics.StatisticsTypeImpl;
 import org.apache.geode.internal.statistics.StripedStatisticsImpl;
 
 public class MaxLongGaugeTest {
-  private MaxLongGauge maxLongGauge;
   private StripedStatisticsImpl fakeStatistics;
 
   @Before

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.apache.geode.internal.statistics.StatisticDescriptorImpl.createLongGauge;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.StatisticDescriptor;
+import org.apache.geode.internal.statistics.StatisticsTypeImpl;
+import org.apache.geode.internal.statistics.StripedStatisticsImpl;
+
+public class MaxLongGaugeTest {
+  private MaxLongGauge maxLongGauge;
+  private StripedStatisticsImpl fakeStatistics;
+
+  @Before
+  public void setup() {
+    StatisticDescriptor descriptor =
+        createLongGauge("1", "", "", true);
+    StatisticDescriptor descriptor2 =
+        createLongGauge("2", "", "", true);
+
+    StatisticDescriptor[] descriptors = {descriptor, descriptor2};
+    StatisticsTypeImpl statisticsType = new StatisticsTypeImpl("abc", "test",
+        descriptors);
+    fakeStatistics = new StripedStatisticsImpl(
+        statisticsType,
+        "def", 12, 10,
+        null);
+  }
+
+  @Test
+  public void recordMax_singleRecord() {
+    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+
+    maxLongGauge.recordMax(12);
+
+    assertThat(fakeStatistics.getLong(0)).isEqualTo(12);
+  }
+
+  @Test
+  public void recordMax_multipleRecords() {
+    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+
+    maxLongGauge.recordMax(12);
+    maxLongGauge.recordMax(13);
+
+    assertThat(fakeStatistics.getLong(0)).isEqualTo(13);
+  }
+
+  @Test
+  public void recordMax_recordNothing_ifMaxIsNotExceeded() {
+    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+
+    maxLongGauge.recordMax(12);
+    maxLongGauge.recordMax(11);
+
+    assertThat(fakeStatistics.getLong(0)).isEqualTo(12);
+  }
+
+  @Test
+  public void recordMax_ignoresNegatives() {
+    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+
+    maxLongGauge.recordMax(-12);
+
+    assertThat(fakeStatistics.getLong(0)).isEqualTo(0);
+  }
+
+  @Test
+  public void recordMax_ignoresZero() {
+    MaxLongGauge maxLongGauge = new MaxLongGauge(0, fakeStatistics);
+
+    maxLongGauge.recordMax(0);
+
+    assertThat(fakeStatistics.getLong(0)).isEqualTo(0);
+  }
+
+  @Test
+  public void recordMax_usesStatId() {
+    MaxLongGauge maxLongGauge = new MaxLongGauge(1, fakeStatistics);
+
+    maxLongGauge.recordMax(17);
+
+    assertThat(fakeStatistics.getLong(1)).isEqualTo(17);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/MaxLongGaugeTest.java
@@ -26,17 +26,21 @@ import org.apache.geode.internal.statistics.StripedStatisticsImpl;
 
 public class MaxLongGaugeTest {
   private StripedStatisticsImpl fakeStatistics;
+  private int statId1;
+  private int statId2;
 
   @Before
   public void setup() {
-    StatisticDescriptor descriptor =
+    StatisticDescriptor descriptor1 =
         createLongGauge("1", "", "", true);
     StatisticDescriptor descriptor2 =
         createLongGauge("2", "", "", true);
 
-    StatisticDescriptor[] descriptors = {descriptor, descriptor2};
+    StatisticDescriptor[] descriptors = {descriptor1, descriptor2};
     StatisticsTypeImpl statisticsType = new StatisticsTypeImpl("abc", "test",
         descriptors);
+    statId1 = descriptor1.getId();
+    statId2 = descriptor2.getId();
     fakeStatistics = new StripedStatisticsImpl(
         statisticsType,
         "def", 12, 10,
@@ -49,7 +53,7 @@ public class MaxLongGaugeTest {
 
     maxLongGauge.recordMax(12);
 
-    assertThat(fakeStatistics.getLong(0)).isEqualTo(12);
+    assertThat(fakeStatistics.getLong(statId1)).isEqualTo(12);
   }
 
   @Test
@@ -59,7 +63,7 @@ public class MaxLongGaugeTest {
     maxLongGauge.recordMax(12);
     maxLongGauge.recordMax(13);
 
-    assertThat(fakeStatistics.getLong(0)).isEqualTo(13);
+    assertThat(fakeStatistics.getLong(statId1)).isEqualTo(13);
   }
 
   @Test
@@ -69,7 +73,7 @@ public class MaxLongGaugeTest {
     maxLongGauge.recordMax(12);
     maxLongGauge.recordMax(11);
 
-    assertThat(fakeStatistics.getLong(0)).isEqualTo(12);
+    assertThat(fakeStatistics.getLong(statId1)).isEqualTo(12);
   }
 
   @Test
@@ -78,7 +82,7 @@ public class MaxLongGaugeTest {
 
     maxLongGauge.recordMax(-12);
 
-    assertThat(fakeStatistics.getLong(0)).isEqualTo(0);
+    assertThat(fakeStatistics.getLong(statId1)).isEqualTo(0);
   }
 
   @Test
@@ -87,7 +91,7 @@ public class MaxLongGaugeTest {
 
     maxLongGauge.recordMax(0);
 
-    assertThat(fakeStatistics.getLong(0)).isEqualTo(0);
+    assertThat(fakeStatistics.getLong(statId1)).isEqualTo(0);
   }
 
   @Test
@@ -96,6 +100,6 @@ public class MaxLongGaugeTest {
 
     maxLongGauge.recordMax(17);
 
-    assertThat(fakeStatistics.getLong(1)).isEqualTo(17);
+    assertThat(fakeStatistics.getLong(statId2)).isEqualTo(17);
   }
 }


### PR DESCRIPTION
We pull the current max from an atomic long instead of reading the
statistic. The profiler showed that reading the statistic was a contention
hotspot.


A couple things I am thinking about in this PR:

- line 1632 - after talking to @dschneider-pivotal we came up with a solution that uses `incLong` instead of `setLong`.  My only concern here is that if `incLong` fails, the metric will forever be out of sync with the `AtomicLong` field.

- still trying to figure out what multi-threaded tests look like. @dschneider-pivotal referenced some files to look at, but I don't know if those need to be written just yet. 


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
