### PR TITLE
GEODE-6999: Fix XML attribute parsing

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testDiskUsageWarningPercentage.cache.xml
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/cache/xmlcache/CacheXmlParserJUnitTest.testDiskUsageWarningPercentage.cache.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance with the License. You may obtain a
+  ~ copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License
+  ~ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  ~ or implied. See the License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<cache xmlns="http://geode.apache.org/schema/cache" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" copy-on-read="false" is-server="false" lock-lease="120" lock-timeout="60" search-timeout="300" version="1.0" xsi:schemaLocation="http://geode.apache.org/schema/cache http://geode.apache.org/schema/cache/cache-1.0.xsd">
+       <disk-store name="${DISK_STORE_NAME}" disk-usage-warning-percentage="70">
+              <disk-dirs>
+                     <disk-dir>${DISK_STORE_DIRECTORY}</disk-dir>
+              </disk-dirs>
+       </disk-store>
+</cache>

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
@@ -1015,7 +1015,7 @@ public class CacheXmlParser extends CacheXml implements ContentHandler {
     }
 
     String criticalPct = atts.getValue(DISK_USAGE_CRITICAL_PERCENTAGE);
-    if (warnPct != null) {
+    if (criticalPct != null) {
       attrs.setDiskUsageCriticalPercentage(parseFloat(criticalPct));
     }
 


### PR DESCRIPTION
- Fixed parsing of the 'disk-usage-warning-percentage' attribute.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
