### PR TITLE
GEODE-6779: fix issue with Bean check variations

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -19,7 +19,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
+import org.apache.logging.log4j.Logger;
 import org.apache.shiro.subject.Subject;
 import org.springframework.shell.core.CommandMarker;
 
@@ -34,6 +36,8 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.internal.cli.CliUtil;
@@ -45,6 +49,7 @@ import org.apache.geode.security.ResourcePermission;
 
 @Experimental
 public abstract class GfshCommand implements CommandMarker {
+  private static final Logger logger = LogService.getLogger();
   public static final String EXPERIMENTAL = "(Experimental) ";
   private InternalCache cache;
 
@@ -249,5 +254,33 @@ public abstract class GfshCommand implements CommandMarker {
 
     return false;
 
+  }
+
+  public boolean diskStoreBeanAndMemberBeanDiskStoreExists(DistributedSystemMXBean dsMXBean,
+      String memberName,
+      String diskStore) {
+    return diskStoreBeanExists(dsMXBean, memberName, diskStore) &&
+        memberBeanDiskStoreExists(dsMXBean, memberName, diskStore);
+  }
+
+  private boolean diskStoreBeanExists(DistributedSystemMXBean dsMXBean, String memberName,
+      String diskStore) {
+    try {
+      dsMXBean.fetchDiskStoreObjectName(memberName, diskStore);
+      return true;
+    } catch (Exception e) {
+      if (!e.getMessage().toLowerCase().contains("not found")) {
+        logger.warn("Unable to retrieve Disk Store ObjectName for member: {}, diskstore: {} - {}",
+            memberName, diskStore, e.getMessage());
+      }
+    }
+    return false;
+  }
+
+  private boolean memberBeanDiskStoreExists(DistributedSystemMXBean dsMXBean, String memberName,
+      String diskStore) {
+    return (Stream.of(dsMXBean.listMemberDiskstore().get(memberName))
+        .filter(dsName -> dsName.equals(diskStore))
+        .findFirst().orElse(null) != null);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CompactDiskStoreCommand.java
@@ -22,8 +22,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
@@ -163,16 +163,9 @@ public class CompactDiskStoreCommand extends GfshCommand {
   private boolean diskStoreExists(String diskStoreName) {
     ManagementService managementService = getManagementService();
     DistributedSystemMXBean dsMXBean = managementService.getDistributedSystemMXBean();
-    Map<String, String[]> diskstore = dsMXBean.listMemberDiskstore();
 
-    Set<Map.Entry<String, String[]>> entrySet = diskstore.entrySet();
-
-    for (Map.Entry<String, String[]> entry : entrySet) {
-      String[] value = entry.getValue();
-      if (diskStoreName != null && ArrayUtils.contains(value, diskStoreName)) {
-        return true;
-      }
-    }
-    return false;
+    return Stream.of(dsMXBean.listMembers())
+        .anyMatch(memberName -> diskStoreBeanAndMemberBeanDiskStoreExists(dsMXBean, memberName,
+            diskStoreName));
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.Logger;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
@@ -36,7 +35,6 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.DiskStoreAttributes;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
-import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
@@ -51,7 +49,6 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 public class CreateDiskStoreCommand extends SingleGfshCommand {
-  private static final Logger logger = LogService.getLogger();
   private static final int MBEAN_CREATION_WAIT_TIME = 10000;
 
   @CliCommand(value = CliStrings.CREATE_DISK_STORE, help = CliStrings.CREATE_DISK_STORE__HELP)
@@ -155,21 +152,8 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
 
     return poll(MBEAN_CREATION_WAIT_TIME, TimeUnit.MILLISECONDS,
         () -> membersToCreateDiskStoreOn.stream()
-            .allMatch(m -> diskStoreBeanExists(dsMXBean, m.getName(), diskStore)));
-  }
-
-  private boolean diskStoreBeanExists(DistributedSystemMXBean dsMXBean, String memberName,
-      String diskStore) {
-    try {
-      dsMXBean.fetchDiskStoreObjectName(memberName, diskStore);
-      return true;
-    } catch (Exception e) {
-      if (!e.getMessage().toLowerCase().contains("not found")) {
-        logger.warn("Unable to retrieve Disk Store ObjectName for member: {}, diskstore: {} - {}",
-            memberName, diskStore, e.getMessage());
-      }
-    }
-    return false;
+            .allMatch(member -> diskStoreBeanAndMemberBeanDiskStoreExists(dsMXBean,
+                member.getName(), diskStore)));
   }
 
   @VisibleForTesting
@@ -218,7 +202,7 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
   }
 
   @SuppressWarnings("unchecked")
-  List<DiskStoreDetails> getDiskStoreListing(Set<DistributedMember> members) {
+  private List<DiskStoreDetails> getDiskStoreListing(Set<DistributedMember> members) {
     final Execution membersFunctionExecutor = getMembersFunctionExecutor(members);
     if (membersFunctionExecutor instanceof AbstractExecution) {
       ((AbstractExecution) membersFunctionExecutor).setIgnoreDepartedMembers(true);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
@@ -18,12 +18,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import joptsimple.internal.Strings;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.springframework.shell.core.annotation.CliCommand;
@@ -316,7 +315,7 @@ public class CreateRegionCommand extends SingleGfshCommand {
           !colocatedRegionBean.getRegionType().equals("PERSISTENT_PARTITION")) {
         return ResultModel.createError(CliStrings.format(
             CliStrings.CREATE_REGION__MSG__COLOCATEDWITH_REGION_0_IS_NOT_PARTITIONEDREGION,
-            (Object) prColocatedWith));
+            prColocatedWith));
       }
     }
 
@@ -565,12 +564,12 @@ public class CreateRegionCommand extends SingleGfshCommand {
     }
 
     String[] regionsOnPath = regionPathData.getRegionsOnParentPath();
-    RegionConfig rootConfig = config.getRegions().stream()
-        .filter(r -> r.getName().equals(regionsOnPath[0]))
+
+    RegionConfig currentConfig = config.getRegions().stream()
+        .filter(r1 -> r1.getName().equals(regionsOnPath[0]))
         .findFirst()
         .get();
 
-    RegionConfig currentConfig = rootConfig;
     for (int i = 1; i < regionsOnPath.length; i++) {
       final String curRegionName = regionsOnPath[i];
       currentConfig = currentConfig.getRegions()
@@ -667,24 +666,16 @@ public class CreateRegionCommand extends SingleGfshCommand {
     DistributedSystemMXBean dsMBean = managementService.getDistributedSystemMXBean();
 
     String[] allRegionPaths = dsMBean.listAllRegionPaths();
-    return Arrays.stream(allRegionPaths).anyMatch(regionPath::equals);
+    return Arrays.asList(allRegionPaths).contains(regionPath);
   }
 
   private boolean diskStoreExists(String diskStoreName) {
     ManagementService managementService = getManagementService();
     DistributedSystemMXBean dsMXBean = managementService.getDistributedSystemMXBean();
-    Map<String, String[]> diskstore = dsMXBean.listMemberDiskstore();
 
-    Set<Map.Entry<String, String[]>> entrySet = diskstore.entrySet();
-
-    for (Map.Entry<String, String[]> entry : entrySet) {
-      String[] value = entry.getValue();
-      if (diskStoreName != null && ArrayUtils.contains(value, diskStoreName)) {
-        return true;
-      }
-    }
-
-    return false;
+    return Stream.of(dsMXBean.listMembers())
+        .anyMatch(memberName -> diskStoreBeanAndMemberBeanDiskStoreExists(dsMXBean, memberName,
+            diskStoreName));
   }
 
   DistributedSystemMXBean getDSMBean() {

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/GfshCommandJUnitTest.java
@@ -14,42 +14,45 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.ObjectName;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.management.cli.GfshCommand;
-import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
 
 public class GfshCommandJUnitTest {
-
+  private String memberName = "memberONe";
+  private String diskStoreName = "diskStoreOne";
   private GfshCommand command;
-  private Gfsh gfsh;
-  private InternalConfigurationPersistenceService clusterConfigurationService;
 
   @Before
   public void before() throws Exception {
     command = spy(GfshCommand.class);
-    gfsh = mock(Gfsh.class);
-    clusterConfigurationService = mock(InternalConfigurationPersistenceService.class);
   }
 
   @Test
-  public void getMember() throws Exception {
+  public void getMember() {
     doReturn(null).when(command).findMember("test");
     assertThatThrownBy(() -> command.getMember("test")).isInstanceOf(EntityNotFoundException.class);
   }
 
   @Test
-  public void getMembers() throws Exception {
+  public void getMembers() {
     String[] members = {"member"};
     doReturn(Collections.emptySet()).when(command).findMembers(members, null);
     assertThatThrownBy(() -> command.getMembers(members, null))
@@ -57,10 +60,52 @@ public class GfshCommandJUnitTest {
   }
 
   @Test
-  public void getMembersIncludingLocators() throws Exception {
+  public void getMembersIncludingLocators() {
     String[] members = {"member"};
     doReturn(Collections.emptySet()).when(command).findMembersIncludingLocators(members, null);
     assertThatThrownBy(() -> command.getMembersIncludingLocators(members, null))
         .isInstanceOf(EntityNotFoundException.class);
+  }
+
+  @Test
+  public void diskStoreBeanAndMemberBeanDiskStoreExists() throws Exception {
+    Map<String, String[]> memberDiskStore = new HashMap<>();
+    memberDiskStore.put(memberName, new String[] {diskStoreName});
+    ObjectName objectName = new ObjectName("");
+
+    DistributedSystemMXBean distributedSystemMXBean = Mockito.mock(DistributedSystemMXBean.class);
+    doReturn(memberDiskStore).when(distributedSystemMXBean).listMemberDiskstore();
+    doReturn(objectName).when(distributedSystemMXBean).fetchDiskStoreObjectName(any(), any());
+
+    assertThat(command.diskStoreBeanAndMemberBeanDiskStoreExists(distributedSystemMXBean,
+        memberName, diskStoreName)).isTrue();
+  }
+
+  @Test
+  public void diskStoreBeanExistsAndMemberDiskStoreNotFound() throws Exception {
+    Map<String, String[]> memberDiskStore = new HashMap<>();
+    memberDiskStore.put(memberName, new String[] {});
+    ObjectName objectName = new ObjectName("");
+
+    DistributedSystemMXBean distributedSystemMXBean = Mockito.mock(DistributedSystemMXBean.class);
+    doReturn(memberDiskStore).when(distributedSystemMXBean).listMemberDiskstore();
+    doReturn(objectName).when(distributedSystemMXBean).fetchDiskStoreObjectName(any(), any());
+
+    assertThat(command.diskStoreBeanAndMemberBeanDiskStoreExists(distributedSystemMXBean,
+        memberName, diskStoreName)).isFalse();
+  }
+
+  @Test
+  public void diskStoreBeanNotFoundAndMemberDiskStoreExists() throws Exception {
+    Map<String, String[]> memberDiskStore = new HashMap<>();
+    memberDiskStore.put(memberName, new String[] {diskStoreName});
+
+    DistributedSystemMXBean distributedSystemMXBean = Mockito.mock(DistributedSystemMXBean.class);
+    doReturn(memberDiskStore).when(distributedSystemMXBean).listMemberDiskstore();
+    doThrow(new Exception("not found")).when(distributedSystemMXBean)
+        .fetchDiskStoreObjectName(any(), any());
+
+    assertThat(command.diskStoreBeanAndMemberBeanDiskStoreExists(distributedSystemMXBean,
+        memberName, diskStoreName)).isFalse();
   }
 }


### PR DESCRIPTION
- When dealing with diskStore several ways of checking their presence 
were employed which ended up causing intermittent failure on DUnit 
testing. This patch rolls up the check which is used by all interested 
commands.

Co-authored-by: Peter Tran <ptran@pivotal.io>
Co-authored-by: Joris Melchior <joris.melchior@gmail.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
