### PR TITLE
GEODE-6706:Export GC logs along with the member logs and stats

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/SizeExportLogsFunctionFileIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/functions/SizeExportLogsFunctionFileIntegrationTest.java
@@ -122,6 +122,29 @@ public class SizeExportLogsFunctionFileIntegrationTest {
             .isEqualTo(0);
   }
 
+  @Test
+  public void AllFiles_returnsCombinedSize() throws Exception {
+    System.setProperty("-Xloggc", dir.getAbsolutePath());
+    List<File> logFiles =
+        createLogFiles(new File(dir.getName(), testName.getMethodName()), 1, 1, FileUtils.ONE_KB);
+    File logFile = logFiles.get(0);
+    long logFileSize = FileUtils.sizeOf(logFiles.get(0));
+
+    List<File> statFiles =
+        createStatFiles(new File(dir.getName(), testName.getMethodName()), 1, 1, FileUtils.ONE_KB);
+    File statArchive = statFiles.get(0);
+    long statFileSize = FileUtils.sizeOf(statArchive);
+
+    List<File> gcLogFiles =
+        createLogFiles(new File(dir.getName(), testName.getMethodName()), 1, 1, FileUtils.ONE_KB);
+    File gcLogFile = gcLogFiles.get(0);
+    long gcLogFileSize = FileUtils.sizeOf(gcLogFiles.get(0));
+
+    SizeExportLogsFunction function = new SizeExportLogsFunction();
+    assertThat(function.estimateLogFileSize(member, logFile, statArchive, nonFilteringArgs))
+        .isEqualTo(logFileSize + statFileSize + gcLogFileSize);
+  }
+
   private List<File> createLogFiles(File logFile, int mainId, int numberOfFiles, long sizeOfFile)
       throws IOException {
     List<File> files = new ArrayList<>();

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterFileIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterFileIntegrationTest.java
@@ -148,4 +148,36 @@ public class LogExporterFileIntegrationTest {
     assertThat(logExporter.findLogFiles(workingDir.toPath()))
         .contains(gcRolledOverLogFile.toPath());
   }
+
+  @Test
+  public void findLogsWhichContainsEmptyConfiguredGCDir() throws Exception {
+    System.setProperty("-Xloggc", "");
+
+    File gcLogFile = new File(workingDir.getAbsolutePath(), "gc.log");
+    FileUtils.writeStringToFile(gcLogFile, "some gc log line");
+
+    File gcRolledOverLogFile = new File(workingDir.getAbsolutePath(), "gc.log.1");
+    FileUtils.writeStringToFile(gcRolledOverLogFile, "some gc log line");
+
+    assertThat(logExporter.findLogFiles((new File(workingDir.getAbsolutePath()).toPath()))
+        .contains(gcLogFile.toPath()));
+    assertThat(logExporter.findLogFiles((new File(workingDir.getAbsolutePath()).toPath()))
+        .contains(gcRolledOverLogFile.toPath()));
+  }
+
+  @Test
+  public void findLogsWhichContainsGCLogFromConfiguredGCDir() throws Exception {
+    System.setProperty("-Xloggc", workingDir.getAbsolutePath());
+
+    File gcLogFile = new File(System.getProperty("-Xloggc"), "gc.log");
+    FileUtils.writeStringToFile(gcLogFile, "some gc log line");
+
+    File gcRolledOverLogFile = new File(System.getProperty("-Xloggc"), "gc.log.1");
+    FileUtils.writeStringToFile(gcRolledOverLogFile, "some gc log line");
+
+    assertThat(logExporter.findLogFiles((new File(System.getProperty("-Xloggc")).toPath()))
+        .contains(gcLogFile.toPath()));
+    assertThat(logExporter.findLogFiles((new File(System.getProperty("-Xloggc")).toPath()))
+        .contains(gcRolledOverLogFile.toPath()));
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/LogExporter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/util/LogExporter.java
@@ -26,6 +26,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -47,6 +49,7 @@ public class LogExporter {
   private final LogFilter logFilter;
   private final File baseLogFile;
   private final File baseStatsFile;
+  private static final String GCLOGJVMSETTING = "-Xloggc";
 
   /**
    * @param logFilter the filter that's used to check if we need to accept the file or the logLine
@@ -61,18 +64,17 @@ public class LogExporter {
   }
 
   /**
-   *
    * @return Path to the zip file that has all the filtered files, null if no files are selected to
    *         export.
    */
   public Path export() throws IOException {
     Path tempDirectory = Files.createTempDirectory("exportLogs");
+    String gcLogJVMSetting = System.getProperty(GCLOGJVMSETTING, System.getProperty("user.dir"));
+    List<Path> filesToExport = getFilesToExport();
 
-    if (baseLogFile != null) {
-      for (Path logFile : findLogFiles(baseLogFile.toPath().getParent())) {
-        Path filteredLogFile = tempDirectory.resolve(logFile.getFileName());
-        writeFilteredLogFile(logFile, filteredLogFile);
-      }
+    for (Path logFile : filesToExport) {
+      Path filteredLogFile = tempDirectory.resolve(logFile.getFileName());
+      writeFilteredLogFile(logFile, filteredLogFile);
     }
 
     if (baseStatsFile != null) {
@@ -130,10 +132,10 @@ public class LogExporter {
    */
   public long estimateFilteredSize() throws IOException {
     long filteredSize = 0;
-    if (baseLogFile != null) {
-      for (Path logFile : findLogFiles(baseLogFile.toPath().getParent())) {
-        filteredSize += filterAndSize(logFile);
-      }
+
+    List<Path> filesToExport = getFilesToExport();
+    for (Path logFile : filesToExport) {
+      filteredSize += filterAndSize(logFile);
     }
 
     if (baseStatsFile != null) {
@@ -188,5 +190,26 @@ public class LogExporter {
     selectedFiles = Files.list(workingDir).filter(fileSelector).filter(this.logFilter::acceptsFile);
 
     return selectedFiles.collect(toList());
+  }
+
+
+  /**
+   * @return the log files and GC log files
+   */
+
+  private List<Path> getFilesToExport() throws IOException {
+
+    String gcLogJVMSetting = System.getProperty(GCLOGJVMSETTING, System.getProperty("user.dir"));
+    List<Path> filesToExport = new ArrayList<>();
+
+    if (baseLogFile != null) {
+      if ((baseLogFile.toPath().getParent()).equals(Paths.get(gcLogJVMSetting))) {
+        filesToExport = findLogFiles(baseLogFile.toPath().getParent());
+      } else {
+        filesToExport.addAll(findLogFiles(baseLogFile.toPath().getParent()));
+        filesToExport.addAll(findLogFiles(Paths.get(gcLogJVMSetting)));
+      }
+    }
+    return filesToExport;
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -122,6 +122,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
     properties.setProperty(LOCATORS, "");
     properties.setProperty(MAX_WAIT_TIME_RECONNECT, "5000");
     systemProperties.setProperty(ClusterManagementService.FEATURE_FLAG, "true");
+    systemProperties.setProperty("-Xloggc", System.getProperty("user.dir"));
   }
 
   @Override


### PR DESCRIPTION
* Added a logic to check for GC log directory and then exporting the logs from that directory alongwith other member logs and stats file. This logic has been added to 2 methods1. export()
2. filterAndSize()

* Also, refactored the above mentioned methods and added a new method named getFilesToExport() for re-use of the same code.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
