### PR TITLE
GEODE-6298: Fix flaky test scanMovesRecentlyUsedNodeToTail

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSortingTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSortingTest.java
@@ -225,10 +225,9 @@ public class LRUListWithAsyncSortingTest {
     when(recentlyUsedNode.isRecentlyUsed()).thenReturn(true);
     list.incrementRecentlyUsed();
 
-    // unsetRecentlyUsed() is called once during scan
-    await()
-        .untilAsserted(() -> verify(recentlyUsedNode, times(1)).unsetRecentlyUsed());
-    assertThat(list.tail.previous()).isEqualTo(recentlyUsedNode);
+    await().untilAsserted(() -> assertThat(list.tail.previous()).isEqualTo(recentlyUsedNode));
+    verify(recentlyUsedNode, times(1)).unsetRecentlyUsed();
+
     realExecutor.shutdown();
   }
 


### PR DESCRIPTION
This test failed in 4 out of the last 22 Windows JDK 11 unit test runs.

There is a race condition within the test. A background thread calls unsetRecentlyUsed() on recentlyUsedNode before setting list.tail.previous() to recentlyUsedNode. Therefore, it's possible for the assertion on list.tail.previous() to fail if the background thread gets interrupted after calling unsetRecentlyUsed() but before setting list.tail.previous().

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
