### PR TITLE
GEODE-7004: Optimized ResourcePermission constructor

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/security/ResourcePermission.java
+++ b/geode-core/src/main/java/org/apache/geode/security/ResourcePermission.java
@@ -16,13 +16,13 @@ package org.apache.geode.security;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shiro.authz.permission.WildcardPermission;
+import org.apache.shiro.util.CollectionUtils;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.cache.Region;
@@ -145,10 +145,10 @@ public class ResourcePermission extends WildcardPermission {
     }
 
     setParts(Arrays.asList(
-        Collections.singleton(this.resource),
-        Collections.singleton(this.operation),
-        Collections.singleton(this.target),
-        Collections.singleton(this.key)));
+        CollectionUtils.asSet(this.resource.split(SUBPART_DIVIDER_TOKEN)),
+        CollectionUtils.asSet(this.operation.split(SUBPART_DIVIDER_TOKEN)),
+        CollectionUtils.asSet(this.target.split(SUBPART_DIVIDER_TOKEN)),
+        CollectionUtils.asSet(this.key.split(SUBPART_DIVIDER_TOKEN))));
   }
 
   private String parsePart(String part, UnaryOperator<String> operator) {

--- a/geode-core/src/main/java/org/apache/geode/security/ResourcePermission.java
+++ b/geode-core/src/main/java/org/apache/geode/security/ResourcePermission.java
@@ -16,6 +16,7 @@ package org.apache.geode.security;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -87,7 +88,11 @@ public class ResourcePermission extends WildcardPermission {
   private String key = ALL;
 
   public ResourcePermission() {
-    setParts(this.resource + ":" + this.operation + ":" + this.target + ":" + this.key, true);
+    setParts(Arrays.asList(
+        Collections.singleton(this.resource),
+        Collections.singleton(this.operation),
+        Collections.singleton(this.target),
+        Collections.singleton(this.key)));
   }
 
   public ResourcePermission(Resource resource, Operation operation) {
@@ -145,8 +150,8 @@ public class ResourcePermission extends WildcardPermission {
     }
 
     setParts(Arrays.asList(
-        CollectionUtils.asSet(this.resource.split(SUBPART_DIVIDER_TOKEN)),
-        CollectionUtils.asSet(this.operation.split(SUBPART_DIVIDER_TOKEN)),
+        Collections.singleton(this.resource),
+        Collections.singleton(this.operation),
         CollectionUtils.asSet(this.target.split(SUBPART_DIVIDER_TOKEN)),
         CollectionUtils.asSet(this.key.split(SUBPART_DIVIDER_TOKEN))));
   }

--- a/geode-core/src/main/java/org/apache/geode/security/ResourcePermission.java
+++ b/geode-core/src/main/java/org/apache/geode/security/ResourcePermission.java
@@ -16,6 +16,7 @@ package org.apache.geode.security;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -102,14 +103,18 @@ public class ResourcePermission extends WildcardPermission {
   }
 
   public ResourcePermission(Resource resource, Operation operation, Target target, String key) {
-    this(resource == null ? null : resource.getName(),
-        operation == null ? null : operation.getName(), target == null ? null : target.getName(),
+    init(resource == null ? NULL : resource.getName(),
+        operation == null ? NULL : operation.getName(), target == null ? null : target.getName(),
         key);
   }
 
   public ResourcePermission(Resource resource, Operation operation, String target, String key) {
-    this(resource == null ? null : resource.getName(),
-        operation == null ? null : operation.getName(), target, key);
+    init(resource == null ? NULL : resource.getName(),
+        operation == null ? NULL : operation.getName(), parseTarget(target), key);
+  }
+
+  private String parseTarget(String target) {
+    return target == null ? null : StringUtils.stripStart(target, Region.SEPARATOR);
   }
 
   public ResourcePermission(String resource, String operation) {
@@ -123,17 +128,27 @@ public class ResourcePermission extends WildcardPermission {
   public ResourcePermission(String resource, String operation, String target, String key) {
     // what's eventually stored are either "*", "NULL" or a valid enum except ALL.
     // Fields are never null.
-    this.resource = parsePart(resource, r -> Resource.valueOf(r).getName());
-    this.operation = parsePart(operation, o -> Operation.valueOf(o).getName());
+    init(parsePart(resource, r -> Resource.valueOf(r).getName()),
+        parsePart(operation, o -> Operation.valueOf(o).getName()), parseTarget(target), key);
+  }
+
+  private void init(String resource, String operation, String target, String key) {
+    this.resource = resource;
+    this.operation = operation;
 
     if (target != null) {
-      this.target = StringUtils.stripStart(target, Region.SEPARATOR);
+      this.target = target;
     }
+
     if (key != null) {
       this.key = key;
     }
 
-    setParts(this.resource + ":" + this.operation + ":" + this.target + ":" + this.key, true);
+    setParts(Arrays.asList(
+        Collections.singleton(this.resource),
+        Collections.singleton(this.operation),
+        Collections.singleton(this.target),
+        Collections.singleton(this.key)));
   }
 
   private String parsePart(String part, UnaryOperator<String> operator) {


### PR DESCRIPTION
When Security Manager is enabled, every put operation calls IntegratedSecurityService.authorize method, which creates new ResourcePermission object.
Every execution of ResourcePermission constructor takes 5 ms. With the optimization, ResourcePermission constructor execution takes less than 0.1 ms.



Co-authored-by: Kamilla Aslami <kaslami@pivotal.io>
Co-authored-by: Jacob Barrett <jbarrett@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
