### PR TITLE
GEODE-6905: Do not wait for region initialization.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -280,9 +280,6 @@ public class DistributionAdvisor {
     // retried operation to be mishandled. See GEODE-5505
     final long delay = getDelay(dr);
 
-    if (!dr.isInitializedWithWait()) {
-      return;
-    }
     if (dr.getDataPolicy().withPersistence() && persistentId == null) {
       // Fix for GEODE-6886 (#46704). The lost member may be an empty accessor
       // of a persistent replicate region. We don't need to do a synchronization

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionAdvisorTest.java
@@ -92,18 +92,6 @@ public class DistributionAdvisorTest {
   }
 
   @Test
-  public void regionSyncIsNotScheduledIfRegionIsNotInitialized() {
-    when(distributedRegion.isInitializedWithWait()).thenReturn(false);
-    doCallRealMethod().when(distributionAdvisor).syncForCrashedMember(member, profile);
-
-    distributionAdvisor.syncForCrashedMember(member, profile);
-
-    verify(distributedRegion, never()).scheduleSynchronizeForLostMember(member, lostVersionID,
-        delay);
-    verify(distributedRegion, never()).setRegionSynchronizeScheduled(lostVersionID);
-  }
-
-  @Test
   public void regionSyncNotInvokedIfLostMemberIsAnEmptyAccessorOfPersistentReplicateRegion() {
     when(dataPolicy.withPersistence()).thenReturn(true);
     when(distributedRegion.getPersistentID()).thenReturn(null);


### PR DESCRIPTION
  * No need to wait for region initialization when scheduling region sync.
    It should be done only before actual executing region sync task.
