### PR TITLE
6904: Fix hang on locator when restarting due to lock

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigLocatorRestartDUnitTest.java
@@ -16,17 +16,26 @@
 package org.apache.geode.management.internal.configuration;
 
 
-
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.apache.geode.GemFireConfigException;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -95,7 +104,6 @@ public class ClusterConfigLocatorRestartDUnitTest {
     IgnoredException.addIgnoredException("org.apache.geode.ForcedDisconnectException: for testing");
     IgnoredException.addIgnoredException("Connection refused");
 
-
     Properties properties = new Properties();
     properties.setProperty(MAX_WAIT_TIME_RECONNECT, "30000");
 
@@ -118,6 +126,86 @@ public class ClusterConfigLocatorRestartDUnitTest {
         .untilAsserted(() -> gfsh.executeAndAssertThat("list members").statusIsSuccess()
             .tableHasColumnOnlyWithValues("Name", "locator-1", "server-2", "server-3", "server-4"));
   }
+
+  @Test(timeout = 300_000)
+  public void serverRestartHangsWaitingForStartupMessageResponse() throws Exception {
+    IgnoredException.addIgnoredException("This member is no longer in the membership view");
+    IgnoredException.addIgnoredException("This node is no longer in the membership view");
+    IgnoredException.addIgnoredException("ForcedDisconnectException");
+    IgnoredException.addIgnoredException("Possible loss of quorum due to the loss");
+    IgnoredException.addIgnoredException("Membership service failure:");
+    IgnoredException.addIgnoredException("Failed to send message:");
+    IgnoredException.addIgnoredException("Cannot form connection to alert listener");
+    IgnoredException.addIgnoredException("Received invalid result");
+    IgnoredException.addIgnoredException("cluster configuration service not available");
+    // With the following steps, a locator can get into state where it is stuck in the middle of
+    // reconnecting.
+    // It allows members to join the system, but they timeout sending it startup messages and
+    // start up without cluster configuration, resulting not being able to restart the cluster.
+    // A- Start 2 locators and some number of servers
+    // B- Kill one locator and trigger a force disconnect in the remaining locators and servers at
+    // the same time
+    // C- Have one of the members take a little bit of time before reconnecting, to let the locator
+    // get to
+    // recovering the _ConfigurationRegion before that remaining member joins.
+
+    // A
+    MemberVM locator0 = rule.startLocatorVM(0);
+    MemberVM locator1 = rule.startLocatorVM(1, locator0.getPort());
+
+    MemberVM server2 = rule.startServerVM(2, locator0.getPort(), locator1.getPort());
+    Properties properties = new Properties();
+    properties.setProperty(MAX_WAIT_TIME_RECONNECT, "10000");
+
+    MemberVM server3 =
+        rule.startServerVM(3, properties, locator0.getPort(), locator1.getPort());
+
+    gfsh.connectAndVerify(locator1);
+    gfsh.executeAndAssertThat("create region --name=region --type=REPLICATE").statusIsSuccess();
+
+    // B
+    server2.forceDisconnect();
+    server3.forceDisconnect();
+    locator1.forceDisconnect();
+
+    rule.crashVM(0); // Shut down hard
+
+    // Wait until locator1 gets stuck waiting for locator0 to start up in order to recover the
+    // cluster configuration region
+    locator1.invoke(() -> {
+      await().untilAsserted(() -> {
+        InternalCache cache = GemFireCacheImpl.getInstance();
+        assertThat(cache).isNotNull();
+        Map<String, Set<PersistentMemberID>> waitingRegions = cache
+            .getPersistentMemberManager()
+            .getWaitingRegions();
+
+        assertThat(waitingRegions).isNotEmpty();
+      });
+    });
+
+    // Start another member. This should fail because it should require cluster configuration in
+    // order to startup
+    assertThatThrownBy(
+        () -> this.rule.startServerVM(4, properties, locator1.getPort(), locator0.getPort()))
+            .hasCauseInstanceOf(
+                GemFireConfigException.class);
+
+
+    // Restart locator 0, which allows the locators to recover cluster configuration
+    rule.startLocatorVM(0, locator1.getPort());
+
+    // Member4 should now be able to startup and get cluster configuartion
+    MemberVM server4 =
+        rule.startServerVM(4, properties, locator1.getPort(), locator0.getPort());
+
+    // Make sure server4 actually gets the cluster configuration
+    server4.invoke(() -> {
+      Cache cache = CacheFactory.getAnyInstance();
+      assertThat(cache.getRegion("/region")).isNotNull();
+    });
+  }
+
 
   private void addDisconnectListener(MemberVM member) {
     member.invoke(() -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/pdx/DistributedSystemIdDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/pdx/DistributedSystemIdDUnitTest.java
@@ -18,6 +18,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_S
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -26,6 +27,7 @@ import java.util.Properties;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.IncompatibleSystemException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.dunit.Host;
@@ -80,12 +82,9 @@ public class DistributedSystemIdDUnitTest extends JUnit4DistributedTestCase {
 
     int locatorPort = createLocator(vm0, "1");
 
-    try {
-      createSystem(vm1, "2", locatorPort);
-      fail("Should have gotten an exception");
-    } catch (Exception expected) {
-
-    }
+    // Creating a member with a different distributed system id should fail
+    assertThatThrownBy(() -> createSystem(vm1, "2", locatorPort))
+        .hasCauseInstanceOf(IncompatibleSystemException.class);
 
     checkId(vm0, 1);
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -114,9 +114,6 @@ public class ClusterDistributionManager implements DistributionManager {
 
   private static final Logger logger = LogService.getLogger();
 
-  private static final int STARTUP_TIMEOUT =
-      Integer.getInteger("DistributionManager.STARTUP_TIMEOUT", 15000);
-
   private static final boolean DEBUG_NO_ACKNOWLEDGEMENTS =
       Boolean.getBoolean("DistributionManager.DEBUG_NO_ACKNOWLEDGEMENTS");
 
@@ -2254,7 +2251,7 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     try {
-      ok = startupOperation.sendStartupMessage(allOthers, STARTUP_TIMEOUT, equivs, redundancyZone,
+      ok = startupOperation.sendStartupMessage(allOthers, equivs, redundancyZone,
           enforceUniqueZone());
     } catch (Exception re) {
       throw new SystemConnectException(

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1161,43 +1161,43 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
         throw new IllegalStateException(
             "A locator can not be created because one already exists in this JVM.");
       }
-      internalDistributedSystem = newSystem;
-      internalCache = newCache;
-      internalDistributedSystem.setDependentLocator(this);
-      logger.info("Locator restart: initializing TcpServer");
-
-      try {
-        server.restarting(newSystem, newCache, configurationPersistenceService);
-      } catch (CancelException e) {
-        internalDistributedSystem = null;
-        internalCache = null;
-        logger.info("Locator restart: attempt to restart location services failed", e);
-        throw e;
-      }
-
-      if (productUseLog.isClosed()) {
-        productUseLog.reopen();
-      }
-
-      productUseLog.monitorUse(newSystem);
-
-      if (isSharedConfigurationEnabled()) {
-        configurationPersistenceService =
-            new InternalConfigurationPersistenceService(newCache, workingDirectory,
-                JAXBService.create());
-        startClusterManagementService();
-      }
-
-      if (!server.isAlive()) {
-        logger.info("Locator restart: starting TcpServer");
-        startTcpServer();
-      }
-
-      logger.info("Locator restart: initializing JMX manager");
-      startJmxManagerLocationService(newCache);
-      endStartLocator(internalDistributedSystem);
-      logger.info("Locator restart completed");
     }
+    internalDistributedSystem = newSystem;
+    internalCache = newCache;
+    internalDistributedSystem.setDependentLocator(this);
+    logger.info("Locator restart: initializing TcpServer");
+
+    try {
+      server.restarting(newSystem, newCache, configurationPersistenceService);
+    } catch (CancelException e) {
+      internalDistributedSystem = null;
+      internalCache = null;
+      logger.info("Locator restart: attempt to restart location services failed", e);
+      throw e;
+    }
+
+    if (productUseLog.isClosed()) {
+      productUseLog.reopen();
+    }
+    productUseLog.monitorUse(newSystem);
+
+    if (isSharedConfigurationEnabled()) {
+      configurationPersistenceService =
+          new InternalConfigurationPersistenceService(newCache, workingDirectory,
+              JAXBService.create());
+      startClusterManagementService();
+    }
+
+    if (!server.isAlive()) {
+      logger.info("Locator restart: starting TcpServer");
+      startTcpServer();
+    }
+
+    logger.info("Locator restart: initializing JMX manager");
+    startJmxManagerLocationService(newCache);
+    endStartLocator(internalDistributedSystem);
+    logger.info("Locator restart completed");
+
     server.restartCompleted(newSystem);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
@@ -181,10 +181,11 @@ public class StartupResponseMessage extends HighPriorityDistributionMessage
         if (!this.responderIsAdmin) {
           proc.setReceivedAcceptance(true);
         }
-        proc.process(this);
-        if (logger.isTraceEnabled(LogMarker.DM_VERBOSE)) {
-          logger.trace(LogMarker.DM_VERBOSE, "{} Processed {}", proc, this);
-        }
+      }
+
+      proc.process(this);
+      if (logger.isTraceEnabled(LogMarker.DM_VERBOSE)) {
+        logger.trace(LogMarker.DM_VERBOSE, "{} Processed {}", proc, this);
       }
     } // proc != null
   }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageJUnitTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+
+public class StartupMessageJUnitTest {
+
+  @Test
+  public void processShouldSendAReplyMessageWhenExceptionThrown() {
+    ClusterDistributionManager distributionManager = mock(ClusterDistributionManager.class);
+
+    InternalDistributedMember id = mock(InternalDistributedMember.class);
+    when(distributionManager.getId()).thenReturn(id);
+
+    // This method will throw an exception in the middle of StartupMessage.process
+    when(distributionManager.getTransport()).thenThrow(new IllegalStateException("FAIL"));
+
+    StartupMessage startupMessage = new StartupMessage();
+    startupMessage.setSender(id);
+    startupMessage.process(distributionManager);
+
+    // We expect process to send a ReplyMessage with an exception
+    // So that the sender is not blocked
+    ArgumentCaptor<DistributionMessage> responseCaptor =
+        ArgumentCaptor.forClass(DistributionMessage.class);
+    verify(distributionManager).putOutgoing(responseCaptor.capture());
+
+    DistributionMessage response = responseCaptor.getValue();
+    assertThat(response).isInstanceOf(ReplyMessage.class);
+    assertThat(((ReplyMessage) response).getException())
+        .isInstanceOf(ReplyException.class)
+        .hasCauseInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void processShouldSendAReplyMessageWhenErrorThrownForNoResponse() {
+    ClusterDistributionManager distributionManager = mock(ClusterDistributionManager.class);
+
+    InternalDistributedMember id = mock(InternalDistributedMember.class);
+    when(distributionManager.getId()).thenReturn(id);
+
+    // This method will throw an error in the middle of StartupMessage.process
+    when(distributionManager.getTransport()).thenThrow(new Error("No Response sent"));
+
+    StartupMessage startupMessage = new StartupMessage();
+    startupMessage.setSender(id);
+    assertThatThrownBy(() -> startupMessage.process(distributionManager))
+        .isInstanceOf(Error.class).hasMessage("No Response sent");
+
+    // We expect process to send a ReplyMessage with an exception
+    // So that the sender is not blocked
+    ArgumentCaptor<DistributionMessage> responseCaptor =
+        ArgumentCaptor.forClass(DistributionMessage.class);
+    verify(distributionManager).putOutgoing(responseCaptor.capture());
+
+    DistributionMessage response = responseCaptor.getValue();
+    assertThat(response).isInstanceOf(ReplyMessage.class);
+    assertThat(((ReplyMessage) response).getException())
+        .isInstanceOf(ReplyException.class)
+        .hasCauseInstanceOf(IllegalStateException.class);
+  }
+}


### PR DESCRIPTION
Only hold the locatorLock while reading the locator variable in
restartWithDS. Holding this lock while recovering cluster configuration
was causing other messages to the locator, including the StartupMessage,
to block waiting for this lock.

In addition, wait forever for StartupMessage responses.
StartupOperation had a 15 second timeout, after which it would stop
waiting. That resulted in not having correct metadata about other
members in the system. We were also not waking up the thread in
waitForReplies when a StartupResponseMessage came in with a
rejectionMessage.

Co-Authored-By: Ernest Burghardt <eburghardt@pivotal.io>