### PR TITLE
GEODE-6904: Fix hangs related to locator reconnecting

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
@@ -19,16 +19,24 @@ package org.apache.geode.management.internal.configuration;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.GemFireConfigException;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -98,7 +106,6 @@ public class ClusterConfigLocatorRestartDUnitTest {
     IgnoredException.addIgnoredException("org.apache.geode.ForcedDisconnectException: for testing");
     IgnoredException.addIgnoredException("Connection refused");
 
-
     Properties properties = new Properties();
     properties.setProperty(MAX_WAIT_TIME_RECONNECT, "30000");
 
@@ -111,10 +118,7 @@ public class ClusterConfigLocatorRestartDUnitTest {
     // Shut down hard
     rule.crashVM(0);
 
-
     server3.forceDisconnect();
-
-
 
     rule.startServerVM(4, locator1.getPort(), locator0.getPort());
 
@@ -158,6 +162,85 @@ public class ClusterConfigLocatorRestartDUnitTest {
         .hasCauseInstanceOf(
             GemFireConfigException.class);
 
+  }
+
+  @Test(timeout = 300_000)
+  public void serverRestartHangsWaitingForStartupMessageResponse() throws Exception {
+    IgnoredException.addIgnoredException("This member is no longer in the membership view");
+    IgnoredException.addIgnoredException("This node is no longer in the membership view");
+    IgnoredException.addIgnoredException("ForcedDisconnectException");
+    IgnoredException.addIgnoredException("Possible loss of quorum due to the loss");
+    IgnoredException.addIgnoredException("Membership service failure:");
+    IgnoredException.addIgnoredException("Failed to send message:");
+    IgnoredException.addIgnoredException("Cannot form connection to alert listener");
+    IgnoredException.addIgnoredException("Received invalid result");
+    IgnoredException.addIgnoredException("cluster configuration service not available");
+    // With the following steps, a locator can get into state where it is stuck in the middle of
+    // reconnecting.
+    // It allows members to join the system, but they timeout sending it startup messages and
+    // start up without cluster configuration, resulting not being able to restart the cluster.
+    // A- Start 2 locators and some number of servers
+    // B- Kill one locator and trigger a force disconnect in the remaining locators and servers at
+    // the same time
+    // C- Have one of the members take a little bit of time before reconnecting, to let the locator
+    // get to
+    // recovering the _ConfigurationRegion before that remaining member joins.
+
+    // A
+    MemberVM locator0 = rule.startLocatorVM(0);
+    MemberVM locator1 = rule.startLocatorVM(1, locator0.getPort());
+
+    MemberVM server2 = rule.startServerVM(2, locator0.getPort(), locator1.getPort());
+    Properties properties = new Properties();
+    properties.setProperty(MAX_WAIT_TIME_RECONNECT, "10000");
+
+    MemberVM server3 =
+        rule.startServerVM(3, properties, locator0.getPort(), locator1.getPort());
+
+    gfsh.connectAndVerify(locator1);
+    gfsh.executeAndAssertThat("create region --name=region --type=REPLICATE").statusIsSuccess();
+
+    // B
+    server2.forceDisconnect();
+    server3.forceDisconnect();
+    locator1.forceDisconnect();
+
+    rule.crashVM(0); // Shut down hard
+
+    // Wait until locator1 gets stuck waiting for locator0 to start up in order to recover the
+    // cluster configuration region
+    locator1.invoke(() -> {
+      await().untilAsserted(() -> {
+        InternalCache cache = GemFireCacheImpl.getInstance();
+        assertThat(cache).isNotNull();
+        Map<String, Set<PersistentMemberID>> waitingRegions = cache
+            .getPersistentMemberManager()
+            .getWaitingRegions();
+
+        assertThat(waitingRegions).isNotEmpty();
+      });
+    });
+
+    // Start another member. This should fail because it should require cluster configuration in
+    // order to startup
+    assertThatThrownBy(
+        () -> this.rule.startServerVM(4, properties, locator1.getPort(), locator0.getPort()))
+            .hasCauseInstanceOf(
+                GemFireConfigException.class);
+
+
+    // Restart locator 0, which allows the locators to recover cluster configuration
+    rule.startLocatorVM(0, locator1.getPort());
+
+    // Member4 should now be able to startup and get cluster configuartion
+    MemberVM server4 =
+        rule.startServerVM(4, properties, locator1.getPort(), locator0.getPort());
+
+    // Make sure server4 actually gets the cluster configuration
+    server4.invoke(() -> {
+      Cache cache = CacheFactory.getAnyInstance();
+      assertThat(cache.getRegion("/region")).isNotNull();
+    });
   }
 
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ClusterConfigurationLoaderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ClusterConfigurationLoaderIntegrationTest.java
@@ -55,9 +55,11 @@ public class ClusterConfigurationLoaderIntegrationTest {
     locators.add((InternalDistributedMember) locator.getLocator().getDistributedSystem()
         .getDistributedMember());
 
-    assertThatThrownBy(() -> loader.requestConfigurationFromLocators("", locators))
-        .isInstanceOf(FunctionException.class).hasCauseInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("The cluster configuration service is not enabled on this member.");
+    assertThatThrownBy(() -> loader.requestConfigurationFromLocators("",
+        locator.getCache().getDistributionManager()))
+            .isInstanceOf(FunctionException.class).hasCauseInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(
+                "The cluster configuration service is not enabled on this member.");
   }
 
   @Test
@@ -71,9 +73,10 @@ public class ClusterConfigurationLoaderIntegrationTest {
     locators.add((InternalDistributedMember) locator.getLocator().getDistributedSystem()
         .getDistributedMember());
 
-    assertThatThrownBy(() -> loader.requestConfigurationFromLocators("", locators))
-        .isInstanceOf(ClusterConfigurationNotAvailableException.class)
-        .hasMessageContaining("Unable to retrieve cluster configuration from the locator.");
+    assertThatThrownBy(() -> loader.requestConfigurationFromLocators("",
+        locator.getCache().getDistributionManager()))
+            .isInstanceOf(ClusterConfigurationNotAvailableException.class)
+            .hasMessageContaining("Unable to retrieve cluster configuration from the locator.");
 
     assertThat(customAnswer.calls).isEqualTo(6);
   }
@@ -88,7 +91,8 @@ public class ClusterConfigurationLoaderIntegrationTest {
     locators.add((InternalDistributedMember) locator.getLocator().getDistributedSystem()
         .getDistributedMember());
 
-    ConfigurationResponse response = loader.requestConfigurationFromLocators("", locators);
+    ConfigurationResponse response =
+        loader.requestConfigurationFromLocators("", locator.getCache().getDistributionManager());
     Map<String, Configuration> configurationMap = response.getRequestedConfiguration();
     assertThat(configurationMap.size()).isEqualTo(1);
     assertThat(configurationMap.get("cluster")).isNotNull();
@@ -107,7 +111,8 @@ public class ClusterConfigurationLoaderIntegrationTest {
     locators.add((InternalDistributedMember) locator.getLocator().getDistributedSystem()
         .getDistributedMember());
 
-    ConfigurationResponse response = loader.requestConfigurationFromLocators("", locators);
+    ConfigurationResponse response =
+        loader.requestConfigurationFromLocators("", locator.getCache().getDistributionManager());
     Map<String, Configuration> configurationMap = response.getRequestedConfiguration();
     assertThat(configurationMap.size()).isEqualTo(1);
     assertThat(configurationMap.get("cluster")).isNotNull();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -114,9 +114,6 @@ public class ClusterDistributionManager implements DistributionManager {
 
   private static final Logger logger = LogService.getLogger();
 
-  private static final int STARTUP_TIMEOUT =
-      Integer.getInteger("DistributionManager.STARTUP_TIMEOUT", 15000);
-
   private static final boolean DEBUG_NO_ACKNOWLEDGEMENTS =
       Boolean.getBoolean("DistributionManager.DEBUG_NO_ACKNOWLEDGEMENTS");
 
@@ -2254,7 +2251,7 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     try {
-      ok = startupOperation.sendStartupMessage(allOthers, STARTUP_TIMEOUT, equivs, redundancyZone,
+      ok = startupOperation.sendStartupMessage(allOthers, equivs, redundancyZone,
           enforceUniqueZone());
     } catch (Exception re) {
       throw new SystemConnectException(

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1155,42 +1155,43 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
         throw new IllegalStateException(
             "A locator can not be created because one already exists in this JVM.");
       }
-      internalDistributedSystem = newSystem;
-      internalCache = newCache;
-      internalDistributedSystem.setDependentLocator(this);
-      logger.info("Locator restart: initializing TcpServer");
-
-      try {
-        server.restarting(newSystem, newCache, configurationPersistenceService);
-      } catch (CancelException e) {
-        internalDistributedSystem = null;
-        internalCache = null;
-        logger.info("Locator restart: attempt to restart location services failed", e);
-        throw e;
-      }
-
-      if (productUseLog.isClosed()) {
-        productUseLog.reopen();
-      }
-
-      productUseLog.monitorUse(newSystem);
-
-      if (isSharedConfigurationEnabled()) {
-        configurationPersistenceService =
-            new InternalConfigurationPersistenceService(newCache);
-        startClusterManagementService();
-      }
-
-      if (!server.isAlive()) {
-        logger.info("Locator restart: starting TcpServer");
-        startTcpServer();
-      }
-
-      logger.info("Locator restart: initializing JMX manager");
-      startJmxManagerLocationService(newCache);
-      endStartLocator(internalDistributedSystem);
-      logger.info("Locator restart completed");
     }
+    internalDistributedSystem = newSystem;
+    internalCache = newCache;
+    internalDistributedSystem.setDependentLocator(this);
+    logger.info("Locator restart: initializing TcpServer");
+
+    try {
+      server.restarting(newSystem, newCache, configurationPersistenceService);
+    } catch (CancelException e) {
+      internalDistributedSystem = null;
+      internalCache = null;
+      logger.info("Locator restart: attempt to restart location services failed", e);
+      throw e;
+    }
+
+    if (productUseLog.isClosed()) {
+      productUseLog.reopen();
+    }
+
+    productUseLog.monitorUse(newSystem);
+
+    if (isSharedConfigurationEnabled()) {
+      configurationPersistenceService =
+          new InternalConfigurationPersistenceService(newCache);
+      startClusterManagementService();
+    }
+
+    if (!server.isAlive()) {
+      logger.info("Locator restart: starting TcpServer");
+      startTcpServer();
+    }
+
+    logger.info("Locator restart: initializing JMX manager");
+    startJmxManagerLocationService(newCache);
+    endStartLocator(internalDistributedSystem);
+    logger.info("Locator restart completed");
+
     server.restartCompleted(newSystem);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ClusterConfigurationLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ClusterConfigurationLoader.java
@@ -56,6 +56,7 @@ import org.apache.geode.distributed.ConfigurationPersistenceService;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.LockServiceDestroyedException;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.ConfigSource;
@@ -271,15 +272,16 @@ public class ClusterConfigurationLoader {
    * @return {@link ConfigurationResponse}
    */
   public ConfigurationResponse requestConfigurationFromLocators(String groupList,
-      Set<InternalDistributedMember> locatorList)
+      DistributionManager distributionManager)
       throws ClusterConfigurationNotAvailableException, UnknownHostException {
 
     Set<String> groups = getGroups(groupList);
-
+    Set<InternalDistributedMember> locatorList;
     ConfigurationResponse response = null;
 
     int attempts = 6;
     OUTER: while (attempts > 0) {
+      locatorList = distributionManager.getAllHostedLocators().keySet();
       for (InternalDistributedMember locator : locatorList) {
         logger.info("Attempting to retrieve cluster configuration from {} - {} attempts remaining",
             locator.getName(), attempts);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -1026,23 +1026,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       return null;
     }
 
-    // can't simply return null if server is not using shared configuration, since we need to find
-    // out if the locator is running in secure mode or not, if yes, then we need to throw an
-    // exception if server is not using cluster config.
-
-    Map<InternalDistributedMember, Collection<String>> locatorsWithClusterConfig =
-        getDistributionManager().getAllHostedLocatorsWithSharedConfiguration();
-
-    // If there are no locators with Shared configuration, that means the system has been started
-    // without shared configuration then do not make requests to the locators.
-    if (locatorsWithClusterConfig.isEmpty()) {
-      logger.info("No locator(s) found with cluster configuration service");
-      return null;
-    }
-
     try {
       ConfigurationResponse response = ccLoader.requestConfigurationFromLocators(
-          system.getConfig().getGroups(), locatorsWithClusterConfig.keySet());
+          system.getConfig().getGroups(), getDistributionManager());
 
       // log the configuration received from the locator
       logger.info("Received cluster configuration from the locator");


### PR DESCRIPTION
GEODE-6896: Fail startup if no cluster config is found

Instead of looking for locators that have shared configuration and
skipping initialization from shared config if none are found, we will
simply try to get the shared configuration from all known locators.

GEODE-6904: Fix hang on locator when restarting due to lock

Only hold the locatorLock while reading the locator variable in
restartWithDS. Holding this lock while recovering cluster configuration
was causing other messages to the locator, including the StartupMessage,
to block waiting for this lock.

In addition, waiting forever for StartupMessage responses.
StartupOperation had a 15 second timeout, after which it would stop
waiting. That resulted in not having correct metadata about other
members in the system.