### PR TITLE
GEODE-6928 peer-to-peer SSL stream corruption with conserve-sockets=false

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/ClusterCommunicationsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/ClusterCommunicationsDUnitTest.java
@@ -145,7 +145,6 @@ public class ClusterCommunicationsDUnitTest implements Serializable {
       verifyCreatedEntry(getVM(i));
     }
     for (int iteration = 1; iteration < 6; iteration++) {
-      System.out.println("Performing update #" + iteration);
       performUpdate(getVM(1));
     }
     for (int i = 1; i <= NUM_SERVERS; i++) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -790,6 +790,8 @@ public class ClusterDistributionManager implements DistributionManager {
 
       localAddress = membershipManager.getLocalMember();
 
+      membershipManager.postConnect();
+
       sb.append(" ms)");
 
       logger.info("Starting DistributionManager {}. {}",

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -790,8 +790,6 @@ public class ClusterDistributionManager implements DistributionManager {
 
       localAddress = membershipManager.getLocalMember();
 
-      membershipManager.postConnect();
-
       sb.append(" ms)");
 
       logger.info("Starting DistributionManager {}. {}",

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DMStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DMStats.java
@@ -297,6 +297,9 @@ public interface DMStats {
    */
   void incReconnectAttempts();
 
+
+  int getReconnectAttempts();
+
   /**
    * @since GemFire 4.1
    */

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
@@ -1657,6 +1657,11 @@ public class DistributionStats implements DMStats {
   }
 
   @Override
+  public int getReconnectAttempts() {
+    return stats.getInt(reconnectAttemptsId);
+  }
+
+  @Override
   public void incLostLease() {
     stats.incInt(lostConnectionLeaseId, 1);
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
@@ -553,6 +553,11 @@ public class LonerDistributionManager implements DistributionManager {
     public void incReconnectAttempts() {}
 
     @Override
+    public int getReconnectAttempts() {
+      return 0;
+    }
+
+    @Override
     public void incLostLease() {}
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
@@ -135,7 +135,7 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
       boolean doUpdate = true; // start with assumption we have key and need value
       if (shouldDoRemoteCreate(rgn, ev)) {
         if (logger.isDebugEnabled()) {
-          logger.debug("doPutOrCreate: attempting to create entry");
+          logger.debug("doPutOrCreate: attempting to update or create entry");
         }
         final long startPut = CachePerfStats.getStatTime();
         final boolean isBucket = rgn.isUsedForPartitionedRegionBucket();

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
@@ -57,6 +57,13 @@ public interface NioFilter {
       throws IOException;
 
   /**
+   * When done reading a direct ack message invoke this method
+   */
+  default void doneReadingDirectAck(ByteBuffer unwrappedBuffer) {
+    doneReading(unwrappedBuffer);
+  }
+
+  /**
    * You must invoke this when done reading from the unwrapped buffer
    */
   default void doneReading(ByteBuffer unwrappedBuffer) {

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -369,6 +369,7 @@ public class NioSslEngine implements NioFilter {
     return peerAppData;
   }
 
+  @Override
   public void doneReadingDirectAck(ByteBuffer unwrappedBuffer) {
     // nothing needs to be done - the next direct-ack message will be
     // read into the same buffer and compaction will be done during

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -369,6 +369,12 @@ public class NioSslEngine implements NioFilter {
     return peerAppData;
   }
 
+  public void doneReadingDirectAck(ByteBuffer unwrappedBuffer) {
+    // nothing needs to be done - the next direct-ack message will be
+    // read into the same buffer and compaction will be done during
+    // read-operations
+  }
+
 
   @Override
   public void close(SocketChannel socketChannel) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
@@ -94,9 +94,7 @@ public class MsgReader {
     try {
       byteBufferInputStream.setBuffer(nioInputBuffer);
       ReplyProcessor21.initMessageRPId();
-      DistributionMessage result =
-          (DistributionMessage) InternalDataSerializer.readDSFID(byteBufferInputStream);
-      return result;
+      return (DistributionMessage) InternalDataSerializer.readDSFID(byteBufferInputStream);
     } catch (RuntimeException e) {
       throw e;
     } catch (IOException e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
@@ -58,9 +58,6 @@ public class MsgReader {
 
     Assert.assertTrue(unwrappedBuffer.remaining() >= Connection.MSG_HEADER_BYTES);
 
-    int position = unwrappedBuffer.position();
-    int limit = unwrappedBuffer.limit();
-
     try {
       int nioMessageLength = unwrappedBuffer.getInt();
       /* nioMessageVersion = */
@@ -94,13 +91,12 @@ public class MsgReader {
     Assert.assertTrue(nioInputBuffer.remaining() >= header.messageLength);
     this.getStats().incMessagesBeingReceived(true, header.messageLength);
     long startSer = this.getStats().startMsgDeserialization();
-    int position = nioInputBuffer.position();
-    int limit = nioInputBuffer.limit();
     try {
       byteBufferInputStream.setBuffer(nioInputBuffer);
       ReplyProcessor21.initMessageRPId();
-      // dumpState("readMessage ready to deserialize", null, nioInputBuffer, position, limit);
-      return (DistributionMessage) InternalDataSerializer.readDSFID(byteBufferInputStream);
+      DistributionMessage result =
+          (DistributionMessage) InternalDataSerializer.readDSFID(byteBufferInputStream);
+      return result;
     } catch (RuntimeException e) {
       throw e;
     } catch (IOException e) {
@@ -108,7 +104,7 @@ public class MsgReader {
     } finally {
       this.getStats().endMsgDeserialization(startSer);
       this.getStats().decMessagesBeingReceived(header.messageLength);
-      ioFilter.doneReading(nioInputBuffer);
+      ioFilter.doneReadingDirectAck(nioInputBuffer);
     }
   }
 


### PR DESCRIPTION
Modified the NioSslEngine to not modify the decrypted SSL buffer after
reading a direct-ack response.  This allows the readFully method to
correctly see what bytes have already been consumed and correctly
compact the buffer for subsequent reads, if necessary.

The cluster communication test is modified to check for aborted
connections created (retries) during operation distribution.  Without the
fix for the problem this check would fail.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
