### PR TITLE
GEODE-6862: Add MALFORMED_LOG4J_MESSAGE to LogConsumer

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/Patterns.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/Patterns.java
@@ -51,10 +51,12 @@ public enum Patterns {
   EXCEPTION_3(compile("( [\\w\\.]+Exception)$")),
   /** "Exception:" matcher 4 */
   EXCEPTION_4(compile("^([^:]+: (([\\w\"]+ ){0,6}))")),
-  /** Misformatted i18n message */
-  MISFORMATTED_I18N_MESSAGE(compile("[^\\d]\\{\\d+\\}")),
+  /** Malformed i18n message */
+  MALFORMED_I18N_MESSAGE(compile("[^\\d]\\{\\d+\\}")),
   /** RegionVersionVector bit set message */
-  RVV_BIT_SET_MESSAGE(compile("RegionVersionVector.+bsv\\d+.+bs=\\{\\d+\\}"));
+  RVV_BIT_SET_MESSAGE(compile("RegionVersionVector.+bsv\\d+.+bs=\\{\\d+\\}")),
+  /** "{}" literal which is probably unused Log4J parameter */
+  MALFORMED_LOG4J_MESSAGE(compile("\\{\\}"));
 
   private final Pattern pattern;
 

--- a/geode-dunit/src/test/java/org/apache/geode/test/greplogs/LogConsumerTest.java
+++ b/geode-dunit/src/test/java/org/apache/geode/test/greplogs/LogConsumerTest.java
@@ -133,4 +133,14 @@ public class LogConsumerTest {
 
     assertThat(value).contains(line);
   }
+
+  @Test
+  public void closeReturnsLineIfLineContainsMalformedLog4jStatement() {
+    String line = "[info 2019/06/13 14:41:05.750 PDT <main> tid=0x1] contains {}";
+    logConsumer.consume(line);
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).contains(line);
+  }
 }


### PR DESCRIPTION
* Rename MALFORMED_I18N_MESSAGE in Patterns
* Add MALFORMED_LOG4J_MESSAGE in Patterns
* Use MALFORMED_LOG4J_MESSAGE in isExceptionErrorOrSomeSpecialCase
* Move call to isExceptionErrorOrSomeSpecialCase because all matches
  in this method seem to be ignored by LogConsumer (this class is
  kind of a mess)

Please review @aaronlindsey 
