### PR TITLE
GEODE-6779: added NPE checks

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
@@ -99,7 +99,10 @@ class DiskStoreCommandsUtils {
         .filter(Objects::nonNull)
         .map(DistributedSystemMXBean::listMemberDiskstore)
         .filter(Objects::nonNull)
-        .flatMap(mds -> Stream.of(mds.get(memberName)))
+        .map(mds -> mds.get(memberName))
+        .filter(Objects::nonNull)
+        .flatMap(Stream::of)
+        .filter(Objects::nonNull)
         .anyMatch(dsName -> dsName.equals(diskStore));
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtilsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtilsTest.java
@@ -91,4 +91,34 @@ public class DiskStoreCommandsUtilsTest {
         DiskStoreCommandsUtils.diskStoreBeanAndMemberBeanDiskStoreExists(distributedSystemMXBean,
             memberName, diskStoreName)).isFalse();
   }
+
+  @Test
+  public void diskStoreBeanExistsMemberDiskStoreContainsNullArray() throws Exception {
+    Map<String, String[]> memberDiskStore = new HashMap<>();
+    memberDiskStore.put(memberName, null);
+    ObjectName objectName = new ObjectName("");
+
+    DistributedSystemMXBean distributedSystemMXBean = Mockito.mock(DistributedSystemMXBean.class);
+    doReturn(memberDiskStore).when(distributedSystemMXBean).listMemberDiskstore();
+    doReturn(objectName).when(distributedSystemMXBean).fetchDiskStoreObjectName(any(), any());
+
+    assertThat(
+        DiskStoreCommandsUtils.diskStoreBeanAndMemberBeanDiskStoreExists(distributedSystemMXBean,
+            memberName, diskStoreName)).isFalse();
+  }
+
+  @Test
+  public void diskStoreBeanExistsMemberDiskStoreNamesHasNullValues() throws Exception {
+    Map<String, String[]> memberDiskStore = new HashMap<>();
+    memberDiskStore.put(memberName, new String[]{null, null});
+    ObjectName objectName = new ObjectName("");
+
+    DistributedSystemMXBean distributedSystemMXBean = Mockito.mock(DistributedSystemMXBean.class);
+    doReturn(memberDiskStore).when(distributedSystemMXBean).listMemberDiskstore();
+    doReturn(objectName).when(distributedSystemMXBean).fetchDiskStoreObjectName(any(), any());
+
+    assertThat(
+        DiskStoreCommandsUtils.diskStoreBeanAndMemberBeanDiskStoreExists(distributedSystemMXBean,
+            memberName, diskStoreName)).isFalse();
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtilsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtilsTest.java
@@ -110,7 +110,7 @@ public class DiskStoreCommandsUtilsTest {
   @Test
   public void diskStoreBeanExistsMemberDiskStoreNamesHasNullValues() throws Exception {
     Map<String, String[]> memberDiskStore = new HashMap<>();
-    memberDiskStore.put(memberName, new String[]{null, null});
+    memberDiskStore.put(memberName, new String[] {null, null});
     ObjectName objectName = new ObjectName("");
 
     DistributedSystemMXBean distributedSystemMXBean = Mockito.mock(DistributedSystemMXBean.class);


### PR DESCRIPTION
- DUnit tests show that beans can contain null values in any imaginable
place so we have to enhance the null value filtering
- Unit test enhanced to verify the checks

Authored-by: Joris Melchior <joris.melchior@gmail.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
