### PR TITLE
GEODE-6922: Use sizeOnServer instead of function

### DIFF
--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCache.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCache.java
@@ -15,7 +15,6 @@
 package org.apache.geode.modules.session.catalina;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -38,7 +37,6 @@ import org.apache.geode.modules.session.catalina.callback.SessionExpirationCache
 import org.apache.geode.modules.util.BootstrappingFunction;
 import org.apache.geode.modules.util.CreateRegionFunction;
 import org.apache.geode.modules.util.RegionConfiguration;
-import org.apache.geode.modules.util.RegionSizeFunction;
 import org.apache.geode.modules.util.RegionStatus;
 import org.apache.geode.modules.util.SessionCustomExpiry;
 import org.apache.geode.modules.util.TouchPartitionedRegionEntriesFunction;
@@ -139,17 +137,7 @@ public class ClientServerSessionCache extends AbstractSessionCache {
 
   @Override
   public int size() {
-    // Add a single dummy key to force the function to go to one server
-    Set<String> filters = new HashSet<String>();
-    filters.add("test-key");
-
-    // Execute the function on the session region
-    Execution execution = FunctionService.onRegion(getSessionRegion()).withFilter(filters);
-    ResultCollector collector = execution.execute(RegionSizeFunction.ID);
-    List<Integer> result = (List<Integer>) collector.getResult();
-
-    // Return the first (and only) element
-    return result.get(0);
+    return getSessionRegion().sizeOnServer();
   }
 
   @Override


### PR DESCRIPTION
- Added Unit tests.
- Fixed some minor warnings.
- Use the `sizeOnServer` method from the `Region` class instead of
  executing the `RegionSizeFunction` on a single server every time
  when getting the actual size of the sessions regions.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
