### PR TITLE
GEODE-6897: refactor ClusterManagementResult into subclasses

### DIFF
--- a/geode-assembly/src/acceptanceTest/resources/ManagementClientCreateRegion.java
+++ b/geode-assembly/src/acceptanceTest/resources/ManagementClientCreateRegion.java
@@ -47,14 +47,14 @@ public class ManagementClientCreateRegion {
     config.setName(regionName);
     config.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> result = cms.create(config);
+    ClusterManagementResult result = cms.create(config);
 
     if (!result.isSuccessful()) {
       throw new RuntimeException(
           "Failure creating region: " + result.getStatusMessage());
     }
 
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> listResult =
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> listResult =
         cms.list(new RegionConfig());
     if (!listResult.isSuccessful()) {
       throw new RuntimeException("failed " + listResult.getStatusMessage());

--- a/geode-assembly/src/acceptanceTest/resources/ManagementClientCreateRegion.java
+++ b/geode-assembly/src/acceptanceTest/resources/ManagementClientCreateRegion.java
@@ -20,7 +20,6 @@ import org.apache.geode.cache.configuration.RegionType;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
-import org.apache.geode.management.runtime.RuntimeRegionInfo;
 
 public class ManagementClientCreateRegion {
   public static void main(String[] args) throws Exception {
@@ -54,8 +53,7 @@ public class ManagementClientCreateRegion {
           "Failure creating region: " + result.getStatusMessage());
     }
 
-    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> listResult =
-        cms.list(new RegionConfig());
+    ClusterManagementResult listResult = cms.list(new RegionConfig());
     if (!listResult.isSuccessful()) {
       throw new RuntimeException("failed " + listResult.getStatusMessage());
     }

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/client/CreateRegionWithDiskstoreAndSecurityDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/client/CreateRegionWithDiskstoreAndSecurityDUnitTest.java
@@ -84,7 +84,7 @@ public class CreateRegionWithDiskstoreAndSecurityDUnitTest {
         ClusterManagementServiceBuilder.buildWithHostAddress()
             .setHostAddress("localhost", locator.getHttpPort())
             .setCredentials("user", "user").build();
-    ClusterManagementResult<?, ?> result = client.create(regionConfig);
+    ClusterManagementResult result = client.create(regionConfig);
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.UNAUTHORIZED);
     assertThat(result.getStatusMessage()).isEqualTo("user not authorized for DATA:MANAGE");
@@ -109,7 +109,7 @@ public class CreateRegionWithDiskstoreAndSecurityDUnitTest {
         ClusterManagementServiceBuilder.buildWithHostAddress()
             .setHostAddress("localhost", locator.getHttpPort())
             .setCredentials("data", "data").build();
-    ClusterManagementResult<?, ?> result = client.create(regionConfig);
+    ClusterManagementResult result = client.create(regionConfig);
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.UNAUTHORIZED);
     assertThat(result.getStatusMessage()).isEqualTo("data not authorized for CLUSTER:WRITE:DISK");
@@ -136,7 +136,7 @@ public class CreateRegionWithDiskstoreAndSecurityDUnitTest {
         ClusterManagementServiceBuilder.buildWithHostAddress()
             .setHostAddress("localhost", locator.getHttpPort())
             .setCredentials("data,cluster", "data,cluster").build();
-    ClusterManagementResult<?, ?> result = client.create(regionConfig);
+    ClusterManagementResult result = client.create(regionConfig);
     assertThat(result.isSuccessful()).isTrue();
 
     gfsh.executeAndAssertThat("describe disk-store --name=DISKSTORE --member=server-1")

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementSSLTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementSSLTest.java
@@ -105,7 +105,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .setCredentials("dataManage", "dataManage").build();
 
-      ClusterManagementResult<?, ?> result = cmsClient.create(region);
+      ClusterManagementResult result = cmsClient.create(region);
       assertThat(result.isSuccessful()).isTrue();
       assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
       assertThat(result.getMemberStatuses()).extracting(RealizationResult::getMemberName)
@@ -146,7 +146,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .setCredentials("dataManage", "wrongPassword").build();
 
-      ClusterManagementResult<?, ?> result = cmsClient.create(region);
+      ClusterManagementResult result = cmsClient.create(region);
       assertThat(result.isSuccessful()).isFalse();
       assertThat(result.getStatusCode())
           .isEqualTo(ClusterManagementResult.StatusCode.UNAUTHENTICATED);
@@ -170,7 +170,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .build();
 
-      ClusterManagementResult<?, ?> result = cmsClient.create(region);
+      ClusterManagementResult result = cmsClient.create(region);
       assertThat(result.isSuccessful()).isFalse();
       assertThat(result.getStatusCode())
           .isEqualTo(ClusterManagementResult.StatusCode.UNAUTHENTICATED);
@@ -193,7 +193,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .setCredentials("dataManage", null).build();
 
-      ClusterManagementResult<?, ?> result = cmsClient.create(region);
+      ClusterManagementResult result = cmsClient.create(region);
       assertThat(result.isSuccessful()).isFalse();
       assertThat(result.getStatusCode())
           .isEqualTo(ClusterManagementResult.StatusCode.UNAUTHENTICATED);
@@ -216,7 +216,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .setCredentials("dataRead", "dataRead").build();
 
-      ClusterManagementResult<?, ?> result = cmsClient.create(region);
+      ClusterManagementResult result = cmsClient.create(region);
       assertThat(result.isSuccessful()).isFalse();
       assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.UNAUTHORIZED);
     });

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementServiceDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementServiceDunitTest.java
@@ -61,7 +61,7 @@ public class ClientClusterManagementServiceDunitTest {
     region.setName("customer");
     region.setType(RegionType.PARTITION);
 
-    ClusterManagementResult<?, ?> result = cmsClient.create(region);
+    ClusterManagementResult result = cmsClient.create(region);
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
@@ -79,7 +79,7 @@ public class ClientClusterManagementServiceDunitTest {
     region.setName("orders");
     region.setType(RegionType.PARTITION);
 
-    ClusterManagementResult<?, ?> result = cmsClient.create(region);
+    ClusterManagementResult result = cmsClient.create(region);
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
@@ -93,7 +93,7 @@ public class ClientClusterManagementServiceDunitTest {
     RegionConfig region = new RegionConfig();
     region.setName("__test");
 
-    ClusterManagementResult<?, ?> result = cmsClient.create(region);
+    ClusterManagementResult result = cmsClient.create(region);
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusCode())
         .isEqualTo(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT);
@@ -106,7 +106,7 @@ public class ClientClusterManagementServiceDunitTest {
     region.setType(RegionType.PARTITION);
     region.setGroup(groupA);
 
-    ClusterManagementResult<?, ?> result = cmsClient.create(region);
+    ClusterManagementResult result = cmsClient.create(region);
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClusterManagementLocatorReconnectDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClusterManagementLocatorReconnectDunitTest.java
@@ -74,7 +74,7 @@ public class ClusterManagementLocatorReconnectDunitTest {
     ObjectMapper mapper = new ObjectMapper();
     String json = mapper.writeValueAsString(regionConfig);
 
-    ClusterManagementResult<?, ?> result =
+    ClusterManagementResult result =
         restClient.doPostAndAssert("/regions", json, "test", "test")
             .hasStatusCode(201)
             .getClusterManagementResult();

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClusterManagementServiceOnServerTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClusterManagementServiceOnServerTest.java
@@ -125,7 +125,7 @@ public class ClusterManagementServiceOnServerTest implements Serializable {
           buildWithCache().setCache(ClusterStartupRule.getCache())
               .build();
       assertThat(service).isNotNull();
-      ClusterManagementResult<?, ?> clusterManagementResult =
+      ClusterManagementResult clusterManagementResult =
           service.create(regionConfig);
       assertThat(clusterManagementResult.isSuccessful()).isTrue();
     });

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GatewayReceiverManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GatewayReceiverManagementDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.rest;
 
+import static org.apache.geode.test.junit.assertions.ClusterManagementListResultAssert.assertManagementListResult;
 import static org.apache.geode.test.junit.assertions.ClusterManagementResultAssert.assertManagementResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,7 +35,7 @@ import org.apache.geode.management.client.ClusterManagementServiceBuilder;
 import org.apache.geode.management.runtime.GatewayReceiverInfo;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
-import org.apache.geode.test.junit.assertions.ClusterManagementResultAssert;
+import org.apache.geode.test.junit.assertions.ClusterManagementListResultAssert;
 import org.apache.geode.test.junit.rules.MemberStarterRule;
 
 public class GatewayReceiverManagementDUnitTest {
@@ -94,8 +95,8 @@ public class GatewayReceiverManagementDUnitTest {
         .hasStatusCode(ClusterManagementResult.StatusCode.ENTITY_EXISTS)
         .containsStatusMessage("Member(s) server-1 already has this element created");
 
-    ClusterManagementResultAssert<GatewayReceiverConfig, GatewayReceiverInfo> listAssert =
-        assertManagementResult(cms.list(new GatewayReceiverConfig())).isSuccessful();
+    ClusterManagementListResultAssert<GatewayReceiverConfig, GatewayReceiverInfo> listAssert =
+        assertManagementListResult(cms.list(new GatewayReceiverConfig())).isSuccessful();
     List<ConfigurationResult<GatewayReceiverConfig, GatewayReceiverInfo>> listResult =
         listAssert.getResult();
 

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
@@ -75,7 +75,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     regionConfig = new RegionConfig();
   }
 
@@ -87,7 +87,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void getRegion() throws Exception {
+  public void getRegion() {
     regionConfig.setName("region1");
     List<RegionConfig> regions = cms.get(regionConfig).getConfigResult();
     assertThat(regions).hasSize(1);
@@ -97,14 +97,14 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void getNonExistRegion() throws Exception {
+  public void getNonExistRegion() {
     regionConfig.setName("notExist");
     assertManagementResult(cms.get(regionConfig)).failed().hasStatusCode(
         ClusterManagementResult.StatusCode.ENTITY_NOT_FOUND);
   }
 
   @Test
-  public void listIndexForOneRegion() throws Exception {
+  public void listIndexForOneRegion() {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> list = cms.list(index);
@@ -113,7 +113,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void getIndex() throws Exception {
+  public void getIndex() {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index1");
@@ -128,7 +128,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void getIndexWithoutIndexId() throws Exception {
+  public void getIndexWithoutIndexId() {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     assertThatThrownBy(() -> cms.get(index)).isInstanceOf(IllegalArgumentException.class)
@@ -136,7 +136,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void getIndexWithoutRegionName() throws Exception {
+  public void getIndexWithoutRegionName() {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setName("index1");
     assertThatThrownBy(() -> cms.get(index)).isInstanceOf(IllegalArgumentException.class)
@@ -144,7 +144,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void listIndexesWithIdFilter() throws Exception {
+  public void listIndexesWithIdFilter() {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index1");
@@ -159,7 +159,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void getNonExistingIndex() throws Exception {
+  public void getNonExistingIndex() {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index333");
@@ -168,7 +168,7 @@ public class ListIndexManagementDUnitTest {
   }
 
   @Test
-  public void listNonExistingIndexesWithIdFilter() throws Exception {
+  public void listNonExistingIndexesWithIdFilter() {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index333");

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.configuration.RegionType;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
@@ -106,7 +107,7 @@ public class ListIndexManagementDUnitTest {
   public void listIndexForOneRegion() throws Exception {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
-    ClusterManagementResult<RegionConfig.Index, RuntimeInfo> list = cms.list(index);
+    ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> list = cms.list(index);
     List<RegionConfig.Index> result = list.getConfigResult();
     assertThat(result).hasSize(2);
   }
@@ -116,7 +117,7 @@ public class ListIndexManagementDUnitTest {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index1");
-    ClusterManagementResult<RegionConfig.Index, RuntimeInfo> list = cms.get(index);
+    ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> list = cms.get(index);
     List<RegionConfig.Index> result = list.getConfigResult();
     assertThat(result).hasSize(1);
     RegionConfig.Index runtimeIndex = result.get(0);
@@ -147,7 +148,7 @@ public class ListIndexManagementDUnitTest {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index1");
-    ClusterManagementResult<RegionConfig.Index, RuntimeInfo> list = cms.list(index);
+    ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> list = cms.list(index);
     List<RegionConfig.Index> result = list.getConfigResult();
     assertThat(result).hasSize(1);
     RegionConfig.Index runtimeIndex = result.get(0);
@@ -171,7 +172,7 @@ public class ListIndexManagementDUnitTest {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index333");
-    ClusterManagementResult<RegionConfig.Index, RuntimeInfo> list = cms.list(index);
+    ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> list = cms.list(index);
     List<RegionConfig.Index> result = list.getConfigResult();
     assertThat(result).hasSize(0);
     assertThat(list.isSuccessful()).isTrue();

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListRegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListRegionManagementDunitTest.java
@@ -30,7 +30,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.configuration.RegionType;
-import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
 import org.apache.geode.management.runtime.RuntimeRegionInfo;
@@ -153,7 +153,7 @@ public class ListRegionManagementDunitTest {
     });
 
     filter.setName("customers");
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> result = client.list(filter);
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> result = client.list(filter);
     List<RegionConfig> regions = result.getConfigResult();
     assertThat(regions).hasSize(1);
     RegionConfig regionConfig = regions.get(0);

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListRegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListRegionManagementDunitTest.java
@@ -104,12 +104,12 @@ public class ListRegionManagementDunitTest {
   }
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     filter = new RegionConfig();
   }
 
   @Test
-  public void listAll() throws Exception {
+  public void listAll() {
     // list all
     List<RegionConfig> regions = client.list(filter).getConfigResult();
     assertThat(regions).hasSize(5);
@@ -128,7 +128,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listClusterLevel() throws Exception {
+  public void listClusterLevel() {
     // list cluster level only
     filter.setGroup("cluster");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
@@ -138,7 +138,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void testEntryCount() throws Exception {
+  public void testEntryCount() {
     server1.invoke(() -> {
       Region<String, String> region = ClusterStartupRule.getCache().getRegion("/customers");
       region.put("k1", "v1");
@@ -165,7 +165,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listGroup1() throws Exception {
+  public void listGroup1() {
     // list group1
     filter.setGroup("group1");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
@@ -182,7 +182,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listGroup2() throws Exception {
+  public void listGroup2() {
     // list group1
     filter.setGroup("group2");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
@@ -196,7 +196,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listNonExistentGroup() throws Exception {
+  public void listNonExistentGroup() {
     // list non-existent group
     filter.setGroup("group3");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
@@ -204,7 +204,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listRegionByName() throws Exception {
+  public void listRegionByName() {
     filter.setName("customers");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
     assertThat(regions).hasSize(1);
@@ -213,7 +213,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listRegionByName1() throws Exception {
+  public void listRegionByName1() {
     filter.setName("customers1");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
     assertThat(regions).hasSize(1);
@@ -222,7 +222,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listRegionByName2() throws Exception {
+  public void listRegionByName2() {
     filter.setName("customers2");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
     assertThat(regions).hasSize(2);
@@ -236,7 +236,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listRegionByName3() throws Exception {
+  public void listRegionByName3() {
     filter.setName("customers3");
     List<RegionConfig> regions = client.list(filter).getConfigResult();
     assertThat(regions).hasSize(1);
@@ -245,7 +245,7 @@ public class ListRegionManagementDunitTest {
   }
 
   @Test
-  public void listNonExistentRegion() throws Exception {
+  public void listNonExistentRegion() {
     // list non-existent region
     filter.setName("customer4");
     List<RegionConfig> regions = client.list(filter).getConfigResult();

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDUnitTest.java
@@ -67,7 +67,7 @@ public class ManagementRequestLoggingDUnitTest {
     regionConfig.setName("customers");
     regionConfig.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> result = service.create(regionConfig);
+    ClusterManagementResult result = service.create(regionConfig);
     assertThat(result.isSuccessful()).isTrue();
 
     locator.invoke(() -> {

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/MemberManagementServiceDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/MemberManagementServiceDunitTest.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
@@ -50,7 +51,7 @@ public class MemberManagementServiceDunitTest {
   @Test
   public void listAllMembers() {
     MemberConfig config = new MemberConfig();
-    ClusterManagementResult<MemberConfig, MemberInformation> result = cmsClient.list(config);
+    ClusterManagementListResult<MemberConfig, MemberInformation> result = cmsClient.list(config);
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
@@ -68,7 +69,7 @@ public class MemberManagementServiceDunitTest {
     MemberConfig config = new MemberConfig();
     config.setId("locator-0");
 
-    ClusterManagementResult<MemberConfig, MemberInformation> result = cmsClient.list(config);
+    ClusterManagementListResult<MemberConfig, MemberInformation> result = cmsClient.list(config);
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
     assertThat(result.getRuntimeResult().size()).isEqualTo(1);
@@ -83,7 +84,7 @@ public class MemberManagementServiceDunitTest {
   public void listNonExistentMember() {
     MemberConfig config = new MemberConfig();
     config.setId("locator");
-    ClusterManagementResult<MemberConfig, MemberInformation> result = cmsClient.list(config);
+    ClusterManagementListResult<MemberConfig, MemberInformation> result = cmsClient.list(config);
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode())
         .isEqualTo(ClusterManagementResult.StatusCode.OK);

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
@@ -72,7 +72,7 @@ public class RegionManagementDunitTest {
     regionConfig.setGroup("group1");
     regionConfig.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> result = cms.create(regionConfig);
+    ClusterManagementResult result = cms.create(regionConfig);
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getMemberStatuses()).extracting(RealizationResult::getMemberName)
@@ -120,7 +120,7 @@ public class RegionManagementDunitTest {
   public void createsAPartitionedRegion() throws Exception {
     String json = "{\"name\": \"orders\", \"type\": \"PARTITION\", \"group\": \"group1\"}";
 
-    ClusterManagementResult<?, ?> result =
+    ClusterManagementResult result =
         restClient.doPostAndAssert("/regions", json)
             .hasStatusCode(201)
             .getClusterManagementResult();
@@ -147,7 +147,7 @@ public class RegionManagementDunitTest {
     IgnoredException.addIgnoredException("Name of the region has to be specified");
     String json = "{\"type\": \"REPLICATE\"}";
 
-    ClusterManagementResult<?, ?> result =
+    ClusterManagementResult result =
         restClient.doPostAndAssert("/regions", json)
             .hasStatusCode(400)
             .getClusterManagementResult();

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -677,11 +677,13 @@ javadoc/org/apache/geode/management/PersistentMemberDetails.html
 javadoc/org/apache/geode/management/RegionAttributesData.html
 javadoc/org/apache/geode/management/RegionMXBean.html
 javadoc/org/apache/geode/management/ServerLoadData.html
+javadoc/org/apache/geode/management/api/ClusterManagementListResult.html
 javadoc/org/apache/geode/management/api/ClusterManagementResult.StatusCode.html
 javadoc/org/apache/geode/management/api/ClusterManagementResult.html
 javadoc/org/apache/geode/management/api/ClusterManagementService.html
 javadoc/org/apache/geode/management/api/ConfigurationResult.html
 javadoc/org/apache/geode/management/api/CorrespondWith.html
+javadoc/org/apache/geode/management/api/JsonSerializable.html
 javadoc/org/apache/geode/management/api/RealizationResult.html
 javadoc/org/apache/geode/management/api/RestfulEndpoint.html
 javadoc/org/apache/geode/management/api/package-frame.html

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/api/RegionAPIDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/api/RegionAPIDUnitTest.java
@@ -64,7 +64,7 @@ public class RegionAPIDUnitTest {
       RegionConfig config = new RegionConfig();
       config.setName(regionName);
       config.setType(RegionType.PARTITION);
-      ClusterManagementResult<?, ?> result =
+      ClusterManagementResult result =
           ClusterStartupRule.getLocator().getClusterManagementService()
               .create(config);
       assertThat(result.isSuccessful()).isTrue();
@@ -90,7 +90,7 @@ public class RegionAPIDUnitTest {
       RegionConfig config = new RegionConfig();
       config.setName(regionName);
       config.setType(RegionType.REPLICATE);
-      ClusterManagementResult<?, ?> result =
+      ClusterManagementResult result =
           ClusterStartupRule.getLocator().getClusterManagementService()
               .create(config);
       assertThat(result.isSuccessful()).isTrue();
@@ -108,7 +108,7 @@ public class RegionAPIDUnitTest {
       RegionConfig config = new RegionConfig();
       config.setName(regionName);
       config.setType(RegionType.PARTITION);
-      ClusterManagementResult<?, ?> result =
+      ClusterManagementResult result =
           ClusterStartupRule.getLocator().getClusterManagementService()
               .create(config);
       assertThat(result.isSuccessful()).isTrue();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -45,6 +45,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.api.ConfigurationResult;
@@ -101,7 +102,7 @@ public class LocatorClusterManagementService implements ClusterManagementService
   }
 
   @Override
-  public <T extends CacheElement> ClusterManagementResult<?, ?> create(T config) {
+  public <T extends CacheElement> ClusterManagementResult create(T config) {
     // validate that user used the correct config object type
     ConfigurationManager configurationManager = getConfigurationManager(config);
 
@@ -164,7 +165,7 @@ public class LocatorClusterManagementService implements ClusterManagementService
   }
 
   @Override
-  public <T extends CacheElement> ClusterManagementResult<?, ?> delete(
+  public <T extends CacheElement> ClusterManagementResult delete(
       T config) {
     // validate that user used the correct config object type
     ConfigurationManager configurationManager = getConfigurationManager(config);
@@ -231,18 +232,18 @@ public class LocatorClusterManagementService implements ClusterManagementService
   }
 
   @Override
-  public <T extends CacheElement> ClusterManagementResult<?, ?> update(
+  public <T extends CacheElement> ClusterManagementResult update(
       T config) {
     throw new NotImplementedException("Not implemented");
   }
 
   @Override
-  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementResult<T, R> list(
+  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> list(
       T filter) {
-    ClusterManagementResult<T, R> result = new ClusterManagementResult<>();
+    ClusterManagementListResult<T, R> result = new ClusterManagementListResult<>();
 
     if (persistenceService == null) {
-      return new ClusterManagementResult<>(false,
+      return new ClusterManagementListResult<>(false,
           "Cluster configuration service needs to be enabled");
     }
 
@@ -340,9 +341,9 @@ public class LocatorClusterManagementService implements ClusterManagementService
   }
 
   @Override
-  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementResult<T, R> get(
+  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> get(
       T config) {
-    ClusterManagementResult<T, R> list = list(config);
+    ClusterManagementListResult<T, R> list = list(config);
     List<ConfigurationResult<T, R>> result = list.getResult();
 
     if (result.size() == 0) {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/ClusterManagementResultTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/ClusterManagementResultTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ConfigurationResult;
 import org.apache.geode.management.runtime.RuntimeRegionInfo;
@@ -38,7 +39,7 @@ public class ClusterManagementResultTest {
 
   @Before
   public void setup() {
-    result = new ClusterManagementResult<>();
+    result = new ClusterManagementResult();
   }
 
   @Test
@@ -99,11 +100,11 @@ public class ClusterManagementResultTest {
     result = new ClusterManagementResult(false, "message");
     assertThat(result.getStatusCode()).isEqualTo(ERROR);
 
-    result = new ClusterManagementResult<>();
+    result = new ClusterManagementResult();
     result.setStatus(false, "message");
     assertThat(result.getStatusCode()).isEqualTo(ERROR);
 
-    result = new ClusterManagementResult<>();
+    result = new ClusterManagementResult();
     result.setStatus(true, "message");
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
     result.addMemberStatus("member-1", true, "message-1");
@@ -115,16 +116,16 @@ public class ClusterManagementResultTest {
   @Test
   public void deserialize() throws Exception {
     String json = "{\"statusCode\":\"OK\"}";
-    ClusterManagementResult result =
-        GeodeJsonMapper.getMapper().readValue(json, ClusterManagementResult.class);
+    ClusterManagementListResult result =
+        GeodeJsonMapper.getMapper().readValue(json, ClusterManagementListResult.class);
     assertThat(result.getResult()).isNotNull().isEmpty();
   }
 
   @Test
   public void serializeResult() throws Exception {
     ObjectMapper mapper = GeodeJsonMapper.getMapper();
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> result =
-        new ClusterManagementResult<>();
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> result =
+        new ClusterManagementListResult<>();
     ConfigurationResult<RegionConfig, RuntimeRegionInfo> response = new ConfigurationResult<>();
     RegionConfig region = new RegionConfig();
     region.setName("region");
@@ -139,8 +140,8 @@ public class ClusterManagementResultTest {
 
     String json = mapper.writeValueAsString(result);
     System.out.println(json);
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> result1 =
-        mapper.readValue(json, ClusterManagementResult.class);
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> result1 =
+        mapper.readValue(json, ClusterManagementListResult.class);
     assertThat(result1.getConfigResult()).hasSize(1)
         .extracting(RegionConfig::getName).containsExactly("region");
     assertThat(result1.getRuntimeResult()).hasSize(1)

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -70,7 +70,7 @@ public class LocatorClusterManagementServiceTest {
   private InternalCache cache;
   private InternalConfigurationPersistenceService persistenceService;
   private RegionConfig regionConfig;
-  private ClusterManagementResult<?, ?> result;
+  private ClusterManagementResult result;
   private Map<Class, ConfigurationValidator> validators = new HashMap<>();
   private Map<Class, ConfigurationManager> managers = new HashMap<>();
   private ConfigurationValidator<RegionConfig> regionValidator;
@@ -310,7 +310,7 @@ public class LocatorClusterManagementServiceTest {
     Region mockRegion = mock(Region.class);
     doReturn(mockRegion).when(persistenceService).getConfigurationRegion();
 
-    ClusterManagementResult<?, ?> result = service.delete(regionConfig);
+    ClusterManagementResult result = service.delete(regionConfig);
     verify(regionManager).delete(eq(regionConfig), any());
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getMemberStatuses()).hasSize(0);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandTest.java
@@ -37,7 +37,7 @@ import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
-import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.result.CommandResult;
@@ -150,7 +150,7 @@ public class CreateIndexCommandTest {
     // the existing configuration has a region named /regionA.B
     doReturn(mock(RegionConfig.class)).when(command).getRegionConfig(cms,
         "/regionA.B");
-    when(cms.list(any())).thenReturn(new ClusterManagementResult<>());
+    when(cms.list(any())).thenReturn(new ClusterManagementListResult<>());
 
     assertThat(command.getValidRegionName("regionB", cms)).isEqualTo("regionB");
     assertThat(command.getValidRegionName("/regionB", cms)).isEqualTo("/regionB");

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/ClusterManagementListResultAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/assertions/ClusterManagementListResultAssert.java
@@ -22,33 +22,39 @@ import java.util.List;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.ListAssert;
 
+import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ConfigurationResult;
+import org.apache.geode.management.api.CorrespondWith;
 import org.apache.geode.management.api.RealizationResult;
+import org.apache.geode.management.runtime.RuntimeInfo;
 
-public class ClusterManagementResultAssert
-    extends AbstractAssert<ClusterManagementResultAssert, ClusterManagementResult> {
-  public ClusterManagementResultAssert(
-      ClusterManagementResult clusterManagementResult, Class<?> selfType) {
+public class ClusterManagementListResultAssert<T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo>
+    extends
+    AbstractAssert<ClusterManagementListResultAssert<T, R>, ClusterManagementListResult<T, R>> {
+  public ClusterManagementListResultAssert(
+      ClusterManagementListResult<T, R> clusterManagementResult, Class<?> selfType) {
     super(clusterManagementResult, selfType);
   }
 
-  public ClusterManagementResultAssert isSuccessful() {
+  public ClusterManagementListResultAssert<T, R> isSuccessful() {
     assertThat(actual.isSuccessful()).isTrue();
     return this;
   }
 
-  public ClusterManagementResultAssert failed() {
+  public ClusterManagementListResultAssert<T, R> failed() {
     assertThat(actual.isSuccessful()).isFalse();
     return this;
   }
 
-  public ClusterManagementResultAssert hasStatusCode(
+  public ClusterManagementListResultAssert<T, R> hasStatusCode(
       ClusterManagementResult.StatusCode... codes) {
     assertThat(actual.getStatusCode()).isIn(codes);
     return this;
   }
 
-  public ClusterManagementResultAssert containsStatusMessage(String statusMessage) {
+  public ClusterManagementListResultAssert<T, R> containsStatusMessage(String statusMessage) {
     assertThat(actual.getStatusMessage()).contains(statusMessage);
     return this;
   }
@@ -61,12 +67,24 @@ public class ClusterManagementResultAssert
     return actual.getMemberStatuses();
   }
 
-  public static ClusterManagementResultAssert assertManagementResult(
-      ClusterManagementResult result) {
-    return new ClusterManagementResultAssert(result, ClusterManagementResultAssert.class);
+  public List<ConfigurationResult<T, R>> getResult() {
+    return actual.getResult();
+  };
+
+  public ListAssert<T> hasConfigurations() {
+    return assertThat(getActual().getConfigResult());
   }
 
-  public ClusterManagementResult getActual() {
+  public ListAssert<R> hasRuntimeInfos() {
+    return assertThat(getActual().getRuntimeResult());
+  }
+
+  public static <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResultAssert<T, R> assertManagementListResult(
+      ClusterManagementListResult<T, R> result) {
+    return new ClusterManagementListResultAssert<>(result, ClusterManagementListResultAssert.class);
+  }
+
+  public ClusterManagementListResult<T, R> getActual() {
     return actual;
   }
 }

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementListResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementListResult.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.geode.annotations.Experimental;
+import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.management.runtime.RuntimeInfo;
+
+@Experimental
+public class ClusterManagementListResult<T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo>
+    extends ClusterManagementResult {
+  public ClusterManagementListResult() {}
+
+  public ClusterManagementListResult(boolean success, String message) {
+    super(success, message);
+  }
+
+  public ClusterManagementListResult(StatusCode statusCode, String message) {
+    super(statusCode, message);
+  }
+
+  // Override the mapper setting so that we always show result
+  @JsonInclude
+  @JsonProperty
+  private List<ConfigurationResult<T, R>> result = new ArrayList<>();
+
+  public List<ConfigurationResult<T, R>> getResult() {
+    return result;
+  }
+
+  @JsonIgnore
+  public List<T> getConfigResult() {
+    return result.stream().map(ConfigurationResult::getConfig).collect(Collectors.toList());
+  }
+
+  @JsonIgnore
+  public List<R> getRuntimeResult() {
+    return result.stream().flatMap(r -> r.getRuntimeInfo().stream()).collect(Collectors.toList());
+  }
+
+  public void setResult(List<ConfigurationResult<T, R>> result) {
+    this.result = result;
+  }
+
+}

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
@@ -16,18 +16,14 @@ package org.apache.geode.management.api;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.geode.annotations.Experimental;
-import org.apache.geode.cache.configuration.CacheElement;
-import org.apache.geode.management.runtime.RuntimeInfo;
+
 
 @Experimental
-public class ClusterManagementResult<T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> {
+public class ClusterManagementResult {
   // this error code should include a one-to-one mapping to the http status code returned
   // by the controller
   public enum StatusCode {
@@ -122,28 +118,4 @@ public class ClusterManagementResult<T extends CacheElement & CorrespondWith<R>,
   public StatusCode getStatusCode() {
     return statusCode;
   }
-
-  // Override the mapper setting so that we always show result
-  @JsonInclude
-  @JsonProperty
-  private List<ConfigurationResult<T, R>> result = new ArrayList<>();
-
-  public List<ConfigurationResult<T, R>> getResult() {
-    return result;
-  }
-
-  @JsonIgnore
-  public List<T> getConfigResult() {
-    return result.stream().map(ConfigurationResult::getConfig).collect(Collectors.toList());
-  }
-
-  @JsonIgnore
-  public List<R> getRuntimeResult() {
-    return result.stream().flatMap(r -> r.getRuntimeInfo().stream()).collect(Collectors.toList());
-  }
-
-  public void setResult(List<ConfigurationResult<T, R>> result) {
-    this.result = result;
-  }
-
 }

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
@@ -36,7 +36,7 @@ public interface ClusterManagementService {
    *        cluster, as well as the group this config belongs to
    * @see CacheElement
    */
-  <T extends CacheElement> ClusterManagementResult<?, ?> create(T config);
+  <T extends CacheElement> ClusterManagementResult create(T config);
 
   /**
    * This method will delete the element on all the applicable members in the cluster and update the
@@ -47,7 +47,7 @@ public interface ClusterManagementService {
    * @throws IllegalArgumentException, NoMemberException, EntityExistsException
    * @see CacheElement
    */
-  <T extends CacheElement> ClusterManagementResult<?, ?> delete(T config);
+  <T extends CacheElement> ClusterManagementResult delete(T config);
 
   /**
    * This method will update the element on all the applicable members in the cluster and persist
@@ -58,12 +58,12 @@ public interface ClusterManagementService {
    * @throws IllegalArgumentException, NoMemberException, EntityExistsException
    * @see CacheElement
    */
-  <T extends CacheElement> ClusterManagementResult<?, ?> update(T config);
+  <T extends CacheElement> ClusterManagementResult update(T config);
 
-  <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementResult<T, R> list(
+  <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> list(
       T config);
 
-  <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementResult<T, R> get(
+  <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> get(
       T config);
 
   /**

--- a/geode-management/src/main/java/org/apache/geode/management/api/JsonSerializable.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/JsonSerializable.java
@@ -13,20 +13,10 @@
  * the License.
  */
 
-package org.apache.geode.management.runtime;
+package org.apache.geode.management.api;
 
-import java.io.Serializable;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
-import org.apache.geode.management.api.JsonSerializable;
-
-public abstract class RuntimeInfo implements Serializable, JsonSerializable {
-  private String memberName;
-
-  public void setMemberName(String memberName) {
-    this.memberName = memberName;
-  }
-
-  public String getMemberName() {
-    return memberName;
-  }
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "class")
+public interface JsonSerializable {
 }

--- a/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
 import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.api.CorrespondWith;
@@ -55,7 +56,7 @@ public class ClientClusterManagementService implements ClusterManagementService 
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T extends CacheElement> ClusterManagementResult<?, ?> create(T config) {
+  public <T extends CacheElement> ClusterManagementResult create(T config) {
     String endPoint = getEndpoint(config);
     // the response status code info is represented by the ClusterManagementResult.errorCode already
     return restTemplate
@@ -65,7 +66,7 @@ public class ClientClusterManagementService implements ClusterManagementService 
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T extends CacheElement> ClusterManagementResult<?, ?> delete(
+  public <T extends CacheElement> ClusterManagementResult delete(
       T config) {
     String uri = getIdentityEndPoint(config);
     return restTemplate
@@ -78,28 +79,28 @@ public class ClientClusterManagementService implements ClusterManagementService 
   }
 
   @Override
-  public <T extends CacheElement> ClusterManagementResult<?, ?> update(
+  public <T extends CacheElement> ClusterManagementResult update(
       T config) {
     throw new NotImplementedException("Not Implemented");
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementResult<T, R> list(
+  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> list(
       T config) {
     String endPoint = getEndpoint(config);
     return restTemplate
         .getForEntity(endPoint + "/?id={id}&group={group}",
-            ClusterManagementResult.class, config.getId(), config.getGroup())
+            ClusterManagementListResult.class, config.getId(), config.getGroup())
         .getBody();
   }
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementResult<T, R> get(
+  public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> get(
       T config) {
     return restTemplate
-        .getForEntity(getIdentityEndPoint(config), ClusterManagementResult.class)
+        .getForEntity(getIdentityEndPoint(config), ClusterManagementListResult.class)
         .getBody();
   }
 

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ClientClusterManagementServiceDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ClientClusterManagementServiceDUnitTest.java
@@ -15,7 +15,7 @@
 
 package org.apache.geode.management.client;
 
-
+import static org.apache.geode.test.junit.assertions.ClusterManagementListResultAssert.assertManagementListResult;
 import static org.apache.geode.test.junit.assertions.ClusterManagementResultAssert.assertManagementResult;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,6 +35,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.configuration.RegionType;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.api.RealizationResult;
@@ -92,16 +93,16 @@ public class ClientClusterManagementServiceDUnitTest {
     region.setName("customer");
     region.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> createResult = client.create(region);
+    ClusterManagementResult createResult = client.create(region);
     assertManagementResult(createResult).hasStatusCode(ClusterManagementResult.StatusCode.OK);
 
-    ClusterManagementResult<?, ?> deleteResult = client.delete(region);
+    ClusterManagementResult deleteResult = client.delete(region);
     assertManagementResult(deleteResult)
         .hasStatusCode(ClusterManagementResult.StatusCode.OK);
 
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> listResult =
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> listResult =
         client.list(new RegionConfig());
-    assertManagementResult(listResult)
+    assertManagementListResult(listResult)
         .hasStatusCode(ClusterManagementResult.StatusCode.OK)
         .hasConfigurations()
         .isEmpty();
@@ -115,17 +116,17 @@ public class ClientClusterManagementServiceDUnitTest {
     region.setGroup("group1");
     region.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> createResult = client.create(region);
+    ClusterManagementResult createResult = client.create(region);
     assertManagementResult(createResult).hasStatusCode(ClusterManagementResult.StatusCode.OK);
 
     region.setGroup(null);
-    ClusterManagementResult<?, ?> deleteResult = client.delete(region);
+    ClusterManagementResult deleteResult = client.delete(region);
     assertManagementResult(deleteResult)
         .hasStatusCode(ClusterManagementResult.StatusCode.OK);
 
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> listResult =
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> listResult =
         client.list(new RegionConfig());
-    assertManagementResult(listResult)
+    assertManagementListResult(listResult)
         .hasStatusCode(ClusterManagementResult.StatusCode.OK)
         .hasConfigurations()
         .isEmpty();
@@ -139,7 +140,7 @@ public class ClientClusterManagementServiceDUnitTest {
     region.setGroup("group1");
     region.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> result = client.create(region);
+    ClusterManagementResult result = client.create(region);
     assertManagementResult(result).isSuccessful().hasMemberStatus()
         .extracting(RealizationResult::getMemberName)
         .containsExactlyInAnyOrder("server-1",
@@ -160,7 +161,7 @@ public class ClientClusterManagementServiceDUnitTest {
     region.setGroup("group1");
     region.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> result = client.create(region);
+    ClusterManagementResult result = client.create(region);
     assertManagementResult(result).isSuccessful().hasMemberStatus()
         .extracting(RealizationResult::getMemberName)
         .containsExactlyInAnyOrder("server-1",
@@ -172,7 +173,7 @@ public class ClientClusterManagementServiceDUnitTest {
         ClusterManagementResult.StatusCode.ENTITY_EXISTS);
 
     region.setGroup(null);
-    ClusterManagementResult<?, ?> deleteResult = client.delete(region);
+    ClusterManagementResult deleteResult = client.delete(region);
 
     assertManagementResult(deleteResult).isSuccessful();
 
@@ -191,7 +192,7 @@ public class ClientClusterManagementServiceDUnitTest {
     region.setGroup("group1");
     region.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> result = client.create(region);
+    ClusterManagementResult result = client.create(region);
     assertManagementResult(result).isSuccessful().hasMemberStatus()
         .extracting(RealizationResult::getMemberName)
         .containsExactlyInAnyOrder("server-1",
@@ -208,7 +209,7 @@ public class ClientClusterManagementServiceDUnitTest {
     RegionConfig region = new RegionConfig();
     region.setName("unknown");
 
-    ClusterManagementResult<?, ?> result = client.delete(region);
+    ClusterManagementResult result = client.delete(region);
     assertManagementResult(result).failed()
         .hasStatusCode(ClusterManagementResult.StatusCode.ENTITY_NOT_FOUND);
   }
@@ -221,7 +222,7 @@ public class ClientClusterManagementServiceDUnitTest {
     region.setGroup("group1");
     region.setType(RegionType.REPLICATE);
 
-    ClusterManagementResult<?, ?> result = client.create(region);
+    ClusterManagementResult result = client.create(region);
     assertManagementResult(result).isSuccessful().hasMemberStatus()
         .extracting(RealizationResult::getMemberName)
         .containsExactlyInAnyOrder("server-1",
@@ -241,9 +242,9 @@ public class ClientClusterManagementServiceDUnitTest {
     assertManagementResult(result)
         .hasStatusCode(ClusterManagementResult.StatusCode.OK);
 
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> listResult =
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> listResult =
         client.list(new RegionConfig());
-    assertManagementResult(listResult)
+    assertManagementListResult(listResult)
         .hasStatusCode(ClusterManagementResult.StatusCode.OK)
         .hasConfigurations()
         .extracting(RegionConfig::getId)

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ConfigurePDXDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ConfigurePDXDUnitTest.java
@@ -77,7 +77,7 @@ public class ConfigurePDXDUnitTest {
   @Test
   public void configurePdx() {
     PdxType pdxType = new PdxType();
-    ClusterManagementResult<?, ?> result = client.create(pdxType);
+    ClusterManagementResult result = client.create(pdxType);
 
     // needed to pass StressNewTest since we haven't yet implemented delete(PdxType)
     if (result.getStatusCode() == ClusterManagementResult.StatusCode.ENTITY_EXISTS)

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/MemberManagementServiceDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/MemberManagementServiceDUnitTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.context.WebApplicationContext;
 
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.configuration.MemberConfig;
@@ -72,7 +73,7 @@ public class MemberManagementServiceDUnitTest {
   @WithMockUser
   public void listAllMembers() {
     MemberConfig memberConfig = new MemberConfig();
-    ClusterManagementResult<MemberConfig, MemberInformation> result = client.list(memberConfig);
+    ClusterManagementListResult<MemberConfig, MemberInformation> result = client.list(memberConfig);
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
@@ -106,7 +107,7 @@ public class MemberManagementServiceDUnitTest {
   public void getOneMember() {
     MemberConfig config = new MemberConfig();
     config.setId("server-1");
-    ClusterManagementResult<MemberConfig, MemberInformation> result = client.list(config);
+    ClusterManagementListResult<MemberConfig, MemberInformation> result = client.list(config);
 
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
@@ -120,7 +121,7 @@ public class MemberManagementServiceDUnitTest {
   public void getMemberStatus() {
     MemberConfig config = new MemberConfig();
     config.setId("locator-0");
-    ClusterManagementResult<MemberConfig, MemberInformation> result = client.list(config);
+    ClusterManagementListResult<MemberConfig, MemberInformation> result = client.list(config);
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
 
@@ -139,7 +140,7 @@ public class MemberManagementServiceDUnitTest {
     MemberConfig config = new MemberConfig();
     // look for a member with a non-existent id
     config.setId("server");
-    ClusterManagementResult<MemberConfig, MemberInformation> result = client.list(config);
+    ClusterManagementListResult<MemberConfig, MemberInformation> result = client.list(config);
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getStatusCode())
         .isEqualTo(ClusterManagementResult.StatusCode.OK);

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GatewayManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GatewayManagementIntegrationTest.java
@@ -32,6 +32,7 @@ import org.springframework.web.context.WebApplicationContext;
 
 import org.apache.geode.cache.configuration.GatewayReceiverConfig;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.api.ConfigurationResult;
@@ -65,7 +66,7 @@ public class GatewayManagementIntegrationTest {
 
   @Test
   public void listEmptyGatewayReceivers() {
-    ClusterManagementResult<GatewayReceiverConfig, GatewayReceiverInfo> result =
+    ClusterManagementListResult<GatewayReceiverConfig, GatewayReceiverInfo> result =
         client.list(receiver);
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getResult().size()).isEqualTo(0);
@@ -88,7 +89,7 @@ public class GatewayManagementIntegrationTest {
       return cacheConfig;
     });
 
-    ClusterManagementResult<GatewayReceiverConfig, GatewayReceiverInfo> results =
+    ClusterManagementListResult<GatewayReceiverConfig, GatewayReceiverInfo> results =
         client.list(receiver);
     assertThat(results.isSuccessful()).isTrue();
     List<ConfigurationResult<GatewayReceiverConfig, GatewayReceiverInfo>> receivers =

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/JsonSerializationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/JsonSerializationTest.java
@@ -67,7 +67,7 @@ public class JsonSerializationTest {
   @Test
   public void invalidAttributes() throws Exception {
     String json = "{'name':'test','Group1':'group1','Group2':'group2'}";
-    when(cms.create(any())).thenReturn(new ClusterManagementResult<>());
+    when(cms.create(any())).thenReturn(new ClusterManagementResult());
     context.perform(post("/v2/regions").content(json))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.statusCode", Matchers.is("ILLEGAL_ARGUMENT")))
@@ -79,7 +79,7 @@ public class JsonSerializationTest {
   @Test
   public void validAttributes() throws Exception {
     String json = "{'name':'test','group':'group1'}";
-    when(cms.create(any())).thenReturn(new ClusterManagementResult<>());
+    when(cms.create(any())).thenReturn(new ClusterManagementResult());
     context.perform(post("/v2/regions").content(json))
         .andExpect(status().isCreated());
     verify(cms, atLeastOnce()).create(regionConfigCaptor.capture());

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/GatewayManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/GatewayManagementController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import org.apache.geode.cache.configuration.GatewayReceiverConfig;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.runtime.GatewayReceiverInfo;
 
@@ -40,7 +41,7 @@ public class GatewayManagementController extends AbstractManagementController {
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ')")
   @RequestMapping(method = RequestMethod.GET, value = GATEWAY_RECEIVERS_ENDPOINTS)
   @ResponseBody
-  public ClusterManagementResult<GatewayReceiverConfig, GatewayReceiverInfo> listGatewayReceivers(
+  public ClusterManagementListResult<GatewayReceiverConfig, GatewayReceiverInfo> listGatewayReceivers(
       @RequestParam(required = false) String group) {
     GatewayReceiverConfig filter = new GatewayReceiverConfig();
     if (StringUtils.isNotBlank(group)) {

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
@@ -28,7 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.configuration.MemberConfig;
 import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
 import org.apache.geode.management.runtime.MemberInformation;
@@ -38,11 +38,11 @@ import org.apache.geode.management.runtime.MemberInformation;
 public class MemberManagementController extends AbstractManagementController {
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ')")
   @RequestMapping(method = RequestMethod.GET, value = MEMBER_CONFIG_ENDPOINT + "/{id}")
-  public ResponseEntity<ClusterManagementResult<MemberConfig, MemberInformation>> getMember(
+  public ResponseEntity<ClusterManagementListResult<MemberConfig, MemberInformation>> getMember(
       @PathVariable(name = "id") String id) {
     MemberConfig config = new MemberConfig();
     config.setId(id);
-    ClusterManagementResult<MemberConfig, MemberInformation> result =
+    ClusterManagementListResult<MemberConfig, MemberInformation> result =
         clusterManagementService.list(config);
     if (result.getRuntimeResult().size() == 0) {
       throw new EntityNotFoundException(
@@ -55,13 +55,13 @@ public class MemberManagementController extends AbstractManagementController {
 
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ')")
   @RequestMapping(method = RequestMethod.GET, value = MEMBER_CONFIG_ENDPOINT)
-  public ResponseEntity<ClusterManagementResult<MemberConfig, MemberInformation>> listMembers(
+  public ResponseEntity<ClusterManagementListResult<MemberConfig, MemberInformation>> listMembers(
       @RequestParam(required = false) String id, @RequestParam(required = false) String group) {
     MemberConfig filter = new MemberConfig();
     if (StringUtils.isNotBlank(id)) {
       filter.setId(id);
     }
-    ClusterManagementResult<MemberConfig, MemberInformation> result =
+    ClusterManagementListResult<MemberConfig, MemberInformation> result =
         clusterManagementService.list(filter);
 
     return new ResponseEntity<>(result,

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
@@ -39,6 +39,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ConfigurationResult;
 import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
@@ -70,7 +71,7 @@ public class RegionManagementController extends AbstractManagementController {
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ')")
   @RequestMapping(method = RequestMethod.GET, value = REGION_CONFIG_ENDPOINT)
   @ResponseBody
-  public ClusterManagementResult<RegionConfig, RuntimeRegionInfo> listRegion(
+  public ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> listRegion(
       @RequestParam(required = false) String id,
       @RequestParam(required = false) String group) {
     RegionConfig filter = new RegionConfig();
@@ -85,7 +86,7 @@ public class RegionManagementController extends AbstractManagementController {
 
   @RequestMapping(method = RequestMethod.GET, value = REGION_CONFIG_ENDPOINT + "/{id}")
   @ResponseBody
-  public ClusterManagementResult<RegionConfig, RuntimeRegionInfo> getRegion(
+  public ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> getRegion(
       @PathVariable(name = "id") String id) {
     securityService.authorize(Resource.CLUSTER, Operation.READ, id);
     RegionConfig config = new RegionConfig();
@@ -111,11 +112,11 @@ public class RegionManagementController extends AbstractManagementController {
       value = REGION_CONFIG_ENDPOINT + "/{regionName}/indexes")
   @ResponseBody
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ', 'QUERY')")
-  public ClusterManagementResult<RegionConfig.Index, RuntimeInfo> listIndex(
+  public ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> listIndex(
       @PathVariable String regionName,
       @RequestParam(required = false) String id) {
 
-    ClusterManagementResult<RegionConfig, RuntimeRegionInfo> result0 = getRegion(regionName);
+    ClusterManagementListResult<RegionConfig, RuntimeRegionInfo> result0 = getRegion(regionName);
     RegionConfig regionConfig = result0.getResult().get(0).getConfig();
 
     // only send the index information back
@@ -132,8 +133,8 @@ public class RegionManagementController extends AbstractManagementController {
       responses.add(new ConfigurationResult<>(index));
     }
 
-    ClusterManagementResult<RegionConfig.Index, RuntimeInfo> result =
-        new ClusterManagementResult<>();
+    ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> result =
+        new ClusterManagementListResult<>();
     result.setResult(responses);
     return result;
   }
@@ -142,10 +143,10 @@ public class RegionManagementController extends AbstractManagementController {
       value = REGION_CONFIG_ENDPOINT + "/{regionName}/indexes/{id}")
   @ResponseBody
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ', 'QUERY')")
-  public ClusterManagementResult<RegionConfig.Index, RuntimeInfo> getIndex(
+  public ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> getIndex(
       @PathVariable String regionName,
       @PathVariable String id) {
-    ClusterManagementResult<RegionConfig.Index, RuntimeInfo> result = listIndex(regionName, id);
+    ClusterManagementListResult<RegionConfig.Index, RuntimeInfo> result = listIndex(regionName, id);
     List<ConfigurationResult<RegionConfig.Index, RuntimeInfo>> indexList = result.getResult();
 
     if (indexList.size() == 0) {


### PR DESCRIPTION
This is refactoring work necessary as a prerequisite to build out async operation framework and rebalance command.

As we have expanded what our CMS API can return, ClusterManagementResult has accreted a variety of unrelated fields, as well as a long list of generic types.   After adding rebalance, ClusterManagementResult would now have fields for
* result code & message & HATEOS uri
* RealizationResult[] member_status
* ConfigurationResult<T, R>[] result
* AsyncOperationResult<V> operationResult
* R[] runtimeResult
and generics types:
* T (extends CacheElement) 
* R (extends RuntimeInfo)
* V (extends JsonSerializable)
This PR splits this into subclasses:
* ClusterManagementResult will have all the non-generic stuff
* ClusterManagementListResult will have the T and R generics
* ClusterManagementOperationResult will have the V generics
This will rely on a small bit of json sleight-of-hand where controller advisors may serialize a ClusterManagementResult (on error) but it will be deserialized as a subtype just with empty subtype fields (e.g. empty result) which should be fine in practice.