### PR TITLE
GEODE-6918: Cleanup and unit test PersistentOplogSet

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskRegion.java
@@ -746,7 +746,7 @@ public class DiskRegion extends AbstractDiskRegion {
   }
 
   Map<Long, Oplog> getOplogIdToOplog() {
-    return getOplogSet().oplogIdToOplog;
+    return getOplogSet().getOplogIdToOplog();
   }
 
   void testHookCloseAllOverflowChannels() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -2049,7 +2049,7 @@ public class DiskStoreImpl implements DiskStore {
   }
 
   void initializeIfNeeded() {
-    if (!getPersistentOplogs().alreadyRecoveredOnce.get()) {
+    if (!getPersistentOplogs().getAlreadyRecoveredOnce().get()) {
       recoverRegionsThatAreReady();
     }
   }
@@ -2756,7 +2756,7 @@ public class DiskStoreImpl implements DiskStore {
     if (!all && max > MAX_OPLOGS_PER_COMPACTION && MAX_OPLOGS_PER_COMPACTION > 0) {
       max = MAX_OPLOGS_PER_COMPACTION;
     }
-    getPersistentOplogs().getCompactableOplogs(l, max);
+    getPersistentOplogs().getCompactableOplogs(l);
 
     // Note this always puts overflow oplogs on the end of the list.
     // They may get starved.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/OplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/OplogSet.java
@@ -19,7 +19,6 @@ import org.apache.geode.internal.cache.entries.DiskEntry.Helper.ValueWrapper;
 
 public interface OplogSet {
 
-
   void create(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async);
 
   void modify(InternalRegion region, DiskEntry entry, ValueWrapper value, boolean async);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PersistentOplogSet.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,41 +49,38 @@ import org.apache.geode.internal.sequencelog.EntryLogger;
 public class PersistentOplogSet implements OplogSet {
   private static final Logger logger = LogService.getLogger();
 
-  /** The active oplog * */
-  protected volatile Oplog child;
-
   /** variable to generate sequential unique oplogEntryId's* */
   private final AtomicLong oplogEntryId = new AtomicLong(DiskStoreImpl.INVALID_ID);
-
-  /** counter used for round-robin logic * */
-  int dirCounter = -1;
 
   /**
    * Contains all the oplogs that only have a drf (i.e. the crf has been deleted).
    */
-  final Map<Long, Oplog> drfOnlyOplogs = new LinkedHashMap<Long, Oplog>();
+  private final Map<Long, Oplog> drfOnlyOplogs = new LinkedHashMap<>();
 
-  /** oplogs that are ready to compact */
-  final Map<Long, Oplog> oplogIdToOplog = new LinkedHashMap<Long, Oplog>();
+  private final Map<Long, Oplog> oplogIdToOplog = new LinkedHashMap<>();
+
   /** oplogs that are done being written to but not yet ready to compact */
-  private final Map<Long, Oplog> inactiveOplogs = new LinkedHashMap<Long, Oplog>(16, 0.75f, true);
+  private final Map<Long, Oplog> inactiveOplogs = new LinkedHashMap<>(16, 0.75f, true);
 
   private final DiskStoreImpl parent;
 
-  final AtomicInteger inactiveOpenCount = new AtomicInteger();
+  private final AtomicInteger inactiveOpenCount = new AtomicInteger();
 
-  private final Map<Long, DiskRecoveryStore> pendingRecoveryMap =
-      new HashMap<Long, DiskRecoveryStore>();
-  private final Map<Long, DiskRecoveryStore> currentRecoveryMap =
-      new HashMap<Long, DiskRecoveryStore>();
+  private final Map<Long, DiskRecoveryStore> pendingRecoveryMap = new HashMap<>();
+  private final Map<Long, DiskRecoveryStore> currentRecoveryMap = new HashMap<>();
 
-  final AtomicBoolean alreadyRecoveredOnce = new AtomicBoolean(false);
+  private final AtomicBoolean alreadyRecoveredOnce = new AtomicBoolean(false);
+
+  /** The active oplog * */
+  private volatile Oplog child;
 
   /**
    * The maximum oplog id we saw while recovering
    */
-  private volatile long maxRecoveredOplogId = 0;
+  private volatile long maxRecoveredOplogId;
 
+  /** counter used for round-robin logic * */
+  private int dirCounter = -1;
 
   public PersistentOplogSet(DiskStoreImpl parent) {
     this.parent = parent;
@@ -92,61 +90,54 @@ public class PersistentOplogSet implements OplogSet {
    * returns the active child
    */
   public Oplog getChild() {
-    return this.child;
+    return child;
   }
 
   /**
    * set the child to a new oplog
-   *
    */
   void setChild(Oplog oplog) {
-    this.child = oplog;
-    // oplogSetAdd(oplog);
+    child = oplog;
   }
 
-  public Oplog[] getAllOplogs() {
-    synchronized (this.oplogIdToOplog) {
-      int rollNum = this.oplogIdToOplog.size();
-      int inactiveNum = this.inactiveOplogs.size();
-      int drfOnlyNum = this.drfOnlyOplogs.size();
+  Oplog[] getAllOplogs() {
+    synchronized (getOplogIdToOplog()) {
+      int rollNum = getOplogIdToOplog().size();
+      int inactiveNum = inactiveOplogs.size();
+      int drfOnlyNum = drfOnlyOplogs.size();
       int num = rollNum + inactiveNum + drfOnlyNum + 1;
       Oplog[] oplogs = new Oplog[num];
       oplogs[0] = getChild();
-      {
-        Iterator<Oplog> itr = this.oplogIdToOplog.values().iterator();
-        for (int i = 1; i <= rollNum; i++) {
-          oplogs[i] = itr.next();
-        }
+
+      Iterator<Oplog> oplogIterator = getOplogIdToOplog().values().iterator();
+      for (int i = 1; i <= rollNum; i++) {
+        oplogs[i] = oplogIterator.next();
       }
-      {
-        Iterator<Oplog> itr = this.inactiveOplogs.values().iterator();
-        for (int i = 1; i <= inactiveNum; i++) {
-          oplogs[i + rollNum] = itr.next();
-        }
+
+      oplogIterator = inactiveOplogs.values().iterator();
+      for (int i = 1; i <= inactiveNum; i++) {
+        oplogs[i + rollNum] = oplogIterator.next();
       }
-      {
-        Iterator<Oplog> itr = this.drfOnlyOplogs.values().iterator();
-        for (int i = 1; i <= drfOnlyNum; i++) {
-          oplogs[i + rollNum + inactiveNum] = itr.next();
-        }
+
+      oplogIterator = drfOnlyOplogs.values().iterator();
+      for (int i = 1; i <= drfOnlyNum; i++) {
+        oplogs[i + rollNum + inactiveNum] = oplogIterator.next();
       }
 
       // Special case - no oplogs found
       if (oplogs.length == 1 && oplogs[0] == null) {
         return new Oplog[0];
       }
+
       return oplogs;
     }
 
   }
 
   private TreeSet<Oplog> getSortedOplogs() {
-    TreeSet<Oplog> result = new TreeSet<Oplog>(new Comparator() {
-      @Override
-      public int compare(Object arg0, Object arg1) {
-        return Long.signum(((Oplog) arg1).getOplogId() - ((Oplog) arg0).getOplogId());
-      }
-    });
+    TreeSet<Oplog> result = new TreeSet<Oplog>(
+        (Comparator) (arg0, arg1) -> Long
+            .signum(((Oplog) arg1).getOplogId() - ((Oplog) arg0).getOplogId()));
     for (Oplog oplog : getAllOplogs()) {
       if (oplog != null) {
         result.add(oplog);
@@ -163,18 +154,17 @@ public class PersistentOplogSet implements OplogSet {
    */
   @Override
   public Oplog getChild(long id) {
-    Oplog localOplog = this.child;
+    Oplog localOplog = child;
     if (localOplog != null && id == localOplog.getOplogId()) {
       return localOplog;
-    } else {
-      Long key = Long.valueOf(id);
-      synchronized (this.oplogIdToOplog) {
-        Oplog result = oplogIdToOplog.get(key);
-        if (result == null) {
-          result = inactiveOplogs.get(key);
-        }
-        return result;
+    }
+
+    synchronized (getOplogIdToOplog()) {
+      Oplog result = getOplogIdToOplog().get(id);
+      if (result == null) {
+        result = inactiveOplogs.get(id);
       }
+      return result;
     }
   }
 
@@ -188,7 +178,7 @@ public class PersistentOplogSet implements OplogSet {
     getChild().modify(region, entry, value, async);
   }
 
-  public void offlineModify(DiskRegionView drv, DiskEntry entry, byte[] value,
+  void offlineModify(DiskRegionView drv, DiskEntry entry, byte[] value,
       boolean isSerializedObject) {
     getChild().offlineModify(drv, entry, value, isSerializedObject);
   }
@@ -205,10 +195,11 @@ public class PersistentOplogSet implements OplogSet {
     }
   }
 
-  public Map<File, DirectoryHolder> findFiles(String partialFileName) {
-    this.dirCounter = 0;
-    Map<File, DirectoryHolder> backupFiles = new HashMap<File, DirectoryHolder>();
+  Map<File, DirectoryHolder> findFiles(String partialFileName) {
+    dirCounter = 0;
+    Map<File, DirectoryHolder> backupFiles = new HashMap<>();
     FilenameFilter backupFileFilter = getFileNameFilter(partialFileName);
+
     for (DirectoryHolder dh : parent.directories) {
       File[] backupList = dh.getDir().listFiles(backupFileFilter);
       if (backupList != null) {
@@ -221,25 +212,28 @@ public class PersistentOplogSet implements OplogSet {
     return backupFiles;
   }
 
-  protected FilenameFilter getFileNameFilter(String partialFileName) {
+  private FilenameFilter getFileNameFilter(String partialFileName) {
     return new DiskStoreFilter(OplogType.BACKUP, false, partialFileName);
   }
 
-  public void createOplogs(boolean needsOplogs, Map<File, DirectoryHolder> backupFiles) {
+  void createOplogs(boolean needsOplogs, Map<File, DirectoryHolder> backupFiles) {
     LongOpenHashSet foundCrfs = new LongOpenHashSet();
     LongOpenHashSet foundDrfs = new LongOpenHashSet();
-
 
     for (Map.Entry<File, DirectoryHolder> entry : backupFiles.entrySet()) {
       File file = entry.getKey();
       String absolutePath = file.getAbsolutePath();
-      int underscorePosition = absolutePath.lastIndexOf("_");
-      int pointPosition = absolutePath.lastIndexOf(".");
-      String opid = absolutePath.substring(underscorePosition + 1, pointPosition);
-      long oplogId = Long.parseLong(opid);
+
+      int underscorePosition = absolutePath.lastIndexOf('_');
+      int pointPosition = absolutePath.lastIndexOf('.');
+      String oplogIdString = absolutePath.substring(underscorePosition + 1, pointPosition);
+      long oplogId = Long.parseLong(oplogIdString);
+
       maxRecoveredOplogId = Math.max(maxRecoveredOplogId, oplogId);
+
       // here look diskinit file and check if this opid already deleted or not
       // if deleted then don't process it.
+
       if (Oplog.isCRFFile(file.getName())) {
         if (!isCrfOplogIdPresent(oplogId)) {
           deleteFileOnRecovery(file);
@@ -247,23 +241,27 @@ public class PersistentOplogSet implements OplogSet {
             String krfFileName = Oplog.getKRFFilenameFromCRFFilename(file.getAbsolutePath());
             File krfFile = new File(krfFileName);
             deleteFileOnRecovery(krfFile);
-          } catch (Exception ex) {// ignore
+          } catch (Exception ignore) {
+            // ignore
           }
-          continue; // this file we unable to delete earlier
+          // this file we unable to delete earlier
+          continue;
         }
+
       } else if (Oplog.isDRFFile(file.getName())) {
         if (!isDrfOplogIdPresent(oplogId)) {
           deleteFileOnRecovery(file);
-          continue; // this file we unable to delete earlier
+          // this file we unable to delete earlier
+          continue;
         }
       }
 
       Oplog oplog = getChild(oplogId);
       if (oplog == null) {
         oplog = new Oplog(oplogId, this);
-        // oplogSet.add(oplog);
         addRecoveredOplog(oplog);
       }
+
       if (oplog.addRecoveredFile(file, entry.getValue())) {
         foundCrfs.add(oplogId);
       } else {
@@ -275,15 +273,15 @@ public class PersistentOplogSet implements OplogSet {
     }
   }
 
-  protected boolean isDrfOplogIdPresent(long oplogId) {
+  private boolean isDrfOplogIdPresent(long oplogId) {
     return parent.getDiskInitFile().isDRFOplogIdPresent(oplogId);
   }
 
-  protected boolean isCrfOplogIdPresent(long oplogId) {
+  private boolean isCrfOplogIdPresent(long oplogId) {
     return parent.getDiskInitFile().isCRFOplogIdPresent(oplogId);
   }
 
-  protected void verifyOplogs(LongOpenHashSet foundCrfs, LongOpenHashSet foundDrfs) {
+  private void verifyOplogs(LongOpenHashSet foundCrfs, LongOpenHashSet foundDrfs) {
     parent.getDiskInitFile().verifyOplogs(foundCrfs, foundDrfs);
   }
 
@@ -291,12 +289,12 @@ public class PersistentOplogSet implements OplogSet {
   private void deleteFileOnRecovery(File f) {
     try {
       f.delete();
-    } catch (Exception e) {
+    } catch (Exception ignore) {
       // ignore, one more attempt to delete the file failed
     }
   }
 
-  void addRecoveredOplog(Oplog oplog) {
+  private void addRecoveredOplog(Oplog oplog) {
     basicAddToBeCompacted(oplog);
     // don't schedule a compaction here. Wait for recovery to complete
   }
@@ -315,56 +313,63 @@ public class PersistentOplogSet implements OplogSet {
   private void basicAddToBeCompacted(Oplog oplog) {
     if (!oplog.isRecovering() && oplog.hasNoLiveValues()) {
       oplog.cancelKrf();
-      oplog.close(); // fix for bug 41687
+      oplog.close();
       oplog.deleteFiles(oplog.getHasDeletes());
+
     } else {
-      int inactivePromotedCount = 0;
       parent.getStats().incCompactableOplogs(1);
-      Long key = Long.valueOf(oplog.getOplogId());
-      synchronized (this.oplogIdToOplog) {
-        if (this.inactiveOplogs.remove(key) != null) {
+      Long key = oplog.getOplogId();
+      int inactivePromotedCount = 0;
+
+      synchronized (getOplogIdToOplog()) {
+        if (inactiveOplogs.remove(key) != null) {
           if (oplog.isRAFOpen()) {
             inactiveOpenCount.decrementAndGet();
           }
           inactivePromotedCount++;
         }
-        this.oplogIdToOplog.put(key, oplog);
+        getOplogIdToOplog().put(key, oplog);
       }
+
       if (inactivePromotedCount > 0) {
         parent.getStats().incInactiveOplogs(-inactivePromotedCount);
       }
     }
   }
 
-  public void recoverRegionsThatAreReady() {
+  void recoverRegionsThatAreReady() {
     // The following sync also prevents concurrent recoveries by multiple regions
     // which is needed currently.
-    synchronized (this.alreadyRecoveredOnce) {
+    synchronized (getAlreadyRecoveredOnce()) {
+
       // need to take a snapshot of DiskRecoveryStores we will recover
-      synchronized (this.pendingRecoveryMap) {
-        this.currentRecoveryMap.clear();
-        this.currentRecoveryMap.putAll(this.pendingRecoveryMap);
-        this.pendingRecoveryMap.clear();
+      synchronized (pendingRecoveryMap) {
+        currentRecoveryMap.clear();
+        currentRecoveryMap.putAll(pendingRecoveryMap);
+        pendingRecoveryMap.clear();
       }
-      if (this.currentRecoveryMap.isEmpty() && this.alreadyRecoveredOnce.get()) {
+
+      if (currentRecoveryMap.isEmpty() && getAlreadyRecoveredOnce().get()) {
         // no recovery needed
         return;
       }
 
-      for (DiskRecoveryStore drs : this.currentRecoveryMap.values()) {
+      for (DiskRecoveryStore drs : currentRecoveryMap.values()) {
         // Call prepare early to fix bug 41119.
         drs.getDiskRegionView().prepareForRecovery();
       }
-      if (!this.alreadyRecoveredOnce.get()) {
+
+      if (!getAlreadyRecoveredOnce().get()) {
         initOplogEntryId();
         // Fix for #43026 - make sure we don't reuse an entry
         // id that has been marked as cleared.
         updateOplogEntryId(parent.getDiskInitFile().getMaxRecoveredClearEntryId());
       }
 
-      final long start = parent.getStats().startRecovery();
-      long byteCount = 0;
+      long start = parent.getStats().startRecovery();
       EntryLogger.setSource(parent.getDiskStoreID(), "recovery");
+
+      long byteCount = 0;
       try {
         byteCount = recoverOplogs(byteCount);
 
@@ -372,10 +377,11 @@ public class PersistentOplogSet implements OplogSet {
         Map<String, Integer> prSizes = null;
         Map<String, Integer> prBuckets = null;
         if (parent.isValidating()) {
-          prSizes = new HashMap<String, Integer>();
-          prBuckets = new HashMap<String, Integer>();
+          prSizes = new HashMap<>();
+          prBuckets = new HashMap<>();
         }
-        for (DiskRecoveryStore drs : this.currentRecoveryMap.values()) {
+
+        for (DiskRecoveryStore drs : currentRecoveryMap.values()) {
           for (Oplog oplog : getAllOplogs()) {
             if (oplog != null) {
               // Need to do this AFTER recovery to protect from concurrent compactions
@@ -386,9 +392,10 @@ public class PersistentOplogSet implements OplogSet {
               oplog.checkForRecoverableRegion(drs.getDiskRegionView());
             }
           }
+
           if (parent.isValidating()) {
             if (drs instanceof ValidatingDiskRegion) {
-              ValidatingDiskRegion vdr = ((ValidatingDiskRegion) drs);
+              ValidatingDiskRegion vdr = (ValidatingDiskRegion) drs;
               if (vdr.isBucket()) {
                 String prName = vdr.getPrName();
                 if (prSizes.containsKey(prName)) {
@@ -409,16 +416,16 @@ public class PersistentOplogSet implements OplogSet {
             }
           }
         }
+
         if (parent.isValidating()) {
           for (Map.Entry<String, Integer> me : prSizes.entrySet()) {
             parent.incLiveEntryCount(me.getValue());
-            System.out.println(me.getKey() + " entryCount=" + me.getValue() + " bucketCount="
-                + prBuckets.get(me.getKey()));
           }
         }
+
         parent.getStats().endRecovery(start, byteCount);
-        this.alreadyRecoveredOnce.set(true);
-        this.currentRecoveryMap.clear();
+        getAlreadyRecoveredOnce().set(true);
+        currentRecoveryMap.clear();
         EntryLogger.clearSource();
       }
     }
@@ -426,10 +433,9 @@ public class PersistentOplogSet implements OplogSet {
 
   private long recoverOplogs(long byteCount) {
     OplogEntryIdSet deletedIds = new OplogEntryIdSet();
-
     TreeSet<Oplog> oplogSet = getSortedOplogs();
-    Set<Oplog> oplogsNeedingValueRecovery = new HashSet<Oplog>();
-    if (!this.alreadyRecoveredOnce.get()) {
+
+    if (!getAlreadyRecoveredOnce().get()) {
       if (getChild() != null && !getChild().hasBeenUsed()) {
         // Then remove the current child since it is empty
         // and does not need to be recovered from
@@ -437,28 +443,32 @@ public class PersistentOplogSet implements OplogSet {
         oplogSet.remove(getChild());
       }
     }
-    if (oplogSet.size() > 0) {
+
+    Set<Oplog> oplogsNeedingValueRecovery = new HashSet<>();
+
+    if (!oplogSet.isEmpty()) {
       long startOpLogRecovery = System.currentTimeMillis();
+
       // first figure out all entries that have been destroyed
       boolean latestOplog = true;
       for (Oplog oplog : oplogSet) {
-        byteCount += oplog.recoverDrf(deletedIds, this.alreadyRecoveredOnce.get(), latestOplog);
+        byteCount += oplog.recoverDrf(deletedIds, getAlreadyRecoveredOnce().get(), latestOplog);
         latestOplog = false;
-        if (!this.alreadyRecoveredOnce.get()) {
+        if (!getAlreadyRecoveredOnce().get()) {
           updateOplogEntryId(oplog.getMaxRecoveredOplogEntryId());
         }
       }
+
       parent.incDeadRecordCount(deletedIds.size());
+
       // now figure out live entries
       latestOplog = true;
       for (Oplog oplog : oplogSet) {
         long startOpLogRead = parent.getStats().startOplogRead();
-        long bytesRead = oplog.recoverCrf(deletedIds,
-            // @todo make recoverValues per region
-            recoverValues(), recoverValuesSync(), this.alreadyRecoveredOnce.get(),
-            oplogsNeedingValueRecovery, latestOplog);
+        long bytesRead = oplog.recoverCrf(deletedIds, recoverValues(), recoverValuesSync(),
+            getAlreadyRecoveredOnce().get(), oplogsNeedingValueRecovery, latestOplog);
         latestOplog = false;
-        if (!this.alreadyRecoveredOnce.get()) {
+        if (!getAlreadyRecoveredOnce().get()) {
           updateOplogEntryId(oplog.getMaxRecoveredOplogEntryId());
         }
         byteCount += bytesRead;
@@ -466,24 +476,27 @@ public class PersistentOplogSet implements OplogSet {
 
         // Callback to the disk regions to indicate the oplog is recovered
         // Used for offline export
-        for (DiskRecoveryStore drs : this.currentRecoveryMap.values()) {
+        for (DiskRecoveryStore drs : currentRecoveryMap.values()) {
           drs.getDiskRegionView().oplogRecovered(oplog.oplogId);
         }
       }
+
       long endOpLogRecovery = System.currentTimeMillis();
       long elapsed = endOpLogRecovery - startOpLogRecovery;
-      logger
-          .info("recovery oplog load took {} ms", elapsed);
+      logger.info("recovery oplog load took {} ms", elapsed);
     }
+
     if (!parent.isOfflineCompacting()) {
       long startRegionInit = System.currentTimeMillis();
+
       // create the oplogs now so that loadRegionData can have them available
       // Create an array of Oplogs so that we are able to add it in a single shot
       // to the map
-      for (DiskRecoveryStore drs : this.currentRecoveryMap.values()) {
+      for (DiskRecoveryStore drs : currentRecoveryMap.values()) {
         drs.getDiskRegionView().initRecoveredEntryCount();
       }
-      if (!this.alreadyRecoveredOnce.get()) {
+
+      if (!getAlreadyRecoveredOnce().get()) {
         for (Oplog oplog : oplogSet) {
           if (oplog != getChild()) {
             oplog.initAfterRecovery(parent.isOffline());
@@ -496,14 +509,11 @@ public class PersistentOplogSet implements OplogSet {
 
       if (!parent.isOffline()) {
         if (recoverValues() && !recoverValuesSync()) {
-          // TODO DAN - should we defer compaction until after
-          // value recovery is complete? Or at least until after
-          // value recovery for a given oplog is complete?
-          // Right now, that's effectively what we're doing
-          // because this uses up the compactor thread.
-          parent.scheduleValueRecovery(oplogsNeedingValueRecovery, this.currentRecoveryMap);
+          // value recovery defers compaction because it is using the compactor thread
+          parent.scheduleValueRecovery(oplogsNeedingValueRecovery, currentRecoveryMap);
         }
-        if (!this.alreadyRecoveredOnce.get()) {
+
+        if (!getAlreadyRecoveredOnce().get()) {
           // Create krfs for oplogs that are missing them
           for (Oplog oplog : oplogSet) {
             if (oplog.needsKrf()) {
@@ -514,41 +524,42 @@ public class PersistentOplogSet implements OplogSet {
         }
 
         long endRegionInit = System.currentTimeMillis();
-        logger
-            .info("recovery region initialization took {} ms",
-                endRegionInit - startRegionInit);
+        logger.info("recovery region initialization took {} ms", endRegionInit - startRegionInit);
       }
     }
     return byteCount;
   }
 
-  protected boolean recoverValuesSync() {
+  private boolean recoverValuesSync() {
     return parent.RECOVER_VALUES_SYNC;
   }
 
-  protected boolean recoverValues() {
+  private boolean recoverValues() {
     return parent.RECOVER_VALUES;
   }
 
   private void setFirstChild(TreeSet<Oplog> oplogSet, boolean force) {
-    if (parent.isOffline() && !parent.isOfflineCompacting() && !parent.isOfflineModify())
+    if (parent.isOffline() && !parent.isOfflineCompacting() && !parent.isOfflineModify()) {
       return;
+    }
+
     if (!oplogSet.isEmpty()) {
       Oplog first = oplogSet.first();
       DirectoryHolder dh = first.getDirectoryHolder();
       dirCounter = dh.getArrayIndex();
-      dirCounter = (++dirCounter) % parent.dirLength;
+      dirCounter = ++dirCounter % parent.dirLength;
       // we want the first child to go in the directory after the directory
       // used by the existing oplog with the max id.
       // This fixes bug 41822.
     }
+
     if (force || maxRecoveredOplogId > 0) {
       setChild(new Oplog(maxRecoveredOplogId + 1, this, getNextDir()));
     }
   }
 
   private void initOplogEntryId() {
-    this.oplogEntryId.set(DiskStoreImpl.INVALID_ID);
+    oplogEntryId.set(DiskStoreImpl.INVALID_ID);
   }
 
   /**
@@ -558,12 +569,12 @@ public class PersistentOplogSet implements OplogSet {
   private void updateOplogEntryId(long v) {
     long curVal;
     do {
-      curVal = this.oplogEntryId.get();
+      curVal = oplogEntryId.get();
       if (curVal >= v) {
         // no need to set
         return;
       }
-    } while (!this.oplogEntryId.compareAndSet(curVal, v));
+    } while (!oplogEntryId.compareAndSet(curVal, v));
   }
 
   /**
@@ -571,7 +582,7 @@ public class PersistentOplogSet implements OplogSet {
    */
   long getOplogEntryId() {
     parent.initializeIfNeeded();
-    return this.oplogEntryId.get();
+    return oplogEntryId.get();
   }
 
   /**
@@ -582,8 +593,7 @@ public class PersistentOplogSet implements OplogSet {
    * @return A disk id that can be used to access this key/value pair on disk
    */
   long newOplogEntryId() {
-    long result = this.oplogEntryId.incrementAndGet();
-    return result;
+    return oplogEntryId.incrementAndGet();
   }
 
   /**
@@ -593,21 +603,21 @@ public class PersistentOplogSet implements OplogSet {
    * @param minAvailableSpace the minimum amount of space we need in this directory.
    */
   DirectoryHolder getNextDir(long minAvailableSpace, boolean checkForWarning) {
-    DirectoryHolder dirHolder = null;
-    DirectoryHolder selectedHolder = null;
     if (minAvailableSpace < parent.getMaxOplogSizeInBytes()
         && !DiskStoreImpl.SET_IGNORE_PREALLOCATE) {
       minAvailableSpace = parent.getMaxOplogSizeInBytes();
     }
-    synchronized (parent.directories) {
+
+    DirectoryHolder selectedHolder = null;
+    synchronized (parent.getDirectoryHolders()) {
       for (int i = 0; i < parent.dirLength; ++i) {
-        dirHolder = parent.directories[this.dirCounter];
-        // Asif :Increment the directory counter to next position so that next
-        // time when this operation is invoked, it checks for the Directory
-        // Space in a cyclical fashion.
-        dirCounter = (++dirCounter) % parent.dirLength;
-        // if the current directory has some space, then quit and
-        // return the dir
+        DirectoryHolder dirHolder = parent.directories[dirCounter];
+
+        // Increment the directory counter to next position so that next time when this operation
+        // is invoked, it checks for the Directory Space in a cyclical fashion.
+        dirCounter = ++dirCounter % parent.dirLength;
+
+        // if the current directory has some space, then quit and return the dir
         if (dirHolder.getAvailableSpace() >= minAvailableSpace) {
           if (checkForWarning && !parent.isDirectoryUsageNormal(dirHolder)) {
             if (logger.isDebugEnabled()) {
@@ -627,51 +637,38 @@ public class PersistentOplogSet implements OplogSet {
         }
 
         if (parent.isCompactionEnabled()) {
-          /*
-           * try { this.isThreadWaitingForSpace = true; this.directories.wait(MAX_WAIT_FOR_SPACE); }
-           * catch (InterruptedException ie) { throw new DiskAccessException(LocalizedStrings.
-           * DiskRegion_UNABLE_TO_GET_FREE_SPACE_FOR_CREATING_AN_OPLOG_AS_THE_THREAD_ENCOUNETERD_EXCEPTION_WHILE_WAITING_FOR_COMPACTOR_THREAD_TO_FREE_SPACE
-           * ), ie); }
-           */
+          selectedHolder = parent.directories[dirCounter];
 
-          selectedHolder = parent.directories[this.dirCounter];
           // Increment the directory counter to next position
-          this.dirCounter = (++this.dirCounter) % parent.dirLength;
+          dirCounter = ++dirCounter % parent.dirLength;
           if (selectedHolder.getAvailableSpace() < minAvailableSpace) {
-            /*
-             * throw new DiskAccessException(LocalizedStrings.
-             * DiskRegion_UNABLE_TO_GET_FREE_SPACE_FOR_CREATING_AN_OPLOG_AFTER_WAITING_FOR_0_1_2_SECONDS
-             * new Object[] {MAX_WAIT_FOR_SPACE, /, (1000)}));
-             */
             logger.warn(
                 "Even though the configured directory size limit has been exceeded a new oplog will be created because compaction is enabled. The configured limit is {}. The current space used in the directory by this disk store is {}.",
-                new Object[] {Long.valueOf(selectedHolder.getUsedSpace()),
-                    Long.valueOf(selectedHolder.getCapacity())});
+                selectedHolder.getUsedSpace(), selectedHolder.getCapacity());
           }
         } else {
           throw new DiskAccessException(
-              "Disk is full and compaction is disabled. No space can be created",
-              parent);
+              "Disk is full and compaction is disabled. No space can be created", parent);
         }
       }
     }
-    return selectedHolder;
 
+    return selectedHolder;
   }
 
   DirectoryHolder getNextDir() {
     return getNextDir(DiskStoreImpl.MINIMUM_DIR_SIZE, true);
   }
 
-  void addDrf(Oplog oplog) {
-    synchronized (this.oplogIdToOplog) {
-      this.drfOnlyOplogs.put(Long.valueOf(oplog.getOplogId()), oplog);
+  private void addDrf(Oplog oplog) {
+    synchronized (getOplogIdToOplog()) {
+      drfOnlyOplogs.put(oplog.getOplogId(), oplog);
     }
   }
 
   void removeDrf(Oplog oplog) {
-    synchronized (this.oplogIdToOplog) {
-      this.drfOnlyOplogs.remove(Long.valueOf(oplog.getOplogId()));
+    synchronized (getOplogIdToOplog()) {
+      drfOnlyOplogs.remove(oplog.getOplogId());
     }
   }
 
@@ -680,114 +677,89 @@ public class PersistentOplogSet implements OplogSet {
    * in the LINKED hash map is first we only need to compare ourselves to it.
    */
   boolean isOldestExistingOplog(long id) {
-    synchronized (this.oplogIdToOplog) {
-      Iterator<Long> it = this.oplogIdToOplog.keySet().iterator();
-      while (it.hasNext()) {
-        long otherId = it.next().longValue();
+    synchronized (getOplogIdToOplog()) {
+      for (long otherId : getOplogIdToOplog().keySet()) {
         if (id > otherId) {
           return false;
         }
       }
+
       // since the inactiveOplogs map is an LRU we need to check each one
-      it = this.inactiveOplogs.keySet().iterator();
-      while (it.hasNext()) {
-        long otherId = it.next().longValue();
+      for (long otherId : inactiveOplogs.keySet()) {
         if (id > otherId) {
           return false;
         }
       }
     }
+
     return true;
   }
 
   /**
-   * Destroy all the oplogs that are: 1. the oldest (based on smallest oplog id) 2. empty (have no
-   * live values)
+   * Destroy all the oplogs that are:
+   *
+   * <pre>
+   * 1. the oldest (based on smallest oplog id)
+   * 2. empty (have no live values)
+   * </pre>
    */
   void destroyOldestReadyToCompact() {
-    synchronized (this.oplogIdToOplog) {
-      if (this.drfOnlyOplogs.isEmpty())
+    synchronized (getOplogIdToOplog()) {
+      if (drfOnlyOplogs.isEmpty()) {
         return;
+      }
     }
+
     Oplog oldestLiveOplog = getOldestLiveOplog();
-    ArrayList<Oplog> toDestroy = new ArrayList<Oplog>();
+    List<Oplog> toDestroy = new ArrayList<>();
+
     if (oldestLiveOplog == null) {
       // remove all oplogs that are empty
-      synchronized (this.oplogIdToOplog) {
-        toDestroy.addAll(this.drfOnlyOplogs.values());
+      synchronized (getOplogIdToOplog()) {
+        toDestroy.addAll(drfOnlyOplogs.values());
       }
+
     } else {
       // remove all empty oplogs that are older than the oldest live one
-      synchronized (this.oplogIdToOplog) {
-        for (Oplog oplog : this.drfOnlyOplogs.values()) {
+      synchronized (getOplogIdToOplog()) {
+        for (Oplog oplog : drfOnlyOplogs.values()) {
           if (oplog.getOplogId() < oldestLiveOplog.getOplogId()) {
             toDestroy.add(oplog);
-            // } else {
-            // // since drfOnlyOplogs is sorted any other ones will be even
-            // bigger
-            // // so we can break out of this loop
-            // break;
           }
         }
       }
     }
+
     for (Oplog oplog : toDestroy) {
       oplog.destroy();
     }
   }
 
-  /**
-   * Returns the oldest oplog that is ready to compact. Returns null if no oplogs are ready to
-   * compact. Age is based on the oplog id.
-   */
-  private Oplog getOldestReadyToCompact() {
-    Oplog oldest = null;
-    synchronized (this.oplogIdToOplog) {
-      Iterator<Oplog> it = this.oplogIdToOplog.values().iterator();
-      while (it.hasNext()) {
-        Oplog oldestCompactable = it.next();
-        if (oldest == null || oldestCompactable.getOplogId() < oldest.getOplogId()) {
-          oldest = oldestCompactable;
-        }
-      }
-      it = this.drfOnlyOplogs.values().iterator();
-      while (it.hasNext()) {
-        Oplog oldestDrfOnly = it.next();
-        if (oldest == null || oldestDrfOnly.getOplogId() < oldest.getOplogId()) {
-          oldest = oldestDrfOnly;
-        }
-      }
-    }
-    return oldest;
-  }
-
   private Oplog getOldestLiveOplog() {
     Oplog result = null;
-    synchronized (this.oplogIdToOplog) {
-      Iterator<Oplog> it = this.oplogIdToOplog.values().iterator();
-      while (it.hasNext()) {
-        Oplog n = it.next();
-        if (result == null || n.getOplogId() < result.getOplogId()) {
-          result = n;
+    synchronized (getOplogIdToOplog()) {
+      for (Oplog oplog : getOplogIdToOplog().values()) {
+        if (result == null || oplog.getOplogId() < result.getOplogId()) {
+          result = oplog;
         }
       }
+
       // since the inactiveOplogs map is an LRU we need to check each one
-      it = this.inactiveOplogs.values().iterator();
-      while (it.hasNext()) {
-        Oplog n = it.next();
-        if (result == null || n.getOplogId() < result.getOplogId()) {
-          result = n;
+      for (Oplog oplog : inactiveOplogs.values()) {
+        if (result == null || oplog.getOplogId() < result.getOplogId()) {
+          result = oplog;
         }
       }
     }
+
     return result;
   }
 
   void inactiveAccessed(Oplog oplog) {
-    Long key = Long.valueOf(oplog.getOplogId());
-    synchronized (this.oplogIdToOplog) {
+    Long key = oplog.getOplogId();
+    synchronized (getOplogIdToOplog()) {
       // update last access time
-      this.inactiveOplogs.get(key);
+      inactiveOplogs.get(key);
     }
   }
 
@@ -800,24 +772,25 @@ public class PersistentOplogSet implements OplogSet {
   }
 
   private void addInactive(Oplog oplog, boolean reopen) {
-    Long key = Long.valueOf(oplog.getOplogId());
-    ArrayList<Oplog> openlist = null;
-    synchronized (this.oplogIdToOplog) {
+    Long key = oplog.getOplogId();
+    List<Oplog> openlist = null;
+    synchronized (getOplogIdToOplog()) {
+
       boolean isInactive = true;
       if (reopen) {
-        // It is possible that 'oplog' is compactable instead of inactive.
-        // So set the isInactive.
-        isInactive = this.inactiveOplogs.get(key) != null;
+        // It is possible that 'oplog' is compactible instead of inactive. So set isInactive.
+        isInactive = inactiveOplogs.get(key) != null;
       } else {
-        this.inactiveOplogs.put(key, oplog);
+        inactiveOplogs.put(key, oplog);
       }
-      if ((reopen && isInactive) || oplog.isRAFOpen()) {
+
+      if (reopen && isInactive || oplog.isRAFOpen()) {
         if (inactiveOpenCount.incrementAndGet() > DiskStoreImpl.MAX_OPEN_INACTIVE_OPLOGS) {
-          openlist = new ArrayList<Oplog>();
-          for (Oplog o : this.inactiveOplogs.values()) {
-            if (o.isRAFOpen()) {
+          openlist = new ArrayList<>();
+          for (Oplog inactiveOplog : inactiveOplogs.values()) {
+            if (inactiveOplog.isRAFOpen()) {
               // add to my list
-              openlist.add(o);
+              openlist.add(inactiveOplog);
             }
           }
         }
@@ -825,8 +798,8 @@ public class PersistentOplogSet implements OplogSet {
     }
 
     if (openlist != null) {
-      for (Oplog o : openlist) {
-        if (o.closeRAF()) {
+      for (Oplog openOplog : openlist) {
+        if (openOplog.closeRAF()) {
           if (inactiveOpenCount.decrementAndGet() <= DiskStoreImpl.MAX_OPEN_INACTIVE_OPLOGS) {
             break;
           }
@@ -839,73 +812,66 @@ public class PersistentOplogSet implements OplogSet {
     }
   }
 
-  public void clear(DiskRegion dr, RegionVersionVector rvv) {
+  public void clear(DiskRegion diskRegion, RegionVersionVector regionVersionVector) {
     // call clear on each oplog
-    // to fix bug 44336 put them in another collection
-    ArrayList<Oplog> oplogsToClear = new ArrayList<Oplog>();
-    synchronized (this.oplogIdToOplog) {
-      for (Oplog oplog : this.oplogIdToOplog.values()) {
-        oplogsToClear.add(oplog);
+    Collection<Oplog> oplogsToClear = new ArrayList<>();
+    synchronized (getOplogIdToOplog()) {
+      oplogsToClear.addAll(getOplogIdToOplog().values());
+      oplogsToClear.addAll(inactiveOplogs.values());
+
+      Oplog child = getChild();
+      if (child != null) {
+        oplogsToClear.add(child);
       }
-      for (Oplog oplog : this.inactiveOplogs.values()) {
-        oplogsToClear.add(oplog);
-      }
-      {
-        Oplog child = getChild();
-        if (child != null) {
-          oplogsToClear.add(child);
-        }
-      }
-    }
-    for (Oplog oplog : oplogsToClear) {
-      oplog.clear(dr, rvv);
     }
 
-    if (rvv != null) {
-      parent.getDiskInitFile().clearRegion(dr, rvv);
+    for (Oplog oplog : oplogsToClear) {
+      oplog.clear(diskRegion, regionVersionVector);
+    }
+
+    if (regionVersionVector != null) {
+      parent.getDiskInitFile().clearRegion(diskRegion, regionVersionVector);
     } else {
       long clearedOplogEntryId = getOplogEntryId();
-      parent.getDiskInitFile().clearRegion(dr, clearedOplogEntryId);
+      parent.getDiskInitFile().clearRegion(diskRegion, clearedOplogEntryId);
     }
   }
 
   public RuntimeException close() {
-    RuntimeException rte = null;
+    RuntimeException firstRuntimeException = null;
     try {
       closeOtherOplogs();
     } catch (RuntimeException e) {
-      if (rte != null) {
-        rte = e;
-      }
+      firstRuntimeException = e;
     }
 
-    if (this.child != null) {
+    if (child != null) {
       try {
-        this.child.finishKrf();
+        child.finishKrf();
       } catch (RuntimeException e) {
-        if (rte != null) {
-          rte = e;
+        if (firstRuntimeException != null) {
+          firstRuntimeException = e;
         }
       }
 
       try {
-        this.child.close();
+        child.close();
       } catch (RuntimeException e) {
-        if (rte != null) {
-          rte = e;
+        if (firstRuntimeException != null) {
+          firstRuntimeException = e;
         }
       }
     }
 
-    return rte;
+    return firstRuntimeException;
   }
 
   /** closes all the oplogs except the current one * */
   private void closeOtherOplogs() {
     // get a snapshot to prevent CME
     Oplog[] oplogs = getAllOplogs();
-    // if there are oplogs which are to be compacted, destroy them
-    // do not do oplogs[0]
+
+    // if there are oplogs which are to be compacted, destroy them do not do oplogs[0]
     for (int i = 1; i < oplogs.length; i++) {
       oplogs[i].finishKrf();
       oplogs[i].close();
@@ -924,30 +890,33 @@ public class PersistentOplogSet implements OplogSet {
   }
 
   Oplog removeOplog(long id, boolean deleting, Oplog olgToAddToDrfOnly) {
-    Oplog oplog = null;
+    Oplog oplog;
     boolean drfOnly = false;
     boolean inactive = false;
-    Long key = Long.valueOf(id);
-    synchronized (this.oplogIdToOplog) {
-      oplog = this.oplogIdToOplog.remove(key);
+
+    synchronized (getOplogIdToOplog()) {
+      Long key = id;
+      oplog = getOplogIdToOplog().remove(key);
       if (oplog == null) {
-        oplog = this.inactiveOplogs.remove(key);
+        oplog = inactiveOplogs.remove(key);
         if (oplog != null) {
           if (oplog.isRAFOpen()) {
             inactiveOpenCount.decrementAndGet();
           }
           inactive = true;
         } else {
-          oplog = this.drfOnlyOplogs.remove(key);
+          oplog = drfOnlyOplogs.remove(key);
           if (oplog != null) {
             drfOnly = true;
           }
         }
       }
+
       if (olgToAddToDrfOnly != null) {
         addDrf(olgToAddToDrfOnly);
       }
     }
+
     if (oplog != null) {
       if (!drfOnly) {
         if (inactive) {
@@ -956,6 +925,7 @@ public class PersistentOplogSet implements OplogSet {
           parent.getStats().incCompactableOplogs(-1);
         }
       }
+
       if (!deleting && !oplog.isOplogEmpty()) {
         // we are removing an oplog whose files are not deleted
         parent.undeletedOplogSize.addAndGet(oplog.getOplogSize());
@@ -965,68 +935,65 @@ public class PersistentOplogSet implements OplogSet {
   }
 
   public void basicClose(DiskRegion dr) {
-    ArrayList<Oplog> oplogsToClose = new ArrayList<Oplog>();
-    synchronized (this.oplogIdToOplog) {
-      oplogsToClose.addAll(this.oplogIdToOplog.values());
-      oplogsToClose.addAll(this.inactiveOplogs.values());
-      oplogsToClose.addAll(this.drfOnlyOplogs.values());
-      {
-        Oplog child = getChild();
-        if (child != null) {
-          oplogsToClose.add(child);
-        }
+    List<Oplog> oplogsToClose = new ArrayList<>();
+    synchronized (getOplogIdToOplog()) {
+      oplogsToClose.addAll(getOplogIdToOplog().values());
+      oplogsToClose.addAll(inactiveOplogs.values());
+      oplogsToClose.addAll(drfOnlyOplogs.values());
+
+      Oplog child = getChild();
+      if (child != null) {
+        oplogsToClose.add(child);
       }
     }
+
     for (Oplog oplog : oplogsToClose) {
       oplog.close(dr);
     }
   }
 
   public void prepareForClose() {
-    ArrayList<Oplog> oplogsToPrepare = new ArrayList<Oplog>();
-    synchronized (this.oplogIdToOplog) {
-      oplogsToPrepare.addAll(this.oplogIdToOplog.values());
-      oplogsToPrepare.addAll(this.inactiveOplogs.values());
+    Collection<Oplog> oplogsToPrepare = new ArrayList<>();
+    synchronized (getOplogIdToOplog()) {
+      oplogsToPrepare.addAll(getOplogIdToOplog().values());
+      oplogsToPrepare.addAll(inactiveOplogs.values());
     }
+
     boolean childPreparedForClose = false;
-    long child_oplogid = this.getChild() == null ? -1 : this.getChild().oplogId;
+    long childOplogId = getChild() == null ? -1 : getChild().oplogId;
+
     for (Oplog oplog : oplogsToPrepare) {
       oplog.prepareForClose();
-      if (child_oplogid != -1 && oplog.oplogId == child_oplogid) {
+      if (childOplogId != -1 && oplog.oplogId == childOplogId) {
         childPreparedForClose = true;
       }
     }
-    if (!childPreparedForClose && this.getChild() != null) {
-      this.getChild().prepareForClose();
+
+    if (!childPreparedForClose && getChild() != null) {
+      getChild().prepareForClose();
     }
   }
 
-  public void basicDestroy(DiskRegion dr) {
-    ArrayList<Oplog> oplogsToDestroy = new ArrayList<Oplog>();
-    synchronized (this.oplogIdToOplog) {
-      for (Oplog oplog : this.oplogIdToOplog.values()) {
-        oplogsToDestroy.add(oplog);
-      }
-      for (Oplog oplog : this.inactiveOplogs.values()) {
-        oplogsToDestroy.add(oplog);
-      }
-      for (Oplog oplog : this.drfOnlyOplogs.values()) {
-        oplogsToDestroy.add(oplog);
-      }
-      {
-        Oplog child = getChild();
-        if (child != null) {
-          oplogsToDestroy.add(child);
-        }
+  public void basicDestroy(DiskRegion diskRegion) {
+    Collection<Oplog> oplogsToDestroy = new ArrayList<>();
+    synchronized (getOplogIdToOplog()) {
+      oplogsToDestroy.addAll(getOplogIdToOplog().values());
+      oplogsToDestroy.addAll(inactiveOplogs.values());
+      oplogsToDestroy.addAll(drfOnlyOplogs.values());
+
+      Oplog child = getChild();
+      if (child != null) {
+        oplogsToDestroy.add(child);
       }
     }
+
     for (Oplog oplog : oplogsToDestroy) {
-      oplog.destroy(dr);
+      oplog.destroy(diskRegion);
     }
   }
 
-  public void destroyAllOplogs() {
-    // get a snapshot to prevent CME
+  void destroyAllOplogs() {
+    // get a snapshot to prevent ConcurrentModificationException
     for (Oplog oplog : getAllOplogs()) {
       if (oplog != null) {
         oplog.destroy();
@@ -1038,35 +1005,26 @@ public class PersistentOplogSet implements OplogSet {
   /**
    * Add compactable oplogs to the list, up to the maximum size.
    */
-  public void getCompactableOplogs(List<CompactableOplog> l, int max) {
-    synchronized (this.oplogIdToOplog) {
-      // Sort this list so we compact the oldest first instead of the one
-      // that was
-      // compactable first.
-      // ArrayList<CompactableOplog> l = new
-      // ArrayList<CompactableOplog>(this.oplogIdToOplog.values());
-      // Collections.sort(l);
-      // Iterator<Oplog> itr = l.iterator();
-      {
-        Iterator<Oplog> itr = this.oplogIdToOplog.values().iterator();
-        while (itr.hasNext() && l.size() < max) {
-          Oplog oplog = itr.next();
-          if (oplog.needsCompaction()) {
-            l.add(oplog);
-          }
+  void getCompactableOplogs(List<CompactableOplog> compactableOplogs) {
+    synchronized (getOplogIdToOplog()) {
+      // Sort this list so we compact the oldest first instead of the first compactable one
+      for (Oplog oplog : getOplogIdToOplog().values()) {
+        if (oplog.needsCompaction()) {
+          compactableOplogs.add(oplog);
         }
       }
     }
   }
 
-  public void scheduleForRecovery(DiskRecoveryStore drs) {
-    DiskRegionView dr = drs.getDiskRegionView();
-    if (dr.isRecreated() && (dr.getMyPersistentID() != null || dr.getMyInitializingID() != null)) {
+  void scheduleForRecovery(DiskRecoveryStore diskRecoveryStore) {
+    DiskRegionView diskRegionView = diskRecoveryStore.getDiskRegionView();
+    if (diskRegionView.isRecreated() &&
+        (diskRegionView.getMyPersistentID() != null
+            || diskRegionView.getMyInitializingID() != null)) {
       // If a region does not have either id then don't pay the cost
       // of scanning the oplogs for recovered data.
-      DiskRecoveryStore p_drs = drs;
-      synchronized (this.pendingRecoveryMap) {
-        this.pendingRecoveryMap.put(dr.getId(), p_drs);
+      synchronized (pendingRecoveryMap) {
+        pendingRecoveryMap.put(diskRegionView.getId(), diskRecoveryStore);
       }
     }
   }
@@ -1074,11 +1032,11 @@ public class PersistentOplogSet implements OplogSet {
   /**
    * Returns null if we are not currently recovering the DiskRegion with the given drId.
    */
-  public DiskRecoveryStore getCurrentlyRecovering(long drId) {
-    return this.currentRecoveryMap.get(drId);
+  DiskRecoveryStore getCurrentlyRecovering(long drId) {
+    return currentRecoveryMap.get(drId);
   }
 
-  public void initChild() {
+  void initChild() {
     if (getChild() == null) {
       setFirstChild(getSortedOplogs(), true);
     }
@@ -1093,37 +1051,36 @@ public class PersistentOplogSet implements OplogSet {
       }
     }
 
-    { // remove any oplogs that only have a drf to fix bug 42036
-      ArrayList<Oplog> toDestroy = new ArrayList<Oplog>();
-      synchronized (this.oplogIdToOplog) {
-        Iterator<Oplog> it = this.oplogIdToOplog.values().iterator();
-        while (it.hasNext()) {
-          Oplog n = it.next();
-          if (n.isDrfOnly()) {
-            toDestroy.add(n);
-          }
+    // remove any oplogs that only have a drf
+    Collection<Oplog> oplogsToDestroy = new ArrayList<>();
+    synchronized (getOplogIdToOplog()) {
+      for (Oplog oplog : getOplogIdToOplog().values()) {
+        if (oplog.isDrfOnly()) {
+          oplogsToDestroy.add(oplog);
         }
       }
-      for (Oplog oplog : toDestroy) {
-        oplog.destroy();
-      }
-      destroyOldestReadyToCompact();
     }
+
+    for (Oplog oplog : oplogsToDestroy) {
+      oplog.destroy();
+    }
+
+    destroyOldestReadyToCompact();
   }
 
   public DiskStoreImpl getParent() {
     return parent;
   }
 
-  public void updateDiskRegion(AbstractDiskRegion dr) {
+  void updateDiskRegion(AbstractDiskRegion diskRegion) {
     for (Oplog oplog : getAllOplogs()) {
       if (oplog != null) {
-        oplog.updateDiskRegion(dr);
+        oplog.updateDiskRegion(diskRegion);
       }
     }
   }
 
-  public void flushChild() {
+  void flushChild() {
     Oplog oplog = getChild();
     if (oplog != null) {
       oplog.flushAll();
@@ -1134,27 +1091,36 @@ public class PersistentOplogSet implements OplogSet {
     return OplogType.BACKUP.getPrefix();
   }
 
-  public void crfCreate(long oplogId) {
+  void crfCreate(long oplogId) {
     getParent().getDiskInitFile().crfCreate(oplogId);
   }
 
-  public void drfCreate(long oplogId) {
+  void drfCreate(long oplogId) {
     getParent().getDiskInitFile().drfCreate(oplogId);
   }
 
-  public void crfDelete(long oplogId) {
+  void crfDelete(long oplogId) {
     getParent().getDiskInitFile().crfDelete(oplogId);
   }
 
-  public void drfDelete(long oplogId) {
+  void drfDelete(long oplogId) {
     getParent().getDiskInitFile().drfDelete(oplogId);
   }
 
-  public boolean couldHaveKrf() {
+  boolean couldHaveKrf() {
     return getParent().couldHaveKrf();
   }
 
   public boolean isCompactionPossible() {
     return getParent().isCompactionPossible();
+  }
+
+  /** oplogs that are ready to compact */
+  Map<Long, Oplog> getOplogIdToOplog() {
+    return oplogIdToOplog;
+  }
+
+  AtomicBoolean getAlreadyRecoveredOnce() {
+    return alreadyRecoveredOnce;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PersistentOplogSetTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PersistentOplogSetTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.internal.cache.entries.DiskEntry;
+import org.apache.geode.internal.cache.entries.DiskEntry.Helper.ValueWrapper;
+
+public class PersistentOplogSetTest {
+
+  private DiskStoreImpl diskStore;
+
+  private DiskStoreStats diskStoreStats;
+  private InternalRegion region;
+  private DiskEntry entry;
+  private ValueWrapper value;
+  private Oplog oplog;
+
+  private PersistentOplogSet persistentOplogSet;
+  private OplogSet oplogSet;
+
+  @Before
+  public void setUp() {
+    diskStore = mock(DiskStoreImpl.class);
+
+    diskStoreStats = mock(DiskStoreStats.class);
+    region = mock(InternalRegion.class);
+    entry = mock(DiskEntry.class);
+    value = mock(ValueWrapper.class);
+    oplog = mock(Oplog.class);
+
+    persistentOplogSet = new PersistentOplogSet(diskStore);
+    persistentOplogSet.setChild(oplog);
+
+    oplogSet = persistentOplogSet;
+  }
+
+  @Test
+  public void createDelegatesToChildOplog() {
+    oplogSet.create(region, entry, value, true);
+
+    verify(oplog).create(same(region), same(entry), same(value), eq(true));
+  }
+
+  @Test
+  public void modifyDelegatesToChildOplog() {
+    oplogSet.modify(region, entry, value, true);
+
+    verify(oplog).modify(same(region), same(entry), same(value), eq(true));
+  }
+
+  @Test
+  public void removeDelegatesToChildOplog() {
+    oplogSet.remove(region, entry, false, true);
+
+    verify(oplog).remove(same(region), same(entry), eq(false), eq(true));
+  }
+
+  @Test
+  public void getChildReturnsChildOplogIfOplogIdMatches() {
+    when(oplog.getOplogId()).thenReturn(42L);
+
+    CompactableOplog value = oplogSet.getChild(42L);
+
+    assertThat(value).isSameAs(oplog);
+  }
+
+  @Test
+  public void getChildReturnsNullIfOplogIdDoesNotMatch() {
+    when(oplog.getOplogId()).thenReturn(42L);
+
+    CompactableOplog value = oplogSet.getChild(24L);
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void getChildReturnsMatchingEntryFromOplogIdToOplogMap() {
+    Oplog oplog = mock(Oplog.class);
+    persistentOplogSet.setChild(null);
+    persistentOplogSet.getOplogIdToOplog().put(24L, oplog);
+
+    CompactableOplog value = oplogSet.getChild(24L);
+
+    assertThat(value).isSameAs(oplog);
+  }
+
+  @Test
+  public void getChildReturnsNullIfEntriesInOplogIdToOplogMapDoNotMatch() {
+    Oplog oplog = mock(Oplog.class);
+    persistentOplogSet.setChild(null);
+    persistentOplogSet.getOplogIdToOplog().put(42L, oplog);
+
+    CompactableOplog value = oplogSet.getChild(24L);
+
+    assertThat(value).isNull();
+  }
+
+  @Test
+  public void getChildReturnsMatchingEntryFromInactiveOplogMap() {
+    Oplog oplog = mock(Oplog.class);
+    persistentOplogSet.setChild(null);
+    when(oplog.getOplogId()).thenReturn(24L);
+    when(diskStore.getStats()).thenReturn(diskStoreStats);
+    persistentOplogSet.addInactive(oplog);
+
+    CompactableOplog value = oplogSet.getChild(24L);
+
+    assertThat(value).isSameAs(oplog);
+  }
+
+  @Test
+  public void getChildReturnsNullIfEntriesInInactiveOplogMapDoNotMatch() {
+    Oplog oplog = mock(Oplog.class);
+    persistentOplogSet.setChild(null);
+    when(oplog.getOplogId()).thenReturn(42L);
+    when(diskStore.getStats()).thenReturn(diskStoreStats);
+    persistentOplogSet.addInactive(oplog);
+
+    CompactableOplog value = oplogSet.getChild(24L);
+
+    assertThat(value).isNull();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PersistentOplogSetTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PersistentOplogSetTest.java
@@ -38,7 +38,6 @@ public class PersistentOplogSetTest {
   private Oplog oplog;
 
   private PersistentOplogSet persistentOplogSet;
-  private OplogSet oplogSet;
 
   @Before
   public void setUp() {
@@ -51,46 +50,51 @@ public class PersistentOplogSetTest {
     oplog = mock(Oplog.class);
 
     persistentOplogSet = new PersistentOplogSet(diskStore);
-    persistentOplogSet.setChild(oplog);
-
-    oplogSet = persistentOplogSet;
   }
 
   @Test
   public void createDelegatesToChildOplog() {
-    oplogSet.create(region, entry, value, true);
+    persistentOplogSet.setChild(oplog);
+
+    persistentOplogSet.create(region, entry, value, true);
 
     verify(oplog).create(same(region), same(entry), same(value), eq(true));
   }
 
   @Test
   public void modifyDelegatesToChildOplog() {
-    oplogSet.modify(region, entry, value, true);
+    persistentOplogSet.setChild(oplog);
+
+    persistentOplogSet.modify(region, entry, value, true);
 
     verify(oplog).modify(same(region), same(entry), same(value), eq(true));
   }
 
   @Test
   public void removeDelegatesToChildOplog() {
-    oplogSet.remove(region, entry, false, true);
+    persistentOplogSet.setChild(oplog);
+
+    persistentOplogSet.remove(region, entry, false, true);
 
     verify(oplog).remove(same(region), same(entry), eq(false), eq(true));
   }
 
   @Test
   public void getChildReturnsChildOplogIfOplogIdMatches() {
+    persistentOplogSet.setChild(oplog);
     when(oplog.getOplogId()).thenReturn(42L);
 
-    CompactableOplog value = oplogSet.getChild(42L);
+    CompactableOplog value = persistentOplogSet.getChild(42L);
 
     assertThat(value).isSameAs(oplog);
   }
 
   @Test
   public void getChildReturnsNullIfOplogIdDoesNotMatch() {
+    persistentOplogSet.setChild(oplog);
     when(oplog.getOplogId()).thenReturn(42L);
 
-    CompactableOplog value = oplogSet.getChild(24L);
+    CompactableOplog value = persistentOplogSet.getChild(24L);
 
     assertThat(value).isNull();
   }
@@ -101,7 +105,7 @@ public class PersistentOplogSetTest {
     persistentOplogSet.setChild(null);
     persistentOplogSet.getOplogIdToOplog().put(24L, oplog);
 
-    CompactableOplog value = oplogSet.getChild(24L);
+    CompactableOplog value = persistentOplogSet.getChild(24L);
 
     assertThat(value).isSameAs(oplog);
   }
@@ -112,7 +116,7 @@ public class PersistentOplogSetTest {
     persistentOplogSet.setChild(null);
     persistentOplogSet.getOplogIdToOplog().put(42L, oplog);
 
-    CompactableOplog value = oplogSet.getChild(24L);
+    CompactableOplog value = persistentOplogSet.getChild(24L);
 
     assertThat(value).isNull();
   }
@@ -125,7 +129,7 @@ public class PersistentOplogSetTest {
     when(diskStore.getStats()).thenReturn(diskStoreStats);
     persistentOplogSet.addInactive(oplog);
 
-    CompactableOplog value = oplogSet.getChild(24L);
+    CompactableOplog value = persistentOplogSet.getChild(24L);
 
     assertThat(value).isSameAs(oplog);
   }
@@ -138,7 +142,7 @@ public class PersistentOplogSetTest {
     when(diskStore.getStats()).thenReturn(diskStoreStats);
     persistentOplogSet.addInactive(oplog);
 
-    CompactableOplog value = oplogSet.getChild(24L);
+    CompactableOplog value = persistentOplogSet.getChild(24L);
 
     assertThat(value).isNull();
   }


### PR DESCRIPTION
* Create PersistentOplogSetTest
* Encapsulate fields
* Reorganize fields
* Fix misc IDE warnings
* Remove unused code
* Remove commented out code
* Remove unnecessary uses of this
* Improve whitespace and comments
* Improve variable names

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>

These commits do not fix GEODE-6918, but they do cleanup some code and tests in preparation for the fix.