### PR TITLE
GEODE-6891: Maintain local copy of SerialQueueBytes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -3231,13 +3231,13 @@ public class ClusterDistributionManager implements DistributionManager {
       ExecutorService executor = getSerialExecutor(sender);
 
       // Get the total serial queue size.
-      int totalSerialQueueMemSize = stats.getSerialQueueBytes();
+      int totalSerialQueueMemSize = stats.getInternalSerialQueueBytes();
 
       // for tcp socket reader threads, this code throttles the thread
       // to keep the sender-side from overwhelming the receiver.
       // UDP readers are throttled in the FC protocol, which queries
       // the queue to see if it should throttle
-      if (stats.getSerialQueueBytes() > TOTAL_SERIAL_QUEUE_THROTTLE
+      if (stats.getInternalSerialQueueBytes() > TOTAL_SERIAL_QUEUE_THROTTLE
           && !DistributionMessage.isPreciousThread()) {
         do {
           boolean interrupted = Thread.interrupted();
@@ -3257,7 +3257,7 @@ public class ClusterDistributionManager implements DistributionManager {
             }
           }
           stats.getSerialQueueHelper().incThrottleCount();
-        } while (stats.getSerialQueueBytes() >= TOTAL_SERIAL_QUEUE_BYTE_LIMIT);
+        } while (stats.getInternalSerialQueueBytes() >= TOTAL_SERIAL_QUEUE_BYTE_LIMIT);
       }
       return executor;
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -3231,7 +3231,7 @@ public class ClusterDistributionManager implements DistributionManager {
       ExecutorService executor = getSerialExecutor(sender);
 
       // Get the total serial queue size.
-      int totalSerialQueueMemSize = stats.getInternalSerialQueueBytes();
+      long totalSerialQueueMemSize = stats.getInternalSerialQueueBytes();
 
       // for tcp socket reader threads, this code throttles the thread
       // to keep the sender-side from overwhelming the receiver.

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.distributed.internal;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongSupplier;
 
 import org.apache.logging.log4j.Logger;
@@ -949,7 +949,7 @@ public class DistributionStats implements DMStats {
 
   private final MaxLongGauge maxReplyWaitTime;
   private final MaxLongGauge maxSentMessagesTime;
-  private AtomicInteger serialQueueBytes = new AtomicInteger();
+  private LongAdder serialQueueBytes = new LongAdder();
 
   //////////////////////// Constructors ////////////////////////
 
@@ -1256,16 +1256,12 @@ public class DistributionStats implements DMStats {
   }
 
   protected void incSerialQueueBytes(int amount) {
-    serialQueueBytes.addAndGet(amount);
+    serialQueueBytes.add(amount);
     this.stats.incInt(serialQueueBytesId, amount);
   }
 
-  public int getSerialQueueBytes() {
-    return this.stats.getInt(serialQueueBytesId);
-  }
-
-  public int getInternalSerialQueueBytes() {
-    return serialQueueBytes.get();
+  public long getInternalSerialQueueBytes() {
+    return serialQueueBytes.longValue();
   }
 
   protected void incSerialPooledThread() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionStats.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.LongSupplier;
 
 import org.apache.logging.log4j.Logger;
@@ -90,7 +91,8 @@ public class DistributionStats implements DMStats {
   private static final int functionExecutionQueueThrottleCountId;
   private static final int functionExecutionQueueThrottleTimeId;
   private static final int serialQueueSizeId;
-  private static final int serialQueueBytesId;
+  @VisibleForTesting
+  static final int serialQueueBytesId;
   private static final int serialPooledThreadId;
   private static final int serialQueueThrottleTimeId;
   private static final int serialQueueThrottleCountId;
@@ -947,6 +949,7 @@ public class DistributionStats implements DMStats {
 
   private final MaxLongGauge maxReplyWaitTime;
   private final MaxLongGauge maxSentMessagesTime;
+  private AtomicInteger serialQueueBytes = new AtomicInteger();
 
   //////////////////////// Constructors ////////////////////////
 
@@ -1253,11 +1256,16 @@ public class DistributionStats implements DMStats {
   }
 
   protected void incSerialQueueBytes(int amount) {
+    serialQueueBytes.addAndGet(amount);
     this.stats.incInt(serialQueueBytesId, amount);
   }
 
   public int getSerialQueueBytes() {
     return this.stats.getInt(serialQueueBytesId);
+  }
+
+  public int getInternalSerialQueueBytes() {
+    return serialQueueBytes.get();
   }
 
   protected void incSerialPooledThread() {

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionStatsTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -56,5 +57,14 @@ public class DistributionStatsTest {
 
     verify(mockStats).incLong(DistributionStats.sentMessagesTimeId, 50000000L);
     verify(mockStats).incLong(DistributionStats.sentMessagesMaxTimeId, 50L);
+  }
+
+  @Test
+  public void incSerialQueueBytes() {
+    distributionStats.incSerialQueueBytes(50000000);
+    distributionStats.incSerialQueueBytes(20000000);
+    assertThat(distributionStats.getInternalSerialQueueBytes()).isEqualTo(70000000);
+    verify(mockStats).incInt(DistributionStats.serialQueueBytesId, 50000000);
+    verify(mockStats).incInt(DistributionStats.serialQueueBytesId, 20000000);
   }
 }


### PR DESCRIPTION
DistributionStats.getSerialQueueBytes(). If stats are disabled then the
throttling would be disabled. Someone needs to maintain this value in a
local atomic.

Co-authored-by: Murtuza Boxwala <mboxwala@pivotal.io>
Co-authored-by: Kamilla Aslami <kaslami@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
