### PR TITLE
GEODE-6948: Use Log4J loggers in Launchers

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -96,7 +96,10 @@ public abstract class AbstractLauncher<T extends Comparable<T>> implements Runna
 
   protected final transient AtomicBoolean running = new AtomicBoolean(false);
 
-  // TODO: use log4j logger instead of JUL
+  /**
+   * @deprecated Please use Log4J 2 instead.
+   */
+  @Deprecated
   protected Logger logger = Logger.getLogger(getClass().getName());
 
   public AbstractLauncher() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Level;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -52,6 +51,7 @@ import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.annotations.internal.MakeNotStatic;
@@ -65,6 +65,7 @@ import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.DistributionLocator;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.lang.ObjectUtils;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.process.ConnectionFailedException;
 import org.apache.geode.internal.process.ControlNotificationHandler;
@@ -92,6 +93,8 @@ import org.apache.geode.management.internal.cli.util.JsonUtil;
  */
 @SuppressWarnings({"unused"})
 public class LocatorLauncher extends AbstractLauncher<String> {
+
+  private static final Logger log = LogService.getLogger();
 
   @Immutable
   private static final Boolean DEFAULT_LOAD_SHARED_CONFIG_FROM_DIR = Boolean.FALSE;
@@ -681,6 +684,7 @@ public class LocatorLauncher extends AbstractLauncher<String> {
 
         debug("Running Locator on (%1$s) in (%2$s) as (%3$s)...", getId(), getWorkingDirectory(),
             getMember());
+        log.debug("Locator is online");
         running.set(true);
 
         return new LocatorState(this, Status.ONLINE);
@@ -730,11 +734,10 @@ public class LocatorLauncher extends AbstractLauncher<String> {
    * @param cause the Throwable thrown during the startup or wait operation on the Locator.
    */
   private void failOnStart(final Throwable cause) {
-
     if (cause != null) {
-      logger.log(Level.INFO, "locator is exiting due to an exception", cause);
+      log.info("locator is exiting due to an exception", cause);
     } else {
-      logger.log(Level.INFO, "locator is exiting normally");
+      log.info("locator is exiting normally");
     }
 
     if (this.locator != null) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ServerLauncher.java
@@ -55,6 +55,7 @@ import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.SystemFailure;
 import org.apache.geode.annotations.Immutable;
@@ -76,6 +77,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerHelper;
 import org.apache.geode.internal.lang.ObjectUtils;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingThread;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.process.ConnectionFailedException;
@@ -108,6 +110,8 @@ import org.apache.geode.security.GemFireSecurityException;
  */
 @SuppressWarnings("unused")
 public class ServerLauncher extends AbstractLauncher<String> {
+
+  private static final Logger log = LogService.getLogger();
 
   @Immutable
   private static final Map<String, String> helpMap;
@@ -808,6 +812,7 @@ public class ServerLauncher extends AbstractLauncher<String> {
 
           cache.setIsServer(true);
           startCacheServer(cache);
+          log.debug("Server is online");
           assignBuckets(cache);
           rebalance(cache);
         } finally {


### PR DESCRIPTION
I added a debug level statement in each launcher stating that either the Server or the Locator is online. This is a place-holder for the new info level statement to be added for GEODE-6918. I think it's ok to add trace or debug level statements like this.