### PR TITLE
GEODE-7008: Function execution by id uses correct bucket filter.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientServerFunctionExecutionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientServerFunctionExecutionDUnitTest.java
@@ -31,6 +31,9 @@ import java.util.Properties;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.DataPolicy;
@@ -59,8 +62,11 @@ import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({ClientServerTest.class, FunctionServiceTest.class})
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBase {
   private static final String TEST_FUNCTION1 = TestFunction.TEST_FUNCTION1;
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientServerFunctionExecutionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientServerFunctionExecutionDUnitTest.java
@@ -97,7 +97,7 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
   }
 
   @Test
-  public void test_Bug_43126_Function_Not_Registered() {
+  public void throwsExceptionWhenFunctionNotRegisteredOnServer() {
     createScenario();
     try {
       client.invoke(ClientServerFunctionExecutionDUnitTest::executeRegisteredFunction);
@@ -109,7 +109,7 @@ public class ClientServerFunctionExecutionDUnitTest extends PRClientServerTestBa
   }
 
   @Test
-  public void test_Bug43126() {
+  public void noExceptionWhenFunctionRegisteredOnServer() {
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION1);
     registerFunctionAtServer(function);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -63,7 +64,6 @@ import org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableCallableIF;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
@@ -80,6 +80,8 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
+
+  private static final Logger logger = LogService.getLogger();
 
   static InternalDistributedSystem ds = null;
 
@@ -233,7 +235,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         noOfExecutionsCompleted_TESTFUNCTION3++;
 
       } catch (Exception e) {
-        LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
+        logger.info("Exception : " + e.getMessage());
         e.printStackTrace();
         fail("Test failed after the put operation");
       }
@@ -251,10 +253,10 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
           functionServiceStats.getFunctionExecutionsCompleted());
       assertTrue(functionServiceStats.getResultsReceived() >= resultReceived_Aggregate);
 
-      LogWriterUtils.getLogWriter().info("Calling FunctionStats for  TEST_FUNCTION2 :");
+      logger.info("Calling FunctionStats for  TEST_FUNCTION2 :");
       FunctionStats functionStats =
           FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
-      LogWriterUtils.getLogWriter().info("Called FunctionStats for  TEST_FUNCTION2 :");
+      logger.info("Called FunctionStats for  TEST_FUNCTION2 :");
       assertEquals(noOfExecutionCalls_TESTFUNCTION2, functionStats.getFunctionExecutionCalls());
       assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
           functionStats.getFunctionExecutionsCompleted());
@@ -324,14 +326,14 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         ds.disconnect();
         ds = getSystem(props);
         cache = CacheFactory.create(ds);
-        LogWriterUtils.getLogWriter().info("Created Cache on Server");
+        logger.info("Created Cache on Server");
         assertNotNull(cache);
         AttributesFactory factory = new AttributesFactory();
         factory.setScope(Scope.DISTRIBUTED_ACK);
         factory.setDataPolicy(DataPolicy.REPLICATE);
         assertNotNull(cache);
         Region<String, Integer> region = cache.createRegion(regionName, factory.create());
-        LogWriterUtils.getLogWriter().info("Region Created :" + region);
+        logger.info("Region Created :" + region);
         assertNotNull(region);
         for (int i = 1; i <= 200; i++) {
           region.put("execKey-" + i, i);
@@ -367,7 +369,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         ds.disconnect();
         ds = getSystem(props);
         cache = CacheFactory.create(ds);
-        LogWriterUtils.getLogWriter().info("Created Cache on Client");
+        logger.info("Created Cache on Client");
         assertNotNull(cache);
 
 
@@ -389,7 +391,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         factory.setPoolName(p.getName());
         assertNotNull(cache);
         Region<String, Integer> region = cache.createRegion(regionName, factory.create());
-        LogWriterUtils.getLogWriter().info("Client Region Created :" + region);
+        logger.info("Client Region Created :" + region);
         assertNotNull(region);
         for (int i = 1; i <= 200; i++) {
           region.put("execKey-" + i, i);
@@ -507,7 +509,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         noOfExecutionsCompleted_TESTFUNCTION1++;
       } catch (Exception ex) {
         ex.printStackTrace();
-        LogWriterUtils.getLogWriter().info("Exception : ", ex);
+        logger.info("Exception : ", ex);
         fail("Test failed after the execute operation nn TRUE");
       }
       function = new TestFunction(true, TestFunction.TEST_FUNCTION5);
@@ -525,7 +527,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         noOfExecutionsCompleted_TESTFUNCTION5++;
       } catch (Exception ex) {
         ex.printStackTrace();
-        LogWriterUtils.getLogWriter().info("Exception : ", ex);
+        logger.info("Exception : ", ex);
         fail("Test failed after the execute operationssssss");
       }
     });
@@ -799,7 +801,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
       factory.setScope(Scope.DISTRIBUTED_ACK);
       factory.setDataPolicy(DataPolicy.EMPTY);
       Region<String, Integer> region = getCache().createRegion(rName, factory.create());
-      LogWriterUtils.getLogWriter().info("Region Created :" + region);
+      logger.info("Region Created :" + region);
       assertNotNull(region);
       FunctionService.registerFunction(new TestFunction(true, TestFunction.TEST_FUNCTION2));
       for (int i = 1; i <= 200; i++) {
@@ -812,7 +814,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
       factory.setScope(Scope.DISTRIBUTED_ACK);
       factory.setDataPolicy(DataPolicy.REPLICATE);
       Region<String, Integer> region = getCache().createRegion(rName, factory.create());
-      LogWriterUtils.getLogWriter().info("Region Created :" + region);
+      logger.info("Region Created :" + region);
       assertNotNull(region);
       FunctionService.registerFunction(new TestFunction(true, TestFunction.TEST_FUNCTION2));
       for (int i = 1; i <= 200; i++) {
@@ -934,7 +936,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         noOfExecutionsCompleted_Inline++;
 
       } catch (Exception e) {
-        LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
+        logger.info("Exception Occurred : " + e.getMessage());
         e.printStackTrace();
         Assert.fail("Test failed", e);
       }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
@@ -60,6 +60,7 @@ import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionTestHelper;
 import org.apache.geode.internal.cache.functions.TestFunction;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.LogWriterUtils;
@@ -85,7 +86,6 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
   private static int noOfExecutionCalls_Aggregate = 0;
   private static int noOfExecutionsCompleted_Aggregate = 0;
   private static int resultReceived_Aggregate = 0;
-  private static int noOfExecutionExceptions_Aggregate = 0;
 
   private static int noOfExecutionCalls_TESTFUNCTION1 = 0;
   private static int noOfExecutionsCompleted_TESTFUNCTION1 = 0;
@@ -107,21 +107,16 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
   private static int noOfExecutionsCompleted_Inline = 0;
   private static int resultReceived_Inline = 0;
 
-  private static int noOfExecutionCalls_TestFunctionException = 0;
-  private static int noOfExecutionsCompleted_TestFunctionException = 0;
-  private static int noOfExecutionExceptions_TestFunctionException = 0;
-
   @Override
   protected final void postSetUpPRClientServerTestBase() {
     // Make sure stats to linger from a previous test
     disconnectAllFromDS();
   }
 
-  private final transient SerializableCallableIF<Boolean> initializeStats = () -> {
+  private final transient SerializableRunnableIF initializeStats = () -> {
     noOfExecutionCalls_Aggregate = 0;
     noOfExecutionsCompleted_Aggregate = 0;
     resultReceived_Aggregate = 0;
-    noOfExecutionExceptions_Aggregate = 0;
 
     noOfExecutionCalls_TESTFUNCTION1 = 0;
     noOfExecutionsCompleted_TESTFUNCTION1 = 0;
@@ -142,11 +137,6 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
     noOfExecutionCalls_Inline = 0;
     noOfExecutionsCompleted_Inline = 0;
     resultReceived_Inline = 0;
-
-    noOfExecutionCalls_TestFunctionException = 0;
-    noOfExecutionsCompleted_TestFunctionException = 0;
-    noOfExecutionExceptions_TestFunctionException = 0;
-    return Boolean.TRUE;
   };
 
   private final transient SerializableRunnableIF closeDistributedSystem = () -> {
@@ -1063,9 +1053,9 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
         // incremented,
         Wait.pause(2000);
         rc.getResult();
+        fail("No exception Occurred");
       } catch (Exception ignored) {
       }
-      fail("No exception Occurred");
     });
 
     datastore0.invoke(closeDistributedSystem);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionServiceStatsDUnitTest.java
@@ -20,17 +20,19 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheFactory;
@@ -44,9 +46,9 @@ import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionAdapter;
 import org.apache.geode.cache.execute.FunctionContext;
-import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedMember;
@@ -61,10 +63,12 @@ import org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.LogWriterUtils;
-import org.apache.geode.test.dunit.SerializableCallable;
+import org.apache.geode.test.dunit.SerializableCallableIF;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 /**
  * This is DUnite Test to test the Function Execution stats under various scenarios like
@@ -72,92 +76,83 @@ import org.apache.geode.test.junit.categories.FunctionServiceTest;
  * Execution
  */
 @Category({FunctionServiceTest.class})
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
-
-  static Boolean isByName = null;
 
   static InternalDistributedSystem ds = null;
 
-  static int noOfExecutionCalls_Aggregate = 0;
-  static int noOfExecutionsCompleted_Aggregate = 0;
-  static int resultReceived_Aggregate = 0;
-  static int noOfExecutionExceptions_Aggregate = 0;
+  private static int noOfExecutionCalls_Aggregate = 0;
+  private static int noOfExecutionsCompleted_Aggregate = 0;
+  private static int resultReceived_Aggregate = 0;
+  private static int noOfExecutionExceptions_Aggregate = 0;
 
-  static int noOfExecutionCalls_TESTFUNCTION1 = 0;
-  static int noOfExecutionsCompleted_TESTFUNCTION1 = 0;
-  static int resultReceived_TESTFUNCTION1 = 0;
-  static int noOfExecutionExceptions_TESTFUNCTION1 = 0;
+  private static int noOfExecutionCalls_TESTFUNCTION1 = 0;
+  private static int noOfExecutionsCompleted_TESTFUNCTION1 = 0;
+  private static int resultReceived_TESTFUNCTION1 = 0;
 
-  static int noOfExecutionCalls_TESTFUNCTION2 = 0;
-  static int noOfExecutionsCompleted_TESTFUNCTION2 = 0;
-  static int resultReceived_TESTFUNCTION2 = 0;
-  static int noOfExecutionExceptions_TESTFUNCTION2 = 0;
+  private static int noOfExecutionCalls_TESTFUNCTION2 = 0;
+  private static int noOfExecutionsCompleted_TESTFUNCTION2 = 0;
+  private static int resultReceived_TESTFUNCTION2 = 0;
 
-  static int noOfExecutionCalls_TESTFUNCTION3 = 0;
-  static int noOfExecutionsCompleted_TESTFUNCTION3 = 0;
-  static int resultReceived_TESTFUNCTION3 = 0;
-  static int noOfExecutionExceptions_TESTFUNCTION3 = 0;
+  private static int noOfExecutionCalls_TESTFUNCTION3 = 0;
+  private static int noOfExecutionsCompleted_TESTFUNCTION3 = 0;
+  private static int resultReceived_TESTFUNCTION3 = 0;
 
-  static int noOfExecutionCalls_TESTFUNCTION5 = 0;
-  static int noOfExecutionsCompleted_TESTFUNCTION5 = 0;
-  static int resultReceived_TESTFUNCTION5 = 0;
-  static int noOfExecutionExceptions_TESTFUNCTION5 = 0;
+  private static int noOfExecutionCalls_TESTFUNCTION5 = 0;
+  private static int noOfExecutionsCompleted_TESTFUNCTION5 = 0;
+  private static int resultReceived_TESTFUNCTION5 = 0;
 
-  static int noOfExecutionCalls_Inline = 0;
-  static int noOfExecutionsCompleted_Inline = 0;
-  static int resultReceived_Inline = 0;
-  static int noOfExecutionExceptions_Inline = 0;
+  private static int noOfExecutionCalls_Inline = 0;
+  private static int noOfExecutionsCompleted_Inline = 0;
+  private static int resultReceived_Inline = 0;
 
-  static int noOfExecutionCalls_TestFunctionException = 0;
-  static int noOfExecutionsCompleted_TestFunctionException = 0;
-  static int resultReceived_TestFunctionException = 0;
-  static int noOfExecutionExceptions_TestFunctionException = 0;
+  private static int noOfExecutionCalls_TestFunctionException = 0;
+  private static int noOfExecutionsCompleted_TestFunctionException = 0;
+  private static int noOfExecutionExceptions_TestFunctionException = 0;
 
   @Override
-  protected final void postSetUpPRClientServerTestBase() throws Exception {
+  protected final void postSetUpPRClientServerTestBase() {
     // Make sure stats to linger from a previous test
     disconnectAllFromDS();
   }
 
-  final SerializableCallable initializeStats = new SerializableCallable("initializeStats") {
-    @Override
-    public Object call() throws Exception {
+  private final transient SerializableCallableIF<Boolean> initializeStats = () -> {
+    noOfExecutionCalls_Aggregate = 0;
+    noOfExecutionsCompleted_Aggregate = 0;
+    resultReceived_Aggregate = 0;
+    noOfExecutionExceptions_Aggregate = 0;
 
-      noOfExecutionCalls_Aggregate = 0;
-      noOfExecutionsCompleted_Aggregate = 0;
-      resultReceived_Aggregate = 0;
-      noOfExecutionExceptions_Aggregate = 0;
+    noOfExecutionCalls_TESTFUNCTION1 = 0;
+    noOfExecutionsCompleted_TESTFUNCTION1 = 0;
+    resultReceived_TESTFUNCTION1 = 0;
 
-      noOfExecutionCalls_TESTFUNCTION1 = 0;
-      noOfExecutionsCompleted_TESTFUNCTION1 = 0;
-      resultReceived_TESTFUNCTION1 = 0;
-      noOfExecutionExceptions_TESTFUNCTION1 = 0;
+    noOfExecutionCalls_TESTFUNCTION2 = 0;
+    noOfExecutionsCompleted_TESTFUNCTION2 = 0;
+    resultReceived_TESTFUNCTION2 = 0;
 
-      noOfExecutionCalls_TESTFUNCTION2 = 0;
-      noOfExecutionsCompleted_TESTFUNCTION2 = 0;
-      resultReceived_TESTFUNCTION2 = 0;
-      noOfExecutionExceptions_TESTFUNCTION2 = 0;
+    noOfExecutionCalls_TESTFUNCTION3 = 0;
+    noOfExecutionsCompleted_TESTFUNCTION3 = 0;
+    resultReceived_TESTFUNCTION3 = 0;
 
-      noOfExecutionCalls_TESTFUNCTION3 = 0;
-      noOfExecutionsCompleted_TESTFUNCTION3 = 0;
-      resultReceived_TESTFUNCTION3 = 0;
-      noOfExecutionExceptions_TESTFUNCTION3 = 0;
+    noOfExecutionCalls_TESTFUNCTION5 = 0;
+    noOfExecutionsCompleted_TESTFUNCTION5 = 0;
+    resultReceived_TESTFUNCTION5 = 0;
 
-      noOfExecutionCalls_TESTFUNCTION5 = 0;
-      noOfExecutionsCompleted_TESTFUNCTION5 = 0;
-      resultReceived_TESTFUNCTION5 = 0;
-      noOfExecutionExceptions_TESTFUNCTION5 = 0;
+    noOfExecutionCalls_Inline = 0;
+    noOfExecutionsCompleted_Inline = 0;
+    resultReceived_Inline = 0;
 
-      noOfExecutionCalls_Inline = 0;
-      noOfExecutionsCompleted_Inline = 0;
-      resultReceived_Inline = 0;
-      noOfExecutionExceptions_Inline = 0;
+    noOfExecutionCalls_TestFunctionException = 0;
+    noOfExecutionsCompleted_TestFunctionException = 0;
+    noOfExecutionExceptions_TestFunctionException = 0;
+    return Boolean.TRUE;
+  };
 
-      noOfExecutionCalls_TestFunctionException = 0;
-      noOfExecutionsCompleted_TestFunctionException = 0;
-      resultReceived_TestFunctionException = 0;
-      noOfExecutionExceptions_TestFunctionException = 0;
-      return Boolean.TRUE;
+  private final transient SerializableRunnableIF closeDistributedSystem = () -> {
+    if (getCache() != null && !getCache().isClosed()) {
+      getCache().close();
+      getCache().getDistributedSystem().disconnect();
     }
   };
 
@@ -190,151 +185,128 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
   @Test
   public void testClientServerPartitonedRegionFunctionExecutionStats() {
     createScenario();
-    Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
-    registerFunctionAtServer(function);
-    function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
-    registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    registerFunctionAtServer(new TestFunction(true, TestFunction.TEST_FUNCTION2));
+    registerFunctionAtServer(new TestFunction(true, TestFunction.TEST_FUNCTION3));
 
     client.invoke(initializeStats);
     server1.invoke(initializeStats);
     server2.invoke(initializeStats);
     server3.invoke(initializeStats);
 
-    SerializableCallable PopulateRegionAndExecuteFunctions =
-        new SerializableCallable("PopulateRegionAndExecuteFunctions") {
-          @Override
-          public Object call() throws Exception {
-            Region region = cache.getRegion(PartitionedRegionName);
-            assertNotNull(region);
-            final HashSet testKeysSet = new HashSet();
-            for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
-              testKeysSet.add("execKey-" + i);
-            }
-            DistributedSystem.setThreadsSocketPolicy(false);
-            Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
-            FunctionService.registerFunction(function);
-            Execution dataSet = FunctionService.onRegion(region);
-            try {
-              int j = 0;
-              HashSet origVals = new HashSet();
-              for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-                Integer val = new Integer(j++);
-                origVals.add(val);
-                region.put(i.next(), val);
-              }
-              ResultCollector rc = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
-                  .execute(function.getId());
-              int resultSize = ((List) rc.getResult()).size();
-              resultReceived_Aggregate += resultSize;
-              resultReceived_TESTFUNCTION2 += resultSize;
-              noOfExecutionCalls_Aggregate++;
-              noOfExecutionCalls_TESTFUNCTION2++;
-              noOfExecutionsCompleted_Aggregate++;
-              noOfExecutionsCompleted_TESTFUNCTION2++;
-
-              rc = dataSet.withFilter(testKeysSet).setArguments(testKeysSet)
-                  .execute(function.getId());
-              resultSize = ((List) rc.getResult()).size();
-              resultReceived_Aggregate += resultSize;
-              resultReceived_TESTFUNCTION2 += resultSize;
-              noOfExecutionCalls_Aggregate++;
-              noOfExecutionCalls_TESTFUNCTION2++;
-              noOfExecutionsCompleted_Aggregate++;
-              noOfExecutionsCompleted_TESTFUNCTION2++;
-
-              function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
-              FunctionService.registerFunction(function);
-              rc = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
-                  .execute(function.getId());
-              resultSize = ((List) rc.getResult()).size();
-              resultReceived_Aggregate += resultSize;
-              resultReceived_TESTFUNCTION3 += resultSize;
-              noOfExecutionCalls_Aggregate++;
-              noOfExecutionCalls_TESTFUNCTION3++;
-              noOfExecutionsCompleted_Aggregate++;
-              noOfExecutionsCompleted_TESTFUNCTION3++;
-
-            } catch (Exception e) {
-              LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
-              e.printStackTrace();
-              fail("Test failed after the put operation");
-            }
-            return Boolean.TRUE;
-          }
-        };
-    client.invoke(PopulateRegionAndExecuteFunctions);
-
-    SerializableCallable checkStatsOnClient = new SerializableCallable("checkStatsOnClient") {
-      @Override
-      public Object call() throws Exception {
-        // checks for the aggregate stats
-        InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
-        FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
-        waitNoFunctionsRunning(functionServiceStats);
-
-        assertEquals(noOfExecutionCalls_Aggregate,
-            functionServiceStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_Aggregate,
-            functionServiceStats.getFunctionExecutionsCompleted());
-        assertTrue(functionServiceStats.getResultsReceived() >= resultReceived_Aggregate);
-
-        LogWriterUtils.getLogWriter().info("Calling FunctionStats for  TEST_FUNCTION2 :");
-        FunctionStats functionStats =
-            FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
-        LogWriterUtils.getLogWriter().info("Called FunctionStats for  TEST_FUNCTION2 :");
-        assertEquals(noOfExecutionCalls_TESTFUNCTION2, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
-            functionStats.getFunctionExecutionsCompleted());
-        assertTrue(functionStats.getResultsReceived() >= resultReceived_TESTFUNCTION2);
-
-        functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
-        assertEquals(noOfExecutionCalls_TESTFUNCTION3, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION3,
-            functionStats.getFunctionExecutionsCompleted());
-        assertTrue(functionStats.getResultsReceived() >= resultReceived_TESTFUNCTION3);
-
-        return Boolean.TRUE;
+    client.invoke(() -> {
+      Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
+      assertNotNull(region);
+      final HashSet<String> testKeysSet = new HashSet<>();
+      for (int i = (totalNumBuckets * 2); i > 0; i--) {
+        testKeysSet.add("execKey-" + i);
       }
-    };
-
-    client.invoke(checkStatsOnClient);
-
-    SerializableCallable checkStatsOnServer = new SerializableCallable("checkStatsOnClient") {
-      @Override
-      public Object call() throws Exception {
-        // checks for the aggregate stats
-        InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
-        FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
-        waitNoFunctionsRunning(functionServiceStats);
-
-        // functions are executed 3 times
-        noOfExecutionCalls_Aggregate += 3;
-        assertTrue(
-            functionServiceStats.getFunctionExecutionCalls() >= noOfExecutionCalls_Aggregate);
-        noOfExecutionsCompleted_Aggregate += 3;
-        assertTrue(functionServiceStats
-            .getFunctionExecutionsCompleted() >= noOfExecutionsCompleted_Aggregate);
-
-        FunctionStats functionStats =
-            FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
-        // TEST_FUNCTION2 is executed twice
-        noOfExecutionCalls_TESTFUNCTION2 += 2;
-        assertTrue(functionStats.getFunctionExecutionCalls() >= noOfExecutionCalls_TESTFUNCTION2);
-        noOfExecutionsCompleted_TESTFUNCTION2 += 2;
-        assertTrue(functionStats
-            .getFunctionExecutionsCompleted() >= noOfExecutionsCompleted_TESTFUNCTION2);
-
-        functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
-        // TEST_FUNCTION3 is executed once
-        noOfExecutionCalls_TESTFUNCTION3 += 1;
-        assertTrue(functionStats.getFunctionExecutionCalls() >= noOfExecutionCalls_TESTFUNCTION3);
-        noOfExecutionsCompleted_TESTFUNCTION3 += 1;
-        assertTrue(functionStats
-            .getFunctionExecutionsCompleted() >= noOfExecutionsCompleted_TESTFUNCTION3);
-
-        return Boolean.TRUE;
+      DistributedSystem.setThreadsSocketPolicy(false);
+      Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
+      if (shouldRegisterFunctionsOnClient()) {
+        FunctionService.registerFunction(function);
       }
+      Execution dataSet = FunctionService.onRegion(region);
+      try {
+        int j = 0;
+        for (String s : testKeysSet) {
+          Integer val = j++;
+          region.put(s, val);
+        }
+        ResultCollector rc =
+            dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
+        int resultSize = ((List) rc.getResult()).size();
+        resultReceived_Aggregate += resultSize;
+        resultReceived_TESTFUNCTION2 += resultSize;
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionCalls_TESTFUNCTION2++;
+        noOfExecutionsCompleted_Aggregate++;
+        noOfExecutionsCompleted_TESTFUNCTION2++;
+
+        rc = dataSet.withFilter(testKeysSet).setArguments(testKeysSet).execute(function.getId());
+        resultSize = ((List) rc.getResult()).size();
+        resultReceived_Aggregate += resultSize;
+        resultReceived_TESTFUNCTION2 += resultSize;
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionCalls_TESTFUNCTION2++;
+        noOfExecutionsCompleted_Aggregate++;
+        noOfExecutionsCompleted_TESTFUNCTION2++;
+
+        function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
+        FunctionService.registerFunction(function);
+        rc = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
+        resultSize = ((List) rc.getResult()).size();
+        resultReceived_Aggregate += resultSize;
+        resultReceived_TESTFUNCTION3 += resultSize;
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionCalls_TESTFUNCTION3++;
+        noOfExecutionsCompleted_Aggregate++;
+        noOfExecutionsCompleted_TESTFUNCTION3++;
+
+      } catch (Exception e) {
+        LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
+        e.printStackTrace();
+        fail("Test failed after the put operation");
+      }
+    });
+
+    client.invoke(() -> {
+      // checks for the aggregate stats
+      InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
+      FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
+
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Aggregate,
+          functionServiceStats.getFunctionExecutionsCompleted());
+      assertTrue(functionServiceStats.getResultsReceived() >= resultReceived_Aggregate);
+
+      LogWriterUtils.getLogWriter().info("Calling FunctionStats for  TEST_FUNCTION2 :");
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
+      LogWriterUtils.getLogWriter().info("Called FunctionStats for  TEST_FUNCTION2 :");
+      assertEquals(noOfExecutionCalls_TESTFUNCTION2, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
+          functionStats.getFunctionExecutionsCompleted());
+      assertTrue(functionStats.getResultsReceived() >= resultReceived_TESTFUNCTION2);
+
+      functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
+      assertEquals(noOfExecutionCalls_TESTFUNCTION3, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION3,
+          functionStats.getFunctionExecutionsCompleted());
+      assertTrue(functionStats.getResultsReceived() >= resultReceived_TESTFUNCTION3);
+    });
+
+    SerializableRunnableIF checkStatsOnServer = () -> {
+      // checks for the aggregate stats
+      InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
+      FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
+
+      // functions are executed 3 times
+      noOfExecutionCalls_Aggregate += 3;
+      assertTrue(
+          functionServiceStats.getFunctionExecutionCalls() >= noOfExecutionCalls_Aggregate);
+      noOfExecutionsCompleted_Aggregate += 3;
+      assertTrue(functionServiceStats
+          .getFunctionExecutionsCompleted() >= noOfExecutionsCompleted_Aggregate);
+
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
+      // TEST_FUNCTION2 is executed twice
+      noOfExecutionCalls_TESTFUNCTION2 += 2;
+      assertTrue(functionStats.getFunctionExecutionCalls() >= noOfExecutionCalls_TESTFUNCTION2);
+      noOfExecutionsCompleted_TESTFUNCTION2 += 2;
+      assertTrue(functionStats
+          .getFunctionExecutionsCompleted() >= noOfExecutionsCompleted_TESTFUNCTION2);
+
+      functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
+      // TEST_FUNCTION3 is executed once
+      noOfExecutionCalls_TESTFUNCTION3 += 1;
+      assertTrue(functionStats.getFunctionExecutionCalls() >= noOfExecutionCalls_TESTFUNCTION3);
+      noOfExecutionsCompleted_TESTFUNCTION3 += 1;
+      assertTrue(functionStats
+          .getFunctionExecutionsCompleted() >= noOfExecutionsCompleted_TESTFUNCTION3);
     };
 
     server1.invoke(checkStatsOnServer);
@@ -354,184 +326,159 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
   public void testClientServerDistributedRegionFunctionExecutionStats() {
 
     final String regionName = "FunctionServiceStatsDUnitTest";
-    SerializableCallable createCahenServer = new SerializableCallable("createCahenServer") {
-      @Override
-      public Object call() throws Exception {
-        try {
-          Properties props = new Properties();
-          DistributedSystem ds = getSystem(props);
-          assertNotNull(ds);
-          ds.disconnect();
-          ds = getSystem(props);
-          cache = CacheFactory.create(ds);
-          LogWriterUtils.getLogWriter().info("Created Cache on Server");
-          assertNotNull(cache);
-          AttributesFactory factory = new AttributesFactory();
-          factory.setScope(Scope.DISTRIBUTED_ACK);
-          factory.setDataPolicy(DataPolicy.REPLICATE);
-          assertNotNull(cache);
-          Region region = cache.createRegion(regionName, factory.create());
-          LogWriterUtils.getLogWriter().info("Region Created :" + region);
-          assertNotNull(region);
-          for (int i = 1; i <= 200; i++) {
-            region.put("execKey-" + i, new Integer(i));
-          }
-          CacheServer server = cache.addCacheServer();
-          assertNotNull(server);
-          int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-          server.setPort(port);
-          try {
-            server.start();
-          } catch (IOException e) {
-            Assert.fail("Failed to start the Server", e);
-          }
-          assertTrue(server.isRunning());
-          return new Integer(server.getPort());
-        } catch (Exception e) {
-          Assert.fail("FunctionServiceStatsDUnitTest#createCache() Failed while creating the cache",
-              e);
-          throw e;
+    SerializableCallableIF<Integer> createCahenServer = () -> {
+      try {
+        Properties props = new Properties();
+        DistributedSystem ds = getSystem(props);
+        assertNotNull(ds);
+        ds.disconnect();
+        ds = getSystem(props);
+        cache = CacheFactory.create(ds);
+        LogWriterUtils.getLogWriter().info("Created Cache on Server");
+        assertNotNull(cache);
+        AttributesFactory factory = new AttributesFactory();
+        factory.setScope(Scope.DISTRIBUTED_ACK);
+        factory.setDataPolicy(DataPolicy.REPLICATE);
+        assertNotNull(cache);
+        Region<String, Integer> region = cache.createRegion(regionName, factory.create());
+        LogWriterUtils.getLogWriter().info("Region Created :" + region);
+        assertNotNull(region);
+        for (int i = 1; i <= 200; i++) {
+          region.put("execKey-" + i, i);
         }
+        CacheServer server = cache.addCacheServer();
+        assertNotNull(server);
+        int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
+        server.setPort(port);
+        try {
+          server.start();
+        } catch (IOException e) {
+          Assert.fail("Failed to start the Server", e);
+        }
+        assertTrue(server.isRunning());
+        return server.getPort();
+      } catch (Exception e) {
+        Assert.fail("FunctionServiceStatsDUnitTest#createCache() Failed while creating the cache",
+            e);
+        throw e;
       }
     };
-    final Integer port1 = (Integer) server1.invoke(createCahenServer);
-    final Integer port2 = (Integer) server2.invoke(createCahenServer);
-    final Integer port3 = (Integer) server3.invoke(createCahenServer);
+    final Integer port1 = server1.invoke(createCahenServer);
+    final Integer port2 = server2.invoke(createCahenServer);
+    final Integer port3 = server3.invoke(createCahenServer);
 
-    SerializableCallable createCaheInClient = new SerializableCallable("createCaheInClient") {
-      @Override
-      public Object call() throws Exception {
+    client.invoke(() -> {
+      try {
+        Properties props = new Properties();
+        props.put(MCAST_PORT, "0");
+        props.put(LOCATORS, "");
+        DistributedSystem ds = getSystem(props);
+        assertNotNull(ds);
+        ds.disconnect();
+        ds = getSystem(props);
+        cache = CacheFactory.create(ds);
+        LogWriterUtils.getLogWriter().info("Created Cache on Client");
+        assertNotNull(cache);
+
+
+        CacheServerTestUtil.disableShufflingOfEndpoints();
+        Pool p;
         try {
-          Properties props = new Properties();
-          props.put(MCAST_PORT, "0");
-          props.put(LOCATORS, "");
-          DistributedSystem ds = getSystem(props);
-          assertNotNull(ds);
-          ds.disconnect();
-          ds = getSystem(props);
-          cache = CacheFactory.create(ds);
-          LogWriterUtils.getLogWriter().info("Created Cache on Client");
-          assertNotNull(cache);
-
-
-          CacheServerTestUtil.disableShufflingOfEndpoints();
-          Pool p;
-          try {
-            p = PoolManager.createFactory().addServer("localhost", port1.intValue())
-                .addServer("localhost", port2.intValue()).addServer("localhost", port3.intValue())
-                .setPingInterval(250).setSubscriptionEnabled(false).setSubscriptionRedundancy(-1)
-                .setReadTimeout(2000).setSocketBufferSize(1000).setMinConnections(6)
-                .setMaxConnections(10).setRetryAttempts(3)
-                .create("FunctionServiceStatsDUnitTest_pool");
-          } finally {
-            CacheServerTestUtil.enableShufflingOfEndpoints();
-          }
-          AttributesFactory factory = new AttributesFactory();
-          factory.setScope(Scope.LOCAL);
-          factory.setDataPolicy(DataPolicy.EMPTY);
-          factory.setPoolName(p.getName());
-          assertNotNull(cache);
-          Region region = cache.createRegion(regionName, factory.create());
-          LogWriterUtils.getLogWriter().info("Client Region Created :" + region);
-          assertNotNull(region);
-          for (int i = 1; i <= 200; i++) {
-            region.put("execKey-" + i, new Integer(i));
-          }
-          return Boolean.TRUE;
-        } catch (Exception e) {
-          Assert.fail("FunctionServiceStatsDUnitTest#createCache() Failed while creating the cache",
-              e);
-          throw e;
+          p = PoolManager.createFactory().addServer("localhost", port1)
+              .addServer("localhost", port2).addServer("localhost", port3)
+              .setPingInterval(250).setSubscriptionEnabled(false).setSubscriptionRedundancy(-1)
+              .setReadTimeout(2000).setSocketBufferSize(1000).setMinConnections(6)
+              .setMaxConnections(10).setRetryAttempts(3)
+              .create("FunctionServiceStatsDUnitTest_pool");
+        } finally {
+          CacheServerTestUtil.enableShufflingOfEndpoints();
         }
+        AttributesFactory factory = new AttributesFactory();
+        factory.setScope(Scope.LOCAL);
+        factory.setDataPolicy(DataPolicy.EMPTY);
+        factory.setPoolName(p.getName());
+        assertNotNull(cache);
+        Region<String, Integer> region = cache.createRegion(regionName, factory.create());
+        LogWriterUtils.getLogWriter().info("Client Region Created :" + region);
+        assertNotNull(region);
+        for (int i = 1; i <= 200; i++) {
+          region.put("execKey-" + i, i);
+        }
+      } catch (Exception e) {
+        Assert.fail("FunctionServiceStatsDUnitTest#createCache() Failed while creating the cache",
+            e);
+        throw e;
       }
-    };
-    client.invoke(createCaheInClient);
+    });
 
     client.invoke(initializeStats);
     server1.invoke(initializeStats);
     server2.invoke(initializeStats);
     server3.invoke(initializeStats);
 
-    Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
-    registerFunctionAtServer(function);
-    function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
-    registerFunctionAtServer(function);
+    registerFunctionAtServer(new TestFunction(true, TestFunction.TEST_FUNCTION2));
+    registerFunctionAtServer(new TestFunction(true, TestFunction.TEST_FUNCTION3));
 
-    SerializableCallable ExecuteFunctions =
-        new SerializableCallable("PopulateRegionAndExecuteFunctions") {
-          @Override
-          public Object call() throws Exception {
-            Function function2 = new TestFunction(true, TestFunction.TEST_FUNCTION2);
-            FunctionService.registerFunction(function2);
-            Function function3 = new TestFunction(true, TestFunction.TEST_FUNCTION3);
-            FunctionService.registerFunction(function3);
-            Region region = cache.getRegion(regionName);
-            Set filter = new HashSet();
-            for (int i = 100; i < 120; i++) {
-              filter.add("execKey-" + i);
-            }
-
-            try {
-              noOfExecutionCalls_Aggregate++;
-              noOfExecutionCalls_TESTFUNCTION2++;
-              List list = (List) FunctionService.onRegion(region).withFilter(filter)
-                  .execute(function2).getResult();
-              noOfExecutionsCompleted_Aggregate++;
-              noOfExecutionsCompleted_TESTFUNCTION2++;
-              int size = list.size();
-              resultReceived_Aggregate += size;
-              resultReceived_TESTFUNCTION2 += size;
-
-              noOfExecutionCalls_Aggregate++;
-              noOfExecutionCalls_TESTFUNCTION2++;
-              list = (List) FunctionService.onRegion(region).withFilter(filter).execute(function2)
-                  .getResult();
-              noOfExecutionsCompleted_Aggregate++;
-              noOfExecutionsCompleted_TESTFUNCTION2++;
-              size = list.size();
-              resultReceived_Aggregate += size;
-              resultReceived_TESTFUNCTION2 += size;
-
-              return Boolean.TRUE;
-            } catch (FunctionException e) {
-              e.printStackTrace();
-              Assert.fail("test failed due to", e);
-              throw e;
-            } catch (Exception e) {
-              e.printStackTrace();
-              Assert.fail("test failed due to", e);
-              throw e;
-            }
-
-          }
-        };
-    client.invoke(ExecuteFunctions);
-
-    SerializableCallable checkStatsOnClient = new SerializableCallable("checkStatsOnClient") {
-      @Override
-      public Object call() throws Exception {
-        // checks for the aggregate stats
-        InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
-        FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
-        waitNoFunctionsRunning(functionServiceStats);
-
-        assertEquals(noOfExecutionCalls_Aggregate,
-            functionServiceStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_Aggregate,
-            functionServiceStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
-
-        FunctionStats functionStats =
-            FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
-        assertEquals(noOfExecutionCalls_TESTFUNCTION2, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
-            functionStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_TESTFUNCTION2, functionStats.getResultsReceived());
-
-        return Boolean.TRUE;
+    client.invoke(() -> {
+      Function function2 = new TestFunction(true, TestFunction.TEST_FUNCTION2);
+      Function function3 = new TestFunction(true, TestFunction.TEST_FUNCTION3);
+      if (shouldRegisterFunctionsOnClient()) {
+        FunctionService.registerFunction(function2);
+        FunctionService.registerFunction(function3);
       }
-    };
-    client.invoke(checkStatsOnClient);
+      Region region = cache.getRegion(regionName);
+      Set<String> filter = new HashSet<>();
+      for (int i = 100; i < 120; i++) {
+        filter.add("execKey-" + i);
+      }
+
+      try {
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionCalls_TESTFUNCTION2++;
+        List list = (List) FunctionService.onRegion(region).withFilter(filter)
+            .execute(function2).getResult();
+        noOfExecutionsCompleted_Aggregate++;
+        noOfExecutionsCompleted_TESTFUNCTION2++;
+        int size = list.size();
+        resultReceived_Aggregate += size;
+        resultReceived_TESTFUNCTION2 += size;
+
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionCalls_TESTFUNCTION2++;
+        list = (List) FunctionService.onRegion(region).withFilter(filter).execute(function2)
+            .getResult();
+        noOfExecutionsCompleted_Aggregate++;
+        noOfExecutionsCompleted_TESTFUNCTION2++;
+        size = list.size();
+        resultReceived_Aggregate += size;
+        resultReceived_TESTFUNCTION2 += size;
+      } catch (Exception e) {
+        e.printStackTrace();
+        Assert.fail("test failed due to", e);
+        throw e;
+      }
+
+    });
+
+    client.invoke(() -> {
+      // checks for the aggregate stats
+      InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
+      FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
+
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Aggregate,
+          functionServiceStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
+
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
+      assertEquals(noOfExecutionCalls_TESTFUNCTION2, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
+          functionStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_TESTFUNCTION2, functionStats.getResultsReceived());
+    });
   }
 
   /**
@@ -543,148 +490,131 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
   @Test
   public void testClientServerwithoutRegion() {
     createClientServerScenarionWithoutRegion();
-    Function function = new TestFunction(true, TestFunction.TEST_FUNCTION1);
-    registerFunctionAtServer(function);
-    function = new TestFunction(true, TestFunction.TEST_FUNCTION5);
-    registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    registerFunctionAtServer(new TestFunction(true, TestFunction.TEST_FUNCTION1));
+    registerFunctionAtServer(new TestFunction(true, TestFunction.TEST_FUNCTION5));
 
     client.invoke(initializeStats);
     server1.invoke(initializeStats);
     server2.invoke(initializeStats);
     server3.invoke(initializeStats);
 
-    SerializableCallable ExecuteFunction = new SerializableCallable("ExecuteFunction") {
-      @Override
-      public Object call() throws Exception {
-        DistributedSystem.setThreadsSocketPolicy(false);
-        Function function = new TestFunction(true, TestFunction.TEST_FUNCTION1);
+    client.invoke(() -> {
+      DistributedSystem.setThreadsSocketPolicy(false);
+      Function function = new TestFunction(true, TestFunction.TEST_FUNCTION1);
+      if (shouldRegisterFunctionsOnClient()) {
         FunctionService.registerFunction(function);
-        Execution member = FunctionService.onServers(pool);
+      }
+      Execution member = FunctionService.onServers(pool);
 
-        try {
-          ResultCollector rs = member.setArguments(Boolean.TRUE).execute(function.getId());
-          int size = ((List) rs.getResult()).size();
-          resultReceived_Aggregate += size;
-          noOfExecutionCalls_Aggregate++;
-          noOfExecutionsCompleted_Aggregate++;
-          resultReceived_TESTFUNCTION1 += size;
-          noOfExecutionCalls_TESTFUNCTION1++;
-          noOfExecutionsCompleted_TESTFUNCTION1++;
-        } catch (Exception ex) {
-          ex.printStackTrace();
-          LogWriterUtils.getLogWriter().info("Exception : ", ex);
-          fail("Test failed after the execute operation nn TRUE");
-        }
-        function = new TestFunction(true, TestFunction.TEST_FUNCTION5);
+      try {
+        ResultCollector rs = member.setArguments(Boolean.TRUE).execute(function.getId());
+        int size = ((List) rs.getResult()).size();
+        resultReceived_Aggregate += size;
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionsCompleted_Aggregate++;
+        resultReceived_TESTFUNCTION1 += size;
+        noOfExecutionCalls_TESTFUNCTION1++;
+        noOfExecutionsCompleted_TESTFUNCTION1++;
+      } catch (Exception ex) {
+        ex.printStackTrace();
+        LogWriterUtils.getLogWriter().info("Exception : ", ex);
+        fail("Test failed after the execute operation nn TRUE");
+      }
+      function = new TestFunction(true, TestFunction.TEST_FUNCTION5);
+      if (shouldRegisterFunctionsOnClient()) {
         FunctionService.registerFunction(function);
+      }
+      try {
+        ResultCollector rs = member.setArguments("Success").execute(function.getId());
+        int size = ((List) rs.getResult()).size();
+        resultReceived_Aggregate += size;
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionsCompleted_Aggregate++;
+        resultReceived_TESTFUNCTION5 += size;
+        noOfExecutionCalls_TESTFUNCTION5++;
+        noOfExecutionsCompleted_TESTFUNCTION5++;
+      } catch (Exception ex) {
+        ex.printStackTrace();
+        LogWriterUtils.getLogWriter().info("Exception : ", ex);
+        fail("Test failed after the execute operationssssss");
+      }
+    });
+
+
+    client.invoke(() -> {
+      // checks for the aggregate stats
+      InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
+      FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
+
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Aggregate,
+          functionServiceStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
+
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION1, iDS);
+      assertEquals(noOfExecutionCalls_TESTFUNCTION1, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION1,
+          functionStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_TESTFUNCTION1, functionStats.getResultsReceived());
+
+      functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION5, iDS);
+      assertEquals(noOfExecutionCalls_TESTFUNCTION5, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION5,
+          functionStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_TESTFUNCTION5, functionStats.getResultsReceived());
+
+    });
+
+    SerializableRunnableIF checkStatsOnServer = () -> {
+      // checks for the aggregate stats
+      InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
+      FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
+
+      // functions are executed 2 times
+      noOfExecutionCalls_Aggregate += 2;
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      noOfExecutionsCompleted_Aggregate += 2;
+      // this check is time sensitive, so allow it to fail a few times
+      // before giving up
+      for (int i = 0; i < 10; i++) {
         try {
-          final HashSet testKeysSet = new HashSet();
-          for (int i = 0; i < 20; i++) {
-            testKeysSet.add("execKey-" + i);
+          assertEquals(noOfExecutionsCompleted_Aggregate,
+              functionServiceStats.getFunctionExecutionsCompleted());
+        } catch (RuntimeException r) {
+          if (i == 9) {
+            throw r;
           }
-          ResultCollector rs = member.setArguments("Success").execute(function.getId());
-          int size = ((List) rs.getResult()).size();
-          resultReceived_Aggregate += size;
-          noOfExecutionCalls_Aggregate++;
-          noOfExecutionsCompleted_Aggregate++;
-          resultReceived_TESTFUNCTION5 += size;
-          noOfExecutionCalls_TESTFUNCTION5++;
-          noOfExecutionsCompleted_TESTFUNCTION5++;
-        } catch (Exception ex) {
-          ex.printStackTrace();
-          LogWriterUtils.getLogWriter().info("Exception : ", ex);
-          fail("Test failed after the execute operationssssss");
-        }
-        return Boolean.TRUE;
-      }
-    };
-    client.invoke(ExecuteFunction);
-
-    SerializableCallable checkStatsOnClient = new SerializableCallable("checkStatsOnClient") {
-      @Override
-      public Object call() throws Exception {
-        // checks for the aggregate stats
-        InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
-        FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
-        waitNoFunctionsRunning(functionServiceStats);
-
-        assertEquals(noOfExecutionCalls_Aggregate,
-            functionServiceStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_Aggregate,
-            functionServiceStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
-
-        FunctionStats functionStats =
-            FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION1, iDS);
-        assertEquals(noOfExecutionCalls_TESTFUNCTION1, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION1,
-            functionStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_TESTFUNCTION1, functionStats.getResultsReceived());
-
-        functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION5, iDS);
-        assertEquals(noOfExecutionCalls_TESTFUNCTION5, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION5,
-            functionStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_TESTFUNCTION5, functionStats.getResultsReceived());
-
-        return Boolean.TRUE;
-      }
-    };
-
-    client.invoke(checkStatsOnClient);
-
-    SerializableCallable checkStatsOnServer = new SerializableCallable("checkStatsOnClient") {
-      @Override
-      public Object call() throws Exception {
-        // checks for the aggregate stats
-        InternalDistributedSystem iDS = (InternalDistributedSystem) cache.getDistributedSystem();
-        FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
-        waitNoFunctionsRunning(functionServiceStats);
-
-        // functions are executed 2 times
-        noOfExecutionCalls_Aggregate += 2;
-        assertEquals(noOfExecutionCalls_Aggregate,
-            functionServiceStats.getFunctionExecutionCalls());
-        noOfExecutionsCompleted_Aggregate += 2;
-        // this check is time sensitive, so allow it to fail a few times
-        // before giving up
-        for (int i = 0; i < 10; i++) {
           try {
-            assertEquals(noOfExecutionsCompleted_Aggregate,
-                functionServiceStats.getFunctionExecutionsCompleted());
-          } catch (RuntimeException r) {
-            if (i == 9) {
-              throw r;
-            }
-            try {
-              Thread.sleep(1000);
-            } catch (InterruptedException ie) {
-              Thread.currentThread().interrupt();
-              throw r;
-            }
+            Thread.sleep(1000);
+          } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw r;
           }
         }
-
-        FunctionStats functionStats =
-            FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION1, iDS);
-        // TEST_FUNCTION1 is executed once
-        noOfExecutionCalls_TESTFUNCTION1 += 1;
-        assertEquals(noOfExecutionCalls_TESTFUNCTION1, functionStats.getFunctionExecutionCalls());
-        noOfExecutionsCompleted_TESTFUNCTION1 += 1;
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION1,
-            functionStats.getFunctionExecutionsCompleted());
-
-        functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION5, iDS);
-        // TEST_FUNCTION5 is executed once
-        noOfExecutionCalls_TESTFUNCTION5 += 1;
-        assertEquals(noOfExecutionCalls_TESTFUNCTION5, functionStats.getFunctionExecutionCalls());
-        noOfExecutionsCompleted_TESTFUNCTION5 += 1;
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION5,
-            functionStats.getFunctionExecutionsCompleted());
-
-        return Boolean.TRUE;
       }
+
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION1, iDS);
+      // TEST_FUNCTION1 is executed once
+      noOfExecutionCalls_TESTFUNCTION1 += 1;
+      assertEquals(noOfExecutionCalls_TESTFUNCTION1, functionStats.getFunctionExecutionCalls());
+      noOfExecutionsCompleted_TESTFUNCTION1 += 1;
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION1,
+          functionStats.getFunctionExecutionsCompleted());
+
+      functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION5, iDS);
+      // TEST_FUNCTION5 is executed once
+      noOfExecutionCalls_TESTFUNCTION5 += 1;
+      assertEquals(noOfExecutionCalls_TESTFUNCTION5, functionStats.getFunctionExecutionCalls());
+      noOfExecutionsCompleted_TESTFUNCTION5 += 1;
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION5,
+          functionStats.getFunctionExecutionsCompleted());
+
     };
 
     server1.invoke(checkStatsOnServer);
@@ -693,23 +623,12 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
   }
 
   @Test
-  public void testP2PDummyExecutionStats() throws Exception {
+  public void testP2PDummyExecutionStats() {
     Host host = Host.getHost(0);
     final VM datastore0 = host.getVM(0);
     final VM datastore1 = host.getVM(1);
     final VM datastore2 = host.getVM(2);
     final VM accessor = host.getVM(3);
-    SerializableCallable closeDistributedSystem =
-        new SerializableCallable("closeDistributedSystem") {
-          @Override
-          public Object call() throws Exception {
-            if (getCache() != null && !getCache().isClosed()) {
-              getCache().close();
-              getCache().getDistributedSystem().disconnect();
-            }
-            return Boolean.TRUE;
-          }
-        };
     accessor.invoke(closeDistributedSystem);
     datastore0.invoke(closeDistributedSystem);
     datastore1.invoke(closeDistributedSystem);
@@ -724,7 +643,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
    * function execution calls from the accessor.
    */
   @Test
-  public void testP2PPartitionedRegionsFunctionExecutionStats() throws Exception {
+  public void testP2PPartitionedRegionsFunctionExecutionStats() {
     final String rName = getUniqueName();
     Host host = Host.getHost(0);
     final VM datastore0 = host.getVM(0);
@@ -737,167 +656,130 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
     datastore2.invoke(initializeStats);
     accessor.invoke(initializeStats);
 
-    accessor.invoke(new SerializableCallable("Create PR") {
-      @Override
-      public Object call() throws Exception {
-        RegionAttributes ra = PartitionedRegionTestHelper.createRegionAttrsForPR(0, 0);
-        AttributesFactory raf = new AttributesFactory(ra);
-        PartitionAttributesImpl pa = new PartitionAttributesImpl();
-        pa.setAll(ra.getPartitionAttributes());
-        pa.setTotalNumBuckets(17);
-        raf.setPartitionAttributes(pa);
+    accessor.invoke(() -> {
+      RegionAttributes ra = PartitionedRegionTestHelper.createRegionAttrsForPR(0, 0);
+      AttributesFactory raf = new AttributesFactory(ra);
+      PartitionAttributesImpl pa = new PartitionAttributesImpl();
+      pa.setAll(ra.getPartitionAttributes());
+      pa.setTotalNumBuckets(17);
+      raf.setPartitionAttributes(pa);
 
-        PartitionedRegion pr = (PartitionedRegion) getCache().createRegion(rName, raf.create());
-        return Boolean.TRUE;
-      }
+      getCache().createRegion(rName, raf.create());
     });
 
-    SerializableCallable dataStoreCreate =
-        new SerializableCallable("Create PR with Function Factory") {
-          @Override
-          public Object call() throws Exception {
-            RegionAttributes ra = PartitionedRegionTestHelper.createRegionAttrsForPR(0, 10);
-            AttributesFactory raf = new AttributesFactory(ra);
-            PartitionAttributesImpl pa = new PartitionAttributesImpl();
-            pa.setAll(ra.getPartitionAttributes());
-            pa.setTotalNumBuckets(17);
-            raf.setPartitionAttributes(pa);
-            PartitionedRegion pr = (PartitionedRegion) getCache().createRegion(rName, raf.create());
-            Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
-            FunctionService.registerFunction(function);
-            function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
-            FunctionService.registerFunction(function);
-            return Boolean.TRUE;
-          }
-        };
+    SerializableRunnableIF dataStoreCreate = () -> {
+      RegionAttributes ra = PartitionedRegionTestHelper.createRegionAttrsForPR(0, 10);
+      AttributesFactory raf = new AttributesFactory(ra);
+      PartitionAttributesImpl pa = new PartitionAttributesImpl();
+      pa.setAll(ra.getPartitionAttributes());
+      pa.setTotalNumBuckets(17);
+      raf.setPartitionAttributes(pa);
+      getCache().createRegion(rName, raf.create());
+      Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
+      FunctionService.registerFunction(function);
+      function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
+      FunctionService.registerFunction(function);
+    };
     datastore0.invoke(dataStoreCreate);
     datastore1.invoke(dataStoreCreate);
     datastore2.invoke(dataStoreCreate);
 
-    accessor.invoke(new SerializableCallable("Create data, invoke exectuable") {
-      @Override
-      public Object call() throws Exception {
-
-        PartitionedRegion pr = (PartitionedRegion) getCache().getRegion(rName);
-        DistributedSystem.setThreadsSocketPolicy(false);
-        final HashSet testKeys = new HashSet();
-        for (int i = (pr.getTotalNumberOfBuckets() * 3); i > 0; i--) {
-          testKeys.add("execKey-" + i);
-        }
-        int j = 0;
-        for (Iterator i = testKeys.iterator(); i.hasNext();) {
-          Integer val = new Integer(j++);
-          pr.put(i.next(), val);
-        }
-        Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
-        FunctionService.registerFunction(function);
-        Execution dataSet = FunctionService.onRegion(pr);
-        ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function);
-        int size = ((List) rc1.getResult()).size();
-        resultReceived_Aggregate += size;
-        resultReceived_TESTFUNCTION2 += size;
-
-        rc1 = dataSet.setArguments(testKeys).execute(function);
-        size = ((List) rc1.getResult()).size();
-        resultReceived_Aggregate += size;
-        resultReceived_TESTFUNCTION2 += size;
-
-        function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
-        FunctionService.registerFunction(function);
-        rc1 = dataSet.setArguments(Boolean.TRUE).execute(function);
-        size = ((List) rc1.getResult()).size();
-        resultReceived_Aggregate += size;
-        resultReceived_TESTFUNCTION3 += size;
-
-        return Boolean.TRUE;
+    accessor.invoke(() -> {
+      PartitionedRegion pr = (PartitionedRegion) getCache().getRegion(rName);
+      DistributedSystem.setThreadsSocketPolicy(false);
+      final HashSet<String> testKeys = new HashSet<>();
+      for (int i = (pr.getTotalNumberOfBuckets() * 3); i > 0; i--) {
+        testKeys.add("execKey-" + i);
       }
+      int j = 0;
+      for (Object testKey : testKeys) {
+        Integer val = j++;
+        pr.put(testKey, val);
+      }
+      Function function = new TestFunction(true, TestFunction.TEST_FUNCTION2);
+      FunctionService.registerFunction(function);
+      Execution dataSet = FunctionService.onRegion(pr);
+      ResultCollector rc1 = dataSet.setArguments(Boolean.TRUE).execute(function);
+      int size = ((List) rc1.getResult()).size();
+      resultReceived_Aggregate += size;
+      resultReceived_TESTFUNCTION2 += size;
+
+      rc1 = dataSet.setArguments(testKeys).execute(function);
+      size = ((List) rc1.getResult()).size();
+      resultReceived_Aggregate += size;
+      resultReceived_TESTFUNCTION2 += size;
+
+      function = new TestFunction(true, TestFunction.TEST_FUNCTION3);
+      FunctionService.registerFunction(function);
+      rc1 = dataSet.setArguments(Boolean.TRUE).execute(function);
+      size = ((List) rc1.getResult()).size();
+      resultReceived_Aggregate += size;
+      resultReceived_TESTFUNCTION3 += size;
     });
 
-    accessor.invoke(new SerializableCallable("checkFunctionExecutionStatsForAccessor") {
-      @Override
-      public Object call() throws Exception {
-        InternalDistributedSystem iDS =
-            ((InternalDistributedSystem) getCache().getDistributedSystem());
-        FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
-        waitNoFunctionsRunning(functionServiceStats);
+    accessor.invoke(() -> {
+      InternalDistributedSystem iDS =
+          ((InternalDistributedSystem) getCache().getDistributedSystem());
+      FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
 
-        assertEquals(noOfExecutionCalls_Aggregate,
-            functionServiceStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_Aggregate,
-            functionServiceStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Aggregate,
+          functionServiceStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
 
-        FunctionStats functionStats =
-            FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
-        assertEquals(noOfExecutionCalls_TESTFUNCTION2, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
-            functionStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_TESTFUNCTION2, functionStats.getResultsReceived());
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
+      assertEquals(noOfExecutionCalls_TESTFUNCTION2, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
+          functionStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_TESTFUNCTION2, functionStats.getResultsReceived());
 
-        functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
-        assertEquals(noOfExecutionCalls_TESTFUNCTION3, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_TESTFUNCTION3,
-            functionStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_TESTFUNCTION3, functionStats.getResultsReceived());
-
-        return Boolean.TRUE;
-      }
+      functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
+      assertEquals(noOfExecutionCalls_TESTFUNCTION3, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION3,
+          functionStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_TESTFUNCTION3, functionStats.getResultsReceived());
     });
 
-    SerializableCallable checkFunctionExecutionStatsForDataStore =
-        new SerializableCallable("checkFunctionExecutionStatsForDataStore") {
-          @Override
-          public Object call() throws Exception {
-            InternalDistributedSystem iDS =
-                ((InternalDistributedSystem) getCache().getDistributedSystem());
-            // 3 Function Executions took place
-            FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
-            waitNoFunctionsRunning(functionServiceStats);
+    SerializableRunnableIF checkFunctionExecutionStatsForDataStore = () -> {
+      InternalDistributedSystem iDS =
+          ((InternalDistributedSystem) getCache().getDistributedSystem());
+      // 3 Function Executions took place
+      FunctionServiceStats functionServiceStats = iDS.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
 
-            noOfExecutionCalls_Aggregate += 3;
-            noOfExecutionsCompleted_Aggregate += 3;
-            assertEquals(noOfExecutionCalls_Aggregate,
-                functionServiceStats.getFunctionExecutionCalls());
-            assertEquals(noOfExecutionsCompleted_Aggregate,
-                functionServiceStats.getFunctionExecutionsCompleted());
+      noOfExecutionCalls_Aggregate += 3;
+      noOfExecutionsCompleted_Aggregate += 3;
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Aggregate,
+          functionServiceStats.getFunctionExecutionsCompleted());
 
-            FunctionStats functionStats =
-                FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
-            // TEST_FUNCTION2 is executed twice
-            noOfExecutionCalls_TESTFUNCTION2 += 2;
-            assertEquals(noOfExecutionCalls_TESTFUNCTION2,
-                functionStats.getFunctionExecutionCalls());
-            noOfExecutionsCompleted_TESTFUNCTION2 += 2;
-            assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
-                functionStats.getFunctionExecutionsCompleted());
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION2, iDS);
+      // TEST_FUNCTION2 is executed twice
+      noOfExecutionCalls_TESTFUNCTION2 += 2;
+      assertEquals(noOfExecutionCalls_TESTFUNCTION2,
+          functionStats.getFunctionExecutionCalls());
+      noOfExecutionsCompleted_TESTFUNCTION2 += 2;
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION2,
+          functionStats.getFunctionExecutionsCompleted());
 
-            functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
-            // TEST_FUNCTION3 is executed once
-            noOfExecutionCalls_TESTFUNCTION3 += 1;
-            assertEquals(noOfExecutionCalls_TESTFUNCTION3,
-                functionStats.getFunctionExecutionCalls());
-            noOfExecutionsCompleted_TESTFUNCTION3 += 1;
-            assertEquals(noOfExecutionsCompleted_TESTFUNCTION3,
-                functionStats.getFunctionExecutionsCompleted());
-
-            return Boolean.TRUE;
-          }
-        };
+      functionStats = FunctionStats.getFunctionStats(TestFunction.TEST_FUNCTION3, iDS);
+      // TEST_FUNCTION3 is executed once
+      noOfExecutionCalls_TESTFUNCTION3 += 1;
+      assertEquals(noOfExecutionCalls_TESTFUNCTION3,
+          functionStats.getFunctionExecutionCalls());
+      noOfExecutionsCompleted_TESTFUNCTION3 += 1;
+      assertEquals(noOfExecutionsCompleted_TESTFUNCTION3,
+          functionStats.getFunctionExecutionsCompleted());
+    };
     datastore0.invoke(checkFunctionExecutionStatsForDataStore);
     datastore1.invoke(checkFunctionExecutionStatsForDataStore);
     datastore2.invoke(checkFunctionExecutionStatsForDataStore);
 
-    SerializableCallable closeDistributedSystem =
-        new SerializableCallable("closeDistributedSystem") {
-          @Override
-          public Object call() throws Exception {
-            if (getCache() != null && !getCache().isClosed()) {
-              getCache().close();
-              getCache().getDistributedSystem().disconnect();
-            }
-            return Boolean.TRUE;
-          }
-        };
     accessor.invoke(closeDistributedSystem);
     datastore0.invoke(closeDistributedSystem);
     datastore1.invoke(closeDistributedSystem);
@@ -922,96 +804,63 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
     datastore2.invoke(initializeStats);
     datastore3.invoke(initializeStats);
 
-    SerializableCallable createAndPopulateRegionWithEmpty =
-        new SerializableCallable("Create PR with Function Factory") {
-          @Override
-          public Object call() throws Exception {
-            AttributesFactory factory = new AttributesFactory();
-            factory.setScope(Scope.DISTRIBUTED_ACK);
-            factory.setDataPolicy(DataPolicy.EMPTY);
-            Region region = getCache().createRegion(rName, factory.create());
-            LogWriterUtils.getLogWriter().info("Region Created :" + region);
-            assertNotNull(region);
-            FunctionService.registerFunction(new TestFunction(true, TestFunction.TEST_FUNCTION2));
-            for (int i = 1; i <= 200; i++) {
-              region.put("execKey-" + i, new Integer(i));
-            }
-            return Boolean.TRUE;
-          }
-        };
-    datastore0.invoke(createAndPopulateRegionWithEmpty);
+    datastore0.invoke(() -> {
+      AttributesFactory factory = new AttributesFactory();
+      factory.setScope(Scope.DISTRIBUTED_ACK);
+      factory.setDataPolicy(DataPolicy.EMPTY);
+      Region<String, Integer> region = getCache().createRegion(rName, factory.create());
+      LogWriterUtils.getLogWriter().info("Region Created :" + region);
+      assertNotNull(region);
+      FunctionService.registerFunction(new TestFunction(true, TestFunction.TEST_FUNCTION2));
+      for (int i = 1; i <= 200; i++) {
+        region.put("execKey-" + i, i);
+      }
+    });
 
-    SerializableCallable createAndPopulateRegionWithReplicate =
-        new SerializableCallable("Create PR with Function Factory") {
-          @Override
-          public Object call() throws Exception {
-            AttributesFactory factory = new AttributesFactory();
-            factory.setScope(Scope.DISTRIBUTED_ACK);
-            factory.setDataPolicy(DataPolicy.REPLICATE);
-            Region region = getCache().createRegion(rName, factory.create());
-            LogWriterUtils.getLogWriter().info("Region Created :" + region);
-            assertNotNull(region);
-            FunctionService.registerFunction(new TestFunction(true, TestFunction.TEST_FUNCTION2));
-            for (int i = 1; i <= 200; i++) {
-              region.put("execKey-" + i, new Integer(i));
-            }
-            return Boolean.TRUE;
-          }
-        };
+    SerializableRunnableIF createAndPopulateRegionWithReplicate = () -> {
+      AttributesFactory factory = new AttributesFactory();
+      factory.setScope(Scope.DISTRIBUTED_ACK);
+      factory.setDataPolicy(DataPolicy.REPLICATE);
+      Region<String, Integer> region = getCache().createRegion(rName, factory.create());
+      LogWriterUtils.getLogWriter().info("Region Created :" + region);
+      assertNotNull(region);
+      FunctionService.registerFunction(new TestFunction(true, TestFunction.TEST_FUNCTION2));
+      for (int i = 1; i <= 200; i++) {
+        region.put("execKey-" + i, i);
+      }
+    };
 
     datastore1.invoke(createAndPopulateRegionWithReplicate);
     datastore2.invoke(createAndPopulateRegionWithReplicate);
     datastore3.invoke(createAndPopulateRegionWithReplicate);
 
-    SerializableCallable executeFunction =
-        new SerializableCallable("ExecuteFunction from Normal Region") {
-          @Override
-          public Object call() throws Exception {
-            Region region = getCache().getRegion(rName);
-            try {
-              List list = (List) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
-                  .execute(TestFunction.TEST_FUNCTION2).getResult();
-              // this is the Distributed Region with Empty Data policy.
-              // therefore no function execution takes place here. it only receives the results.
-              resultReceived_Aggregate += list.size();
-              assertEquals(resultReceived_Aggregate,
-                  ((InternalDistributedSystem) getCache().getDistributedSystem())
-                      .getFunctionServiceStats().getResultsReceived());
+    datastore0.invoke(() -> {
+      Region region = getCache().getRegion(rName);
+      try {
+        List list = (List) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
+            .execute(TestFunction.TEST_FUNCTION2).getResult();
+        // this is the Distributed Region with Empty Data policy.
+        // therefore no function execution takes place here. it only receives the results.
+        resultReceived_Aggregate += list.size();
+        assertEquals(resultReceived_Aggregate,
+            ((InternalDistributedSystem) getCache().getDistributedSystem())
+                .getFunctionServiceStats().getResultsReceived());
 
-              resultReceived_TESTFUNCTION2 += list.size();
-              assertEquals(resultReceived_TESTFUNCTION2,
-                  ((InternalDistributedSystem) getCache().getDistributedSystem())
-                      .getFunctionServiceStats().getResultsReceived());
+        resultReceived_TESTFUNCTION2 += list.size();
+        assertEquals(resultReceived_TESTFUNCTION2,
+            ((InternalDistributedSystem) getCache().getDistributedSystem())
+                .getFunctionServiceStats().getResultsReceived());
 
-              return Boolean.TRUE;
-            } catch (FunctionException e) {
-              e.printStackTrace();
-              Assert.fail("test failed due to", e);
-              return Boolean.FALSE;
-            } catch (Exception e) {
-              e.printStackTrace();
-              Assert.fail("test failed due to", e);
-              return Boolean.FALSE;
-            }
+      } catch (Exception e) {
+        e.printStackTrace();
+        Assert.fail("test failed due to", e);
+      }
+    });
 
-          }
-        };
-    datastore0.invoke(executeFunction);
     // there is a replicated region on 3 nodes so we cannot predict on which
     // node the function execution will take place
     // so i have avoided that check.
 
-    SerializableCallable closeDistributedSystem =
-        new SerializableCallable("closeDistributedSystem") {
-          @Override
-          public Object call() throws Exception {
-            if (getCache() != null && !getCache().isClosed()) {
-              getCache().close();
-              getCache().getDistributedSystem().disconnect();
-            }
-            return Boolean.TRUE;
-          }
-        };
     datastore0.invoke(closeDistributedSystem);
     datastore1.invoke(closeDistributedSystem);
     datastore2.invoke(closeDistributedSystem);
@@ -1028,27 +877,22 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
    * equal tio the no of functions from member 1
    */
   @Test
-  public void testP2PMembersFunctionExecutionStats() throws Exception {
+  public void testP2PMembersFunctionExecutionStats() {
     Host host = Host.getHost(0);
     VM member1 = host.getVM(0);
     VM member2 = host.getVM(1);
     VM member3 = host.getVM(2);
     VM member4 = host.getVM(3);
 
-    SerializableCallable connectToDistributedSystem =
-        new SerializableCallable("connectToDistributedSystem") {
-          @Override
-          public Object call() throws Exception {
-            Properties props = new Properties();
-            try {
-              ds = getSystem(props);
-              assertNotNull(ds);
-            } catch (Exception e) {
-              Assert.fail("Failed while creating the Distribued System", e);
-            }
-            return Boolean.TRUE;
-          }
-        };
+    SerializableRunnableIF connectToDistributedSystem = () -> {
+      Properties props = new Properties();
+      try {
+        ds = getSystem(props);
+        assertNotNull(ds);
+      } catch (Exception e) {
+        Assert.fail("Failed while creating the Distribued System", e);
+      }
+    };
     member1.invoke(connectToDistributedSystem);
     member2.invoke(connectToDistributedSystem);
     member3.invoke(connectToDistributedSystem);
@@ -1059,14 +903,15 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
     member3.invoke(initializeStats);
     member4.invoke(initializeStats);
 
-    final int noOfMembers = 1;
     final Function inlineFunction = new FunctionAdapter() {
       @Override
       public void execute(FunctionContext context) {
+        @SuppressWarnings("unchecked")
+        final ResultSender<String> resultSender = context.getResultSender();
         if (context.getArguments() instanceof String) {
-          context.getResultSender().lastResult("Success");
+          resultSender.lastResult("Success");
         } else {
-          context.getResultSender().lastResult("Failure");
+          resultSender.lastResult("Failure");
         }
       }
 
@@ -1081,96 +926,71 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
       }
     };
 
-    member1.invoke(new SerializableCallable("excuteOnMembers_InlineFunction") {
-      @Override
-      public Object call() throws Exception {
+    member1.invoke(() -> {
 
-        assertNotNull(ds);
-        Execution memberExecution = null;
-        DistributedMember localmember = ds.getDistributedMember();
-        memberExecution = FunctionService.onMember(localmember);
+      assertNotNull(ds);
+      DistributedMember localmember = ds.getDistributedMember();
+      Execution memberExecution = FunctionService.onMember(localmember);
 
-        memberExecution.setArguments("Key");
-        try {
-          ResultCollector rc = memberExecution.execute(inlineFunction);
-          int size = ((List) rc.getResult()).size();
-          resultReceived_Aggregate += size;
-          noOfExecutionCalls_Aggregate++;
-          noOfExecutionsCompleted_Aggregate++;
-          resultReceived_Inline += size;
-          noOfExecutionCalls_Inline++;
-          noOfExecutionsCompleted_Inline++;
+      memberExecution.setArguments("Key");
+      try {
+        ResultCollector rc = memberExecution.execute(inlineFunction);
+        int size = ((List) rc.getResult()).size();
+        resultReceived_Aggregate += size;
+        noOfExecutionCalls_Aggregate++;
+        noOfExecutionsCompleted_Aggregate++;
+        resultReceived_Inline += size;
+        noOfExecutionCalls_Inline++;
+        noOfExecutionsCompleted_Inline++;
 
-        } catch (Exception e) {
-          LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
-          e.printStackTrace();
-          Assert.fail("Test failed", e);
-        }
-        return Boolean.TRUE;
+      } catch (Exception e) {
+        LogWriterUtils.getLogWriter().info("Exception Occurred : " + e.getMessage());
+        e.printStackTrace();
+        Assert.fail("Test failed", e);
       }
     });
 
-    member1.invoke(new SerializableCallable("checkFunctionExecutionStatsForMember1") {
-      @Override
-      public Object call() throws Exception {
-        FunctionServiceStats functionServiceStats = ds.getFunctionServiceStats();
-        waitNoFunctionsRunning(functionServiceStats);
+    member1.invoke(() -> {
+      FunctionServiceStats functionServiceStats = ds.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
 
-        assertEquals(noOfExecutionCalls_Aggregate,
-            functionServiceStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_Aggregate,
-            functionServiceStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Aggregate,
+          functionServiceStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_Aggregate, functionServiceStats.getResultsReceived());
 
-        FunctionStats functionStats = FunctionStats.getFunctionStats(inlineFunction.getId(), ds);
-        assertEquals(noOfExecutionCalls_Inline, functionStats.getFunctionExecutionCalls());
-        assertEquals(noOfExecutionsCompleted_Inline,
-            functionStats.getFunctionExecutionsCompleted());
-        assertEquals(resultReceived_Inline, functionStats.getResultsReceived());
-        return Boolean.TRUE;
-      }
+      FunctionStats functionStats = FunctionStats.getFunctionStats(inlineFunction.getId(), ds);
+      assertEquals(noOfExecutionCalls_Inline, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Inline,
+          functionStats.getFunctionExecutionsCompleted());
+      assertEquals(resultReceived_Inline, functionStats.getResultsReceived());
     });
 
-    SerializableCallable checkFunctionExecutionStatsForOtherMember =
-        new SerializableCallable("checkFunctionExecutionStatsForOtherMember") {
-          @Override
-          public Object call() throws Exception {
-            FunctionServiceStats functionServiceStats = ds.getFunctionServiceStats();
-            waitNoFunctionsRunning(functionServiceStats);
+    SerializableRunnableIF checkFunctionExecutionStatsForOtherMember = () -> {
+      FunctionServiceStats functionServiceStats = ds.getFunctionServiceStats();
+      waitNoFunctionsRunning(functionServiceStats);
 
-            // One function Execution took place on there members
-            // noOfExecutionCalls_Aggregate++;
-            // noOfExecutionsCompleted_Aggregate++;
-            assertEquals(noOfExecutionCalls_Aggregate,
-                functionServiceStats.getFunctionExecutionCalls());
-            assertEquals(noOfExecutionsCompleted_Aggregate,
-                functionServiceStats.getFunctionExecutionsCompleted());
+      // One function Execution took place on there members
+      // noOfExecutionCalls_Aggregate++;
+      // noOfExecutionsCompleted_Aggregate++;
+      assertEquals(noOfExecutionCalls_Aggregate,
+          functionServiceStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Aggregate,
+          functionServiceStats.getFunctionExecutionsCompleted());
 
-            FunctionStats functionStats =
-                FunctionStats.getFunctionStats(inlineFunction.getId(), ds);
-            // noOfExecutionCalls_Inline++;
-            // noOfExecutionsCompleted_Inline++;
-            assertEquals(noOfExecutionCalls_Inline, functionStats.getFunctionExecutionCalls());
-            assertEquals(noOfExecutionsCompleted_Inline,
-                functionStats.getFunctionExecutionsCompleted());
-            return Boolean.TRUE;
-          }
-        };
+      FunctionStats functionStats =
+          FunctionStats.getFunctionStats(inlineFunction.getId(), ds);
+      // noOfExecutionCalls_Inline++;
+      // noOfExecutionsCompleted_Inline++;
+      assertEquals(noOfExecutionCalls_Inline, functionStats.getFunctionExecutionCalls());
+      assertEquals(noOfExecutionsCompleted_Inline,
+          functionStats.getFunctionExecutionsCompleted());
+    };
     member2.invoke(checkFunctionExecutionStatsForOtherMember);
     member3.invoke(checkFunctionExecutionStatsForOtherMember);
     member4.invoke(checkFunctionExecutionStatsForOtherMember);
 
-    SerializableCallable closeDistributedSystem =
-        new SerializableCallable("closeDistributedSystem") {
-          @Override
-          public Object call() throws Exception {
-            if (getCache() != null && !getCache().isClosed()) {
-              getCache().close();
-              getCache().getDistributedSystem().disconnect();
-            }
-            return Boolean.TRUE;
-          }
-        };
     member1.invoke(closeDistributedSystem);
     member2.invoke(closeDistributedSystem);
     member3.invoke(closeDistributedSystem);
@@ -1192,7 +1012,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
    * in datatostore1
    */
   @Test
-  public void testFunctionExecutionExceptionStatsOnAllNodesPRegion() throws Exception {
+  public void testFunctionExecutionExceptionStatsOnAllNodesPRegion() {
     final String rName = getUniqueName();
     Host host = Host.getHost(0);
     final VM datastore0 = host.getVM(0);
@@ -1205,108 +1025,49 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
     datastore2.invoke(initializeStats);
     datastore3.invoke(initializeStats);
 
-    SerializableCallable dataStoreCreate =
-        new SerializableCallable("Create PR with Function Factory") {
-          @Override
-          public Object call() throws Exception {
-            RegionAttributes ra = PartitionedRegionTestHelper.createRegionAttrsForPR(0, 10);
-            AttributesFactory raf = new AttributesFactory(ra);
-            PartitionAttributesImpl pa = new PartitionAttributesImpl();
-            pa.setAll(ra.getPartitionAttributes());
-            pa.setTotalNumBuckets(17);
-            raf.setPartitionAttributes(pa);
-            getCache().createRegion(rName, raf.create());
-            Function function = new TestFunction(true, "TestFunctionException");
-            FunctionService.registerFunction(function);
-            return Boolean.TRUE;
-          }
-        };
+    SerializableRunnableIF dataStoreCreate = () -> {
+      RegionAttributes ra = PartitionedRegionTestHelper.createRegionAttrsForPR(0, 10);
+      AttributesFactory raf = new AttributesFactory(ra);
+      PartitionAttributesImpl pa = new PartitionAttributesImpl();
+      pa.setAll(ra.getPartitionAttributes());
+      pa.setTotalNumBuckets(17);
+      raf.setPartitionAttributes(pa);
+      getCache().createRegion(rName, raf.create());
+      Function function = new TestFunction(true, "TestFunctionException");
+      FunctionService.registerFunction(function);
+    };
     datastore0.invoke(dataStoreCreate);
     datastore1.invoke(dataStoreCreate);
     datastore2.invoke(dataStoreCreate);
     datastore3.invoke(dataStoreCreate);
 
-    Object o = datastore3.invoke(new SerializableCallable("Create data, invoke exectuable") {
-      @Override
-      public Object call() throws Exception {
-        PartitionedRegion pr = (PartitionedRegion) getCache().getRegion(rName);
-        DistributedSystem.setThreadsSocketPolicy(false);
-        final HashSet testKeys = new HashSet();
-        for (int i = (pr.getTotalNumberOfBuckets() * 3); i > 0; i--) {
-          testKeys.add("execKey-" + i);
-        }
-        int j = 0;
-        for (Iterator i = testKeys.iterator(); i.hasNext();) {
-          Integer key = new Integer(j++);
-          pr.put(key, i.next());
-        }
-        try {
-          Function function = new TestFunction(true, "TestFunctionException");
-          FunctionService.registerFunction(function);
-          Execution dataSet = FunctionService.onRegion(pr);
-          ResultCollector rc = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
-          // Wait Criterion is added to make sure that the function execution
-          // happens on all nodes and all nodes get the FunctionException so that the stats will get
-          // incremented,
-          Wait.pause(2000);
-          rc.getResult();
-        } catch (Exception expected) {
-          return Boolean.TRUE;
-        }
-        fail("No exception Occurred");
-        return Boolean.FALSE;
+    datastore3.invoke(() -> {
+      PartitionedRegion pr = (PartitionedRegion) getCache().getRegion(rName);
+      DistributedSystem.setThreadsSocketPolicy(false);
+      final HashSet<String> testKeys = new HashSet<>();
+      for (int i = (pr.getTotalNumberOfBuckets() * 3); i > 0; i--) {
+        testKeys.add("execKey-" + i);
       }
+      int j = 0;
+      for (Object testKey : testKeys) {
+        Integer key = j++;
+        pr.put(key, testKey);
+      }
+      try {
+        Function function = new TestFunction(true, "TestFunctionException");
+        FunctionService.registerFunction(function);
+        Execution dataSet = FunctionService.onRegion(pr);
+        ResultCollector rc = dataSet.setArguments(Boolean.TRUE).execute(function.getId());
+        // Wait Criterion is added to make sure that the function execution
+        // happens on all nodes and all nodes get the FunctionException so that the stats will get
+        // incremented,
+        Wait.pause(2000);
+        rc.getResult();
+      } catch (Exception ignored) {
+      }
+      fail("No exception Occurred");
     });
-    assertEquals(Boolean.TRUE, o);
 
-    SerializableCallable checkFunctionExecutionStatsForDataStore =
-        new SerializableCallable("checkFunctionExecutionStatsForDataStore") {
-          @Override
-          public Object call() throws Exception {
-            FunctionStats functionStats =
-                FunctionStats.getFunctionStats("TestFunctionException", getSystem());
-            noOfExecutionCalls_TestFunctionException++;
-            noOfExecutionExceptions_TestFunctionException++;
-            assertEquals(noOfExecutionCalls_TestFunctionException,
-                functionStats.getFunctionExecutionCalls());
-            assertEquals(noOfExecutionsCompleted_TestFunctionException,
-                functionStats.getFunctionExecutionsCompleted());
-            assertEquals(noOfExecutionExceptions_TestFunctionException,
-                functionStats.getFunctionExecutionExceptions());
-
-            noOfExecutionCalls_Aggregate++;
-            noOfExecutionExceptions_Aggregate++;
-            FunctionServiceStats functionServiceStats =
-                ((InternalDistributedSystem) getCache().getDistributedSystem())
-                    .getFunctionServiceStats();
-            assertEquals(noOfExecutionCalls_Aggregate,
-                functionServiceStats.getFunctionExecutionCalls());
-            assertEquals(noOfExecutionsCompleted_Aggregate,
-                functionServiceStats.getFunctionExecutionsCompleted());
-            assertEquals(noOfExecutionExceptions_Aggregate,
-                functionServiceStats.getFunctionExecutionExceptions());
-            return Boolean.TRUE;
-          }
-        };
-
-    /*
-     * datastore0.invoke(checkFunctionExecutionStatsForDataStore);
-     * datastore1.invoke(checkFunctionExecutionStatsForDataStore);
-     * datastore2.invoke(checkFunctionExecutionStatsForDataStore);
-     * datastore3.invoke(checkFunctionExecutionStatsForDataStore);
-     */
-
-    SerializableCallable closeDistributedSystem =
-        new SerializableCallable("closeDistributedSystem") {
-          @Override
-          public Object call() throws Exception {
-            if (getCache() != null && !getCache().isClosed()) {
-              getCache().close();
-              getCache().getDistributedSystem().disconnect();
-            }
-            return Boolean.TRUE;
-          }
-        };
     datastore0.invoke(closeDistributedSystem);
     datastore1.invoke(closeDistributedSystem);
     datastore2.invoke(closeDistributedSystem);
@@ -1315,7 +1076,7 @@ public class FunctionServiceStatsDUnitTest extends PRClientServerTestBase {
 
   private void createScenario() {
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 0, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 0, null);
     createClientServerScenarion(commonAttributes, 20, 20, 20);
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerFunctionExecutionNoAckDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerFunctionExecutionNoAckDUnitTest.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.functions.TestFunction;
-import org.apache.geode.test.dunit.LogWriterUtils;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
@@ -43,6 +44,8 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServerTestBase {
+  private static final Logger logger = LogService.getLogger();
+
   private static final String TEST_FUNCTION1 = TestFunction.TEST_FUNCTION1;
 
   Boolean isByName = null;
@@ -71,7 +74,7 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
 
     isByName = new Boolean(true);
     toRegister = new Boolean(true);
-    LogWriterUtils.getLogWriter().info(
+    logger.info(
         "PRClientServerFunctionExecutionNoAckDUnitTest#testServerFunctionExecution_NoAck : Starting test");
     client.invoke(() -> PRClientServerFunctionExecutionNoAckDUnitTest.serverExecution(isByName,
         functionNoAck, functionAck, toRegister));
@@ -89,7 +92,7 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
     registerFunctionAtServer(functionAck);
     toRegister = new Boolean(false);
     isByName = new Boolean(true);
-    LogWriterUtils.getLogWriter().info(
+    logger.info(
         "PRClientServerFunctionExecutionNoAckDUnitTest#testServerFunctionExecution_NoAck : Starting test");
     client.invoke(() -> PRClientServerFunctionExecutionNoAckDUnitTest.serverExecution(isByName,
         functionNoAck, functionAck, toRegister));
@@ -98,7 +101,7 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
   }
 
   private void createScenario() {
-    LogWriterUtils.getLogWriter()
+    logger
         .info("PRClientServerFFunctionExecutionDUnitTest#createScenario : creating scenario");
     createClientServerScenarionWithoutRegion();
   }
@@ -120,11 +123,11 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
       for (int i = 0; i < NUM_ITERATION; i++)
         execute(member, Boolean.TRUE, functionNoAck, isByName, toRegister);
       t.stop();
-      LogWriterUtils.getLogWriter().info("Time taken to execute boolean based" + NUM_ITERATION
+      logger.info("Time taken to execute boolean based" + NUM_ITERATION
           + "NoAck functions :" + t.getTimeInMs());
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       fail("Test failed after the execute operation");
     }
 
@@ -138,11 +141,11 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
       for (int i = 0; i < NUM_ITERATION; i++)
         execute(member, testKeysSet, functionNoAck, isByName, toRegister);
       t.stop();
-      LogWriterUtils.getLogWriter().info(
+      logger.info(
           "Time taken to execute setbased" + NUM_ITERATION + "NoAck functions :" + t.getTimeInMs());
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       fail("Test failed after the execute operationssssss");
     }
     if (toRegister.booleanValue()) {
@@ -160,11 +163,11 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
         timeinms += t.getTimeInMs();
         assertEquals(Boolean.TRUE, ((List) rc.getResult()).get(0));
       }
-      LogWriterUtils.getLogWriter().info("Time taken to execute boolean based" + NUM_ITERATION
+      logger.info("Time taken to execute boolean based" + NUM_ITERATION
           + "haveResults functions :" + timeinms);
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       fail("Test failed after the execute operation");
     }
 
@@ -186,11 +189,11 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
         }
 
       }
-      LogWriterUtils.getLogWriter().info(
+      logger.info(
           "Time taken to execute setbased" + NUM_ITERATION + "haveResults functions :" + timeinms);
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       fail("Test failed after the execute operationssssss");
     }
   }
@@ -210,7 +213,7 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
       execute(member, Boolean.TRUE, function, isByName, toRegister);
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       fail("Test failed after the execute operation allserver   ");
     }
 
@@ -222,7 +225,7 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
       execute(member, testKeysSet, function, isByName, toRegister);
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       fail("Test failed after the execute operation");
     }
   }
@@ -231,15 +234,15 @@ public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServe
       Boolean isByName, Boolean toRegister) throws Exception {
     if (isByName.booleanValue()) {// by name
       if (toRegister.booleanValue()) {
-        LogWriterUtils.getLogWriter().info("The function name to execute : " + function.getId());
+        logger.info("The function name to execute : " + function.getId());
         Execution me = member.setArguments(args);
-        LogWriterUtils.getLogWriter().info("The args passed  : " + args);
+        logger.info("The args passed  : " + args);
         return me.execute(function.getId());
       } else {
-        LogWriterUtils.getLogWriter()
+        logger
             .info("The function name to execute : (without Register) " + function.getId());
         Execution me = member.setArguments(args);
-        LogWriterUtils.getLogWriter().info("The args passed  : " + args);
+        logger.info("The args passed  : " + args);
         return me.execute(function.getId());
       }
     } else { // By Instance

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerFunctionExecutionNoAckDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerFunctionExecutionNoAckDUnitTest.java
@@ -24,6 +24,9 @@ import java.util.List;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
@@ -34,8 +37,11 @@ import org.apache.geode.internal.cache.functions.TestFunction;
 import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({ClientServerTest.class, FunctionServiceTest.class})
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerFunctionExecutionNoAckDUnitTest extends PRClientServerTestBase {
   private static final String TEST_FUNCTION1 = TestFunction.TEST_FUNCTION1;
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
@@ -32,6 +32,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -61,9 +62,9 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
@@ -75,6 +76,8 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServerTestBase {
+
+  private static final Logger logger = LogService.getLogger();
 
   private static final String TEST_FUNCTION7 = TestFunction.TEST_FUNCTION7;
 
@@ -656,7 +659,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       @Override
       public boolean done() {
         int sz = pool.getConnectedServerCount();
-        LogWriterUtils.getLogWriter().info("Checking for the Live Servers : Expected  : "
+        logger.info("Checking for the Live Servers : Expected  : "
             + expectedLiveServers + " Available :" + sz);
         if (sz == expectedLiveServers) {
           return true;
@@ -689,7 +692,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       ResultCollector rc1 =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
 
       for (Object o : l) {
@@ -713,7 +716,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     ResultCollector rc1 =
         dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
-    LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+    logger.info("Result size : " + l.size());
     return l;
   }
 
@@ -761,7 +764,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   private static void checkBucketsOnServer() {
     PartitionedRegion region = (PartitionedRegion) cache.getRegion(PartitionedRegionName);
     HashMap localBucket2RegionMap = (HashMap) region.getDataStore().getSizeLocally();
-    LogWriterUtils.getLogWriter().info(
+    logger.info(
         "Size of the " + PartitionedRegionName + " in this VM :- " + localBucket2RegionMap.size());
     Set entrySet = localBucket2RegionMap.entrySet();
     assertNotNull(entrySet);
@@ -821,7 +824,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object item : l) {
         assertEquals(Boolean.TRUE, item);
@@ -867,7 +870,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     try {
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertTrue(o instanceof MyFunctionExecutionException);
@@ -939,7 +942,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
@@ -1012,13 +1015,13 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
             }
           });
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
+      logger.info("Exception : " + e.getMessage());
       e.printStackTrace();
       fail("Test failed after the put operation");
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
@@ -24,7 +24,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
-import java.rmi.ServerException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +34,9 @@ import java.util.Set;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import org.apache.geode.DataSerializable;
 import org.apache.geode.cache.AttributesFactory;
@@ -53,8 +55,8 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.RegionFunctionContext;
 import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
@@ -67,41 +69,44 @@ import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({ClientServerTest.class, FunctionServiceTest.class})
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServerTestBase {
 
   private static final String TEST_FUNCTION7 = TestFunction.TEST_FUNCTION7;
 
   private static final String TEST_FUNCTION2 = TestFunction.TEST_FUNCTION2;
-  Boolean isByName = null;
+  private Boolean isByName = null;
 
   private static int retryCount = 0;
-  Boolean toRegister = null;
+  private Boolean toRegister = null;
 
   private static Region metaDataRegion;
 
-  static final String retryRegionName = "RetryDataRegion";
+  private static final String retryRegionName = "RetryDataRegion";
 
   @Test
-  public void test_Bug_43126_Function_Not_Registered() throws InterruptedException {
+  public void test_Bug_43126_Function_Not_Registered() {
     createScenario();
     try {
       client
-          .invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest.executeRegisteredFunction());
+          .invoke(PRClientServerRegionFunctionExecutionDUnitTest::executeRegisteredFunction);
     } catch (Exception e) {
-      assertEquals(true, (e.getCause() instanceof ServerOperationException));
+      assertTrue((e.getCause() instanceof ServerOperationException));
       assertTrue(
           e.getCause().getMessage().contains("The function is not registered for function id"));
     }
   }
 
   @Test
-  public void test_Bug43126() throws InterruptedException {
+  public void test_Bug43126() {
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest.executeRegisteredFunction());
+    client.invoke(PRClientServerRegionFunctionExecutionDUnitTest::executeRegisteredFunction);
   }
 
   /*
@@ -113,8 +118,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
-    toRegister = new Boolean(true);
+    isByName = Boolean.TRUE;
+    toRegister = Boolean.TRUE;
     SerializableRunnable suspect = new SerializableRunnable() {
       @Override
       public void run() {
@@ -142,8 +147,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   @Test
   public void testServerSingleKeyExecution_Bug43513_OnRegion() {
     createScenario_SingleConnection();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
-        .serverSingleKeyExecutionOnRegion_SingleConnection());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionDUnitTest::serverSingleKeyExecutionOnRegion_SingleConnection);
   }
 
   @Test
@@ -151,8 +156,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SEND_EXCEPTION);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
-    toRegister = new Boolean(true);
+    isByName = Boolean.TRUE;
+    toRegister = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverSingleKeyExecution_SendException(isByName, toRegister));
   }
@@ -162,8 +167,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_THROW_EXCEPTION);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
-    toRegister = new Boolean(true);
+    isByName = Boolean.TRUE;
+    toRegister = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverSingleKeyExecution_ThrowException(isByName, toRegister));
   }
@@ -173,8 +178,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenarioWith2Regions();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
-    toRegister = new Boolean(true);
+    isByName = Boolean.TRUE;
+    toRegister = Boolean.TRUE;
     SerializableRunnable suspect = new SerializableRunnable() {
       @Override
       public void run() {
@@ -186,7 +191,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     };
     runOnAllServers(suspect);
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
-        .serverSingleKeyExecutionWith2Regions(isByName, toRegister));
+        .serverSingleKeyExecutionWith2Regions(toRegister));
     SerializableRunnable endSuspect = new SerializableRunnable() {
       @Override
       public void run() {
@@ -208,8 +213,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_NO_LASTRESULT);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
-    toRegister = new Boolean(true);
+    isByName = Boolean.TRUE;
+    toRegister = Boolean.TRUE;
 
     final IgnoredException ex = IgnoredException.addIgnoredException("did not send last result");
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
@@ -222,8 +227,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
-    toRegister = new Boolean(false);
+    isByName = Boolean.TRUE;
+    toRegister = Boolean.FALSE;
     SerializableRunnable suspect = new SerializableRunnable() {
       @Override
       public void run() {
@@ -256,8 +261,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   @Test
   public void testserverSingleKeyExecution_FunctionInvocationTargetException() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
-        .serverSingleKeyExecution_FunctionInvocationTargetException());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionDUnitTest::serverSingleKeyExecution_FunctionInvocationTargetException);
   }
 
   @Test
@@ -265,7 +270,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SOCKET_TIMEOUT);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverSingleKeyExecutionSocketTimeOut(isByName));
   }
@@ -279,7 +284,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     toRegister = true;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverSingleKeyExecution(isByName, toRegister));
@@ -292,7 +297,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   public void testServerSingleKeyExecution_byInlineFunction() {
     createScenario();
     client.invoke(
-        () -> PRClientServerRegionFunctionExecutionDUnitTest.serverSingleKeyExecution_Inline());
+        PRClientServerRegionFunctionExecutionDUnitTest::serverSingleKeyExecution_Inline);
   }
 
   /*
@@ -304,12 +309,12 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(
         () -> PRClientServerRegionFunctionExecutionDUnitTest.serverMultiKeyExecution(isByName));
-    server1.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest.checkBucketsOnServer());
-    server2.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest.checkBucketsOnServer());
-    server3.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest.checkBucketsOnServer());
+    server1.invoke(PRClientServerRegionFunctionExecutionDUnitTest::checkBucketsOnServer);
+    server2.invoke(PRClientServerRegionFunctionExecutionDUnitTest::checkBucketsOnServer);
+    server3.invoke(PRClientServerRegionFunctionExecutionDUnitTest::checkBucketsOnServer);
   }
 
   /*
@@ -321,15 +326,15 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_BUCKET_FILTER);
     registerFunctionAtServer(function);
     // test multi key filter
-    Set<Integer> bucketFilterSet = new HashSet<Integer>();
+    Set<Integer> bucketFilterSet = new HashSet<>();
     bucketFilterSet.add(3);
     bucketFilterSet.add(6);
     bucketFilterSet.add(8);
-    client.invoke(() -> PRClientServerTestBase.serverBucketFilterExecution(bucketFilterSet));
+    client.invoke(() -> serverBucketFilterExecution(bucketFilterSet));
     bucketFilterSet.clear();
     // Test single filter
     bucketFilterSet.add(7);
-    client.invoke(() -> PRClientServerTestBase.serverBucketFilterExecution(bucketFilterSet));
+    client.invoke(() -> serverBucketFilterExecution(bucketFilterSet));
 
   }
 
@@ -339,17 +344,16 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_BUCKET_FILTER);
     registerFunctionAtServer(function);
     // test multi key filter
-    Set<Integer> bucketFilterSet = new HashSet<Integer>();
+    Set<Integer> bucketFilterSet = new HashSet<>();
     bucketFilterSet.add(3);
     bucketFilterSet.add(6);
     bucketFilterSet.add(8);
 
-    Set<Integer> keyFilterSet = new HashSet<Integer>();
+    Set<Integer> keyFilterSet = new HashSet<>();
     keyFilterSet.add(75);
     keyFilterSet.add(25);
 
-    client.invoke(() -> PRClientServerTestBase.serverBucketFilterOverrideExecution(bucketFilterSet,
-        keyFilterSet));
+    client.invoke(() -> serverBucketFilterOverrideExecution(bucketFilterSet, keyFilterSet));
 
   }
 
@@ -358,7 +362,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SEND_EXCEPTION);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverMultiKeyExecution_SendException(isByName));
   }
@@ -368,7 +372,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_THROW_EXCEPTION);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverMultiKeyExecution_ThrowException(isByName));
   }
@@ -382,7 +386,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   public void testserverMultiKeyExecution_byInlineFunction() {
     createScenario();
     client.invoke(
-        () -> PRClientServerRegionFunctionExecutionDUnitTest.serverMultiKeyExecution_Inline());
+        PRClientServerRegionFunctionExecutionDUnitTest::serverMultiKeyExecution_Inline);
   }
 
   /*
@@ -394,8 +398,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   @Test
   public void testserverMultiKeyExecution_FunctionInvocationTargetException() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
-        .serverMultiKeyExecution_FunctionInvocationTargetException());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionDUnitTest::serverMultiKeyExecution_FunctionInvocationTargetException);
   }
 
   /*
@@ -407,7 +411,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(false, TEST_FUNCTION7);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverMultiKeyExecutionNoResult(isByName));
   }
@@ -421,7 +425,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(
         () -> PRClientServerRegionFunctionExecutionDUnitTest.serverMultiKeyExecution(isByName));
   }
@@ -435,7 +439,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverMultiKeyExecutionOnASingleBucket(isByName));
   }
@@ -449,22 +453,22 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .serverMultiKeyExecutionOnASingleBucket(isByName));
   }
 
 
-  public static void regionSingleKeyExecutionNonHA(Boolean isByName, Function function,
-      Boolean toRegister) throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  static void regionSingleKeyExecutionNonHA(Boolean isByName, Function function,
+      Boolean toRegister) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -473,13 +477,13 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
 
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
-      ArrayList<String> args = new ArrayList<String>();
+      ArrayList<String> args = new ArrayList<>();
       args.add(retryRegionName);
       args.add("regionSingleKeyExecutionNonHA");
 
-      ResultCollector rs = execute(dataSet, testKeysSet, args, function, isByName);
+      execute(dataSet, testKeysSet, args, function, isByName);
       fail("Expected ServerConnectivityException not thrown!");
     } catch (Exception ex) {
       if (!(ex.getCause() instanceof ServerConnectivityException)
@@ -489,17 +493,17 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void regionExecutionHAOneServerDown(Boolean isByName, Function function,
-      Boolean toRegister) throws Exception {
+  static void regionExecutionHAOneServerDown(Boolean isByName, Function function,
+      Boolean toRegister) {
 
-    Region region = cache.getRegion(PartitionedRegionName);
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -508,9 +512,9 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
 
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
 
-    ArrayList<String> args = new ArrayList<String>();
+    ArrayList<String> args = new ArrayList<>();
     args.add(retryRegionName);
     args.add("regionExecutionHAOneServerDown");
 
@@ -518,17 +522,17 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertEquals(1, ((List) rs.getResult()).size());
   }
 
-  public static void regionExecutionHATwoServerDown(Boolean isByName, Function function,
-      Boolean toRegister) throws Exception {
+  static void regionExecutionHATwoServerDown(Boolean isByName, Function function,
+      Boolean toRegister) {
 
-    Region region = cache.getRegion(PartitionedRegionName);
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -537,9 +541,9 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
 
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
 
-    ArrayList<String> args = new ArrayList<String>();
+    ArrayList<String> args = new ArrayList<>();
     args.add(retryRegionName);
     args.add("regionExecutionHATwoServerDown");
 
@@ -547,11 +551,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertEquals(1, ((List) rs.getResult()).size());
   }
 
-  public static void createReplicatedRegion() {
+  static void createReplicatedRegion() {
     metaDataRegion = cache.createRegionFactory(RegionShortcut.REPLICATE).create(retryRegionName);
   }
 
-  public static void createProxyRegion(String hostName) {
+  public static void createProxyRegion() {
     CacheServerTestUtil.disableShufflingOfEndpoints();
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.LOCAL);
@@ -562,7 +566,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertNotNull(metaDataRegion);
   }
 
-  public static void verifyMetaData(Integer arg1, Integer arg2) {
+  static void verifyMetaData(Integer arg1, Integer arg2) {
 
     if (arg1 == 0) {
       assertNull(metaDataRegion.get("stopped"));
@@ -581,10 +585,12 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     FunctionService.registerFunction(new FunctionAdapter() {
       @Override
       public void execute(FunctionContext context) {
+        @SuppressWarnings("unchecked")
+        final ResultSender<Object> resultSender = context.getResultSender();
         if (context.getArguments() instanceof String) {
-          context.getResultSender().lastResult("Failure");
+          resultSender.lastResult("Failure");
         } else if (context.getArguments() instanceof Boolean) {
-          context.getResultSender().lastResult(Boolean.FALSE);
+          resultSender.lastResult(Boolean.FALSE);
         }
       }
 
@@ -600,26 +606,28 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     });
   }
 
-  public static void FunctionExecution_Inline_Bug40714() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  static void FunctionExecution_Inline_Bug40714() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     int j = 0;
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      region.put(i.next(), val);
+    for (String s : testKeysSet) {
+      Integer val = j++;
+      region.put(s, val);
     }
     List list = (List) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
         .execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
+            @SuppressWarnings("unchecked")
+            final ResultSender<Object> resultSender = context.getResultSender();
             if (context.getArguments() instanceof String) {
-              context.getResultSender().lastResult("Success");
+              resultSender.lastResult("Success");
             } else if (context.getArguments() instanceof Boolean) {
-              context.getResultSender().lastResult(Boolean.TRUE);
+              resultSender.lastResult(Boolean.TRUE);
             }
           }
 
@@ -641,8 +649,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void verifyDeadAndLiveServers(final Integer expectedDeadServers,
-      final Integer expectedLiveServers) {
+  public static void verifyDeadAndLiveServers(final Integer expectedLiveServers) {
     WaitCriterion wc = new WaitCriterion() {
       String excuse;
 
@@ -651,10 +658,10 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
         int sz = pool.getConnectedServerCount();
         LogWriterUtils.getLogWriter().info("Checking for the Live Servers : Expected  : "
             + expectedLiveServers + " Available :" + sz);
-        if (sz == expectedLiveServers.intValue()) {
+        if (sz == expectedLiveServers) {
           return true;
         }
-        excuse = "Expected " + expectedLiveServers.intValue() + " but found " + sz;
+        excuse = "Expected " + expectedLiveServers + " but found " + sz;
         return false;
       }
 
@@ -666,12 +673,12 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     Wait.waitForCriterion(wc, 3 * 60 * 1000, 1000, true);
   }
 
-  public static void executeFunction() throws ServerException, InterruptedException {
+  public static void executeFunction() {
 
     Region region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -685,18 +692,18 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
 
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object o : l) {
+        assertEquals(Boolean.TRUE, o);
       }
     } catch (CacheClosedException e) {
       // okay - ignore
     }
   }
 
-  public static Object executeFunctionHA() throws Exception {
+  static Object executeFunctionHA() {
     Region region = cache.getRegion(PartitionedRegionName);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -710,50 +717,48 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     return l;
   }
 
-  public static void putOperation() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  static void putOperation() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String s : testKeysSet) {
+      Integer val = j++;
+      region.put(s, val);
     }
   }
 
   protected void createScenario() {
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 0, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 0, null);
     createClientServerScenarion(commonAttributes, 20, 20, 20);
   }
 
-  protected void createScenarioForBucketFilter() {
+  private void createScenarioForBucketFilter() {
     ArrayList commonAttributes = createCommonServerAttributes("TestPartitionedRegion",
-        new BucketFilterPRResolver(), 0, 113, null);
+        new BucketFilterPRResolver(), 0, null);
     createClientServerScenarion(commonAttributes, 20, 20, 20);
   }
 
   private void createScenario_SingleConnection() {
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 0, 13, null);
-    createClientServerScenarion_SingleConnection(commonAttributes, 0, 20, 20);
+        createCommonServerAttributes("TestPartitionedRegion", null, 0, null);
+    createClientServerScenarion_SingleConnection(commonAttributes, 0, 20);
   }
 
 
 
   private void createScenarioWith2Regions() {
     ArrayList commonAttributes =
-        createCommonServerAttributes(PartitionedRegionName, null, 0, 13, null);
+        createCommonServerAttributes(PartitionedRegionName, null, 0, null);
     createClientServerScenarionWith2Regions(commonAttributes, 20, 20, 20);
 
   }
 
-  public static void checkBucketsOnServer() {
+  private static void checkBucketsOnServer() {
     PartitionedRegion region = (PartitionedRegion) cache.getRegion(PartitionedRegionName);
     HashMap localBucket2RegionMap = (HashMap) region.getDataStore().getSizeLocally();
     LogWriterUtils.getLogWriter().info(
@@ -762,33 +767,31 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertNotNull(entrySet);
   }
 
-  public static void serverMultiKeyExecutionOnASingleBucket(Boolean isByName) throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionOnASingleBucket(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     int j = 0;
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      region.put(i.next(), val);
+    for (String value : testKeysSet) {
+      Integer val = j++;
+      region.put(value, val);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
-    for (Iterator kiter = testKeysSet.iterator(); kiter.hasNext();) {
-      Set singleKeySet = Collections.singleton(kiter.next());
+    for (String o : testKeysSet) {
+      Set<String> singleKeySet = Collections.singleton(o);
       Function function = new TestFunction(true, TEST_FUNCTION2);
       FunctionService.registerFunction(function);
       Execution dataSet = FunctionService.onRegion(region);
       ResultCollector rc1 = execute(dataSet, singleKeySet, Boolean.TRUE, function, isByName);
-      List l = null;
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       assertEquals(1, l.size());
 
       ResultCollector rc2 =
-          execute(dataSet, singleKeySet, new HashSet(singleKeySet), function, isByName);
-      List l2 = null;
-      l2 = ((List) rc2.getResult());
+          execute(dataSet, singleKeySet, new HashSet<>(singleKeySet), function, isByName);
+      List l2 = ((List) rc2.getResult());
 
       assertEquals(1, l2.size());
       List subList = (List) l2.iterator().next();
@@ -797,11 +800,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void serverMultiKeyExecution(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -810,31 +813,29 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
+      HashSet<Integer> origVals = new HashSet<>();
+      for (String element : testKeysSet) {
+        Integer val = j++;
         origVals.add(val);
-        region.put(i.next(), val);
+        region.put(element, val);
       }
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object item : l) {
+        assertEquals(Boolean.TRUE, item);
       }
 
-      List l2 = null;
       ResultCollector rc2 = execute(dataSet, testKeysSet, testKeysSet, function, isByName);
-      l2 = ((List) rc2.getResult());
+      List l2 = ((List) rc2.getResult());
       assertEquals(3, l2.size());
-      HashSet foundVals = new HashSet();
-      for (Iterator i = l2.iterator(); i.hasNext();) {
-        ArrayList subL = (ArrayList) i.next();
+      HashSet<Integer> foundVals = new HashSet<>();
+      for (Object value : l2) {
+        ArrayList subL = (ArrayList) value;
         assertTrue(subL.size() > 0);
-        for (Iterator subI = subL.iterator(); subI.hasNext();) {
-          assertTrue(foundVals.add(subI.next()));
+        for (Object o : subL) {
+          assertTrue(foundVals.add((Integer) o));
         }
       }
       assertEquals(origVals, foundVals);
@@ -847,11 +848,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
 
 
 
-  public static void serverMultiKeyExecution_SendException(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_SendException(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -859,20 +860,17 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String value : testKeysSet) {
+      Integer val = j++;
+      region.put(value, val);
     }
     try {
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertTrue(i.next() instanceof MyFunctionExecutionException);
+      for (Object o : l) {
+        assertTrue(o instanceof MyFunctionExecutionException);
       }
     } catch (Exception ex) {
       ex.printStackTrace();
@@ -880,7 +878,6 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
 
     try {
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, testKeysSet, function, isByName);
       List resultList = (List) rc1.getResult();
       assertEquals(((testKeysSet.size() * 3) + 3), resultList.size());
@@ -899,11 +896,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void serverMultiKeyExecution_ThrowException(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_ThrowException(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -911,26 +908,23 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String o : testKeysSet) {
+      Integer val = j++;
+      region.put(o, val);
     }
     try {
-      List l = null;
-      ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
+      execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       fail("Exception Expected");
     } catch (Exception ex) {
       ex.printStackTrace();
     }
   }
 
-  public static void serverMultiKeyExecutionSocketTimeOut(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  static void serverMultiKeyExecutionSocketTimeOut(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -939,19 +933,16 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String value : testKeysSet) {
+        Integer val = j++;
+        region.put(value, val);
       }
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object o : l) {
+        assertEquals(Boolean.TRUE, o);
       }
 
     } catch (Exception e) {
@@ -960,11 +951,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void serverSingleKeyExecutionSocketTimeOut(Boolean isByName) throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecutionSocketTimeOut(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -972,7 +963,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
 
     ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
     assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
@@ -982,32 +973,31 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
 
   }
 
-  public static void serverMultiKeyExecution_Inline() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_Inline() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String value : testKeysSet) {
+        Integer val = j++;
+        region.put(value, val);
       }
-      List l = null;
       ResultCollector rc1 =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               } else if (context.getArguments() instanceof Boolean) {
-                context.getResultSender().lastResult(Boolean.TRUE);
+                resultSender.lastResult(Boolean.TRUE);
               }
             }
 
@@ -1021,11 +1011,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
               return true;
             }
           });
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object o : l) {
+        assertEquals(Boolean.TRUE, o);
       }
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
@@ -1035,30 +1025,27 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void serverMultiKeyExecution_FunctionInvocationTargetException() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_FunctionInvocationTargetException() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution dataSet = FunctionService.onRegion(region);
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String o : testKeysSet) {
+      Integer val = j++;
+      region.put(o, val);
     }
-    ResultCollector rc1 = null;
     try {
-      rc1 =
+      ResultCollector rc1 =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
-              if (((RegionFunctionContext) context).isPossibleDuplicate()) {
-                context.getResultSender().lastResult(new Integer(retryCount));
+              if (context.isPossibleDuplicate()) {
+                context.getResultSender().lastResult(retryCount);
                 return;
               }
               if (context.getArguments() instanceof Boolean) {
@@ -1086,11 +1073,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
 
   }
 
-  public static void serverMultiKeyExecutionNoResult(Boolean isByName) throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionNoResult(Boolean isByName) throws Exception {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -1101,11 +1088,9 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       String msg = "<ExpectedException action=add>" + "FunctionException" + "</ExpectedException>";
       cache.getLogger().info(msg);
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String o : testKeysSet) {
+        Integer val = j++;
+        region.put(o, val);
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       rc1.getResult();
@@ -1121,41 +1106,31 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void serverSingleKeyExecutionOnRegion_SingleConnection() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecutionOnRegion_SingleConnection() {
+    Region<Integer, String> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     for (int i = 0; i < 13; i++) {
-      region.put(new Integer(i), "KB_" + i);
+      region.put(i, "KB_" + i);
     }
     Function function = new TestFunction(false, TEST_FUNCTION2);
     Execution dataSet = FunctionService.onRegion(region);
     dataSet.setArguments(Boolean.TRUE).execute(function);
-    region.put(new Integer(2), "KB_2");
-    assertEquals("KB_2", region.get(new Integer(2)));
+    region.put(2, "KB_2");
+    assertEquals("KB_2", region.get(2));
   }
 
-  public static void serverSingleKeyExecutionOnServer_SingleConnection() {
-    Region region = cache.getRegion(PartitionedRegionName);
-    assertNotNull(region);
-    Function function = new TestFunction(false, TEST_FUNCTION2);
-    Execution dataSet = FunctionService.onServer(pool);
-    dataSet.setArguments(Boolean.TRUE).execute(function);
-    region.put(new Integer(1), "KB_1");
-    assertEquals("KB_1", region.get(new Integer(1)));
-  }
-
-  public static void serverSingleKeyExecution(Boolean isByName, Boolean toRegister)
+  private static void serverSingleKeyExecution(Boolean isByName, Boolean toRegister)
       throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
     Function function = new TestFunction(true, TEST_FUNCTION2);
 
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -1171,33 +1146,33 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
         throw ex;
       }
     }
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
 
     ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
     assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
 
     ResultCollector rs2 = execute(dataSet, testKeysSet, testKey, function, isByName);
-    assertEquals(new Integer(1), ((List) rs2.getResult()).get(0));
+    assertEquals(1, ((List) rs2.getResult()).get(0));
 
-    HashMap putData = new HashMap();
-    putData.put(testKey + "1", new Integer(2));
-    putData.put(testKey + "2", new Integer(3));
+    HashMap<String, Integer> putData = new HashMap<>();
+    putData.put(testKey + "1", 2);
+    putData.put(testKey + "2", 3);
 
     ResultCollector rs1 = execute(dataSet, testKeysSet, putData, function, isByName);
     assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
 
-    assertEquals(new Integer(2), region.get(testKey + "1"));
-    assertEquals(new Integer(3), region.get(testKey + "2"));
+    assertEquals((Integer) 2, region.get(testKey + "1"));
+    assertEquals((Integer) 3, region.get(testKey + "2"));
   }
 
-  public static void executeRegisteredFunction() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void executeRegisteredFunction() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     Execution dataSet = FunctionService.onRegion(region);
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     ((AbstractExecution) dataSet).removeFunctionAttributes(TestFunction.TEST_FUNCTION2);
     ResultCollector rs = dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE)
         .execute(TestFunction.TEST_FUNCTION2);
@@ -1212,18 +1187,17 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertNotNull(functionAttributes);
   }
 
-  public static void serverSingleKeyExecution_SendException(Boolean isByName, Boolean toRegister)
-      throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_SendException(Boolean isByName, Boolean toRegister) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SEND_EXCEPTION);
 
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -1231,10 +1205,9 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
 
     Execution dataSet = FunctionService.onRegion(region);
-    region.put(testKey, new Integer(1));
-    ResultCollector rs = null;
+    region.put(testKey, 1);
 
-    rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
+    ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
     assertTrue(((List) rs.getResult()).get(0) instanceof MyFunctionExecutionException);
 
     rs = execute(dataSet, testKeysSet, (Serializable) testKeysSet, function, isByName);
@@ -1251,17 +1224,18 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     assertEquals(1, exceptionCount);
   }
 
-  public static void serverSingleKeyExecution_ThrowException(Boolean isByName, Boolean toRegister) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_ThrowException(Boolean isByName,
+      Boolean toRegister) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_THROW_EXCEPTION);
 
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -1269,24 +1243,21 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
 
     Execution dataSet = FunctionService.onRegion(region);
-    region.put(testKey, new Integer(1));
-    ResultCollector rs = null;
+    region.put(testKey, 1);
     try {
-      rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
+      execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       fail("Exception Expected");
-    } catch (Exception ex) {
+    } catch (Exception ignored) {
     }
   }
 
-  public static void serverSingleKeyExecutionWith2Regions(Boolean isByName, Boolean toRegister) {
-    Region region1 = cache.getRegion(PartitionedRegionName + "1");
+  private static void serverSingleKeyExecutionWith2Regions(Boolean toRegister) {
+    Region<String, Integer> region1 = cache.getRegion(PartitionedRegionName + "1");
     assertNotNull(region1);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
-    testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
     Function function = new TestFunction(true, TEST_FUNCTION2);
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -1294,16 +1265,16 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
 
     Execution dataSet1 = FunctionService.onRegion(region1);
-    region1.put(testKey, new Integer(1));
+    region1.put(testKey, 1);
 
     ResultCollector rs = dataSet1.execute(function.getId());
     assertEquals(Boolean.FALSE, ((List) rs.getResult()).get(0));
 
-    Region region2 = cache.getRegion(PartitionedRegionName + "2");
+    Region<String, Integer> region2 = cache.getRegion(PartitionedRegionName + "2");
     assertNotNull(region2);
 
     Execution dataSet2 = FunctionService.onRegion(region2);
-    region2.put(testKey, new Integer(1));
+    region2.put(testKey, 1);
     try {
       rs = dataSet2.execute(function.getId());
       assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
@@ -1315,18 +1286,17 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void serverSingleKeyExecution_NoLastResult(Boolean isByName, Boolean toRegister)
-      throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_NoLastResult(Boolean isByName, Boolean toRegister) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_NO_LASTRESULT);
 
-    if (toRegister.booleanValue()) {
+    if (toRegister) {
       FunctionService.registerFunction(function);
     } else {
       FunctionService.unregisterFunction(function.getId());
@@ -1334,7 +1304,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
 
     Execution dataSet = FunctionService.onRegion(region);
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
@@ -1347,11 +1317,11 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  public static void serverSingleKeyExecution_FunctionInvocationTargetException() throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_FunctionInvocationTargetException() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1359,18 +1329,18 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
 
     ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, false);
     ArrayList list = (ArrayList) rs.getResult();
     assertTrue(((Integer) list.get(0)) >= 5);
   }
 
-  public static void serverSingleKeyExecution_Inline() throws Exception {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_Inline() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1383,10 +1353,12 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         @Override
         public void execute(FunctionContext context) {
+          @SuppressWarnings("unchecked")
+          final ResultSender<Object> resultSender = context.getResultSender();
           if (context.getArguments() instanceof String) {
-            context.getResultSender().lastResult("Success");
+            resultSender.lastResult("Success");
           }
-          context.getResultSender().lastResult("Failure");
+          resultSender.lastResult("Failure");
         }
 
         @Override
@@ -1412,16 +1384,18 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
               + "</ExpectedException>");
     }
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
 
     ResultCollector rs =
         dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
+            @SuppressWarnings("unchecked")
+            final ResultSender<Object> resultSender = context.getResultSender();
             if (context.getArguments() instanceof String) {
-              context.getResultSender().lastResult("Success");
+              resultSender.lastResult("Success");
             } else {
-              context.getResultSender().lastResult("Failure");
+              resultSender.lastResult("Failure");
             }
           }
 
@@ -1441,10 +1415,12 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
         dataSet.withFilter(testKeysSet).setArguments(testKey).execute(new FunctionAdapter() {
           @Override
           public void execute(FunctionContext context) {
+            @SuppressWarnings("unchecked")
+            final ResultSender<Object> resultSender = context.getResultSender();
             if (context.getArguments() instanceof String) {
-              context.getResultSender().lastResult("Success");
+              resultSender.lastResult("Success");
             } else {
-              context.getResultSender().lastResult("Failure");
+              resultSender.lastResult("Failure");
             }
           }
 
@@ -1479,16 +1455,16 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
 
   }
 
-  public static void serverBug43430() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverBug43430() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
     Execution dataSet = FunctionService.onRegion(region);
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       cache.getLogger()
           .info("<ExpectedException action=add>"
@@ -1498,10 +1474,12 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
           .execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               }
-              context.getResultSender().lastResult("Failure");
+              resultSender.lastResult("Failure");
             }
 
             @Override
@@ -1518,7 +1496,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       if (!expected.getCause().getMessage().contains(
           "Could not create an instance of org.apache.geode.internal.cache.execute.PRClientServerRegionFunctionExecutionDUnitTest$UnDeserializable")) {
         throw expected;
-      } ;
+      }
     } finally {
       cache.getLogger()
           .info("<ExpectedException action=remove>"
@@ -1528,8 +1506,8 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
   }
 
   private static ResultCollector execute(Execution dataSet, Set testKeysSet, Serializable args,
-      Function function, Boolean isByName) throws Exception {
-    if (isByName.booleanValue()) {// by name
+      Function function, Boolean isByName) {
+    if (isByName) {// by name
       return dataSet.withFilter(testKeysSet).setArguments(args).execute(function.getId());
     } else { // By Instance
       return dataSet.withFilter(testKeysSet).setArguments(args).execute(function);
@@ -1555,7 +1533,7 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
       }
     };
     runOnAllServers(suspect);
-    client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest.serverBug43430());
+    client.invoke(PRClientServerRegionFunctionExecutionDUnitTest::serverBug43430);
     SerializableRunnable endSuspect = new SerializableRunnable() {
       @Override
       public void run() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -52,12 +53,12 @@ import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
@@ -71,6 +72,8 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @RunWith(Parameterized.class)
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRClientServerTestBase {
+
+  private static final Logger logger = LogService.getLogger();
 
   private static Locator locator = null;
 
@@ -436,7 +439,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
     attr.setPartitionAttributes(paf.create());
     region = cache.createRegion(regionName, attr.create());
     assertNotNull(region);
-    LogWriterUtils.getLogWriter()
+    logger
         .info("Partitioned Region " + regionName + " created Successfully :" + region.toString());
     return port;
   }
@@ -464,7 +467,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
     RegionAttributes attrs = factory.create();
     region = cache.createRegion(regionName, attrs);
     assertNotNull(region);
-    LogWriterUtils.getLogWriter()
+    logger
         .info("Distributed Region " + regionName + " created Successfully :" + region.toString());
   }
 
@@ -472,7 +475,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
     for (int i = 0; i < 113; i++) {
       region.put(i, "KB_" + i);
     }
-    LogWriterUtils.getLogWriter()
+    logger
         .info("Distributed Region " + regionName + " Have size :" + region.size());
   }
 
@@ -480,7 +483,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
     Execution execute = FunctionService.onRegion(region);
     ResultCollector rc = execute.setArguments(Boolean.TRUE)
         .execute(new TestFunction(true, TestFunction.TEST_FUNCTION_LASTRESULT));
-    LogWriterUtils.getLogWriter().info("Exeuction Result :" + rc.getResult());
+    logger.info("Exeuction Result :" + rc.getResult());
     List l = ((List) rc.getResult());
     return l;
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -48,10 +49,10 @@ import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.Wait;
@@ -65,6 +66,9 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     extends PRClientServerTestBase {
+
+  private static final Logger logger = LogService.getLogger();
+
   private static final String TEST_FUNCTION7 = TestFunction.TEST_FUNCTION7;
 
   private static final String TEST_FUNCTION2 = TestFunction.TEST_FUNCTION2;
@@ -434,8 +438,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       @Override
       public boolean done() {
         int sz = pool.getConnectedServerCount();
-        LogWriterUtils.getLogWriter().info("Checking for the Live Servers : Expected  : "
-            + expectedLiveServers + " Available :" + sz);
+        logger.info("Checking for the Live Servers : Expected  : " + expectedLiveServers
+            + " Available :" + sz);
         if (sz == expectedLiveServers) {
           return true;
         }
@@ -479,7 +483,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         }
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Got an exception : " + e.getMessage());
+      logger.info("Got an exception : " + e.getMessage());
       assertTrue(e instanceof CacheClosedException);
     }
   }
@@ -497,7 +501,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     ResultCollector rc1 =
         dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
-    LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+    logger.info("Result size : " + l.size());
     return l;
   }
 
@@ -530,7 +534,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   private static void checkBucketsOnServer() {
     PartitionedRegion region = (PartitionedRegion) cache.getRegion(PartitionedRegionName);
     HashMap localBucket2RegionMap = (HashMap) region.getDataStore().getSizeLocally();
-    LogWriterUtils.getLogWriter().info(
+    logger.info(
         "Size of the " + PartitionedRegionName + " in this VM :- " + localBucket2RegionMap.size());
     Set entrySet = localBucket2RegionMap.entrySet();
     assertNotNull(entrySet);
@@ -557,8 +561,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       }
       ResultCollector rc1 = executeOnAll(dataSet, Boolean.TRUE, function, isByName);
       List resultList = (List) rc1.getResult();
-      LogWriterUtils.getLogWriter().info("Result size : " + resultList.size());
-      LogWriterUtils.getLogWriter().info("Result are SSSS : " + resultList);
+      logger.info("Result size : " + resultList.size());
+      logger.info("Result are SSSS : " + resultList);
       assertEquals(3, resultList.size());
 
       for (Object result : resultList) {
@@ -671,7 +675,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         assertEquals(1, subList.size());
         assertEquals(region.get(singleKeySet.iterator().next()), subList.iterator().next());
       } catch (Exception expected) {
-        LogWriterUtils.getLogWriter().info("Exception : " + expected.getMessage());
+        logger.info("Exception : " + expected.getMessage());
         expected.printStackTrace();
         fail("Test failed after the put operation");
       }
@@ -699,7 +703,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object item : l) {
         assertEquals(Boolean.TRUE, item);
@@ -744,7 +748,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
@@ -778,7 +782,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }
@@ -822,13 +826,13 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
             }
           });
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
+      logger.info("Exception : " + e.getMessage());
       e.printStackTrace();
       fail("Test failed after the put operation");
 
@@ -908,7 +912,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       fail("Test failed after the put operation");
     } catch (FunctionException expected) {
       expected.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : " + expected.getMessage());
+      logger.info("Exception : " + expected.getMessage());
       assertTrue(expected.getMessage()
           .startsWith((String.format("Cannot %s result as the Function#hasResult() is false",
               "return any"))));
@@ -959,7 +963,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }
@@ -1023,7 +1027,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         }
       });
     } catch (Exception expected) {
-      LogWriterUtils.getLogWriter().fine("Exception occurred : " + expected.getMessage());
+      logger.debug("Exception occurred : " + expected.getMessage());
       assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey)
           || expected.getMessage().startsWith("Server could not send the reply")
           || expected.getMessage().startsWith("Unexpected exception during"));
@@ -1088,7 +1092,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.java
@@ -19,23 +19,20 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.EOFException;
-import java.io.IOException;
 import java.io.Serializable;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.rmi.ServerException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Region;
@@ -46,9 +43,8 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.RegionFunctionContext;
 import org.apache.geode.cache.execute.ResultCollector;
-import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
@@ -56,20 +52,24 @@ import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.LogWriterUtils;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({ClientServerTest.class, FunctionServiceTest.class})
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     extends PRClientServerTestBase {
   private static final String TEST_FUNCTION7 = TestFunction.TEST_FUNCTION7;
 
   private static final String TEST_FUNCTION2 = TestFunction.TEST_FUNCTION2;
 
-  Boolean isByName = null;
+  private Boolean isByName = null;
 
   private static int retryCount = 0;
 
@@ -85,7 +85,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverAllKeyExecution(isByName));
   }
@@ -96,7 +96,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   @Test
   public void testServerGetAllFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.getAll());
+    client.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::getAll);
   }
 
   /*
@@ -105,7 +105,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   @Test
   public void testServerPutAllFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.putAll());
+    client.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::putAll);
   }
 
   /*
@@ -117,7 +117,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverSingleKeyExecution(isByName));
   }
@@ -130,8 +130,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   @Test
   public void testserverSingleKeyExecution_FunctionInvocationTargetException() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
-        .serverSingleKeyExecution_FunctionInvocationTargetException());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::serverSingleKeyExecution_FunctionInvocationTargetException);
   }
 
   /*
@@ -143,15 +143,15 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_BUCKET_FILTER);
     registerFunctionAtServer(function);
 
-    Set<Integer> bucketFilterSet = new HashSet<Integer>();
+    Set<Integer> bucketFilterSet = new HashSet<>();
     bucketFilterSet.add(3);
     bucketFilterSet.add(6);
     bucketFilterSet.add(8);
-    client.invoke(() -> PRClientServerTestBase.serverBucketFilterExecution(bucketFilterSet));
+    client.invoke(() -> serverBucketFilterExecution(bucketFilterSet));
     bucketFilterSet.clear();
     // Test single filter
     bucketFilterSet.add(7);
-    client.invoke(() -> PRClientServerTestBase.serverBucketFilterExecution(bucketFilterSet));
+    client.invoke(() -> serverBucketFilterExecution(bucketFilterSet));
   }
 
   @Test
@@ -160,16 +160,16 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_BUCKET_FILTER);
     registerFunctionAtServer(function);
     // test multi key filter
-    Set<Integer> bucketFilterSet = new HashSet<Integer>();
+    Set<Integer> bucketFilterSet = new HashSet<>();
     bucketFilterSet.add(3);
     bucketFilterSet.add(6);
     bucketFilterSet.add(8);
 
-    Set<Integer> keyFilterSet = new HashSet<Integer>();
+    Set<Integer> keyFilterSet = new HashSet<>();
     keyFilterSet.add(75);
     keyFilterSet.add(25);
 
-    client.invoke(() -> PRClientServerTestBase.serverBucketFilterOverrideExecution(bucketFilterSet,
+    client.invoke(() -> serverBucketFilterOverrideExecution(bucketFilterSet,
         keyFilterSet));
 
   }
@@ -179,7 +179,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SOCKET_TIMEOUT);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverSingleKeyExecutionSocketTimeOut(isByName));
   }
@@ -193,7 +193,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverSingleKeyExecution(isByName));
   }
@@ -204,8 +204,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   @Test
   public void testServerSingleKeyExecution_byInlineFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
-        .serverSingleKeyExecution_Inline());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::serverSingleKeyExecution_Inline);
   }
 
   /*
@@ -217,15 +217,15 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverMultiKeyExecution(isByName));
     server1.invoke(
-        () -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.checkBucketsOnServer());
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::checkBucketsOnServer);
     server2.invoke(
-        () -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.checkBucketsOnServer());
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::checkBucketsOnServer);
     server3.invoke(
-        () -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.checkBucketsOnServer());
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::checkBucketsOnServer);
   }
 
   @Test
@@ -233,7 +233,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SOCKET_TIMEOUT);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverMultiKeyExecutionSocketTimeOut(isByName));
   }
@@ -244,8 +244,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   @Test
   public void testserverMultiKeyExecution_byInlineFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
-        .serverMultiKeyExecution_Inline());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::serverMultiKeyExecution_Inline);
   }
 
   /*
@@ -257,8 +257,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   @Test
   public void testserverMultiKeyExecution_FunctionInvocationTargetException() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
-        .serverMultiKeyExecution_FunctionInvocationTargetException());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::serverMultiKeyExecution_FunctionInvocationTargetException);
   }
 
   /*
@@ -270,7 +270,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(false, TEST_FUNCTION7);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverMultiKeyExecutionNoResult(isByName));
   }
@@ -284,7 +284,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverMultiKeyExecution(isByName));
   }
@@ -298,7 +298,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverMultiKeyExecutionOnASingleBucket(isByName));
   }
@@ -312,7 +312,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         .serverMultiKeyExecutionOnASingleBucket(isByName));
   }
@@ -322,26 +322,26 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
    * failover to other available server
    */
   @Test
-  public void testServerFailoverWithTwoServerAliveHA() throws InterruptedException {
+  public void testServerFailoverWithTwoServerAliveHA() {
     IgnoredException.addIgnoredException("FunctionInvocationTargetException");
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 1, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 1, null);
     createClientServerScenarion(commonAttributes, 20, 20, 20);
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_HA);
     registerFunctionAtServer(function);
-    server2.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.stopServerHA());
-    server3.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.stopServerHA());
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.putOperation());
+    server2.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::stopServerHA);
+    server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::stopServerHA);
+    client.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::putOperation);
 
     int AsyncInvocationArrSize = 1;
     AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
     async[0] = client.invokeAsync(
-        () -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.executeFunctionHA());
-    server2.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.startServerHA());
-    server3.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.startServerHA());
-    server1.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.stopServerHA());
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::executeFunctionHA);
+    server2.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::startServerHA);
+    server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::startServerHA);
+    server1.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::stopServerHA);
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
-        .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
+        .verifyDeadAndLiveServers(2));
     ThreadUtils.join(async[0], 6 * 60 * 1000);
     if (async[0].getException() != null) {
       Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
@@ -356,25 +356,25 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
    * failover to other available server
    */
   @Test
-  public void testServerCacheClosedFailoverWithTwoServerAliveHA() throws InterruptedException {
+  public void testServerCacheClosedFailoverWithTwoServerAliveHA() {
     IgnoredException.addIgnoredException("FunctionInvocationTargetException");
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 1, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 1, null);
     createClientServerScenarion(commonAttributes, 20, 20, 20);
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_HA);
     registerFunctionAtServer(function);
-    server2.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.stopServerHA());
-    server3.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.stopServerHA());
-    client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.putOperation());
+    server2.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::stopServerHA);
+    server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::stopServerHA);
+    client.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::putOperation);
     int AsyncInvocationArrSize = 1;
     AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
     async[0] = client.invokeAsync(
-        () -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.executeFunctionHA());
-    server2.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.startServerHA());
-    server3.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.startServerHA());
-    server1.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.closeCacheHA());
+        PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::executeFunctionHA);
+    server2.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::startServerHA);
+    server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::startServerHA);
+    server1.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::closeCacheHA);
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
-        .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
+        .verifyDeadAndLiveServers(2));
     ThreadUtils.join(async[0], 5 * 60 * 1000);
     if (async[0].getException() != null) {
       Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
@@ -387,25 +387,31 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   public void testBug40714() {
     createScenario();
     server1
-        .invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.registerFunction());
+        .invoke(
+            (SerializableRunnableIF) PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::registerFunction);
     server1
-        .invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.registerFunction());
+        .invoke(
+            (SerializableRunnableIF) PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::registerFunction);
     server1
-        .invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.registerFunction());
+        .invoke(
+            (SerializableRunnableIF) PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::registerFunction);
     client
-        .invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest.registerFunction());
+        .invoke(
+            (SerializableRunnableIF) PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest::registerFunction);
     client.invoke(
-        () -> PRClientServerRegionFunctionExecutionDUnitTest.FunctionExecution_Inline_Bug40714());
+        PRClientServerRegionFunctionExecutionDUnitTest::FunctionExecution_Inline_Bug40714);
   }
 
   public static void registerFunction() {
     FunctionService.registerFunction(new FunctionAdapter() {
       @Override
       public void execute(FunctionContext context) {
+        @SuppressWarnings("unchecked")
+        final ResultSender<Object> resultSender = context.getResultSender();
         if (context.getArguments() instanceof String) {
-          context.getResultSender().lastResult("Failure");
+          resultSender.lastResult("Failure");
         } else if (context.getArguments() instanceof Boolean) {
-          context.getResultSender().lastResult(Boolean.FALSE);
+          resultSender.lastResult(Boolean.FALSE);
         }
       }
 
@@ -421,61 +427,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     });
   }
 
-  public static void FunctionExecution_Inline_Bug40714() {
-    Region region = cache.getRegion(PartitionedRegionName);
-    assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
-      testKeysSet.add("execKey-" + i);
-    }
-    int j = 0;
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      region.put(i.next(), val);
-    }
-    HashMap resultMap = (HashMap) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
-        .execute(new FunctionAdapter() {
-          @Override
-          public void execute(FunctionContext context) {
-            if (context.getArguments() instanceof String) {
-              context.getResultSender().lastResult("Success");
-            } else if (context.getArguments() instanceof Boolean) {
-              context.getResultSender().lastResult(Boolean.TRUE);
-            }
-          }
-
-          @Override
-          public String getId() {
-            return "Function";
-          }
-
-          @Override
-          public boolean hasResult() {
-            return true;
-          }
-        }).getResult();
-
-    assertEquals(3, resultMap.size());
-
-    Iterator mapIterator = resultMap.entrySet().iterator();
-    Map.Entry entry = null;
-    DistributedMember key = null;
-    ArrayList resultListForMember = null;
-
-    while (mapIterator.hasNext()) {
-      entry = (Map.Entry) mapIterator.next();
-      key = (DistributedMember) entry.getKey();
-      resultListForMember = (ArrayList) entry.getValue();
-
-      for (Object result : resultListForMember) {
-        assertEquals(Boolean.TRUE, result);
-      }
-    }
-
-  }
-
-  public static void verifyDeadAndLiveServers(final Integer expectedDeadServers,
-      final Integer expectedLiveServers) {
+  public static void verifyDeadAndLiveServers(final Integer expectedLiveServers) {
     WaitCriterion wc = new WaitCriterion() {
       String excuse;
 
@@ -484,10 +436,10 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
         int sz = pool.getConnectedServerCount();
         LogWriterUtils.getLogWriter().info("Checking for the Live Servers : Expected  : "
             + expectedLiveServers + " Available :" + sz);
-        if (sz == expectedLiveServers.intValue()) {
+        if (sz == expectedLiveServers) {
           return true;
         }
-        excuse = "Expected " + expectedLiveServers.intValue() + " but found " + sz;
+        excuse = "Expected " + expectedLiveServers + " but found " + sz;
         return false;
       }
 
@@ -499,12 +451,12 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     Wait.waitForCriterion(wc, 3 * 60 * 1000, 1000, true);
   }
 
-  public static void executeFunction() throws ServerException, InterruptedException {
+  public static void executeFunction() {
 
     Region region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -518,15 +470,9 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       HashMap resultMap = ((HashMap) rc1.getResult());
       assertEquals(3, resultMap.size());
 
-      Iterator mapIterator = resultMap.entrySet().iterator();
-      Map.Entry entry = null;
-      DistributedMember key = null;
-      ArrayList resultListForMember = null;
-
-      while (mapIterator.hasNext()) {
-        entry = (Map.Entry) mapIterator.next();
-        key = (DistributedMember) entry.getKey();
-        resultListForMember = (ArrayList) entry.getValue();
+      for (Object o : resultMap.entrySet()) {
+        Map.Entry entry = (Map.Entry) o;
+        ArrayList resultListForMember = (ArrayList) entry.getValue();
 
         for (Object result : resultListForMember) {
           assertEquals(Boolean.TRUE, result);
@@ -534,16 +480,14 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       }
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().info("Got an exception : " + e.getMessage());
-      assertTrue(e instanceof EOFException || e instanceof SocketException
-          || e instanceof SocketTimeoutException || e instanceof ServerException
-          || e instanceof IOException || e instanceof CacheClosedException);
+      assertTrue(e instanceof CacheClosedException);
     }
   }
 
-  public static Object executeFunctionHA() throws Exception {
+  private static Object executeFunctionHA() {
     Region region = cache.getRegion(PartitionedRegionName);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -557,35 +501,33 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     return l;
   }
 
-  public static void putOperation() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void putOperation() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String s : testKeysSet) {
+      Integer val = j++;
+      region.put(s, val);
     }
   }
 
   private void createScenario() {
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 0, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 0, null);
     createClientServerScenarioNoSingleHop(commonAttributes, 20, 20, 20);
   }
 
   private void createScenarioForBucketFilter() {
     ArrayList commonAttributes = createCommonServerAttributes("TestPartitionedRegion",
-        new BucketFilterPRResolver(), 0, 113, null);
+        new BucketFilterPRResolver(), 0, null);
     createClientServerScenarioNoSingleHop(commonAttributes, 20, 20, 20);
   }
 
-  public static void checkBucketsOnServer() {
+  private static void checkBucketsOnServer() {
     PartitionedRegion region = (PartitionedRegion) cache.getRegion(PartitionedRegionName);
     HashMap localBucket2RegionMap = (HashMap) region.getDataStore().getSizeLocally();
     LogWriterUtils.getLogWriter().info(
@@ -594,11 +536,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     assertNotNull(entrySet);
   }
 
-  public static void serverAllKeyExecution(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverAllKeyExecution(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() / 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets / 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -607,43 +549,30 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
+      HashSet<Integer> origVals = new HashSet<>();
+      for (String item : testKeysSet) {
+        Integer val = j++;
         origVals.add(val);
-        region.put(i.next(), val);
+        region.put(item, val);
       }
       ResultCollector rc1 = executeOnAll(dataSet, Boolean.TRUE, function, isByName);
-      List resultList = (List) ((List) rc1.getResult());
+      List resultList = (List) rc1.getResult();
       LogWriterUtils.getLogWriter().info("Result size : " + resultList.size());
       LogWriterUtils.getLogWriter().info("Result are SSSS : " + resultList);
       assertEquals(3, resultList.size());
 
-      Iterator resultIterator = resultList.iterator();
-      Map.Entry entry = null;
-      DistributedMember key = null;
-      List resultListForMember = new ArrayList();
-
-      // while (resultIterator.hasNext()) {
-      // resultListForMember.add(resultIterator.next());
-      //
-      // for (Object result : resultListForMember) {
-      // assertIndexDetailsEquals(Boolean.TRUE, result);
-      // }
-      // }
       for (Object result : resultList) {
         assertEquals(Boolean.TRUE, result);
       }
-      List l2 = null;
       ResultCollector rc2 = executeOnAll(dataSet, testKeysSet, function, isByName);
-      l2 = ((List) rc2.getResult());
+      List l2 = ((List) rc2.getResult());
       assertEquals(3, l2.size());
-      HashSet foundVals = new HashSet();
-      for (Iterator i = l2.iterator(); i.hasNext();) {
-        ArrayList subL = (ArrayList) (i.next());
+      HashSet<Integer> foundVals = new HashSet<>();
+      for (Object value : l2) {
+        ArrayList subL = (ArrayList) (value);
         assertTrue(subL.size() > 0);
-        for (Iterator subI = subL.iterator(); subI.hasNext();) {
-          assertTrue(foundVals.add(subI.next()));
+        for (Object o : subL) {
+          assertTrue(foundVals.add((Integer) o));
         }
       }
       assertEquals(origVals, foundVals);
@@ -655,27 +584,26 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   }
 
   public static void getAll() {
-    Region region = cache.getRegion(PartitionedRegionName);
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final List testKeysList = new ArrayList();
-    for (int i = (totalNumBuckets.intValue() * 3); i > 0; i--) {
+    final List<String> testKeysList = new ArrayList<>();
+    for (int i = (totalNumBuckets * 3); i > 0; i--) {
       testKeysList.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     try {
       int j = 0;
-      Map origVals = new HashMap();
-      for (Iterator i = testKeysList.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        Object key = i.next();
+      Map<String, Integer> origVals = new HashMap<>();
+      for (String key : testKeysList) {
+        Integer val = j++;
         origVals.put(key, val);
         region.put(key, val);
       }
       Map resultMap = region.getAll(testKeysList);
-      assertTrue(resultMap.equals(origVals));
+      assertEquals(resultMap, origVals);
       Wait.pause(2000);
       Map secondResultMap = region.getAll(testKeysList);
-      assertTrue(secondResultMap.equals(origVals));
+      assertEquals(secondResultMap, origVals);
 
     } catch (Exception e) {
       Assert.fail("Test failed after the put operation", e);
@@ -684,27 +612,26 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   }
 
   public static void putAll() {
-    Region region = cache.getRegion(PartitionedRegionName);
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final List testKeysList = new ArrayList();
-    for (int i = (totalNumBuckets.intValue() * 3); i > 0; i--) {
+    final List<String> testKeysList = new ArrayList<>();
+    for (int i = (totalNumBuckets * 3); i > 0; i--) {
       testKeysList.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     try {
       int j = 0;
-      Map origVals = new HashMap();
-      for (Iterator i = testKeysList.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        Object key = i.next();
+      Map<String, Integer> origVals = new HashMap<>();
+      for (String key : testKeysList) {
+        Integer val = j++;
         origVals.put(key, val);
         region.put(key, val);
       }
       Map resultMap = region.getAll(testKeysList);
-      assertTrue(resultMap.equals(origVals));
+      assertEquals(resultMap, origVals);
       Wait.pause(2000);
       Map secondResultMap = region.getAll(testKeysList);
-      assertTrue(secondResultMap.equals(origVals));
+      assertEquals(secondResultMap, origVals);
 
     } catch (Exception e) {
       Assert.fail("Test failed after the put operation", e);
@@ -712,34 +639,32 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecutionOnASingleBucket(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionOnASingleBucket(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     int j = 0;
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      region.put(i.next(), val);
+    for (String value : testKeysSet) {
+      Integer val = j++;
+      region.put(value, val);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
-    for (Iterator kiter = testKeysSet.iterator(); kiter.hasNext();) {
+    for (String o : testKeysSet) {
       try {
-        Set singleKeySet = Collections.singleton(kiter.next());
+        Set<String> singleKeySet = Collections.singleton(o);
         Function function = new TestFunction(true, TEST_FUNCTION2);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(region);
         ResultCollector rc1 = execute(dataSet, singleKeySet, Boolean.TRUE, function, isByName);
-        List l = null;
-        l = ((List) rc1.getResult());
+        List l = ((List) rc1.getResult());
         assertEquals(1, l.size());
 
         ResultCollector rc2 =
-            execute(dataSet, singleKeySet, new HashSet(singleKeySet), function, isByName);
-        List l2 = null;
-        l2 = ((List) rc2.getResult());
+            execute(dataSet, singleKeySet, new HashSet<>(singleKeySet), function, isByName);
+        List l2 = ((List) rc2.getResult());
 
         assertEquals(1, l2.size());
         List subList = (List) l2.iterator().next();
@@ -753,11 +678,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecution(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -766,31 +691,29 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
+      HashSet<Integer> origVals = new HashSet<>();
+      for (String element : testKeysSet) {
+        Integer val = j++;
         origVals.add(val);
-        region.put(i.next(), val);
+        region.put(element, val);
       }
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object item : l) {
+        assertEquals(Boolean.TRUE, item);
       }
 
-      List l2 = null;
       ResultCollector rc2 = execute(dataSet, testKeysSet, testKeysSet, function, isByName);
-      l2 = ((List) rc2.getResult());
+      List l2 = ((List) rc2.getResult());
       assertEquals(3, l2.size());
-      HashSet foundVals = new HashSet();
-      for (Iterator i = l2.iterator(); i.hasNext();) {
-        ArrayList subL = (ArrayList) i.next();
+      HashSet<Integer> foundVals = new HashSet<>();
+      for (Object value : l2) {
+        ArrayList subL = (ArrayList) value;
         assertTrue(subL.size() > 0);
-        for (Iterator subI = subL.iterator(); subI.hasNext();) {
-          assertTrue(foundVals.add(subI.next()));
+        for (Object o : subL) {
+          assertTrue(foundVals.add((Integer) o));
         }
       }
       assertEquals(origVals, foundVals);
@@ -802,11 +725,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   }
 
 
-  public static void serverMultiKeyExecutionSocketTimeOut(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionSocketTimeOut(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -815,19 +738,16 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String value : testKeysSet) {
+        Integer val = j++;
+        region.put(value, val);
       }
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object o : l) {
+        assertEquals(Boolean.TRUE, o);
       }
 
     } catch (Exception e) {
@@ -836,11 +756,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecutionSocketTimeOut(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecutionSocketTimeOut(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -848,7 +768,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
@@ -863,32 +783,31 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecution_Inline() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_Inline() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String value : testKeysSet) {
+        Integer val = j++;
+        region.put(value, val);
       }
-      List l = null;
       ResultCollector rc1 =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               } else if (context.getArguments() instanceof Boolean) {
-                context.getResultSender().lastResult(Boolean.TRUE);
+                resultSender.lastResult(Boolean.TRUE);
               }
             }
 
@@ -902,11 +821,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
               return true;
             }
           });
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object o : l) {
+        assertEquals(Boolean.TRUE, o);
       }
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
@@ -916,30 +835,27 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecution_FunctionInvocationTargetException() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_FunctionInvocationTargetException() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution dataSet = FunctionService.onRegion(region);
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String o : testKeysSet) {
+      Integer val = j++;
+      region.put(o, val);
     }
-    ResultCollector rc1 = null;
     try {
-      rc1 =
+      ResultCollector rc1 =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
-              if (((RegionFunctionContext) context).isPossibleDuplicate()) {
-                context.getResultSender().lastResult(new Integer(retryCount));
+              if (context.isPossibleDuplicate()) {
+                context.getResultSender().lastResult(retryCount);
                 return;
               }
               if (context.getArguments() instanceof Boolean) {
@@ -967,11 +883,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
 
   }
 
-  public static void serverMultiKeyExecutionNoResult(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionNoResult(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -982,11 +898,9 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       String msg = "<ExpectedException action=add>" + "FunctionException" + "</ExpectedException>";
       cache.getLogger().info(msg);
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String o : testKeysSet) {
+        Integer val = j++;
+        region.put(o, val);
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       rc1.getResult();
@@ -1006,11 +920,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecution(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1025,23 +939,23 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
           || expected.getMessage().startsWith("Unexpected exception during"));
     }
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
 
       ResultCollector rs2 = execute(dataSet, testKeysSet, testKey, function, isByName);
-      assertEquals(new Integer(1), ((List) rs2.getResult()).get(0));
+      assertEquals(1, ((List) rs2.getResult()).get(0));
 
-      HashMap putData = new HashMap();
-      putData.put(testKey + "1", new Integer(2));
-      putData.put(testKey + "2", new Integer(3));
+      HashMap<String, Integer> putData = new HashMap<>();
+      putData.put(testKey + "1", 2);
+      putData.put(testKey + "2", 3);
 
       ResultCollector rs1 = execute(dataSet, testKeysSet, putData, function, isByName);
       assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
 
-      assertEquals(new Integer(2), region.get(testKey + "1"));
-      assertEquals(new Integer(3), region.get(testKey + "2"));
+      assertEquals((Integer) 2, region.get(testKey + "1"));
+      assertEquals((Integer) 3, region.get(testKey + "2"));
 
     } catch (Exception ex) {
       ex.printStackTrace();
@@ -1050,11 +964,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecution_FunctionInvocationTargetException() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_FunctionInvocationTargetException() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1062,7 +976,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, false);
       ArrayList list = (ArrayList) rs.getResult();
@@ -1073,11 +987,11 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecution_Inline() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_Inline() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1090,10 +1004,12 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
       dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         @Override
         public void execute(FunctionContext context) {
+          @SuppressWarnings("unchecked")
+          final ResultSender<Object> resultSender = context.getResultSender();
           if (context.getArguments() instanceof String) {
-            context.getResultSender().lastResult("Success");
+            resultSender.lastResult("Success");
           }
-          context.getResultSender().lastResult("Failure");
+          resultSender.lastResult("Failure");
         }
 
         @Override
@@ -1118,16 +1034,18 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
               + "</ExpectedException>");
     }
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               } else {
-                context.getResultSender().lastResult("Failure");
+                resultSender.lastResult("Failure");
               }
             }
 
@@ -1147,10 +1065,12 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
           dataSet.withFilter(testKeysSet).setArguments(testKey).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               } else {
-                context.getResultSender().lastResult("Failure");
+                resultSender.lastResult("Failure");
               }
             }
 
@@ -1174,8 +1094,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   }
 
   private static ResultCollector execute(Execution dataSet, Set testKeysSet, Serializable args,
-      Function function, Boolean isByName) throws Exception {
-    if (isByName.booleanValue()) {// by name
+      Function function, Boolean isByName) {
+    if (isByName) {// by name
       return dataSet.withFilter(testKeysSet).setArguments(args).execute(function.getId());
     } else { // By Instance
       return dataSet.withFilter(testKeysSet).setArguments(args).execute(function);
@@ -1183,8 +1103,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDUnitTest
   }
 
   private static ResultCollector executeOnAll(Execution dataSet, Serializable args,
-      Function function, Boolean isByName) throws Exception {
-    if (isByName.booleanValue()) {// by name
+      Function function, Boolean isByName) {
+    if (isByName) {// by name
       return dataSet.setArguments(args).execute(function.getId());
     } else { // By Instance
       return dataSet.setArguments(args).execute(function);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -50,10 +51,10 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.Wait;
@@ -67,6 +68,8 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     extends PRClientServerTestBase {
+  private static final Logger logger = LogService.getLogger();
+
   private static final String TEST_FUNCTION7 = TestFunction.TEST_FUNCTION7;
 
   private static final String TEST_FUNCTION2 = TestFunction.TEST_FUNCTION2;
@@ -422,7 +425,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       @Override
       public boolean done() {
         int sz = pool.getConnectedServerCount();
-        LogWriterUtils.getLogWriter().info("Checking for the Live Servers : Expected  : "
+        logger.info("Checking for the Live Servers : Expected  : "
             + expectedLiveServers + " Available :" + sz);
         if (sz == expectedLiveServers) {
           return true;
@@ -466,7 +469,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         }
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Got an exception : " + e.getMessage());
+      logger.info("Got an exception : " + e.getMessage());
       assertTrue(e instanceof CacheClosedException);
     }
   }
@@ -484,7 +487,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     ResultCollector rc1 =
         dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
-    LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+    logger.info("Result size : " + l.size());
     return l;
   }
 
@@ -511,7 +514,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   private static void checkBucketsOnServer() {
     PartitionedRegion region = (PartitionedRegion) cache.getRegion(PartitionedRegionName);
     HashMap localBucket2RegionMap = (HashMap) region.getDataStore().getSizeLocally();
-    LogWriterUtils.getLogWriter().info(
+    logger.info(
         "Size of the " + PartitionedRegionName + " in this VM :- " + localBucket2RegionMap.size());
     Set entrySet = localBucket2RegionMap.entrySet();
     assertNotNull(entrySet);
@@ -538,8 +541,8 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       }
       ResultCollector rc1 = executeOnAll(dataSet, Boolean.TRUE, function, isByName);
       List resultList = (List) rc1.getResult();
-      LogWriterUtils.getLogWriter().info("Result size : " + resultList.size());
-      LogWriterUtils.getLogWriter().info("Result are SSSS : " + resultList);
+      logger.info("Result size : " + resultList.size());
+      logger.info("Result are SSSS : " + resultList);
       assertEquals(3, resultList.size());
 
       for (Object result : resultList) {
@@ -652,7 +655,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         assertEquals(1, subList.size());
         assertEquals(region.get(singleKeySet.iterator().next()), subList.iterator().next());
       } catch (Exception expected) {
-        LogWriterUtils.getLogWriter().info("Exception : " + expected.getMessage());
+        logger.info("Exception : " + expected.getMessage());
         expected.printStackTrace();
         fail("Test failed after the put operation");
       }
@@ -680,7 +683,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object item : l) {
         assertEquals(Boolean.TRUE, item);
@@ -724,7 +727,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
@@ -758,7 +761,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }
@@ -802,13 +805,13 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
             }
           });
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
+      logger.info("Exception : " + e.getMessage());
       e.printStackTrace();
       fail("Test failed after the put operation");
 
@@ -888,7 +891,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       fail("Test failed after the put operation");
     } catch (FunctionException expected) {
       expected.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : " + expected.getMessage());
+      logger.info("Exception : " + expected.getMessage());
       assertTrue(expected.getMessage()
           .startsWith((String.format("Cannot %s result as the Function#hasResult() is false",
               "return any"))));
@@ -939,7 +942,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }
@@ -1003,7 +1006,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         }
       });
     } catch (Exception expected) {
-      LogWriterUtils.getLogWriter().fine("Exception occurred : " + expected.getMessage());
+      logger.debug("Exception occurred : " + expected.getMessage());
       assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey)
           || expected.getMessage().startsWith("Server could not send the reply")
           || expected.getMessage().startsWith("Unexpected exception during"));
@@ -1068,7 +1071,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.java
@@ -19,17 +19,11 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import java.io.EOFException;
-import java.io.IOException;
 import java.io.Serializable;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.rmi.ServerException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -37,6 +31,9 @@ import java.util.Set;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Region;
@@ -47,10 +44,9 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.RegionFunctionContext;
 import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.cache.execute.ResultSender;
 import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
@@ -58,20 +54,24 @@ import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.LogWriterUtils;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 @Category({ClientServerTest.class, FunctionServiceTest.class})
+@RunWith(Parameterized.class)
+@UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     extends PRClientServerTestBase {
   private static final String TEST_FUNCTION7 = TestFunction.TEST_FUNCTION7;
 
   private static final String TEST_FUNCTION2 = TestFunction.TEST_FUNCTION2;
 
-  Boolean isByName = null;
+  private Boolean isByName = null;
 
   private static int retryCount = 0;
 
@@ -95,7 +95,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverAllKeyExecution(isByName));
   }
@@ -106,7 +106,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   @Test
   public void testServerGetAllFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.getAll());
+    client.invoke(PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::getAll);
   }
 
   /*
@@ -115,7 +115,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   @Test
   public void testServerPutAllFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.putAll());
+    client.invoke(PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::putAll);
   }
 
   /*
@@ -127,7 +127,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverSingleKeyExecution(isByName));
   }
@@ -140,8 +140,8 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   @Test
   public void testserverSingleKeyExecution_FunctionInvocationTargetException() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .serverSingleKeyExecution_FunctionInvocationTargetException());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::serverSingleKeyExecution_FunctionInvocationTargetException);
   }
 
   @Test
@@ -149,7 +149,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SOCKET_TIMEOUT);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverSingleKeyExecutionSocketTimeOut(isByName));
   }
@@ -163,7 +163,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverSingleKeyExecution(isByName));
   }
@@ -174,8 +174,8 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   @Test
   public void testServerSingleKeyExecution_byInlineFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .serverSingleKeyExecution_Inline());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::serverSingleKeyExecution_Inline);
   }
 
   /*
@@ -187,15 +187,15 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverMultiKeyExecution(isByName));
-    server1.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .checkBucketsOnServer());
-    server2.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .checkBucketsOnServer());
-    server3.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .checkBucketsOnServer());
+    server1.invoke(
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::checkBucketsOnServer);
+    server2.invoke(
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::checkBucketsOnServer);
+    server3.invoke(
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::checkBucketsOnServer);
   }
 
   @Test
@@ -203,7 +203,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_SOCKET_TIMEOUT);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverMultiKeyExecutionSocketTimeOut(isByName));
   }
@@ -214,8 +214,8 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   @Test
   public void testserverMultiKeyExecution_byInlineFunction() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .serverMultiKeyExecution_Inline());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::serverMultiKeyExecution_Inline);
   }
 
   /*
@@ -227,8 +227,8 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   @Test
   public void testserverMultiKeyExecution_FunctionInvocationTargetException() {
     createScenario();
-    client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .serverMultiKeyExecution_FunctionInvocationTargetException());
+    client.invoke(
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::serverMultiKeyExecution_FunctionInvocationTargetException);
   }
 
   /*
@@ -240,7 +240,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(false, TEST_FUNCTION7);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverMultiKeyExecutionNoResult(isByName));
   }
@@ -254,7 +254,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverMultiKeyExecution(isByName));
   }
@@ -268,7 +268,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(true);
+    isByName = Boolean.TRUE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverMultiKeyExecutionOnASingleBucket(isByName));
   }
@@ -282,7 +282,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     createScenario();
     Function function = new TestFunction(true, TEST_FUNCTION2);
     registerFunctionAtServer(function);
-    isByName = new Boolean(false);
+    isByName = Boolean.FALSE;
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         .serverMultiKeyExecutionOnASingleBucket(isByName));
   }
@@ -292,37 +292,37 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
    * failover to other available server
    */
   @Test
-  public void testServerFailoverWithTwoServerAliveHA() throws InterruptedException {
+  public void testServerFailoverWithTwoServerAliveHA() {
     IgnoredException.addIgnoredException("FunctionInvocationTargetException");
     IgnoredException.addIgnoredException("Connection reset");
     IgnoredException.addIgnoredException("SocketTimeoutException");
     IgnoredException.addIgnoredException("ServerConnectivityException");
     IgnoredException.addIgnoredException("Socket Closed");
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 1, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 1, null);
     createClientServerScenarion(commonAttributes, 20, 20, 20);
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_HA);
     registerFunctionAtServer(function);
     server2.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.stopServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::stopServerHA);
     server3.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.stopServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::stopServerHA);
     client.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.putOperation());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::putOperation);
 
     int AsyncInvocationArrSize = 1;
     AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
     async[0] =
-        client.invokeAsync(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-            .executeFunctionHA());
+        client.invokeAsync(
+            PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::executeFunctionHA);
     server2.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.startServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::startServerHA);
     server3.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.startServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::startServerHA);
     server1.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.stopServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::stopServerHA);
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
-        .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
+        .verifyDeadAndLiveServers(2));
     ThreadUtils.join(async[0], 6 * 60 * 1000);
     if (async[0].getException() != null) {
       Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
@@ -337,36 +337,36 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
    * failover to other available server
    */
   @Test
-  public void testServerCacheClosedFailoverWithTwoServerAliveHA() throws InterruptedException {
+  public void testServerCacheClosedFailoverWithTwoServerAliveHA() {
     IgnoredException.addIgnoredException("FunctionInvocationTargetException");
     IgnoredException.addIgnoredException("Connection reset");
     IgnoredException.addIgnoredException("SocketTimeoutException");
     IgnoredException.addIgnoredException("ServerConnectivityException");
     IgnoredException.addIgnoredException("Socket Closed");
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 1, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 1, null);
     createClientServerScenarion(commonAttributes, 20, 20, 20);
     Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_HA);
     registerFunctionAtServer(function);
     server2.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.stopServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::stopServerHA);
     server3.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.stopServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::stopServerHA);
     client.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.putOperation());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::putOperation);
     int AsyncInvocationArrSize = 1;
     AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
     async[0] =
-        client.invokeAsync(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-            .executeFunctionHA());
+        client.invokeAsync(
+            PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::executeFunctionHA);
     server2.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.startServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::startServerHA);
     server3.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.startServerHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::startServerHA);
     server1.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.closeCacheHA());
+        PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::closeCacheHA);
     client.invoke(() -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
-        .verifyDeadAndLiveServers(new Integer(1), new Integer(2)));
+        .verifyDeadAndLiveServers(2));
     ThreadUtils.join(async[0], 5 * 60 * 1000);
     if (async[0].getException() != null) {
       Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
@@ -379,25 +379,27 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   public void testBug40714() {
     createScenario();
     server1.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.registerFunction());
+        (SerializableRunnableIF) PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::registerFunction);
     server1.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.registerFunction());
+        (SerializableRunnableIF) PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::registerFunction);
     server1.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.registerFunction());
+        (SerializableRunnableIF) PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::registerFunction);
     client.invoke(
-        () -> PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest.registerFunction());
+        (SerializableRunnableIF) PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest::registerFunction);
     client.invoke(
-        () -> PRClientServerRegionFunctionExecutionDUnitTest.FunctionExecution_Inline_Bug40714());
+        PRClientServerRegionFunctionExecutionDUnitTest::FunctionExecution_Inline_Bug40714);
   }
 
   public static void registerFunction() {
     FunctionService.registerFunction(new FunctionAdapter() {
       @Override
       public void execute(FunctionContext context) {
+        @SuppressWarnings("unchecked")
+        final ResultSender<Object> resultSender = context.getResultSender();
         if (context.getArguments() instanceof String) {
-          context.getResultSender().lastResult("Failure");
+          resultSender.lastResult("Failure");
         } else if (context.getArguments() instanceof Boolean) {
-          context.getResultSender().lastResult(Boolean.FALSE);
+          resultSender.lastResult(Boolean.FALSE);
         }
       }
 
@@ -413,61 +415,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     });
   }
 
-  public static void FunctionExecution_Inline_Bug40714() {
-    Region region = cache.getRegion(PartitionedRegionName);
-    assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
-      testKeysSet.add("execKey-" + i);
-    }
-    int j = 0;
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      region.put(i.next(), val);
-    }
-    HashMap resultMap = (HashMap) FunctionService.onRegion(region).setArguments(Boolean.TRUE)
-        .execute(new FunctionAdapter() {
-          @Override
-          public void execute(FunctionContext context) {
-            if (context.getArguments() instanceof String) {
-              context.getResultSender().lastResult("Success");
-            } else if (context.getArguments() instanceof Boolean) {
-              context.getResultSender().lastResult(Boolean.TRUE);
-            }
-          }
-
-          @Override
-          public String getId() {
-            return "Function";
-          }
-
-          @Override
-          public boolean hasResult() {
-            return true;
-          }
-        }).getResult();
-
-    assertEquals(3, resultMap.size());
-
-    Iterator mapIterator = resultMap.entrySet().iterator();
-    Map.Entry entry = null;
-    DistributedMember key = null;
-    ArrayList resultListForMember = null;
-
-    while (mapIterator.hasNext()) {
-      entry = (Map.Entry) mapIterator.next();
-      key = (DistributedMember) entry.getKey();
-      resultListForMember = (ArrayList) entry.getValue();
-
-      for (Object result : resultListForMember) {
-        assertEquals(Boolean.TRUE, result);
-      }
-    }
-
-  }
-
-  public static void verifyDeadAndLiveServers(final Integer expectedDeadServers,
-      final Integer expectedLiveServers) {
+  public static void verifyDeadAndLiveServers(final Integer expectedLiveServers) {
     WaitCriterion wc = new WaitCriterion() {
       String excuse;
 
@@ -476,10 +424,10 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
         int sz = pool.getConnectedServerCount();
         LogWriterUtils.getLogWriter().info("Checking for the Live Servers : Expected  : "
             + expectedLiveServers + " Available :" + sz);
-        if (sz == expectedLiveServers.intValue()) {
+        if (sz == expectedLiveServers) {
           return true;
         }
-        excuse = "Expected " + expectedLiveServers.intValue() + " but found " + sz;
+        excuse = "Expected " + expectedLiveServers + " but found " + sz;
         return false;
       }
 
@@ -491,12 +439,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     Wait.waitForCriterion(wc, 3 * 60 * 1000, 1000, true);
   }
 
-  public static void executeFunction() throws ServerException, InterruptedException {
-
+  public static void executeFunction() {
     Region region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -510,15 +457,9 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       HashMap resultMap = ((HashMap) rc1.getResult());
       assertEquals(3, resultMap.size());
 
-      Iterator mapIterator = resultMap.entrySet().iterator();
-      Map.Entry entry = null;
-      DistributedMember key = null;
-      ArrayList resultListForMember = null;
-
-      while (mapIterator.hasNext()) {
-        entry = (Map.Entry) mapIterator.next();
-        key = (DistributedMember) entry.getKey();
-        resultListForMember = (ArrayList) entry.getValue();
+      for (Object o : resultMap.entrySet()) {
+        Map.Entry entry = (Map.Entry) o;
+        ArrayList resultListForMember = (ArrayList) entry.getValue();
 
         for (Object result : resultListForMember) {
           assertEquals(Boolean.TRUE, result);
@@ -526,16 +467,14 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       }
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().info("Got an exception : " + e.getMessage());
-      assertTrue(e instanceof EOFException || e instanceof SocketException
-          || e instanceof SocketTimeoutException || e instanceof ServerException
-          || e instanceof IOException || e instanceof CacheClosedException);
+      assertTrue(e instanceof CacheClosedException);
     }
   }
 
-  public static Object executeFunctionHA() throws Exception {
+  private static Object executeFunctionHA() {
     Region region = cache.getRegion(PartitionedRegionName);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -549,29 +488,27 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     return l;
   }
 
-  public static void putOperation() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void putOperation() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 10); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 10); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String s : testKeysSet) {
+      Integer val = j++;
+      region.put(s, val);
     }
   }
 
   private void createScenario() {
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 0, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 0, null);
     createClientServerScenarioSelectorNoSingleHop(commonAttributes, 20, 20, 20);
   }
 
-  public static void checkBucketsOnServer() {
+  private static void checkBucketsOnServer() {
     PartitionedRegion region = (PartitionedRegion) cache.getRegion(PartitionedRegionName);
     HashMap localBucket2RegionMap = (HashMap) region.getDataStore().getSizeLocally();
     LogWriterUtils.getLogWriter().info(
@@ -580,11 +517,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     assertNotNull(entrySet);
   }
 
-  public static void serverAllKeyExecution(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverAllKeyExecution(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() / 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets / 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -593,43 +530,30 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
+      HashSet<Integer> origVals = new HashSet<>();
+      for (String item : testKeysSet) {
+        Integer val = j++;
         origVals.add(val);
-        region.put(i.next(), val);
+        region.put(item, val);
       }
       ResultCollector rc1 = executeOnAll(dataSet, Boolean.TRUE, function, isByName);
-      List resultList = (List) ((List) rc1.getResult());
+      List resultList = (List) rc1.getResult();
       LogWriterUtils.getLogWriter().info("Result size : " + resultList.size());
       LogWriterUtils.getLogWriter().info("Result are SSSS : " + resultList);
       assertEquals(3, resultList.size());
 
-      Iterator resultIterator = resultList.iterator();
-      Map.Entry entry = null;
-      DistributedMember key = null;
-      List resultListForMember = new ArrayList();
-
-      // while (resultIterator.hasNext()) {
-      // resultListForMember.add(resultIterator.next());
-      //
-      // for (Object result : resultListForMember) {
-      // assertIndexDetailsEquals(Boolean.TRUE, result);
-      // }
-      // }
       for (Object result : resultList) {
         assertEquals(Boolean.TRUE, result);
       }
-      List l2 = null;
       ResultCollector rc2 = executeOnAll(dataSet, testKeysSet, function, isByName);
-      l2 = ((List) rc2.getResult());
+      List l2 = ((List) rc2.getResult());
       assertEquals(3, l2.size());
-      HashSet foundVals = new HashSet();
-      for (Iterator i = l2.iterator(); i.hasNext();) {
-        ArrayList subL = (ArrayList) (i.next());
+      HashSet<Integer> foundVals = new HashSet();
+      for (Object value : l2) {
+        ArrayList subL = (ArrayList) (value);
         assertTrue(subL.size() > 0);
-        for (Iterator subI = subL.iterator(); subI.hasNext();) {
-          assertTrue(foundVals.add(subI.next()));
+        for (Object o : subL) {
+          assertTrue(foundVals.add((Integer) o));
         }
       }
       assertEquals(origVals, foundVals);
@@ -641,27 +565,26 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   }
 
   public static void getAll() {
-    Region region = cache.getRegion(PartitionedRegionName);
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final List testKeysList = new ArrayList();
-    for (int i = (totalNumBuckets.intValue() * 3); i > 0; i--) {
+    final List<String> testKeysList = new ArrayList<>();
+    for (int i = (totalNumBuckets * 3); i > 0; i--) {
       testKeysList.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     try {
       int j = 0;
-      Map origVals = new HashMap();
-      for (Iterator i = testKeysList.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        Object key = i.next();
+      Map<String, Integer> origVals = new HashMap<>();
+      for (String key : testKeysList) {
+        Integer val = j++;
         origVals.put(key, val);
         region.put(key, val);
       }
       Map resultMap = region.getAll(testKeysList);
-      assertTrue(resultMap.equals(origVals));
+      assertEquals(resultMap, origVals);
       Wait.pause(2000);
       Map secondResultMap = region.getAll(testKeysList);
-      assertTrue(secondResultMap.equals(origVals));
+      assertEquals(secondResultMap, origVals);
 
     } catch (Exception e) {
       Assert.fail("Test failed after the put operation", e);
@@ -670,27 +593,26 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   }
 
   public static void putAll() {
-    Region region = cache.getRegion(PartitionedRegionName);
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final List testKeysList = new ArrayList();
-    for (int i = (totalNumBuckets.intValue() * 3); i > 0; i--) {
+    final List<String> testKeysList = new ArrayList<>();
+    for (int i = (totalNumBuckets * 3); i > 0; i--) {
       testKeysList.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     try {
       int j = 0;
-      Map origVals = new HashMap();
-      for (Iterator i = testKeysList.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        Object key = i.next();
+      Map<String, Integer> origVals = new HashMap<>();
+      for (String key : testKeysList) {
+        Integer val = j++;
         origVals.put(key, val);
         region.put(key, val);
       }
       Map resultMap = region.getAll(testKeysList);
-      assertTrue(resultMap.equals(origVals));
+      assertEquals(resultMap, origVals);
       Wait.pause(2000);
       Map secondResultMap = region.getAll(testKeysList);
-      assertTrue(secondResultMap.equals(origVals));
+      assertEquals(secondResultMap, origVals);
 
     } catch (Exception e) {
       Assert.fail("Test failed after the put operation", e);
@@ -698,34 +620,32 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecutionOnASingleBucket(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionOnASingleBucket(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     int j = 0;
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      region.put(i.next(), val);
+    for (String value : testKeysSet) {
+      Integer val = j++;
+      region.put(value, val);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
-    for (Iterator kiter = testKeysSet.iterator(); kiter.hasNext();) {
+    for (String o : testKeysSet) {
       try {
-        Set singleKeySet = Collections.singleton(kiter.next());
+        Set<String> singleKeySet = Collections.singleton(o);
         Function function = new TestFunction(true, TEST_FUNCTION2);
         FunctionService.registerFunction(function);
         Execution dataSet = FunctionService.onRegion(region);
         ResultCollector rc1 = execute(dataSet, singleKeySet, Boolean.TRUE, function, isByName);
-        List l = null;
-        l = ((List) rc1.getResult());
+        List l = ((List) rc1.getResult());
         assertEquals(1, l.size());
 
         ResultCollector rc2 =
-            execute(dataSet, singleKeySet, new HashSet(singleKeySet), function, isByName);
-        List l2 = null;
-        l2 = ((List) rc2.getResult());
+            execute(dataSet, singleKeySet, new HashSet<>(singleKeySet), function, isByName);
+        List l2 = ((List) rc2.getResult());
 
         assertEquals(1, l2.size());
         List subList = (List) l2.iterator().next();
@@ -739,11 +659,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecution(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -752,31 +672,29 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
+      HashSet<Integer> origVals = new HashSet<>();
+      for (String element : testKeysSet) {
+        Integer val = j++;
         origVals.add(val);
-        region.put(i.next(), val);
+        region.put(element, val);
       }
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object item : l) {
+        assertEquals(Boolean.TRUE, item);
       }
 
-      List l2 = null;
       ResultCollector rc2 = execute(dataSet, testKeysSet, testKeysSet, function, isByName);
-      l2 = ((List) rc2.getResult());
+      List l2 = ((List) rc2.getResult());
       assertEquals(3, l2.size());
-      HashSet foundVals = new HashSet();
-      for (Iterator i = l2.iterator(); i.hasNext();) {
-        ArrayList subL = (ArrayList) i.next();
+      HashSet<Integer> foundVals = new HashSet<>();
+      for (Object value : l2) {
+        ArrayList subL = (ArrayList) value;
         assertTrue(subL.size() > 0);
-        for (Iterator subI = subL.iterator(); subI.hasNext();) {
-          assertTrue(foundVals.add(subI.next()));
+        for (Object o : subL) {
+          assertTrue(foundVals.add((Integer) o));
         }
       }
       assertEquals(origVals, foundVals);
@@ -787,11 +705,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecutionSocketTimeOut(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionSocketTimeOut(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -800,19 +718,16 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String value : testKeysSet) {
+        Integer val = j++;
+        region.put(value, val);
       }
-      List l = null;
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object o : l) {
+        assertEquals(Boolean.TRUE, o);
       }
 
     } catch (Exception e) {
@@ -821,11 +736,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecutionSocketTimeOut(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecutionSocketTimeOut(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -833,7 +748,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
@@ -848,32 +763,31 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecution_Inline() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_Inline() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution dataSet = FunctionService.onRegion(region);
     try {
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String value : testKeysSet) {
+        Integer val = j++;
+        region.put(value, val);
       }
-      List l = null;
       ResultCollector rc1 =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               } else if (context.getArguments() instanceof Boolean) {
-                context.getResultSender().lastResult(Boolean.TRUE);
+                resultSender.lastResult(Boolean.TRUE);
               }
             }
 
@@ -887,11 +801,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
               return true;
             }
           });
-      l = ((List) rc1.getResult());
+      List l = ((List) rc1.getResult());
       LogWriterUtils.getLogWriter().info("Result size : " + l.size());
       assertEquals(3, l.size());
-      for (Iterator i = l.iterator(); i.hasNext();) {
-        assertEquals(Boolean.TRUE, i.next());
+      for (Object o : l) {
+        assertEquals(Boolean.TRUE, o);
       }
     } catch (Exception e) {
       LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
@@ -901,30 +815,27 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverMultiKeyExecution_FunctionInvocationTargetException() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecution_FunctionInvocationTargetException() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
     Execution dataSet = FunctionService.onRegion(region);
     int j = 0;
-    HashSet origVals = new HashSet();
-    for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-      Integer val = new Integer(j++);
-      origVals.add(val);
-      region.put(i.next(), val);
+    for (String o : testKeysSet) {
+      Integer val = j++;
+      region.put(o, val);
     }
-    ResultCollector rc1 = null;
     try {
-      rc1 =
+      ResultCollector rc1 =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
-              if (((RegionFunctionContext) context).isPossibleDuplicate()) {
-                context.getResultSender().lastResult(new Integer(retryCount));
+              if (context.isPossibleDuplicate()) {
+                context.getResultSender().lastResult(retryCount);
                 return;
               }
               if (context.getArguments() instanceof Boolean) {
@@ -952,11 +863,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
 
   }
 
-  public static void serverMultiKeyExecutionNoResult(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverMultiKeyExecutionNoResult(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
-    final HashSet testKeysSet = new HashSet();
-    for (int i = (totalNumBuckets.intValue() * 2); i > 0; i--) {
+    final HashSet<String> testKeysSet = new HashSet<>();
+    for (int i = (totalNumBuckets * 2); i > 0; i--) {
       testKeysSet.add("execKey-" + i);
     }
     DistributedSystem.setThreadsSocketPolicy(false);
@@ -967,11 +878,9 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       String msg = "<ExpectedException action=add>" + "FunctionException" + "</ExpectedException>";
       cache.getLogger().info(msg);
       int j = 0;
-      HashSet origVals = new HashSet();
-      for (Iterator i = testKeysSet.iterator(); i.hasNext();) {
-        Integer val = new Integer(j++);
-        origVals.add(val);
-        region.put(i.next(), val);
+      for (String o : testKeysSet) {
+        Integer val = j++;
+        region.put(o, val);
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       rc1.getResult();
@@ -991,11 +900,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecution(Boolean isByName) {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution(Boolean isByName) {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1010,23 +919,23 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
           || expected.getMessage().startsWith("Unexpected exception during"));
     }
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       assertEquals(Boolean.TRUE, ((List) rs.getResult()).get(0));
 
       ResultCollector rs2 = execute(dataSet, testKeysSet, testKey, function, isByName);
-      assertEquals(new Integer(1), ((List) rs2.getResult()).get(0));
+      assertEquals(1, ((List) rs2.getResult()).get(0));
 
-      HashMap putData = new HashMap();
-      putData.put(testKey + "1", new Integer(2));
-      putData.put(testKey + "2", new Integer(3));
+      HashMap<String, Integer> putData = new HashMap<>();
+      putData.put(testKey + "1", 2);
+      putData.put(testKey + "2", 3);
 
       ResultCollector rs1 = execute(dataSet, testKeysSet, putData, function, isByName);
       assertEquals(Boolean.TRUE, ((List) rs1.getResult()).get(0));
 
-      assertEquals(new Integer(2), region.get(testKey + "1"));
-      assertEquals(new Integer(3), region.get(testKey + "2"));
+      assertEquals((Integer) 2, region.get(testKey + "1"));
+      assertEquals((Integer) 3, region.get(testKey + "2"));
 
     } catch (Exception ex) {
       ex.printStackTrace();
@@ -1035,11 +944,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecution_FunctionInvocationTargetException() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_FunctionInvocationTargetException() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1047,7 +956,7 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     FunctionService.registerFunction(function);
     Execution dataSet = FunctionService.onRegion(region);
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs = execute(dataSet, testKeysSet, Boolean.TRUE, function, false);
       ArrayList list = (ArrayList) rs.getResult();
@@ -1058,11 +967,11 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
     }
   }
 
-  public static void serverSingleKeyExecution_Inline() {
-    Region region = cache.getRegion(PartitionedRegionName);
+  private static void serverSingleKeyExecution_Inline() {
+    Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);
     final String testKey = "execKey";
-    final Set testKeysSet = new HashSet();
+    final Set<String> testKeysSet = new HashSet<>();
     testKeysSet.add(testKey);
     DistributedSystem.setThreadsSocketPolicy(false);
 
@@ -1075,10 +984,12 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
       dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
         @Override
         public void execute(FunctionContext context) {
+          @SuppressWarnings("unchecked")
+          final ResultSender<Object> resultSender = context.getResultSender();
           if (context.getArguments() instanceof String) {
-            context.getResultSender().lastResult("Success");
+            resultSender.lastResult("Success");
           }
-          context.getResultSender().lastResult("Failure");
+          resultSender.lastResult("Failure");
         }
 
         @Override
@@ -1103,16 +1014,18 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
               + "</ExpectedException>");
     }
 
-    region.put(testKey, new Integer(1));
+    region.put(testKey, 1);
     try {
       ResultCollector rs =
           dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               } else {
-                context.getResultSender().lastResult("Failure");
+                resultSender.lastResult("Failure");
               }
             }
 
@@ -1132,10 +1045,12 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
           dataSet.withFilter(testKeysSet).setArguments(testKey).execute(new FunctionAdapter() {
             @Override
             public void execute(FunctionContext context) {
+              @SuppressWarnings("unchecked")
+              final ResultSender<Object> resultSender = context.getResultSender();
               if (context.getArguments() instanceof String) {
-                context.getResultSender().lastResult("Success");
+                resultSender.lastResult("Success");
               } else {
-                context.getResultSender().lastResult("Failure");
+                resultSender.lastResult("Failure");
               }
             }
 
@@ -1159,8 +1074,8 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   }
 
   private static ResultCollector execute(Execution dataSet, Set testKeysSet, Serializable args,
-      Function function, Boolean isByName) throws Exception {
-    if (isByName.booleanValue()) {// by name
+      Function function, Boolean isByName) {
+    if (isByName) {// by name
       return dataSet.withFilter(testKeysSet).setArguments(args).execute(function.getId());
     } else { // By Instance
       return dataSet.withFilter(testKeysSet).setArguments(args).execute(function);
@@ -1168,8 +1083,8 @@ public class PRClientServerRegionFunctionExecutionSelectorNoSingleHopDUnitTest
   }
 
   private static ResultCollector executeOnAll(Execution dataSet, Serializable args,
-      Function function, Boolean isByName) throws Exception {
-    if (isByName.booleanValue()) {// by name
+      Function function, Boolean isByName) {
+    if (isByName) {// by name
       return dataSet.setArguments(args).execute(function.getId());
     } else { // By Instance
       return dataSet.setArguments(args).execute(function);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSingleHopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionSingleHopDUnitTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -51,10 +52,10 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.functions.TestFunction;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.Wait;
@@ -68,6 +69,8 @@ import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactor
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
     extends PRClientServerTestBase {
+
+  private static final Logger logger = LogService.getLogger();
 
   private static final String TEST_FUNCTION7 = TestFunction.TEST_FUNCTION7;
 
@@ -452,7 +455,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       @Override
       public boolean done() {
         int sz = pool.getConnectedServerCount();
-        LogWriterUtils.getLogWriter().info("Checking for the Live Servers : Expected  : "
+        logger.info("Checking for the Live Servers : Expected  : "
             + expectedLiveServers + " Available :" + sz);
         if (sz == expectedLiveServers) {
           return true;
@@ -501,7 +504,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
         }
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Got an exception : " + e.getMessage());
+      logger.info("Got an exception : " + e.getMessage());
       assertTrue(e instanceof CacheClosedException);
     }
   }
@@ -519,7 +522,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
     ResultCollector rc1 =
         dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
     List l = ((List) rc1.getResult());
-    LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+    logger.info("Result size : " + l.size());
     return l;
   }
 
@@ -552,7 +555,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
   private static void checkBucketsOnServer() {
     PartitionedRegion region = (PartitionedRegion) cache.getRegion(PartitionedRegionName);
     HashMap localBucket2RegionMap = (HashMap) region.getDataStore().getSizeLocally();
-    LogWriterUtils.getLogWriter().info(
+    logger.info(
         "Size of the " + PartitionedRegionName + " in this VM :- " + localBucket2RegionMap.size());
     Set entrySet = localBucket2RegionMap.entrySet();
     assertNotNull(entrySet);
@@ -579,8 +582,8 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       }
       ResultCollector rc1 = executeOnAll(dataSet, Boolean.TRUE, function, isByName);
       List resultList = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + resultList.size());
-      LogWriterUtils.getLogWriter().info("Result are SSSS : " + resultList);
+      logger.info("Result size : " + resultList.size());
+      logger.info("Result are SSSS : " + resultList);
       assertEquals(3, resultList.size());
 
       // while (resultIterator.hasNext()) {
@@ -704,7 +707,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
         assertEquals(1, subList.size());
         assertEquals(region.get(singleKeySet.iterator().next()), subList.iterator().next());
       } catch (Exception expected) {
-        LogWriterUtils.getLogWriter().info("Exception : " + expected.getMessage());
+        logger.info("Exception : " + expected.getMessage());
         expected.printStackTrace();
         fail("Test failed after the put operation");
       }
@@ -732,7 +735,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object item : l) {
         assertEquals(Boolean.TRUE, item);
@@ -776,7 +779,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       }
       ResultCollector rc1 = execute(dataSet, testKeysSet, Boolean.TRUE, function, isByName);
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
@@ -809,7 +812,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }
@@ -853,13 +856,13 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
             }
           });
       List l = ((List) rc1.getResult());
-      LogWriterUtils.getLogWriter().info("Result size : " + l.size());
+      logger.info("Result size : " + l.size());
       assertEquals(3, l.size());
       for (Object o : l) {
         assertEquals(Boolean.TRUE, o);
       }
     } catch (Exception e) {
-      LogWriterUtils.getLogWriter().info("Exception : " + e.getMessage());
+      logger.info("Exception : " + e.getMessage());
       e.printStackTrace();
       fail("Test failed after the put operation");
 
@@ -939,7 +942,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
       fail("Test failed after the put operation");
     } catch (FunctionException expected) {
       expected.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : " + expected.getMessage());
+      logger.info("Exception : " + expected.getMessage());
       assertTrue(expected.getMessage()
           .startsWith((String.format("Cannot %s result as the Function#hasResult() is false",
               "return any"))));
@@ -990,7 +993,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }
@@ -1054,7 +1057,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
         }
       });
     } catch (Exception expected) {
-      LogWriterUtils.getLogWriter().fine("Exception occurred : " + expected.getMessage());
+      logger.debug("Exception occurred : " + expected.getMessage());
       assertTrue(expected.getMessage().contains("No target node found for KEY = " + testKey)
           || expected.getMessage().startsWith("Server could not send the reply")
           || expected.getMessage().startsWith("Unexpected exception during"));
@@ -1119,7 +1122,7 @@ public class PRClientServerRegionFunctionExecutionSingleHopDUnitTest
 
     } catch (Exception ex) {
       ex.printStackTrace();
-      LogWriterUtils.getLogWriter().info("Exception : ", ex);
+      logger.info("Exception : ", ex);
       Assert.fail("Test failed after the put operation", ex);
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerTestBase.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.AttributesFactory;
@@ -55,9 +56,9 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.cache.functions.TestFunction;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil;
+import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Host;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableCallableIF;
 import org.apache.geode.test.dunit.SerializableRunnable;
@@ -66,6 +67,7 @@ import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 
 public class PRClientServerTestBase extends JUnit4CacheTestCase {
+  private static final Logger logger = LogService.getLogger();
 
   protected VM server1 = null;
 
@@ -369,7 +371,7 @@ public class PRClientServerTestBase extends JUnit4CacheTestCase {
   private static void createCacheClientWithoutRegion(String host, Integer port1, Integer port2,
       Integer port3) {
     CacheServerTestUtil.disableShufflingOfEndpoints();
-    LogWriterUtils.getLogWriter()
+    logger
         .info("PRClientServerTestBase#createCacheClientWithoutRegion : creating pool");
 
     Pool p;
@@ -388,7 +390,7 @@ public class PRClientServerTestBase extends JUnit4CacheTestCase {
   private static void createCacheClientWithDistributedRegion(String host, Integer port1,
       Integer port2, Integer port3) throws Exception {
     CacheServerTestUtil.disableShufflingOfEndpoints();
-    LogWriterUtils.getLogWriter()
+    logger
         .info("PRClientServerTestBase#createCacheClientWithoutRegion : creating pool");
 
     Pool p;
@@ -504,7 +506,7 @@ public class PRClientServerTestBase extends JUnit4CacheTestCase {
 
 
   void createClientServerScenarionWithoutRegion() {
-    LogWriterUtils.getLogWriter().info(
+    logger.info(
         "PRClientServerTestBase#createClientServerScenarionWithoutRegion : creating client server");
     createCacheInClientServer();
     Integer port1 = server1.invoke(
@@ -572,11 +574,11 @@ public class PRClientServerTestBase extends JUnit4CacheTestCase {
   static void startServerHA() throws Exception {
     Wait.pause(2000);
     Collection bridgeServers = cache.getCacheServers();
-    LogWriterUtils.getLogWriter()
+    logger
         .info("Start Server cache servers list : " + bridgeServers.size());
     Iterator bridgeIterator = bridgeServers.iterator();
     CacheServer bridgeServer = (CacheServer) bridgeIterator.next();
-    LogWriterUtils.getLogWriter().info("start Server cache server" + bridgeServer);
+    logger.info("start Server cache server" + bridgeServer);
     bridgeServer.start();
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/SingleHopGetAllPutAllDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/SingleHopGetAllPutAllDUnitTest.java
@@ -55,7 +55,7 @@ public class SingleHopGetAllPutAllDUnitTest extends PRClientServerTestBase {
   @Before
   public void createScenario() {
     ArrayList commonAttributes =
-        createCommonServerAttributes("TestPartitionedRegion", null, 2, 13, null);
+        createCommonServerAttributes("TestPartitionedRegion", null, 2, null);
     createClientServerScenarioSingleHop(commonAttributes, 20, 20, 20);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ServerRegionProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ServerRegionProxy.java
@@ -15,8 +15,9 @@
 
 package org.apache.geode.cache.client.internal;
 
+import static java.util.Collections.emptySet;
+
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -686,7 +687,7 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             ExecuteRegionFunctionOp.execute(pool, resultCollector, retryAttempts, function.isHA(),
                 (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
                     .get(),
-                false, Collections.EMPTY_SET);
+                false, emptySet());
 
             cms.scheduleGetPRMetaData(region, false);
 
@@ -695,7 +696,7 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             final java.util.function.Function<ServerRegionFunctionExecutor, AbstractOp> regionFunctionSingleHopOpFunction =
                 executor -> new ExecuteRegionFunctionSingleHopOp.ExecuteRegionFunctionSingleHopOpImpl(
                     region.getFullPath(), function, executor, resultCollector,
-                    hasResult, Collections.EMPTY_SET, true, timeoutMs);
+                    hasResult, emptySet(), true, timeoutMs);
 
             ExecuteRegionFunctionSingleHopOp.execute(pool, region, serverRegionExecutor,
                 resultCollector, serverToBuckets, retryAttempts, function.isHA(),
@@ -712,7 +713,7 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             ExecuteRegionFunctionOp.execute(pool, resultCollector, retryAttempts, function.isHA(),
                 (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
                     .get(),
-                false, Collections.EMPTY_SET);
+                false, emptySet());
 
             cms.scheduleGetPRMetaData(region, false);
 
@@ -721,7 +722,7 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             final java.util.function.Function<ServerRegionFunctionExecutor, AbstractOp> regionFunctionSingleHopOpFunction =
                 executor -> new ExecuteRegionFunctionSingleHopOp.ExecuteRegionFunctionSingleHopOpImpl(
                     region.getFullPath(), function, executor, resultCollector,
-                    hasResult, Collections.EMPTY_SET, isBucketFilter, timeoutMs);
+                    hasResult, emptySet(), isBucketFilter, timeoutMs);
 
             ExecuteRegionFunctionSingleHopOp.execute(pool, region,
                 serverRegionExecutor, resultCollector, serverToFilterMap, retryAttempts,
@@ -734,14 +735,14 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
         ExecuteRegionFunctionOp.execute(pool, resultCollector, retryAttempts, function.isHA(),
             (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
                 .get(),
-            false, Collections.EMPTY_SET);
+            false, emptySet());
       }
     } else {
       ExecuteRegionFunctionOp.execute(pool,
           resultCollector, retryAttempts, function.isHA(),
           (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
               .get(),
-          false, Collections.EMPTY_SET);
+          false, emptySet());
     }
   }
 
@@ -774,14 +775,14 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             ExecuteRegionFunctionOp.execute(pool, resultCollector, retryAttempts, isHA,
                 (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
                     .get(),
-                false, Collections.EMPTY_SET);
+                false, emptySet());
 
             cms.scheduleGetPRMetaData(region, false);
           } else {
             final java.util.function.Function<ServerRegionFunctionExecutor, AbstractOp> regionFunctionSingleHopOpFunction =
                 executor1 -> new ExecuteRegionFunctionSingleHopOp.ExecuteRegionFunctionSingleHopOpImpl(
                     region.getFullPath(), functionId, executor1, resultCollector, hasResult,
-                    Collections.EMPTY_SET, true, isHA, optimizeForWrite, timeoutMs);
+                    emptySet(), true, isHA, optimizeForWrite, timeoutMs);
 
             ExecuteRegionFunctionSingleHopOp.execute(pool, region,
                 serverRegionExecutor, resultCollector, serverToBuckets, retryAttempts, isHA,
@@ -797,7 +798,7 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             ExecuteRegionFunctionOp.execute(pool, resultCollector, retryAttempts, isHA,
                 (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
                     .get(),
-                false, Collections.EMPTY_SET);
+                false, emptySet());
 
             cms.scheduleGetPRMetaData(region, false);
           } else {
@@ -805,7 +806,7 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             final java.util.function.Function<ServerRegionFunctionExecutor, AbstractOp> regionFunctionSingleHopOpFunction =
                 executor -> new ExecuteRegionFunctionSingleHopOp.ExecuteRegionFunctionSingleHopOpImpl(
                     region.getFullPath(), functionId, executor, resultCollector, hasResult,
-                    Collections.EMPTY_SET, false, isHA, optimizeForWrite, timeoutMs);
+                    emptySet(), isBucketsAsFilter, isHA, optimizeForWrite, timeoutMs);
 
             ExecuteRegionFunctionSingleHopOp.execute(pool, region,
                 serverRegionExecutor, resultCollector, serverToFilterMap, retryAttempts,
@@ -818,14 +819,14 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
             resultCollector, retryAttempts, isHA,
             (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
                 .get(),
-            false, Collections.EMPTY_SET);
+            false, emptySet());
       }
     } else {
       ExecuteRegionFunctionOp.execute(pool,
           resultCollector, retryAttempts, isHA,
           (ExecuteRegionFunctionOp.ExecuteRegionFunctionOpImpl) executeRegionFunctionOpSupplier
               .get(),
-          false, Collections.EMPTY_SET);
+          false, emptySet());
     }
   }
 


### PR DESCRIPTION
* Modifies tests to execute by both object and id.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
