### PR TITLE
GEODE-7003: Fix flaky tests in GemFireTransactionDataSourceIntegratio…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/datasource/GemFireTransactionDataSourceIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/datasource/GemFireTransactionDataSourceIntegrationTest.java
@@ -100,7 +100,11 @@ public class GemFireTransactionDataSourceIntegrationTest {
         .hasMessageContaining("SQL exception");
 
     // wait for activation of clean thread
-    await().untilAsserted(() -> assertThat(connection.isClosed()).isTrue());
+    await()
+        // BrokeredConnection.isClosed() throws a SQLException if the clean thread closes the
+        // connection while we are in the middle of checking whether it is closed.
+        .ignoreExceptionsInstanceOf(SQLException.class)
+        .untilAsserted(() -> assertThat(connection.isClosed()).isTrue());
 
     // Check that all connections are cleaned
     assertThat(poolCache.getActiveCacheSize()).isZero();
@@ -135,7 +139,11 @@ public class GemFireTransactionDataSourceIntegrationTest {
         .hasMessageContaining("SQL exception2");
 
     // wait for activation of clean thread
-    await().untilAsserted(() -> assertThat(connection.isClosed()).isTrue());
+    await()
+        // BrokeredConnection.isClosed() throws a SQLException if the clean thread closes the
+        // connection while we are in the middle of checking whether it is closed.
+        .ignoreExceptionsInstanceOf(SQLException.class)
+        .untilAsserted(() -> assertThat(connection.isClosed()).isTrue());
 
     // Check that all connections are cleaned
     assertThat(poolCache.getActiveCacheSize()).isZero();


### PR DESCRIPTION
…nTest

There is a race condition within the test. When the test calls dataSource.getConnection(), that method will throw an (expected) exception and expire the connection from the connection pool. There is a background thread which goes through all the expired connections and calls Connection.close(). If this background thread calls close() while the main thread is in the middle of calling BrokeredConnection.isClosed(), the method isClosed() can throw a SQLNonTransientConnectionException.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
