### PR TITLE
GEODE-6883: Save the cache xml for reconnect outside membership

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectedCacheServerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectedCacheServerDUnitTest.java
@@ -18,15 +18,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
+import java.util.Properties;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
-import org.apache.geode.distributed.internal.membership.gms.mgr.GMSMembershipManager;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
@@ -53,6 +54,13 @@ public class ReconnectedCacheServerDUnitTest extends JUnit4CacheTestCase {
   }
 
   @Override
+  public Properties getDistributedSystemProperties() {
+    Properties props = new Properties(super.getDistributedSystemProperties());
+    props.setProperty(ConfigurationProperties.USE_CLUSTER_CONFIGURATION, "true");
+    return props;
+  }
+
+  @Override
   public final void preTearDownCacheTestCase() throws Exception {
     if (addedCacheServer && this.cache != null && !this.cache.isClosed()) {
       // since I polluted the cache I should shut it down in order
@@ -70,9 +78,7 @@ public class ReconnectedCacheServerDUnitTest extends JUnit4CacheTestCase {
     InternalCache gc = (InternalCache) this.cache;
 
     // fool the system into thinking cluster-config is being used
-    GMSMembershipManager mgr = (GMSMembershipManager) MembershipManagerHelper
-        .getMembershipManager(gc.getDistributedSystem());
-    mgr.saveCacheXmlForReconnect(true);
+    gc.saveCacheXmlForReconnect();
 
     // the cache server config should now be stored in the cache's config
     assertFalse(gc.getCacheServers().isEmpty());
@@ -87,11 +93,7 @@ public class ReconnectedCacheServerDUnitTest extends JUnit4CacheTestCase {
 
     GemFireCacheImpl gc = (GemFireCacheImpl) this.cache;
 
-    // fool the system into thinking cluster-config is being used
-    GMSMembershipManager mgr = (GMSMembershipManager) MembershipManagerHelper
-        .getMembershipManager(gc.getDistributedSystem());
-    final boolean sharedConfigEnabled = true;
-    mgr.saveCacheXmlForReconnect(sharedConfigEnabled);
+    gc.saveCacheXmlForReconnect();
 
     // the cache server config should now be stored in the cache's config
     assertFalse(gc.getCacheServers().isEmpty());

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -3385,11 +3385,6 @@ public class ClusterDistributionManager implements DistributionManager {
     }
 
     @Override
-    public boolean isShutdownMsgSent() {
-      return shutdownMsgSent;
-    }
-
-    @Override
     public void membershipFailure(String reason, Throwable t) {
       exceptionInThreads = true;
       rootCause = t;
@@ -3453,6 +3448,12 @@ public class ClusterDistributionManager implements DistributionManager {
       return dm;
     }
 
+    @Override
+    public void saveConfig() {
+      if (!getConfig().getDisableAutoReconnect()) {
+        cache.saveCacheXmlForReconnect();
+      }
+    }
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/DistributedMembershipListener.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/DistributedMembershipListener.java
@@ -64,17 +64,6 @@ public interface DistributedMembershipListener extends DirectChannelListener {
   void messageReceived(DistributionMessage o);
 
   /**
-   * Indicates whether, during the shutdown sequence, if other members of the distributed system
-   * have been notified.
-   *
-   * This allows a membership manager to identify potential race conditions during the shutdown
-   * process.
-   *
-   * @return true if other members of the distributed system have been notified.
-   */
-  boolean isShutdownMsgSent();
-
-  /**
    * Event indicating that the membership service has failed catastrophically.
    *
    */
@@ -86,5 +75,14 @@ public interface DistributedMembershipListener extends DirectChannelListener {
    * @return a printable string for this listener
    */
   String toString();
+
+  /**
+   * Save the configuration before a force disconnect.
+   *
+   * This method should probably be merged with memberFailure, but currently the
+   * places we save the configuration don't line up with where we call
+   * memberFailure.
+   */
+  void saveConfig();
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -383,4 +383,6 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, Reco
   void throwCacheExistsException();
 
   MeterRegistry getMeterRegistry();
+
+  void saveCacheXmlForReconnect();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -1251,4 +1251,9 @@ public class InternalCacheForClientAccess implements InternalCache {
   public Set<MeterRegistry> getMeterSubregistries() {
     return delegate.getMeterSubregistries();
   }
+
+  @Override
+  public void saveCacheXmlForReconnect() {
+    delegate.saveCacheXmlForReconnect();
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -2421,6 +2421,11 @@ public class CacheCreation implements InternalCache {
     throw new UnsupportedOperationException("Should not be invoked");
   }
 
+  @Override
+  public void saveCacheXmlForReconnect() {
+    throw new UnsupportedOperationException("Should not be invoked");
+  }
+
   CacheTransactionManagerCreation getCacheTransactionManagerCreation() {
     return cacheTransactionManagerCreation;
   }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -71,13 +71,9 @@ import org.apache.geode.internal.VersionedObjectInput;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.alerting.AlertingAction;
-import org.apache.geode.internal.cache.CacheConfig;
-import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.DirectReplyMessage;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.xmlcache.CacheServerCreation;
-import org.apache.geode.internal.cache.xmlcache.CacheXmlGenerator;
 import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingExecutors;
@@ -87,7 +83,6 @@ import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
-import org.apache.geode.internal.shared.StringPrintWriter;
 import org.apache.geode.internal.tcp.ConnectExceptions;
 import org.apache.geode.internal.util.Breadcrumbs;
 import org.apache.geode.internal.util.JavaWorkarounds;
@@ -244,13 +239,6 @@ public class MembershipDependenciesJUnitTest {
 
               // TODO:
               .or(type(DistributedMember.class))
-
-              // TODO: This stuff is just used in GMSMembershipManager.saveCacheXmlForReconnect
-              .or(type(CacheServerImpl.class))
-              .or(type(StringPrintWriter.class))
-              .or(type(CacheXmlGenerator.class))
-              .or(type(CacheServerCreation.class))
-              .or(type(CacheConfig.class))
 
               // TODO:
               .or(type(JavaWorkarounds.class))


### PR DESCRIPTION
Membership shouldn't be concerned with saving a cache.xml file, Do that
outside of the membership layer.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
