### PR TITLE
GEODE-6652 : Change in checks for next dir in disk store

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DiskStoreImplIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/DiskStoreImplIntegrationTest.java
@@ -261,6 +261,11 @@ public class DiskStoreImplIntegrationTest {
 
     File[] dirs = diskStore.getDiskDirs();
 
+    /**
+     * 8 oplog files should be created.
+     * The eighth one does not fit in dir1, so that directory should
+     * be skipped, and the file should be stored in dir2.
+     */
     assertThat(oplogFileIsInDir(1, dirs[0])).isTrue();
     assertThat(oplogFileIsInDir(2, dirs[1])).isTrue();
     assertThat(oplogFileIsInDir(3, dirs[2])).isTrue();
@@ -274,8 +279,6 @@ public class DiskStoreImplIntegrationTest {
     assertThat(oplogFileIsInDir(8, dirs[2])).isTrue();
 
     assertThat(oplogFileIsInDir(9, dirs[0])).isFalse();
-
-    cache.close();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
@@ -595,9 +595,7 @@ public class PersistentOplogSet implements OplogSet {
   DirectoryHolder getNextDir(long minAvailableSpace, boolean checkForWarning) {
     DirectoryHolder dirHolder = null;
     DirectoryHolder selectedHolder = null;
-    long MAX_OPLOG_SIZE_IN_BYTES = 1024 * 1024 * 1024 * 10L;
     if (minAvailableSpace < parent.getMaxOplogSizeInBytes()
-        && parent.getMaxOplogSize() != MAX_OPLOG_SIZE_IN_BYTES
         && !DiskStoreImpl.SET_IGNORE_PREALLOCATE) {
       minAvailableSpace = parent.getMaxOplogSizeInBytes();
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
@@ -592,9 +592,15 @@ public class PersistentOplogSet implements OplogSet {
    *
    * @param minAvailableSpace the minimum amount of space we need in this directory.
    */
-  DirectoryHolder getNextDir(int minAvailableSpace, boolean checkForWarning) {
+  DirectoryHolder getNextDir(long minAvailableSpace, boolean checkForWarning) {
     DirectoryHolder dirHolder = null;
     DirectoryHolder selectedHolder = null;
+    long MAX_OPLOG_SIZE_IN_BYTES = 1024 * 1024 * 1024 * 10L;
+    if (minAvailableSpace < parent.getMaxOplogSizeInBytes()
+        && parent.getMaxOplogSize() != MAX_OPLOG_SIZE_IN_BYTES
+        && !DiskStoreImpl.SET_IGNORE_PREALLOCATE) {
+      minAvailableSpace = parent.getMaxOplogSizeInBytes();
+    }
     synchronized (parent.directories) {
       for (int i = 0; i < parent.dirLength; ++i) {
         dirHolder = parent.directories[this.dirCounter];


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

### Extra info:

After implementing the test, I added some logs to PersistenOplogSet which are not included in the commit:

```
diff --git a/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java b/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
index a59bde6552..47949fa813 100644
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
@@ -610,13 +610,17 @@ public class PersistentOplogSet implements OplogSet {
         dirCounter = (++dirCounter) % parent.dirLength;
         // if the current directory has some space, then quit and
         // return the dir
+        logger.info("GEODE-6652 Evaluating dirHolder : " + dirHolder.toString());
+        logger.info("GEODE-6652 minAvailableSpace=" + minAvailableSpace);
         if (dirHolder.getAvailableSpace() >= minAvailableSpace) {
           if (checkForWarning && !parent.isDirectoryUsageNormal(dirHolder)) {
             if (logger.isDebugEnabled()) {
               logger.debug("Ignoring directory {} due to insufficient disk space", dirHolder);
             }
+            logger.info("GEODE-6652 Ignoring : " + dirHolder.toString());
           } else {
             selectedHolder = dirHolder;
+            logger.info("GEODE-6652 selectedHolder : " + selectedHolder.toString());
             break;
           }
         }
```

With this info, I saw the following info when the test failed:

```
[info 2019/06/19 15:02:19.877 CEST <Test worker> tid=0xb] GEODE-6652 Evaluating dirHolder : dir=/tmp/junit6240170980751459624/dir2 maxSpace=5242880 usedSpace=3777220 availableSpace=1465660
[info 2019/06/19 15:02:19.877 CEST <Test worker> tid=0xb] GEODE-6652 minAvailableSpace=53
[info 2019/06/19 15:02:19.877 CEST <Test worker> tid=0xb] GEODE-6652 selectedHolder : dir=/tmp/junit6240170980751459624/dir2 maxSpace=5242880 usedSpace=3777220 availableSpace=1465660
[info 2019/06/19 15:02:19.879 CEST <Test worker> tid=0xb] Created oplog#8 drf for disk store testDiskStore.
[error 2019/06/19 15:02:19.880 CEST <Test worker> tid=0xb] A DiskAccessException has occurred while writing to the disk for region /__PR/_B__testRegion_96. The cache will be closed.
org.apache.geode.cache.DiskAccessException: For DiskStore: testDiskStore: Could not pre-allocate file /tmp/junit6240170980751459624/dir2/BACKUPtestDiskStore_8.crf with size=1887436, caused by java.io.IOException: not enough space left to pre-blow, available=1465400, required=1887436
	at org.apache.geode.internal.cache.Oplog.preblow(Oplog.java:1045)
```

Here you can see that the dir2 is wrongly selected, because although it has enough space to store the required space (minAvailableSpace), when it tries to create the new oplog file,
an exception is raised due to the available free space is smaller than the oplog files being created (defined by max oplog size).