### PR TITLE
GEODE-6967: Added awaitility clause.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingPoolDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingPoolDUnitTest.java
@@ -960,11 +960,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
     vm2.invoke("closeClient", () -> closeClient());
 
     // Validate maintained compiled queries.
-    vm0.invoke("validate compiled query", () -> {
-      long compiledQueryCount =
-          CacheClientNotifier.getInstance().getStats().getCompiledQueryCount();
-      assertEquals(0, compiledQueryCount);
-    });
+    vm0.invoke("validate Compiled query", () -> validateCompiledQuery(0));
 
     // Stop server
     vm0.invoke("Stop CacheServer", () -> stopBridgeServer(getCache()));


### PR DESCRIPTION
	* Test now wait for 60 sec for the compiled query counters to come down to zero.
	* Async query invocations may take some time to complete execution when there is a resource constraint.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
