### PR TITLE
GEODE-6918: Cleanup PRHARedundancyProvider and tests

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDUnitTest.java
@@ -14,19 +14,31 @@
  */
 package org.apache.geode.internal.cache.control;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.geode.cache.EvictionAction.OVERFLOW_TO_DISK;
+import static org.apache.geode.cache.EvictionAttributes.createLRUEntryAttributes;
+import static org.apache.geode.cache.RegionShortcut.PARTITION;
+import static org.apache.geode.cache.RegionShortcut.PARTITION_PERSISTENT;
+import static org.apache.geode.cache.RegionShortcut.REPLICATE;
 import static org.apache.geode.distributed.ConfigurationProperties.ENFORCE_UNIQUE_HOST;
 import static org.apache.geode.distributed.ConfigurationProperties.REDUNDANCY_ZONE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
+import static org.apache.geode.test.dunit.VM.getAllVMs;
+import static org.apache.geode.test.dunit.VM.getController;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.VM.toArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.spy;
 
+import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,33 +49,35 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Ignore;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.After;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheLoader;
 import org.apache.geode.cache.CacheLoaderException;
 import org.apache.geode.cache.CacheWriterException;
-import org.apache.geode.cache.DataPolicy;
-import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.cache.EvictionAction;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.LoaderHelper;
-import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.asyncqueue.AsyncEvent;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
-import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
 import org.apache.geode.cache.control.RebalanceOperation;
 import org.apache.geode.cache.control.RebalanceResults;
 import org.apache.geode.cache.control.ResourceManager;
@@ -73,1524 +87,840 @@ import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.cache.partition.PartitionRegionInfo;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.ColocationHelper;
 import org.apache.geode.internal.cache.DiskStoreImpl;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PRHARedundancyProvider;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionDataStore;
 import org.apache.geode.internal.cache.control.InternalResourceManager.ResourceObserverAdapter;
 import org.apache.geode.internal.cache.partitioned.BucketCountLoadProbe;
-import org.apache.geode.internal.cache.partitioned.LoadProbe;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
-import org.apache.geode.test.dunit.Host;
-import org.apache.geode.test.dunit.Invoke;
-import org.apache.geode.test.dunit.LogWriterUtils;
-import org.apache.geode.test.dunit.SerializableCallable;
 import org.apache.geode.test.dunit.SerializableRunnable;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
+import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
-@SuppressWarnings("synthetic-access")
+/**
+ * TODO test colocated regions where buckets aren't created for all subregions
+ *
+ * <p>
+ * TODO test colocated regions where members aren't consistent in which regions they have
+ */
+@RunWith(JUnitParamsRunner.class)
+@SuppressWarnings("serial")
+public class RebalanceOperationDUnitTest extends CacheTestCase {
 
-public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
+  private static final long TIMEOUT_SECONDS = GeodeAwaitility.getTimeout().getValue();
 
-  private static final long MAX_WAIT = 60;
+  @Rule
+  public DistributedRestoreSystemProperties restoreSystemProperties =
+      new DistributedRestoreSystemProperties();
 
-  @Override
-  public final void postTearDownCacheTestCase() throws Exception {
-    Invoke.invokeInEveryVM(new SerializableRunnable() {
-      @Override
-      public void run() {
-        InternalResourceManager.setResourceObserver(null);
-        System.clearProperty(DistributionConfig.GEMFIRE_PREFIX + "resource.manager.threads");
-      }
-    });
-    InternalResourceManager.setResourceObserver(null);
-    System.clearProperty(DistributionConfig.GEMFIRE_PREFIX + "resource.manager.threads");
+  @Rule
+  public ExecutorServiceRule executorServiceRule = new ExecutorServiceRule();
+
+  @After
+  public void tearDown() {
+    for (VM vm : toArray(getAllVMs(), getController())) {
+      vm.invoke(() -> InternalResourceManager.setResourceObserver(null));
+    }
   }
 
   @Test
-  public void testRecoverRedundancySimulation() {
-    recoverRedundancy(true);
-  }
-
-  @Test
-  public void testRecoverRedundancy() {
-    recoverRedundancy(false);
-  }
-
-  public void recoverRedundancy(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-      }
-    };
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testRecoverRedundancy(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Create the region in only 1 VM
-    vm0.invoke(createPrRegion);
+    vm0.invoke(() -> createPartitionedRegion("region1", 1));
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        region.put(Integer.valueOf(1), "A");
-        region.put(Integer.valueOf(2), "A");
-        region.put(Integer.valueOf(3), "A");
-        region.put(Integer.valueOf(4), "A");
-        region.put(Integer.valueOf(5), "A");
-        region.put(Integer.valueOf(6), "A");
-      }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      region.put(1, "A");
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
     });
 
-    SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(6, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(6, details.getLowRedundancyBucketCount());
-      }
-    };
-
     // make sure we can tell that the buckets have low redundancy
-    vm0.invoke(checkLowRedundancy);
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
 
     // Create the region in the other VM (should have no effect)
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> createPartitionedRegion("region1", 1));
 
     // Make sure we still have low redundancy
-    vm0.invoke(checkLowRedundancy);
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
 
     // Now simulate a rebalance
-    vm0.invoke(new SerializableRunnable("simulateRebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(6, results.getTotalBucketCreatesCompleted());
-        assertEquals(3, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(0, results.getTotalBucketTransferBytes());
-        assertEquals(0, results.getTotalBucketTransfersCompleted());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(6, details.getBucketCreatesCompleted());
-        assertEquals(3, details.getPrimaryTransfersCompleted());
-        assertEquals(0, details.getBucketTransferBytes());
-        assertEquals(0, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(6);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(3);
+      assertThat(results.getTotalBucketTransferBytes()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
 
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(2, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(6, memberDetails.getBucketCount());
-          assertEquals(3, memberDetails.getPrimaryCount());
-        }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
 
-        if (!simulate) {
-          verifyStats(manager, results);
-        }
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(6);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(3);
+      assertThat(details.getBucketTransferBytes()).isEqualTo(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(2);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
+      }
+
+      if (!simulate) {
+        validateStatistics(manager, results);
       }
     });
 
-    if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkLowRedundancy") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-        }
-      };
-
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
-    } else {
+    if (simulate) {
       // Make sure the simulation didn't do anything
-      vm0.invoke(checkLowRedundancy);
-    }
-  }
-
-  /** Manual test. */
-  @Ignore
-  @Test
-  public void testRedundancyLoop() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-    VM vm3 = host.getVM(3);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(2);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-      }
-    };
-
-    // Create the region in only 1 VM
-    vm0.invoke(createPrRegion);
-    vm3.invoke(createPrRegion);
-
-    // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        for (int i = 0; i < 500; i++) {
-          region.put(Integer.valueOf(i), "A");
-        }
-      }
-    });
-
-    SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(113, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(113, details.getLowRedundancyBucketCount());
-      }
-    };
-
-    // make sure we can tell that the buckets have low redundancy
-    vm0.invoke(checkLowRedundancy);
-
-    SerializableRunnable closePrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        disconnectFromDS();
-        // Cache cache = getCache();
-        // Region region = cache.getRegion("region1");
-        // region.localDestroyRegion();
-      }
-    };
-
-    for (int i = 0; i < 50; i++) {
-      long start = System.nanoTime();
-      // Create the region in the other VM (should have no effect)
-      vm1.invoke(createPrRegion);
-      vm2.invoke(createPrRegion);
-
-
-      // Now simulate a rebalance
-      vm1.invoke(new SerializableRunnable("simulateRebalance") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          ResourceManager manager = cache.getResourceManager();
-          RebalanceResults results = doRebalance(false, manager);
-          // assertIndexDetailsEquals(113, results.getTotalBucketCreatesCompleted());
-        }
-      });
-
-      vm1.invoke(closePrRegion);
-      vm2.invoke(closePrRegion);
-      long end = System.nanoTime();
-      System.err.println("Elapsed = " + TimeUnit.NANOSECONDS.toMillis(end - start));
+      vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
+    } else {
+      vm0.invoke(() -> validateRedundancy("region1", 6, 1, 0));
+      vm1.invoke(() -> validateRedundancy("region1", 6, 1, 0));
     }
   }
 
   @Test
-  public void testEnforceIP() {
-    enforceIp(false);
-  }
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testEnforceIP(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
-  @Test
-  public void testEnforceIPSimulation() {
-    enforceIp(true);
-  }
-
-  public void enforceIp(final boolean simulate) {
-    Invoke.invokeInEveryVM(new SerializableRunnable() {
-      @Override
-      public void run() {
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
         Properties props = new Properties();
         props.setProperty(ENFORCE_UNIQUE_HOST, "true");
-        getSystem(props);
-      }
-    });
-    try {
-      Host host = Host.getHost(0);
-      VM vm0 = host.getVM(0);
-      VM vm1 = host.getVM(1);
-
-      SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          AttributesFactory attr = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(1);
-          paf.setRecoveryDelay(-1);
-          paf.setStartupRecoveryDelay(-1);
-          PartitionAttributes prAttr = paf.create();
-          attr.setPartitionAttributes(prAttr);
-          cache.createRegion("region1", attr.create());
-        }
-      };
-
-      // Create the region in only 1 VM
-      vm0.invoke(createPrRegion);
-
-      // Create some buckets
-      vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          region.put(Integer.valueOf(1), "A");
-          region.put(Integer.valueOf(2), "A");
-          region.put(Integer.valueOf(3), "A");
-          region.put(Integer.valueOf(4), "A");
-          region.put(Integer.valueOf(5), "A");
-          region.put(Integer.valueOf(6), "A");
-        }
-      });
-
-      SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(0, details.getActualRedundantCopies());
-          assertEquals(6, details.getLowRedundancyBucketCount());
-        }
-      };
-
-      // make sure we can tell that the buckets have low redundancy
-      vm0.invoke(checkLowRedundancy);
-
-      // Create the region in the other VM (should have no effect)
-      vm1.invoke(createPrRegion);
-
-      // Make sure we still have low redundancy
-      vm0.invoke(checkLowRedundancy);
-
-      // Now simulate a rebalance
-      vm0.invoke(new SerializableRunnable("simulateRebalance") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          ResourceManager manager = cache.getResourceManager();
-          RebalanceResults results = doRebalance(simulate, manager);
-          assertEquals(0, results.getTotalBucketCreatesCompleted());
-          assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-          // We actually *will* transfer buckets, because that improves
-          // the balance
-          assertEquals(3, results.getTotalBucketTransfersCompleted());
-          // assertIndexDetailsEquals(0, results.getTotalBucketTransferBytes());
-          Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-          assertEquals(1, detailSet.size());
-          PartitionRebalanceInfo details = detailSet.iterator().next();
-          assertEquals(0, details.getBucketCreatesCompleted());
-          assertEquals(0, details.getPrimaryTransfersCompleted());
-          assertEquals(3, details.getBucketTransfersCompleted());
-          // assertIndexDetailsEquals(0, details.getBucketTransferBytes());
-          if (!simulate) {
-            verifyStats(manager, results);
-          }
-        }
-      });
-
-      // Make sure we still have low redundancy
-      vm0.invoke(checkLowRedundancy);
-      vm1.invoke(checkLowRedundancy);
-
-    } finally {
-      disconnectFromDS();
-      Invoke.invokeInEveryVM(new SerializableRunnable() {
-        @Override
-        public void run() {
-          disconnectFromDS();
-        }
+        getCache(props);
       });
     }
-  }
 
-  @Test
-  public void testEnforceZone() {
-    enforceZone(false);
-  }
+    // Create the region in only 1 VM
+    vm0.invoke(() -> createPartitionedRegion("region1", 1));
 
-  @Test
-  public void testEnforceZoneSimulation() {
-    enforceZone(true);
+    // Create some buckets
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      region.put(1, "A");
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
+    });
+
+    // make sure we can tell that the buckets have low redundancy
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
+
+    // Create the region in the other VM (should have no effect)
+    vm1.invoke(() -> createPartitionedRegion("region1", 1));
+
+    // Make sure we still have low redundancy
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
+
+    // Now simulate a rebalance
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
+
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+
+      // We actually *will* transfer buckets, because that improves the balance
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(3);
+
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(3);
+
+      if (!simulate) {
+        validateStatistics(manager, results);
+      }
+    });
+
+    // Make sure we still have low redundancy
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
+    vm1.invoke(() -> validateRedundancy("region1", 6, 0, 6));
   }
 
   /**
    * Test that we correctly use the redundancy-zone property to determine where to place redundant
    * copies of a buckets.
-   *
    */
-  public void enforceZone(final boolean simulate) {
+  @Test
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testEnforceZone(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    try {
-      Host host = Host.getHost(0);
-      VM vm0 = host.getVM(0);
-      VM vm1 = host.getVM(1);
-      VM vm2 = host.getVM(2);
+    vm0.invoke(() -> setRedundancyZone("A"));
+    vm1.invoke(() -> setRedundancyZone("A"));
 
-      setRedundancyZone(vm0, "A");
-      setRedundancyZone(vm1, "A");
-      final DistributedMember zoneBMember = setRedundancyZone(vm2, "B");
+    DistributedMember zoneBMember = vm2.invoke(() -> {
+      setRedundancyZone("B");
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
 
-      SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          AttributesFactory attr = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(1);
-          paf.setRecoveryDelay(-1);
-          paf.setStartupRecoveryDelay(-1);
-          PartitionAttributes prAttr = paf.create();
-          attr.setPartitionAttributes(prAttr);
-          cache.createRegion("region1", attr.create());
+    // Create the region in only 1 VM
+    vm0.invoke(() -> createPartitionedRegion("region1", 1));
+
+    // Create some buckets
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      region.put(1, "A");
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
+    });
+
+    // make sure we can tell that the buckets have low redundancy
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
+
+    // Create the region in the other VMs (should have no effect)
+    vm1.invoke(() -> createPartitionedRegion("region1", 1));
+    vm2.invoke(() -> createPartitionedRegion("region1", 1));
+
+    // Make sure we still have low redundancy
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
+
+    // Now simulate a rebalance
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
+
+      // We expect to satisfy redundancy with the zone B member
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(6);
+
+      // 2 primaries will go to vm2, leaving vm0 and vm1 with 2 primaries each
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(2);
+
+      // We actually *will* transfer 3 buckets to the other member in zone A, because that
+      // improves
+      // the balance
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(3);
+
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(6);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(2);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(3);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      for (PartitionMemberInfo info : afterDetails) {
+        if (info.getDistributedMember().equals(zoneBMember)) {
+          assertThat(info.getBucketCount()).isEqualTo(6);
+        } else {
+          assertThat(info.getBucketCount()).isEqualTo(3);
         }
-      };
+        assertThat(info.getPrimaryCount()).isEqualTo(2);
+      }
 
-      // Create the region in only 1 VM
-      vm0.invoke(createPrRegion);
-
-      // Create some buckets
-      vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          region.put(Integer.valueOf(1), "A");
-          region.put(Integer.valueOf(2), "A");
-          region.put(Integer.valueOf(3), "A");
-          region.put(Integer.valueOf(4), "A");
-          region.put(Integer.valueOf(5), "A");
-          region.put(Integer.valueOf(6), "A");
-        }
-      });
-
-      SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(0, details.getActualRedundantCopies());
-          assertEquals(6, details.getLowRedundancyBucketCount());
-        }
-      };
-
-      // make sure we can tell that the buckets have low redundancy
-      vm0.invoke(checkLowRedundancy);
-
-      // Create the region in the other VMs (should have no effect)
-      vm1.invoke(createPrRegion);
-      vm2.invoke(createPrRegion);
-
-      // Make sure we still have low redundancy
-      vm0.invoke(checkLowRedundancy);
-
-      // Now simulate a rebalance
-      vm0.invoke(new SerializableRunnable("simulateRebalance") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          ResourceManager manager = cache.getResourceManager();
-          RebalanceResults results = doRebalance(simulate, manager);
-          // We expect to satisfy redundancy with the zone B member
-          assertEquals(6, results.getTotalBucketCreatesCompleted());
-          // 2 primaries will go to vm2, leaving vm0 and vm1 with 2 primaries each
-          assertEquals(2, results.getTotalPrimaryTransfersCompleted());
-          // We actually *will* transfer 3 buckets to the other member in zone A, because that
-          // improves
-          // the balance
-          assertEquals(3, results.getTotalBucketTransfersCompleted());
-          Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-          assertEquals(1, detailSet.size());
-          PartitionRebalanceInfo details = detailSet.iterator().next();
-          assertEquals(6, details.getBucketCreatesCompleted());
-          assertEquals(2, details.getPrimaryTransfersCompleted());
-          assertEquals(3, details.getBucketTransfersCompleted());
-          Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-          for (PartitionMemberInfo info : afterDetails) {
-            if (info.getDistributedMember().equals(zoneBMember)) {
-              assertEquals(6, info.getBucketCount());
-            } else {
-              assertEquals(3, info.getBucketCount());
-            }
-            assertEquals(2, info.getPrimaryCount());
-          }
-          // assertIndexDetailsEquals(0, details.getBucketTransferBytes());
-          if (!simulate) {
-            verifyStats(manager, results);
-          }
-        }
-      });
-
-
+      // assertIndexDetailsEquals(0, details.getBucketTransferBytes());
       if (!simulate) {
-        checkBucketCount(vm0, "region1", 3);
-        checkBucketCount(vm1, "region1", 3);
-        checkBucketCount(vm2, "region1", 6);
+        validateStatistics(manager, results);
       }
+    });
 
-    } finally {
-      disconnectFromDS();
-      Invoke.invokeInEveryVM(new SerializableRunnable() {
-        @Override
-        public void run() {
-          // clear the redundancy zone setting
-          disconnectFromDS();
-        }
-      });
-    }
-  }
-
-  private void createPR(String regionName) {
-    Cache cache = getCache();
-    AttributesFactory attr = new AttributesFactory();
-    PartitionAttributesFactory paf = new PartitionAttributesFactory();
-    paf.setRedundantCopies(1);
-    paf.setRecoveryDelay(-1);
-    paf.setStartupRecoveryDelay(-1);
-    PartitionAttributes prAttr = paf.create();
-    attr.setPartitionAttributes(prAttr);
-    cache.createRegion(regionName, attr.create());
-  }
-
-  private void doPuts(String regionName) {
-    Cache cache = getCache();
-    Region region = cache.getRegion(regionName);
-    region.put(Integer.valueOf(1), "A");
-    region.put(Integer.valueOf(2), "A");
-    region.put(Integer.valueOf(3), "A");
-    region.put(Integer.valueOf(4), "A");
-    region.put(Integer.valueOf(5), "A");
-    region.put(Integer.valueOf(6), "A");
-  }
-
-  public static class ParallelRecoveryObserver
-      extends InternalResourceManager.ResourceObserverAdapter {
-
-    HashSet<String> regions = new HashSet<String>();
-    private volatile boolean observerCalled;
-    private CyclicBarrier barrier;
-
-    public ParallelRecoveryObserver(int numRegions) {
-      this.barrier = new CyclicBarrier(numRegions);
-    }
-
-    public void observeRegion(String region) {
-      regions.add(region);
-    }
-
-    private void checkAllRegionRecoveryOrRebalanceStarted(String rn) {
-      if (regions.contains(rn)) {
-        try {
-          barrier.await(MAX_WAIT, TimeUnit.SECONDS);
-        } catch (Exception e) {
-          Assert.fail("failed waiting for barrier", e);
-        }
-        observerCalled = true;
-      } else {
-        throw new RuntimeException("region not registered " + rn);
-      }
-    }
-
-    public boolean isObserverCalled() {
-      return observerCalled;
-    }
-
-    @Override
-    public void rebalancingStarted(Region region) {
-
-      // TODO Auto-generated method stub
-      super.rebalancingStarted(region);
-      checkAllRegionRecoveryOrRebalanceStarted(region.getName());
-    }
-
-    @Override
-    public void recoveryStarted(Region region) {
-      // TODO Auto-generated method stub
-      super.recoveryStarted(region);
-      checkAllRegionRecoveryOrRebalanceStarted(region.getName());
+    if (!simulate) {
+      vm0.invoke(() -> validateBucketCount("region1", 3));
+      vm1.invoke(() -> validateBucketCount("region1", 3));
+      vm2.invoke(() -> validateBucketCount("region1", 6));
     }
   }
 
   @Test
   public void testEnforceZoneWithMultipleRegions() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    try {
-      setRedundancyZone(vm0, "A");
-      setRedundancyZone(vm1, "A");
+    vm0.invoke(() -> setRedundancyZone("A"));
+    vm1.invoke(() -> setRedundancyZone("A"));
 
-      final DistributedMember zoneBMember = setRedundancyZone(vm2, "B");
+    DistributedMember zoneBMember = vm2.invoke(() -> {
+      setRedundancyZone("B");
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
 
-      SerializableRunnable setRebalanceObserver = new SerializableRunnable("RebalanceObserver") {
-        @Override
-        public void run() {
-          InternalResourceManager.setResourceObserver(new ParallelRecoveryObserver(2));
-        }
-      };
+    vm0.invoke(() -> InternalResourceManager.setResourceObserver(new ParallelRecoveryObserver(2)));
 
-      SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-        @Override
-        public void run() {
-          ParallelRecoveryObserver ob =
-              (ParallelRecoveryObserver) InternalResourceManager.getResourceObserver();
-          ob.observeRegion("region1");
-          ob.observeRegion("region2");
-          createPR("region1");
-          createPR("region2");
+    // Create the region in only 1 VM
+    vm0.invoke(() -> createTwoRegionsWithParallelRecoveryObserver());
 
-        }
-      };
+    // Create some buckets
+    vm0.invoke(() -> {
+      doPuts("region1");
+      doPuts("region2");
+    });
 
-      vm0.invoke(setRebalanceObserver);
-      // Create the region in only 1 VM
-      vm0.invoke(createPrRegion);
+    // make sure we can tell that the buckets have low redundancy
+    vm0.invoke(() -> validateRedundancyOfTwoRegions("region1", "region2", 6, 0, 6));
 
-      // Create some buckets
-      vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-        @Override
-        public void run() {
-          doPuts("region1");
-          doPuts("region2");
-        }
-      });
-
-      SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(0, details.getActualRedundantCopies());
-          assertEquals(6, details.getLowRedundancyBucketCount());
-
-          region = cache.getRegion("region2");
-          details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(0, details.getActualRedundantCopies());
-          assertEquals(6, details.getLowRedundancyBucketCount());
-        }
-      };
-
-      // make sure we can tell that the buckets have low redundancy
-      vm0.invoke(checkLowRedundancy);
-
-      // Create the region in the other VMs (should have no effect)
-      vm1.invoke(setRebalanceObserver);
-      vm1.invoke(createPrRegion);
-      vm2.invoke(setRebalanceObserver);
-      vm2.invoke(createPrRegion);
-
-      // Make sure we still have low redundancy
-      vm0.invoke(checkLowRedundancy);
-
-      // Now do a rebalance
-      vm0.invoke(new SerializableRunnable("simulateRebalance") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          ResourceManager manager = cache.getResourceManager();
-          RebalanceResults results = doRebalance(false, manager);
-          // We expect to satisfy redundancy with the zone B member
-          assertEquals(12, results.getTotalBucketCreatesCompleted());
-          // 2 primaries will go to vm2, leaving vm0 and vm1 with 2 primaries each
-          assertEquals(4, results.getTotalPrimaryTransfersCompleted());
-          // We actually *will* transfer 3 buckets to the other member in zone A, because that
-          // improves
-          // the balance
-          assertEquals(6, results.getTotalBucketTransfersCompleted());
-          Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-          assertEquals(2, detailSet.size());
-          for (PartitionRebalanceInfo details : detailSet) {
-            assertEquals(6, details.getBucketCreatesCompleted());
-            assertEquals(2, details.getPrimaryTransfersCompleted());
-            assertEquals(3, details.getBucketTransfersCompleted());
-            Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-            for (PartitionMemberInfo info : afterDetails) {
-              if (info.getDistributedMember().equals(zoneBMember)) {
-                assertEquals(6, info.getBucketCount());
-              } else {
-                assertEquals(3, info.getBucketCount());
-              }
-              assertEquals(2, info.getPrimaryCount());
-            }
-          }
-          // assertIndexDetailsEquals(0, details.getBucketTransferBytes());
-          verifyStats(manager, results);
-        }
-      });
-
-      vm0.invoke(new SerializableRunnable() {
-
-        @Override
-        public void run() {
-          assertTrue(((ParallelRecoveryObserver) InternalResourceManager.getResourceObserver())
-              .isObserverCalled());
-        }
-      });
-
-      checkBucketCount(vm0, "region1", 3);
-      checkBucketCount(vm1, "region1", 3);
-      checkBucketCount(vm2, "region1", 6);
-
-      checkBucketCount(vm0, "region2", 3);
-      checkBucketCount(vm1, "region2", 3);
-      checkBucketCount(vm2, "region2", 6);
-    } finally {
-      disconnectFromDS();
-      Invoke.invokeInEveryVM(new SerializableRunnable() {
-        @Override
-        public void run() {
-          // clear the redundancy zone setting
-          disconnectFromDS();
-        }
+    // Create the region in the other VMs (should have no effect)
+    for (VM vm : toArray(vm1, vm2)) {
+      vm.invoke(() -> {
+        InternalResourceManager.setResourceObserver(new ParallelRecoveryObserver(2));
+        createTwoRegionsWithParallelRecoveryObserver();
       });
     }
-  }
 
-  private void checkBucketCount(VM vm0, final String regionName, final int numLocalBuckets) {
-    vm0.invoke(new SerializableRunnable("checkLowRedundancy") {
+    // Make sure we still have low redundancy
+    vm0.invoke(() -> validateRedundancyOfTwoRegions("region1", "region2", 6, 0, 6));
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        PartitionedRegion region = (PartitionedRegion) cache.getRegion(regionName);
-        assertEquals(numLocalBuckets, region.getLocalBucketsListTestOnly().size());
-      }
-    });
-  }
+    // Now do a rebalance
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(false, manager);
 
+      // We expect to satisfy redundancy with the zone B member
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(12);
 
-  private DistributedMember setRedundancyZone(VM vm, final String zone) {
-    return (DistributedMember) vm.invoke(new SerializableCallable("set redundancy zone") {
-      @Override
-      public Object call() {
-        System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "resource.manager.threads", "2");
-        Properties props = new Properties();
-        props.setProperty(REDUNDANCY_ZONE, zone);
-        DistributedSystem system = getSystem(props);
-        return system.getDistributedMember();
+      // 2 primaries will go to vm2, leaving vm0 and vm1 with 2 primaries each
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(4);
 
-      }
-    });
+      // We actually *will* transfer 3 buckets to the other member in zone A, because that
+      // improves the balance
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(6);
 
-  }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(2);
 
-  private RebalanceResults doRebalance(final boolean simulate, ResourceManager manager) {
-    return doRebalance(simulate, manager, null, null);
-  }
-
-  private RebalanceResults doRebalance(final boolean simulate, ResourceManager manager,
-      Set<String> includes, Set<String> excludes) {
-    RebalanceResults results = null;
-    if (simulate) {
-      try {
-        results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
-            .simulate().getResults(MAX_WAIT, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        Assert.fail("Interrupted waiting on rebalance", e);
-      } catch (TimeoutException e) {
-        Assert.fail("Timeout waiting on rebalance", e);
-      }
-    } else {
-      try {
-        results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
-            .start().getResults(MAX_WAIT, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        Assert.fail("Interrupted waiting on rebalance", e);
-      } catch (TimeoutException e) {
-        Assert.fail("Timeout waiting on rebalance", e);
-      }
-    }
-    assertEquals(Collections.emptySet(), manager.getRebalanceOperations());
-    return results;
-  }
-
-  @Test
-  public void testRecoverRedundancyBalancingSimulation() {
-    recoverRedundancyBalancing(true);
-  }
-
-  @Test
-  public void testRecoverRedundancyBalancing() {
-    recoverRedundancyBalancing(false);
-  }
-
-  public void recoverRedundancyBalancing(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-
-    final DistributedMember member1 = createPrRegion(vm0, "region1", 200, null);
-
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        for (int i = 0; i < 12; i++) {
-          region.put(Integer.valueOf(i), "A");
-        }
-      }
-    });
-
-
-    SerializableRunnable checkRedundancy = new SerializableRunnable("checkRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(12, details.getLowRedundancyBucketCount());
-      }
-    };
-
-    vm0.invoke(checkRedundancy);
-
-
-
-    // Now create the region in 2 more VMs with half the localMaxMemory
-    createPrRegion(vm1, "region1", 100, null);
-    createPrRegion(vm2, "region1", 100, null);
-
-    vm0.invoke(checkRedundancy);
-
-    // Now simulate a rebalance
-    vm0.invoke(new SerializableRunnable("rebalance") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(12, results.getTotalBucketCreatesCompleted());
-        assertEquals(6, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(0, results.getTotalBucketTransferBytes());
-        assertEquals(0, results.getTotalBucketTransfersCompleted());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(12, details.getBucketCreatesCompleted());
-        assertEquals(6, details.getPrimaryTransfersCompleted());
-        assertEquals(0, details.getBucketTransferBytes());
-        assertEquals(0, details.getBucketTransfersCompleted());
+      for (PartitionRebalanceInfo details : detailSet) {
+        assertThat(details.getBucketCreatesCompleted()).isEqualTo(6);
+        assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(2);
+        assertThat(details.getBucketTransfersCompleted()).isEqualTo(3);
 
         Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(3, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          // We have 1 member with a size of 200 and two members with size 100
-          if (memberDetails.getDistributedMember().equals(member1)) {
-            assertEquals(12, memberDetails.getBucketCount());
-            assertEquals(6, memberDetails.getPrimaryCount());
+        for (PartitionMemberInfo info : afterDetails) {
+          if (info.getDistributedMember().equals(zoneBMember)) {
+            assertThat(info.getBucketCount()).isEqualTo(6);
           } else {
-            assertEquals(6, memberDetails.getBucketCount());
-            assertEquals(3, memberDetails.getPrimaryCount());
+            assertThat(info.getBucketCount()).isEqualTo(3);
           }
+          assertThat(info.getPrimaryCount()).isEqualTo(2);
         }
+      }
 
-        if (!simulate) {
-          verifyStats(manager, results);
+      validateStatistics(manager, results);
+    });
+
+    vm0.invoke(() -> {
+      assertThat(((ParallelRecoveryObserver) InternalResourceManager.getResourceObserver())
+          .isObserverCalled()).isTrue();
+    });
+
+    vm0.invoke(() -> validateBucketCount("region1", 3));
+    vm1.invoke(() -> validateBucketCount("region1", 3));
+    vm2.invoke(() -> validateBucketCount("region1", 6));
+
+    vm0.invoke(() -> validateBucketCount("region2", 3));
+    vm1.invoke(() -> validateBucketCount("region2", 3));
+    vm2.invoke(() -> validateBucketCount("region2", 6));
+  }
+
+  @Test
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testRecoverRedundancyBalancing(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
+
+    DistributedMember member1 = vm0.invoke(() -> {
+      createPartitionedRegion("region1", 1, 200);
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
+
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      for (int i = 0; i < 12; i++) {
+        region.put(i, "A");
+      }
+    });
+
+    vm0.invoke(() -> validateRedundancy("region1", 12, 0, 12));
+
+    // Now create the region in 2 more VMs with half the localMaxMemory
+    vm1.invoke(() -> createPartitionedRegion("region1", 1, 100));
+    vm2.invoke(() -> createPartitionedRegion("region1", 1, 100));
+
+    vm0.invoke(() -> validateRedundancy("region1", 12, 0, 12));
+
+    // Now simulate a rebalance
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
+
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(12);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(6);
+      assertThat(results.getTotalBucketTransferBytes()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
+
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(12);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(6);
+      assertThat(details.getBucketTransferBytes()).isEqualTo(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(3);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        // We have 1 member with a size of 200 and two members with size 100
+        if (memberDetails.getDistributedMember().equals(member1)) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(12);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(6);
+        } else {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
         }
+      }
+
+      if (!simulate) {
+        validateStatistics(manager, results);
       }
     });
 
     if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkLowRedundancy") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-        }
-      };
-
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
-      vm2.invoke(checkRedundancyFixed);
-    }
-  }
-
-  private DistributedMember createPrRegion(VM vm, final String region, final int localMaxMemory,
-      final String colocatedWith) {
-    SerializableCallable createPrRegion = new SerializableCallable("createRegion") {
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        paf.setLocalMaxMemory(localMaxMemory);
-        if (colocatedWith != null) {
-          paf.setColocatedWith(colocatedWith);
-        }
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion(region, attr.create());
-        return cache.getDistributedSystem().getDistributedMember();
+      for (VM vm : toArray(vm0, vm1, vm2)) {
+        vm.invoke(() -> validateRedundancy("region1", 12, 1, 0));
       }
-    };
-    return (DistributedMember) vm.invoke(createPrRegion);
+    }
   }
 
   @Test
   public void testRecoverRedundancyBalancingIfCreateBucketFails() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
+    DistributedMember member1 = vm0.invoke(() -> {
+      createPartitionedRegion("region1", 1, 100);
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
 
-    final DistributedMember member1 = createPrRegion(vm0, "region1", 100, null);
-
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        for (int i = 0; i < 1; i++) {
-          region.put(Integer.valueOf(i), "A");
-        }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      for (int i = 0; i < 1; i++) {
+        region.put(i, "A");
       }
     });
 
-
-    SerializableRunnable checkRedundancy = new SerializableRunnable("checkRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(1, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(1, details.getLowRedundancyBucketCount());
-      }
-    };
-
-    vm0.invoke(checkRedundancy);
+    vm0.invoke(() -> validateRedundancy("region1", 1, 0, 1));
 
     // Now create the region in 2 more VMs
     // Let localMaxMemory(VM1) > localMaxMemory(VM2)
     // so that redundant bucket will always be attempted on VM1
-    final DistributedMember member2 = createPrRegion(vm1, "region1", 100, null);
-    final DistributedMember member3 = createPrRegion(vm2, "region1", 90, null);
+    DistributedMember member2 = vm1.invoke(() -> {
+      createPartitionedRegion("region1", 1, 100);
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
+    DistributedMember member3 = vm2.invoke(() -> {
+      createPartitionedRegion("region1", 1, 90);
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
 
-    vm0.invoke(checkRedundancy);
+    vm0.invoke(() -> validateRedundancy("region1", 1, 0, 1));
 
     // Inject mock PRHARedundancyProvider to simulate createBucketFailures
-    vm0.invoke(new SerializableRunnable("injectCreateBucketFailureAndRebalance") {
+    vm0.invoke(() -> {
+      InternalCache cache = spy(getCache());
 
-      @Override
-      public void run() {
-        GemFireCacheImpl cache = spy(getGemfireCache());
+      PartitionedRegion origRegion = (PartitionedRegion) cache.getRegion("region1");
+      PartitionedRegion spyRegion = spy(origRegion);
+      PRHARedundancyProvider redundancyProvider = spy(new PRHARedundancyProvider(spyRegion));
 
-        PartitionedRegion origRegion = (PartitionedRegion) cache.getRegion("region1");
-        PartitionedRegion spyRegion = spy(origRegion);
-        PRHARedundancyProvider redundancyProvider = spy(new PRHARedundancyProvider(spyRegion));
+      // return the spied region when ever getPartitionedRegions() is invoked
+      Set<PartitionedRegion> parRegions = cache.getPartitionedRegions();
+      parRegions.remove(origRegion);
+      parRegions.add(spyRegion);
 
-        // return the spied region when ever getPartitionedRegions() is invoked
-        Set<PartitionedRegion> parRegions = cache.getPartitionedRegions();
-        parRegions.remove(origRegion);
-        parRegions.add(spyRegion);
+      doReturn(parRegions).when(cache).getPartitionedRegions();
+      doReturn(redundancyProvider).when(spyRegion).getRedundancyProvider();
 
-        doReturn(parRegions).when(cache).getPartitionedRegions();
-        doReturn(redundancyProvider).when(spyRegion).getRedundancyProvider();
+      // simulate create bucket fails on member2 and test if it creates on member3
+      doReturn(false).when(redundancyProvider).createBackupBucketOnMember(anyInt(),
+          eq((InternalDistributedMember) member2), anyBoolean(), anyBoolean(), any(),
+          anyBoolean());
 
+      // Now simulate a rebalance
+      // Create operationImpl and not factory as we need spied cache to be passed to operationImpl
+      RegionFilter filter = new FilterByPath(null, null);
+      RebalanceOperationImpl operation = new RebalanceOperationImpl(cache, false, filter);
+      operation.start();
 
-        // simulate create bucket fails on member2 and test if it creates on member3
-        doReturn(false).when(redundancyProvider).createBackupBucketOnMember(anyInt(),
-            eq((InternalDistributedMember) member2), anyBoolean(), anyBoolean(), any(),
-            anyBoolean());
+      RebalanceResults results = operation.getResults(TIMEOUT_SECONDS, SECONDS);
 
-        // Now simulate a rebalance
-        // Create operationImpl and not factory as we need spied cache to be passed to operationImpl
-        RegionFilter filter = new FilterByPath(null, null);
-        RebalanceOperationImpl operation = new RebalanceOperationImpl(cache, false, filter);
-        operation.start();
-        RebalanceResults results = null;
-        try {
-          results = operation.getResults(MAX_WAIT, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-          Assert.fail("Interrupted waiting on rebalance", e);
-        } catch (TimeoutException e) {
-          Assert.fail("Timeout waiting on rebalance", e);
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(1);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransferBytes()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
+
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(1);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isEqualTo(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(3);
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        if (memberDetails.getDistributedMember().equals(member1)) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(1);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(1);
+        } else if (memberDetails.getDistributedMember().equals(member2)) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(0);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(0);
+        } else if (memberDetails.getDistributedMember().equals(member3)) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(1);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(0);
         }
-        assertEquals(1, results.getTotalBucketCreatesCompleted());
-        assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(0, results.getTotalBucketTransferBytes());
-        assertEquals(0, results.getTotalBucketTransfersCompleted());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(1, details.getBucketCreatesCompleted());
-        assertEquals(0, details.getPrimaryTransfersCompleted());
-        assertEquals(0, details.getBucketTransferBytes());
-        assertEquals(0, details.getBucketTransfersCompleted());
-
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(3, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          if (memberDetails.getDistributedMember().equals(member1)) {
-            assertEquals(1, memberDetails.getBucketCount());
-            assertEquals(1, memberDetails.getPrimaryCount());
-          } else if (memberDetails.getDistributedMember().equals(member2)) {
-            assertEquals(0, memberDetails.getBucketCount());
-            assertEquals(0, memberDetails.getPrimaryCount());
-          } else if (memberDetails.getDistributedMember().equals(member3)) {
-            assertEquals(1, memberDetails.getBucketCount());
-            assertEquals(0, memberDetails.getPrimaryCount());
-          }
-        }
-
-        ResourceManagerStats stats = cache.getInternalResourceManager().getStats();
-
-        assertEquals(0, stats.getRebalancesInProgress());
-        assertEquals(1, stats.getRebalancesCompleted());
-        assertEquals(0, stats.getRebalanceBucketCreatesInProgress());
-        assertEquals(results.getTotalBucketCreatesCompleted(),
-            stats.getRebalanceBucketCreatesCompleted());
-        assertEquals(1, stats.getRebalanceBucketCreatesFailed());
       }
+
+      ResourceManagerStats stats = cache.getInternalResourceManager().getStats();
+
+      assertThat(stats.getRebalancesInProgress()).isEqualTo(0);
+      assertThat(stats.getRebalancesCompleted()).isEqualTo(1);
+      assertThat(stats.getRebalanceBucketCreatesInProgress()).isEqualTo(0);
+      assertThat(stats.getRebalanceBucketCreatesCompleted())
+          .isEqualTo(results.getTotalBucketCreatesCompleted());
+      assertThat(stats.getRebalanceBucketCreatesFailed()).isEqualTo(1);
     });
 
-    SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkLowRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(1, details.getCreatedBucketCount());
-        assertEquals(1, details.getActualRedundantCopies());
-        assertEquals(0, details.getLowRedundancyBucketCount());
-      }
-    };
-
-    vm0.invoke(checkRedundancyFixed);
-    vm1.invoke(checkRedundancyFixed);
-    vm2.invoke(checkRedundancyFixed);
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> validateRedundancy("region1", 1, 1, 0));
+    }
   }
 
   @Test
-  public void testRecoverRedundancyColocatedRegionsSimulation() {
-    recoverRedundancyColocatedRegions(true);
-  }
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testRecoverRedundancyColocatedRegions(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-  @Test
-  public void testRecoverRedundancyColocatedRegions() {
-    recoverRedundancyColocatedRegions(false);
-  }
+    DistributedMember member1 = vm0.invoke(() -> {
+      createPartitionedRegion("region1", 1, 200);
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
 
-  public void recoverRedundancyColocatedRegions(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-    final DistributedMember member1 = createPrRegion(vm0, "region1", 200, null);
-    createPrRegion(vm0, "region2", 200, "region1");
+    vm0.invoke(() -> createPartitionedRegion("region2", 200, "region1"));
 
     // Create some buckets.
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        Region region2 = cache.getRegion("region2");
-        for (int i = 0; i < 12; i++) {
-          region.put(Integer.valueOf(i), "A");
-          region2.put(Integer.valueOf(i), "A");
-        }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      Region<Number, String> region2 = getCache().getRegion("region2");
+      for (int i = 0; i < 12; i++) {
+        region.put(i, "A");
+        region2.put(i, "A");
       }
     });
 
-
     // check to make sure our redundancy is impaired
-    SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(12, details.getLowRedundancyBucketCount());
-        region = cache.getRegion("region2");
-        details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(12, details.getLowRedundancyBucketCount());
-      }
-    };
-
-    vm0.invoke(checkLowRedundancy);
+    vm0.invoke(() -> validateRedundancyOfTwoRegions("region1", "region2", 12, 0, 12));
 
     // Now create the region in 2 more vms, each which
     // has local max memory of 1/2 that of the original VM.
-    createPrRegion(vm1, "region1", 100, null);
-    createPrRegion(vm2, "region1", 100, null);
-    createPrRegion(vm1, "region2", 100, "region1");
-    createPrRegion(vm2, "region2", 100, "region1");
+    vm1.invoke(() -> createPartitionedRegion("region1", 1, 100));
+    vm2.invoke(() -> createPartitionedRegion("region1", 1, 100));
+    vm1.invoke(() -> createPartitionedRegion("region2", 100, "region1"));
+    vm2.invoke(() -> createPartitionedRegion("region2", 100, "region1"));
 
-    vm0.invoke(checkLowRedundancy);
+    vm0.invoke(() -> validateRedundancyOfTwoRegions("region1", "region2", 12, 0, 12));
 
     // Now simulate a rebalance
-    vm0.invoke(new SerializableRunnable("rebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(24, results.getTotalBucketCreatesCompleted());
-        assertEquals(12, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(0, results.getTotalBucketTransferBytes());
-        assertEquals(0, results.getTotalBucketTransfersCompleted());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(2, detailSet.size());
-        for (PartitionRebalanceInfo details : detailSet) {
-          assertEquals(12, details.getBucketCreatesCompleted());
-          assertEquals(6, details.getPrimaryTransfersCompleted());
-          assertEquals(0, details.getBucketTransferBytes());
-          assertEquals(0, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(24);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(12);
+      assertThat(results.getTotalBucketTransferBytes()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
 
-          Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-          assertEquals(3, afterDetails.size());
-          for (PartitionMemberInfo memberDetails : afterDetails) {
-            if (memberDetails.getDistributedMember().equals(member1)) {
-              assertEquals(12, memberDetails.getBucketCount());
-              assertEquals(6, memberDetails.getPrimaryCount());
-            } else {
-              assertEquals(6, memberDetails.getBucketCount());
-              assertEquals(3, memberDetails.getPrimaryCount());
-            }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(2);
+
+      for (PartitionRebalanceInfo details : detailSet) {
+        assertThat(details.getBucketCreatesCompleted()).isEqualTo(12);
+        assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(6);
+        assertThat(details.getBucketTransferBytes()).isEqualTo(0);
+        assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
+
+        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+        assertThat(afterDetails).hasSize(3);
+
+        for (PartitionMemberInfo memberDetails : afterDetails) {
+          if (memberDetails.getDistributedMember().equals(member1)) {
+            assertThat(memberDetails.getBucketCount()).isEqualTo(12);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(6);
+          } else {
+            assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
           }
-          if (!simulate) {
-            verifyStats(manager, results);
-          }
+        }
+        if (!simulate) {
+          validateStatistics(manager, results);
         }
       }
     });
 
     if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkLowRedundancy") {
+      for (VM vm : toArray(vm0, vm1, vm2)) {
+        vm.invoke(() -> {
+          PartitionedRegion region1 = (PartitionedRegion) getCache().getRegion("region1");
+          PartitionedRegion region2 = (PartitionedRegion) getCache().getRegion("region2");
 
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          PartitionedRegion region1 = (PartitionedRegion) cache.getRegion("region1");
-          PartitionedRegion region2 = (PartitionedRegion) cache.getRegion("region2");
           PartitionRegionInfo details =
-              PartitionRegionHelper.getPartitionRegionInfo(cache.getRegion("region1"));
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-          details = PartitionRegionHelper.getPartitionRegionInfo(cache.getRegion("region2"));
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
+              PartitionRegionHelper.getPartitionRegionInfo(getCache().getRegion("region1"));
+          assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
 
-          assertEquals(region1.getLocalPrimaryBucketsListTestOnly(),
-              region2.getLocalPrimaryBucketsListTestOnly());
+          details = PartitionRegionHelper.getPartitionRegionInfo(getCache().getRegion("region2"));
+          assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
 
-          assertEquals(region1.getLocalBucketsListTestOnly(),
-              region2.getLocalBucketsListTestOnly());
-        }
-      };
+          assertThat(region2.getLocalPrimaryBucketsListTestOnly())
+              .isEqualTo(region1.getLocalPrimaryBucketsListTestOnly());
 
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
-      vm2.invoke(checkRedundancyFixed);
-    }
-  }
-
-  @Test
-  public void testRecoverRedundancyParallelAsyncEventQueueSimulation()
-      throws NoSuchFieldException, SecurityException {
-    Invoke.invokeInEveryVM(new SerializableRunnable() {
-
-      @Override
-      public void run() {
-        System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "LOG_REBALANCE", "true");
+          assertThat(region2.getLocalBucketsListTestOnly())
+              .isEqualTo(region1.getLocalBucketsListTestOnly());
+        });
       }
-    });
-    try {
-      recoverRedundancyParallelAsyncEventQueue(true);
-    } finally {
-      System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "LOG_REBALANCE", "false");
     }
   }
 
   @Test
-  public void testRecoverRedundancyParallelAsyncEventQueue() {
-    recoverRedundancyParallelAsyncEventQueue(false);
-  }
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testRecoverRedundancyParallelAsyncEventQueue(boolean simulate)
+      throws SecurityException {
+    if (simulate) {
+      invokeInEveryVM(
+          () -> System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "LOG_REBALANCE", "true"));
+    }
 
-  public void recoverRedundancyParallelAsyncEventQueue(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    final DistributedMember member1 = createPRRegionWithAsyncQueue(vm0, 200);
+    DistributedMember member1 = vm0.invoke(() -> {
+      createPRRegionWithAsyncQueue(200);
+      return getCache().getDistributedSystem().getDistributedMember();
+    });
 
     // Create some buckets. Put enough data to cause the queue to overflow (more than 1 MB)
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        Region region2 = cache.getRegion("region2");
-        for (int i = 0; i < 12; i++) {
-          region.put(Integer.valueOf(i), "A", new byte[1024 * 512]);
-        }
-
-        // GEODE-244 - the async event queue uses asnychronous writes. Flush
-        // the default disk store to make sure all values have overflowed
-        cache.findDiskStore(null).flush();
+    vm0.invoke(() -> {
+      Region<Number, String> region = ((Cache) getCache()).getRegion("region1");
+      for (int i = 0; i < 12; i++) {
+        region.put(i, "A", new byte[1024 * 512]);
       }
+
+      // The async event queue uses asynchronous writes.
+      // Flush the default disk store to make sure all values have overflowed
+      getCache().findDiskStore(null).flush();
     });
 
     // check to make sure our redundancy is impaired
-    SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(12, details.getLowRedundancyBucketCount());
-        // Get the async event queue region (It's a colocated region)
-        PartitionedRegion region2 =
-            ColocationHelper.getColocatedChildRegions((PartitionedRegion) region).get(0);
-        details = PartitionRegionHelper.getPartitionRegionInfo(region2);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(12, details.getLowRedundancyBucketCount());
-        AsyncEventQueue queue = cache.getAsyncEventQueue("parallelQueue");
-        assertEquals(12, queue.size());
-      }
-    };
+    vm0.invoke(() -> {
+      Region region1 = getCache().getRegion("region1");
+      PartitionedRegion region2 =
+          ColocationHelper.getColocatedChildRegions((PartitionedRegion) region1).get(0);
 
-    vm0.invoke(checkLowRedundancy);
+      validateRedundancyOfTwoRegions(region1, region2, 12, 0, 12);
 
+      assertThat(getCache().getAsyncEventQueue("parallelQueue").size()).isEqualTo(12);
+    });
 
     // Create the region on two more members, each with 1/2 of the memory
-    createPRRegionWithAsyncQueue(vm1, 100);
-    createPRRegionWithAsyncQueue(vm2, 100);
+    vm1.invoke(() -> createPRRegionWithAsyncQueue(100));
+    vm2.invoke(() -> createPRRegionWithAsyncQueue(100));
 
-    vm0.invoke(checkLowRedundancy);
+    vm0.invoke(() -> {
+      Region region1 = getCache().getRegion("region1");
+      PartitionedRegion region2 =
+          ColocationHelper.getColocatedChildRegions((PartitionedRegion) region1).get(0);
+
+      validateRedundancyOfTwoRegions(region1, region2, 12, 0, 12);
+
+      assertThat(getCache().getAsyncEventQueue("parallelQueue").size()).isEqualTo(12);
+    });
 
     // Now simulate a rebalance
-    vm0.invoke(new SerializableRunnable("rebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(24, results.getTotalBucketCreatesCompleted());
-        assertEquals(12, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(0, results.getTotalBucketTransferBytes());
-        assertEquals(0, results.getTotalBucketTransfersCompleted());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(2, detailSet.size());
-        for (PartitionRebalanceInfo details : detailSet) {
-          assertEquals(12, details.getBucketCreatesCompleted());
-          assertEquals(6, details.getPrimaryTransfersCompleted());
-          assertEquals(0, details.getBucketTransferBytes());
-          assertEquals(0, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(24);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(12);
+      assertThat(results.getTotalBucketTransferBytes()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
 
-          Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-          assertEquals(3, afterDetails.size());
-          for (PartitionMemberInfo memberDetails : afterDetails) {
-            if (memberDetails.getDistributedMember().equals(member1)) {
-              assertEquals(12, memberDetails.getBucketCount());
-              assertEquals(6, memberDetails.getPrimaryCount());
-            } else {
-              assertEquals(6, memberDetails.getBucketCount());
-              assertEquals(3, memberDetails.getPrimaryCount());
-            }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(2);
+
+      for (PartitionRebalanceInfo details : detailSet) {
+        assertThat(details.getBucketCreatesCompleted()).isEqualTo(12);
+        assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(6);
+        assertThat(details.getBucketTransferBytes()).isEqualTo(0);
+        assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
+
+        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+        assertThat(afterDetails).hasSize(3);
+
+        for (PartitionMemberInfo memberDetails : afterDetails) {
+          if (memberDetails.getDistributedMember().equals(member1)) {
+            assertThat(memberDetails.getBucketCount()).isEqualTo(12);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(6);
+          } else {
+            assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
           }
-          if (!simulate) {
-            verifyStats(manager, results);
-          }
+        }
+
+        if (!simulate) {
+          validateStatistics(manager, results);
         }
       }
     });
 
     if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkLowRedundancy") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          PartitionedRegion region1 = (PartitionedRegion) cache.getRegion("region1");
+      for (VM vm : toArray(vm0, vm1, vm2)) {
+        vm.invoke(() -> {
+          PartitionedRegion region1 = (PartitionedRegion) getCache().getRegion("region1");
           // Get the async event queue region (It's a colocated region)
           PartitionedRegion region2 = ColocationHelper.getColocatedChildRegions(region1).get(0);
-          PartitionRegionInfo details =
-              PartitionRegionHelper.getPartitionRegionInfo(cache.getRegion("region1"));
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-          details = PartitionRegionHelper.getPartitionRegionInfo(region2);
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
 
-          assertEquals(region1.getLocalPrimaryBucketsListTestOnly(),
-              region2.getLocalPrimaryBucketsListTestOnly());
+          validateRedundancyOfTwoRegions(region1, region2, 12, 1, 0);
 
-          assertEquals(region1.getLocalBucketsListTestOnly(),
-              region2.getLocalBucketsListTestOnly());
-        }
-      };
+          assertThat(region2.getLocalPrimaryBucketsListTestOnly())
+              .isEqualTo(region1.getLocalPrimaryBucketsListTestOnly());
 
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
-      vm2.invoke(checkRedundancyFixed);
-    }
-  }
-
-  private DistributedMember createPRRegionWithAsyncQueue(VM vm0, final int localMaxMemory) {
-    SerializableCallable createPrRegion = new SerializableCallable("createRegion") {
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-
-        // Create an async event listener that doesn't dispatch anything
-        cache.createAsyncEventQueueFactory().setMaximumQueueMemory(1).setParallel(true)
-            .create("parallelQueue", new AsyncEventListener() {
-              @Override
-              public void close() {}
-
-              @Override
-              public boolean processEvents(List<AsyncEvent> events) {
-                try {
-                  Thread.sleep(100);
-                } catch (InterruptedException e) {
-                  return false;
-                }
-                return false;
-              }
-
-            });
-        AttributesFactory attr = new AttributesFactory();
-        attr.addAsyncEventQueueId("parallelQueue");
-
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        paf.setLocalMaxMemory(localMaxMemory);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-
-        return cache.getDistributedSystem().getDistributedMember();
+          assertThat(region2.getLocalBucketsListTestOnly())
+              .isEqualTo(region1.getLocalBucketsListTestOnly());
+        });
       }
-    };
-
-    final DistributedMember member1 = (DistributedMember) vm0.invoke(createPrRegion);
-    return member1;
+    }
   }
 
   @Test
   public void testCancelOperation() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-      }
-    };
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Create the region in only 1 VM
-    vm0.invoke(createPrRegion);
+    vm0.invoke(() -> createPartitionedRegion("region1", 1));
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        region.put(Integer.valueOf(1), "A");
-      }
+    vm0.invoke(() -> {
+      Region<Number, String> region = ((Cache) getCache()).getRegion("region1");
+      region.put(1, "A");
     });
 
-    SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(1, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(1, details.getLowRedundancyBucketCount());
-      }
-    };
-
     // make sure we can tell that the buckets have low redundancy
-    vm0.invoke(checkLowRedundancy);
+    vm0.invoke(() -> validateRedundancy("region1", 1, 0, 1));
 
     // Create the region in the other VM (should have no effect)
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> createPartitionedRegion("region1", 1));
 
     // Make sure we still have low redundancy
-    vm0.invoke(checkLowRedundancy);
+    vm0.invoke(() -> validateRedundancy("region1", 1, 0, 1));
 
     // Now do a rebalance, but cancel it in the middle
-    vm0.invoke(new SerializableCallable("D rebalance") {
+    vm0.invoke(() -> {
+      CountDownLatch rebalancingCancelled = new CountDownLatch(1);
+      CountDownLatch rebalancingFinished = new CountDownLatch(1);
 
-      @Override
-      public Object call() throws Exception {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        InternalResourceManager manager = cache.getInternalResourceManager();
-        final CountDownLatch rebalancingCancelled = new CountDownLatch(1);
-        final CountDownLatch rebalancingFinished = new CountDownLatch(1);
-        InternalResourceManager.setResourceObserver(new ResourceObserverAdapter() {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
 
-          @Override
-          public void rebalancingOrRecoveryStarted(Region region) {
-            try {
-              rebalancingCancelled.await();
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-            }
+      InternalResourceManager.setResourceObserver(new ResourceObserverAdapter() {
+
+        @Override
+        public void rebalancingOrRecoveryStarted(Region region) {
+          try {
+            rebalancingCancelled.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
           }
-
-          @Override
-          public void rebalancingOrRecoveryFinished(Region region) {
-            rebalancingFinished.countDown();
-          }
-        });
-        RebalanceOperation op = manager.createRebalanceFactory().start();
-        assertFalse(op.isCancelled());
-        assertFalse(op.isDone());
-        assertEquals(Collections.singleton(op), manager.getRebalanceOperations());
-        try {
-          op.getResults(5, TimeUnit.SECONDS);
-          fail("Should have received a timeout exception");
-        } catch (TimeoutException expected) {
         }
-        assertTrue(op.cancel());
-        rebalancingCancelled.countDown();
-        assertTrue(op.isCancelled());
-        assertTrue(op.isDone());
 
-        rebalancingFinished.await();
-        try {
-          op.getResults(60, TimeUnit.SECONDS);
-          fail("Should have received a cancellation exception");
-        } catch (CancellationException expected) {
+        @Override
+        public void rebalancingOrRecoveryFinished(Region region) {
+          rebalancingFinished.countDown();
         }
-        assertEquals(Collections.emptySet(), manager.getRebalanceOperations());
+      });
 
-        return null;
-      }
+      RebalanceOperation op = manager.createRebalanceFactory().start();
+      assertThat(op.isCancelled()).isFalse();
+      assertThat(op.isDone()).isFalse();
+      assertThat(manager.getRebalanceOperations()).isEqualTo(Collections.singleton(op));
+
+      Throwable thrown = catchThrowable(() -> op.getResults(5, SECONDS));
+      assertThat(thrown).isInstanceOf(TimeoutException.class);
+
+      boolean result = op.cancel();
+      assertThat(result).isTrue();
+
+      rebalancingCancelled.countDown();
+
+      assertThat(op.isCancelled()).isTrue();
+      assertThat(op.isDone()).isTrue();
+
+      rebalancingFinished.await();
+
+      thrown = catchThrowable(() -> op.getResults(60, SECONDS));
+      assertThat(thrown).isInstanceOf(CancellationException.class);
+
+      assertThat(manager.getRebalanceOperations()).isEqualTo(Collections.emptySet());
     });
 
     // We should still have low redundancy, because the rebalancing was cancelled
-    vm0.invoke(checkLowRedundancy);
-
+    vm0.invoke(() -> validateRedundancy("region1", 1, 0, 1));
   }
 
   /**
@@ -1598,729 +928,564 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
    */
   @Test
   public void testMembershipChange() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    final VM vm2 = host.getVM(2);
-
-    final SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-      }
-    };
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
     // Create the region in only 1 VM
-    vm0.invoke(createPrRegion);
+    vm0.invoke(() -> createPartitionedRegion("region1", 0));
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        region.put(Integer.valueOf(1), "A");
-        region.put(Integer.valueOf(2), "A");
-        region.put(Integer.valueOf(3), "A");
-        region.put(Integer.valueOf(4), "A");
-        region.put(Integer.valueOf(5), "A");
-        region.put(Integer.valueOf(6), "A");
-      }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      region.put(1, "A");
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
     });
-
 
     // Create the region in the other VM (should have no effect)
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> createPartitionedRegion("region1", 0));
 
     // Now do a rebalance, but start another member in the middle
-    vm0.invoke(new SerializableCallable("D rebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
 
-      @Override
-      public Object call() throws Exception {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        InternalResourceManager manager = cache.getInternalResourceManager();
-        final CountDownLatch rebalancingStarted = new CountDownLatch(1);
-        final CountDownLatch memberAdded = new CountDownLatch(1);
-        InternalResourceManager.setResourceObserver(new ResourceObserverAdapter() {
-          boolean firstBucket = true;
+      InternalResourceManager.setResourceObserver(new ResourceObserverAdapter() {
+        private volatile boolean firstBucket = true;
 
-          @Override
-          public void movingBucket(Region region, int bucketId, DistributedMember source,
-              DistributedMember target) {
-            if (firstBucket) {
-              firstBucket = false;
-              vm2.invoke(createPrRegion);
-            }
+        @Override
+        public void movingBucket(Region region, int bucketId, DistributedMember source,
+            DistributedMember target) {
+          if (firstBucket) {
+            firstBucket = false;
+            // NOTE: do not replace createPartitionedRegionRunnable with lambda
+            // because ResourceObserverAdapter is NOT serializable
+            vm2.invoke(createPartitionedRegionRunnable("region1", 0));
           }
-        });
-        RebalanceResults results = doRebalance(false, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(4, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(0, details.getBucketCreatesCompleted());
-        assertEquals(0, details.getPrimaryTransfersCompleted());
-        assertTrue(0 < details.getBucketTransferBytes());
-        assertEquals(4, details.getBucketTransfersCompleted());
-
-        Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsBefore();
-        // there should have only been 2 members when the rebalancing started.
-        assertEquals(2, beforeDetails.size());
-
-        // if it was done, there should now be 3 members.
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(3, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(2, memberDetails.getBucketCount());
-          assertEquals(2, memberDetails.getPrimaryCount());
         }
-        verifyStats(manager, results);
-        InternalResourceManager mgr = (InternalResourceManager) manager;
-        ResourceManagerStats stats = mgr.getStats();
-        assertEquals(1, stats.getRebalanceMembershipChanges());
-        return null;
+      });
+
+      RebalanceResults results = doRebalance(false, manager);
+
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(4);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
+
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(4);
+
+      Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsBefore();
+      // there should have only been 2 members when the rebalancing started.
+      assertThat(beforeDetails).hasSize(2);
+
+      // if it was done, there should now be 3 members.
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(3);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(2);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(2);
       }
+
+      validateStatistics(manager, results);
+
+      ResourceManagerStats stats = manager.getStats();
+      assertThat(stats.getRebalanceMembershipChanges()).isEqualTo(1);
     });
-  }
-
-
-  @Test
-  public void testMoveBucketsNoRedundancySimulation() {
-    moveBucketsNoRedundancy(true);
-  }
-
-  @Test
-  public void testMoveBucketsNoRedundancy() {
-    moveBucketsNoRedundancy(false);
   }
 
   /**
    * Check to make sure that we balance buckets between two hosts with no redundancy.
-   *
    */
-  public void moveBucketsNoRedundancy(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        attr.setCacheLoader(new Bug40228Loader());
-        cache.createRegion("region1", attr.create());
-      }
-    };
+  @Test
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testMoveBucketsNoRedundancy(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Create the region in only 1 VM
-    vm0.invoke(createPrRegion);
+    vm0.invoke(() -> createPartitionedRegion("region1", new NullReturningLoader()));
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        region.put(Integer.valueOf(1), "A");
-        region.put(Integer.valueOf(2), "A");
-        region.put(Integer.valueOf(3), "A");
-        region.put(Integer.valueOf(4), "A");
-        region.put(Integer.valueOf(5), "A");
-        region.put(Integer.valueOf(6), "A");
-      }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      region.put(1, "A");
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
     });
 
     // Create the region in the other VM (should have no effect)
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> createPartitionedRegion("region1", new NullReturningLoader()));
 
     // Now simulate a rebalance
-    vm0.invoke(new SerializableRunnable("simulateRebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(3, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(0, details.getBucketCreatesCompleted());
-        assertEquals(0, details.getPrimaryTransfersCompleted());
-        assertTrue(0 < details.getBucketTransferBytes());
-        assertEquals(3, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(3);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
 
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(2, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(3, memberDetails.getBucketCount());
-          assertEquals(3, memberDetails.getPrimaryCount());
-        }
-        if (!simulate) {
-          verifyStats(manager, results);
-        }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(3);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(2);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
+      }
+
+      if (!simulate) {
+        validateStatistics(manager, results);
       }
     });
 
     if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkRedundancyFixed") {
+      for (VM vm : toArray(vm0, vm1)) {
+        vm.invoke(() -> {
+          Region region = getCache().getRegion("region1");
 
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
           PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(0, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-          assertEquals(2, details.getPartitionMemberInfo().size());
+          assertThat(details.getCreatedBucketCount()).isEqualTo(6);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(0);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
+          assertThat(details.getPartitionMemberInfo()).hasSize(2);
+
           for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-            assertEquals(3, memberDetails.getBucketCount());
-            assertEquals(3, memberDetails.getPrimaryCount());
+            assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
           }
 
           // check to make sure that moving buckets didn't close the cache loader
-          Bug40228Loader loader =
-              (Bug40228Loader) cache.getRegion("region1").getAttributes().getCacheLoader();
-          assertFalse(loader.isClosed());
-        }
-      };
+          NullReturningLoader loader =
+              (NullReturningLoader) getCache().getRegion("region1").getAttributes()
+                  .getCacheLoader();
+          assertThat(loader.isClosed()).isFalse();
+        });
+      }
 
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
-
-      SerializableRunnable checkBug40228Fixed = new SerializableRunnable("checkBug40228Fixed") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Bug40228Loader loader =
-              (Bug40228Loader) cache.getRegion("region1").getAttributes().getCacheLoader();
-          assertFalse(loader.isClosed());
+      for (VM vm : toArray(vm0, vm1)) {
+        vm.invoke(() -> {
+          NullReturningLoader loader =
+              (NullReturningLoader) getCache().getRegion("region1").getAttributes()
+                  .getCacheLoader();
+          assertThat(loader.isClosed()).isFalse();
           // check to make sure that closing the PR closes the cache loader
-          cache.getRegion("region1").close();
-          assertTrue(loader.isClosed());
-        }
-      };
-
-      vm0.invoke(checkBug40228Fixed);
-      vm1.invoke(checkBug40228Fixed);
+          getCache().getRegion("region1").close();
+          assertThat(loader.isClosed()).isTrue();
+        });
+      }
     }
-  }
-
-  @Test
-  public void testFilterRegionsSimulation() {
-    filterRegions(true);
-  }
-
-  @Test
-  public void testFilterRegions() {
-    filterRegions(false);
   }
 
   /**
    * Check to make sure that we balance buckets between two hosts with no redundancy.
-   *
    */
-  public void filterRegions(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  @Test
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testFilterRegions(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
-    final int NUM_REGIONS = 4;
-    final Set<String> INCLUDED = new HashSet<String>();
-    INCLUDED.add("region0");
-    INCLUDED.add("region1");
-    final Set<String> EXCLUDED = new HashSet<String>();
-    EXCLUDED.add("region0");
-    EXCLUDED.add("region3");
+    Set<String> included = new HashSet<>();
+    included.add("region0");
+    included.add("region1");
 
-    final HashSet<String> EXPECTED_REBALANCED = new HashSet<String>();
-    EXPECTED_REBALANCED.add("/region0");
-    EXPECTED_REBALANCED.add("/region1");
+    Set<String> excluded = new HashSet<>();
+    excluded.add("region0");
+    excluded.add("region3");
 
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        for (int i = 0; i < NUM_REGIONS; i++) {
-          cache.createRegion("region" + i, attr.create());
-        }
-      }
-    };
+    Set<String> expectedRebalanced = new HashSet<>();
+    expectedRebalanced.add("/region0");
+    expectedRebalanced.add("/region1");
+
+    int numRegions = 4;
 
     // Create the region in only 1 VM
-    vm0.invoke(createPrRegion);
+    vm0.invoke(() -> {
+      for (int whichRegion = 0; whichRegion < numRegions; whichRegion++) {
+        createPartitionedRegion("region" + whichRegion, 0);
+      }
+    });
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        for (int i = 0; i < NUM_REGIONS; i++) {
-          Region region = cache.getRegion("region" + i);
-          for (int j = 0; j < 6; j++) {
-            region.put(Integer.valueOf(j), "A");
-          }
+    vm0.invoke(() -> {
+      for (int whichRegion = 0; whichRegion < numRegions; whichRegion++) {
+        Region<Number, String> region = getCache().getRegion("region" + whichRegion);
+        for (int key = 0; key < 6; key++) {
+          region.put(key, "A");
         }
       }
     });
 
     // Create the region in the other VM (should have no effect)
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> {
+      for (int whichRegion = 0; whichRegion < numRegions; whichRegion++) {
+        createPartitionedRegion("region" + whichRegion, 0);
+      }
+    });
 
     // Now simulate a rebalance
-    vm0.invoke(new SerializableRunnable("simulateRebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager, INCLUDED, EXCLUDED);
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        // assertIndexDetailsEquals(3, detailSet.size());
-        Set<String> names = new HashSet<String>();
-        for (PartitionRebalanceInfo details : detailSet) {
-          assertEquals(0, details.getBucketCreatesCompleted());
-          assertEquals(0, details.getPrimaryTransfersCompleted());
-          assertTrue(0 < details.getBucketTransferBytes());
-          assertEquals(3, details.getBucketTransfersCompleted());
-          names.add(details.getRegionPath());
-          Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-          assertEquals(2, afterDetails.size());
-          for (PartitionMemberInfo memberDetails : afterDetails) {
-            assertEquals(3, memberDetails.getBucketCount());
-            assertEquals(3, memberDetails.getPrimaryCount());
-          }
+      RebalanceResults results = doRebalance(simulate, manager, included, excluded);
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      Set<String> names = new HashSet<>();
+
+      for (PartitionRebalanceInfo details : detailSet) {
+        assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+        assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+        assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+        assertThat(details.getBucketTransfersCompleted()).isEqualTo(3);
+
+        names.add(details.getRegionPath());
+
+        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+        assertThat(afterDetails).hasSize(2);
+
+        for (PartitionMemberInfo memberDetails : afterDetails) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
         }
+      }
 
-        assertEquals(EXPECTED_REBALANCED, names);
+      assertThat(names).isEqualTo(expectedRebalanced);
 
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(6, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(6);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
 
-        if (!simulate) {
-          verifyStats(manager, results);
-        }
+      if (!simulate) {
+        validateStatistics(manager, results);
       }
     });
 
     if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkRedundancyFixed") {
+      for (VM vm : toArray(vm0, vm1)) {
+        vm.invoke(() -> {
+          for (String name : expectedRebalanced) {
+            Region region = getCache().getRegion(name);
 
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          for (String name : EXPECTED_REBALANCED) {
-            Region region = cache.getRegion(name);
             PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-            assertEquals(6, details.getCreatedBucketCount());
-            assertEquals(0, details.getActualRedundantCopies());
-            assertEquals(0, details.getLowRedundancyBucketCount());
-            assertEquals(2, details.getPartitionMemberInfo().size());
+            assertThat(details.getCreatedBucketCount()).isEqualTo(6);
+            assertThat(details.getActualRedundantCopies()).isEqualTo(0);
+            assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
+            assertThat(details.getPartitionMemberInfo()).hasSize(2);
+
             for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-              assertEquals(3, memberDetails.getBucketCount());
-              assertEquals(3, memberDetails.getPrimaryCount());
+              assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+              assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
             }
           }
-          Region region = cache.getRegion("region2");
+
+          Region region = getCache().getRegion("region2");
+
           PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(0, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-          assertEquals(2, details.getPartitionMemberInfo().size());
+          assertThat(details.getCreatedBucketCount()).isEqualTo(6);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(0);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
+          assertThat(details.getPartitionMemberInfo()).hasSize(2);
+
           for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
             int bucketCount = memberDetails.getBucketCount();
             int primaryCount = memberDetails.getPrimaryCount();
-            assertTrue(
-                "Wrong number of buckets on non rebalanced region buckets=" + bucketCount
-                    + " primarys=" + primaryCount,
-                bucketCount == 6 && primaryCount == 6 || bucketCount == 0 && primaryCount == 0);
+            assertThat(
+                bucketCount == 6 && primaryCount == 6 || bucketCount == 0 && primaryCount == 0)
+                    .as("Wrong number of buckets on non rebalanced region buckets=" + bucketCount
+                        + " primaries=" + primaryCount)
+                    .isTrue();
           }
-        }
-      };
-
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
+        });
+      }
     }
   }
 
   @Test
-  public void testMoveBucketsWithRedundancySimulation() {
-    moveBucketsWithRedundancy(true);
-  }
-
-  @Test
-  public void testMoveBucketsWithRedundancy() {
-    moveBucketsWithRedundancy(false);
-  }
-
-  /**
-   * Test to make sure we balance buckets between three hosts with redundancy
-   */
-  public void moveBucketsWithRedundancy(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-      }
-    };
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testMoveBucketsWithRedundancy(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
     // Create the region in two VMs
-    vm0.invoke(createPrRegion);
-    vm1.invoke(createPrRegion);
+    vm0.invoke(() -> createPartitionedRegion("region1", 1));
+    vm1.invoke(() -> createPartitionedRegion("region1", 1));
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        for (int i = 0; i < 12; i++) {
-          region.put(Integer.valueOf(i), "A");
-        }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      for (int i = 0; i < 12; i++) {
+        region.put(i, "A");
       }
     });
 
     // Create the region in one more VM.
-    vm2.invoke(createPrRegion);
+    vm2.invoke(() -> createPartitionedRegion("region1", 1));
 
     // Now simulate a rebalance
-    final Long totalSize = (Long) vm0.invoke(new SerializableCallable("simulateRebalance") {
+    long totalSize = vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        // We don't know how many primaries will move, it depends on
-        // if the move bucket code moves the primary or a redundant bucket
-        // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(8, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(0, details.getBucketCreatesCompleted());
-        assertTrue(0 < details.getBucketTransferBytes());
-        assertEquals(8, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
 
-        long totalSize = 0;
-        Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
-        for (PartitionMemberInfo memberDetails : beforeDetails) {
-          totalSize += memberDetails.getSize();
-        }
+      // We don't know how many primaries will move, it depends on
+      // if the move bucket code moves the primary or a redundant bucket
+      // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(8);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
 
-        long afterSize = 0;
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(3, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(8, memberDetails.getBucketCount());
-          assertEquals(4, memberDetails.getPrimaryCount());
-          afterSize += memberDetails.getSize();
-        }
-        assertEquals(totalSize, afterSize);
-        if (!simulate) {
-          verifyStats(manager, results);
-        }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
 
-        return Long.valueOf(totalSize);
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(8);
+
+      long value = 0;
+      Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
+      for (PartitionMemberInfo memberDetails : beforeDetails) {
+        value += memberDetails.getSize();
       }
+
+      long afterSize = 0;
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(3);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(8);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(4);
+        afterSize += memberDetails.getSize();
+      }
+
+      assertThat(afterSize).isEqualTo(value);
+
+      if (!simulate) {
+        validateStatistics(manager, results);
+      }
+
+      return value;
     });
 
     if (!simulate) {
-      SerializableRunnable checkBalance = new SerializableRunnable("checkBalance") {
+      for (VM vm : toArray(vm0, vm1, vm2)) {
+        vm.invoke(() -> {
+          Region region = getCache().getRegion("region1");
 
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
           PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-          LogWriterUtils.getLogWriter().info("details=" + details.getPartitionMemberInfo());
+          assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
+
           long afterSize = 0;
           for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-            assertEquals(8, memberDetails.getBucketCount());
-            assertEquals(4, memberDetails.getPrimaryCount());
+            assertThat(memberDetails.getBucketCount()).isEqualTo(8);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(4);
             afterSize += memberDetails.getSize();
           }
-          assertEquals(totalSize.longValue(), afterSize);
-        }
-      };
 
-      vm0.invoke(checkBalance);
-      vm1.invoke(checkBalance);
-      vm2.invoke(checkBalance);
+          assertThat(afterSize).isEqualTo(totalSize);
+        });
+      }
     }
   }
 
   /**
-   * A test that the stats when overflowing entries to disk are correct and we still rebalance
+   * Verifies when overflowing entries to disk that the stats are correct and we still rebalance
    * correctly
    */
   @Test
-  public void testMoveBucketsOverflowToDisk() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-    VM vm3 = host.getVM(3);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        attr.setEvictionAttributes(
-            EvictionAttributes.createLRUEntryAttributes(1, EvictionAction.OVERFLOW_TO_DISK));
-        cache.createRegion("region1", attr.create());
-      }
-    };
+  public void testMoveBucketsOverflowToDisk() {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
+    VM vm3 = getVM(3);
 
     // Create the region in two VMs
-    vm0.invoke(createPrRegion);
-    vm1.invoke(createPrRegion);
+    vm0.invoke(
+        () -> createPartitionedRegion("region1", createLRUEntryAttributes(1, OVERFLOW_TO_DISK)));
+    vm1.invoke(
+        () -> createPartitionedRegion("region1", createLRUEntryAttributes(1, OVERFLOW_TO_DISK)));
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        for (int i = 0; i < 12; i++) {
-          Map m = new HashMap();
-          for (int j = 0; j < 200; j++) {
-            m.put(Integer.valueOf(i + 113 * j), "A");
-          }
-          region.putAll(m);
+    vm0.invoke(() -> {
+      Region<Number, String> region = ((Cache) getCache()).getRegion("region1");
+      for (int bucket = 0; bucket < 12; bucket++) {
+        Map<Number, String> map = new HashMap<>();
+        for (int key = 0; key < 200; key++) {
+          map.put(bucket + 113 * key, "A");
         }
+        region.putAll(map);
       }
     });
 
     // Do some puts and gets, to trigger eviction
-    SerializableRunnable doOps = new SerializableRunnable("doOps") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-
-        Random rand = new Random();
-
-        for (int count = 0; count < 5000; count++) {
-          int bucket = (int) (count % 12);
-          int key = rand.nextInt(20);
-          region.put(Integer.valueOf(bucket + 113 * key), "B");
-        }
-
-        for (int count = 0; count < 500; count++) {
-          int bucket = (int) (count % 12);
-          int key = rand.nextInt(20);
-          region.get(Integer.valueOf(bucket + 113 * key));
-        }
-      }
-    };
 
     // Do some operations
-    vm0.invoke(doOps);
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+
+      Random random = new Random();
+
+      for (int count = 0; count < 5000; count++) {
+        int bucket = count % 12;
+        int key = random.nextInt(20);
+        region.put(bucket + 113 * key, "B");
+      }
+
+      for (int count = 0; count < 500; count++) {
+        int bucket = count % 12;
+        int key = random.nextInt(20);
+        region.get(bucket + 113 * key);
+      }
+    });
 
     // Create the region in one more VM.
-    vm2.invoke(createPrRegion);
+    vm2.invoke(
+        () -> createPartitionedRegion("region1", createLRUEntryAttributes(1, OVERFLOW_TO_DISK)));
 
     // Now do a rebalance
-    final Long totalSize = (Long) vm0.invoke(new SerializableCallable("simulateRebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(false, manager);
 
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(false, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        // We don't know how many primaries will move, it depends on
-        // if the move bucket code moves the primary or a redundant bucket
-        // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(8, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(0, details.getBucketCreatesCompleted());
-        assertTrue(0 < details.getBucketTransferBytes());
-        assertEquals(8, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
 
-        long totalSize = 0;
-        Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
-        for (PartitionMemberInfo memberDetails : beforeDetails) {
-          totalSize += memberDetails.getSize();
-        }
+      // We don't know how many primaries will move, it depends on
+      // if the move bucket code moves the primary or a redundant bucket
+      // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(8);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
 
-        long afterSize = 0;
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(3, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(8, memberDetails.getBucketCount());
-          assertEquals(4, memberDetails.getPrimaryCount());
-          afterSize += memberDetails.getSize();
-        }
-        assertEquals(totalSize, afterSize);
-        verifyStats(manager, results);
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
 
-        return Long.valueOf(totalSize);
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(8);
+
+      long value = 0;
+      Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
+      for (PartitionMemberInfo memberDetails : beforeDetails) {
+        value += memberDetails.getSize();
       }
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(3);
+
+      long afterSize = 0;
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(8);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(4);
+        afterSize += memberDetails.getSize();
+      }
+      assertThat(afterSize).isEqualTo(value);
+
+      validateStatistics(manager, results);
     });
 
-    SerializableRunnable checkBalance = new SerializableRunnable("checkBalance") {
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        Region region = getCache().getRegion("region1");
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
         PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(1, details.getActualRedundantCopies());
-        assertEquals(0, details.getLowRedundancyBucketCount());
-        LogWriterUtils.getLogWriter().info("details=" + details.getPartitionMemberInfo());
-        long afterSize = 0;
-        for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-          assertEquals(8, memberDetails.getBucketCount());
-          assertEquals(4, memberDetails.getPrimaryCount());
-          afterSize += memberDetails.getSize();
-        }
-        // assertIndexDetailsEquals(totalSize.longValue(), afterSize);
-      }
-    };
+        assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+        assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+        assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
 
-    vm0.invoke(checkBalance);
-    vm1.invoke(checkBalance);
-    vm2.invoke(checkBalance);
+        for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(8);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(4);
+        }
+      });
+    }
 
     // Create the region in one more VM.
-    vm3.invoke(createPrRegion);
+    vm3.invoke(
+        () -> createPartitionedRegion("region1", createLRUEntryAttributes(1, OVERFLOW_TO_DISK)));
 
     // Do another rebalance
-    vm0.invoke(new SerializableCallable("simulateRebalance") {
+    vm0.invoke(() -> {
+      ResourceManager manager = getCache().getResourceManager();
+      RebalanceResults results = doRebalance(false, manager);
 
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(false, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        // We don't know how many primaries will move, it depends on
-        // if the move bucket code moves the primary or a redundant bucket
-        // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(6, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(0, details.getBucketCreatesCompleted());
-        assertTrue(0 < details.getBucketTransferBytes());
-        assertEquals(6, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
 
-        long totalSize = 0;
-        Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
-        for (PartitionMemberInfo memberDetails : beforeDetails) {
-          totalSize += memberDetails.getSize();
-        }
+      // We don't know how many primaries will move, it depends on
+      // if the move bucket code moves the primary or a redundant bucket
+      // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(6);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
 
-        long afterSize = 0;
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(4, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(6, memberDetails.getBucketCount());
-          // assertIndexDetailsEquals(3, memberDetails.getPrimaryCount());
-          afterSize += memberDetails.getSize();
-        }
-        assertEquals(totalSize, afterSize);
-        // TODO - need to fix verifyStats to handle a second rebalance
-        // verifyStats(manager, results);
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
 
-        return Long.valueOf(totalSize);
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(6);
+
+      long totalSize = 0;
+      Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
+      for (PartitionMemberInfo memberDetails : beforeDetails) {
+        totalSize += memberDetails.getSize();
       }
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(4);
+
+      long afterSize = 0;
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+
+        afterSize += memberDetails.getSize();
+      }
+      assertThat(afterSize).isEqualTo(totalSize);
     });
 
-    checkBalance = new SerializableRunnable("checkBalance") {
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        Region region = getCache().getRegion("region1");
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
         PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(1, details.getActualRedundantCopies());
-        assertEquals(0, details.getLowRedundancyBucketCount());
-        LogWriterUtils.getLogWriter().info("details=" + details.getPartitionMemberInfo());
-        long afterSize = 0;
-        for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-          assertEquals(6, memberDetails.getBucketCount());
-          // assertIndexDetailsEquals(3, memberDetails.getPrimaryCount());
-          afterSize += memberDetails.getSize();
-        }
-        // assertIndexDetailsEquals(totalSize.longValue(), afterSize);
-      }
-    };
+        assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+        assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+        assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
 
-    vm0.invoke(checkBalance);
-    vm1.invoke(checkBalance);
-    vm2.invoke(checkBalance);
+        for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+        }
+      });
+    }
   }
 
   /**
@@ -2328,685 +1493,395 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
    */
   @Test
   public void testMoveBucketsNestedPR() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Region parent;
-        Cache cache = getCache();
-        {
-          AttributesFactory attr = new AttributesFactory();
-          attr.setDataPolicy(DataPolicy.REPLICATE);
-          parent = cache.createRegion("parent", attr.create());
-        }
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        parent.createSubregion("region1", attr.create());
-      }
-    };
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
     // Create the region in two VMs
-    vm0.invoke(createPrRegion);
-    vm1.invoke(createPrRegion);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        Region parent = getCache().createRegionFactory(REPLICATE).create("parent");
+        createPartitionedRegionAsSubregion(parent, "region1");
+      });
+    }
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("parent/region1");
-        for (int i = 0; i < 12; i++) {
-          region.put(Integer.valueOf(i), "A");
-        }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("parent/region1");
+      for (int i = 0; i < 12; i++) {
+        region.put(i, "A");
       }
     });
 
     // Create the region in one more VM.
-    vm2.invoke(createPrRegion);
-
-    // Now simulate a rebalance
-    final Long totalSize = (Long) vm0.invoke(new SerializableCallable("simulateRebalance") {
-
-      @Override
-      public Object call() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(false, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        // We don't know how many primaries will move, it depends on
-        // if the move bucket code moves the primary or a redundant bucket
-        // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(8, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(0, details.getBucketCreatesCompleted());
-        assertTrue(0 < details.getBucketTransferBytes());
-        assertEquals(8, details.getBucketTransfersCompleted());
-
-        long totalSize = 0;
-        Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
-        for (PartitionMemberInfo memberDetails : beforeDetails) {
-          totalSize += memberDetails.getSize();
-        }
-
-        long afterSize = 0;
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(3, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(8, memberDetails.getBucketCount());
-          assertEquals(4, memberDetails.getPrimaryCount());
-          afterSize += memberDetails.getSize();
-        }
-        assertEquals(totalSize, afterSize);
-        verifyStats(manager, results);
-
-        return Long.valueOf(totalSize);
-      }
+    vm2.invoke(() -> {
+      Region parent = getCache().createRegionFactory(REPLICATE).create("parent");
+      createPartitionedRegionAsSubregion(parent, "region1");
     });
 
-    SerializableRunnable checkBalance = new SerializableRunnable("checkBalance") {
+    // Now simulate a rebalance
+    long totalSize = vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(false, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("parent/region1");
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+
+      // We don't know how many primaries will move, it depends on
+      // if the move bucket code moves the primary or a redundant bucket
+      // assertIndexDetailsEquals(0, results.getTotalPrimaryTransfersCompleted());
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(8);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
+
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(0 < details.getBucketTransferBytes()).isTrue();
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(8);
+
+      long value = 0;
+      Set<PartitionMemberInfo> beforeDetails = details.getPartitionMemberDetailsAfter();
+      for (PartitionMemberInfo memberDetails : beforeDetails) {
+        value += memberDetails.getSize();
+      }
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(3);
+
+      long afterSize = 0;
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(8);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(4);
+        afterSize += memberDetails.getSize();
+      }
+      assertThat(afterSize).isEqualTo(value);
+      validateStatistics(manager, results);
+
+      return value;
+    });
+
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        Region region = getCache().getRegion("parent/region1");
+
         PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(12, details.getCreatedBucketCount());
-        assertEquals(1, details.getActualRedundantCopies());
-        assertEquals(0, details.getLowRedundancyBucketCount());
-        LogWriterUtils.getLogWriter().info("details=" + details.getPartitionMemberInfo());
+        assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+        assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+        assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
+
         long afterSize = 0;
         for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-          assertEquals(8, memberDetails.getBucketCount());
-          assertEquals(4, memberDetails.getPrimaryCount());
+          assertThat(memberDetails.getBucketCount()).isEqualTo(8);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(4);
           afterSize += memberDetails.getSize();
         }
-        assertEquals(totalSize.longValue(), afterSize);
-      }
-    };
-
-    vm0.invoke(checkBalance);
-    vm1.invoke(checkBalance);
-    vm2.invoke(checkBalance);
-  }
-
-  @Test
-  public void testMoveBucketsColocatedRegionsSimulation() {
-    moveBucketsColocatedRegions(true);
-  }
-
-  @Test
-  public void testMoveBucketsColocatedRegions() {
-    moveBucketsColocatedRegions(false);
+        assertThat(afterSize).isEqualTo(totalSize);
+      });
+    }
   }
 
   /**
    * Test to make sure that we move buckets to balance between three hosts with a redundancy of 1
    * and two colocated regions. Makes sure that the buckets stay colocated when we move them.
-   *
    */
-  public void moveBucketsColocatedRegions(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+  @Test
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testMoveBucketsColocatedRegions(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
 
-    createPrRegion(vm0, "region1", 200, null);
-    createPrRegion(vm0, "region2", 200, "region1");
-    createPrRegion(vm1, "region1", 200, null);
-    createPrRegion(vm1, "region2", 200, "region1");
+    vm0.invoke(() -> createPartitionedRegion("region1", 1, 200));
+    vm0.invoke(() -> createPartitionedRegion("region2", 200, "region1"));
+    vm1.invoke(() -> createPartitionedRegion("region1", 1, 200));
+    vm1.invoke(() -> createPartitionedRegion("region2", 200, "region1"));
 
     // Create some buckets.
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        Region region2 = cache.getRegion("region2");
-        for (int i = 0; i < 12; i++) {
-          region.put(Integer.valueOf(i), "A");
-          region2.put(Integer.valueOf(i), "A");
-        }
+    vm0.invoke(() -> {
+      Region<Number, String> region1 = getCache().getRegion("region1");
+      Region<Number, String> region2 = getCache().getRegion("region2");
+      for (int key = 0; key < 12; key++) {
+        region1.put(key, "A");
+        region2.put(key, "A");
       }
     });
 
-    // create the leader region, but not the colocated
-    // region in one of the VMs.
-    createPrRegion(vm2, "region1", 200, null);
-
+    // create the leader region, but not the colocated region in one of the VMs.
+    vm2.invoke(() -> createPartitionedRegion("region1", 1, 200));
 
     // Simulate a rebalance, and make sure we don't
     // move any buckets yet, because we don't have
     // the colocated region in the new VMs.
-    vm0.invoke(new SerializableRunnable("rebalance") {
+    vm0.invoke(() -> {
+      ResourceManager manager = getCache().getResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(0, results.getTotalBucketTransferBytes());
-        assertEquals(0, results.getTotalBucketTransfersCompleted());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(2, detailSet.size());
-        for (PartitionRebalanceInfo details : detailSet) {
-          assertEquals(0, details.getBucketCreatesCompleted());
-          assertEquals(0, details.getPrimaryTransfersCompleted());
-          assertEquals(0, details.getBucketTransferBytes());
-          assertEquals(0, details.getBucketTransfersCompleted());
-        }
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransferBytes()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
 
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(2);
+
+      for (PartitionRebalanceInfo details : detailSet) {
+        assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+        assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+        assertThat(details.getBucketTransferBytes()).isEqualTo(0);
+        assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
       }
     });
-
 
     // now create the colocated region in the last VM.
-    createPrRegion(vm2, "region2", 200, "region1");
+    vm2.invoke(() -> createPartitionedRegion("region2", 200, "region1"));
 
-    vm0.invoke(new SerializableRunnable("rebalance") {
+    vm0.invoke(() -> {
+      ResourceManager manager = getCache().getResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        assertEquals(16, results.getTotalBucketTransfersCompleted());
-        assertTrue(0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(2, detailSet.size());
-        for (PartitionRebalanceInfo details : detailSet) {
-          assertEquals(0, details.getBucketCreatesCompleted());
-          assertTrue(0 < details.getBucketTransferBytes());
-          assertEquals(8, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(16);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
 
-          Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-          assertEquals(3, afterDetails.size());
-          for (PartitionMemberInfo memberDetails : afterDetails) {
-            assertEquals(8, memberDetails.getBucketCount());
-            assertEquals(4, memberDetails.getPrimaryCount());
-          }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(2);
+
+      for (PartitionRebalanceInfo details : detailSet) {
+        assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+        assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+        assertThat(details.getBucketTransfersCompleted()).isEqualTo(8);
+
+        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+        assertThat(afterDetails).hasSize(3);
+
+        for (PartitionMemberInfo memberDetails : afterDetails) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(8);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(4);
         }
       }
     });
 
-
     if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkLowRedundancy") {
+      for (VM vm : toArray(vm0, vm1, vm2)) {
+        vm.invoke(() -> {
+          PartitionedRegion region1 = (PartitionedRegion) getCache().getRegion("region1");
+          PartitionedRegion region2 = (PartitionedRegion) getCache().getRegion("region2");
 
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          PartitionedRegion region1 = (PartitionedRegion) cache.getRegion("region1");
-          PartitionedRegion region2 = (PartitionedRegion) cache.getRegion("region2");
-          ResourceManager manager = cache.getResourceManager();
           PartitionRegionInfo details =
-              PartitionRegionHelper.getPartitionRegionInfo(cache.getRegion("region1"));
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-          details = PartitionRegionHelper.getPartitionRegionInfo(cache.getRegion("region2"));
-          assertEquals(12, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
+              PartitionRegionHelper.getPartitionRegionInfo(getCache().getRegion("region1"));
+          assertThat(details).isNotNull();
+          assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
 
-          assertEquals(region1.getLocalPrimaryBucketsListTestOnly(),
-              region2.getLocalPrimaryBucketsListTestOnly());
+          details = PartitionRegionHelper.getPartitionRegionInfo(getCache().getRegion("region2"));
+          assertThat(details).isNotNull();
+          assertThat(details.getCreatedBucketCount()).isEqualTo(12);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(1);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
 
-          assertEquals(region1.getLocalBucketsListTestOnly(),
-              region2.getLocalBucketsListTestOnly());
-        }
-      };
+          assertThat(region2.getLocalPrimaryBucketsListTestOnly())
+              .isEqualTo(region1.getLocalPrimaryBucketsListTestOnly());
 
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
-      vm2.invoke(checkRedundancyFixed);
+          assertThat(region2.getLocalBucketsListTestOnly())
+              .isEqualTo(region1.getLocalBucketsListTestOnly());
+        });
+      }
     }
   }
 
   /**
-   * Test to make sure that moving primaries waits for a put
-   *
-   */
-  @Test
-  public void testWaitForPut() throws Exception {
-    runTestWaitForOperation(new Operation() {
-      @Override
-      public void execute(Region region, Integer key) {
-        region.put(key, "B");
-      }
-    });
-  }
-
-  /**
-   * Test to make sure that moving primaries waits for a put
-   *
-   */
-  @Test
-  public void testWaitForInvalidate() throws Exception {
-    runTestWaitForOperation(new Operation() {
-      @Override
-      public void execute(Region region, Integer key) {
-        region.invalidate(key);
-      }
-    });
-  }
-
-  /**
-   * Test to make sure that moving primaries waits for a put
-   *
-   */
-  @Test
-  public void testWaitForDestroy() throws Exception {
-    runTestWaitForOperation(new Operation() {
-      @Override
-      public void execute(Region region, Integer key) {
-        region.destroy(key);
-      }
-    });
-  }
-
-  /**
-   * Test to make sure that moving primaries waits for a put
-   *
-   */
-  @Test
-  public void testWaitForCacheLoader() throws Exception {
-    runTestWaitForOperation(new Operation() {
-      @Override
-      public void execute(Region region, Integer key) {
-        PartitionedRegion r = (PartitionedRegion) region;
-        // get a key that doesn't exist, but is in the same bucket as the given key
-        region.get(key + r.getPartitionAttributes().getTotalNumBuckets());
-      }
-    });
-  }
-
-  /**
    * Test to ensure that we wait for in progress write operations before moving a primary.
-   *
    */
-  public void runTestWaitForOperation(final Operation op) throws Exception {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        AttributesFactory attr = new AttributesFactory();
-        attr.setCacheLoader(new CacheLoader() {
-          @Override
-          public Object load(LoaderHelper helper) throws CacheLoaderException {
-            return "anobject";
-          }
-
-          @Override
-          public void close() {}
-        });
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        paf.setLocalMaxMemory(100);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-      }
-    };
+  @Test
+  @Parameters({"PUT", "INVALIDATE", "DESTROY", "CACHE_LOADER"})
+  @TestCaseName("{method}(operation={0})")
+  public void runTestWaitForOperation(OperationEnum operation) throws Exception {
+    VM vm1 = getVM(1);
 
     // Create a region in this VM with a cache writer
     // and cache loader
-    Cache cache = getCache();
-    AttributesFactory attr = new AttributesFactory();
-    attr.setCacheLoader(new CacheLoader() {
-      @Override
-      public Object load(LoaderHelper helper) throws CacheLoaderException {
-        return "anobject";
-      }
-
-      @Override
-      public void close() {}
-    });
-
-    PartitionAttributesFactory paf = new PartitionAttributesFactory();
-    paf.setRedundantCopies(1);
-    paf.setRecoveryDelay(-1);
-    paf.setStartupRecoveryDelay(-1);
-    paf.setLocalMaxMemory(100);
-    PartitionAttributes prAttr = paf.create();
-    attr.setPartitionAttributes(prAttr);
-    final Region region = cache.createRegion("region1", attr.create());
+    createPartitionedRegion("region1", 1, 100, (CacheLoader<Number, String>) helper1 -> "anobject");
+    Region<Number, String> region = getCache().getRegion("region1");
 
     // create some buckets
-    region.put(Integer.valueOf(1), "A");
-    region.put(Integer.valueOf(2), "A");
+    region.put(1, "A");
+    region.put(2, "A");
 
-    BlockingCacheListener cacheWriter = new BlockingCacheListener(2);
+    BlockingCacheListener<Number, String> cacheWriter = new BlockingCacheListener<>(2);
     region.getAttributesMutator().addCacheListener(cacheWriter);
 
     // start two threads doing operations, one on each bucket
     // the threads will block on the cache writer. The rebalance operation
     // will try to move one of these buckets, but it shouldn't
     // be able to because of the in progress operation.
-    Thread thread1 = new Thread() {
-      @Override
-      public void run() {
-        op.execute(region, Integer.valueOf(1));
-      }
-    };
-    thread1.start();
+    executorServiceRule.submit(() -> operation.execute(region, 1));
+    executorServiceRule.submit(() -> operation.execute(region, 2));
 
-    Thread thread2 = new Thread() {
-      @Override
-      public void run() {
-        op.execute(region, Integer.valueOf(2));
-      }
-    };
-    thread2.start();
     cacheWriter.waitForOperationsStarted();
 
-    SerializableRunnable checkLowRedundancy = new SerializableRunnable("checkLowRedundancy") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-        assertEquals(2, details.getCreatedBucketCount());
-        assertEquals(0, details.getActualRedundantCopies());
-        assertEquals(2, details.getLowRedundancyBucketCount());
-      }
-    };
-
     // make sure we can tell that the buckets have low redundancy
-    checkLowRedundancy.run();
+    validateRedundancy("region1", 2, 0, 2);
 
     // Create the region in the other VM (should have no effect)
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> createPartitionedRegion("region1", 1, 100,
+        (CacheLoader<Number, String>) helper1 -> "anobject"));
 
     // Make sure we still have low redundancy
-    checkLowRedundancy.run();
+    validateRedundancy("region1", 2, 0, 2);
 
-    ResourceManager manager = cache.getResourceManager();
+    ResourceManager manager = getCache().getResourceManager();
     RebalanceOperation rebalance = manager.createRebalanceFactory().start();
-    try {
-      rebalance.getResults(5, TimeUnit.SECONDS);
-      fail("Operation should not have completed");
-    } catch (TimeoutException expected) {
-      // do nothing
-    }
+
+    Throwable thrown = catchThrowable(() -> rebalance.getResults(5, SECONDS));
+    assertThat(thrown).isInstanceOf(TimeoutException.class);
+
     cacheWriter.release();
 
-    LogWriterUtils.getLogWriter()
-        .info("starting wait for rebalance.  Will wait for " + MAX_WAIT + " seconds");
-    RebalanceResults results = rebalance.getResults(MAX_WAIT, TimeUnit.SECONDS);
-    assertEquals(2, results.getTotalBucketCreatesCompleted());
-    assertEquals(1, results.getTotalPrimaryTransfersCompleted());
-    assertEquals(0, results.getTotalBucketTransferBytes());
-    assertEquals(0, results.getTotalBucketTransfersCompleted());
+    RebalanceResults results = rebalance.getResults(TIMEOUT_SECONDS, SECONDS);
+    assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(2);
+    assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(1);
+    assertThat(results.getTotalBucketTransferBytes()).isEqualTo(0);
+    assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
+
     Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-    assertEquals(1, detailSet.size());
+    assertThat(detailSet).hasSize(1);
+
     PartitionRebalanceInfo details = detailSet.iterator().next();
-    assertEquals(2, details.getBucketCreatesCompleted());
-    assertEquals(1, details.getPrimaryTransfersCompleted());
-    assertEquals(0, details.getBucketTransferBytes());
-    assertEquals(0, details.getBucketTransfersCompleted());
+    assertThat(details.getBucketCreatesCompleted()).isEqualTo(2);
+    assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(1);
+    assertThat(details.getBucketTransferBytes()).isEqualTo(0);
+    assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
 
     Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-    assertEquals(2, afterDetails.size());
+    assertThat(afterDetails).hasSize(2);
+
     for (PartitionMemberInfo memberDetails : afterDetails) {
-      assertEquals(2, memberDetails.getBucketCount());
-      assertEquals(1, memberDetails.getPrimaryCount());
+      assertThat(memberDetails.getBucketCount()).isEqualTo(2);
+      assertThat(memberDetails.getPrimaryCount()).isEqualTo(1);
 
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkRedundancyFixed") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(2, details.getCreatedBucketCount());
-          assertEquals(1, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-        }
-      };
-
-      checkRedundancyFixed.run();
-      vm1.invoke(checkRedundancyFixed);
+      validateRedundancy("region1", 2, 1, 0);
+      vm1.invoke(() -> validateRedundancy("region1", 2, 1, 0));
     }
   }
 
   @Test
-  public void testRecoverRedundancyWithOfflinePersistenceSimulation() throws Throwable {
-    recoverRedundancyWithOfflinePersistence(true, false);
-  }
-
-  @Test
-  public void testRecoverRedundancyWithOfflinePersistence() throws Throwable {
-    recoverRedundancyWithOfflinePersistence(false, false);
-  }
-
-  @Test
-  public void testRecoverRedundancyWithOfflinePersistenceAccessorSimulation() throws Throwable {
-    recoverRedundancyWithOfflinePersistence(true, true);
-  }
-
-  @Test
-  public void testRecoverRedundancyWithOfflinePersistenceAccessor() throws Throwable {
-    recoverRedundancyWithOfflinePersistence(false, true);
-  }
-
-  public void recoverRedundancyWithOfflinePersistence(final boolean simulate,
-      final boolean useAccessor) throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    final VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-    VM vm3 = host.getVM(3);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DiskStoreFactory dsf = cache.createDiskStoreFactory();
-        DiskStore ds1 = dsf.setDiskDirs(getDiskDirs()).create(getUniqueName());
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        attr.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        attr.setDiskSynchronous(true);
-        attr.setDiskStoreName(getUniqueName());
-        cache.createRegion("region1", attr.create());
-      }
-    };
+  @Parameters({"true,false", "false,false", "true,true", "false,true"})
+  @TestCaseName("{method}(simulate={0}, userAccessor={1})")
+  public void testRecoverRedundancyWithOfflinePersistence(boolean simulate, boolean useAccessor)
+      throws Exception {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
+    VM vm2 = getVM(2);
+    VM vm3 = getVM(3);
 
     // Create the region in only 2 VMs
-    vm0.invoke(createPrRegion);
-    vm1.invoke(createPrRegion);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> createPersistentPartitionedRegion("region1", getUniqueName(), getDiskDirs()));
+    }
 
-    VM rebalanceVM;
-    SerializableRunnable createAccessor = new SerializableRunnable(("createAccessor")) {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        DiskStoreFactory dsf = cache.createDiskStoreFactory();
-        DiskStore ds1 = dsf.setDiskDirs(getDiskDirs()).create("ds1");
-        AttributesFactory attr = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        paf.setLocalMaxMemory(0);
-        PartitionAttributes prAttr = paf.create();
-        attr.setPartitionAttributes(prAttr);
-        cache.createRegion("region1", attr.create());
-      }
-    };
-
+    VM rebalanceVM = useAccessor ? vm3 : vm0;
     if (useAccessor) {
-      // Create an accessor and reblance from that VM
-      vm3.invoke(createAccessor);
-      rebalanceVM = vm3;
-    } else {
-      rebalanceVM = vm0;
+      // Create an accessor
+      rebalanceVM.invoke(() -> createAccessor("region1", "ds1"));
     }
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        region.put(Integer.valueOf(1), "A");
-        region.put(Integer.valueOf(2), "A");
-        region.put(Integer.valueOf(3), "A");
-        region.put(Integer.valueOf(4), "A");
-        region.put(Integer.valueOf(5), "A");
-        region.put(Integer.valueOf(6), "A");
-      }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      region.put(1, "A");
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
     });
 
-    SerializableRunnable closeCache = new SerializableRunnable("close cache") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        cache.getRegion("region1").close();
-      }
-    };
-
     // Close the cache in vm1
-    final Set<Integer> vm1Buckets = getBucketList("region1", vm1);
-    vm1.invoke(closeCache);
-
-    SerializableRunnable checkLowRedundancyBeforeRebalance =
-        new SerializableRunnable("checkLowRedundancyBeforeRebalance") {
-
-          @Override
-          public void run() {
-            Cache cache = getCache();
-            Region region = cache.getRegion("region1");
-            PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-            assertEquals(6, details.getCreatedBucketCount());
-            assertEquals(0, details.getActualRedundantCopies());
-            assertEquals(6, details.getLowRedundancyBucketCount());
-          }
-        };
-
-    SerializableRunnable checkLowRedundancyAfterRebalance =
-        new SerializableRunnable("checkLowRedundancyAfterRebalance") {
-
-          @Override
-          public void run() {
-            Cache cache = getCache();
-            Region region = cache.getRegion("region1");
-            PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-            assertEquals(6, details.getCreatedBucketCount());
-            assertEquals(1, details.getActualRedundantCopies());
-            assertEquals(0, details.getLowRedundancyBucketCount());
-          }
-        };
+    Set<Integer> bucketsOnVM1 = vm1.invoke(() -> getBucketList("region1"));
+    vm1.invoke(() -> getCache().getRegion("region1").close());
 
     // make sure we can tell that the buckets have low redundancy
-    vm0.invoke(checkLowRedundancyBeforeRebalance);
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
 
     // Now create the cache in another member
-    vm2.invoke(createPrRegion);
+    vm2.invoke(() -> createPersistentPartitionedRegion("region1", getUniqueName(), getDiskDirs()));
 
     // Make sure we still have low redundancy
-    vm0.invoke(checkLowRedundancyBeforeRebalance);
+    vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
 
     /*
      * Simulates a rebalance if simulation flag is set. Otherwise, performs a rebalance.
      *
      * A rebalance will replace offline buckets, so this should restore redundancy
      */
-    rebalanceVM.invoke(new SerializableRunnable("simulateRebalance") {
+    rebalanceVM.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(6, results.getTotalBucketCreatesCompleted());
-        assertEquals(3, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(0, results.getTotalBucketTransfersCompleted());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(6, details.getBucketCreatesCompleted());
-        assertEquals(3, details.getPrimaryTransfersCompleted());
-        assertEquals(0, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(6);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(3);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
 
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(2, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(6, memberDetails.getBucketCount());
-          assertEquals(3, memberDetails.getPrimaryCount());
-        }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
 
-        if (!simulate) {
-          verifyStats(manager, results);
-        }
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(6);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(3);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(2);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
+      }
+
+      if (!simulate) {
+        validateStatistics(manager, results);
       }
     });
 
-    Set<Integer> vm0Buckets = getBucketList("region1", vm0);
-    Set<Integer> vm2Buckets = getBucketList("region1", vm2);
+    Set<Integer> bucketsOnVM0 = vm0.invoke(() -> getBucketList("region1"));
+    Set<Integer> bucketsOnVM2 = vm2.invoke(() -> getBucketList("region1"));
 
-    // Make sure redundancy is repaired if not simulated
-    if (!simulate) {
-      vm0.invoke(checkLowRedundancyAfterRebalance);
+    if (simulate) {
+      // Otherwise, we should still have broken redundancy at this point
+      vm0.invoke(() -> validateRedundancy("region1", 6, 0, 6));
     } else {
-      // Othewise, we should still have broken redundancy at this point
-      vm0.invoke(checkLowRedundancyBeforeRebalance);
+      // Make sure redundancy is repaired if not simulated
+      vm0.invoke(() -> validateRedundancy("region1", 6, 1, 0));
     }
 
-    vm2.invoke(closeCache);
-    vm0.invoke(closeCache);
+    vm2.invoke(() -> getCache().getRegion("region1").close());
+    vm0.invoke(() -> getCache().getRegion("region1").close());
 
     if (useAccessor) {
-      vm3.invoke(closeCache);
+      vm3.invoke(() -> getCache().getRegion("region1").close());
     }
 
     // We need to restart both VMs at the same time, because
     // they will wait for each other before allowing operations.
-    AsyncInvocation async0 = vm0.invokeAsync(createPrRegion);
-    AsyncInvocation async2 = vm2.invokeAsync(createPrRegion);
-    async0.getResult(30000);
-    async0.getResult(30000);
+    AsyncInvocation createRegionOnVM0 = vm0.invokeAsync(
+        () -> createPersistentPartitionedRegion("region1", getUniqueName(), getDiskDirs()));
+    AsyncInvocation createRegionOnVM2 = vm2.invokeAsync(
+        () -> createPersistentPartitionedRegion("region1", getUniqueName(), getDiskDirs()));
+
+    createRegionOnVM0.await();
+    createRegionOnVM2.await();
 
     if (useAccessor) {
-      vm3.invoke(createAccessor);
+      vm3.invoke(() -> createAccessor("region1", "ds1"));
     }
 
     // pause for async bucket recovery threads to finish their work. Otherwise
     // the rebalance op may think that the other member doesn't have buckets, then
     // ask it to create them and get a negative reply because it actually does
     // have the buckets, causing the test to fail
-    Wait.pause(10000);
 
     // Try to rebalance again. This shouldn't do anything, because
     // we already recovered redundancy earlier.
@@ -3015,495 +1890,747 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
     // to rebalance primaries. So this thread might end up rebalancing primaries,
     // or it might not.
     if (!simulate) {
-      rebalanceVM.invoke(new SerializableRunnable("rebalance") {
+      rebalanceVM.invoke(() -> {
+        ResourceManager manager = getCache().getResourceManager();
 
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          ResourceManager manager = cache.getResourceManager();
-          RebalanceResults results = doRebalance(simulate, manager);
-          assertEquals(0, results.getTotalBucketCreatesCompleted());
-          assertEquals(0, results.getTotalBucketTransfersCompleted());
-          Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-          assertEquals(1, detailSet.size());
-          PartitionRebalanceInfo details = detailSet.iterator().next();
-          assertEquals(0, details.getBucketCreatesCompleted());
-          assertEquals(0, details.getBucketTransfersCompleted());
+        RebalanceResults results = doRebalance(simulate, manager);
 
-          Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-          assertEquals(2, afterDetails.size());
-          for (PartitionMemberInfo memberDetails : afterDetails) {
-            assertEquals(6, memberDetails.getBucketCount());
-            assertEquals(3, memberDetails.getPrimaryCount());
-          }
+        assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+        assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(0);
+
+        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+        assertThat(detailSet).hasSize(1);
+
+        PartitionRebalanceInfo details = detailSet.iterator().next();
+        assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+        assertThat(details.getBucketTransfersCompleted()).isEqualTo(0);
+
+        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+        assertThat(afterDetails).hasSize(2);
+
+        for (PartitionMemberInfo memberDetails : afterDetails) {
+          assertThat(memberDetails.getBucketCount()).isEqualTo(6);
+          assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
         }
       });
 
       // Redundancy should be repaired.
-      vm0.invoke(checkLowRedundancyAfterRebalance);
+      vm0.invoke(() -> validateRedundancy("region1", 6, 1, 0));
     }
 
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> createPersistentPartitionedRegion("region1", getUniqueName(), getDiskDirs()));
 
     // Look at vm0 buckets.
-    assertEquals(vm0Buckets, getBucketList("region1", vm0));
+    assertThat(vm0.invoke(() -> getBucketList("region1"))).isEqualTo(bucketsOnVM0);
 
     /*
      * Look at vm1 buckets.
      */
-    if (!simulate) {
-      /*
-       * vm1 should have no buckets because offline buckets were recovered when vm0 and vm2 were
-       * rebalanced above.
-       */
-      assertEquals(0, getBucketList("region1", vm1).size());
-    } else {
+    if (simulate) {
       /*
        * No rebalancing above because the simulation flag is on. Therefore, vm1 will have recovered
        * its buckets. We need to wait for the buckets because they might still be in the middle of
        * creation in the background
        */
-      waitForBucketList("region1", vm1, vm1Buckets);
+      vm1.invoke(() -> waitForBucketList("region1", bucketsOnVM1));
+    } else {
+      /*
+       * vm1 should have no buckets because offline buckets were recovered when vm0 and vm2 were
+       * rebalanced above.
+       */
+      assertThat(vm1.invoke(() -> getBucketList("region1"))).isEmpty();
     }
 
     // look at vm2 buckets
-    assertEquals(vm2Buckets, getBucketList("region1", vm2));
+    assertThat(vm2.invoke(() -> getBucketList("region1"))).isEqualTo(bucketsOnVM2);
   }
 
   @Test
-  public void testMoveBucketsWithUnrecoveredValues() {
-    moveBucketsWithUnrecoveredValuesRedundancy(false);
-  }
-
-  @Test
-  public void testBalanceBucketsByCountSimulation() {
-    balanceBucketsByCount(true);
-  }
-
-  @Test
-  public void testBalanceBucketsByCount() {
-    balanceBucketsByCount(false);
-  }
-
-  /**
-   * Check to make sure that we balance buckets between two hosts with no redundancy.
-   *
-   */
-  public void balanceBucketsByCount(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    LoadProbe oldProbe = setLoadProbe(vm0, new BucketCountLoadProbe());
-    try {
-      SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          AttributesFactory attr = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(-1);
-          paf.setStartupRecoveryDelay(-1);
-          PartitionAttributes prAttr = paf.create();
-          attr.setPartitionAttributes(prAttr);
-          attr.setCacheLoader(new Bug40228Loader());
-          cache.createRegion("region1", attr.create());
-        }
-      };
-
-      // Create the region in only 1 VM
-      vm0.invoke(createPrRegion);
-
-      // Create some buckets with very uneven sizes
-      vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
-          region.put(Integer.valueOf(1), new byte[1024 * 1024]);
-          region.put(Integer.valueOf(2), "A");
-          region.put(Integer.valueOf(3), "A");
-          region.put(Integer.valueOf(4), "A");
-          region.put(Integer.valueOf(5), "A");
-          region.put(Integer.valueOf(6), "A");
-        }
-      });
-
-      // Create the region in the other VM (should have no effect)
-      vm1.invoke(createPrRegion);
-
-      // Now simulate a rebalance
-      vm0.invoke(new SerializableRunnable("simulateRebalance") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          ResourceManager manager = cache.getResourceManager();
-          RebalanceResults results = doRebalance(simulate, manager);
-          assertEquals(0, results.getTotalBucketCreatesCompleted());
-          assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-          assertEquals(3, results.getTotalBucketTransfersCompleted());
-          assertTrue(0 < results.getTotalBucketTransferBytes());
-          Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-          assertEquals(1, detailSet.size());
-          PartitionRebalanceInfo details = detailSet.iterator().next();
-          assertEquals(0, details.getBucketCreatesCompleted());
-          assertEquals(0, details.getPrimaryTransfersCompleted());
-          assertTrue(0 < details.getBucketTransferBytes());
-          assertEquals(3, details.getBucketTransfersCompleted());
-
-          Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-          assertEquals(2, afterDetails.size());
-          for (PartitionMemberInfo memberDetails : afterDetails) {
-            assertEquals(3, memberDetails.getBucketCount());
-            assertEquals(3, memberDetails.getPrimaryCount());
-          }
-          if (!simulate) {
-            verifyStats(manager, results);
-          }
-        }
-      });
-
-      if (!simulate) {
-        SerializableRunnable checkRedundancyFixed =
-            new SerializableRunnable("checkRedundancyFixed") {
-
-              @Override
-              public void run() {
-                Cache cache = getCache();
-                Region region = cache.getRegion("region1");
-                PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-                assertEquals(6, details.getCreatedBucketCount());
-                assertEquals(0, details.getActualRedundantCopies());
-                assertEquals(0, details.getLowRedundancyBucketCount());
-                assertEquals(2, details.getPartitionMemberInfo().size());
-                for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-                  assertEquals(3, memberDetails.getBucketCount());
-                  assertEquals(3, memberDetails.getPrimaryCount());
-                }
-
-                // check to make sure that moving buckets didn't close the cache loader
-                Bug40228Loader loader =
-                    (Bug40228Loader) cache.getRegion("region1").getAttributes().getCacheLoader();
-                assertFalse(loader.isClosed());
-              }
-            };
-
-        vm0.invoke(checkRedundancyFixed);
-        vm1.invoke(checkRedundancyFixed);
-      }
-    } finally {
-      setLoadProbe(vm0, oldProbe);
-    }
-  }
-
-  private LoadProbe setLoadProbe(VM vm, final LoadProbe probe) {
-    LoadProbe oldProbe = (LoadProbe) vm.invoke(new SerializableCallable("set load probe") {
-
-      @Override
-      public Object call() {
-        GemFireCacheImpl cache = (GemFireCacheImpl) getCache();
-        InternalResourceManager mgr = cache.getInternalResourceManager();
-        return mgr.setLoadProbe(probe);
-      }
-    });
-
-    return oldProbe;
-  }
-
-  /**
-   * Test to ensure that we wait for in progress write operations before moving a primary.
-   *
-   */
-  public void moveBucketsWithUnrecoveredValuesRedundancy(final boolean simulate) {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    SerializableRunnable createPrRegion = new SerializableRunnable("createRegion") {
-      @Override
-      public void run() {
-        System.setProperty(DiskStoreImpl.RECOVER_VALUE_PROPERTY_NAME, "false");
-        try {
-          Cache cache = getCache();
-          if (cache.findDiskStore("store") == null) {
-            cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).setMaxOplogSize(1)
-                .create("store");
-          }
-          AttributesFactory attr = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          attr.setDiskStoreName("store");
-          attr.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(-1);
-          paf.setStartupRecoveryDelay(-1);
-          PartitionAttributes prAttr = paf.create();
-          attr.setPartitionAttributes(prAttr);
-          attr.setCacheLoader(new Bug40228Loader());
-          cache.createRegion("region1", attr.create());
-        } finally {
-          System.setProperty(DiskStoreImpl.RECOVER_VALUE_PROPERTY_NAME, "true");
-        }
-      }
-    };
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testMoveBucketsWithUnrecoveredValues(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
     // Create the region in only 1 VM
-    vm0.invoke(createPrRegion);
-
+    vm0.invoke(() -> createPersistentPartitionedRegion("region1", "store", getDiskDirs(),
+        new NullReturningLoader<>()));
 
     // Create some buckets
-    vm0.invoke(new SerializableRunnable("createSomeBuckets") {
-
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion("region1");
-        region.put(Integer.valueOf(1), "A");
-        region.put(Integer.valueOf(2), "A");
-        region.put(Integer.valueOf(3), "A");
-        region.put(Integer.valueOf(4), "A");
-        region.put(Integer.valueOf(5), "A");
-        region.put(Integer.valueOf(6), "A");
-      }
+    vm0.invoke(() -> {
+      Region<Number, String> region = getCache().getRegion("region1");
+      region.put(1, "A");
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
     });
 
-    final long[] bucketSizes =
-        (long[]) vm0.invoke(new SerializableCallable("get sizes and close cache") {
+    vm0.invoke(() -> {
+      PartitionedRegion region = (PartitionedRegion) getCache().getRegion("region1");
+      PartitionedRegionDataStore dataStore = region.getDataStore();
 
-          @Override
-          public Object call() {
-            PartitionedRegion region = (PartitionedRegion) getCache().getRegion("region1");
-            PartitionedRegionDataStore dataStore = region.getDataStore();
-            long[] bucketSizes = new long[7];
-            for (int i = 1; i <= 6; i++) {
-              BucketRegion bucket = dataStore.getLocalBucketById(i);
-              bucketSizes[i] = bucket.getTotalBytes();
-              assertEquals(0, bucket.getNumOverflowBytesOnDisk());
-              assertEquals(0, bucket.getNumOverflowOnDisk());
-              assertEquals(1, bucket.getNumEntriesInVM());
-            }
-            getCache().close();
+      for (int i = 1; i <= 6; i++) {
+        BucketRegion bucket = dataStore.getLocalBucketById(i);
 
-            return bucketSizes;
-          }
-        });
+        assertThat(bucket.getNumOverflowBytesOnDisk()).isEqualTo(0);
+        assertThat(bucket.getNumOverflowOnDisk()).isEqualTo(0);
+        assertThat(bucket.getNumEntriesInVM()).isEqualTo(1);
+      }
+      getCache().close();
+    });
 
     // now recover the region
-    vm0.invoke(createPrRegion);
+    vm0.invoke(() -> createPersistentPartitionedRegion("region1", "store", getDiskDirs(),
+        new NullReturningLoader<>()));
 
-    vm0.invoke(new SerializableRunnable("check sizes") {
+    vm0.invoke(() -> {
+      PartitionedRegion region = (PartitionedRegion) getCache().getRegion("region1");
+      PartitionedRegionDataStore dataStore = region.getDataStore();
 
-      @Override
-      public void run() {
-        PartitionedRegion region = (PartitionedRegion) getCache().getRegion("region1");
-        PartitionedRegionDataStore dataStore = region.getDataStore();
-        for (int i = 1; i <= 6; i++) {
-          BucketRegion bucket = dataStore.getLocalBucketById(i);
-          assertEquals(1, bucket.getNumOverflowOnDisk());
-          assertEquals(0, bucket.getNumEntriesInVM());
-          // the size recorded on disk is not the same is the in memory size, apparently
-          assertTrue("Bucket size was " + bucket.getNumOverflowBytesOnDisk(),
-              1 < bucket.getNumOverflowBytesOnDisk());
-          assertEquals(bucket.getNumOverflowBytesOnDisk(), bucket.getTotalBytes());
-        }
+      for (int i = 1; i <= 6; i++) {
+        BucketRegion bucket = dataStore.getLocalBucketById(i);
+
+        assertThat(bucket.getNumOverflowOnDisk()).isEqualTo(1);
+        assertThat(bucket.getNumEntriesInVM()).isEqualTo(0);
+
+        // the size recorded on disk is not the same is the in memory size, apparently
+        assertThat(bucket.getNumOverflowBytesOnDisk())
+            .as("Bucket size was " + bucket.getNumOverflowBytesOnDisk())
+            .isGreaterThan(1);
+        assertThat(bucket.getTotalBytes()).isEqualTo(bucket.getNumOverflowBytesOnDisk());
       }
     });
 
     // Create the region in the other VM (should have no effect)
-    vm1.invoke(createPrRegion);
+    vm1.invoke(() -> createPersistentPartitionedRegion("region1", "store", getDiskDirs(),
+        new NullReturningLoader<>()));
 
     // Now simulate a rebalance
-    vm0.invoke(new SerializableRunnable("simulateRebalance") {
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        ResourceManager manager = cache.getResourceManager();
-        RebalanceResults results = doRebalance(simulate, manager);
-        assertEquals(0, results.getTotalBucketCreatesCompleted());
-        assertEquals(0, results.getTotalPrimaryTransfersCompleted());
-        assertEquals(3, results.getTotalBucketTransfersCompleted());
-        assertTrue("Transfered Bytes = " + results.getTotalBucketTransferBytes(),
-            0 < results.getTotalBucketTransferBytes());
-        Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
-        assertEquals(1, detailSet.size());
-        PartitionRebalanceInfo details = detailSet.iterator().next();
-        assertEquals(0, details.getBucketCreatesCompleted());
-        assertEquals(0, details.getPrimaryTransfersCompleted());
-        assertTrue(0 < details.getBucketTransferBytes());
-        assertEquals(3, details.getBucketTransfersCompleted());
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(3);
+      assertThat(results.getTotalBucketTransferBytes())
+          .as("Transferred Bytes = " + results.getTotalBucketTransferBytes())
+          .isGreaterThan(0);
 
-        Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
-        assertEquals(2, afterDetails.size());
-        for (PartitionMemberInfo memberDetails : afterDetails) {
-          assertEquals(3, memberDetails.getBucketCount());
-          assertEquals(3, memberDetails.getPrimaryCount());
-        }
-        if (!simulate) {
-          verifyStats(manager, results);
-        }
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(3);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(2);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
+      }
+
+      if (!simulate) {
+        validateStatistics(manager, results);
       }
     });
 
     if (!simulate) {
-      SerializableRunnable checkRedundancyFixed = new SerializableRunnable("checkRedundancyFixed") {
+      for (VM vm : toArray(vm0, vm1)) {
+        vm.invoke(() -> {
+          Region region = getCache().getRegion("region1");
 
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Region region = cache.getRegion("region1");
           PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
-          assertEquals(6, details.getCreatedBucketCount());
-          assertEquals(0, details.getActualRedundantCopies());
-          assertEquals(0, details.getLowRedundancyBucketCount());
-          assertEquals(2, details.getPartitionMemberInfo().size());
+          assertThat(details.getCreatedBucketCount()).isEqualTo(6);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(0);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
+          assertThat(details.getPartitionMemberInfo()).hasSize(2);
+
           for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
-            assertEquals(3, memberDetails.getBucketCount());
-            assertEquals(3, memberDetails.getPrimaryCount());
+            assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
           }
 
           // check to make sure that moving buckets didn't close the cache loader
-          Bug40228Loader loader =
-              (Bug40228Loader) cache.getRegion("region1").getAttributes().getCacheLoader();
-          assertFalse(loader.isClosed());
-        }
-      };
+          NullReturningLoader loader =
+              (NullReturningLoader) getCache().getRegion("region1").getAttributes()
+                  .getCacheLoader();
+          assertThat(loader.isClosed()).isFalse();
+        });
+      }
 
-      vm0.invoke(checkRedundancyFixed);
-      vm1.invoke(checkRedundancyFixed);
+      for (VM vm : toArray(vm0, vm1)) {
+        vm.invoke(() -> {
+          NullReturningLoader loader =
+              (NullReturningLoader) getCache().getRegion("region1").getAttributes()
+                  .getCacheLoader();
+          assertThat(loader.isClosed()).isFalse();
 
-      SerializableRunnable checkBug40228Fixed = new SerializableRunnable("checkBug40228Fixed") {
-
-        @Override
-        public void run() {
-          Cache cache = getCache();
-          Bug40228Loader loader =
-              (Bug40228Loader) cache.getRegion("region1").getAttributes().getCacheLoader();
-          assertFalse(loader.isClosed());
           // check to make sure that closing the PR closes the cache loader
-          cache.getRegion("region1").close();
-          assertTrue(loader.isClosed());
-        }
-      };
-
-      vm0.invoke(checkBug40228Fixed);
-      vm1.invoke(checkBug40228Fixed);
+          getCache().getRegion("region1").close();
+          assertThat(loader.isClosed()).isTrue();
+        });
+      }
     }
   }
 
-  // TODO test colocated regions where buckets aren't created for all subregions
+  @Test
+  @Parameters({"true", "false"})
+  @TestCaseName("{method}(simulate={0})")
+  public void testBalanceBucketsByCount(boolean simulate) {
+    VM vm0 = getVM(0);
+    VM vm1 = getVM(1);
 
-  // TODO test colocated regions where members aren't consistent in which regions they have
+    // Cache is closed so loadProbeToRestore does not need to be restored
+    vm0.invoke(
+        () -> getCache().getInternalResourceManager().setLoadProbe(new BucketCountLoadProbe()));
 
-  private void verifyStats(ResourceManager manager, RebalanceResults results) {
-    InternalResourceManager mgr = (InternalResourceManager) manager;
-    ResourceManagerStats stats = mgr.getStats();
+    // Create the region in only 1 VM
+    vm0.invoke(() -> createPartitionedRegion("region1", 0, new NullReturningLoader()));
 
-    assertEquals(0, stats.getRebalancesInProgress());
-    assertEquals(1, stats.getRebalancesCompleted());
-    assertEquals(0, stats.getRebalanceBucketCreatesInProgress());
-    assertEquals(results.getTotalBucketCreatesCompleted(),
-        stats.getRebalanceBucketCreatesCompleted());
-    assertEquals(0, stats.getRebalanceBucketCreatesFailed());
-    // The time stats may not be exactly the same, because they are not
-    // incremented at exactly the same time.
-    assertEquals(results.getTotalBucketCreateTime(),
-        TimeUnit.NANOSECONDS.toMillis(stats.getRebalanceBucketCreateTime()), 2000);
-    assertEquals(results.getTotalBucketCreateBytes(), stats.getRebalanceBucketCreateBytes());
-    assertEquals(0, stats.getRebalanceBucketTransfersInProgress());
-    assertEquals(results.getTotalBucketTransfersCompleted(),
-        stats.getRebalanceBucketTransfersCompleted());
-    assertEquals(0, stats.getRebalanceBucketTransfersFailed());
-    assertEquals(results.getTotalBucketTransferTime(),
-        TimeUnit.NANOSECONDS.toMillis(stats.getRebalanceBucketTransfersTime()), 2000);
-    assertEquals(results.getTotalBucketTransferBytes(), stats.getRebalanceBucketTransfersBytes());
-    assertEquals(0, stats.getRebalancePrimaryTransfersInProgress());
-    assertEquals(results.getTotalPrimaryTransfersCompleted(),
-        stats.getRebalancePrimaryTransfersCompleted());
-    assertEquals(0, stats.getRebalancePrimaryTransfersFailed());
-    assertEquals(results.getTotalPrimaryTransferTime(),
-        TimeUnit.NANOSECONDS.toMillis(stats.getRebalancePrimaryTransferTime()), 2000);
+    // Create some buckets with very uneven sizes
+    vm0.invoke(() -> {
+      Region<Number, Object> region = getCache().getRegion("region1");
+      region.put(1, new byte[1024 * 1024]);
+      region.put(2, "A");
+      region.put(3, "A");
+      region.put(4, "A");
+      region.put(5, "A");
+      region.put(6, "A");
+    });
+
+    // Create the region in the other VM (should have no effect)
+    vm1.invoke(() -> createPartitionedRegion("region1", 0, new NullReturningLoader()));
+
+    // Now simulate a rebalance
+    vm0.invoke(() -> {
+      InternalResourceManager manager = getCache().getInternalResourceManager();
+      RebalanceResults results = doRebalance(simulate, manager);
+
+      assertThat(results.getTotalBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(results.getTotalPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(results.getTotalBucketTransfersCompleted()).isEqualTo(3);
+      assertThat(results.getTotalBucketTransferBytes()).isGreaterThan(0);
+
+      Set<PartitionRebalanceInfo> detailSet = results.getPartitionRebalanceDetails();
+      assertThat(detailSet).hasSize(1);
+
+      PartitionRebalanceInfo details = detailSet.iterator().next();
+      assertThat(details.getBucketCreatesCompleted()).isEqualTo(0);
+      assertThat(details.getPrimaryTransfersCompleted()).isEqualTo(0);
+      assertThat(details.getBucketTransferBytes()).isGreaterThan(0);
+      assertThat(details.getBucketTransfersCompleted()).isEqualTo(3);
+
+      Set<PartitionMemberInfo> afterDetails = details.getPartitionMemberDetailsAfter();
+      assertThat(afterDetails).hasSize(2);
+
+      for (PartitionMemberInfo memberDetails : afterDetails) {
+        assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+        assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
+      }
+
+      if (!simulate) {
+        validateStatistics(manager, results);
+      }
+    });
+
+    if (!simulate) {
+      for (VM vm : toArray(vm0, vm1)) {
+        vm.invoke(() -> {
+          Region region = getCache().getRegion("region1");
+
+          PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
+          assertThat(details.getCreatedBucketCount()).isEqualTo(6);
+          assertThat(details.getActualRedundantCopies()).isEqualTo(0);
+          assertThat(details.getLowRedundancyBucketCount()).isEqualTo(0);
+          assertThat(details.getPartitionMemberInfo()).hasSize(2);
+
+          for (PartitionMemberInfo memberDetails : details.getPartitionMemberInfo()) {
+            assertThat(memberDetails.getBucketCount()).isEqualTo(3);
+            assertThat(memberDetails.getPrimaryCount()).isEqualTo(3);
+          }
+
+          // check to make sure that moving buckets didn't close the cache loader
+          NullReturningLoader loader =
+              (NullReturningLoader) getCache().getRegion("region1").getAttributes()
+                  .getCacheLoader();
+          assertThat(loader.isClosed()).isFalse();
+        });
+      }
+    }
   }
 
-  private Set<Integer> getBucketList(final String regionName, VM vm0) {
-    SerializableCallable getBuckets = new SerializableCallable("get buckets") {
+  private void createPartitionedRegion(String regionName, EvictionAttributes evictionAttributes) {
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(1);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
 
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setEvictionAttributes(evictionAttributes);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(regionName);
+  }
+
+  private <K, V> void createPartitionedRegion(String regionName, CacheLoader<K, V> cacheLoader) {
+    PartitionAttributesFactory<K, V> partitionAttributesFactory =
+        new PartitionAttributesFactory<>();
+    partitionAttributesFactory.setRedundantCopies(0);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+
+    RegionFactory<K, V> regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+    regionFactory.setCacheLoader(cacheLoader);
+
+    regionFactory.create(regionName);
+  }
+
+  private void createPartitionedRegion(String regionName, int redundantCopies) {
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(redundantCopies);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(regionName);
+  }
+
+  /**
+   * NOTE: do not replace createPartitionedRegionRunnable with lambda
+   * because ResourceObserverAdapter is NOT serializable
+   */
+  private SerializableRunnableIF createPartitionedRegionRunnable(String regionName,
+      int redundantCopies) {
+    return new SerializableRunnable() {
       @Override
-      public Object call() throws Exception {
-        Cache cache = getCache();
-        PartitionedRegion region = (PartitionedRegion) cache.getRegion(regionName);
-        return new TreeSet<Integer>(region.getDataStore().getAllLocalBucketIds());
+      public void run() {
+        createPartitionedRegion(regionName, redundantCopies);
       }
     };
-
-    return (Set<Integer>) vm0.invoke(getBuckets);
   }
 
-  private void waitForBucketList(final String regionName, VM vm0,
-      final Collection<Integer> expected) {
-    SerializableCallable getBuckets = new SerializableCallable("get buckets") {
+  private void createPartitionedRegion(String region, int redundantCopies, int localMaxMemory) {
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setLocalMaxMemory(localMaxMemory);
+    partitionAttributesFactory.setRedundantCopies(redundantCopies);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
 
-      @Override
-      public Object call() throws Exception {
-        Cache cache = getCache();
-        final PartitionedRegion region = (PartitionedRegion) cache.getRegion(regionName);
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
 
-        GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
+    regionFactory.create(region);
+  }
 
+  private <K, V> void createPartitionedRegion(String regionName, int redundantCopies,
+      CacheLoader<K, V> cacheLoader) {
+    PartitionAttributesFactory<K, V> partitionAttributesFactory =
+        new PartitionAttributesFactory<>();
+    partitionAttributesFactory.setRedundantCopies(redundantCopies);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+
+    RegionFactory<K, V> regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setCacheLoader(cacheLoader);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(regionName);
+  }
+
+  private <K, V> void createPartitionedRegion(String regionName, int redundantCopies,
+      int localMaxMemory, CacheLoader<K, V> cacheLoader) {
+    PartitionAttributesFactory<K, V> partitionAttributesFactory =
+        new PartitionAttributesFactory<>();
+    partitionAttributesFactory.setRedundantCopies(redundantCopies);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+    partitionAttributesFactory.setLocalMaxMemory(localMaxMemory);
+
+    RegionFactory<K, V> regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setCacheLoader(cacheLoader);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(regionName);
+  }
+
+  private void createPartitionedRegion(String region, int localMaxMemory, String colocatedWith) {
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setLocalMaxMemory(localMaxMemory);
+    partitionAttributesFactory.setRedundantCopies(1);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+    partitionAttributesFactory.setColocatedWith(colocatedWith);
+
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(region);
+  }
+
+  private void createPersistentPartitionedRegion(String regionName, String diskStoreName,
+      File[] diskDirs) {
+    DiskStoreFactory diskStoreFactory = getCache().createDiskStoreFactory();
+    diskStoreFactory.setDiskDirs(diskDirs).create(diskStoreName);
+
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(1);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION_PERSISTENT);
+    regionFactory.setDiskSynchronous(true);
+    regionFactory.setDiskStoreName(diskStoreName);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(regionName);
+  }
+
+  private <K, V> void createPersistentPartitionedRegion(String regionName, String diskStoreName,
+      File[] diskDirs, CacheLoader<K, V> cacheLoader) {
+    System.setProperty(DiskStoreImpl.RECOVER_VALUE_PROPERTY_NAME, "false");
+    try {
+      DiskStoreFactory diskStoreFactory = getCache().createDiskStoreFactory();
+      diskStoreFactory.setDiskDirs(diskDirs).setMaxOplogSize(1).create(diskStoreName);
+
+      PartitionAttributesFactory<K, V> partitionAttributesFactory =
+          new PartitionAttributesFactory<>();
+      partitionAttributesFactory.setRedundantCopies(0);
+      partitionAttributesFactory.setRecoveryDelay(-1);
+      partitionAttributesFactory.setStartupRecoveryDelay(-1);
+
+      RegionFactory<K, V> regionFactory = getCache().createRegionFactory(PARTITION_PERSISTENT);
+      regionFactory.setCacheLoader(cacheLoader);
+      regionFactory.setDiskStoreName(diskStoreName);
+      regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+      regionFactory.create(regionName);
+    } finally {
+      System.setProperty(DiskStoreImpl.RECOVER_VALUE_PROPERTY_NAME, "true");
+    }
+  }
+
+  private void createAccessor(String regionName, String diskStoreName) {
+    DiskStoreFactory diskStoreFactory = getCache().createDiskStoreFactory();
+    diskStoreFactory.setDiskDirs(getDiskDirs()).create(diskStoreName);
+
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(1);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+    partitionAttributesFactory.setLocalMaxMemory(0);
+
+    AttributesFactory attr = new AttributesFactory();
+    attr.setPartitionAttributes(partitionAttributesFactory.create());
+
+    getCache().createRegion(regionName, attr.create());
+  }
+
+  private void createPartitionedRegionAsSubregion(Region parent, String regionName) {
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(1);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+    regionFactory.createSubregion(parent, regionName);
+  }
+
+  private void createTwoRegionsWithParallelRecoveryObserver() {
+    ParallelRecoveryObserver ob =
+        (ParallelRecoveryObserver) InternalResourceManager.getResourceObserver();
+
+    ob.observeRegion("region1");
+    ob.observeRegion("region2");
+
+    createPartitionedRegion("region1", 1);
+    createPartitionedRegion("region2", 1);
+  }
+
+  private void createPRRegionWithAsyncQueue(int localMaxMemory) {
+    // Create an async event listener that doesn't dispatch anything
+
+    // NOTE: "new AsyncEventListener" cannot be converted to a lambda -- only one class is
+    // allowed per cluster and the lambda may create a different class name in different VMs.
+    getCache().createAsyncEventQueueFactory()
+        .setMaximumQueueMemory(1)
+        .setParallel(true)
+        .create("parallelQueue", new AsyncEventListener() {
           @Override
-          public boolean done() {
-            TreeSet<Integer> results = getBuckets();
-            return results.equals(expected);
-          }
-
-          protected TreeSet<Integer> getBuckets() {
-            TreeSet<Integer> results =
-                new TreeSet<Integer>(region.getDataStore().getAllLocalBucketIds());
-            return results;
-          }
-
-          @Override
-          public String description() {
-            return "Timeout waiting for buckets to match. Expected " + expected + " but got "
-                + getBuckets();
+          public boolean processEvents(List<AsyncEvent> events) {
+            try {
+              Thread.sleep(100);
+            } catch (InterruptedException e) {
+              return false;
+            }
+            return false;
           }
         });
 
-        return null;
-      }
-    };
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(1);
+    partitionAttributesFactory.setRecoveryDelay(-1);
+    partitionAttributesFactory.setStartupRecoveryDelay(-1);
+    partitionAttributesFactory.setLocalMaxMemory(localMaxMemory);
 
-    vm0.invoke(getBuckets);
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.addAsyncEventQueueId("parallelQueue");
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create("region1");
   }
 
-  private static class BlockingCacheListener extends CacheListenerAdapter {
-    CountDownLatch operationStartedLatch;
-    CountDownLatch resumeOperationLatch = new CountDownLatch(1);
+  private void doPuts(String regionName) {
+    Region<Number, String> region = getCache().getRegion(regionName);
+    region.put(1, "A");
+    region.put(2, "A");
+    region.put(3, "A");
+    region.put(4, "A");
+    region.put(5, "A");
+    region.put(6, "A");
+  }
 
-    public BlockingCacheListener(int threads) {
-      operationStartedLatch = new CountDownLatch(threads);
+  private void setRedundancyZone(String zone) {
+    System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "resource.manager.threads", "2");
+
+    Properties props = new Properties();
+    props.setProperty(REDUNDANCY_ZONE, zone);
+
+    getCache(props);
+  }
+
+  private RebalanceResults doRebalance(boolean simulate, ResourceManager manager)
+      throws TimeoutException, InterruptedException {
+    return doRebalance(simulate, manager, null, null);
+  }
+
+  private RebalanceResults doRebalance(boolean simulate, ResourceManager manager,
+      Set<String> includes, Set<String> excludes) throws TimeoutException, InterruptedException {
+    RebalanceResults results;
+    if (simulate) {
+      results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
+          .simulate().getResults(TIMEOUT_SECONDS, SECONDS);
+    } else {
+      results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
+          .start().getResults(TIMEOUT_SECONDS, SECONDS);
     }
+    assertThat(manager.getRebalanceOperations()).isEmpty();
+    return results;
+  }
 
-    public void waitForOperationsStarted() throws InterruptedException {
-      operationStartedLatch.await(MAX_WAIT, TimeUnit.SECONDS);
+  private Set<Integer> getBucketList(String regionName) {
+    PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+    return new TreeSet<>(region.getDataStore().getAllLocalBucketIds());
+  }
 
+  private void waitForBucketList(String regionName, Collection<Integer> expected) {
+    PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+
+    await().untilAsserted(new WaitCriterion() {
+
+      @Override
+      public boolean done() {
+        return getBuckets().equals(expected);
+      }
+
+      private Set<Integer> getBuckets() {
+        return new TreeSet<>(region.getDataStore().getAllLocalBucketIds());
+      }
+
+      @Override
+      public String description() {
+        return "Timeout waiting for buckets to match. Expected " + expected + " but got "
+            + getBuckets();
+      }
+    });
+  }
+
+  private void validateRedundancy(String regionName, int expectedCreatedBucketCount,
+      int expectedRedundantCopies, int expectedLowRedundancyBucketCount) {
+    Region region = getCache().getRegion(regionName);
+    PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region);
+
+    assertThat(details).isNotNull();
+    assertThat(details.getCreatedBucketCount()).isEqualTo(expectedCreatedBucketCount);
+    assertThat(details.getActualRedundantCopies()).isEqualTo(expectedRedundantCopies);
+    assertThat(details.getLowRedundancyBucketCount()).isEqualTo(expectedLowRedundancyBucketCount);
+  }
+
+  private void validateRedundancyOfTwoRegions(String regionName1, String regionName2,
+      int expectedCreatedBucketCount, int expectedRedundantCopies,
+      int expectedLowRedundancyBucketCount) {
+    Region region1 = getCache().getRegion(regionName1);
+    Region region2 = getCache().getRegion(regionName2);
+
+    validateRedundancyOfTwoRegions(region1, region2, expectedCreatedBucketCount,
+        expectedRedundantCopies, expectedLowRedundancyBucketCount);
+  }
+
+  private void validateRedundancyOfTwoRegions(Region region1, Region region2,
+      int expectedCreatedBucketCount, int expectedRedundantCopies,
+      int expectedLowRedundancyBucketCount) {
+    PartitionRegionInfo details = PartitionRegionHelper.getPartitionRegionInfo(region1);
+    assertThat(details).isNotNull();
+    assertThat(details.getCreatedBucketCount()).isEqualTo(expectedCreatedBucketCount);
+    assertThat(details.getActualRedundantCopies()).isEqualTo(expectedRedundantCopies);
+    assertThat(details.getLowRedundancyBucketCount()).isEqualTo(expectedLowRedundancyBucketCount);
+
+    details = PartitionRegionHelper.getPartitionRegionInfo(region2);
+    assertThat(details).isNotNull();
+    assertThat(details.getCreatedBucketCount()).isEqualTo(expectedCreatedBucketCount);
+    assertThat(details.getActualRedundantCopies()).isEqualTo(expectedRedundantCopies);
+    assertThat(details.getLowRedundancyBucketCount()).isEqualTo(expectedLowRedundancyBucketCount);
+  }
+
+  private void validateBucketCount(String regionName, int numLocalBuckets) {
+    PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+
+    assertThat(region.getLocalBucketsListTestOnly()).hasSize(numLocalBuckets);
+  }
+
+  private void validateStatistics(InternalResourceManager manager, RebalanceResults results) {
+    ResourceManagerStats stats = manager.getStats();
+
+    assertThat(stats.getRebalancesInProgress())
+        .isEqualTo(0);
+    assertThat(stats.getRebalancesCompleted())
+        .isEqualTo(1);
+    assertThat(stats.getRebalanceBucketCreatesInProgress())
+        .isEqualTo(0);
+    assertThat(stats.getRebalanceBucketCreatesCompleted())
+        .isEqualTo(results.getTotalBucketCreatesCompleted());
+    assertThat(stats.getRebalanceBucketCreatesFailed())
+        .isEqualTo(0);
+
+    // The time stats may not be exactly the same, because they are not
+    // incremented at exactly the same time.
+    assertThat(TimeUnit.NANOSECONDS.toMillis(stats.getRebalanceBucketCreateTime()))
+        .isCloseTo(results.getTotalBucketCreateTime(), within(2000L));
+    assertThat(stats.getRebalanceBucketCreateBytes())
+        .isEqualTo(results.getTotalBucketCreateBytes());
+    assertThat(stats.getRebalanceBucketTransfersInProgress())
+        .isEqualTo(0);
+    assertThat(stats.getRebalanceBucketTransfersCompleted())
+        .isEqualTo(results.getTotalBucketTransfersCompleted());
+    assertThat(stats.getRebalanceBucketTransfersFailed())
+        .isEqualTo(0);
+    assertThat(TimeUnit.NANOSECONDS.toMillis(stats.getRebalanceBucketTransfersTime()))
+        .isCloseTo(results.getTotalBucketTransferTime(), within(2000L));
+    assertThat(stats.getRebalanceBucketTransfersBytes())
+        .isEqualTo(results.getTotalBucketTransferBytes());
+    assertThat(stats.getRebalancePrimaryTransfersInProgress())
+        .isEqualTo(0);
+    assertThat(stats.getRebalancePrimaryTransfersCompleted())
+        .isEqualTo(results.getTotalPrimaryTransfersCompleted());
+    assertThat(stats.getRebalancePrimaryTransfersFailed())
+        .isEqualTo(0);
+    assertThat(TimeUnit.NANOSECONDS.toMillis(stats.getRebalancePrimaryTransferTime()))
+        .isCloseTo(results.getTotalPrimaryTransferTime(), within(2000L));
+  }
+
+  @FunctionalInterface
+  private interface Operation {
+
+    void execute(Region region, Integer key);
+  }
+
+  private enum OperationEnum implements Operation {
+    PUT((region, key) -> region.put(key, "B")),
+    INVALIDATE((region, key) -> region.invalidate(key)),
+    DESTROY((region, key) -> region.destroy(key)),
+    CACHE_LOADER((region, key) -> {
+      PartitionedRegion partitionedRegion = (PartitionedRegion) region;
+      // get a key that doesn't exist, but is in the same bucket as the given key
+      region.get(key + partitionedRegion.getPartitionAttributes().getTotalNumBuckets());
+    });
+
+    private final Operation delegate;
+
+    OperationEnum(Operation delegate) {
+      this.delegate = delegate;
     }
 
     @Override
-    public void close() {
+    public void execute(Region region, Integer key) {
+      delegate.execute(region, key);
+    }
+  }
+
+  private static class ParallelRecoveryObserver extends ResourceObserverAdapter {
+
+    private final Set<String> regions = new HashSet<>();
+    private final CyclicBarrier barrier;
+    private volatile boolean observerCalled;
+
+    private ParallelRecoveryObserver(int numRegions) {
+      barrier = new CyclicBarrier(numRegions);
+    }
+
+    private void observeRegion(String region) {
+      regions.add(region);
+    }
+
+    private void checkAllRegionRecoveryOrRebalanceStarted(String rn) {
+      if (regions.contains(rn)) {
+        try {
+          barrier.await(TIMEOUT_SECONDS, SECONDS);
+        } catch (BrokenBarrierException | InterruptedException | TimeoutException e) {
+          throw new RuntimeException("failed waiting for barrier", e);
+        }
+        observerCalled = true;
+      } else {
+        throw new RuntimeException("region not registered " + rn);
+      }
+    }
+
+    private boolean isObserverCalled() {
+      return observerCalled;
+    }
+
+    @Override
+    public void rebalancingStarted(Region region) {
+      super.rebalancingStarted(region);
+      checkAllRegionRecoveryOrRebalanceStarted(region.getName());
+    }
+
+    @Override
+    public void recoveryStarted(Region region) {
+      super.recoveryStarted(region);
+      checkAllRegionRecoveryOrRebalanceStarted(region.getName());
+    }
+  }
+
+  private static class BlockingCacheListener<K, V> extends CacheListenerAdapter<K, V> {
+
+    private final CountDownLatch operationStartedLatch;
+    private final CountDownLatch resumeOperationLatch = new CountDownLatch(1);
+
+    private BlockingCacheListener(int threads) {
+      operationStartedLatch = new CountDownLatch(threads);
+    }
+
+    private void waitForOperationsStarted() throws InterruptedException {
+      operationStartedLatch.await(TIMEOUT_SECONDS, SECONDS);
 
     }
 
     private void doWait() {
       operationStartedLatch.countDown();
       try {
-        resumeOperationLatch.await(MAX_WAIT, TimeUnit.SECONDS);
+        resumeOperationLatch.await(TIMEOUT_SECONDS, SECONDS);
       } catch (InterruptedException e) {
         throw new CacheWriterException(e);
       }
-
     }
 
     @Override
@@ -3531,17 +2658,12 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  private static interface Operation {
+  private static class NullReturningLoader<K, V> implements CacheLoader<K, V> {
 
-    void execute(Region region, Integer key);
-
-  }
-
-  private static class Bug40228Loader implements CacheLoader {
-    private volatile boolean closed = false;
+    private volatile boolean closed;
 
     @Override
-    public Object load(LoaderHelper helper) throws CacheLoaderException {
+    public V load(LoaderHelper helper) throws CacheLoaderException {
       return null;
     }
 
@@ -3553,6 +2675,5 @@ public class RebalanceOperationDUnitTest extends JUnit4CacheTestCase {
     public void close() {
       closed = true;
     }
-
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
@@ -116,7 +116,7 @@ import org.apache.geode.test.junit.rules.ExecutorServiceRule;
  */
 @RunWith(JUnitParamsRunner.class)
 @SuppressWarnings("serial")
-public class RebalanceOperationDUnitTest extends CacheTestCase {
+public class RebalanceOperationDistributedTest extends CacheTestCase {
 
   private static final long TIMEOUT_SECONDS = GeodeAwaitility.getTimeout().getValue();
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipListener.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipListener.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.distributed.internal;
 
 import java.util.List;
@@ -22,7 +21,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 
 /**
  * This interface specifies callback methods that are invoked when remote GemFire systems enter and
- * exit the distributed cache. Note that a <code>MembershipListener</code> can be added from any VM,
+ * exit the distributed cache. Note that a {@code MembershipListener} can be added from any VM,
  * but the callback methods are always invoked in the GemFire manager VM. Thus, the callback methods
  * should not perform time-consuming operations.
  *
@@ -36,7 +35,9 @@ public interface MembershipListener {
    * @param distributionManager that is calling this listener
    * @param id The id of the new member that has joined the system
    */
-  void memberJoined(DistributionManager distributionManager, InternalDistributedMember id);
+  default void memberJoined(DistributionManager distributionManager, InternalDistributedMember id) {
+    // implement if needed
+  }
 
   /**
    * This method is invoked after a member has explicitly left the system. It may not get invoked if
@@ -46,8 +47,10 @@ public interface MembershipListener {
    * @param id The id of the new member that has joined the system
    * @param crashed True if member did not depart in an orderly manner.
    */
-  void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
-      boolean crashed);
+  default void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id,
+      boolean crashed) {
+    // implement if needed
+  }
 
   /**
    * This method is invoked after the group membership service has suspected that a member is no
@@ -58,8 +61,10 @@ public interface MembershipListener {
    * @param whoSuspected the member that initiated suspect processing
    * @param reason the reason the member was suspected
    */
-  void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
-      InternalDistributedMember whoSuspected, String reason);
+  default void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
+      InternalDistributedMember whoSuspected, String reason) {
+    // implement if needed
+  }
 
   /**
    * This is notification that more than 50% of member weight has been lost in a single view change.
@@ -69,7 +74,9 @@ public interface MembershipListener {
    * @param failures members that have been lost
    * @param remaining members that remain
    */
-  void quorumLost(DistributionManager distributionManager, Set<InternalDistributedMember> failures,
-      List<InternalDistributedMember> remaining);
-
+  default void quorumLost(DistributionManager distributionManager,
+      Set<InternalDistributedMember> failures,
+      List<InternalDistributedMember> remaining) {
+    // implement if needed
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -3428,10 +3428,10 @@ public class PartitionedRegion extends LocalRegion
     // conditions
     final long startTime = PartitionedRegionStats.startTime();
     if (isDataStore()) {
-      ret = this.redundancyProvider.createBucketAtomically(bucketId, size, startTime, false,
+      ret = this.redundancyProvider.createBucketAtomically(bucketId, size, false,
           partitionName);
     } else {
-      ret = this.redundancyProvider.createBucketOnDataStore(bucketId, size, startTime, snoozer);
+      ret = this.redundancyProvider.createBucketOnDataStore(bucketId, size, snoozer);
     }
     return ret;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -2317,7 +2317,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
    * @return the map of bucketIds and their associated sizes, or {@link Collections#EMPTY_MAP}when
    *         the size is zero
    */
-  public Map getSizeLocally() {
+  public Map<Integer, Integer> getSizeLocally() {
     return getSizeLocally(false);
   }
 
@@ -2331,7 +2331,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
     if (this.localBucket2RegionMap.isEmpty()) {
       return Collections.EMPTY_MAP;
     }
-    mySizeMap = new HashMap<Integer, Integer>(this.localBucket2RegionMap.size());
+    mySizeMap = new HashMap<>(this.localBucket2RegionMap.size());
     Map.Entry<Integer, BucketRegion> me;
     BucketRegion r;
     for (Iterator<Map.Entry<Integer, BucketRegion>> itr =
@@ -2350,7 +2350,6 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
           }
         }
       } catch (CacheRuntimeException skip) {
-        continue;
       }
     } // for
     if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateBucketMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateBucketMessage.java
@@ -145,7 +145,7 @@ public class CreateBucketMessage extends PartitionMessage {
     }
     r.checkReadiness();
     InternalDistributedMember primary = r.getRedundancyProvider().createBucketAtomically(bucketId,
-        bucketSize, startTime, false, partitionName);
+        bucketSize, false, partitionName);
     r.getPrStats().endPartitionMessagesProcessing(startTime);
     CreateBucketReplyMessage.sendResponse(getSender(), getProcessorId(), dm, primary);
     return false;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateMissingBucketsTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateMissingBucketsTask.java
@@ -31,11 +31,12 @@ public class CreateMissingBucketsTask extends RecoveryRunnable {
 
   @Override
   public void run2() {
-    PartitionedRegion leaderRegion = ColocationHelper.getLeaderRegion(redundancyProvider.prRegion);
+    PartitionedRegion leaderRegion =
+        ColocationHelper.getLeaderRegion(redundancyProvider.getPartitionedRegion());
     RecoveryLock lock = leaderRegion.getRecoveryLock();
     lock.lock();
     try {
-      createMissingBuckets(redundancyProvider.prRegion);
+      createMissingBuckets(redundancyProvider.getPartitionedRegion());
     } finally {
       lock.unlock();
     }
@@ -56,7 +57,7 @@ public class CreateMissingBucketsTask extends RecoveryRunnable {
           .getRegionAdvisor().getBucketAdvisor(i).getBucketRedundancy()) {
         /* if (leaderRegion.getRegionAdvisor().isStorageAssignedForBucket(i)) { */
         final long startTime = PartitionedRegionStats.startTime();
-        region.getRedundancyProvider().createBucketAtomically(i, 0, startTime, true, null);
+        region.getRedundancyProvider().createBucketAtomically(i, 0, true, null);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/DataStoreBuckets.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/DataStoreBuckets.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.partitioned;
+
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+
+public class DataStoreBuckets {
+
+  private final InternalDistributedMember memberId;
+  private final int numBuckets;
+  private final int numPrimaries;
+  private final int localMaxMemoryMB;
+
+  public DataStoreBuckets(InternalDistributedMember mem, int buckets, int primaryBuckets,
+      int localMaxMemory) {
+    memberId = mem;
+    numBuckets = buckets;
+    numPrimaries = primaryBuckets;
+    localMaxMemoryMB = localMaxMemory;
+  }
+
+  public InternalDistributedMember memberId() {
+    return memberId;
+  }
+
+  public int numBuckets() {
+    return numBuckets;
+  }
+
+  public int numPrimaries() {
+    return numPrimaries;
+  }
+
+  public int localMaxMemoryMB() {
+    return localMaxMemoryMB;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof DataStoreBuckets)) {
+      return false;
+    }
+    DataStoreBuckets other = (DataStoreBuckets) obj;
+    return numBuckets == other.numBuckets && memberId.equals(other.memberId);
+  }
+
+  @Override
+  public int hashCode() {
+    return memberId.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "DataStoreBuckets memberId=" + memberId + "; numBuckets=" + numBuckets
+        + "; numPrimaries=" + numPrimaries;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PersistentBucketRecoverer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PersistentBucketRecoverer.java
@@ -78,7 +78,8 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
   public PersistentBucketRecoverer(PRHARedundancyProvider prhaRedundancyProvider,
       int proxyBuckets) {
     super(prhaRedundancyProvider);
-    PartitionedRegion baseRegion = ColocationHelper.getLeaderRegion(redundancyProvider.prRegion);
+    PartitionedRegion baseRegion =
+        ColocationHelper.getLeaderRegion(redundancyProvider.getPartitionedRegion());
     List<PartitionedRegion> colocatedRegions =
         getColocatedChildRegions(baseRegion);
     List<RegionStatus> allRegions = new ArrayList<RegionStatus>(colocatedRegions.size() + 1);
@@ -104,7 +105,9 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
 
   public void startLoggingThread() {
     Thread loggingThread = new LoggingThread(
-        "PersistentBucketRecoverer for region " + redundancyProvider.prRegion.getName(), false,
+        "PersistentBucketRecoverer for region "
+            + redundancyProvider.getPartitionedRegion().getName(),
+        false,
         this);
     loggingThread.start();
   }
@@ -287,7 +290,7 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
         }
 
         return (new PersistentMemberID(null, localHost, diskDir, name,
-            redundancyProvider.prRegion.getCache().cacheTimeMillis(), (short) 0));
+            redundancyProvider.getPartitionedRegion().getCache().cacheTimeMillis(), (short) 0));
       }
     }
 
@@ -419,7 +422,7 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
     boolean interrupted = false;
     while (true) {
       try {
-        redundancyProvider.prRegion.getCancelCriterion().checkCancelInProgress(null);
+        redundancyProvider.getPartitionedRegion().getCancelCriterion().checkCancelInProgress(null);
         boolean done = allBucketsRecoveredFromDisk.await(timeout, unit);
         if (done) {
           break;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RecoveryRunnable.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RecoveryRunnable.java
@@ -49,7 +49,8 @@ public abstract class RecoveryRunnable implements Runnable {
   @Override
   public void run() {
     CancelCriterion stopper =
-        redundancyProvider.prRegion.getGemFireCache().getDistributedSystem().getCancelCriterion();
+        redundancyProvider.getPartitionedRegion().getGemFireCache().getDistributedSystem()
+            .getCancelCriterion();
     DistributedSystem.setThreadsSocketPolicy(true /* conserve sockets */);
     SystemFailure.checkFailure();
     if (stopper.isCancelInProgress()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
@@ -58,7 +58,6 @@ import org.apache.geode.internal.cache.BucketServerLocation66;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor;
 import org.apache.geode.internal.cache.FixedPartitionAttributesImpl;
 import org.apache.geode.internal.cache.InternalRegionArguments;
-import org.apache.geode.internal.cache.PRHARedundancyProvider.DataStoreBuckets;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionStats;
 import org.apache.geode.internal.cache.ProxyBucketRegion;


### PR DESCRIPTION
These commits do not fix GEODE-6918, but they do cleanup some code and tests in preparation for the fix.

Please review: @aaronlindsey 

1. [Cleanup PRHARedundancyProvider](https://github.com/apache/geode/pull/3773/commits/3adf3f55c48b7a7d078f3e5801aebc652336a7af)
```
commit 3adf3f55c48b7a7d078f3e5801aebc652336a7af
Author: Kirk Lund <klund@apache.org>
Date:   Fri Jun 28 11:07:43 2019 -0700

    GEODE-6918: Cleanup PRHARedundancyProvider
    
    * Reorder constants and fields
    * Move inner-classes to bottom of outer-class
    * Extract DataStoreBuckets
    * Encapuslate fields behind accessors
    * Remove unused fields, contants and methods
    * Reduce scope where possible
    * Fix misc IDE warnings
    * Remove bug system numbers
    * Remove todos, useless comments/javadocs
    * Fix typos
    * Improve comments
    * Delete commented out code
    
    Co-authored-by: Michael Oleske <moleske@pivotal.io>
    Co-authored-by: Mark Hanson <mhanson@pivotal.io>
```
2. [Cleanup PartitionedRegionDataStore](https://github.com/apache/geode/pull/3773/commits/54db190f3b7471f72d1cd9883bbede5c103c50eb)
```
commit 54db190f3b7471f72d1cd9883bbede5c103c50eb
Author: Kirk Lund <klund@apache.org>
Date:   Tue Jul 2 16:30:29 2019 -0700

    GEODE-6918: Cleanup PartitionedRegionDataStore
    
    * Fix some raw types
    * Fix misc IDE warnings
    
    Co-authored-by: Michael Oleske <moleske@pivotal.io>
    Co-authored-by: Mark Hanson <mhanson@pivotal.io>
```
3. [Cleanup PRHARedundancyProviderTest](https://github.com/apache/geode/pull/3773/commits/16719686c5935aab42297bc698be8cb623eca7fb)
```
commit 16719686c5935aab42297bc698be8cb623eca7fb
Author: Kirk Lund <klund@apache.org>
Date:   Tue Jul 2 16:31:02 2019 -0700

    GEODE-6918: Cleanup PRHARedundancyProviderTest
    
    Co-authored-by: Michael Oleske <moleske@pivotal.io>
```
4. [Cleanup RebalanceOperationDUnitTest](https://github.com/apache/geode/pull/3773/commits/06456980e83f5c2f3605a8963e4c15850a587f01)
```
commit 06456980e83f5c2f3605a8963e4c15850a587f01
Author: Kirk Lund <klund@apache.org>
Date:   Tue Jul 2 16:31:14 2019 -0700

    GEODE-6918: Cleanup RebalanceOperationDUnitTest
    
    Co-authored-by: Michael Oleske <moleske@pivotal.io>
    Co-authored-by: Mark Hanson <mhanson@pivotal.io>
    Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
```
5. [Rename RebalanceOperationDUnitTest as RebalanceOperationDistributedTest](https://github.com/apache/geode/pull/3773/commits/fc244b63742fc266c753ef8c3e39d8815c4366af)
```
commit fc244b63742fc266c753ef8c3e39d8815c4366af (HEAD -> GEODE-6918-cleanup-classes)
Author: Kirk Lund <klund@apache.org>
Date:   Tue Jul 2 16:31:55 2019 -0700

    GEODE-6918: Rename RebalanceOperationDistributedTest
    
    Rename RebalanceOperationDUnitTest as RebalanceOperationDistributedTest
```


