### PR TITLE
GEODE-6897: Provide asynchronous operation execution endpoint

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -731,6 +731,11 @@ javadoc/org/apache/geode/management/membership/UniversalMembershipListenerAdapte
 javadoc/org/apache/geode/management/membership/package-frame.html
 javadoc/org/apache/geode/management/membership/package-summary.html
 javadoc/org/apache/geode/management/membership/package-tree.html
+javadoc/org/apache/geode/management/operation/OperationResult.Status.html
+javadoc/org/apache/geode/management/operation/OperationResult.html
+javadoc/org/apache/geode/management/operation/package-frame.html
+javadoc/org/apache/geode/management/operation/package-summary.html
+javadoc/org/apache/geode/management/operation/package-tree.html
 javadoc/org/apache/geode/management/package-frame.html
 javadoc/org/apache/geode/management/package-summary.html
 javadoc/org/apache/geode/management/package-tree.html

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -72,6 +72,7 @@ org/apache/geode/management/internal/cli/commands/ShowMetricsCommand$Category
 org/apache/geode/management/internal/cli/exceptions/UserErrorException
 org/apache/geode/management/internal/cli/json/AbstractJSONFormatter$PreventReserializationModule
 org/apache/geode/management/internal/cli/json/QueryResultFormatter$TypeSerializationEnforcerModule
+org/apache/geode/management/operation/OperationResult$Status
 org/apache/geode/security/ResourcePermission
 org/apache/geode/security/ResourcePermission$Operation
 org/apache/geode/security/ResourcePermission$Resource

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -72,12 +72,12 @@ import org.apache.geode.management.runtime.RuntimeInfo;
 
 public class LocatorClusterManagementService implements ClusterManagementService {
   private static final Logger logger = LogService.getLogger();
-  private ConfigurationPersistenceService persistenceService;
-  private Map<Class, ConfigurationManager> managers;
-  private Map<Class, ConfigurationValidator> validators;
-  private MemberValidator memberValidator;
-  private CacheElementValidator commonValidator;
-  private OperationManager operationManager;
+  private final ConfigurationPersistenceService persistenceService;
+  private final Map<Class, ConfigurationManager> managers;
+  private final Map<Class, ConfigurationValidator> validators;
+  private final MemberValidator memberValidator;
+  private final CacheElementValidator commonValidator;
+  private final OperationManager operationManager;
 
   public LocatorClusterManagementService(InternalCache cache,
       ConfigurationPersistenceService persistenceService) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/operations/OperationExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/operations/OperationExecutor.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.operations;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.apache.geode.management.internal.api.LocatorClusterManagementService;
+import org.apache.geode.management.operation.OperationResult;
+
+/**
+ * Interface which any Management service operation must implement. {@code OperationExecutor}s are
+ * registered in the {@link LocatorClusterManagementService}
+ */
+public interface OperationExecutor {
+
+  /**
+   * Return the id of the {@code OperationExecutor}. This id will also be used in the background
+   * thread performing the operation.
+   *
+   * @return the id
+   */
+  String getId();
+
+  /**
+   * An optional description of the operation
+   *
+   * @return the description or empty string if not overridden
+   */
+  default String getDescription() {
+    return "";
+  }
+
+  /**
+   * Method which actually performs the operation. For example:
+   *
+   * <pre>
+   *   public CompletableFuture&lt;OperationResult&gt; run(
+   *       Map<String, String> arguments, OperationResult operationResult,
+   *       Executor exe) {
+   *     final CompletableFuture&lt;OperationResult&gt; future = new CompletableFuture&lt;&gt;();
+   *     exe.execute(() -> {
+   *       operationResult.setStartTime(System.currentTimeMillis());
+   *       operationResult.setEndTime(System.currentTimeMillis());
+   *       operationResult.setStatus(OperationResult.Status.COMPLETED);
+   *     });
+   *
+   *     return future;
+   *   }
+   * </pre>
+   *
+   * @param arguments possible arguments to the operation
+   * @param operationResult a {@code OperationResult} instance which must be used to complete the
+   *        returned {@code CompletableFuture}
+   * @param executor an {@link Executor} which must be used to execute the background task.
+   */
+  CompletableFuture<OperationResult> run(Map<String, String> arguments,
+      OperationResult operationResult, Executor executor);
+
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/operations/OperationManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/operations/OperationManager.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.operations;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.apache.geode.internal.logging.LoggingExecutors;
+import org.apache.geode.management.operation.OperationResult;
+
+/**
+ * Maintains a list of known, possible operations and can run them when requested. Maintains state
+ * of running operations
+ */
+public class OperationManager {
+
+  private final Map<String, OperationExecutor> operations = new HashMap<>();
+
+  private final Map<String, OperationResult> operationResults = new HashMap<>();
+
+  public void registerOperation(OperationExecutor executor) {
+    operations.put(executor.getId(), executor);
+  }
+
+  /**
+   * Launch an operation...
+   */
+  public synchronized CompletableFuture<OperationResult> run(String operation,
+      Map<String, String> arguments) {
+    OperationExecutor opExecutor = operations.get(operation);
+    if (opExecutor == null) {
+      throw new IllegalArgumentException("No operation for " + operation + " exists");
+    }
+
+    Executor executor = LoggingExecutors.newThreadOnEachExecute(operation);
+    OperationResult result = new OperationResult(operation);
+    CompletableFuture<OperationResult> future = opExecutor.run(arguments, result, executor);
+
+    operationResults.put(operation, result);
+
+    return future;
+  }
+
+  /**
+   * Return a copy of the latest result of an operation
+   */
+  public synchronized OperationResult getResult(String operation) {
+    OperationResult result = operationResults.get(operation);
+    return result != null ? result.clone() : null;
+  }
+
+}

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
@@ -15,8 +15,12 @@
 
 package org.apache.geode.management.api;
 
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.management.operation.OperationResult;
 import org.apache.geode.management.runtime.RuntimeInfo;
 
 /**
@@ -65,6 +69,24 @@ public interface ClusterManagementService {
 
   <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementResult<T, R> get(
       T config);
+
+  /**
+   * Execute a given operation asynchronously.
+   *
+   * @param operation name of the operation
+   * @param arguments arguments to the operation
+   * @return a {@code CompletableFuture} which will provide the final result of the operation
+   */
+  CompletableFuture<OperationResult> perform(String operation, Map<String, String> arguments);
+
+  /**
+   * Retrieve the latest result of an operation. If no operation is currently executing, then this
+   * will be the result of the last executed operation. If an operation is in progress, then this is
+   * an intermediate result which may contain progress information.
+   *
+   * @param operation to query
+   */
+  OperationResult getOperationResult(String operation);
 
   /**
    * Test to see if this instance of ClusterManagementService retrieved from the client side is

--- a/geode-management/src/main/java/org/apache/geode/management/internal/SpringClusterManagemnetServiceBuilder.java
+++ b/geode-management/src/main/java/org/apache/geode/management/internal/SpringClusterManagemnetServiceBuilder.java
@@ -26,7 +26,7 @@ import org.apache.geode.management.client.ClusterManagementServiceBuilder;
 public class SpringClusterManagemnetServiceBuilder implements
     ClusterManagementServiceBuilder.HttpRequestFactoryBuilder {
 
-  protected ClientHttpRequestFactory requestFactory;
+  private ClientHttpRequestFactory requestFactory;
 
   public ClusterManagementService build() {
     RestTemplate restTemplate = new RestTemplate();

--- a/geode-management/src/main/java/org/apache/geode/management/operation/OperationResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/operation/OperationResult.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.operation;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.geode.annotations.Experimental;
+
+/**
+ * Encapsulate the result of running one of the possible Management service operations.
+ */
+@Experimental
+public class OperationResult implements Cloneable {
+
+  private String name;
+  private Status status;
+  private String message;
+  private long startTime;
+  private long endTime;
+
+  public enum Status {
+    COMPLETED,
+    FAILED,
+    RUNNING
+  }
+
+  @JsonCreator
+  public OperationResult(@JsonProperty("name") String name) {
+    this.name = name;
+  }
+
+  private OperationResult(String name, Status status, long startTime, long endTime,
+      String message) {
+    this(name);
+    this.status = status;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.message = message;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public Status getStatus() {
+    return status;
+  }
+
+  public void setStatus(Status status) {
+    this.status = status;
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public void setStartTime(long startTime) {
+    this.startTime = startTime;
+  }
+
+  public long getEndTime() {
+    return endTime;
+  }
+
+  public void setEndTime(long endTime) {
+    this.endTime = endTime;
+  }
+
+  public OperationResult clone() {
+    try {
+      return (OperationResult) super.clone();
+    } catch (CloneNotSupportedException e) {
+      return new OperationResult(name, status, startTime, endTime, message);
+    }
+  }
+}

--- a/geode-management/src/main/java/org/apache/geode/management/operation/OperationResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/operation/OperationResult.java
@@ -33,14 +33,16 @@ public class OperationResult implements Cloneable {
   private long endTime;
 
   public enum Status {
+    PENDING,
+    RUNNING,
     COMPLETED,
-    FAILED,
-    RUNNING
+    FAILED
   }
 
   @JsonCreator
   public OperationResult(@JsonProperty("name") String name) {
     this.name = name;
+    this.status = Status.PENDING;
   }
 
   private OperationResult(String name, Status status, long startTime, long endTime,

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/OperationManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/OperationManagementIntegrationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.management.api.ClusterManagementService;
+import org.apache.geode.management.client.ClusterManagementServiceBuilder;
+import org.apache.geode.management.internal.api.LocatorClusterManagementService;
+import org.apache.geode.management.internal.operations.OperationExecutor;
+import org.apache.geode.management.operation.OperationResult;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/management-servlet.xml"},
+    loader = PlainLocatorContextLoader.class)
+@WebAppConfiguration
+public class OperationManagementIntegrationTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  // needs to be used together with any BaseLocatorContextLoader
+  private LocatorWebContext context;
+
+  private ClusterManagementService client;
+
+  @Before
+  public void before() {
+    context = new LocatorWebContext(webApplicationContext);
+    client = ClusterManagementServiceBuilder.buildWithRequestFactory()
+        .setRequestFactory(context.getRequestFactory()).build();
+
+    OperationExecutor goodOperation = new OperationExecutor() {
+      @Override
+      public CompletableFuture<OperationResult> run(
+          Map<String, String> arguments, OperationResult operationResult,
+          Executor exe) {
+        final CompletableFuture<OperationResult> future = new CompletableFuture<>();
+        exe.execute(() -> {
+          operationResult.setStartTime(System.currentTimeMillis());
+          // Do stuff
+          if (arguments != null) {
+            operationResult.setMessage(arguments.toString());
+          }
+          operationResult.setEndTime(System.currentTimeMillis());
+          operationResult.setStatus(OperationResult.Status.COMPLETED);
+          future.complete(operationResult);
+        });
+
+        return future;
+      }
+
+      @Override
+      public String getId() {
+        return "good-operation";
+      }
+    };
+
+    OperationExecutor badOperation = new OperationExecutor() {
+
+      @Override
+      public CompletableFuture<OperationResult> run(
+          Map<String, String> arguments, OperationResult operationResult,
+          Executor exe) {
+        final CompletableFuture<OperationResult> future = new CompletableFuture<>();
+        exe.execute(() -> {
+          if (arguments != null) {
+            operationResult.setMessage(arguments.toString());
+          }
+          operationResult.setStatus(OperationResult.Status.FAILED);
+        });
+
+        return future;
+      }
+
+      @Override
+      public String getId() {
+        return "bad-operation";
+      }
+    };
+
+    ((LocatorClusterManagementService) context.getLocator().getClusterManagementService())
+        .registerOperation(goodOperation);
+    ((LocatorClusterManagementService) context.getLocator().getClusterManagementService())
+        .registerOperation(badOperation);
+  }
+
+  @Test
+  public void submitSuccessfulOperationWithoutArguments() throws Exception {
+    CompletableFuture<OperationResult> future = client.perform("good-operation", null);
+    OperationResult result = future.get(1, TimeUnit.SECONDS);
+
+    assertThat(result.getStatus()).isEqualTo(OperationResult.Status.COMPLETED);
+  }
+
+  @Test
+  public void submitSuccessfulOperationWithArguments() throws Exception {
+    Map<String, String> args = new HashMap<>();
+    args.put("key", "value");
+    CompletableFuture<OperationResult> future = client.perform("good-operation", args);
+    OperationResult result = future.get(1, TimeUnit.SECONDS);
+
+    assertThat(result.getStatus()).isEqualTo(OperationResult.Status.COMPLETED);
+    assertThat(result.getMessage()).isEqualTo("{key=value}");
+  }
+
+  @Test
+  public void submitOperationWithError() throws Exception {
+    CompletableFuture<OperationResult> future = client.perform("bad-operation", null);
+    OperationResult result = future.get(1000, TimeUnit.SECONDS);
+
+    assertThat(result.getStatus()).isEqualTo(OperationResult.Status.FAILED);
+  }
+
+  @Test
+  public void submitUnknownOperation() throws Exception {
+    CompletableFuture<OperationResult> result = client.perform("unknown-operation", null);
+
+    assertThat(result.isCompletedExceptionally()).isTrue();
+  }
+
+}

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/OperationManagementRestIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/OperationManagementRestIntegrationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest;
+
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.management.internal.api.LocatorClusterManagementService;
+import org.apache.geode.management.internal.operations.OperationExecutor;
+import org.apache.geode.management.operation.OperationResult;
+
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/management-servlet.xml"},
+    loader = PlainLocatorContextLoader.class)
+@WebAppConfiguration
+public class OperationManagementRestIntegrationTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  // needs to be used together with any BaseLocatorContextLoader
+  private LocatorWebContext context;
+
+  @Before
+  public void before() {
+    context = new LocatorWebContext(webApplicationContext);
+
+    OperationExecutor goodOperation = new OperationExecutor() {
+      @Override
+      public CompletableFuture<OperationResult> run(
+          Map<String, String> arguments, OperationResult operationResult,
+          Executor exe) {
+        final CompletableFuture<OperationResult> future = new CompletableFuture<>();
+        exe.execute(() -> {
+          operationResult.setStartTime(System.currentTimeMillis());
+          // Do stuff
+          operationResult.setEndTime(System.currentTimeMillis());
+          operationResult.setStatus(OperationResult.Status.COMPLETED);
+          future.complete(operationResult);
+        });
+
+        return future;
+      }
+
+      @Override
+      public String getId() {
+        return "good-operation";
+      }
+    };
+
+    OperationExecutor badOperation = new OperationExecutor() {
+      @Override
+      public CompletableFuture<OperationResult> run(
+          Map<String, String> arguments, OperationResult operationResult,
+          Executor exe) {
+        final CompletableFuture<OperationResult> future = new CompletableFuture<>();
+        exe.execute(() -> {
+          operationResult.setStartTime(System.currentTimeMillis());
+          operationResult.setStatus(OperationResult.Status.FAILED);
+          operationResult.setMessage("operation failed");
+          future.completeExceptionally(new RuntimeException("operation failed"));
+        });
+
+        return future;
+      }
+
+      @Override
+      public String getId() {
+        return "bad-operation";
+      }
+    };
+
+    ((LocatorClusterManagementService) context.getLocator().getClusterManagementService())
+        .registerOperation(goodOperation);
+    ((LocatorClusterManagementService) context.getLocator().getClusterManagementService())
+        .registerOperation(badOperation);
+  }
+
+  @Test
+  public void submitOperation() throws Exception {
+    context.perform(post("/v2/operations/good-operation"))
+        .andDo(print())
+        .andExpect(status().isAccepted())
+        .andExpect(header().string("Location", "http://localhost/v2/operations/good-operation"));
+  }
+
+  @Test
+  public void querySuccessfulOperation() throws Exception {
+    context.perform(post("/v2/operations/good-operation"))
+        .andDo(print())
+        .andExpect(status().isAccepted())
+        .andExpect(header().string("Location", "http://localhost/v2/operations/good-operation"));
+
+    context.perform(get("/v2/operations/good-operation"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status", is("COMPLETED")))
+        .andExpect(jsonPath("$.startTime", is(greaterThan(0L))))
+        .andExpect(jsonPath("$.endTime", is(greaterThan(0L))));
+  }
+
+  @Test
+  public void queryOperationWithException() throws Exception {
+    context.perform(post("/v2/operations/bad-operation"))
+        .andDo(print())
+        .andExpect(status().isAccepted())
+        .andExpect(header().string("Location", "http://localhost/v2/operations/bad-operation"));
+
+    context.perform(get("/v2/operations/bad-operation"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status", is("FAILED")));
+  }
+
+  @Test
+  public void queryNonExistentOperation() throws Exception {
+    context.perform(get("/v2/operations/unknown"))
+        .andDo(print())
+        .andExpect(status().isNotFound());
+  }
+
+}

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/OperationManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/OperationManagementController.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.rest.controllers;
+
+import static org.apache.geode.management.internal.rest.controllers.AbstractManagementController.MANAGEMENT_API_VERSION;
+
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import org.apache.geode.management.operation.OperationResult;
+
+@Controller("operationManagement")
+@RequestMapping(MANAGEMENT_API_VERSION)
+public class OperationManagementController extends AbstractManagementController {
+
+  @PreAuthorize("@securityService.authorize('CLUSTER', 'READ')")
+  @RequestMapping(method = RequestMethod.GET, value = "/operations/{operation}")
+  @ResponseBody
+  public ResponseEntity<OperationResult> queryOperation(
+      @PathVariable String operation) {
+
+    OperationResult operationResult = clusterManagementService.getOperationResult(operation);
+    if (operationResult == null) {
+      return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+    }
+
+    return new ResponseEntity<>(operationResult, HttpStatus.OK);
+  }
+
+  @PreAuthorize("@securityService.authorize('CLUSTER', 'MANAGE')")
+  @RequestMapping(method = RequestMethod.POST, value = "/operations/{operation}")
+  public ResponseEntity<?> acceptOperation(
+      @PathVariable String operation,
+      @RequestBody(required = false) Map<String, String> arguments,
+      UriComponentsBuilder b) {
+
+    clusterManagementService.perform(operation, arguments);
+
+    UriComponents uriComponents =
+        b.path(MANAGEMENT_API_VERSION + "/operations/{operationType}").buildAndExpand(operation);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setLocation(uriComponents.toUri());
+
+    return new ResponseEntity<>(headers, HttpStatus.ACCEPTED);
+  }
+
+}


### PR DESCRIPTION
- Introduce new public `perform()` method to ClusterManagementService
  which will allow a known operation to be run asynchronously.
- Introduce new internal `OperationManager` component which is
  responsible for launching defined operations and maintaining state of
  running and past operations. This component is attached to the
  LocatorClusterManagementService.
- New operations are created by implementing the `OperationExecutor`
  interface.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
