### PR TITLE
GEODE-3942 - Add timeout and retry to Packer image jobs

### DIFF
--- a/ci/pipelines/images/jinja.template.yml
+++ b/ci/pipelines/images/jinja.template.yml
@@ -166,6 +166,7 @@ jobs:
       trigger: true
     - get: alpine-tools-docker-image
   - task: build-image
+    timeout: 1h
     image: alpine-tools-docker-image
     config:
       inputs:
@@ -193,6 +194,8 @@ jobs:
       passed:
       - build-alpine-tools-docker-image
   - task: build-image
+    timeout: 1h
+    attempts: 5
     image: alpine-tools-docker-image
     config:
       inputs:


### PR DESCRIPTION
To run our unit tests, we create Google Compute images. We have observed
infrastructure issues on GCP that has made this process fail or hang, so
we need timeout and retry logic around these tasks

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
