### PR TITLE
GEODE-7005: Fix Race Condition in Unit Test

### DIFF
--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
@@ -307,6 +307,8 @@ public class LocatorMembershipListenerImpl implements LocatorMembershipListener 
                   Thread.sleep(memberTimeout);
                 } catch (InterruptedException e) {
                   Thread.currentThread().interrupt();
+                  logger.warn(
+                      "Locator Membership listener permanently failed to exchange locator information due to interruption.");
                 }
               }
             }

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
@@ -42,7 +42,7 @@ import org.apache.geode.internal.logging.LoggingThreadFactory;
 public class LocatorMembershipListenerImpl implements LocatorMembershipListener {
   private static final Logger logger = LogService.getLogger();
   static final int LOCATOR_DISTRIBUTION_RETRY_ATTEMPTS = 3;
-  static final String LOCATORS_DISTRIBUTOR_THREAD_NAME = "LocatorsDistributorThread";
+  private static final String LOCATORS_DISTRIBUTOR_THREAD_NAME = "LocatorsDistributorThread";
   private static final String LISTENER_FAILURE_MESSAGE =
       "Locator Membership listener could not exchange locator information {}:{} with {}:{} after {} retry attempts";
   private static final String LISTENER_FINAL_FAILURE_MESSAGE =
@@ -72,6 +72,10 @@ public class LocatorMembershipListenerImpl implements LocatorMembershipListener 
   @Override
   public void setConfig(DistributionConfig config) {
     this.config = config;
+  }
+
+  void launchLocatorsDistributorThread(Thread thread) {
+    thread.start();
   }
 
   /**
@@ -116,8 +120,8 @@ public class LocatorMembershipListenerImpl implements LocatorMembershipListener 
         tcpClient, localLocatorId, localCopy, locator, distributedSystemId);
     ThreadFactory threadFactory =
         new LoggingThreadFactory(LOCATORS_DISTRIBUTOR_THREAD_NAME, true);
-    Thread distributeLocatorsThread = threadFactory.newThread(distributeLocatorsRunnable);
-    distributeLocatorsThread.start();
+    Thread locatorsDistributorThread = threadFactory.newThread(distributeLocatorsRunnable);
+    launchLocatorsDistributorThread(locatorsDistributorThread);
   }
 
   @Override

--- a/geode-wan/src/test/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerTest.java
@@ -56,7 +56,6 @@ import org.apache.geode.test.junit.ResultCaptor;
 
 public class LocatorMembershipListenerTest {
   private TcpClient tcpClient;
-  private ResultCaptor<Thread> resultCaptor;
   private LocatorMembershipListenerImpl locatorMembershipListener;
 
   private DistributionLocatorId buildDistributionLocatorId(int port) {
@@ -93,7 +92,7 @@ public class LocatorMembershipListenerTest {
         DistributionConfig.DEFAULT_MEMBER_TIMEOUT, false);
   }
 
-  private void joinLocatorsDistributorThread() {
+  private void joinLocatorsDistributorThread(ResultCaptor<Thread> resultCaptor) {
     Thread distributorThread = resultCaptor.getResult();
     await().untilAsserted(
         () -> assertThat(distributorThread.getState()).isEqualTo(Thread.State.TERMINATED));
@@ -107,11 +106,8 @@ public class LocatorMembershipListenerTest {
         .thenReturn(DistributionConfig.DEFAULT_MEMBER_TIMEOUT);
 
     tcpClient = mock(TcpClient.class);
-    resultCaptor = new ResultCaptor<>();
     locatorMembershipListener = spy(new LocatorMembershipListenerImpl(tcpClient));
     locatorMembershipListener.setConfig(distributionConfig);
-    doAnswer(resultCaptor).when(locatorMembershipListener).buildLocatorsDistributorThread(
-        any(DistributionLocatorId.class), anyMap(), any(DistributionLocatorId.class), anyInt());
   }
 
   @Test
@@ -210,8 +206,11 @@ public class LocatorMembershipListenerTest {
     DistributionLocatorId locator1Site1 = buildDistributionLocatorId(10101);
     when(locatorMembershipListener.getAllLocatorsInfo()).thenReturn(allLocatorsInfo);
 
+    ResultCaptor<Thread> resultCaptor = new ResultCaptor<>();
+    doAnswer(resultCaptor).when(locatorMembershipListener).buildLocatorsDistributorThread(
+        any(DistributionLocatorId.class), anyMap(), any(DistributionLocatorId.class), anyInt());
     locatorMembershipListener.locatorJoined(2, joiningLocator, locator1Site1);
-    joinLocatorsDistributorThread();
+    joinLocatorsDistributorThread(resultCaptor);
     verify(tcpClient, times(0)).requestToServer(any(InetSocketAddress.class),
         any(LocatorJoinMessage.class), anyInt(), anyBoolean());
   }
@@ -226,8 +225,11 @@ public class LocatorMembershipListenerTest {
     allLocatorsInfo.put(3, new HashSet<>(Collections.singletonList(locator3Site3)));
     when(locatorMembershipListener.getAllLocatorsInfo()).thenReturn(allLocatorsInfo);
 
+    ResultCaptor<Thread> resultCaptor = new ResultCaptor<>();
+    doAnswer(resultCaptor).when(locatorMembershipListener).buildLocatorsDistributorThread(
+        any(DistributionLocatorId.class), anyMap(), any(DistributionLocatorId.class), anyInt());
     locatorMembershipListener.locatorJoined(2, joiningLocator, locator1Site1);
-    joinLocatorsDistributorThread();
+    joinLocatorsDistributorThread(resultCaptor);
     verifyMessagesSentBothWays(locator1Site1, 2, joiningLocator, 3, locator3Site3);
   }
 
@@ -249,8 +251,11 @@ public class LocatorMembershipListenerTest {
         new HashSet<>(Arrays.asList(locator1Site3, locator2Site3, locator3Site3)));
     when(locatorMembershipListener.getAllLocatorsInfo()).thenReturn(allLocatorsInfo);
 
+    ResultCaptor<Thread> resultCaptor = new ResultCaptor<>();
+    doAnswer(resultCaptor).when(locatorMembershipListener).buildLocatorsDistributorThread(
+        any(DistributionLocatorId.class), anyMap(), any(DistributionLocatorId.class), anyInt());
     locatorMembershipListener.locatorJoined(1, joiningLocator, locator1Site1);
-    joinLocatorsDistributorThread();
+    joinLocatorsDistributorThread(resultCaptor);
     verifyMessagesSentBothWays(locator1Site1, 1, joiningLocator, 1, locator3Site1);
     verifyMessagesSentBothWays(locator1Site1, 1, joiningLocator, 2, locator1Site2);
     verifyMessagesSentBothWays(locator1Site1, 1, joiningLocator, 2, locator2Site2);
@@ -273,8 +278,11 @@ public class LocatorMembershipListenerTest {
         DistributionConfig.DEFAULT_MEMBER_TIMEOUT, false))
             .thenThrow(new EOFException("Mock Exception"));
 
+    ResultCaptor<Thread> resultCaptor = new ResultCaptor<>();
+    doAnswer(resultCaptor).when(locatorMembershipListener).buildLocatorsDistributorThread(
+        any(DistributionLocatorId.class), anyMap(), any(DistributionLocatorId.class), anyInt());
     locatorMembershipListener.locatorJoined(1, joiningLocator, locator1Site1);
-    joinLocatorsDistributorThread();
+    joinLocatorsDistributorThread(resultCaptor);
 
     verify(tcpClient, times(LOCATOR_DISTRIBUTION_RETRY_ATTEMPTS + 1)).requestToServer(
         locator3Site1.getHost(),
@@ -300,8 +308,11 @@ public class LocatorMembershipListenerTest {
             .thenThrow(new EOFException("Mock Exception"))
             .thenReturn(null);
 
+    ResultCaptor<Thread> resultCaptor = new ResultCaptor<>();
+    doAnswer(resultCaptor).when(locatorMembershipListener).buildLocatorsDistributorThread(
+        any(DistributionLocatorId.class), anyMap(), any(DistributionLocatorId.class), anyInt());
     locatorMembershipListener.locatorJoined(1, joiningLocator, locator1Site1);
-    joinLocatorsDistributorThread();
+    joinLocatorsDistributorThread(resultCaptor);
 
     verify(tcpClient, times(2)).requestToServer(locator3Site1.getHost(),
         new LocatorJoinMessage(1, joiningLocator, locator1Site1, ""),
@@ -338,8 +349,11 @@ public class LocatorMembershipListenerTest {
         DistributionConfig.DEFAULT_MEMBER_TIMEOUT, false))
             .thenThrow(new EOFException("Mock Exception"));
 
+    ResultCaptor<Thread> resultCaptor = new ResultCaptor<>();
+    doAnswer(resultCaptor).when(locatorMembershipListener).buildLocatorsDistributorThread(
+        any(DistributionLocatorId.class), anyMap(), any(DistributionLocatorId.class), anyInt());
     locatorMembershipListener.locatorJoined(1, joiningLocator, locator1Site1);
-    joinLocatorsDistributorThread();
+    joinLocatorsDistributorThread(resultCaptor);
 
     verifyMessagesSentBothWays(locator1Site1, 1, joiningLocator, 2, locator1Site2);
     verify(tcpClient, times(3)).requestToServer(locator3Site1.getHost(),


### PR DESCRIPTION
- Added a warn logging message so users know that the distributor
  thread has been interrupted.
- Use awaitility instead of trying to find the daemon thread right
  away, it might have not finished and, as such, the assertions
  would fail.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
