### PR TITLE
Fix packer configuration for windows image.

### DIFF
--- a/ci/images/google-windows-geode-builder/build_image.sh
+++ b/ci/images/google-windows-geode-builder/build_image.sh
@@ -18,6 +18,7 @@
 set -x
 
 PACKER=${PACKER:-packer135}
+PACKER_ARGS="${*}"
 INTERNAL=${INTERNAL:-true}
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
@@ -56,7 +57,7 @@ fi
 HASHED_PIPELINE_PREFIX="i$(uuidgen -n @dns -s -N "${PIPELINE_PREFIX}")-"
 
 echo "Running packer"
-PACKER_LOG=1 ${PACKER} build \
+PACKER_LOG=1 ${PACKER} build ${PACKER_ARGS} \
   --var "geode_docker_image=${GEODE_DOCKER_IMAGE}" \
   --var "pipeline_prefix=${PIPELINE_PREFIX}" \
   --var "hashed_pipeline_prefix=${HASHED_PIPELINE_PREFIX}" \

--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -61,7 +61,6 @@
         "Move-Item \"C:\\java8tmp\" c:\\java8",
         "choco install -y openssh --version 7.7.2.1 /SSHServerFeature",
         "refreshenv",
-
         "$a = 10",
         "do {",
         "write-output \">>>>>>>>>> Installing rsync: $a attempts remaining <<<<<<<<<<\"",
@@ -69,7 +68,6 @@
         "$a--",
         "} while (-not (test-path C:\\ProgramData\\chocolatey\\bin\\rsync.exe) -and $a -gt 0)",
         "get-item C:\\ProgramData\\chocolatey\\bin\\rsync.exe",
-
         "winrm set winrm/config/service '@{AllowUnencrypted=\"true\"}'",
         "New-NetFirewallRule -DisplayName sshd -Direction inbound -Action allow -Protocol tcp -LocalPort 22",
         "New-NetFirewallRule -DisplayName \"Docker containers\" -LocalAddress 172.0.0.0/8 -Action allow -Direction inbound",
@@ -78,14 +76,24 @@
         "$NewPath = $OldPath + ';' + 'c:\\Program Files\\Git\\bin'",
         "Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\\Environment' -Name PATH -Value $NewPath",
         "write-output '>>>>>>>>>> Modify sshd config to comment use of administrators authorized key file <<<<<<<<<<'",
-        "(Get-Content \"C:\\Program Files\\OpenSSH-Win64\\sshd_config_default\") -replace '(Match Group administrators)', '#$1' -replace '(\\s*AuthorizedKeysFile.*)', '#$1' | Out-File \"C:\\Program Files\\OpenSSH-Win64\\sshd_config_default\" -encoding UTF8",
+        "(Get-Content \"C:\\Program Files\\OpenSSH-Win64\\sshd_config_default\") -replace '(Match Group administrators)', '#$1' -replace '(\\s*AuthorizedKeysFile.*)', '#$1' | Out-File \"C:\\Program Files\\OpenSSH-Win64\\sshd_config_default\" -encoding UTF8"
+      ]
+    },
+    {
+      "type":  "powershell",
+      "elevated_user": "geode",
+      "elevated_password": "{{.WinRMPassword}}",
+      "inline": [
+        "net start \"Docker Engine\"",
         "write-output '>>>>>>>>>> Adding openjdk docker image <<<<<<<<<<'",
-        "docker pull openjdk:8u212-jdk-windowsservercore-1809",
+        "docker pull openjdk:8",
         "write-output '>>>>>>>>>> Removing unused docker images <<<<<<<<<<'",
-        "docker rmi microsoft/windowsservercore:1809",
-        "docker rmi microsoft/nanoserver:1809",
-
-        "Set-Content -Path c:\\ProgramData\\docker\\config\\daemon.json -Value '{ \"hosts\": [\"tcp://0.0.0.0:2375\", \"npipe://\"] }'",
+        "Set-Content -Path c:\\ProgramData\\docker\\config\\daemon.json -Value '{ \"hosts\": [\"tcp://0.0.0.0:2375\", \"npipe://\"] }'"
+      ]
+    },
+    {
+      "type":  "powershell",
+      "inline": [
 
         "write-output '>>>>>>>>>> Cloning geode repo <<<<<<<<<<'",
         "& 'c:\\Program Files\\Git\\bin\\git.exe' clone -b develop --depth 1 https://github.com/apache/geode.git geode",


### PR DESCRIPTION
* Docker needs to be started up, and needs to be elevated.
* Made openjdk image pulled to be generic because they change
* Added option to build script to add build arguments to packer call.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
