### PR TITLE
GEODE-6883: Introduce ArchUnit test for membership

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -134,6 +134,12 @@
         <scope>compile</scope>
       </dependency>
       <dependency>
+        <groupId>com.tngtech.archunit</groupId>
+        <artifactId>archunit-junit4</artifactId>
+        <version>0.10.2</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
         <version>3.2.0</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -100,6 +100,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'com.mockrunner', name: 'mockrunner-servlet', version: '1.1.2')
         api(group: 'com.sun.activation', name: 'javax.activation', version: '1.2.0')
         api(group: 'com.sun.istack', name: 'istack-commons-runtime', version: '2.2')
+        api(group: 'com.tngtech.archunit', name:'archunit-junit4', version: '0.10.2')
         api(group: 'com.zaxxer', name: 'HikariCP', version: '3.2.0')
         api(group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.3')
         api(group: 'commons-collections', name: 'commons-collections', version: '3.2.2')

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -360,6 +360,7 @@ dependencies {
   testCompile('org.powermock:powermock-module-junit4')
   testCompile('org.powermock:powermock-api-mockito2')
   testCompile('pl.pragmatists:JUnitParams')
+  testCompile('com.tngtech.archunit:archunit-junit4:0.10.2')
 
   testCompile files("${System.getProperty('java.home')}/../lib/tools.jar")
 

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -360,7 +360,7 @@ dependencies {
   testCompile('org.powermock:powermock-module-junit4')
   testCompile('org.powermock:powermock-api-mockito2')
   testCompile('pl.pragmatists:JUnitParams')
-  testCompile('com.tngtech.archunit:archunit-junit4:0.10.2')
+  testImplementation('com.tngtech.archunit:archunit-junit4')
 
   testCompile files("${System.getProperty('java.home')}/../lib/tools.jar")
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -248,13 +248,13 @@ public class MembershipJUnitTest {
     final DistributedMembershipListener listener = mock(DistributedMembershipListener.class);
     final DMStats stats1 = mock(DMStats.class);
     final InternalDistributedSystem mockSystem = mock(InternalDistributedSystem.class);
-    when(mockSystem.getConfig()).thenReturn(config);
     System.out.println("creating 1st membership manager");
     final SecurityService securityService = SecurityServiceFactory.create();
     final MembershipManager m1 =
-        MemberFactory.newMembershipManager(listener, mockSystem, transport, stats1,
-            securityService, new GMSAuthenticator(config.getSecurityProps(), securityService,
-                mockSystem.getSecurityLogWriter(), mockSystem.getInternalLogWriter()));
+        MemberFactory.newMembershipManager(listener, transport, stats1,
+            new GMSAuthenticator(config.getSecurityProps(), securityService,
+                mockSystem.getSecurityLogWriter(), mockSystem.getInternalLogWriter()),
+            config);
     m1.startEventProcessing();
     return Pair.of(m1, listener);
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -56,7 +56,6 @@ import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.net.SocketCreator;
-import org.apache.geode.internal.security.SecurityServiceFactory;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
 @Category(MembershipTest.class)
@@ -162,10 +161,11 @@ public class GMSLocatorRecoveryIntegrationTest {
     when(mockSystem.getConfig()).thenReturn(config);
 
     // start the membership manager
-    membershipManager = MemberFactory.newMembershipManager(mockListener, mockSystem, transport,
-        mockDmStats, SecurityServiceFactory.create(),
+    membershipManager = MemberFactory.newMembershipManager(mockListener, transport,
+        mockDmStats,
         new GMSAuthenticator(mockSystem.getSecurityProperties(), mockSystem.getSecurityService(),
-            mockSystem.getSecurityLogWriter(), mockSystem.getInternalLogWriter()));
+            mockSystem.getSecurityLogWriter(), mockSystem.getInternalLogWriter()),
+        mockSystem.getConfig());
 
     GMSLocator gmsLocator = new GMSLocator(localHost,
         membershipManager.getLocalMember().getHost() + "[" + port + "]", true, true,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -780,10 +780,11 @@ public class ClusterDistributionManager implements DistributionManager {
       long start = System.currentTimeMillis();
 
       DMListener l = new DMListener(this);
-      membershipManager = MemberFactory.newMembershipManager(l, system, transport,
-          stats, system.getSecurityService(),
+      membershipManager = MemberFactory.newMembershipManager(l, transport,
+          stats,
           new GMSAuthenticator(system.getSecurityProperties(), system.getSecurityService(),
-              system.getSecurityLogWriter(), system.getInternalLogWriter()));
+              system.getSecurityLogWriter(), system.getInternalLogWriter()),
+          system.getConfig());
 
       sb.append(System.currentTimeMillis() - start);
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
@@ -19,13 +19,12 @@ import java.net.InetAddress;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.distributed.internal.DMStats;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.gms.GMSMemberFactory;
 import org.apache.geode.distributed.internal.membership.gms.NetLocator;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Authenticator;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
-import org.apache.geode.internal.security.SecurityService;
 
 /**
  * Create a new Member based on the given inputs. TODO: need to implement a real factory
@@ -87,14 +86,14 @@ public class MemberFactory {
    * @param stats are used for recording statistical communications information
    * @return a MembershipManager
    */
-  public static MembershipManager newMembershipManager(DistributedMembershipListener listener,
-      InternalDistributedSystem system,
-      RemoteTransportConfig transport,
-      DMStats stats,
-      SecurityService securityService,
-      final Authenticator authenticator) {
-    return services.newMembershipManager(listener, transport, stats,
-        authenticator, system.getConfig());
+  public static MembershipManager newMembershipManager(
+      final DistributedMembershipListener listener,
+      final RemoteTransportConfig transport,
+      final DMStats stats,
+      final Authenticator authenticator,
+      final DistributionConfig config) {
+    return services.newMembershipManager(listener, transport, stats, authenticator,
+        config);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
@@ -78,7 +78,7 @@ public interface MemberServices {
   MembershipManager newMembershipManager(DistributedMembershipListener listener,
       RemoteTransportConfig transport,
       DMStats stats,
-      final Authenticator authenticator,
+      Authenticator authenticator,
       DistributionConfig config);
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
@@ -97,10 +97,11 @@ public class GMSMemberFactory implements MemberServices {
   }
 
   @Override
-  public MembershipManager newMembershipManager(DistributedMembershipListener listener,
-      RemoteTransportConfig transport, DMStats stats,
+  public MembershipManager newMembershipManager(
+      final DistributedMembershipListener listener,
+      final RemoteTransportConfig transport, DMStats stats,
       final Authenticator authenticator,
-      DistributionConfig config) throws DistributionException {
+      final DistributionConfig config) throws DistributionException {
     Services services = new Services(listener, transport, stats, authenticator, config);
     try {
       services.init();

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.distributed.internal.membership;
 
 import static com.tngtech.archunit.base.DescribedPredicate.not;

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -1,0 +1,261 @@
+package org.apache.geode.distributed.internal.membership;
+
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchIgnore;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.DataSerializer;
+import org.apache.geode.GemFireException;
+import org.apache.geode.InternalGemFireError;
+import org.apache.geode.SystemFailure;
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.DurableClientAttributes;
+import org.apache.geode.distributed.Locator;
+import org.apache.geode.distributed.Role;
+import org.apache.geode.distributed.internal.ClusterDistributionManager;
+import org.apache.geode.distributed.internal.DMStats;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.DistributionMessage;
+import org.apache.geode.distributed.internal.FlowControlParams;
+import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.distributed.internal.LocatorStats;
+import org.apache.geode.distributed.internal.OverflowQueueWithDMStats;
+import org.apache.geode.distributed.internal.ServerLocation;
+import org.apache.geode.distributed.internal.SizeableRunnable;
+import org.apache.geode.distributed.internal.direct.DirectChannel;
+import org.apache.geode.distributed.internal.direct.DirectChannelListener;
+import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
+import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+import org.apache.geode.internal.Assert;
+import org.apache.geode.internal.ClassPathLoader;
+import org.apache.geode.internal.ConnectionWatcher;
+import org.apache.geode.internal.DataSerializableFixedID;
+import org.apache.geode.internal.HeapDataOutputStream;
+import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.OSProcess;
+import org.apache.geode.internal.SystemTimer;
+import org.apache.geode.internal.Version;
+import org.apache.geode.internal.VersionedDataInputStream;
+import org.apache.geode.internal.VersionedObjectInput;
+import org.apache.geode.internal.admin.remote.DistributionLocatorId;
+import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
+import org.apache.geode.internal.alerting.AlertingAction;
+import org.apache.geode.internal.cache.CacheConfig;
+import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.internal.cache.DirectReplyMessage;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.xmlcache.CacheServerCreation;
+import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
+import org.apache.geode.internal.concurrent.ConcurrentHashSet;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.logging.LoggingExecutors;
+import org.apache.geode.internal.logging.LoggingThread;
+import org.apache.geode.internal.logging.log4j.AlertAppender;
+import org.apache.geode.internal.logging.log4j.LogMarker;
+import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
+import org.apache.geode.internal.shared.StringPrintWriter;
+import org.apache.geode.internal.tcp.ConnectExceptions;
+import org.apache.geode.internal.util.Breadcrumbs;
+import org.apache.geode.internal.util.JavaWorkarounds;
+
+@RunWith(ArchUnitRunner.class)
+@AnalyzeClasses(packages = "org.apache.geode.distributed.internal.membership..")
+public class MembershipDependenciesJUnitTest {
+
+  /*
+   * This test verifies that the membership component (which is currently made up of classes
+   * inside the geode-core module, but which may someday reside in a separate module)
+   * depends only on packages within itself (within the membership component) or packages
+   * outside apache.geode.
+   *
+   * For purposes of this test, classes in the membership...adapter package are not considered.
+   * They will eventually become part of geode-core.
+   *
+   * While this rule is ignored, comment-out the ignore annotation to run it periodically to get
+   * the current count of deviations.
+   */
+  // TODO: remove ignore once membershipDoesntDependOnCoreProvisional matches this rule exactly
+  @ArchIgnore
+  @ArchTest
+  public static final ArchRule membershipDoesntDependOnCore = classes()
+      .that()
+      .resideInAPackage("org.apache.geode.distributed.internal.membership..")
+      .and()
+      .resideOutsideOfPackage("org.apache.geode.distributed.internal.membership.adapter..")
+      .should()
+      .onlyDependOnClassesThat(
+          resideInAPackage("org.apache.geode.distributed.internal.membership..")
+              .or(not(resideInAPackage("org.apache.geode.."))));
+
+  /*
+   * This test is a work-in-progress. It starts from the membershipDoesntDependOnCore rule
+   * and adds deviations. Each deviation has a comment like TODO:...
+   * Those deviations comprise a to do list for the membership team as it modularizes
+   * the membership component--severing its dependency on the geode-core component.
+   */
+  @ArchTest
+  public static final ArchRule membershipDoesntDependOnCoreProvisional = classes()
+      .that()
+      .resideInAPackage("org.apache.geode.distributed.internal.membership..")
+      .and()
+      .resideOutsideOfPackage("org.apache.geode.distributed.internal.membership.adapter..")
+      .and()
+
+      // TODO: InternalDistributedMember needs to move out of the package
+      .areNotAssignableFrom(InternalDistributedMember.class)
+
+
+      .should()
+      .onlyDependOnClassesThat(
+          resideInAPackage("org.apache.geode.distributed.internal.membership..")
+
+              .or(not(resideInAPackage("org.apache.geode..")))
+
+              // TODO: Create a new stats interface for membership
+              .or(assignableTo(DMStats.class))
+              .or(type(LocatorStats.class))
+              .or(type(OverflowQueueWithDMStats.class))
+
+              // TODO: Figure out what to do with exceptions
+              .or(assignableTo(GemFireException.class))
+              .or(type(InternalGemFireError.class))
+              .or(type(ConnectExceptions.class))
+
+              // TODO: Serialization needs to become its own module
+              .or(type(DataSerializer.class))
+              .or(type(DataSerializableFixedID.class))
+              .or(type(InternalDataSerializer.class))
+              .or(type(Version.class))
+              .or(type(Version[].class)) // ArchUnit needs the array type to be explicitly mentioned
+              .or(type(VersionedObjectInput.class))
+              .or(type(HeapDataOutputStream.class))
+              .or(type(VersionedDataInputStream.class))
+
+              // TODO: Figure out what to do with messaging
+              // Membership messages don't need to extend DistributionMessage
+              .or(assignableTo(DistributionMessage.class))
+              .or(assignableTo(DirectReplyMessage.class))
+
+              // TODO: Membership needs its own config object
+              .or(type(DistributionConfig.class))
+              .or(type(DistributionConfigImpl.class))
+              .or(type(RemoteTransportConfig.class))
+              .or(type(FlowControlParams.class))
+
+
+              // TODO: Break dependency on geode logger
+              .or(type(LogService.class))
+              .or(assignableTo(LoggingThread.class))
+              .or(type(LoggingExecutors.class))
+              .or(type(LogMarker.class))
+              .or(type(AlertAppender.class))
+
+              // TODO
+              .or(type(SystemFailure.class))
+
+              // TODO: Break dependency on Role
+              .or(assignableTo(Role.class))
+
+              // TODO: Break dependency on SystemTimerTask
+              .or(assignableTo(SystemTimer.SystemTimerTask.class))
+              .or(type(SystemTimer.class))
+
+              // TODO: Break dependency on SizeableRunnable
+              .or(assignableTo(SizeableRunnable.class))
+
+              // TODO: Break dependency on DirectChannelListener (and its getDM method!)
+              .or(assignableTo(DirectChannelListener.class))
+
+              // TODO: This and TCP conduit be moved inside membership.
+              // Do we even need this class since it is just forwarding to TCPConduit?
+              .or(type(DirectChannel.class))
+
+              // TODO: Break dependency on geode DurableClientAttributes
+              .or(type(DurableClientAttributes.class))
+
+              // TODO
+              .or(assignableTo(CancelCriterion.class))
+
+              // TODO
+              .or(assignableTo(ConnectionWatcher.class))
+
+              // TODO:
+              .or(type(SocketCreator.class))
+              .or(type(SocketCreatorFactory.class))
+
+              // TODO:
+              .or(type(Assert.class))
+
+              // TODO: break dependencies on locator-related classes
+              .or(type(Locator.class))
+              .or(type(TcpHandler.class))
+              .or(type(TcpClient.class))
+              .or(type(TcpServer.class))
+              .or(type(ServerLocation.class))
+              .or(type(InternalLocator.class))
+              .or(type(DistributionLocatorId.class))
+              .or(type(InternalConfigurationPersistenceService.class))
+
+              // TODO: Mt. Olympus (G*D objects live here)
+              .or(type(DistributionManager.class))
+              .or(type(InternalDistributedSystem.class))
+              .or(type(DistributedSystem.class))
+              .or(type(GemFireCache.class))
+              .or(type(GemFireCacheImpl.class))
+              .or(type(InternalCache.class))
+              .or(type(ClusterDistributionManager.class))
+
+              // TODO: break dependency on internal.security
+              .or(type(SecurableCommunicationChannel.class))
+
+              // TODO:
+              .or(type(DistributedMember.class))
+
+              // TODO: This stuff is just used in GMSMembershipManager.saveCacheXmlForReconnect
+              .or(type(CacheServerImpl.class))
+              .or(type(StringPrintWriter.class))
+              .or(type(CacheXmlGenerator.class))
+              .or(type(CacheServerCreation.class))
+              .or(type(CacheConfig.class))
+
+              // TODO:
+              .or(type(JavaWorkarounds.class))
+
+              // TODO:
+              .or(type(ConcurrentHashSet.class))
+
+              // TODO:
+              .or(type(OSProcess.class))
+
+              // TODO:
+              .or(type(ClassPathLoader.class))
+
+              // TODO:
+              .or(type(AlertingAction.class))
+
+              // TODO:
+              .or(type(Breadcrumbs.class))
+
+  );
+
+}

--- a/gradle/check-pom.gradle
+++ b/gradle/check-pom.gradle
@@ -127,7 +127,7 @@ A possible exception is the listed Geode project dependencies, which are modifie
 
 Once the differences in the above files are reviewed and confirmed to be intentional,
   please update the expected POM file to reflect your changes.
-Alternatively, run './gradlew ${project.name}:updateExpectedPom' to replace the expected POM with the generated POM.
+Alternatively, run './gradlew ${project.path}:updateExpectedPom' to replace the expected POM with the generated POM.
 """
         thisOutput.write(message)
         throw new RuntimeException(message)


### PR DESCRIPTION
Using ArchUnit to write a test that membership classes must only
depend on other membership classes.

Co-Authored-By: Bill Burcham <bburcham@pivotal.io>
Co-Authored-By: Ernest Burghardt <eburghardt@pivotal.io>
Co-Authored-By: Dan Smith <dsmith@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
