### PR TITLE
GEODE-6918: Cleanup PRHARedundancyProvider and PRHARedundancyProviderTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import java.io.File;
@@ -566,7 +567,8 @@ public class RebalanceOperationDistributedTest extends CacheTestCase {
 
       PartitionedRegion origRegion = (PartitionedRegion) cache.getRegion("region1");
       PartitionedRegion spyRegion = spy(origRegion);
-      PRHARedundancyProvider redundancyProvider = spy(new PRHARedundancyProvider(spyRegion));
+      PRHARedundancyProvider redundancyProvider =
+          spy(new PRHARedundancyProvider(spyRegion, mock(InternalResourceManager.class)));
 
       // return the spied region when ever getPartitionedRegions() is invoked
       Set<PartitionedRegion> parRegions = cache.getPartitionedRegions();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -768,7 +768,7 @@ public class PartitionedRegion extends LocalRegion
     this.distAdvisor = RegionAdvisor.createRegionAdvisor(this);
     senderIdMonitor = createSenderIdMonitor();
     // Warning: potential early escape of instance
-    this.redundancyProvider = new PRHARedundancyProvider(this);
+    this.redundancyProvider = new PRHARedundancyProvider(this, cache.getInternalResourceManager());
 
     // localCacheEnabled = ra.getPartitionAttributes().isLocalCacheEnabled();
     // This is to make sure that local-cache get and put works properly.

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -24,60 +23,76 @@ import static org.mockito.Mockito.when;
 import java.util.HashSet;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.internal.cache.control.InternalResourceManager;
 import org.apache.geode.internal.cache.partitioned.InternalPRInfo;
 import org.apache.geode.internal.cache.partitioned.LoadProbe;
 import org.apache.geode.internal.cache.partitioned.PersistentBucketRecoverer;
+import org.apache.geode.internal.cache.partitioned.RegionAdvisor;
 
 public class PRHARedundancyProviderTest {
 
+  private InternalCache cache;
   private PartitionedRegion partitionedRegion;
+  private InternalResourceManager resourceManager;
+
   private PRHARedundancyProvider prHaRedundancyProvider;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Before
   public void setUp() {
-    partitionedRegion = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
-    InternalCache cache = mock(InternalCache.class);
-    DistributedRegion rootRegion = mock(DistributedRegion.class);
-
-    when(partitionedRegion.getCache()).thenReturn(cache);
-    when(cache.getRegion(PartitionedRegionHelper.PR_ROOT_REGION_NAME, true)).thenReturn(rootRegion);
-
-    prHaRedundancyProvider = spy(new PRHARedundancyProvider(partitionedRegion));
+    cache = mock(InternalCache.class);
+    partitionedRegion = mock(PartitionedRegion.class);
+    resourceManager = mock(InternalResourceManager.class);
   }
 
   @Test
   public void waitForPersistentBucketRecoveryProceedsWhenPersistentBucketRecovererLatchIsNotSet() {
-    PersistentBucketRecoverer recoverer = mock(PersistentBucketRecoverer.class);
-    when(prHaRedundancyProvider.getPersistentBucketRecoverer()).thenReturn(recoverer);
+    prHaRedundancyProvider = new PRHARedundancyProvider(partitionedRegion, resourceManager,
+        (a, b) -> mock(PersistentBucketRecoverer.class));
 
     prHaRedundancyProvider.waitForPersistentBucketRecovery();
   }
 
   @Test
   public void waitForPersistentBucketRecoveryProceedsAfterLatchCountDown() {
-    PersistentBucketRecoverer recoverer =
-        spy(new PersistentBucketRecoverer(prHaRedundancyProvider, 1));
-    when(prHaRedundancyProvider.getPersistentBucketRecoverer()).thenReturn(recoverer);
+    when(cache.getRegion(PartitionedRegionHelper.PR_ROOT_REGION_NAME, true))
+        .thenReturn(mock(DistributedRegion.class));
+    when(partitionedRegion.getCache()).thenReturn(cache);
+    when(partitionedRegion.getDataPolicy()).thenReturn(DataPolicy.PARTITION);
+    when(partitionedRegion.getPartitionAttributes()).thenReturn(mock(PartitionAttributes.class));
+    prHaRedundancyProvider = new PRHARedundancyProvider(partitionedRegion, resourceManager,
+        (a, b) -> spy(new ThreadlessPersistentBucketRecoverer(a, b)));
+    prHaRedundancyProvider.createPersistentBucketRecoverer(1);
     prHaRedundancyProvider.getPersistentBucketRecoverer().countDown();
 
     prHaRedundancyProvider.waitForPersistentBucketRecovery();
 
-    verify(recoverer).await();
+    verify(prHaRedundancyProvider.getPersistentBucketRecoverer()).await();
   }
 
   @Test
   public void buildPartitionedRegionInfo() {
-    when(partitionedRegion.getRegionAdvisor().adviseDataStore()).thenReturn(new HashSet<>());
-    when(partitionedRegion.getRegionAdvisor().getProxyBucketArray())
-        .thenReturn(new ProxyBucketRegion[] {});
-
-    when(partitionedRegion.getTotalNumberOfBuckets()).thenReturn(42);
-    when(partitionedRegion.getRegionAdvisor().getCreatedBucketsCount()).thenReturn(17);
+    prHaRedundancyProvider = new PRHARedundancyProvider(partitionedRegion, resourceManager,
+        (a, b) -> mock(PersistentBucketRecoverer.class));
+    when(partitionedRegion.getRedundancyTracker())
+        .thenReturn(mock(PartitionedRegionRedundancyTracker.class));
+    when(partitionedRegion.getRedundancyTracker().getActualRedundancy()).thenReturn(33);
     when(partitionedRegion.getRedundancyTracker().getLowRedundancyBuckets()).thenReturn(3);
     when(partitionedRegion.getRedundantCopies()).thenReturn(12);
-    when(partitionedRegion.getRedundancyTracker().getActualRedundancy()).thenReturn(33);
+    when(partitionedRegion.getRegionAdvisor()).thenReturn(mock(RegionAdvisor.class));
+    when(partitionedRegion.getRegionAdvisor().adviseDataStore()).thenReturn(new HashSet<>());
+    when(partitionedRegion.getRegionAdvisor().getCreatedBucketsCount()).thenReturn(17);
+    when(partitionedRegion.getTotalNumberOfBuckets()).thenReturn(42);
 
     InternalPRInfo internalPRInfo =
         prHaRedundancyProvider.buildPartitionedRegionInfo(false, mock(LoadProbe.class));
@@ -87,5 +102,18 @@ public class PRHARedundancyProviderTest {
     assertThat(internalPRInfo.getLowRedundancyBucketCount()).isEqualTo(3);
     assertThat(internalPRInfo.getConfiguredRedundantCopies()).isEqualTo(12);
     assertThat(internalPRInfo.getActualRedundantCopies()).isEqualTo(33);
+  }
+
+  private static class ThreadlessPersistentBucketRecoverer extends PersistentBucketRecoverer {
+
+    public ThreadlessPersistentBucketRecoverer(
+        PRHARedundancyProvider prhaRedundancyProvider, int proxyBuckets) {
+      super(prhaRedundancyProvider, proxyBuckets);
+    }
+
+    @Override
+    public void startLoggingThread() {
+      // do nothing
+    }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PersistentBucketRecovererTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PersistentBucketRecovererTest.java
@@ -27,21 +27,27 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PRHARedundancyProvider;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionHelper;
+import org.apache.geode.internal.cache.control.InternalResourceManager;
 
 public class PersistentBucketRecovererTest {
+
   private PartitionedRegion partitionedRegion;
   private InternalCache cache;
   private DistributedRegion root;
   private PRHARedundancyProvider provider;
+  private InternalResourceManager resourceManager;
 
   @Before
   public void setUp() {
     partitionedRegion = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
+    resourceManager = mock(InternalResourceManager.class);
     cache = mock(InternalCache.class);
     root = mock(DistributedRegion.class);
+
     when(partitionedRegion.getCache()).thenReturn(cache);
     when(cache.getRegion(PartitionedRegionHelper.PR_ROOT_REGION_NAME, true)).thenReturn(root);
-    provider = new PRHARedundancyProvider(partitionedRegion);
+
+    provider = new PRHARedundancyProvider(partitionedRegion, resourceManager);
   }
 
   @Test


### PR DESCRIPTION
* Cleanup recommendations found in review
* Use constructor injection
* Use MockitoRule and STRICT_STUBS
* Improve field and variable names
* Improve overall consistency, formatting, and comments

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
