### PR TITLE
GEODE-6918: Cleanup InternalLocator use of workingDirectory

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalLocatorIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.when;
@@ -65,7 +66,7 @@ public class InternalLocatorIntegrationTest {
 
   @Before
   public void setUp() throws IOException {
-    port = 42;
+    port = getRandomAvailableTCPPort();
     hostnameForClients = "";
     bindAddress = null;
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/InternalLocatorIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+import org.apache.geode.internal.logging.InternalLogWriter;
+import org.apache.geode.internal.logging.LoggingSession;
+
+public class InternalLocatorIntegrationTest {
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private int port;
+  @Mock
+  private LoggingSession loggingSession;
+  @Mock
+  private File logFile;
+  @Mock
+  private InternalLogWriter logWriter;
+  @Mock
+  private InternalLogWriter securityLogWriter;
+  private InetAddress bindAddress;
+  private String hostnameForClients;
+  @Mock
+  private Properties distributedSystemProperties;
+  @Mock
+  private DistributionConfigImpl distributionConfig;
+  private Path workingDirectory;
+  private InternalLocator internalLocator;
+
+  @Before
+  public void setUp() throws IOException {
+    port = 42;
+    hostnameForClients = "";
+    bindAddress = null;
+
+    logFile = temporaryFolder.newFile("logfile.log");
+    workingDirectory = temporaryFolder.getRoot().toPath();
+  }
+
+  @After
+  public void tearDown() {
+    if (internalLocator != null) {
+      internalLocator.stop();
+    }
+  }
+
+  @Test
+  public void constructs() {
+    when(distributionConfig.getLogFile()).thenReturn(logFile);
+
+    assertThatCode(() -> {
+      internalLocator =
+          new InternalLocator(port, loggingSession, logFile, logWriter, securityLogWriter,
+              bindAddress, hostnameForClients, distributedSystemProperties, distributionConfig,
+              workingDirectory);
+    }).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void startedLocatorIsRunning() throws IOException {
+    internalLocator = InternalLocator.startLocator(port, logFile, logWriter,
+        securityLogWriter, bindAddress, true,
+        distributedSystemProperties, hostnameForClients, workingDirectory);
+
+    assertThat(internalLocator.isStopped()).isFalse();
+  }
+
+  @Test
+  public void startedLocatorHasLocator() throws IOException {
+    internalLocator = InternalLocator.startLocator(port, logFile, logWriter,
+        securityLogWriter, bindAddress, true,
+        distributedSystemProperties, hostnameForClients, workingDirectory);
+
+    assertThat(InternalLocator.hasLocator()).isTrue();
+  }
+
+  @Test
+  public void stoppedLocatorIsStopped() throws IOException {
+    internalLocator = InternalLocator.startLocator(port, logFile, logWriter,
+        securityLogWriter, bindAddress, true,
+        distributedSystemProperties, hostnameForClients, workingDirectory);
+
+    internalLocator.stop();
+
+    assertThat(internalLocator.isStopped()).isTrue();
+  }
+
+  @Test
+  public void stoppedLocatorDoesNotHaveLocator() throws IOException {
+    internalLocator = InternalLocator.startLocator(port, logFile, logWriter,
+        securityLogWriter, bindAddress, true,
+        distributedSystemProperties, hostnameForClients, workingDirectory);
+
+    internalLocator.stop();
+
+    assertThat(InternalLocator.hasLocator()).isFalse();
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -134,7 +134,7 @@ public class MembershipJUnitTest {
       // this locator will hook itself up with the first MembershipManager
       // to be created
       l = InternalLocator.startLocator(port, new File(""), null, null, localHost, false,
-          new Properties(), null, temporaryFolder.getRoot());
+          new Properties(), null, temporaryFolder.getRoot().toPath());
 
       // create configuration objects
       Properties nonDefault = new Properties();
@@ -285,7 +285,7 @@ public class MembershipJUnitTest {
       // this locator will hook itself up with the first MembershipManager
       // to be created
       l = InternalLocator.startLocator(port, new File(""), null, null, localHost, false, p, null,
-          temporaryFolder.getRoot());
+          temporaryFolder.getRoot().toPath());
 
       // create configuration objects
       Properties nonDefault = new Properties();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -42,7 +42,8 @@ public class GMSLocatorIntegrationTest {
     tcpServer = mock(TcpServer.class);
     view = new NetView();
     gmsLocator =
-        new GMSLocator(null, null, false, false, new LocatorStats(), "", temporaryFolder.getRoot());
+        new GMSLocator(null, null, false, false, new LocatorStats(), "",
+            temporaryFolder.getRoot().toPath());
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -77,7 +77,7 @@ public class GMSLocatorRecoveryIntegrationTest {
     stateFile = new File(temporaryFolder.getRoot(), getClass().getSimpleName() + "_locator.dat");
 
     gmsLocator = new GMSLocator(null, null, false, false, new LocatorStats(), "",
-        temporaryFolder.getRoot());
+        temporaryFolder.getRoot().toPath());
     gmsLocator.setViewFile(stateFile);
   }
 
@@ -143,7 +143,7 @@ public class GMSLocatorRecoveryIntegrationTest {
 
     // this locator will hook itself up with the first MembershipManager to be created
     locator = InternalLocator.startLocator(port, null, null, null, localHost, false,
-        new Properties(), null, temporaryFolder.getRoot());
+        new Properties(), null, temporaryFolder.getRoot().toPath());
 
     // create configuration objects
     Properties nonDefault = new Properties();
@@ -169,7 +169,7 @@ public class GMSLocatorRecoveryIntegrationTest {
 
     GMSLocator gmsLocator = new GMSLocator(localHost,
         membershipManager.getLocalMember().getHost() + "[" + port + "]", true, true,
-        new LocatorStats(), "", temporaryFolder.getRoot());
+        new LocatorStats(), "", temporaryFolder.getRoot().toPath());
     gmsLocator.setViewFile(new File(temporaryFolder.getRoot(), "locator2.dat"));
     gmsLocator.init(null);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/LoggingWithLocatorIntegrationTest.java
@@ -90,7 +90,7 @@ public class LoggingWithLocatorIntegrationTest {
     Properties config = new Properties();
 
     locator = InternalLocator.startLocator(port, null, null, null, null, false, config, null,
-        temporaryFolder.getRoot());
+        temporaryFolder.getRoot().toPath());
 
     LogConfig logConfig = locator.getLogConfig();
 
@@ -109,7 +109,7 @@ public class LoggingWithLocatorIntegrationTest {
     Properties config = new Properties();
 
     locator = InternalLocator.startLocator(port, logFile, null, null, null, false, config, null,
-        temporaryFolder.getRoot());
+        temporaryFolder.getRoot().toPath());
 
     LogConfig logConfig = locator.getLogConfig();
 
@@ -167,7 +167,7 @@ public class LoggingWithLocatorIntegrationTest {
     config.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
 
     locator = InternalLocator.startLocator(port, null, null, null, null, false, config, null,
-        temporaryFolder.getRoot());
+        temporaryFolder.getRoot().toPath());
     Logger logger = LogService.getLogger();
 
     // assert that logging goes to logFile

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -674,7 +675,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
         try {
           this.locator = InternalLocator.startLocator(getPort(), getLogFile(), null, null,
               getBindAddress(), true, getDistributedSystemProperties(), getHostnameForClients(),
-              new File(workingDirectory));
+              Paths.get(workingDirectory));
         } finally {
           ProcessLauncherContext.remove();
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Properties;
@@ -42,6 +44,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.cache.client.internal.locator.ClientConnectionRequest;
 import org.apache.geode.cache.client.internal.locator.ClientReplacementRequest;
@@ -155,7 +158,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
   private final LoggingSession loggingSession;
   private final Set<LogConfigListener> logConfigListeners = new HashSet<>();
   private final LocatorStats locatorStats;
-  private final File workingDirectory;
+  private final Path workingDirectory;
 
   /**
    * whether the locator was stopped during forced-disconnect processing but a reconnect will occur
@@ -238,14 +241,19 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @param distributedSystemProperties optional properties to configure the distributed system
    *        (e.g., mcast addr/port, other locators)
    * @param startDistributedSystem if true then this locator will also start its own ds
+   *
+   * @deprecated Please use
+   *             {@link #createLocator(int, LoggingSession, File, InternalLogWriter, InternalLogWriter, InetAddress, String, Properties, Path)}
+   *             instead.
    */
+  @Deprecated
   public static InternalLocator createLocator(int port, LoggingSession loggingSession, File logFile,
       InternalLogWriter logWriter, InternalLogWriter securityLogWriter, InetAddress bindAddress,
       String hostnameForClients, Properties distributedSystemProperties,
       boolean startDistributedSystem) {
     return createLocator(port, loggingSession, logFile, logWriter, securityLogWriter, bindAddress,
-        hostnameForClients, distributedSystemProperties, startDistributedSystem,
-        new File(System.getProperty("user.dir")));
+        hostnameForClients, distributedSystemProperties,
+        Paths.get(System.getProperty("user.dir")));
   }
 
   /**
@@ -261,13 +269,11 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @param securityLogWriter the logWriter to be used for security related log messages
    * @param distributedSystemProperties optional properties to configure the distributed system
    *        (e.g., mcast addr/port, other locators)
-   * @param startDistributedSystem if true then this locator will also start its own ds
    * @param workingDirectory the working directory to use for any files
    */
   public static InternalLocator createLocator(int port, LoggingSession loggingSession, File logFile,
       InternalLogWriter logWriter, InternalLogWriter securityLogWriter, InetAddress bindAddress,
-      String hostnameForClients, Properties distributedSystemProperties,
-      boolean startDistributedSystem, File workingDirectory) {
+      String hostnameForClients, Properties distributedSystemProperties, Path workingDirectory) {
     synchronized (locatorLock) {
       if (hasLocator()) {
         throw new IllegalStateException(
@@ -276,7 +282,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       InternalLocator locator =
           new InternalLocator(port, loggingSession, logFile, logWriter, securityLogWriter,
               bindAddress, hostnameForClients, distributedSystemProperties, null,
-              startDistributedSystem, workingDirectory);
+              workingDirectory);
       InternalLocator.locator = locator;
       return locator;
     }
@@ -316,7 +322,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       throws IOException {
     return startLocator(port, logFile, logWriter, securityLogWriter, bindAddress,
         startDistributedSystem, distributedSystemProperties, hostnameForClients,
-        new File(System.getProperty("user.dir")));
+        Paths.get(System.getProperty("user.dir")));
   }
 
   /**
@@ -339,7 +345,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    */
   public static InternalLocator startLocator(int port, File logFile, InternalLogWriter logWriter,
       InternalLogWriter securityLogWriter, InetAddress bindAddress, boolean startDistributedSystem,
-      Properties distributedSystemProperties, String hostnameForClients, File workingDirectory)
+      Properties distributedSystemProperties, String hostnameForClients, Path workingDirectory)
       throws IOException {
     System.setProperty(FORCE_LOCATOR_DM_TYPE, "true");
     InternalLocator newLocator = null;
@@ -352,7 +358,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
           startDistributedSystem ? NullLoggingSession.create() : LoggingSession.create();
 
       newLocator = createLocator(port, loggingSession, logFile, logWriter, securityLogWriter,
-          bindAddress, hostnameForClients, distributedSystemProperties, startDistributedSystem,
+          bindAddress, hostnameForClients, distributedSystemProperties,
           workingDirectory);
 
       loggingSession.createSession(newLocator);
@@ -440,14 +446,13 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
    * @param distributedSystemProperties optional properties to configure the distributed system
    *        (e.g., mcast addr/port, other locators)
    * @param distributionConfig the config if being called from a distributed system; otherwise null.
-   * @param startDistributedSystem if true locator will start its own distributed system
+   * @param workingDirectory the working directory to use for files
    */
-  private InternalLocator(int port, LoggingSession loggingSession, File logFile,
+  @VisibleForTesting
+  InternalLocator(int port, LoggingSession loggingSession, File logFile,
       InternalLogWriter logWriter, InternalLogWriter securityLogWriter, InetAddress bindAddress,
       String hostnameForClients, Properties distributedSystemProperties,
-      DistributionConfigImpl distributionConfig, boolean startDistributedSystem,
-      File workingDirectory) {
-    // TODO: the following three assignments are already done in superclass
+      DistributionConfigImpl distributionConfig, Path workingDirectory) {
     this.logFile = logFile;
     this.bindAddress = bindAddress;
     this.hostnameForClients = hostnameForClients;
@@ -607,7 +612,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       startTcpServer();
     }
     int boundPort = server.getPort();
-    File productUseFile = new File(workingDirectory, "locator" + boundPort + "views.log");
+    File productUseFile = workingDirectory.resolve("locator" + boundPort + "views.log").toFile();
     productUseLog = new ProductUseLog(productUseFile);
 
     return boundPort;
@@ -1177,7 +1182,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
 
       if (isSharedConfigurationEnabled()) {
         configurationPersistenceService =
-            new InternalConfigurationPersistenceService(newCache);
+            new InternalConfigurationPersistenceService(newCache, workingDirectory);
         startClusterManagementService();
       }
 
@@ -1334,7 +1339,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       if (locator.configurationPersistenceService == null) {
         // configurationPersistenceService will already be created in case of auto-reconnect
         locator.configurationPersistenceService =
-            new InternalConfigurationPersistenceService(locator.internalCache);
+            new InternalConfigurationPersistenceService(locator.internalCache, workingDirectory);
       }
       locator.configurationPersistenceService
           .initSharedConfiguration(locator.loadFromSharedConfigDir());

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -72,6 +72,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheBuilder;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.cache.wan.WANServiceProvider;
+import org.apache.geode.internal.config.JAXBService;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LogConfig;
 import org.apache.geode.internal.logging.LogConfigListener;
@@ -1182,7 +1183,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
 
       if (isSharedConfigurationEnabled()) {
         configurationPersistenceService =
-            new InternalConfigurationPersistenceService(newCache, workingDirectory);
+            new InternalConfigurationPersistenceService(newCache, workingDirectory,
+                JAXBService.create());
         startClusterManagementService();
       }
 
@@ -1339,7 +1341,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       if (locator.configurationPersistenceService == null) {
         // configurationPersistenceService will already be created in case of auto-reconnect
         locator.configurationPersistenceService =
-            new InternalConfigurationPersistenceService(locator.internalCache, workingDirectory);
+            new InternalConfigurationPersistenceService(locator.internalCache, workingDirectory,
+                JAXBService.create());
       }
       locator.configurationPersistenceService
           .initSharedConfiguration(locator.loadFromSharedConfigDir());

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberFactory.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.distributed.internal.membership;
 
-import java.io.File;
 import java.net.InetAddress;
+import java.nio.file.Path;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.distributed.internal.DMStats;
@@ -102,7 +102,7 @@ public class MemberFactory {
    */
   public static NetLocator newLocatorHandler(InetAddress bindAddress, String locatorString,
       boolean usePreferredCoordinators, boolean networkPartitionDetectionEnabled,
-      LocatorStats stats, String securityUDPDHAlgo, File workingDirectory) {
+      LocatorStats stats, String securityUDPDHAlgo, Path workingDirectory) {
     return services.newLocatorHandler(bindAddress, locatorString, usePreferredCoordinators,
         networkPartitionDetectionEnabled, stats, securityUDPDHAlgo, workingDirectory);
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MemberServices.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.distributed.internal.membership;
 
-import java.io.File;
 import java.net.InetAddress;
+import java.nio.file.Path;
 
 import org.apache.geode.distributed.internal.DMStats;
 import org.apache.geode.distributed.internal.DistributionConfig;
@@ -88,5 +88,5 @@ public interface MemberServices {
    */
   NetLocator newLocatorHandler(InetAddress bindAddress, String locatorString,
       boolean usePreferredCoordinators, boolean networkPartitionDetectionEnabled,
-      LocatorStats stats, String securityUDPDHAlgo, File workingDirectory);
+      LocatorStats stats, String securityUDPDHAlgo, Path workingDirectory);
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberFactory.java
@@ -14,9 +14,9 @@
  */
 package org.apache.geode.distributed.internal.membership.gms;
 
-import java.io.File;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Path;
 
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.SystemConnectException;
@@ -122,7 +122,7 @@ public class GMSMemberFactory implements MemberServices {
   @Override
   public NetLocator newLocatorHandler(InetAddress bindAddress, String locatorString,
       boolean usePreferredCoordinators, boolean networkPartitionDetectionEnabled,
-      LocatorStats stats, String securityUDPDHAlgo, File workingDirectory) {
+      LocatorStats stats, String securityUDPDHAlgo, Path workingDirectory) {
 
     return new GMSLocator(bindAddress, locatorString, usePreferredCoordinators,
         networkPartitionDetectionEnabled, stats, securityUDPDHAlgo, workingDirectory);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -23,6 +23,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,7 +76,7 @@ public class GMSLocator implements Locator, NetLocator {
   private final Set<InternalDistributedMember> registrants = new HashSet<>();
   private final Map<InternalDistributedMemberWrapper, byte[]> publicKeys =
       new ConcurrentHashMap<>();
-  private final File workingDirectory;
+  private final Path workingDirectory;
 
   private volatile boolean isCoordinator;
 
@@ -102,7 +103,7 @@ public class GMSLocator implements Locator, NetLocator {
    */
   public GMSLocator(InetAddress bindAddress, String locatorString, boolean usePreferredCoordinators,
       boolean networkPartitionDetectionEnabled, LocatorStats locatorStats,
-      String securityUDPDHAlgo, File workingDirectory) {
+      String securityUDPDHAlgo, Path workingDirectory) {
     this.usePreferredCoordinators = usePreferredCoordinators;
     this.networkPartitionDetectionEnabled = networkPartitionDetectionEnabled;
     this.securityUDPDHAlgo = securityUDPDHAlgo;
@@ -167,8 +168,7 @@ public class GMSLocator implements Locator, NetLocator {
   @Override
   public void init(TcpServer server) throws InternalGemFireException {
     if (viewFile == null) {
-      viewFile =
-          new File(workingDirectory, "locator" + server.getPort() + "view.dat").getAbsoluteFile();
+      viewFile = workingDirectory.resolve("locator" + server.getPort() + "view.dat").toFile();
     }
     logger.info(
         "GemFire peer location service starting.  Other locators: {}  Locators preferred as coordinators: {}  Network partition detection enabled: {}  View persistence file: {}",

--- a/geode-core/src/main/java/org/apache/geode/internal/config/JAXBService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/config/JAXBService.java
@@ -14,20 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.geode.internal.config;
 
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.transform.Source;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -40,11 +42,14 @@ import org.xml.sax.helpers.XMLReaderFactory;
 
 import org.apache.geode.cache.configuration.XSDRootElement;
 import org.apache.geode.internal.ClassPathLoader;
+import org.apache.geode.internal.lang.SystemPropertyHelper;
+import org.apache.geode.management.internal.cli.util.ClasspathScanLoadHelper;
 
 public class JAXBService {
-  Marshaller marshaller;
-  Unmarshaller unmarshaller;
-  NameSpaceFilter nameSpaceFilter;
+
+  private final Marshaller marshaller;
+  private final Unmarshaller unmarshaller;
+  private final NameSpaceFilter nameSpaceFilter;
 
   public JAXBService(Class<?>... xsdRootClasses) {
     try {
@@ -58,7 +63,7 @@ public class JAXBService {
         XSDRootElement element = c.getAnnotation(XSDRootElement.class);
         if (element != null && StringUtils.isNotEmpty(element.namespace())
             && StringUtils.isNotEmpty(element.schemaLocation())) {
-          return (element.namespace() + " " + element.schemaLocation());
+          return element.namespace() + " " + element.schemaLocation();
         }
         return null;
       }).filter(Objects::nonNull).collect(Collectors.joining(" "));
@@ -73,15 +78,48 @@ public class JAXBService {
     }
   }
 
-  public void validateWith(URL url) {
+  public static JAXBService create(Class<?>... xsdClasses) {
+    if (xsdClasses != null && xsdClasses.length > 0) {
+      return new JAXBService(xsdClasses);
+    }
+    // else, scan the classpath to find all the classes annotated with XSDRootElement
+    return new JAXBService(scanForClasses().toArray(new Class[0]));
+  }
+
+  public static JAXBService createWithValidation(Class<?>... xsdClasses) {
+    JAXBService jaxbService = create(xsdClasses);
+    jaxbService.validateWithLocalCacheXSD();
+    return jaxbService;
+  }
+
+  static Set<String> getPackagesToScan() {
+    Set<String> packages = new HashSet<>();
+    String sysProperty = SystemPropertyHelper.getProperty(SystemPropertyHelper.PACKAGES_TO_SCAN);
+    if (sysProperty != null) {
+      packages = Arrays.stream(sysProperty.split(",")).collect(Collectors.toSet());
+    } else {
+      packages.add("*");
+    }
+    return packages;
+  }
+
+  private static Set<Class<?>> scanForClasses() {
+    // scan the classpath to find all the classes annotated with XSDRootElement
+    Set<String> packages = getPackagesToScan();
+    try (ClasspathScanLoadHelper scanner = new ClasspathScanLoadHelper(packages)) {
+      return scanner.scanClasspathForAnnotation(XSDRootElement.class,
+          packages.toArray(new String[] {}));
+    }
+  }
+
+  private void validateWith(URL url) {
     SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-    Schema schema;
     try {
-      schema = factory.newSchema(url);
+      Schema schema = factory.newSchema(url);
+      marshaller.setSchema(schema);
     } catch (SAXException e) {
       throw new RuntimeException(e.getMessage(), e);
     }
-    marshaller.setSchema(schema);
   }
 
   public void validateWithLocalCacheXSD() {
@@ -104,7 +142,7 @@ public class JAXBService {
 
   public <T> T unMarshall(String xml) {
     try {
-      SAXSource source = new SAXSource(nameSpaceFilter, new InputSource(new StringReader(xml)));
+      Source source = new SAXSource(nameSpaceFilter, new InputSource(new StringReader(xml)));
       return (T) unmarshaller.unmarshal(source);
     } catch (Exception e) {
       throw new RuntimeException(e.getMessage(), e);
@@ -113,11 +151,10 @@ public class JAXBService {
 
   public <T> T unMarshall(String xml, Class<T> klass) {
     try {
-      SAXSource source = new SAXSource(nameSpaceFilter, new InputSource(new StringReader(xml)));
+      Source source = new SAXSource(nameSpaceFilter, new InputSource(new StringReader(xml)));
       return unmarshaller.unmarshal(source, klass).getValue();
     } catch (Exception e) {
       throw new RuntimeException(e.getMessage(), e);
     }
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceServiceTest.java
@@ -57,7 +57,9 @@ import org.apache.geode.management.internal.configuration.utils.XmlUtils;
 
 @RunWith(JUnitParamsRunner.class)
 public class InternalConfigurationPersistenceServiceTest {
-  private InternalConfigurationPersistenceService service, service2;
+
+  private InternalConfigurationPersistenceService service;
+  private InternalConfigurationPersistenceService service2;
   private Configuration configuration;
 
   @Rule

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceServiceTest.java
@@ -14,10 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.geode.distributed.internal;
 
-import static junitparams.JUnitParamsRunner.$;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,9 +34,7 @@ import java.util.Set;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
 
@@ -48,10 +44,10 @@ import org.apache.geode.cache.configuration.GatewayReceiverConfig;
 import org.apache.geode.cache.configuration.JndiBindingsType;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.configuration.RegionType;
+import org.apache.geode.internal.config.JAXBService;
 import org.apache.geode.internal.config.JAXBServiceTest;
 import org.apache.geode.internal.config.JAXBServiceTest.ElementOne;
 import org.apache.geode.internal.config.JAXBServiceTest.ElementTwo;
-import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.management.internal.configuration.utils.XmlUtils;
 
@@ -62,21 +58,21 @@ public class InternalConfigurationPersistenceServiceTest {
   private InternalConfigurationPersistenceService service2;
   private Configuration configuration;
 
-  @Rule
-  public RestoreSystemProperties restore = new RestoreSystemProperties();
-
   @Before
   public void setUp() throws Exception {
-    service = spy(new InternalConfigurationPersistenceService(CacheConfig.class, ElementOne.class,
-        ElementTwo.class));
-    service2 = spy(new InternalConfigurationPersistenceService(CacheConfig.class));
+    service = spy(new InternalConfigurationPersistenceService(
+        JAXBService.createWithValidation(CacheConfig.class, ElementOne.class, ElementTwo.class)));
+    service2 = spy(new InternalConfigurationPersistenceService(
+        JAXBService.createWithValidation(CacheConfig.class)));
     configuration = new Configuration("cluster");
+
     doReturn(configuration).when(service).getConfiguration(any());
     doReturn(configuration).when(service2).getConfiguration(any());
     doReturn(mock(Region.class)).when(service).getConfigurationRegion();
     doReturn(mock(Region.class)).when(service2).getConfigurationRegion();
     doReturn(true).when(service).lockSharedConfiguration();
     doReturn(true).when(service2).lockSharedConfiguration();
+
     doNothing().when(service).unlockSharedConfiguration();
     doNothing().when(service2).unlockSharedConfiguration();
   }
@@ -194,20 +190,6 @@ public class InternalConfigurationPersistenceServiceTest {
   }
 
   @Test
-  public void getPackagesToScanWithoutSystemProperty() {
-    Set<String> packages = service.getPackagesToScan();
-    assertThat(packages).containsExactly("*");
-  }
-
-  @Test
-  public void getPackagesToScanWithSystemProperty() {
-    System.setProperty("geode." + SystemPropertyHelper.PACKAGES_TO_SCAN,
-        "org.apache.geode,io.pivotal");
-    Set<String> packages = service.getPackagesToScan();
-    assertThat(packages).containsExactly("org.apache.geode", "io.pivotal");
-  }
-
-  @Test
   public void updateGatewayReceiverConfig() {
     service.updateCacheConfig("cluster", cacheConfig -> {
       GatewayReceiverConfig receiver = new GatewayReceiverConfig();
@@ -312,13 +294,13 @@ public class InternalConfigurationPersistenceServiceTest {
   }
 
   protected Object[] getXmlAndExpectedElements() {
-    return $(
+    return new Object[] {
         new Object[] {getDuplicateReceiversWithDefaultPropertiesXml(), 2, 1},
         new Object[] {getDuplicateReceiversWithDifferentHostNameForSendersXml(), 2, 0},
         new Object[] {getDuplicateReceiversWithDifferentBindAddressesXml(), 2, 0},
         new Object[] {getSingleReceiverWithDefaultBindAddressXml(), 1, 1},
         new Object[] {getDuplicateReceiversWithDefaultBindAddressesXml(), 2, 1},
         new Object[] {getValidReceiversXml(), 1, 1},
-        new Object[] {getNoReceiversXml(), 0, 0});
+        new Object[] {getNoReceiversXml(), 0, 0}};
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -50,6 +50,7 @@ import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.config.JAXBService;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.RealizationResult;
 import org.apache.geode.management.configuration.MemberConfig;
@@ -89,7 +90,9 @@ public class LocatorClusterManagementServiceTest {
     managers.put(GatewayReceiverConfig.class, new GatewayReceiverConfigManager(cache));
 
     memberValidator = mock(MemberValidator.class);
-    persistenceService = spy(InternalConfigurationPersistenceService.class);
+
+    persistenceService = spy(new InternalConfigurationPersistenceService(
+        JAXBService.create(CacheConfig.class)));
 
     Set<String> groups = new HashSet<>();
     groups.add("cluster");

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -33,6 +32,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.cache.AbstractRegion;
+import org.apache.geode.internal.config.JAXBService;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 
 public class AlterAsyncEventQueueCommandTest {
@@ -46,9 +46,10 @@ public class AlterAsyncEventQueueCommandTest {
   private Set<String> groupSet = new HashSet<>();
 
   @Before
-  public void before() throws Exception {
+  public void setUp() {
     command = spy(AlterAsyncEventQueueCommand.class);
-    service = spy(InternalConfigurationPersistenceService.class);
+    service =
+        spy(new InternalConfigurationPersistenceService(JAXBService.create(CacheConfig.class)));
     configRegion = mock(AbstractRegion.class);
 
     doReturn(service).when(command).getConfigurationPersistenceService();
@@ -75,26 +76,26 @@ public class AlterAsyncEventQueueCommandTest {
   }
 
   @Test
-  public void mandatoryOption() throws Exception {
+  public void mandatoryOption() {
     gfsh.executeAndAssertThat(command, "alter async-event-queue").statusIsError()
         .containsOutput("Invalid command");
   }
 
   @Test
-  public void noOptionToModify() throws Exception {
+  public void noOptionToModify() {
     gfsh.executeAndAssertThat(command, "alter async-event-queue --id=test").statusIsError()
         .containsOutput("need to specify at least one option to modify.");
   }
 
   @Test
-  public void emptyConfiguration() throws Exception {
+  public void emptyConfiguration() {
     gfsh.executeAndAssertThat(command, "alter async-event-queue --id=test --batch-size=100")
         .statusIsError().containsOutput("Can not find an async event queue");
 
   }
 
   @Test
-  public void emptyConfiguration_ifExists() throws Exception {
+  public void emptyConfiguration_ifExists() {
     gfsh.executeAndAssertThat(command,
         "alter async-event-queue --id=test --batch-size=100 --if-exists").statusIsSuccess()
         .containsOutput("Skipping: Can not find an async event queue with id");
@@ -102,14 +103,14 @@ public class AlterAsyncEventQueueCommandTest {
   }
 
   @Test
-  public void cluster_config_service_not_available() throws Exception {
+  public void cluster_config_service_not_available() {
     doReturn(null).when(command).getConfigurationPersistenceService();
     gfsh.executeAndAssertThat(command, "alter async-event-queue --id=test --batch-size=100")
         .statusIsError().containsOutput("Cluster Configuration Service is not available");
   }
 
   @Test
-  public void queueIdNotFoundInTheMap() throws Exception {
+  public void queueIdNotFoundInTheMap() {
     gfsh.executeAndAssertThat(command,
         "alter async-event-queue --batch-size=100 --id=queue")
         .statusIsError().containsOutput("Can not find an async event queue");
@@ -117,7 +118,7 @@ public class AlterAsyncEventQueueCommandTest {
   }
 
   @Test
-  public void queueIdFoundInTheMap_updateBatchSize() throws Exception {
+  public void queueIdFoundInTheMap_updateBatchSize() {
     gfsh.executeAndAssertThat(command, "alter async-event-queue --batch-size=100 --id=queue1")
         .statusIsSuccess()
         .containsOutput("Cluster configuration for group 'group1' is updated")
@@ -126,7 +127,7 @@ public class AlterAsyncEventQueueCommandTest {
   }
 
   @Test
-  public void queueIdFoundInTheMap_updateBatchTimeInterval() throws Exception {
+  public void queueIdFoundInTheMap_updateBatchTimeInterval() {
     gfsh.executeAndAssertThat(command,
         "alter async-event-queue --batch-time-interval=100 --id=queue1")
         .statusIsSuccess()
@@ -140,7 +141,7 @@ public class AlterAsyncEventQueueCommandTest {
   }
 
   @Test
-  public void queueIdFoundInTheMap_updateMaxMemory() throws Exception {
+  public void queueIdFoundInTheMap_updateMaxMemory() {
     gfsh.executeAndAssertThat(command, "alter async-event-queue --max-queue-memory=100 --id=queue1")
         .statusIsSuccess()
         .containsOutput("Cluster configuration for group 'group1' is updated")


### PR DESCRIPTION
* Pass workingDirectory to InternalConfigurationPersistenceService
* Fixup InternalConfigurationPersistenceService constructors
* Create InternalLocatorIntegrationTest
* Use Path instead of String or File

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Michael Oleske <moleske@pivotal.io>
