### PR TITLE
GEODE-6893: Make sure the git resource is on its branch and SHA, not …

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -70,6 +70,7 @@ GRADLE_TASK_OPTIONS: {{ test.GRADLE_TASK_OPTIONS }}
   {%- endif %}
 DUNIT_PARALLEL_FORKS: {{ test.DUNIT_PARALLEL_FORKS }}
 MAINTENANCE_VERSION: ((geode-build-branch ))
+BUILD_BRANCH: ((geode-build-branch))
 PARALLEL_DUNIT: {{ test.PARALLEL_DUNIT }}
 {% if test.PARALLEL_GRADLE is defined %}
 PARALLEL_GRADLE: {{ test.PARALLEL_GRADLE }}
@@ -190,12 +191,14 @@ resources:
     initial_version: 1.10.0
     json_key: ((!concourse-gcp-key))
     key: ((pipeline-prefix))((geode-build-branch))/passing-version
+{% if repository.sanitized_fork == "apache" or repository.branch == "develop" %}
 - name: geode-passing-sha
   type: gcs-resource
   source:
     bucket: ((version-bucket))
     json_key: ((!concourse-gcp-key))
     regexp: ((pipeline-prefix))((geode-build-branch))/passing-sha
+{%- endif -%}
 - name: geode-passing-tokens
   type: gcs-resource
   source:

--- a/ci/scripts/attach_sha_to_branch.sh
+++ b/ci/scripts/attach_sha_to_branch.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+
+REPO_DIR=${1:-$(pwd)}
+DESIRED_BRANCH=${2:--}
+
+pushd ${REPO_DIR}
+  DESIRED_SHA=$(git rev-parse HEAD)
+  git checkout ${DESIRED_BRANCH}
+  git reset --hard ${DESIRED_SHA}
+popd

--- a/ci/scripts/execute_build.sh
+++ b/ci/scripts/execute_build.sh
@@ -100,6 +100,10 @@ GRADLE_ARGS="\
     -PbuildId=${BUILD_ID} \
     build install javadoc spotlessCheck rat checkPom resolveDependencies pmdMain -x test"
 
-EXEC_COMMAND="mkdir -p tmp && cd geode && ${SET_JAVA_HOME} && ./gradlew ${GRADLE_ARGS}"
+EXEC_COMMAND="mkdir -p tmp \
+  && geode/ci/scripts/attach_sha_to_branch.sh geode ${BUILD_BRANCH} \
+  && cd geode \
+  && ${SET_JAVA_HOME} \
+  && ./gradlew ${GRADLE_ARGS}"
 echo "${EXEC_COMMAND}"
 ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "${EXEC_COMMAND}"

--- a/ci/scripts/execute_publish.sh
+++ b/ci/scripts/execute_publish.sh
@@ -69,4 +69,8 @@ GRADLE_COMMAND="./gradlew \
     publish"
 
 echo "${GRADLE_COMMAND}"
-ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "mkdir -p tmp && cd geode && ${SET_JAVA_HOME} && ${GRADLE_COMMAND}"
+ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "mkdir -p tmp \
+  && geode/ci/scripts/attach_sha_to_branch.sh geode ${BUILD_BRANCH} \
+  && cd geode \
+  && ${SET_JAVA_HOME} \
+  && ${GRADLE_COMMAND}"

--- a/ci/scripts/execute_tests.sh
+++ b/ci/scripts/execute_tests.sh
@@ -96,6 +96,14 @@ GRADLE_ARGS=" \
     ${GRADLE_TASK_OPTIONS} \
     ${GRADLE_GLOBAL_ARGS}"
 
-EXEC_COMMAND="bash -c 'echo Building with: $SEP ${JAVA_BUILD_PATH}/bin/java -version $SEP echo Testing with: $SEP ${JAVA_TEST_PATH}/bin/java -version $SEP cd geode $SEP cp gradlew gradlewStrict $SEP sed -e 's/JAVA_HOME/GRADLE_JVM/g' -i.bak gradlewStrict $SEP GRADLE_JVM=${JAVA_BUILD_PATH} ./gradlewStrict ${GRADLE_ARGS}'"
+EXEC_COMMAND="bash -c 'echo Building with: $SEP \
+  ${JAVA_BUILD_PATH}/bin/java -version $SEP \
+  echo Testing with: $SEP \
+  ${JAVA_TEST_PATH}/bin/java -version $SEP \
+  geode/ci/scripts/attach_sha_to_branch.sh geode ${BUILD_BRANCH} $SEP \
+  cd geode $SEP \
+  cp gradlew gradlewStrict $SEP \
+  sed -e 's/JAVA_HOME/GRADLE_JVM/g' -i.bak gradlewStrict $SEP \
+  GRADLE_JVM=${JAVA_BUILD_PATH} ./gradlewStrict ${GRADLE_ARGS}'"
 echo "${EXEC_COMMAND}"
 ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "${EXEC_COMMAND}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,7 +22,6 @@ rootProject.name = 'geode'
 // We want to see all test results.  This is equivalent to setting --continue on the command line.
 gradle.startParameter.continueOnFailure = true
 
-
 include 'geode-common'
 include 'geode-junit'
 include 'geode-dunit'


### PR DESCRIPTION
…detached HEAD

Use a little bash script to get the current SHA, change to the desired
branch name, then reset to our SHA on that branch.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Sean Goller <sgoller@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
