### PR TITLE
DO NOT REVIEW: GEODE-7010: Replace static globals in CachePerfStats with StatisticsClock

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache.query.dunit;
 
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -672,7 +673,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
       Set buckets = getBucketsForFilter((Set) args[1]);
       Region localDataSet = new LocalDataSet(
           (PartitionedRegion) CacheFactory.getAnyInstance().getRegion(PartitionedRegionName1),
-          buckets);
+          buckets, disabledClock());
 
       try {
         Query query = queryService.newQuery((String) args[0]);
@@ -866,7 +867,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
     Set buckets = getBucketsForFilter(filter);
     Region localDataSet = new LocalDataSet(
         (PartitionedRegion) CacheFactory.getAnyInstance().getRegion(PartitionedRegionName1),
-        buckets);
+        buckets, disabledClock());
 
     QueryService qservice = CacheFactory.getAnyInstance().getQueryService();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.cache.query.dunit;
 
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
-import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -673,7 +672,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
       Set buckets = getBucketsForFilter((Set) args[1]);
       Region localDataSet = new LocalDataSet(
           (PartitionedRegion) CacheFactory.getAnyInstance().getRegion(PartitionedRegionName1),
-          buckets, disabledClock());
+          buckets);
 
       try {
         Query query = queryService.newQuery((String) args[0]);
@@ -867,7 +866,7 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
     Set buckets = getBucketsForFilter(filter);
     Region localDataSet = new LocalDataSet(
         (PartitionedRegion) CacheFactory.getAnyInstance().getRegion(PartitionedRegionName1),
-        buckets, disabledClock());
+        buckets);
 
     QueryService qservice = CacheFactory.getAnyInstance().getQueryService();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearDuringGiiOplogWithMissingCreateRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearDuringGiiOplogWithMissingCreateRegressionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -148,7 +149,8 @@ public class ClearDuringGiiOplogWithMissingCreateRegressionTest extends CacheTes
 
     DistributedRegion distRegion = new DistributedRegion(regionName, factory.create(), null,
         getCache(), new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
-            .setSnapshotInputStream(null).setImageTarget(null));
+            .setSnapshotInputStream(null).setImageTarget(null),
+        enabledClock());
 
     distRegion.entries.setEntryFactory(new TestableDiskRegionEntryFactory());
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GiiDiskAccessExceptionRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GiiDiskAccessExceptionRegressionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -133,7 +134,8 @@ public class GiiDiskAccessExceptionRegressionTest extends CacheTestCase {
 
     DistributedRegion distributedRegion = new DistributedRegion(uniqueName, factory.create(), null,
         getCache(), new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
-            .setSnapshotInputStream(null).setImageTarget(null));
+            .setSnapshotInputStream(null).setImageTarget(null),
+        enabledClock());
 
     distributedRegion.entries.setEntryFactory(new DiskRegionEntryThrowsFactory());
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAConflationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAConflationDUnitTest.java
@@ -130,7 +130,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
 
   /**
    * In this test do a create & then update on same key , the client should receive 2 calabcks.
-   *
    */
 
   @Test
@@ -146,7 +145,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
   /**
    * In this test do create , then update & update. The client should receive 2 callbacks , one for
    * create & one for the last update.
-   *
    */
   @Test
   public void testConflationUpdate() throws Exception {
@@ -169,7 +167,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
   /**
    * In this test do create , then update, update, invalidate. The client should receive 3
    * callbacks, one for create one for the last update and one for the invalidate.
-   *
    */
   @Test
   public void testConflationCreateUpdateInvalidate() throws Exception {
@@ -187,7 +184,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
   /**
    * In this test do a create , update , update & destroy. The client should receive 3 callbacks (
    * craete , conflated update & destroy).
-   *
    */
   @Test
   public void testConflationCreateUpdateDestroy() throws Exception {
@@ -348,86 +344,83 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
     return new Integer(server.getPort());
   }
 
-}
+  private static class HAClientCountEventListener implements CacheListener, Declarable {
 
-
-class HAClientCountEventListener implements CacheListener, Declarable {
-
-  @Override
-  public void afterCreate(EntryEvent event) {
-    String key = (String) event.getKey();
-    if (key.equals(HAConflationDUnitTest.LAST_KEY)) {
-      synchronized (HAConflationDUnitTest.LOCK) {
-        HAConflationDUnitTest.lastKeyArrived = true;
-        HAConflationDUnitTest.LOCK.notifyAll();
+    @Override
+    public void afterCreate(EntryEvent event) {
+      String key = (String) event.getKey();
+      if (key.equals(LAST_KEY)) {
+        synchronized (LOCK) {
+          lastKeyArrived = true;
+          LOCK.notifyAll();
+        }
+      } else {
+        actualNoEvents++;
       }
-    } else {
-      HAConflationDUnitTest.actualNoEvents++;
+
     }
 
-  }
+    @Override
+    public void afterUpdate(EntryEvent event) {
 
-  @Override
-  public void afterUpdate(EntryEvent event) {
+      actualNoEvents++;
 
-    HAConflationDUnitTest.actualNoEvents++;
+    }
 
-  }
+    @Override
+    public void afterInvalidate(EntryEvent event) {
 
-  @Override
-  public void afterInvalidate(EntryEvent event) {
+      actualNoEvents++;
 
-    HAConflationDUnitTest.actualNoEvents++;
+    }
 
-  }
+    @Override
+    public void afterDestroy(EntryEvent event) {
+      actualNoEvents++;
 
-  @Override
-  public void afterDestroy(EntryEvent event) {
-    HAConflationDUnitTest.actualNoEvents++;
+    }
 
-  }
+    @Override
+    public void afterRegionInvalidate(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionInvalidate(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionDestroy(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionDestroy(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionClear(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionClear(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionCreate(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionCreate(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionLive(RegionEvent event) {
+      // TODO NOT Auto-generated method stub, added by vrao
 
-  @Override
-  public void afterRegionLive(RegionEvent event) {
-    // TODO NOT Auto-generated method stub, added by vrao
-
-  }
+    }
 
 
+    @Override
+    public void close() {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void close() {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void init(Properties props) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void init(Properties props) {
-    // TODO Auto-generated method stub
-
+    }
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HADuplicateDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HADuplicateDUnitTest.java
@@ -275,35 +275,32 @@ public class HADuplicateDUnitTest extends JUnit4DistributedTestCase {
       cache.getDistributedSystem().disconnect();
     }
   }
-}
 
-// TODO: move these classes to be inner static classes
-
-
-// Listener class for the validation purpose
-class HAValidateDuplicateListener extends CacheListenerAdapter {
-  @Override
-  public void afterCreate(EntryEvent event) {
-    System.out.println("After Create");
-    HADuplicateDUnitTest.storeEvents.put(event.getKey(), event.getNewValue());
-  }
-
-  @Override
-  public void afterUpdate(EntryEvent event) {
-    Object value = HADuplicateDUnitTest.storeEvents.get(event.getKey());
-    if (value == null)
-      HADuplicateDUnitTest.isEventDuplicate = false;
-    synchronized (HADuplicateDUnitTest.dummyObj) {
-      try {
-        HADuplicateDUnitTest.put_counter++;
-        if (HADuplicateDUnitTest.put_counter == HADuplicateDUnitTest.NO_OF_PUTS) {
-          HADuplicateDUnitTest.waitFlag = false;
-          HADuplicateDUnitTest.dummyObj.notifyAll();
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+  // Listener class for the validation purpose
+  private static class HAValidateDuplicateListener extends CacheListenerAdapter {
+    @Override
+    public void afterCreate(EntryEvent event) {
+      System.out.println("After Create");
+      storeEvents.put(event.getKey(), event.getNewValue());
     }
 
+    @Override
+    public void afterUpdate(EntryEvent event) {
+      Object value = storeEvents.get(event.getKey());
+      if (value == null)
+        isEventDuplicate = false;
+      synchronized (dummyObj) {
+        try {
+          put_counter++;
+          if (put_counter == NO_OF_PUTS) {
+            waitFlag = false;
+            dummyObj.notifyAll();
+          }
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+
+    }
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAExpiryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAExpiryDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.createRegionName;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Properties;
@@ -245,7 +246,7 @@ public class HAExpiryDUnitTest extends JUnit4DistributedTestCase {
     // setting expiry time for the regionqueue.
     hattr.setExpiryTime(4);
     RegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(regionQueueName, cache, hattr,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, isDurable.booleanValue());
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, isDurable.booleanValue(), enabledClock());
     assertNotNull(regionqueue);
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAGIIBugDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAGIIBugDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -167,7 +168,7 @@ public class HAGIIBugDUnitTest extends JUnit4DistributedTestCase {
           hattr.setExpiryTime(12000000);
           RegionQueue regionqueue = null;
           regionqueue = HARegionQueue.getHARegionQueueInstance(regionQueueName, cache, hattr,
-              HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+              HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
           isHARegionQueueUp = true;
           vm0.invoke(setStopFlag());
           assertNotNull(regionqueue);
@@ -325,7 +326,7 @@ public class HAGIIBugDUnitTest extends JUnit4DistributedTestCase {
     // setting expiry time for the regionqueue.
     hattr.setExpiryTime(12000000);
     RegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(regionQueueName, cache, hattr,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     assertNotNull(regionqueue);
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);
@@ -344,45 +345,41 @@ public class HAGIIBugDUnitTest extends JUnit4DistributedTestCase {
     }
   }
 
-}
+  /**
+   * This listener performs the put of Conflatable object in the regionqueue.
+   */
+  private static class vmListenerToPutInHARegionQueue extends CacheListenerAdapter {
+    @Override
+    public void afterCreate(EntryEvent event) {
 
-
-/**
- * This listener performs the put of Conflatable object in the regionqueue.
- */
-
-class vmListenerToPutInHARegionQueue extends CacheListenerAdapter {
-  @Override
-  public void afterCreate(EntryEvent event) {
-
-    Cache cache = event.getRegion().getCache();
-    HARegion regionForQueue = (HARegion) cache.getRegion(
-        Region.SEPARATOR + HARegionQueue.createRegionName(HAGIIBugDUnitTest.regionQueueName));
-    HARegionQueue regionqueue = regionForQueue.getOwner();
-
-    try {
-      regionqueue.put(new ConflatableObject(event.getKey(), event.getNewValue(),
-          ((EntryEventImpl) event).getEventId(), false, "region1"));
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
-  }
-}
-
-
-class vmListenerToCheckHARegionQueue extends CacheListenerAdapter {
-  @Override
-  public void afterCreate(EntryEvent event) {
-    if (HAGIIBugDUnitTest.isHARegionQueueUp) {
       Cache cache = event.getRegion().getCache();
       HARegion regionForQueue = (HARegion) cache.getRegion(
-          Region.SEPARATOR + HARegionQueue.createRegionName(HAGIIBugDUnitTest.regionQueueName));
+          Region.SEPARATOR + HARegionQueue.createRegionName(regionQueueName));
       HARegionQueue regionqueue = regionForQueue.getOwner();
+
       try {
         regionqueue.put(new ConflatableObject(event.getKey(), event.getNewValue(),
             ((EntryEventImpl) event).getEventId(), false, "region1"));
       } catch (Exception e) {
         e.printStackTrace();
+      }
+    }
+  }
+
+  private static class vmListenerToCheckHARegionQueue extends CacheListenerAdapter {
+    @Override
+    public void afterCreate(EntryEvent event) {
+      if (isHARegionQueueUp) {
+        Cache cache = event.getRegion().getCache();
+        HARegion regionForQueue = (HARegion) cache.getRegion(
+            Region.SEPARATOR + HARegionQueue.createRegionName(regionQueueName));
+        HARegionQueue regionqueue = regionForQueue.getOwner();
+        try {
+          regionqueue.put(new ConflatableObject(event.getKey(), event.getNewValue(),
+              ((EntryEventImpl) event).getEventId(), false, "region1"));
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
       }
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -224,7 +225,8 @@ public class HARegionDUnitTest extends JUnit4DistributedTestCase {
     when(harq.updateHAEventWrapper(any(), any(), any()))
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
 
-    HARegion.getInstance(REGION_NAME, (GemFireCacheImpl) cache, harq, factory.create());
+    HARegion.getInstance(REGION_NAME, (GemFireCacheImpl) cache, harq, factory.create(),
+        enabledClock());
   }
 
   private static HARegionQueue hrq = null;
@@ -239,7 +241,7 @@ public class HARegionDUnitTest extends JUnit4DistributedTestCase {
      * factory.setDataPolicy(DataPolicy.REPLICATE);
      */
     hrq = HARegionQueue.getHARegionQueueInstance(REGION_NAME, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     EventID id1 = new EventID(new byte[] {1}, 1, 1);
     EventID id2 = new EventID(new byte[] {1}, 1, 2);
     ConflatableObject c1 = new ConflatableObject("1", "1", id1, false, REGION_NAME);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache.ha;
 import static java.lang.Thread.yield;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.NON_BLOCKING_HA_QUEUE;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.getHARegionQueueInstance;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertNotNull;
@@ -219,7 +220,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
             hrqa.setExpiryTime(300);
             try {
               hrq = HARegionQueue.getHARegionQueueInstance("testregion1", cache, hrqa,
-                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
               // Do 1000 putand 100 take in a separate thread
               hrq.put(new ConflatableObject(new Long(1), new Long(1),
                   new EventID(new byte[] {0}, 1, 1), false, "dummy"));
@@ -281,7 +282,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
 
     HARegion.getInstance("HARegionQueueDUnitTest_region", (GemFireCacheImpl) cache, harq,
-        factory.create());
+        factory.create(), enabledClock());
   }
 
   private static void createRegionQueue() throws Exception {
@@ -292,7 +293,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
      * factory.setDataPolicy(DataPolicy.REPLICATE);
      */
     hrq = HARegionQueue.getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     EventID id1 = new EventID(new byte[] {1}, 1, 1);
     EventID id2 = new EventID(new byte[] {1}, 1, 2);
     ConflatableObject c1 =
@@ -313,7 +314,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
     HARegionQueueAttributes harqAttr = new HARegionQueueAttributes();
     harqAttr.setExpiryTime(3);
     hrq = HARegionQueue.getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache, harqAttr,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
   }
 
   private static void clearRegion() {
@@ -592,10 +593,10 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
         try {
           if (createBlockingQueue) {
             hrq = HARegionQueue.getHARegionQueueInstance("testregion1", cache, hrqa,
-                HARegionQueue.BLOCKING_HA_QUEUE, false);
+                HARegionQueue.BLOCKING_HA_QUEUE, false, enabledClock());
           } else {
             hrq = HARegionQueue.getHARegionQueueInstance("testregion1", cache, hrqa,
-                HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
           }
         } catch (Exception e) {
           throw new AssertionError(e);
@@ -777,7 +778,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
             try {
               hrq = HARegionQueue.getHARegionQueueInstance(
                   "testNPEDueToHARegionQueueEscapeInConstructor", cache, hrqa,
-                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
               // changing OP_COUNT to 20 makes no difference in test time
               final int OP_COUNT = 200;
               // Do 1000 putand 100 take in a separate thread
@@ -824,7 +825,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
             try {
               hrq = HARegionQueue.getHARegionQueueInstance(
                   "testNPEDueToHARegionQueueEscapeInConstructor", cache, hrqa,
-                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
             } catch (Exception e) {
               throw new AssertionError(e);
             }
@@ -955,7 +956,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
     HARegionQueueAttributes attrs = new HARegionQueueAttributes();
     attrs.setExpiryTime(1);
     hrq = getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache, attrs,
-        NON_BLOCKING_HA_QUEUE, false);
+        NON_BLOCKING_HA_QUEUE, false, enabledClock());
     // wait until we have a dead
     // server
     WaitCriterion ev = new WaitCriterion() {
@@ -987,7 +988,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
     cache = test.createCache();
 
     hrq = HARegionQueue.getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
 
     assertEquals(2, hrq.size());
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/HABug36738DUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/HABug36738DUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
 import static org.junit.Assert.assertEquals;
@@ -124,7 +125,7 @@ public class HABug36738DUnitTest extends JUnit4DistributedTestCase {
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
 
     haRegion = HARegion.getInstance(HAREGION_NAME, (GemFireCacheImpl) cache, harq,
-        factory.createRegionAttributes());
+        factory.createRegionAttributes(), enabledClock());
   }
 
   private void checkRegionQueueSize() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImplJUnitTest.java
@@ -47,7 +47,9 @@ public class SerialAsyncEventQueueImplJUnitTest {
   public void testStopClearsStats() {
     GatewaySenderAttributes attrs = new GatewaySenderAttributes();
     attrs.id = AsyncEventQueueImpl.ASYNC_EVENT_QUEUE_PREFIX + "id";
-    SerialAsyncEventQueueImpl queue = new SerialAsyncEventQueueImpl(cache, attrs);
+    SerialAsyncEventQueueImpl queue = new SerialAsyncEventQueueImpl(cache,
+        cache.getInternalDistributedSystem().getStatisticsManager(), cache.getStatisticsClock(),
+        attrs);
     queue.getStatistics().incQueueSize(5);
     queue.getStatistics().incSecondaryQueueSize(6);
     queue.getStatistics().incTempQueueSize(10);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryServiceRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryServiceRegressionTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache.query;
 
 import static org.apache.geode.cache.query.data.TestData.createAndPopulateSet;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -434,7 +435,7 @@ public class QueryServiceRegressionTest {
 
     createAllNumPRAndEvenNumPR(pr1, pr2, 80);
     Set<Integer> set = createAndPopulateSet(15);
-    LocalDataSet lds = new LocalDataSet(pr1, set);
+    LocalDataSet lds = new LocalDataSet(pr1, set, disabledClock());
 
     QueryObserverImpl observer = new QueryObserverImpl();
     QueryObserverHolder.setInstance(observer);
@@ -507,7 +508,7 @@ public class QueryServiceRegressionTest {
 
     createAllNumPRAndEvenNumPR(pr1, pr2, 80);
     Set<Integer> set = createAndPopulateSet(15);
-    LocalDataSet lds = new LocalDataSet(pr1, set);
+    LocalDataSet lds = new LocalDataSet(pr1, set, disabledClock());
 
     QueryObserverImpl observer = new QueryObserverImpl();
     QueryObserverHolder.setInstance(observer);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryServiceRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryServiceRegressionTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.cache.query;
 
 import static org.apache.geode.cache.query.data.TestData.createAndPopulateSet;
-import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -435,7 +434,7 @@ public class QueryServiceRegressionTest {
 
     createAllNumPRAndEvenNumPR(pr1, pr2, 80);
     Set<Integer> set = createAndPopulateSet(15);
-    LocalDataSet lds = new LocalDataSet(pr1, set, disabledClock());
+    LocalDataSet lds = new LocalDataSet(pr1, set);
 
     QueryObserverImpl observer = new QueryObserverImpl();
     QueryObserverHolder.setInstance(observer);
@@ -508,7 +507,7 @@ public class QueryServiceRegressionTest {
 
     createAllNumPRAndEvenNumPR(pr1, pr2, 80);
     Set<Integer> set = createAndPopulateSet(15);
-    LocalDataSet lds = new LocalDataSet(pr1, set, disabledClock());
+    LocalDataSet lds = new LocalDataSet(pr1, set);
 
     QueryObserverImpl observer = new QueryObserverImpl();
     QueryObserverHolder.setInstance(observer);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryWithBucketParameterIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryWithBucketParameterIntegrationTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.cache.query;
 
 import static org.apache.geode.cache.query.data.TestData.createAndPopulateSet;
 import static org.apache.geode.cache.query.data.TestData.populateRegion;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -71,7 +72,7 @@ public class QueryWithBucketParameterIntegrationTest {
     String query = "select distinct e1.value from /pr1 e1";
     queryExecutor = (DefaultQuery) CacheUtils.getQueryService().newQuery(query);
     Set<Integer> set = createAndPopulateSet(totalBuckets);
-    lds = new LocalDataSet(pr1, set);
+    lds = new LocalDataSet(pr1, set, disabledClock());
   }
 
   @After

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryWithBucketParameterIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/QueryWithBucketParameterIntegrationTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.cache.query;
 
 import static org.apache.geode.cache.query.data.TestData.createAndPopulateSet;
 import static org.apache.geode.cache.query.data.TestData.populateRegion;
-import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -72,7 +71,7 @@ public class QueryWithBucketParameterIntegrationTest {
     String query = "select distinct e1.value from /pr1 e1";
     queryExecutor = (DefaultQuery) CacheUtils.getQueryService().newQuery(query);
     Set<Integer> set = createAndPopulateSet(totalBuckets);
-    lds = new LocalDataSet(pr1, set, disabledClock());
+    lds = new LocalDataSet(pr1, set);
   }
 
   @After

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/LRUClearWithDiskRegionOpRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/LRUClearWithDiskRegionOpRegressionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -83,7 +84,7 @@ public class LRUClearWithDiskRegionOpRegressionTest {
         .setRecreateFlag(false).setSnapshotInputStream(null).setImageTarget(null);
 
     DistributedRegion distributedRegion =
-        new DistributedRegion(regionName, regionAttributes, null, cache, args);
+        new DistributedRegion(regionName, regionAttributes, null, cache, args, enabledClock());
 
     region = cache.createVMRegion(regionName, regionAttributes,
         new InternalRegionArguments().setInternalMetaRegion(distributedRegion)

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PRTXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PRTXJUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -88,7 +90,7 @@ public class PRTXJUnitTest extends TXJUnitTest {
 
     PRWithLocalOps(String regionName, RegionAttributes ra, LocalRegion parentRegion,
         GemFireCacheImpl cache, InternalRegionArguments internalRegionArgs) {
-      super(regionName, ra, parentRegion, cache, internalRegionArgs, cache.getStatisticsClock());
+      super(regionName, ra, parentRegion, cache, internalRegionArgs, disabledClock());
     }
 
     @Override

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PRTXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PRTXJUnitTest.java
@@ -88,7 +88,7 @@ public class PRTXJUnitTest extends TXJUnitTest {
 
     PRWithLocalOps(String regionName, RegionAttributes ra, LocalRegion parentRegion,
         GemFireCacheImpl cache, InternalRegionArguments internalRegionArgs) {
-      super(regionName, ra, parentRegion, cache, internalRegionArgs);
+      super(regionName, ra, parentRegion, cache, internalRegionArgs, cache.getStatisticsClock());
     }
 
     @Override

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionDataStoreJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionDataStoreJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -79,7 +80,7 @@ public class PartitionedRegionDataStoreJUnitTest {
     PartitionedRegion pr = null;
     pr = (PartitionedRegion) cache.createRegion("PR2", ra);
     paf.setLocalProperties(null).create();
-    /* PartitionedRegionDataStore prDS = */ new PartitionedRegionDataStore(pr);
+    /* PartitionedRegionDataStore prDS = */ new PartitionedRegionDataStore(pr, disabledClock());
     /*
      * PartitionedRegionHelper.removeGlobalMetadataForFailedNode(PartitionedRegion.node,
      * prDS.partitionedRegion.getRegionIdentifier(), prDS.partitionedRegion.cache);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ServerBuilderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ServerBuilderIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
 import org.apache.geode.internal.cache.tier.Acceptor;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category(ClientServerTest.class)
@@ -64,8 +65,9 @@ public class ServerBuilderIntegrationTest {
 
   @Test
   public void byDefaultCreatesServerWithCacheServerAcceptor() throws IOException {
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .createServer();
     server.setPort(0);
 
     server.start();
@@ -78,9 +80,10 @@ public class ServerBuilderIntegrationTest {
   public void forGatewayReceiverCreatesServerWithGatewayReceiverAcceptor() throws IOException {
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .forGatewayReceiver(gatewayReceiver)
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .forGatewayReceiver(gatewayReceiver)
+            .createServer();
     server.setPort(0);
 
     server.start();
@@ -94,8 +97,9 @@ public class ServerBuilderIntegrationTest {
     cache.close();
     String membershipGroup = "group-m0";
     cache = (InternalCache) new CacheFactory().set(GROUPS, membershipGroup).create();
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .createServer();
 
     assertThat(server.getCombinedGroups()).containsExactly(membershipGroup);
   }
@@ -107,9 +111,10 @@ public class ServerBuilderIntegrationTest {
     cache.close();
     String membershipGroup = "group-m0";
     cache = (InternalCache) new CacheFactory().set(GROUPS, membershipGroup).create();
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .forGatewayReceiver(gatewayReceiver)
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .forGatewayReceiver(gatewayReceiver)
+            .createServer();
 
     assertThat(server.getCombinedGroups()).doesNotContain(membershipGroup);
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQAddOperationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQAddOperationJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -51,7 +52,8 @@ public class BlockingHARQAddOperationJUnitTest extends HARQAddOperationJUnitTest
   protected HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue =
-        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false,
+            enabledClock());
     return regionqueue;
   }
 
@@ -64,7 +66,7 @@ public class BlockingHARQAddOperationJUnitTest extends HARQAddOperationJUnitTest
   protected HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.BLOCKING_HA_QUEUE, false, enabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQStatsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQStatsJUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
+
 import java.io.IOException;
 
 import org.junit.experimental.categories.Category;
@@ -40,7 +42,8 @@ public class BlockingHARQStatsJUnitTest extends HARegionQueueStatsJUnitTest {
   protected HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue =
-        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false,
+            enabledClock());
     return regionqueue;
   }
 
@@ -55,7 +58,7 @@ public class BlockingHARQStatsJUnitTest extends HARegionQueueStatsJUnitTest {
   protected HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.BLOCKING_HA_QUEUE, false, enabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARegionJUnitTest.java
@@ -18,6 +18,7 @@ import static java.lang.Thread.sleep;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.BLOCKING_HA_QUEUE;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.getHARegionQueueInstance;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.apache.geode.test.dunit.ThreadUtils.join;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -72,7 +73,7 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(1);
     HARegionQueue hrq = HARegionQueue.getHARegionQueueInstance("BlockingHARegionJUnitTest_Region",
-        cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false, enabledClock());
     hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
     Thread thread1 = new DoPuts(hrq, 1000);
     Thread thread2 = new DoTake(hrq, 1000);
@@ -105,7 +106,7 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(1);
     final HARegionQueue hrq = getHARegionQueueInstance(
-        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false);
+        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false, enabledClock());
     hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
     final Thread thread1 = new DoPuts(hrq, 2);
     thread1.start();
@@ -176,7 +177,7 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(10000);
     final HARegionQueue hrq = getHARegionQueueInstance(
-        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false);
+        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false, enabledClock());
     hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
     Thread thread1 = new DoPuts(hrq, 20000, 1);
     Thread thread2 = new DoPuts(hrq, 20000, 2);
@@ -246,7 +247,7 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(10000);
     final HARegionQueue hrq = getHARegionQueueInstance(
-        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false);
+        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false, enabledClock());
     Thread thread1 = new DoPuts(hrq, 40000, 1);
     Thread thread2 = new DoPuts(hrq, 40000, 2);
     Thread thread3 = new DoPuts(hrq, 40000, 3);
@@ -336,7 +337,8 @@ public class BlockingHARegionJUnitTest {
       harqa.setBlockingQueueCapacity(1);
       harqa.setExpiryTime(180);
       final HARegionQueue hrq = HARegionQueue.getHARegionQueueInstance(
-          "BlockingHARegionJUnitTest_Region", cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false);
+          "BlockingHARegionJUnitTest_Region", cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false,
+          enabledClock());
       hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
       final EventID id1 = new EventID(new byte[] {1}, 1, 2); // violation
       final EventID ignore = new EventID(new byte[] {1}, 1, 1); //

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -111,7 +112,7 @@ public class HARQAddOperationJUnitTest {
     factory.setDataPolicy(DataPolicy.REPLICATE);
     factory.setScope(Scope.DISTRIBUTED_ACK);
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     return regionqueue;
   }
 
@@ -121,7 +122,7 @@ public class HARQAddOperationJUnitTest {
   protected HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     return regionqueue;
   }
 
@@ -891,7 +892,7 @@ public class HARQAddOperationJUnitTest {
       HARegionQueueAttributes attrs = new HARegionQueueAttributes();
       attrs.setExpiryTime(10);
       final HARegionQueue regionqueue =
-          new HARegionQueue.TestOnlyHARegionQueue("testing", cache, attrs) {
+          new HARegionQueue.TestOnlyHARegionQueue("testing", cache, attrs, enabledClock()) {
             @Override
             CacheListener createCacheListenerForHARegion() {
               return new CacheListenerAdapter() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
@@ -892,7 +892,7 @@ public class HARQAddOperationJUnitTest {
       HARegionQueueAttributes attrs = new HARegionQueueAttributes();
       attrs.setExpiryTime(10);
       final HARegionQueue regionqueue =
-          new HARegionQueue.TestOnlyHARegionQueue("testing", cache, attrs, enabledClock()) {
+          new TestOnlyHARegionQueue("testing", cache, attrs, enabledClock()) {
             @Override
             CacheListener createCacheListenerForHARegion() {
               return new CacheListenerAdapter() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -100,7 +101,8 @@ public class HARegionJUnitTest {
     });
     RegionAttributes ra = factory.create();
     Region region =
-        HARegion.getInstance("HARegionJUnitTest_region", (GemFireCacheImpl) cache, null, ra);
+        HARegion.getInstance("HARegionJUnitTest_region", (GemFireCacheImpl) cache, null, ra,
+            enabledClock());
     region.getAttributesMutator().setEntryTimeToLive(ea);
     return region;
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -50,8 +49,6 @@ import org.mockito.MockitoAnnotations;
 import util.TestException;
 
 import org.apache.geode.CancelCriterion;
-import org.apache.geode.Statistics;
-import org.apache.geode.StatisticsType;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -61,12 +58,7 @@ import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
-import org.apache.geode.distributed.internal.DSClock;
-import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.DistributionManager;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.SystemTimer;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.CachedDeserializable;
@@ -86,6 +78,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
 import org.apache.geode.internal.concurrent.ConcurrentHashSet;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock;
 
@@ -108,7 +101,6 @@ public class HARegionQueueIntegrationTest {
     dataRegion = createDataRegion();
     ccn = createCacheClientNotifier();
     member = createMember();
-    HAContainerWrapper haContainerWrapper = (HAContainerWrapper) ccn.getHaContainer();
   }
 
   @After
@@ -125,38 +117,11 @@ public class HARegionQueueIntegrationTest {
     return cache.createRegionFactory(RegionShortcut.REPLICATE).create("data");
   }
 
-  private InternalCache createMockInternalCache() {
-    InternalCache mockInternalCache = mock(InternalCache.class);
-    doReturn(mock(SystemTimer.class)).when(mockInternalCache).getCCPTimer();
-    doReturn(mock(CancelCriterion.class)).when(mockInternalCache).getCancelCriterion();
-
-    InternalDistributedSystem mockInteralDistributedSystem = createMockInternalDistributedSystem();
-    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getInternalDistributedSystem();
-    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getDistributedSystem();
-
-    return mockInternalCache;
-  }
-
-  private InternalDistributedSystem createMockInternalDistributedSystem() {
-    InternalDistributedSystem mockInternalDistributedSystem =
-        mock(InternalDistributedSystem.class);
-    DistributionManager mockDistributionManager = mock(DistributionManager.class);
-
-    doReturn(mock(InternalDistributedMember.class)).when(mockInternalDistributedSystem)
-        .getDistributedMember();
-    doReturn(mock(Statistics.class)).when(mockInternalDistributedSystem)
-        .createAtomicStatistics(any(StatisticsType.class), any(String.class));
-    doReturn(mock(DistributionConfig.class)).when(mockDistributionManager).getConfig();
-    doReturn(mockDistributionManager).when(mockInternalDistributedSystem).getDistributionManager();
-    doReturn(mock(DSClock.class)).when(mockInternalDistributedSystem).getClock();
-
-    return mockInternalDistributedSystem;
-  }
-
   private CacheClientNotifier createCacheClientNotifier() {
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance((InternalCache) cache, mock(CacheServerStats.class),
-            100000, 100000, mock(ConnectionListener.class), null, false);
+        CacheClientNotifier.getInstance((InternalCache) cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 100000, 100000, mock(ConnectionListener.class), null,
+            false);
     return ccn;
   }
 
@@ -653,7 +618,7 @@ public class HARegionQueueIntegrationTest {
 
     return new HARegionQueue("haRegion+" + index, haRegion, (InternalCache) cache, haContainer,
         null, (byte) 1, true, mock(HARegionQueueStats.class), giiLock, rwLock,
-        mock(CancelCriterion.class), puttingGIIDataInQueue);
+        mock(CancelCriterion.class), puttingGIIDataInQueue, mock(StatisticsClock.class));
   }
 
   private HARegionQueue createHARegionQueue(Map haContainer, int index) throws Exception {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -1212,7 +1212,7 @@ public class HARegionQueueJUnitTest {
     haa.setExpiryTime(3);
 
     RegionQueue regionqueue =
-        new HARegionQueue.TestOnlyHARegionQueue(testName.getMethodName(), cache, haa,
+        new TestOnlyHARegionQueue(testName.getMethodName(), cache, haa,
             enabledClock()) {
           @Override
           CacheListener createCacheListenerForHARegion() {
@@ -1897,7 +1897,7 @@ public class HARegionQueueJUnitTest {
   /**
    * Extends HARegionQueue for testing purposes. used by testSafeConflationRemoval
    */
-  static class HARQTestClass extends HARegionQueue.TestOnlyHARegionQueue {
+  static class HARQTestClass extends TestOnlyHARegionQueue {
 
     HARQTestClass(String regionName, InternalCache cache)
         throws IOException, ClassNotFoundException, CacheException, InterruptedException {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache.ha;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -188,7 +189,7 @@ public class HARegionQueueJUnitTest {
   @Test
   public void testBlockQueue() throws Exception {
     HARegionQueue regionQueue = HARegionQueue.getHARegionQueueInstance(testName.getMethodName(),
-        cache, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        cache, HARegionQueue.BLOCKING_HA_QUEUE, false, enabledClock());
     Thread[] threads = new Thread[10];
     int threadsLength = threads.length;
     CyclicBarrier barrier = new CyclicBarrier(threadsLength + 1);
@@ -1075,7 +1076,8 @@ public class HARegionQueueJUnitTest {
   @Test
   public void testBlockingQueueForConcurrentPeekAndTake() throws Exception {
     TestBlockingHARegionQueue regionQueue =
-        new TestBlockingHARegionQueue("testBlockQueueForConcurrentPeekAndTake", cache);
+        new TestBlockingHARegionQueue("testBlockQueueForConcurrentPeekAndTake", cache,
+            enabledClock());
     Thread[] threads = new Thread[3];
 
     for (int i = 0; i < 3; i++) {
@@ -1136,7 +1138,8 @@ public class HARegionQueueJUnitTest {
   @Test
   public void testBlockingQueueForTakeWhenPeekInProgress() throws Exception {
     TestBlockingHARegionQueue regionQueue =
-        new TestBlockingHARegionQueue("testBlockQueueForTakeWhenPeekInProgress", cache);
+        new TestBlockingHARegionQueue("testBlockQueueForTakeWhenPeekInProgress", cache,
+            enabledClock());
     Thread[] threads = new Thread[3];
 
     for (int i = 0; i < 3; i++) {
@@ -1209,7 +1212,8 @@ public class HARegionQueueJUnitTest {
     haa.setExpiryTime(3);
 
     RegionQueue regionqueue =
-        new HARegionQueue.TestOnlyHARegionQueue(testName.getMethodName(), cache, haa) {
+        new HARegionQueue.TestOnlyHARegionQueue(testName.getMethodName(), cache, haa,
+            enabledClock()) {
           @Override
           CacheListener createCacheListenerForHARegion() {
 
@@ -1333,10 +1337,10 @@ public class HARegionQueueJUnitTest {
 
     if (createBlockingQueue) {
       return HARegionQueue.getHARegionQueueInstance(testName.getMethodName(), cache, haa,
-          HARegionQueue.BLOCKING_HA_QUEUE, false);
+          HARegionQueue.BLOCKING_HA_QUEUE, false, enabledClock());
     } else {
       return HARegionQueue.getHARegionQueueInstance(testName.getMethodName(), cache, haa,
-          HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+          HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     }
   }
 
@@ -1852,7 +1856,7 @@ public class HARegionQueueJUnitTest {
    */
   private HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType(), false);
+    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType(), false, enabledClock());
   }
 
   /**
@@ -1860,7 +1864,7 @@ public class HARegionQueueJUnitTest {
    */
   private HARegionQueue createHARegionQueue(String name, int queueType)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType, false);
+    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType, false, enabledClock());
   }
 
   /**
@@ -1868,7 +1872,8 @@ public class HARegionQueueJUnitTest {
    */
   HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    return HARegionQueue.getHARegionQueueInstance(name, cache, attrs, queueType(), false);
+    return HARegionQueue.getHARegionQueueInstance(name, cache, attrs, queueType(), false,
+        enabledClock());
   }
 
   /**
@@ -1896,7 +1901,7 @@ public class HARegionQueueJUnitTest {
 
     HARQTestClass(String regionName, InternalCache cache)
         throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      super(regionName, cache);
+      super(regionName, cache, enabledClock());
     }
 
     @Override

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStartStopJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStartStopJUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class HARegionQueueStartStopJUnitTest {
   private RegionQueue createHARegionQueue(String name, InternalCache cache)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     RegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStatsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStatsJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -85,7 +86,7 @@ public class HARegionQueueStatsJUnitTest {
   protected HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     return regionqueue;
   }
 
@@ -102,7 +103,7 @@ public class HARegionQueueStatsJUnitTest {
     factory.setDataPolicy(DataPolicy.REPLICATE);
     factory.setScope(Scope.DISTRIBUTED_ACK);
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, enabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.net.SocketCloser;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
@@ -49,7 +50,6 @@ public class CacheClientProxyTest {
 
   @Test
   public void closeSocketShouldBeAtomic() {
-
     final CacheServerStats stats = mock(CacheServerStats.class);
     doNothing().when(stats).incCurrentQueueConnections();
 
@@ -73,7 +73,7 @@ public class CacheClientProxyTest {
 
     CacheClientProxy proxy = new CacheClientProxy(ccn, socket, proxyID, true,
         Handshake.CONFLATION_DEFAULT, Version.CURRENT, 1L, true,
-        null, null);
+        null, null, mock(StatisticsClock.class));
 
     CompletableFuture<Void> result1 = executorServiceRule.runAsync(() -> proxy.close());
     CompletableFuture<Void> result2 = executorServiceRule.runAsync(() -> proxy.close());
@@ -93,5 +93,4 @@ public class CacheClientProxyTest {
       closeSocketShouldBeAtomic();
     }
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/AsyncEventQueueStatsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/AsyncEventQueueStatsJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.bean.stats;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -33,7 +34,7 @@ public class AsyncEventQueueStatsJUnitTest extends MBeanStatsTestCase {
 
   @Override
   public void init() {
-    asyncEventQueueStats = new AsyncEventQueueStats(system, "test");
+    asyncEventQueueStats = new AsyncEventQueueStats(system, "test", enabledClock());
 
     bridge = new AsyncEventQueueMBeanBridge();
     bridge.addAsyncEventQueueStats(asyncEventQueueStats);

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayMBeanBridgeJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayMBeanBridgeJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.bean.stats;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +41,7 @@ public class GatewayMBeanBridgeJUnitTest extends MBeanStatsTestCase {
 
   @Override
   public void init() {
-    senderStats = new GatewaySenderStats(system, "test");
+    senderStats = new GatewaySenderStats(system, "gatewaySenderStats-", "test", disabledClock());
 
     sender = Mockito.mock(AbstractGatewaySender.class);
     Mockito.when(sender.getStatistics()).thenReturn(senderStats);

--- a/geode-core/src/main/java/org/apache/geode/cache/DynamicRegionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/DynamicRegionFactory.java
@@ -879,7 +879,8 @@ public abstract class DynamicRegionFactory {
   // the meta data
   private class LocalMetaRegion extends LocalRegion {
     protected LocalMetaRegion(RegionAttributes attrs, InternalRegionArguments ira) {
-      super(DYNAMIC_REGION_LIST_NAME, attrs, null, DynamicRegionFactory.this.cache, ira);
+      super(DYNAMIC_REGION_LIST_NAME, attrs, null, DynamicRegionFactory.this.cache, ira,
+          DynamicRegionFactory.this.cache.getStatisticsClock());
       Assert.assertTrue(attrs.getScope().isLocal());
     }
 
@@ -989,7 +990,7 @@ public abstract class DynamicRegionFactory {
   private class DistributedMetaRegion extends DistributedRegion {
     protected DistributedMetaRegion(RegionAttributes attrs) {
       super(DYNAMIC_REGION_LIST_NAME, attrs, null, DynamicRegionFactory.this.cache,
-          new InternalRegionArguments());
+          new InternalRegionArguments(), DynamicRegionFactory.this.cache.getStatisticsClock());
     }
 
     // This is an internal uses only region

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueFactoryImpl.java
@@ -204,7 +204,9 @@ public class AsyncEventQueueFactoryImpl implements AsyncEventQueueFactory {
       if (cache instanceof CacheCreation) {
         sender = new ParallelAsyncEventQueueCreation(cache, gatewaySenderAttributes);
       } else {
-        sender = new ParallelAsyncEventQueueImpl(cache, gatewaySenderAttributes);
+        sender = new ParallelAsyncEventQueueImpl(cache,
+            cache.getInternalDistributedSystem().getStatisticsManager(), cache.getStatisticsClock(),
+            gatewaySenderAttributes);
       }
       cache.addGatewaySender(sender);
 
@@ -217,7 +219,9 @@ public class AsyncEventQueueFactoryImpl implements AsyncEventQueueFactory {
       if (cache instanceof CacheCreation) {
         sender = new SerialAsyncEventQueueCreation(cache, gatewaySenderAttributes);
       } else {
-        sender = new SerialAsyncEventQueueImpl(cache, gatewaySenderAttributes);
+        sender = new SerialAsyncEventQueueImpl(cache,
+            cache.getInternalDistributedSystem().getStatisticsManager(), cache.getStatisticsClock(),
+            gatewaySenderAttributes);
       }
       cache.addGatewaySender(sender);
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueStats.java
@@ -19,6 +19,7 @@ import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.internal.cache.wan.GatewaySenderStats;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 public class AsyncEventQueueStats extends GatewaySenderStats {
@@ -42,7 +43,8 @@ public class AsyncEventQueueStats extends GatewaySenderStats {
    * @param asyncQueueId The id of the <code>AsyncEventQueue</code> used to generate the name of the
    *        <code>Statistics</code>
    */
-  public AsyncEventQueueStats(StatisticsFactory f, String asyncQueueId) {
-    super(f, asyncQueueId, type);
+  public AsyncEventQueueStats(StatisticsFactory f, String asyncQueueId,
+      StatisticsClock statisticsClock) {
+    super(f, "asyncEventQueueStats-", asyncQueueId, type, statisticsClock);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImpl.java
@@ -16,6 +16,7 @@ package org.apache.geode.cache.asyncqueue.internal;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.EntryOperation;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
@@ -38,18 +39,20 @@ import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySen
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class ParallelAsyncEventQueueImpl extends AbstractGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public ParallelAsyncEventQueueImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs, cache.getStatisticsClock());
+  public ParallelAsyncEventQueueImpl(InternalCache cache, StatisticsFactory statisticsFactory,
+      StatisticsClock statisticsClock, GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
     if (!(this.cache instanceof CacheCreation)) {
       // this sender lies underneath the AsyncEventQueue. Need to have
       // AsyncEventQueueStats
-      this.statistics = new AsyncEventQueueStats(cache.getDistributedSystem(),
-          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), cache.getStatisticsClock());
+      this.statistics = new AsyncEventQueueStats(statisticsFactory,
+          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), statisticsClock);
     }
     this.isForInternalUse = true;
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImpl.java
@@ -44,12 +44,12 @@ public class ParallelAsyncEventQueueImpl extends AbstractGatewaySender {
   private static final Logger logger = LogService.getLogger();
 
   public ParallelAsyncEventQueueImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, attrs, cache.getStatisticsClock());
     if (!(this.cache instanceof CacheCreation)) {
       // this sender lies underneath the AsyncEventQueue. Need to have
       // AsyncEventQueueStats
       this.statistics = new AsyncEventQueueStats(cache.getDistributedSystem(),
-          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id));
+          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), cache.getStatisticsClock());
     }
     this.isForInternalUse = true;
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
@@ -17,6 +17,7 @@ package org.apache.geode.cache.asyncqueue.internal;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
 import org.apache.geode.distributed.DistributedLockService;
@@ -40,18 +41,20 @@ import org.apache.geode.internal.cache.wan.serial.SerialGatewaySenderQueue;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class SerialAsyncEventQueueImpl extends AbstractGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public SerialAsyncEventQueueImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs, cache.getStatisticsClock());
+  public SerialAsyncEventQueueImpl(InternalCache cache, StatisticsFactory statisticsFactory,
+      StatisticsClock statisticsClock, GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
     if (!(this.cache instanceof CacheCreation)) {
       // this sender lies underneath the AsyncEventQueue. Need to have
       // AsyncEventQueueStats
-      this.statistics = new AsyncEventQueueStats(cache.getDistributedSystem(),
-          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), cache.getStatisticsClock());
+      this.statistics = new AsyncEventQueueStats(statisticsFactory,
+          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), statisticsClock);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
@@ -46,12 +46,12 @@ public class SerialAsyncEventQueueImpl extends AbstractGatewaySender {
   private static final Logger logger = LogService.getLogger();
 
   public SerialAsyncEventQueueImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, attrs, cache.getStatisticsClock());
     if (!(this.cache instanceof CacheCreation)) {
       // this sender lies underneath the AsyncEventQueue. Need to have
       // AsyncEventQueueStats
       this.statistics = new AsyncEventQueueStats(cache.getDistributedSystem(),
-          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id));
+          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), cache.getStatisticsClock());
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -15,7 +15,6 @@
 package org.apache.geode.cache.client.internal;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -66,7 +65,6 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingExecutors;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
 import org.apache.geode.internal.statistics.DummyStatisticsFactory;
-import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Manages the client side of client to server connections and client queues.
@@ -151,17 +149,15 @@ public class PoolImpl implements InternalPool {
 
   public static final int PRIMARY_QUEUE_NOT_AVAILABLE = -2;
   public static final int PRIMARY_QUEUE_TIMED_OUT = -1;
-  private AtomicInteger primaryQueueSize = new AtomicInteger(PRIMARY_QUEUE_NOT_AVAILABLE);
+  private final AtomicInteger primaryQueueSize = new AtomicInteger(PRIMARY_QUEUE_NOT_AVAILABLE);
 
   private final ThreadsMonitoring threadMonitoring;
-  private final StatisticsClock statisticsClock;
 
   public static PoolImpl create(PoolManagerImpl pm, String name, Pool attributes,
       List<HostAddress> locatorAddresses, InternalDistributedSystem distributedSystem,
       InternalCache cache, ThreadsMonitoring tMonitoring) {
     PoolImpl pool =
-        new PoolImpl(pm, name, attributes, locatorAddresses, distributedSystem, cache, tMonitoring,
-            cache == null ? disabledClock() : cache.getStatisticsClock());
+        new PoolImpl(pm, name, attributes, locatorAddresses, distributedSystem, cache, tMonitoring);
     pool.finishCreate(pm);
     return pool;
   }
@@ -189,7 +185,7 @@ public class PoolImpl implements InternalPool {
 
   protected PoolImpl(PoolManagerImpl pm, String name, Pool attributes,
       List<HostAddress> locatorAddresses, InternalDistributedSystem distributedSystem,
-      InternalCache cache, ThreadsMonitoring threadMonitoring, StatisticsClock statisticsClock) {
+      InternalCache cache, ThreadsMonitoring threadMonitoring) {
     this.pm = pm;
     this.name = name;
     this.locatorAddresses = locatorAddresses;
@@ -200,7 +196,6 @@ public class PoolImpl implements InternalPool {
     this.distributedSystem = distributedSystem;
     this.cache = cache;
     this.threadMonitoring = threadMonitoring;
-    this.statisticsClock = statisticsClock;
 
     socketConnectTimeout = attributes.getSocketConnectTimeout();
     freeConnectionTimeout = attributes.getFreeConnectionTimeout();
@@ -1413,7 +1408,7 @@ public class PoolImpl implements InternalPool {
             "Cache must be created before creating pool");
       }
     }
-    ProxyCache proxy = new ProxyCache(props, cache, this, statisticsClock);
+    ProxyCache proxy = new ProxyCache(props, cache, this);
     synchronized (proxyCacheList) {
       proxyCacheList.add(proxy);
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache.client.internal;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -160,7 +161,7 @@ public class PoolImpl implements InternalPool {
       InternalCache cache, ThreadsMonitoring tMonitoring) {
     PoolImpl pool =
         new PoolImpl(pm, name, attributes, locatorAddresses, distributedSystem, cache, tMonitoring,
-            cache.getStatisticsClock());
+            cache == null ? disabledClock() : cache.getStatisticsClock());
     pool.finishCreate(pm);
     return pool;
   }
@@ -220,7 +221,8 @@ public class PoolImpl implements InternalPool {
     subscriptionAckInterval = attributes.getSubscriptionAckInterval();
     subscriptionTimeoutMultiplier = attributes.getSubscriptionTimeoutMultiplier();
     if (subscriptionTimeoutMultiplier < 0) {
-      throw new IllegalArgumentException("The subscription timeout multipler must not be negative");
+      throw new IllegalArgumentException(
+          "The subscription timeout multiplier must not be negative");
     }
     serverGroup = attributes.getServerGroup();
     multiuserSecureModeEnabled = attributes.getMultiuserAuthentication();

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyCache.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyCache.java
@@ -29,7 +29,6 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.internal.ProxyQueryService;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
@@ -61,13 +60,10 @@ public class ProxyCache implements RegionService {
   private ProxyQueryService proxyQueryService;
   private boolean isClosed = false;
   private final Stopper stopper = new Stopper();
-  private final StatisticsClock statisticsClock;
 
-  public ProxyCache(Properties properties, InternalCache cache, PoolImpl pool,
-      StatisticsClock statisticsClock) {
+  public ProxyCache(Properties properties, InternalCache cache, PoolImpl pool) {
     this.userAttributes = new UserAttributes(properties, pool);
     this.cache = cache;
-    this.statisticsClock = statisticsClock;
   }
 
   @Override
@@ -131,7 +127,7 @@ public class ProxyCache implements RegionService {
         throw new IllegalStateException(
             "Region's data-policy must be EMPTY when multiuser-authentication is true");
       }
-      return new ProxyRegion(this, this.cache.getRegion(path), statisticsClock);
+      return new ProxyRegion(this, this.cache.getRegion(path), cache.getStatisticsClock());
     }
   }
 
@@ -213,7 +209,7 @@ public class ProxyCache implements RegionService {
     Set<Region<?, ?>> rootRegions = new HashSet<>();
     for (Region<?, ?> region : this.cache.rootRegions()) {
       if (!region.getAttributes().getDataPolicy().withStorage()) {
-        rootRegions.add(new ProxyRegion(this, region, statisticsClock));
+        rootRegions.add(new ProxyRegion(this, region, cache.getStatisticsClock()));
       }
     }
     return Collections.unmodifiableSet(rootRegions);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
@@ -44,6 +44,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.snapshot.RegionSnapshotService;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * A wrapper class over an actual Region instance. This is used when the multiuser-authentication
@@ -56,10 +57,12 @@ public class ProxyRegion implements Region {
 
   private final ProxyCache proxyCache;
   private final Region realRegion;
+  private final StatisticsClock statisticsClock;
 
-  public ProxyRegion(ProxyCache proxyCache, Region realRegion) {
+  public ProxyRegion(ProxyCache proxyCache, Region realRegion, StatisticsClock statisticsClock) {
     this.proxyCache = proxyCache;
     this.realRegion = realRegion;
+    this.statisticsClock = statisticsClock;
   }
 
   @Override
@@ -366,7 +369,7 @@ public class ProxyRegion implements Region {
   @Override
   public Region getSubregion(String path) {
     Region region = this.realRegion.getSubregion(path);
-    return region != null ? new ProxyRegion(this.proxyCache, region) : null;
+    return region != null ? new ProxyRegion(this.proxyCache, region, statisticsClock) : null;
   }
 
   @Override
@@ -764,7 +767,7 @@ public class ProxyRegion implements Region {
 
   @Override
   public RegionSnapshotService<?, ?> getSnapshotService() {
-    return new RegionSnapshotServiceImpl(this);
+    return new RegionSnapshotServiceImpl(this, statisticsClock);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
@@ -767,7 +767,7 @@ public class ProxyRegion implements Region {
 
   @Override
   public RegionSnapshotService<?, ?> getSnapshotService() {
-    return new RegionSnapshotServiceImpl(this, statisticsClock);
+    return new RegionSnapshotServiceImpl(this);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/partition/PartitionRegionHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/partition/PartitionRegionHelper.java
@@ -383,7 +383,7 @@ public final class PartitionRegionHelper {
       } else {
         buckets = Collections.emptySet();
       }
-      return new LocalDataSet(pr, buckets, pr.getStatisticsClock());
+      return new LocalDataSet(pr, buckets);
     } else if (r instanceof LocalDataSet) {
       return r;
     } else {
@@ -413,7 +413,7 @@ public final class PartitionRegionHelper {
       } else {
         buckets = Collections.emptySet();
       }
-      return new LocalDataSet(pr, buckets, pr.getStatisticsClock());
+      return new LocalDataSet(pr, buckets);
     } else if (r instanceof LocalDataSet) {
       return r;
     } else {

--- a/geode-core/src/main/java/org/apache/geode/cache/partition/PartitionRegionHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/partition/PartitionRegionHelper.java
@@ -383,7 +383,7 @@ public final class PartitionRegionHelper {
       } else {
         buckets = Collections.emptySet();
       }
-      return new LocalDataSet(pr, buckets);
+      return new LocalDataSet(pr, buckets, pr.getStatisticsClock());
     } else if (r instanceof LocalDataSet) {
       return r;
     } else {
@@ -413,7 +413,7 @@ public final class PartitionRegionHelper {
       } else {
         buckets = Collections.emptySet();
       }
-      return new LocalDataSet(pr, buckets);
+      return new LocalDataSet(pr, buckets, pr.getStatisticsClock());
     } else if (r instanceof LocalDataSet) {
       return r;
     } else {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
@@ -99,8 +99,7 @@ public class QRegion implements SelectResults {
     if (context.getBucketList() != null && region instanceof PartitionedRegion) {
       PartitionedRegion partitionedRegion = (PartitionedRegion) region;
       LocalDataSet localData =
-          new LocalDataSet(partitionedRegion, new HashSet(context.getBucketList()),
-              partitionedRegion.getStatisticsClock());
+          new LocalDataSet(partitionedRegion, new HashSet(context.getBucketList()));
       this.region = localData;
       if (includeKeys) {
         res = new ResultsCollectionWrapper(TypeUtils.getObjectType(constraint),

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
@@ -97,8 +97,10 @@ public class QRegion implements SelectResults {
 
     ResultsCollectionWrapper res = null;
     if (context.getBucketList() != null && region instanceof PartitionedRegion) {
+      PartitionedRegion partitionedRegion = (PartitionedRegion) region;
       LocalDataSet localData =
-          new LocalDataSet(((PartitionedRegion) region), new HashSet(context.getBucketList()));
+          new LocalDataSet(partitionedRegion, new HashSet(context.getBucketList()),
+              partitionedRegion.getStatisticsClock());
       this.region = localData;
       if (includeKeys) {
         res = new ResultsCollectionWrapper(TypeUtils.getObjectType(constraint),

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndexSet.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndexSet.java
@@ -314,7 +314,7 @@ public class HashIndexSet implements Set {
 
     long start = -1L;
     if (this.cacheStats != null) {
-      start = this.cacheStats.getStatTime();
+      start = this.cacheStats.getTime();
       this.cacheStats.incQueryResultsHashCollisions();
     }
     try {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStats.java
@@ -20,7 +20,8 @@ import org.apache.geode.StatisticsFactory;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.internal.cache.CachePerfStats;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 /**
@@ -45,6 +46,8 @@ public class IndexStats {
 
   /** The Statistics object that we delegate most behavior to */
   private final Statistics stats;
+
+  private final StatisticsClock clock;
 
   static {
     StatisticsTypeFactory f = StatisticsTypeFactoryImpl.singleton();
@@ -85,11 +88,16 @@ public class IndexStats {
   }
 
   /**
-   * Creates a new <code>CachePerfStats</code> and registers itself with the given statistics
+   * Creates a new <code>IndexStats</code> and registers itself with the given statistics
    * factory.
    */
   public IndexStats(StatisticsFactory factory, String indexName) {
+    this(factory, indexName, StatisticsClockFactory.clock());
+  }
+
+  private IndexStats(StatisticsFactory factory, String indexName, StatisticsClock clock) {
     stats = factory.createAtomicStatistics(type, indexName);
+    this.clock = clock;
   }
 
   public long getNumberOfKeys() {
@@ -109,11 +117,11 @@ public class IndexStats {
   }
 
   public long getTotalUpdateTime() {
-    return CachePerfStats.enableClockStats ? stats.getLong(updateTimeId) : 0;
+    return clock.isEnabled() ? stats.getLong(updateTimeId) : 0;
   }
 
   public long getUseTime() {
-    return CachePerfStats.enableClockStats ? stats.getLong(useTimeId) : 0;
+    return clock.isEnabled() ? stats.getLong(useTimeId) : 0;
   }
 
   public int getReadLockCount() {
@@ -149,7 +157,7 @@ public class IndexStats {
   }
 
   public void incUpdateTime(long delta) {
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(updateTimeId, delta);
     }
   }
@@ -167,7 +175,7 @@ public class IndexStats {
   }
 
   public void incUseTime(long delta) {
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(useTimeId, delta);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteBridgeServer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteBridgeServer.java
@@ -43,6 +43,7 @@ import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * A remote (serializable) implementation of <code>BridgeServer</code> that is passed between
@@ -189,6 +190,11 @@ public class RemoteBridgeServer extends AbstractCacheServer
 
   @Override
   public String[] getCombinedGroups() {
+    throw new UnsupportedOperationException("Unsupported in RemoteBridgeServer");
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
     throw new UnsupportedOperationException("Unsupported in RemoteBridgeServer");
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
@@ -42,6 +42,7 @@ import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySen
 import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public abstract class AbstractBucketRegionQueue extends BucketRegion {
   protected static final Logger logger = LogService.getLogger();
@@ -68,8 +69,9 @@ public abstract class AbstractBucketRegionQueue extends BucketRegion {
   private final ConcurrentHashSet<Object> failedBatchRemovalMessageKeys = new ConcurrentHashSet<>();
 
   AbstractBucketRegionQueue(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     this.gatewaySenderStats =
         this.getPartitionedRegion().getParallelGatewaySender().getStatistics();
   }
@@ -348,7 +350,7 @@ public abstract class AbstractBucketRegionQueue extends BucketRegion {
     }
 
     boolean didPut = false;
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = cache.getStatisticsClock().getTime();
     // Value will always be an instanceof GatewaySenderEventImpl which
     // is never stored offheap so this EntryEventImpl values will never be off-heap.
     // So the value that ends up being stored in this region is a GatewaySenderEventImpl

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
@@ -350,7 +350,7 @@ public abstract class AbstractBucketRegionQueue extends BucketRegion {
     }
 
     boolean didPut = false;
-    long startPut = cache.getStatisticsClock().getTime();
+    long startPut = getStatisticsClock().getTime();
     // Value will always be an instanceof GatewaySenderEventImpl which
     // is never stored offheap so this EntryEventImpl values will never be off-heap.
     // So the value that ends up being stored in this region is a GatewaySenderEventImpl

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.ANY_INIT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -94,6 +95,7 @@ import org.apache.geode.internal.cache.extension.ExtensionPoint;
 import org.apache.geode.internal.cache.extension.SimpleExtensionPoint;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.ArrayUtils;
 import org.apache.geode.pdx.internal.PeerTypeRegistration;
 
@@ -274,10 +276,14 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
 
   private final PoolFinder poolFinder;
 
+  private final StatisticsClock statisticsClock;
+
   /** Creates a new instance of AbstractRegion */
   protected AbstractRegion(InternalCache cache, RegionAttributes<?, ?> attrs, String regionName,
-      InternalRegionArguments internalRegionArgs, PoolFinder poolFinder) {
+      InternalRegionArguments internalRegionArgs, PoolFinder poolFinder,
+      StatisticsClock statisticsClock) {
     this.poolFinder = poolFinder;
+    this.statisticsClock = statisticsClock;
 
     this.cache = cache;
     serialNumber = DistributionAdvisor.createSerialNumber();
@@ -387,6 +393,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
 
   @VisibleForTesting
   AbstractRegion() {
+    statisticsClock = disabledClock();
     cache = null;
     serialNumber = 0;
     isPdxTypesRegion = false;
@@ -1841,7 +1848,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
   @SuppressWarnings("unchecked")
   @Override
   public RegionSnapshotService getSnapshotService() {
-    return new RegionSnapshotServiceImpl(this);
+    return new RegionSnapshotServiceImpl(this, statisticsClock);
   }
 
   @Override
@@ -1865,6 +1872,11 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
   @Override
   public void incRecentlyUsed() {
     // nothing
+  }
+
+  // TODO:KIRK: reduce scope of getStatisticsClock
+  public StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 
   protected interface PoolFinder {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -1848,7 +1848,7 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
   @SuppressWarnings("unchecked")
   @Override
   public RegionSnapshotService getSnapshotService() {
-    return new RegionSnapshotServiceImpl(this, statisticsClock);
+    return new RegionSnapshotServiceImpl(this);
   }
 
   @Override
@@ -1874,8 +1874,14 @@ public abstract class AbstractRegion implements InternalRegion, AttributesMutato
     // nothing
   }
 
-  // TODO:KIRK: reduce scope of getStatisticsClock
-  public StatisticsClock getStatisticsClock() {
+  /**
+   * Only subclasses of {@code AbstractRegion} should use this supplier to acquire the
+   * {@code StatisticsClock}.
+   *
+   * <p>
+   * Please do not use this accessor from any class other than a Region.
+   */
+  protected StatisticsClock getStatisticsClock() {
     return statisticsClock;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
@@ -137,7 +137,7 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
         if (logger.isDebugEnabled()) {
           logger.debug("doPutOrCreate: attempting to update or create entry");
         }
-        final long startPut = rgn.getCache().getStatisticsClock().getTime();
+        final long startPut = rgn.getCachePerfStats().getTime();
         final boolean isBucket = rgn.isUsedForPartitionedRegionBucket();
         if (isBucket) {
           BucketRegion br = (BucketRegion) rgn;
@@ -169,7 +169,7 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
       // from this message.
       if (doUpdate) {
         if (!ev.isLocalInvalid()) {
-          final long startPut = rgn.getCache().getStatisticsClock().getTime();
+          final long startPut = rgn.getCachePerfStats().getTime();
           boolean overwriteDestroyed = ev.getOperation().isCreate();
           final boolean isBucket = rgn.isUsedForPartitionedRegionBucket();
           if (isBucket) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
@@ -137,7 +137,7 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
         if (logger.isDebugEnabled()) {
           logger.debug("doPutOrCreate: attempting to update or create entry");
         }
-        final long startPut = CachePerfStats.getStatTime();
+        final long startPut = rgn.getCache().getStatisticsClock().getTime();
         final boolean isBucket = rgn.isUsedForPartitionedRegionBucket();
         if (isBucket) {
           BucketRegion br = (BucketRegion) rgn;
@@ -169,7 +169,7 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
       // from this message.
       if (doUpdate) {
         if (!ev.isLocalInvalid()) {
-          final long startPut = CachePerfStats.getStatTime();
+          final long startPut = rgn.getCache().getStatisticsClock().getTime();
           boolean overwriteDestroyed = ev.getOperation().isCreate();
           final boolean isBucket = rgn.isUsedForPartitionedRegionBucket();
           if (isBucket) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketPerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketPerfStats.java
@@ -14,28 +14,13 @@
  */
 package org.apache.geode.internal.cache;
 
-import org.apache.logging.log4j.Logger;
-
-import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.internal.statistics.StatisticsClock;
 
-public abstract class DistTXStateProxyImpl extends TXStateProxyImpl {
+public class BucketPerfStats extends RegionPerfStats {
 
-  protected static final Logger logger = LogService.getLogger();
-
-  public DistTXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
-    super(cache, managerImpl, id, clientMember, statisticsClock);
-  }
-
-  public DistTXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      boolean isjta, StatisticsClock statisticsClock) {
-    super(cache, managerImpl, id, isjta, statisticsClock);
-  }
-
-  @Override
-  public boolean isDistTx() {
-    return true;
+  BucketPerfStats(StatisticsFactory statisticsFactory, CachePerfStats cachePerfStats,
+      String regionName, StatisticsClock statisticsClock) {
+    super(statisticsFactory, cachePerfStats, regionName, statisticsClock);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -93,6 +93,7 @@ import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 
 /**
@@ -223,8 +224,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   public BucketRegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     if (PartitionedRegion.DISABLE_SECONDARY_BUCKET_ACK) {
       Assert.assertTrue(attrs.getScope().isDistributedNoAck());
     } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
@@ -48,6 +48,7 @@ import org.apache.geode.internal.concurrent.Atomics;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class BucketRegionQueue extends AbstractBucketRegionQueue {
 
@@ -73,8 +74,9 @@ public class BucketRegionQueue extends AbstractBucketRegionQueue {
   private final AtomicLong latestAcknowledgedKey = new AtomicLong();
 
   public BucketRegionQueue(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     this.keySet();
     this.indexes = new ConcurrentHashMap<Object, Long>();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -14,28 +14,22 @@
  */
 package org.apache.geode.internal.cache;
 
-import java.util.function.LongSupplier;
-
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.annotations.VisibleForTesting;
-import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.QueueStatHelper;
 import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 /**
  * CachePerfStats tracks statistics about Geode cache performance and usage.
  */
 public class CachePerfStats {
-  @MakeNotStatic
-  public static boolean enableClockStats;
-
   @Immutable
   private static final StatisticsType type;
 
@@ -622,54 +616,23 @@ public class CachePerfStats {
   /** The Statistics object that we delegate most behavior to */
   protected final Statistics stats;
 
-  private final LongSupplier clock;
+  private final StatisticsClock clock;
 
-  /**
-   * Created specially for bug 39348. Should not be invoked in any other case.
-   */
-  public CachePerfStats() {
-    this(null);
+  public CachePerfStats(StatisticsFactory factory, StatisticsClock clock) {
+    this(factory, "cachePerfStats", clock);
   }
 
-  /**
-   * Creates a new <code>CachePerfStats</code> and registers itself with the given statistics
-   * factory.
-   */
-  public CachePerfStats(StatisticsFactory factory) {
-    this(factory, "cachePerfStats", enableClockStats ? NanoTimer::getTime : () -> 0);
-  }
-
-  /**
-   * Creates a new <code>CachePerfStats</code> and registers itself with the given statistics
-   * factory.
-   */
-  public CachePerfStats(StatisticsFactory factory, String regionName) {
-    this(factory, "RegionStats-" + regionName, enableClockStats ? NanoTimer::getTime : () -> 0);
-  }
-
-  @VisibleForTesting
-  public CachePerfStats(StatisticsFactory factory, String textId, LongSupplier clock) {
+  public CachePerfStats(StatisticsFactory factory, String textId, StatisticsClock clock) {
     stats = factory == null ? null : factory.createAtomicStatistics(type, textId);
     this.clock = clock;
-  }
-
-  /**
-   * Returns the current NanoTime or, if clock stats are disabled, zero.
-   *
-   * @since GemFire 5.0
-   * @deprecated Please use instance method {@link #getTime()} instead.
-   */
-  @Deprecated
-  public static long getStatTime() {
-    return enableClockStats ? NanoTimer.getTime() : 0;
   }
 
   public static StatisticsType getStatisticsType() {
     return type;
   }
 
-  protected long getTime() {
-    return clock.getAsLong();
+  public long getTime() {
+    return clock.getTime();
   }
 
   public int getLoadsCompleted() {
@@ -874,7 +837,7 @@ public class CachePerfStats {
   }
 
   public void endCompression(long startTime, long startSize, long endSize) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(compressionCompressTimeId, getTime() - startTime);
     }
     stats.incLong(compressionPreCompressedBytesId, startSize);
@@ -887,7 +850,7 @@ public class CachePerfStats {
   }
 
   public void endDecompression(long startTime) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(compressionDecompressTimeId, getTime() - startTime);
     }
   }
@@ -924,7 +887,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endNetload(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(netloadTimeId, getTime() - start);
     }
     stats.incInt(netloadsInProgressId, -1);
@@ -963,7 +926,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endCacheWriterCall(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(cacheWriterCallTimeId, getTime() - start);
     }
     stats.incInt(cacheWriterCallsInProgressId, -1);
@@ -988,7 +951,7 @@ public class CachePerfStats {
    * @since GemFire 3.5
    */
   public void endCacheListenerCall(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(cacheListenerCallTimeId, getTime() - start);
     }
     stats.incInt(cacheListenerCallsInProgressId, -1);
@@ -1011,7 +974,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endGetInitialImage(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(getInitialImageTimeId, getTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
@@ -1022,7 +985,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endNoGIIDone(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(getInitialImageTimeId, getTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
@@ -1099,7 +1062,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endGet(long start, boolean miss) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       long delta = getTime() - start;
       stats.incLong(getTimeId, delta);
     }
@@ -1117,13 +1080,13 @@ public class CachePerfStats {
     long total = 0;
     if (isUpdate) {
       stats.incLong(updatesId, 1L);
-      if (enableClockStats) {
+      if (clock.isEnabled()) {
         total = getTime() - start;
         stats.incLong(updateTimeId, total);
       }
     } else {
       stats.incLong(putsId, 1L);
-      if (enableClockStats) {
+      if (clock.isEnabled()) {
         total = getTime() - start;
         stats.incLong(putTimeId, total);
       }
@@ -1133,19 +1096,19 @@ public class CachePerfStats {
 
   public void endPutAll(long start) {
     stats.incInt(putAllsId, 1);
-    if (enableClockStats)
+    if (clock.isEnabled())
       stats.incLong(putAllTimeId, getTime() - start);
   }
 
   public void endRemoveAll(long start) {
     stats.incInt(removeAllsId, 1);
-    if (enableClockStats)
+    if (clock.isEnabled())
       stats.incLong(removeAllTimeId, getTime() - start);
   }
 
   public void endQueryExecution(long executionTime) {
     stats.incInt(queryExecutionsId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(queryExecutionTimeId, executionTime);
     }
   }
@@ -1155,7 +1118,7 @@ public class CachePerfStats {
   }
 
   public void endQueryResultsHashCollisionProbe(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(queryResultsHashCollisionProbeTimeId, getTime() - start);
     }
   }
@@ -1239,7 +1202,7 @@ public class CachePerfStats {
 
   void endDeltaUpdate(long start) {
     stats.incInt(deltaUpdatesId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(deltaUpdatesTimeId, getTime() - start);
     }
   }
@@ -1250,7 +1213,7 @@ public class CachePerfStats {
 
   public void endDeltaPrepared(long start) {
     stats.incInt(deltasPreparedId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(deltasPreparedTimeId, getTime() - start);
     }
   }
@@ -1476,14 +1439,14 @@ public class CachePerfStats {
 
   public void endImport(long entryCount, long start) {
     stats.incLong(importedEntriesCountId, entryCount);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(importTimeId, getTime() - start);
     }
   }
 
   public void endExport(long entryCount, long start) {
     stats.incLong(exportedEntriesCountId, entryCount);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(exportTimeId, getTime() - start);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
@@ -77,6 +77,7 @@ import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.membership.ClientMembership;
 import org.apache.geode.management.membership.ClientMembershipListener;
 
@@ -93,10 +94,12 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   private static final int FORCE_LOAD_UPDATE_FREQUENCY = getInteger(
       DistributionConfig.GEMFIRE_PREFIX + "BridgeServer.FORCE_LOAD_UPDATE_FREQUENCY", 10);
 
+  static final String CACHE_SERVER_BIND_ADDRESS_NOT_AVAILABLE_EXCEPTION_MESSAGE =
+      "A cache server's bind address is only available if it has been started";
+
   private final SecurityService securityService;
 
-  public static final String CACHE_SERVER_BIND_ADDRESS_NOT_AVAILABLE_EXCEPTION_MESSAGE =
-      "A cache server's bind address is only available if it has been started";
+  private final StatisticsClock statisticsClock;
 
   private final AcceptorBuilder acceptorBuilder;
 
@@ -146,6 +149,7 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
 
   CacheServerImpl(final InternalCache cache,
       final SecurityService securityService,
+      final StatisticsClock statisticsClock,
       final AcceptorBuilder acceptorBuilder,
       final boolean sendResourceEvents,
       final boolean includeMembershipGroups,
@@ -155,6 +159,7 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
       final Function<DistributionAdvisee, CacheServerAdvisor> cacheServerAdvisorProvider) {
     super(cache);
     this.securityService = securityService;
+    this.statisticsClock = statisticsClock;
     this.acceptorBuilder = acceptorBuilder;
     this.sendResourceEvents = sendResourceEvents;
     this.includeMembershipGroups = includeMembershipGroups;
@@ -167,6 +172,11 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   @Override
   public CancelCriterion getCancelCriterion() {
     return cache.getCancelCriterion();
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 
   /**
@@ -275,7 +285,6 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   public int getMessageTimeToLive() {
     return this.messageTimeToLive;
   }
-
 
   @Override
   public ClientSubscriptionConfig getClientSubscriptionConfig() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
@@ -337,16 +337,19 @@ public class ColocationHelper {
       PartitionedRegion region, Set<Integer> bucketSet) {
     Map<String, LocalDataSet> colocatedLocalDataSets = new HashMap<String, LocalDataSet>();
     if (region.getColocatedWith() == null && (!region.isColocatedBy())) {
-      colocatedLocalDataSets.put(region.getFullPath(), new LocalDataSet(region, bucketSet));
+      colocatedLocalDataSets.put(region.getFullPath(),
+          new LocalDataSet(region, bucketSet, region.getStatisticsClock()));
       return colocatedLocalDataSets;
     }
     Map<String, PartitionedRegion> colocatedRegions =
         ColocationHelper.getAllColocationRegions(region);
     for (Region colocatedRegion : colocatedRegions.values()) {
       colocatedLocalDataSets.put(colocatedRegion.getFullPath(),
-          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet));
+          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet,
+              region.getStatisticsClock()));
     }
-    colocatedLocalDataSets.put(region.getFullPath(), new LocalDataSet(region, bucketSet));
+    colocatedLocalDataSets.put(region.getFullPath(),
+        new LocalDataSet(region, bucketSet, region.getStatisticsClock()));
     return colocatedLocalDataSets;
   }
 
@@ -360,7 +363,8 @@ public class ColocationHelper {
         ColocationHelper.getAllColocationRegions(region);
     for (Region colocatedRegion : colocatedRegions.values()) {
       ret.put(colocatedRegion.getFullPath(),
-          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet));
+          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet,
+              region.getStatisticsClock()));
     }
     return ret;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
@@ -338,18 +338,17 @@ public class ColocationHelper {
     Map<String, LocalDataSet> colocatedLocalDataSets = new HashMap<String, LocalDataSet>();
     if (region.getColocatedWith() == null && (!region.isColocatedBy())) {
       colocatedLocalDataSets.put(region.getFullPath(),
-          new LocalDataSet(region, bucketSet, region.getStatisticsClock()));
+          new LocalDataSet(region, bucketSet));
       return colocatedLocalDataSets;
     }
     Map<String, PartitionedRegion> colocatedRegions =
         ColocationHelper.getAllColocationRegions(region);
     for (Region colocatedRegion : colocatedRegions.values()) {
       colocatedLocalDataSets.put(colocatedRegion.getFullPath(),
-          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet,
-              region.getStatisticsClock()));
+          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet));
     }
     colocatedLocalDataSets.put(region.getFullPath(),
-        new LocalDataSet(region, bucketSet, region.getStatisticsClock()));
+        new LocalDataSet(region, bucketSet));
     return colocatedLocalDataSets;
   }
 
@@ -363,8 +362,7 @@ public class ColocationHelper {
         ColocationHelper.getAllColocationRegions(region);
     for (Region colocatedRegion : colocatedRegions.values()) {
       ret.put(colocatedRegion.getFullPath(),
-          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet,
-              region.getStatisticsClock()));
+          new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet));
     }
     return ret;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXState.java
@@ -44,6 +44,7 @@ import org.apache.geode.internal.cache.tx.DistTxEntryEvent;
 import org.apache.geode.internal.cache.tx.DistTxKeyInfo;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.offheap.annotations.Released;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * TxState on a data node VM
@@ -59,8 +60,9 @@ public class DistTXState extends TXState {
 
   private boolean updatingTxStateDuringPreCommit = false;
 
-  public DistTXState(TXStateProxy proxy, boolean onBehalfOfRemoteStub) {
-    super(proxy, onBehalfOfRemoteStub);
+  public DistTXState(TXStateProxy proxy, boolean onBehalfOfRemoteStub,
+      StatisticsClock statisticsClock) {
+    super(proxy, onBehalfOfRemoteStub, statisticsClock);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
@@ -24,6 +24,7 @@ import org.apache.geode.cache.UnsupportedOperationInTransactionException;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
 import org.apache.geode.internal.cache.tx.DistTxEntryEvent;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * TxState on TX coordinator, created when coordinator is also a data node
@@ -38,8 +39,9 @@ public class DistTXStateOnCoordinator extends DistTXState implements DistTXCoord
   private boolean preCommitResponse = false;
   private boolean rollbackResponse = false;
 
-  public DistTXStateOnCoordinator(TXStateProxy proxy, boolean onBehalfOfRemoteStub) {
-    super(proxy, onBehalfOfRemoteStub);
+  public DistTXStateOnCoordinator(TXStateProxy proxy, boolean onBehalfOfRemoteStub,
+      StatisticsClock statisticsClock) {
+    super(proxy, onBehalfOfRemoteStub, statisticsClock);
     primaryTransactionalOperations = new ArrayList<DistTxEntryEvent>();
     secondaryTransactionalOperations = new ArrayList<DistTxEntryEvent>();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnCoordinator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnCoordinator.java
@@ -35,6 +35,7 @@ import org.apache.geode.internal.cache.TXEntryState.DistTxThinEntryState;
 import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
 import org.apache.geode.internal.cache.tx.DistClientTXStateStub;
 import org.apache.geode.internal.cache.tx.DistTxEntryEvent;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
 
@@ -52,13 +53,13 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
   private HashMap<String, ArrayList<DistTxThinEntryState>> txEntryEventMap = null;
 
   public DistTXStateProxyImplOnCoordinator(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember) {
-    super(cache, managerImpl, id, clientMember);
+      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, clientMember, statisticsClock);
   }
 
   public DistTXStateProxyImplOnCoordinator(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      boolean isjta) {
-    super(cache, managerImpl, id, isjta);
+      boolean isjta, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, isjta, statisticsClock);
   }
 
   /*
@@ -159,7 +160,7 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
                 DistTXCoordinatorInterface newTxStub = null;
                 if (currentNode.equals(dm)) {
                   // [DISTTX] TODO add a test case for this condition?
-                  newTxStub = new DistTXStateOnCoordinator(this, false);
+                  newTxStub = new DistTXStateOnCoordinator(this, false, getStatisticsClock());
                 } else {
                   newTxStub = new DistPeerTXStateStub(this, dm, onBehalfOfClientMember);
                 }
@@ -316,7 +317,7 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
     if (this.realDeal == null) {
       // assert (r != null);
       if (r == null) { // TODO: stop gap to get tests working
-        this.realDeal = new DistTXStateOnCoordinator(this, false);
+        this.realDeal = new DistTXStateOnCoordinator(this, false, getStatisticsClock());
         target = this.txMgr.getDM().getId();
       } else {
         // Code to keep going forward
@@ -334,7 +335,7 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
         } else {
           // (r != null) code block above
           if (target == null || target.equals(this.txMgr.getDM().getId())) {
-            this.realDeal = new DistTXStateOnCoordinator(this, false);
+            this.realDeal = new DistTXStateOnCoordinator(this, false, getStatisticsClock());
           } else {
             this.realDeal = new DistPeerTXStateStub(this, target, onBehalfOfClientMember);
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnDatanode.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnDatanode.java
@@ -22,6 +22,7 @@ import org.apache.geode.cache.UnsupportedOperationInTransactionException;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.TXEntryState.DistTxThinEntryState;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class DistTXStateProxyImplOnDatanode extends DistTXStateProxyImpl {
 
@@ -29,19 +30,19 @@ public class DistTXStateProxyImplOnDatanode extends DistTXStateProxyImpl {
   private boolean preCommitResponse = false;
 
   public DistTXStateProxyImplOnDatanode(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember) {
-    super(cache, managerImpl, id, clientMember);
+      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, clientMember, statisticsClock);
   }
 
   public DistTXStateProxyImplOnDatanode(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      boolean isjta) {
-    super(cache, managerImpl, id, isjta);
+      boolean isjta, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, isjta, statisticsClock);
   }
 
   @Override
   public TXStateInterface getRealDeal(KeyInfo key, InternalRegion r) {
     if (this.realDeal == null) {
-      this.realDeal = new DistTXState(this, false);
+      this.realDeal = new DistTXState(this, false, getStatisticsClock());
       if (r != null) {
         // wait for the region to be initialized fixes bug 44652
         r.waitOnInitialization(r.getInitializationLatchBeforeGetInitialImage());
@@ -60,7 +61,7 @@ public class DistTXStateProxyImplOnDatanode extends DistTXStateProxyImpl {
     assert t != null;
     if (this.realDeal == null) {
       this.target = t;
-      this.realDeal = new DistTXState(this, false);
+      this.realDeal = new DistTXState(this, false, getStatisticsClock());
       if (logger.isDebugEnabled()) {
         logger.debug("Built a new DistTXState: {} me:{}", this.realDeal,
             this.txMgr.getDM().getId());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -2361,7 +2361,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     // Set eventId. Required for interested clients.
     event.setNewEventId(cache.getDistributedSystem());
 
-    long startPut = cache.getStatisticsClock().getTime();
+    long startPut = getStatisticsClock().getTime();
     validateKey(event.getKey());
     // this next step also distributes the object to other processes, if necessary
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -130,6 +130,7 @@ import org.apache.geode.internal.logging.LoggingThread;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.sequencelog.RegionLogger;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
 
 @SuppressWarnings("deprecation")
@@ -197,8 +198,9 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
 
   /** Creates a new instance of DistributedRegion */
   protected DistributedRegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     initializationLatchAfterMemberTimeout =
         new StoppableCountDownLatch(getCancelCriterion(), 1);
     distAdvisor = createDistributionAdvisor(internalRegionArgs);
@@ -2359,7 +2361,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     // Set eventId. Required for interested clients.
     event.setNewEventId(cache.getDistributedSystem());
 
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = cache.getStatisticsClock().getTime();
     validateKey(event.getKey());
     // this next step also distributes the object to other processes, if necessary
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import org.apache.geode.Statistics;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 
@@ -27,7 +29,9 @@ public class DummyCachePerfStats extends CachePerfStats {
   /**
    * Creates a new <code>DummyCachePerfStats</code>
    */
-  public DummyCachePerfStats() {}
+  public DummyCachePerfStats() {
+    super(null, disabledClock());
+  }
 
   // //////////////////// Accessing Stats //////////////////////
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -1831,7 +1831,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       }
       boolean deltaBytesApplied = false;
       try {
-        long start = getRegion().getCache().getStatisticsClock().getTime();
+        long start = getRegion().getCachePerfStats().getTime();
         ((org.apache.geode.Delta) value)
             .fromDelta(new ByteArrayDataInput(getDeltaBytes()));
         getRegion().getCachePerfStats().endDeltaUpdate(start);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -1831,7 +1831,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       }
       boolean deltaBytesApplied = false;
       try {
-        long start = CachePerfStats.getStatTime();
+        long start = getRegion().getCache().getStatisticsClock().getTime();
         ((org.apache.geode.Delta) value)
             .fromDelta(new ByteArrayDataInput(getDeltaBytes()));
         getRegion().getCachePerfStats().endDeltaUpdate(start);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -3758,7 +3758,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     throwIfClient();
     stopper.checkCancelInProgress(null);
 
-    InternalCacheServer server = new ServerBuilder(this, securityService).createServer();
+    InternalCacheServer server = new ServerBuilder(this, securityService,
+        StatisticsClockFactory.disabledClock()).createServer();
     allCacheServers.add(server);
 
     sendAddCacheServerProfileMessage();
@@ -3850,8 +3851,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     requireNonNull(gatewayReceiver.get(),
         "GatewayReceiver must be added before adding a server endpoint.");
 
-    InternalCacheServer receiverServer = new ServerBuilder(this, securityService)
-        .forGatewayReceiver(receiver).createServer();
+    InternalCacheServer receiverServer = new ServerBuilder(this, securityService,
+        StatisticsClockFactory.disabledClock())
+            .forGatewayReceiver(receiver).createServer();
     gatewayReceiverServer.set(receiverServer);
 
     sendAddCacheServerProfileMessage();
@@ -5359,6 +5361,14 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     }
   }
 
+  /**
+   * Feature factories may use this supplier to acquire the {@code StatisticsClock} which is
+   * created by the Cache as configured by {@link DistributionConfig#getEnableTimeStatistics()}.
+   *
+   * <p>
+   * Please pass the {@code StatisticsClock} through constructors where possible instead of
+   * accessing it from this supplier.
+   */
   public StatisticsClock getStatisticsClock() {
     return statisticsClock;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
@@ -46,6 +46,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.annotations.Released;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * This region is being implemented to suppress distribution of puts and to allow localDestroys on
@@ -90,10 +91,11 @@ public class HARegion extends DistributedRegion {
   private volatile HARegionQueue owningQueue;
 
   private HARegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache) {
+      InternalCache cache, StatisticsClock statisticsClock) {
     super(regionName, attrs, parentRegion, cache,
         new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
-            .setSnapshotInputStream(null).setImageTarget(null));
+            .setSnapshotInputStream(null).setImageTarget(null),
+        statisticsClock);
     this.haRegionStats = new DummyCachePerfStats();
   }
 
@@ -244,10 +246,10 @@ public class HARegion extends DistributedRegion {
    * @throws RegionExistsException if a region of the same name exists in the same Cache
    */
   public static HARegion getInstance(String regionName, InternalCache cache, HARegionQueue hrq,
-      RegionAttributes ra)
+      RegionAttributes ra, StatisticsClock statisticsClock)
       throws TimeoutException, RegionExistsException, IOException, ClassNotFoundException {
 
-    HARegion haRegion = new HARegion(regionName, ra, null, cache);
+    HARegion haRegion = new HARegion(regionName, ra, null, cache, statisticsClock);
     haRegion.setOwner(hrq);
     Region region = cache.createVMRegion(regionName, ra,
         new InternalRegionArguments().setInternalMetaRegion(haRegion).setDestroyLockFlag(true)

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -66,6 +66,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClockSupplier;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
 import org.apache.geode.pdx.PdxInstanceFactory;
@@ -78,7 +79,8 @@ import org.apache.geode.pdx.internal.TypeRegistry;
  * @see org.apache.geode.cache.Cache
  * @since GemFire 7.0
  */
-public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, ReconnectableCache {
+public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, ReconnectableCache,
+    StatisticsClockSupplier {
 
   InternalDistributedMember getMyId();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -89,6 +89,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
 import org.apache.geode.pdx.JSONFormatter;
@@ -1255,5 +1256,10 @@ public class InternalCacheForClientAccess implements InternalCache {
   @Override
   public void saveCacheXmlForReconnect() {
     delegate.saveCacheXmlForReconnect();
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
+    return delegate.getStatisticsClock();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheServer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheServer.java
@@ -26,6 +26,7 @@ import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public interface InternalCacheServer extends CacheServer {
 
@@ -52,4 +53,6 @@ public interface InternalCacheServer extends CacheServer {
   ClientHealthMonitorProvider getClientHealthMonitorProvider();
 
   String[] getCombinedGroups();
+
+  StatisticsClock getStatisticsClock();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
@@ -63,8 +63,6 @@ import org.apache.geode.internal.cache.execute.BucketMovedException;
 import org.apache.geode.internal.cache.execute.InternalRegionFunctionContext;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl;
 import org.apache.geode.internal.logging.LogService;
-import org.apache.geode.internal.statistics.StatisticsClock;
-
 
 public class LocalDataSet implements Region, QueryExecutor {
 
@@ -72,13 +70,11 @@ public class LocalDataSet implements Region, QueryExecutor {
 
   private final PartitionedRegion proxy;
   private final Set<Integer> buckets;
-  private final StatisticsClock statisticsClock;
   private InternalRegionFunctionContext rfContext;
 
-  public LocalDataSet(PartitionedRegion pr, Set<Integer> buckets, StatisticsClock statisticsClock) {
+  public LocalDataSet(PartitionedRegion pr, Set<Integer> buckets) {
     this.proxy = pr;
     this.buckets = buckets;
-    this.statisticsClock = statisticsClock;
   }
 
   @Override
@@ -707,7 +703,7 @@ public class LocalDataSet implements Region, QueryExecutor {
 
   @Override
   public RegionSnapshotService<?, ?> getSnapshotService() {
-    return new RegionSnapshotServiceImpl(this, statisticsClock);
+    return new RegionSnapshotServiceImpl(this);
   }
 
   protected class LocalEntriesSet extends EntriesSet {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
@@ -63,6 +63,7 @@ import org.apache.geode.internal.cache.execute.BucketMovedException;
 import org.apache.geode.internal.cache.execute.InternalRegionFunctionContext;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 
 public class LocalDataSet implements Region, QueryExecutor {
@@ -71,11 +72,13 @@ public class LocalDataSet implements Region, QueryExecutor {
 
   private final PartitionedRegion proxy;
   private final Set<Integer> buckets;
+  private final StatisticsClock statisticsClock;
   private InternalRegionFunctionContext rfContext;
 
-  public LocalDataSet(PartitionedRegion pr, Set<Integer> buckets) {
+  public LocalDataSet(PartitionedRegion pr, Set<Integer> buckets, StatisticsClock statisticsClock) {
     this.proxy = pr;
     this.buckets = buckets;
+    this.statisticsClock = statisticsClock;
   }
 
   @Override
@@ -704,7 +707,7 @@ public class LocalDataSet implements Region, QueryExecutor {
 
   @Override
   public RegionSnapshotService<?, ?> getSnapshotService() {
-    return new RegionSnapshotServiceImpl(this);
+    return new RegionSnapshotServiceImpl(this, statisticsClock);
   }
 
   protected class LocalEntriesSet extends EntriesSet {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -604,7 +604,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         hasOwnStats = true;
         cachePerfStats = new RegionPerfStats(
             cache.getInternalDistributedSystem().getStatisticsManager(), cache.getCachePerfStats(),
-            regionName, cache.getStatisticsClock());
+            regionName, getStatisticsClock());
       }
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -546,7 +546,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   public boolean remove(Object key, Object value, Object callbackArg) {
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       return super.remove(key, value, callbackArg);
     } finally {
@@ -1330,7 +1330,8 @@ public class PartitionedRegion extends LocalRegion
   private void initializeDataStore(RegionAttributes ra) {
 
     this.dataStore =
-        PartitionedRegionDataStore.createDataStore(cache, this, ra.getPartitionAttributes());
+        PartitionedRegionDataStore.createDataStore(cache, this, ra.getPartitionAttributes(),
+            getStatisticsClock());
   }
 
   protected DistributedLockService getPartitionedRegionLockService() {
@@ -1671,7 +1672,7 @@ public class PartitionedRegion extends LocalRegion
   @Override
   protected Region.Entry<?, ?> nonTXGetEntry(KeyInfo keyInfo, boolean access,
       boolean allowTombstones) {
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     final Object key = keyInfo.getKey();
     try {
       int bucketId = keyInfo.getBucketId();
@@ -2151,7 +2152,7 @@ public class PartitionedRegion extends LocalRegion
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
       boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     boolean result = false;
     final DistributedPutAllOperation putAllOp_save = event.setPutAllOperation(null);
 
@@ -2322,7 +2323,7 @@ public class PartitionedRegion extends LocalRegion
       throw cache.getCacheClosedException("Cache is shutting down");
     }
 
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     // build all the msgs by bucketid
     HashMap prMsgMap = putAllOp.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(putAllOp.putAllDataSize);
@@ -2414,7 +2415,7 @@ public class PartitionedRegion extends LocalRegion
       throw cache.getCacheClosedException("Cache is shutting down");
     }
 
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     // build all the msgs by bucketid
     HashMap<Integer, RemoveAllPRMessage> prMsgMap = op.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(op.removeAllDataSize);
@@ -3429,7 +3430,7 @@ public class PartitionedRegion extends LocalRegion
     }
     // Potentially no storage assigned, start bucket creation, be careful of race
     // conditions
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     if (isDataStore()) {
       ret = this.redundancyProvider.createBucketAtomically(bucketId, size, false,
           partitionName);
@@ -3447,7 +3448,7 @@ public class PartitionedRegion extends LocalRegion
     Object obj = null;
     final Object key = keyInfo.getKey();
     final Object aCallbackArgument = keyInfo.getCallbackArg();
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       int bucketId = keyInfo.getBucketId();
       if (bucketId == KeyInfo.UNKNOWN_BUCKET) {
@@ -5230,7 +5231,7 @@ public class PartitionedRegion extends LocalRegion
       final Object expectedOldValue)
       throws TimeoutException, EntryNotFoundException, CacheWriterException {
 
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       if (event.getEventId() == null) {
         event.setNewEventId(this.cache.getDistributedSystem());
@@ -5717,7 +5718,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   public void basicInvalidate(EntryEventImpl event) throws EntryNotFoundException {
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       if (event.getEventId() == null) {
         event.setNewEventId(this.cache.getDistributedSystem());
@@ -6366,7 +6367,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   boolean nonTXContainsKey(KeyInfo keyInfo) {
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     boolean contains = false;
     try {
       int bucketId = keyInfo.getBucketId();
@@ -6540,7 +6541,7 @@ public class PartitionedRegion extends LocalRegion
     // checkClosed();
     checkReadiness();
     validateKey(key);
-    final long startTime = prStats.startTime();
+    final long startTime = prStats.getTime();
     boolean containsValueForKey = false;
     try {
       containsValueForKey = getDataView().containsValueForKey(getKeyInfo(key), this);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -246,6 +246,7 @@ import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.sequencelog.RegionLogger;
 import org.apache.geode.internal.size.Sizeable;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.TransformUtils;
 import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
 
@@ -545,7 +546,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   public boolean remove(Object key, Object value, Object callbackArg) {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     try {
       return super.remove(key, value, callbackArg);
     } finally {
@@ -739,12 +740,14 @@ public class PartitionedRegion extends LocalRegion
    * and also by invoking Cache.createRegion(). (Cache.xml etc to be added)
    */
   public PartitionedRegion(String regionName, RegionAttributes regionAttributes,
-      LocalRegion parentRegion, InternalCache cache, InternalRegionArguments internalRegionArgs) {
+      LocalRegion parentRegion, InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
     super(regionName, regionAttributes, parentRegion, cache, internalRegionArgs,
-        new PartitionedRegionDataView());
+        new PartitionedRegionDataView(), statisticsClock);
 
     this.node = initializeNode();
-    this.prStats = new PartitionedRegionStats(cache.getDistributedSystem(), getFullPath());
+    this.prStats = new PartitionedRegionStats(cache.getDistributedSystem(), getFullPath(),
+        statisticsClock);
     this.regionIdentifier = getFullPath().replace('/', '#');
 
     if (logger.isDebugEnabled()) {
@@ -1668,7 +1671,7 @@ public class PartitionedRegion extends LocalRegion
   @Override
   protected Region.Entry<?, ?> nonTXGetEntry(KeyInfo keyInfo, boolean access,
       boolean allowTombstones) {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     final Object key = keyInfo.getKey();
     try {
       int bucketId = keyInfo.getBucketId();
@@ -2148,7 +2151,7 @@ public class PartitionedRegion extends LocalRegion
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
       boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     boolean result = false;
     final DistributedPutAllOperation putAllOp_save = event.setPutAllOperation(null);
 
@@ -2319,7 +2322,7 @@ public class PartitionedRegion extends LocalRegion
       throw cache.getCacheClosedException("Cache is shutting down");
     }
 
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     // build all the msgs by bucketid
     HashMap prMsgMap = putAllOp.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(putAllOp.putAllDataSize);
@@ -2411,7 +2414,7 @@ public class PartitionedRegion extends LocalRegion
       throw cache.getCacheClosedException("Cache is shutting down");
     }
 
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     // build all the msgs by bucketid
     HashMap<Integer, RemoveAllPRMessage> prMsgMap = op.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(op.removeAllDataSize);
@@ -3426,7 +3429,7 @@ public class PartitionedRegion extends LocalRegion
     }
     // Potentially no storage assigned, start bucket creation, be careful of race
     // conditions
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     if (isDataStore()) {
       ret = this.redundancyProvider.createBucketAtomically(bucketId, size, false,
           partitionName);
@@ -3444,7 +3447,7 @@ public class PartitionedRegion extends LocalRegion
     Object obj = null;
     final Object key = keyInfo.getKey();
     final Object aCallbackArgument = keyInfo.getCallbackArg();
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     try {
       int bucketId = keyInfo.getBucketId();
       if (bucketId == KeyInfo.UNKNOWN_BUCKET) {
@@ -5227,7 +5230,7 @@ public class PartitionedRegion extends LocalRegion
       final Object expectedOldValue)
       throws TimeoutException, EntryNotFoundException, CacheWriterException {
 
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     try {
       if (event.getEventId() == null) {
         event.setNewEventId(this.cache.getDistributedSystem());
@@ -5714,7 +5717,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   public void basicInvalidate(EntryEventImpl event) throws EntryNotFoundException {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     try {
       if (event.getEventId() == null) {
         event.setNewEventId(this.cache.getDistributedSystem());
@@ -6363,7 +6366,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   boolean nonTXContainsKey(KeyInfo keyInfo) {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     boolean contains = false;
     try {
       int bucketId = keyInfo.getBucketId();
@@ -6537,7 +6540,7 @@ public class PartitionedRegion extends LocalRegion
     // checkClosed();
     checkReadiness();
     validateKey(key);
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.startTime();
     boolean containsValueForKey = false;
     try {
       containsValueForKey = getDataView().containsValueForKey(getKeyInfo(key), this);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -203,8 +203,9 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
 
     // this.bucketStats = new CachePerfStats(pr.getSystem(), "partition-" + pr.getName());
     this.bucketStats =
-        new RegionPerfStats(pr.getCache().getInternalDistributedSystem().getStatisticsManager(),
-            pr.getCachePerfStats(), "partition-" + pr.getName());
+        new BucketPerfStats(pr.getCache().getInternalDistributedSystem().getStatisticsManager(),
+            pr.getCachePerfStats(), "partition-" + pr.getName(),
+            pr.getCache().getStatisticsClock());
     this.keysOfInterest = new ConcurrentHashMap();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -95,6 +97,7 @@ import org.apache.geode.internal.cache.wan.AbstractGatewaySenderEventProcessor;
 import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
 import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySenderQueue;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock.StoppableReadLock;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock.StoppableWriteLock;
@@ -162,6 +165,8 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
 
   private final Object keysOfInterestLock = new Object();
 
+  private final StatisticsClock statisticsClock;
+
   /**
    * Update an entry's last access time if a client is interested in the entry.
    */
@@ -171,6 +176,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
 
   // Only for testing
   PartitionedRegionDataStore() {
+    statisticsClock = disabledClock();
     this.bucketCreationLock = null;
     bucketStats = null;
     partitionedRegion = null;
@@ -185,7 +191,8 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
    *
    * @param pr PartitionedRegion associated with this DataStore.
    */
-  PartitionedRegionDataStore(final PartitionedRegion pr) {
+  PartitionedRegionDataStore(final PartitionedRegion pr, StatisticsClock statisticsClock) {
+    this.statisticsClock = statisticsClock;
     final int bucketCount = pr.getTotalNumberOfBuckets();
     this.localBucket2RegionMap = new ConcurrentHashMap<Integer, BucketRegion>(bucketCount);
     this.partitionedRegion = pr;
@@ -205,7 +212,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
     this.bucketStats =
         new BucketPerfStats(pr.getCache().getInternalDistributedSystem().getStatisticsManager(),
             pr.getCachePerfStats(), "partition-" + pr.getName(),
-            pr.getCache().getStatisticsClock());
+            statisticsClock);
     this.keysOfInterest = new ConcurrentHashMap();
   }
 
@@ -215,9 +222,8 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
    * @return @throws PartitionedRegionException
    */
   static PartitionedRegionDataStore createDataStore(Cache cache, PartitionedRegion pr,
-      PartitionAttributes pa) throws PartitionedRegionException {
-    PartitionedRegionDataStore prd = new PartitionedRegionDataStore(pr);
-    return prd;
+      PartitionAttributes pa, StatisticsClock statisticsClock) throws PartitionedRegionException {
+    return new PartitionedRegionDataStore(pr, statisticsClock);
   }
 
   ConcurrentMap<Integer, BucketRegion> getLocalBucket2RegionMap() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
@@ -268,7 +268,8 @@ public class PartitionedRegionHelper {
       final HasCachePerfStats prMetaStatsHolder = new HasCachePerfStats() {
         @Override
         public CachePerfStats getCachePerfStats() {
-          return new CachePerfStats(cache.getDistributedSystem(), "partitionMetaData");
+          return new CachePerfStats(cache.getDistributedSystem(), "partitionMetaData",
+              cache.getStatisticsClock());
         }
       };
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStats.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache;
 
 import java.util.Collections;
@@ -26,6 +25,7 @@ import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.cache.Region;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 /**
@@ -534,6 +534,8 @@ public class PartitionedRegionStats {
 
   private final Statistics stats;
 
+  private final StatisticsClock clock;
+
   /**
    * Utility map for temporarily holding stat start times.
    * <p>
@@ -545,22 +547,16 @@ public class PartitionedRegionStats {
    */
   private final Map startTimeMap;
 
-  public static long startTime() {
-    return CachePerfStats.getStatTime();
-  }
+  public PartitionedRegionStats(StatisticsFactory factory, String name, StatisticsClock clock) {
+    stats = factory.createAtomicStatistics(type, name);
 
-  public static long getStatTime() {
-    return CachePerfStats.getStatTime();
-  }
-
-  public PartitionedRegionStats(StatisticsFactory factory, String name) {
-    this.stats = factory.createAtomicStatistics(type, name /* fixes bug 42343 */);
-
-    if (CachePerfStats.enableClockStats) {
-      this.startTimeMap = new ConcurrentHashMap();
+    if (clock.isEnabled()) {
+      startTimeMap = new ConcurrentHashMap();
     } else {
-      this.startTimeMap = Collections.EMPTY_MAP;
+      startTimeMap = Collections.emptyMap();
     }
+
+    this.clock = clock;
   }
 
   public void close() {
@@ -569,6 +565,14 @@ public class PartitionedRegionStats {
 
   public Statistics getStats() {
     return this.stats;
+  }
+
+  public long startTime() {
+    return clock.getTime();
+  }
+
+  public long getStatTime() {
+    return clock.getTime();
   }
 
   // ------------------------------------------------------------------------
@@ -608,8 +612,8 @@ public class PartitionedRegionStats {
   }
 
   public void endPut(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      long delta = CachePerfStats.getStatTime() - start;
+    if (clock.isEnabled()) {
+      long delta = clock.getTime() - start;
       this.stats.incLong(putTimeId, delta);
     }
     this.stats.incLong(putsCompletedId, numInc);
@@ -620,8 +624,8 @@ public class PartitionedRegionStats {
    *
    */
   public void endPutAll(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      long delta = CachePerfStats.getStatTime() - start;
+    if (clock.isEnabled()) {
+      long delta = clock.getTime() - start;
       this.stats.incLong(fieldId_PUTALL_TIME, delta);
       // this.putStatsHistogram.endOp(delta);
 
@@ -630,52 +634,52 @@ public class PartitionedRegionStats {
   }
 
   public void endRemoveAll(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      long delta = CachePerfStats.getStatTime() - start;
+    if (clock.isEnabled()) {
+      long delta = clock.getTime() - start;
       this.stats.incLong(fieldId_REMOVE_ALL_TIME, delta);
     }
     this.stats.incLong(fieldId_REMOVE_ALLS_COMPLETED, numInc);
   }
 
   public void endCreate(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      this.stats.incLong(createTimeId, CachePerfStats.getStatTime() - start);
+    if (clock.isEnabled()) {
+      this.stats.incLong(createTimeId, clock.getTime() - start);
     }
     this.stats.incLong(createsCompletedId, numInc);
   }
 
   public void endGet(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      final long delta = CachePerfStats.getStatTime() - start;
+    if (clock.isEnabled()) {
+      final long delta = clock.getTime() - start;
       this.stats.incLong(getTimeId, delta);
     }
     this.stats.incLong(getsCompletedId, numInc);
   }
 
   public void endDestroy(long start) {
-    if (CachePerfStats.enableClockStats) {
-      this.stats.incLong(destroyTimeId, CachePerfStats.getStatTime() - start);
+    if (clock.isEnabled()) {
+      this.stats.incLong(destroyTimeId, clock.getTime() - start);
     }
     this.stats.incLong(destroysCompletedId, 1);
   }
 
   public void endInvalidate(long start) {
-    if (CachePerfStats.enableClockStats) {
-      this.stats.incLong(invalidateTimeId, CachePerfStats.getStatTime() - start);
+    if (clock.isEnabled()) {
+      this.stats.incLong(invalidateTimeId, clock.getTime() - start);
     }
     this.stats.incLong(invalidatesCompletedId, 1);
   }
 
   public void endContainsKey(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      this.stats.incLong(containsKeyTimeId, CachePerfStats.getStatTime() - start);
+    if (clock.isEnabled()) {
+      this.stats.incLong(containsKeyTimeId, clock.getTime() - start);
     }
     this.stats.incLong(containsKeyCompletedId, numInc);
   }
 
   public void endContainsValueForKey(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      this.stats.incLong(containsValueForKeyTimeId, CachePerfStats.getStatTime() - start);
+    if (clock.isEnabled()) {
+      this.stats.incLong(containsValueForKeyTimeId, clock.getTime() - start);
     }
     this.stats.incLong(containsValueForKeyCompletedId, numInc);
   }
@@ -750,8 +754,8 @@ public class PartitionedRegionStats {
   }
 
   public void endPartitionMessagesProcessing(long start) {
-    if (CachePerfStats.enableClockStats) {
-      long delta = CachePerfStats.getStatTime() - start;
+    if (clock.isEnabled()) {
+      long delta = clock.getTime() - start;
       this.stats.incLong(partitionMessagesProcessingTimeId, delta);
     }
     this.stats.incLong(partitionMessagesProcessedId, 1);
@@ -843,34 +847,34 @@ public class PartitionedRegionStats {
 
   public long startVolunteering() {
     this.stats.incLong(volunteeringInProgressId, 1);
-    return CachePerfStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endVolunteeringBecamePrimary(long start) {
-    long ts = CachePerfStats.getStatTime();
+    long ts = clock.getTime();
     this.stats.incLong(volunteeringInProgressId, -1);
     this.stats.incLong(volunteeringBecamePrimaryId, 1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       long time = ts - start;
       this.stats.incLong(volunteeringBecamePrimaryTimeId, time);
     }
   }
 
   public void endVolunteeringOtherPrimary(long start) {
-    long ts = CachePerfStats.getStatTime();
+    long ts = clock.getTime();
     this.stats.incLong(volunteeringInProgressId, -1);
     this.stats.incLong(volunteeringOtherPrimaryId, 1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       long time = ts - start;
       this.stats.incLong(volunteeringOtherPrimaryTimeId, time);
     }
   }
 
   public void endVolunteeringClosed(long start) {
-    long ts = CachePerfStats.getStatTime();
+    long ts = clock.getTime();
     this.stats.incLong(volunteeringInProgressId, -1);
     this.stats.incLong(volunteeringClosedId, 1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       long time = ts - start;
       this.stats.incLong(volunteeringClosedTimeId, time);
     }
@@ -938,7 +942,7 @@ public class PartitionedRegionStats {
 
   /** Put stat start time in holding map for later removal and use by caller */
   public void putStartTime(Object key, long startTime) {
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.startTimeMap.put(key, Long.valueOf(startTime));
     }
   }
@@ -963,8 +967,8 @@ public class PartitionedRegionStats {
    *
    */
   public void endGetEntry(long start, int numInc) {
-    if (CachePerfStats.enableClockStats) {
-      this.stats.incLong(getEntryTimeId, CachePerfStats.getStatTime() - start);
+    if (clock.isEnabled()) {
+      this.stats.incLong(getEntryTimeId, clock.getTime() - start);
     }
     this.stats.incLong(getEntriesCompletedId, numInc);
   }
@@ -974,13 +978,13 @@ public class PartitionedRegionStats {
   // ------------------------------------------------------------------------
   public long startRecovery() {
     this.stats.incLong(recoveriesInProgressId, 1);
-    return PartitionedRegionStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endRecovery(long start) {
-    long ts = PartitionedRegionStats.getStatTime();
+    long ts = clock.getTime();
     this.stats.incLong(recoveriesInProgressId, -1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(recoveriesTimeId, ts - start);
     }
     this.stats.incLong(recoveriesCompletedId, 1);
@@ -991,13 +995,13 @@ public class PartitionedRegionStats {
     if (isRebalance) {
       startRebalanceBucketCreate();
     }
-    return PartitionedRegionStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endBucketCreate(long start, boolean success, boolean isRebalance) {
-    long ts = PartitionedRegionStats.getStatTime();
+    long ts = clock.getTime();
     this.stats.incLong(bucketCreatesInProgressId, -1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(bucketCreateTimeId, ts - start);
     }
     if (success) {
@@ -1015,13 +1019,13 @@ public class PartitionedRegionStats {
     if (isRebalance) {
       startRebalancePrimaryTransfer();
     }
-    return PartitionedRegionStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endPrimaryTransfer(long start, boolean success, boolean isRebalance) {
-    long ts = PartitionedRegionStats.getStatTime();
+    long ts = clock.getTime();
     this.stats.incLong(primaryTransfersInProgressId, -1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(primaryTransferTimeId, ts - start);
     }
     if (success) {
@@ -1076,7 +1080,7 @@ public class PartitionedRegionStats {
 
   private void endRebalanceBucketCreate(long start, long end, boolean success) {
     this.stats.incLong(rebalanceBucketCreatesInProgressId, -1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(rebalanceBucketCreateTimeId, end - start);
     }
     if (success) {
@@ -1092,7 +1096,7 @@ public class PartitionedRegionStats {
 
   private void endRebalancePrimaryTransfer(long start, long end, boolean success) {
     this.stats.incLong(rebalancePrimaryTransfersInProgressId, -1);
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(rebalancePrimaryTransferTimeId, end - start);
     }
     if (success) {
@@ -1136,11 +1140,11 @@ public class PartitionedRegionStats {
 
   public long startApplyReplication() {
     stats.incLong(applyReplicationInProgressId, 1);
-    return CachePerfStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endApplyReplication(long start) {
-    long delta = CachePerfStats.getStatTime() - start;
+    long delta = clock.getTime() - start;
     stats.incLong(applyReplicationInProgressId, -1);
     stats.incLong(applyReplicationCompletedId, 1);
     stats.incLong(applyReplicationTimeId, delta);
@@ -1148,11 +1152,11 @@ public class PartitionedRegionStats {
 
   public long startSendReplication() {
     stats.incLong(sendReplicationInProgressId, 1);
-    return CachePerfStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endSendReplication(long start) {
-    long delta = CachePerfStats.getStatTime() - start;
+    long delta = clock.getTime() - start;
     stats.incLong(sendReplicationInProgressId, -1);
     stats.incLong(sendReplicationCompletedId, 1);
     stats.incLong(sendReplicationTimeId, delta);
@@ -1160,11 +1164,11 @@ public class PartitionedRegionStats {
 
   public long startPutRemote() {
     stats.incLong(putRemoteInProgressId, 1);
-    return CachePerfStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endPutRemote(long start) {
-    long delta = CachePerfStats.getStatTime() - start;
+    long delta = clock.getTime() - start;
     stats.incLong(putRemoteInProgressId, -1);
     stats.incLong(putRemoteCompletedId, 1);
     stats.incLong(putRemoteTimeId, delta);
@@ -1172,11 +1176,11 @@ public class PartitionedRegionStats {
 
   public long startPutLocal() {
     stats.incLong(putLocalInProgressId, 1);
-    return CachePerfStats.getStatTime();
+    return clock.getTime();
   }
 
   public void endPutLocal(long start) {
-    long delta = CachePerfStats.getStatTime() - start;
+    long delta = clock.getTime() - start;
     stats.incLong(putLocalInProgressId, -1);
     stats.incLong(putLocalCompletedId, 1);
     stats.incLong(putLocalTimeId, delta);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStats.java
@@ -567,11 +567,7 @@ public class PartitionedRegionStats {
     return this.stats;
   }
 
-  public long startTime() {
-    return clock.getTime();
-  }
-
-  public long getStatTime() {
+  public long getTime() {
     return clock.getTime();
   }
 
@@ -750,7 +746,7 @@ public class PartitionedRegionStats {
 
   public long startPartitionMessageProcessing() {
     this.stats.incLong(partitionMessagesReceivedId, 1);
-    return startTime();
+    return getTime();
   }
 
   public void endPartitionMessagesProcessing(long start) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
@@ -57,7 +57,7 @@ public class PoolFactoryImpl implements PoolFactory {
    */
   private PoolAttributes attributes = new PoolAttributes();
 
-  private List<HostAddress> locatorAddresses = new ArrayList<>();
+  private final List<HostAddress> locatorAddresses = new ArrayList<>();
 
   /**
    * The cache that created this factory

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionStats.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+public interface RegionStats {
+
+  void incReliableQueuedOps(int inc);
+
+  void incReliableQueueSize(int inc);
+
+  void incReliableQueueMax(int inc);
+
+  void incReliableRegions(int inc);
+
+  void incReliableRegionsMissing(int inc);
+
+  void incReliableRegionsQueuing(int inc);
+
+  void incReliableRegionsMissingFullAccess(int inc);
+
+  void incReliableRegionsMissingLimitedAccess(int inc);
+
+  void incReliableRegionsMissingNoAccess(int inc);
+
+  void incQueuedEvents(int inc);
+
+  long startLoad();
+
+  void endLoad(long start);
+
+  long startNetload();
+
+  void endNetload(long start);
+
+  long startNetsearch();
+
+  void endNetsearch(long start);
+
+  long startCacheWriterCall();
+
+  void endCacheWriterCall(long start);
+
+  long startCacheListenerCall();
+
+  void endCacheListenerCall(long start);
+
+  long startGetInitialImage();
+
+  void endGetInitialImage(long start);
+
+  void endNoGIIDone(long start);
+
+  void incGetInitialImageKeysReceived();
+
+  long startIndexUpdate();
+
+  void endIndexUpdate(long start);
+
+  void incRegions(int inc);
+
+  void incPartitionedRegions(int inc);
+
+  void incDestroys();
+
+  void incCreates();
+
+  void incInvalidates();
+
+  void incTombstoneCount(int amount);
+
+  void incTombstoneGCCount();
+
+  void incClearTimeouts();
+
+  void incConflatedEventsCount();
+
+  void endGet(long start, boolean miss);
+
+  long endPut(long start, boolean isUpdate);
+
+  void endPutAll(long start);
+
+  void endQueryExecution(long executionTime);
+
+  void endQueryResultsHashCollisionProbe(long start);
+
+  void incQueryResultsHashCollisions();
+
+  void incTxConflictCheckTime(long delta);
+
+  void txSuccess(long opTime, long txLifeTime, int txChanges);
+
+  void txFailure(long opTime, long txLifeTime, int txChanges);
+
+  void txRollback(long opTime, long txLifeTime, int txChanges);
+
+  void incEventQueueSize(int items);
+
+  void incEventQueueThrottleCount(int items);
+
+  void incEventQueueThrottleTime(long nanos);
+
+  void incEventThreads(int items);
+
+  void incEntryCount(int delta);
+
+  void incRetries();
+
+  void incDiskTasksWaiting();
+
+  void decDiskTasksWaiting();
+
+  void decDiskTasksWaiting(int count);
+
+  void incEvictorJobsStarted();
+
+  void incEvictorJobsCompleted();
+
+  void incEvictorQueueSize(int delta);
+
+  void incEvictWorkTime(long delta);
+
+  void incClearCount();
+
+  void incPRQueryRetries();
+
+  void incMetaDataRefreshCount();
+
+  void endImport(long entryCount, long start);
+
+  void endExport(long entryCount, long start);
+
+  long startCompression();
+
+  void endCompression(long startTime, long startSize, long endSize);
+
+  long startDecompression();
+
+  void endDecompression(long startTime);
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ServerBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ServerBuilder.java
@@ -35,6 +35,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHe
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Builds instances of {@link InternalCacheServer}.
@@ -43,6 +44,7 @@ class ServerBuilder implements ServerFactory {
 
   private final InternalCache cache;
   private final SecurityService securityService;
+  private final StatisticsClock statisticsClock;
 
   private boolean sendResourceEvents = true;
   private boolean includeMemberGroups = true;
@@ -58,9 +60,11 @@ class ServerBuilder implements ServerFactory {
 
   private List<GatewayTransportFilter> gatewayTransportFilters = Collections.emptyList();
 
-  ServerBuilder(InternalCache cache, SecurityService securityService) {
+  ServerBuilder(InternalCache cache, SecurityService securityService,
+      StatisticsClock statisticsClock) {
     this.cache = cache;
     this.securityService = securityService;
+    this.statisticsClock = statisticsClock;
   }
 
   /**
@@ -109,8 +113,8 @@ class ServerBuilder implements ServerFactory {
     acceptorBuilder.setIsGatewayReceiver(socketCreatorType.isGateway());
     acceptorBuilder.setGatewayTransportFilters(gatewayTransportFilters);
 
-    return new CacheServerImpl(cache, securityService, acceptorBuilder, sendResourceEvents,
-        includeMemberGroups, socketCreatorSupplier, cacheClientNotifierProvider,
+    return new CacheServerImpl(cache, securityService, statisticsClock, acceptorBuilder,
+        sendResourceEvents, includeMemberGroups, socketCreatorSupplier, cacheClientNotifierProvider,
         clientHealthMonitorProvider, cacheServerAdvisorProvider);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -63,6 +63,7 @@ import org.apache.geode.internal.cache.tier.MessageType;
 import org.apache.geode.internal.cache.tier.sockets.Message;
 import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.MapCallback;
@@ -182,11 +183,14 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
    */
   private int transactionTimeToLive;
 
+  private final StatisticsClock statisticsClock;
+
   /**
    * Constructor that implements the {@link CacheTransactionManager} interface. Only only one
    * instance per {@link org.apache.geode.cache.Cache}
    */
-  public TXManagerImpl(CachePerfStats cachePerfStats, InternalCache cache) {
+  public TXManagerImpl(CachePerfStats cachePerfStats, InternalCache cache,
+      StatisticsClock statisticsClock) {
     this.cache = cache;
     this.dm = ((InternalDistributedSystem) cache.getDistributedSystem()).getDistributionManager();
     this.distributionMgrId = this.dm.getDistributionManagerId();
@@ -199,6 +203,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     this.transactionTimeToLive = Integer
         .getInteger(DistributionConfig.GEMFIRE_PREFIX + "cacheServer.transactionTimeToLive", 180);
     currentInstance = this;
+    this.statisticsClock = statisticsClock;
   }
 
   public static TXManagerImpl getCurrentInstanceForTest() {
@@ -352,9 +357,9 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     TXId id = new TXId(this.distributionMgrId, this.uniqId.incrementAndGet());
     TXStateProxyImpl proxy = null;
     if (isDistributed()) {
-      proxy = new DistTXStateProxyImplOnCoordinator(cache, this, id, null);
+      proxy = new DistTXStateProxyImplOnCoordinator(cache, this, id, null, statisticsClock);
     } else {
-      proxy = new TXStateProxyImpl(cache, this, id, null);
+      proxy = new TXStateProxyImpl(cache, this, id, null, statisticsClock);
     }
     setTXState(proxy);
     if (logger.isDebugEnabled()) {
@@ -375,9 +380,9 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     TXStateProxy newState = null;
 
     if (isDistributed()) {
-      newState = new DistTXStateProxyImplOnCoordinator(cache, this, id, true);
+      newState = new DistTXStateProxyImplOnCoordinator(cache, this, id, true, statisticsClock);
     } else {
-      newState = new TXStateProxyImpl(cache, this, id, true);
+      newState = new TXStateProxyImpl(cache, this, id, true, statisticsClock);
     }
     setTXState(newState);
     return newState;
@@ -419,7 +424,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     tx.checkJTA(
         "Can not commit this transaction because it is enlisted with a JTA transaction, use the JTA manager to perform the commit.");
 
-    final long opStart = CachePerfStats.getStatTime();
+    final long opStart = statisticsClock.getTime();
     final long lifeTime = opStart - tx.getBeginTime();
     try {
       setTXState(null);
@@ -448,7 +453,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
   }
 
   void noteCommitFailure(long opStart, long lifeTime, TXStateInterface tx) {
-    long opEnd = CachePerfStats.getStatTime();
+    long opEnd = statisticsClock.getTime();
     this.cachePerfStats.txFailure(opEnd - opStart, lifeTime, tx.getChanges());
     TransactionListener[] listeners = getListeners();
     if (tx.isFireCallbacks() && listeners.length > 0) {
@@ -479,7 +484,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
   }
 
   void noteCommitSuccess(long opStart, long lifeTime, TXStateInterface tx) {
-    long opEnd = CachePerfStats.getStatTime();
+    long opEnd = statisticsClock.getTime();
     this.cachePerfStats.txSuccess(opEnd - opStart, lifeTime, tx.getChanges());
     TransactionListener[] listeners = getListeners();
     if (tx.isFireCallbacks() && listeners.length > 0) {
@@ -536,7 +541,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     tx.checkJTA(
         "Can not rollback this transaction is enlisted with a JTA transaction, use the JTA manager to perform the rollback.");
 
-    final long opStart = CachePerfStats.getStatTime();
+    final long opStart = statisticsClock.getTime();
     final long lifeTime = opStart - tx.getBeginTime();
     setTXState(null);
     tx.rollback();
@@ -546,7 +551,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
   }
 
   void noteRollbackSuccess(long opStart, long lifeTime, TXStateInterface tx) {
-    long opEnd = CachePerfStats.getStatTime();
+    long opEnd = statisticsClock.getTime();
     this.cachePerfStats.txRollback(opEnd - opStart, lifeTime, tx.getChanges());
     TransactionListener[] listeners = getListeners();
     if (tx.isFireCallbacks() && listeners.length > 0) {
@@ -918,11 +923,13 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
         val = this.hostedTXStates.get(key);
         if (val == null && msg.canStartRemoteTransaction()) {
           if (msg.isTransactionDistributed()) {
-            val = new DistTXStateProxyImplOnDatanode(cache, this, key, msg.getTXOriginatorClient());
-            val.setLocalTXState(new DistTXState(val, true));
+            val = new DistTXStateProxyImplOnDatanode(cache, this, key, msg.getTXOriginatorClient(),
+                statisticsClock);
+            val.setLocalTXState(new DistTXState(val, true, statisticsClock));
           } else {
-            val = new TXStateProxyImpl(cache, this, key, msg.getTXOriginatorClient());
-            val.setLocalTXState(new TXState(val, true));
+            val = new TXStateProxyImpl(cache, this, key, msg.getTXOriginatorClient(),
+                statisticsClock);
+            val.setLocalTXState(new TXState(val, true, statisticsClock));
             val.setTarget(cache.getDistributedSystem().getDistributedMember());
           }
           this.hostedTXStates.put(key, val);
@@ -984,10 +991,10 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
           // TODO: Conditionally create object based on distributed or non-distributed tx mode
           if (msg instanceof TransactionMessage
               && ((TransactionMessage) msg).isTransactionDistributed()) {
-            val = new DistTXStateProxyImplOnDatanode(cache, this, key, memberId);
+            val = new DistTXStateProxyImplOnDatanode(cache, this, key, memberId, statisticsClock);
             // val.setLocalTXState(new DistTXState(val,true));
           } else {
-            val = new TXStateProxyImpl(cache, this, key, memberId);
+            val = new TXStateProxyImpl(cache, this, key, memberId, statisticsClock);
             // val.setLocalTXState(new TXState(val,true));
           }
           this.hostedTXStates.put(key, val);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -44,6 +44,7 @@ import org.apache.geode.internal.cache.tx.ClientTXStateStub;
 import org.apache.geode.internal.cache.tx.TransactionalOperation.ServerRegionOperation;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class TXStateProxyImpl implements TXStateProxy {
   private static final Logger logger = LogService.getLogger();
@@ -77,26 +78,34 @@ public class TXStateProxyImpl implements TXStateProxy {
 
   private final InternalCache cache;
   private long lastOperationTimeFromClient;
+  private final StatisticsClock statisticsClock;
 
   public TXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember) {
+      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
     this.cache = cache;
     this.txMgr = managerImpl;
     this.txId = id;
     this.isJTA = false;
     this.onBehalfOfClientMember = clientMember;
+    this.statisticsClock = statisticsClock;
   }
 
-  public TXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id, boolean isjta) {
+  public TXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id, boolean isjta,
+      StatisticsClock statisticsClock) {
     this.cache = cache;
     this.txMgr = managerImpl;
     this.txId = id;
     this.isJTA = isjta;
+    this.statisticsClock = statisticsClock;
   }
 
   @Override
   public ReentrantLock getLock() {
     return this.lock;
+  }
+
+  protected StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 
   boolean isJTA() {
@@ -124,7 +133,7 @@ public class TXStateProxyImpl implements TXStateProxy {
   public TXStateInterface getRealDeal(KeyInfo key, InternalRegion r) {
     if (this.realDeal == null) {
       if (r == null) { // TODO: stop gap to get tests working
-        this.realDeal = new TXState(this, false);
+        this.realDeal = new TXState(this, false, statisticsClock);
       } else {
         // Code to keep going forward
         if (r.hasServerProxy()) {
@@ -143,7 +152,7 @@ public class TXStateProxyImpl implements TXStateProxy {
           r.waitOnInitialization(r.getInitializationLatchBeforeGetInitialImage());
           target = r.getOwnerForKey(key);
           if (target == null || target.equals(this.txMgr.getDM().getId())) {
-            this.realDeal = new TXState(this, false);
+            this.realDeal = new TXState(this, false, statisticsClock);
           } else {
             this.realDeal = new PeerTXStateStub(this, target, onBehalfOfClientMember);
           }
@@ -161,7 +170,7 @@ public class TXStateProxyImpl implements TXStateProxy {
     if (this.realDeal == null) {
       this.target = t;
       if (target.equals(getCache().getDistributedSystem().getDistributedMember())) {
-        this.realDeal = new TXState(this, false);
+        this.realDeal = new TXState(this, false, statisticsClock);
       } else {
         /*
          * txtodo: // what to do!! We don't know if this is client or server!!!

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/OffHeapEvictor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/OffHeapEvictor.java
@@ -20,6 +20,7 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.control.InternalResourceManager.ResourceType;
 import org.apache.geode.internal.offheap.MemoryAllocator;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Triggers centralized eviction(asynchronously) when the ResourceManager sends an eviction event
@@ -33,8 +34,8 @@ public class OffHeapEvictor extends HeapEvictor {
 
   private long bytesToEvictWithEachBurst;
 
-  public OffHeapEvictor(final InternalCache cache) {
-    super(cache, EVICTOR_THREAD_NAME);
+  public OffHeapEvictor(final InternalCache cache, StatisticsClock statisticsClock) {
+    super(cache, EVICTOR_THREAD_NAME, statisticsClock);
     calculateEvictionBurst();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateMissingBucketsTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateMissingBucketsTask.java
@@ -18,7 +18,6 @@ import org.apache.geode.internal.cache.ColocationHelper;
 import org.apache.geode.internal.cache.PRHARedundancyProvider;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegion.RecoveryLock;
-import org.apache.geode.internal.cache.PartitionedRegionStats;
 
 /**
  * A task for creating buckets in a child colocated region that are present in the leader region.
@@ -47,7 +46,7 @@ public class CreateMissingBucketsTask extends RecoveryRunnable {
     if (parentRegion == null) {
       return;
     }
-    // Fix for 48954 - Make sure the parent region has created missing buckets
+    // Make sure the parent region has created missing buckets
     // before we create missing buckets for this child region.
     createMissingBuckets(parentRegion);
 
@@ -55,8 +54,6 @@ public class CreateMissingBucketsTask extends RecoveryRunnable {
 
       if (parentRegion.getRegionAdvisor().getBucketAdvisor(i).getBucketRedundancy() != region
           .getRegionAdvisor().getBucketAdvisor(i).getBucketRedundancy()) {
-        /* if (leaderRegion.getRegionAdvisor().isStorageAssignedForBucket(i)) { */
-        final long startTime = PartitionedRegionStats.startTime();
         region.getRedundancyProvider().createBucketAtomically(i, 0, true, null);
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -50,7 +50,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.DSCODE;
 import org.apache.geode.internal.InternalEntity;
-import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.CachedDeserializable;
 import org.apache.geode.internal.cache.CachedDeserializableFactory;
 import org.apache.geode.internal.cache.InternalCache;
@@ -61,6 +60,7 @@ import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.cache.snapshot.GFSnapshot.GFSnapshotImporter;
 import org.apache.geode.internal.cache.snapshot.GFSnapshot.SnapshotWriter;
 import org.apache.geode.internal.cache.snapshot.SnapshotPacket.SnapshotRecord;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Provides an implementation for region snapshots.
@@ -133,8 +133,11 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
   /** the region */
   private final Region<K, V> region;
 
-  public RegionSnapshotServiceImpl(Region<K, V> region) {
+  private final StatisticsClock statisticsClock;
+
+  public RegionSnapshotServiceImpl(Region<K, V> region, StatisticsClock statisticsClock) {
     this.region = region;
+    this.statisticsClock = statisticsClock;
   }
 
   @Override
@@ -234,7 +237,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
       throws IOException, ClassNotFoundException {
     long count = 0;
     long bytes = 0;
-    long start = CachePerfStats.getStatTime();
+    long start = statisticsClock.getTime();
 
     // Would be interesting to use a PriorityQueue ordered on isDone()
     // but this is probably close enough in practice.
@@ -349,7 +352,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
     }
 
     long count = 0;
-    long start = CachePerfStats.getStatTime();
+    long start = statisticsClock.getTime();
     SnapshotWriter writer =
         GFSnapshot.create(snapshot, region.getFullPath(), (InternalCache) region.getCache());
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -60,7 +60,6 @@ import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.cache.snapshot.GFSnapshot.GFSnapshotImporter;
 import org.apache.geode.internal.cache.snapshot.GFSnapshot.SnapshotWriter;
 import org.apache.geode.internal.cache.snapshot.SnapshotPacket.SnapshotRecord;
-import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Provides an implementation for region snapshots.
@@ -133,11 +132,8 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
   /** the region */
   private final Region<K, V> region;
 
-  private final StatisticsClock statisticsClock;
-
-  public RegionSnapshotServiceImpl(Region<K, V> region, StatisticsClock statisticsClock) {
+  public RegionSnapshotServiceImpl(Region<K, V> region) {
     this.region = region;
-    this.statisticsClock = statisticsClock;
   }
 
   @Override
@@ -237,7 +233,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
       throws IOException, ClassNotFoundException {
     long count = 0;
     long bytes = 0;
-    long start = statisticsClock.getTime();
+    long start = local.getCachePerfStats().getTime();
 
     // Would be interesting to use a PriorityQueue ordered on isDone()
     // but this is probably close enough in practice.
@@ -352,7 +348,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
     }
 
     long count = 0;
-    long start = statisticsClock.getTime();
+    long start = local.getCachePerfStats().getTime();
     SnapshotWriter writer =
         GFSnapshot.create(snapshot, region.getFullPath(), (InternalCache) region.getCache());
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilder.java
@@ -29,6 +29,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier.CacheCli
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHealthMonitorProvider;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Builds an instance of {@link Acceptor}.
@@ -51,6 +52,7 @@ public class AcceptorBuilder implements AcceptorFactory {
   private ServerConnectionFactory serverConnectionFactory;
   private long timeLimitMillis;
   private SecurityService securityService;
+  private StatisticsClock statisticsClock;
 
   private boolean isGatewayReceiver;
   private List<GatewayTransportFilter> gatewayTransportFilters = Collections.emptyList();
@@ -79,6 +81,7 @@ public class AcceptorBuilder implements AcceptorFactory {
     serverConnectionFactory = server.getServerConnectionFactory();
     timeLimitMillis = server.getTimeLimitMillis();
     securityService = server.getSecurityService();
+    statisticsClock = server.getStatisticsClock();
 
     socketCreatorSupplier = server.getSocketCreatorSupplier();
     cacheClientNotifierProvider = server.getCacheClientNotifierProvider();
@@ -285,6 +288,16 @@ public class AcceptorBuilder implements AcceptorFactory {
     return this;
   }
 
+  /**
+   * Sets {@code statisticsClock}. Must be invoked after or instead of
+   * {@link #forServer(InternalCacheServer)}.
+   */
+  @VisibleForTesting
+  AcceptorBuilder setStatisticsClock(StatisticsClock statisticsClock) {
+    this.statisticsClock = statisticsClock;
+    return this;
+  }
+
   @Override
   public Acceptor create(OverflowAttributes overflowAttributes) throws IOException {
     return new AcceptorImpl(port, bindAddress, notifyBySubscription, socketBufferSize,
@@ -292,7 +305,7 @@ public class AcceptorBuilder implements AcceptorFactory {
         messageTimeToLive, connectionListener, overflowAttributes, tcpNoDelay,
         serverConnectionFactory, timeLimitMillis, securityService, socketCreatorSupplier,
         cacheClientNotifierProvider, clientHealthMonitorProvider, isGatewayReceiver,
-        gatewayTransportFilters);
+        gatewayTransportFilters, statisticsClock);
   }
 
   @VisibleForTesting
@@ -393,5 +406,10 @@ public class AcceptorBuilder implements AcceptorFactory {
   @VisibleForTesting
   ClientHealthMonitorProvider getClientHealthMonitorProvider() {
     return clientHealthMonitorProvider;
+  }
+
+  @VisibleForTesting
+  StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -98,6 +98,8 @@ import org.apache.geode.internal.logging.LoggingThreadFactory.ThreadInitializer;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.internal.tcp.ConnectionTable;
 import org.apache.geode.internal.util.ArrayUtils;
 
@@ -336,6 +338,7 @@ public class AcceptorImpl implements Acceptor, Runnable {
   private final boolean isGatewayReceiver;
 
   private final List<GatewayTransportFilter> gatewayTransportFilters;
+  private final StatisticsClock statisticsClock;
 
   private final SocketCreator socketCreator;
 
@@ -380,7 +383,8 @@ public class AcceptorImpl implements Acceptor, Runnable {
         internalCache, maxConnections, maxThreads, maximumMessageCount, messageTimeToLive,
         connectionListener, overflowAttributes, tcpNoDelay, serverConnectionFactory,
         timeLimitMillis, securityService, socketCreatorSupplier, cacheClientNotifierProvider,
-        clientHealthMonitorProvider, false, Collections.emptyList());
+        clientHealthMonitorProvider, false, Collections.emptyList(),
+        StatisticsClockFactory.disabledClock());
   }
 
   /**
@@ -389,6 +393,8 @@ public class AcceptorImpl implements Acceptor, Runnable {
    * <p>
    * Initializes this acceptor thread to listen for connections on the given port.
    *
+   * @param gatewayReceiver the GatewayReceiver that will use this AcceptorImpl instance
+   * @param gatewayReceiverMetrics the GatewayReceiverMetrics to use for exposing metrics
    * @param port The port on which this acceptor listens for connections. If {@code 0}, a
    *        random port will be chosen.
    * @param bindHostName The ip address or host name this acceptor listens on for connections. If
@@ -400,23 +406,24 @@ public class AcceptorImpl implements Acceptor, Runnable {
    * @param maxConnections the maximum number of connections allowed in the server pool
    * @param maxThreads the maximum number of threads allowed in the server pool
    * @param securityService the SecurityService to use for authentication and authorization
-   * @param gatewayReceiver the GatewayReceiver that will use this AcceptorImpl instance
-   * @param gatewayReceiverMetrics the GatewayReceiverMetrics to use for exposing metrics
    * @param gatewayTransportFilters List of GatewayTransportFilters
    */
   AcceptorImpl(final int port, final String bindHostName, final boolean notifyBySubscription,
       final int socketBufferSize, final int maximumTimeBetweenPings,
       final InternalCache internalCache, final int maxConnections, final int maxThreads,
       final int maximumMessageCount, final int messageTimeToLive,
-      final ConnectionListener connectionListener, final OverflowAttributes overflowAttributes,
+      final ConnectionListener connectionListener,
+      final OverflowAttributes overflowAttributes,
       final boolean tcpNoDelay, final ServerConnectionFactory serverConnectionFactory,
       final long timeLimitMillis, final SecurityService securityService,
       final Supplier<SocketCreator> socketCreatorSupplier,
       final CacheClientNotifierProvider cacheClientNotifierProvider,
       final ClientHealthMonitorProvider clientHealthMonitorProvider,
       final boolean isGatewayReceiver,
-      final List<GatewayTransportFilter> gatewayTransportFilters) throws IOException {
+      final List<GatewayTransportFilter> gatewayTransportFilters,
+      final StatisticsClock statisticsClock) throws IOException {
     this.securityService = securityService;
+    this.statisticsClock = statisticsClock;
 
     this.isGatewayReceiver = isGatewayReceiver;
     this.gatewayTransportFilters = gatewayTransportFilters;
@@ -609,8 +616,9 @@ public class AcceptorImpl implements Acceptor, Runnable {
     cache = internalCache;
     crHelper = new CachedRegionHelper(cache);
 
-    clientNotifier = cacheClientNotifierProvider.get(internalCache, stats, maximumMessageCount,
-        messageTimeToLive, this.connectionListener, overflowAttributes, isGatewayReceiver());
+    clientNotifier =
+        cacheClientNotifierProvider.get(internalCache, statisticsClock, stats, maximumMessageCount,
+            messageTimeToLive, this.connectionListener, overflowAttributes, isGatewayReceiver());
 
     this.socketBufferSize = socketBufferSize;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -100,6 +100,7 @@ import org.apache.geode.internal.logging.LoggingThread;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.security.AuthorizeRequestPP;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.security.AccessControl;
 
 /**
@@ -1704,7 +1705,7 @@ public class CacheClientProxy implements ClientSession {
   }
 
   MessageDispatcher createMessageDispatcher(String name) {
-    return new MessageDispatcher(this, name);
+    return new MessageDispatcher(this, name, _cache.getStatisticsClock());
   }
 
   protected void startOrResumeMessageDispatcher(boolean processedMarker) {
@@ -2225,7 +2226,8 @@ public class CacheClientProxy implements ClientSession {
      *        messages
      * @param name thread name for this dispatcher
      */
-    protected MessageDispatcher(CacheClientProxy proxy, String name) throws CacheException {
+    protected MessageDispatcher(CacheClientProxy proxy, String name,
+        StatisticsClock statisticsClock) throws CacheException {
       super(name);
 
       this._proxy = proxy;
@@ -2252,7 +2254,7 @@ public class CacheClientProxy implements ClientSession {
         this._messageQueue = HARegionQueue.getHARegionQueueInstance(getProxy().getHARegionName(),
             getCache(), harq, HARegionQueue.BLOCKING_HA_QUEUE, createDurableQueue,
             proxy._cacheClientNotifier.getHaContainer(), proxy.getProxyID(),
-            this._proxy.clientConflation, this._proxy.isPrimary(), canHandleDelta);
+            this._proxy.clientConflation, this._proxy.isPrimary(), canHandleDelta, statisticsClock);
         // Check if interests were registered during HARegion GII.
         if (this._proxy.hasRegisteredInterested()) {
           this._messageQueue.setHasRegisteredInterest(true);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -316,6 +316,7 @@ public class CacheClientProxy implements ClientSession {
   private final Object drainsInProgressLock = new Object();
 
   private final SecurityService securityService;
+  private final StatisticsClock statisticsClock;
 
   /**
    * Constructor.
@@ -329,7 +330,8 @@ public class CacheClientProxy implements ClientSession {
   protected CacheClientProxy(CacheClientNotifier ccn, Socket socket,
       ClientProxyMembershipID proxyID, boolean isPrimary, byte clientConflation,
       Version clientVersion, long acceptorId, boolean notifyBySubscription,
-      SecurityService securityService, Subject subject) throws CacheException {
+      SecurityService securityService, Subject subject, StatisticsClock statisticsClock)
+      throws CacheException {
 
     initializeTransientFields(socket, proxyID, isPrimary, clientConflation, clientVersion);
     this._cacheClientNotifier = ccn;
@@ -339,7 +341,8 @@ public class CacheClientProxy implements ClientSession {
     this._messageTimeToLive = ccn.getMessageTimeToLive();
     this._acceptorId = acceptorId;
     this.notifyBySubscription = notifyBySubscription;
-    StatisticsFactory factory = this._cache.getDistributedSystem();
+    StatisticsFactory factory = this._cache.getInternalDistributedSystem().getStatisticsManager();
+    this.statisticsClock = statisticsClock;
     this._statistics =
         new CacheClientProxyStats(factory, "id_" + this.proxyID.getDistributedMember().getId()
             + "_at_" + this._remoteHostAddress + ":" + this._socket.getPort());
@@ -1705,7 +1708,7 @@ public class CacheClientProxy implements ClientSession {
   }
 
   MessageDispatcher createMessageDispatcher(String name) {
-    return new MessageDispatcher(this, name, _cache.getStatisticsClock());
+    return new MessageDispatcher(this, name, statisticsClock);
   }
 
   protected void startOrResumeMessageDispatcher(boolean processedMarker) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
@@ -400,7 +400,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     }
 
     PartitionedRegion pr = (PartitionedRegion) r;
-    final long startTime = r.getCache().getStatisticsClock().getTime();
+    final long startTime = pr.prStats.getTime();
     // build all the msgs by bucketid
     HashMap prMsgMap = putallO.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(putallO.putAllDataSize);
@@ -460,7 +460,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     }
 
     PartitionedRegion pr = (PartitionedRegion) r;
-    final long startTime = r.getCache().getStatisticsClock().getTime();
+    final long startTime = pr.prStats.getTime();
     // build all the msgs by bucketid
     HashMap<Integer, RemoveAllPRMessage> prMsgMap = op.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(op.removeAllDataSize);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
@@ -40,7 +40,6 @@ import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.KeyInfo;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegion.RetryTimeKeeper;
-import org.apache.geode.internal.cache.PartitionedRegionStats;
 import org.apache.geode.internal.cache.PrimaryBucketException;
 import org.apache.geode.internal.cache.PutAllPartialResultException;
 import org.apache.geode.internal.cache.PutAllPartialResultException.PutAllPartialResult;
@@ -401,7 +400,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     }
 
     PartitionedRegion pr = (PartitionedRegion) r;
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = r.getCache().getStatisticsClock().getTime();
     // build all the msgs by bucketid
     HashMap prMsgMap = putallO.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(putallO.putAllDataSize);
@@ -461,7 +460,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     }
 
     PartitionedRegion pr = (PartitionedRegion) r;
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = r.getCache().getStatisticsClock().getTime();
     // build all the msgs by bucketid
     HashMap<Integer, RemoveAllPRMessage> prMsgMap = op.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(op.removeAllDataSize);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.wan;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -231,6 +233,10 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   final Object lockForConcurrentDispatcher = new Object();
 
   private final StatisticsClock statisticsClock;
+
+  protected AbstractGatewaySender() {
+    statisticsClock = disabledClock();
+  }
 
   public AbstractGatewaySender(InternalCache cache, GatewaySenderAttributes attrs,
       StatisticsClock statisticsClock) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -238,8 +238,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     statisticsClock = disabledClock();
   }
 
-  public AbstractGatewaySender(InternalCache cache, GatewaySenderAttributes attrs,
-      StatisticsClock statisticsClock) {
+  public AbstractGatewaySender(InternalCache cache, StatisticsClock statisticsClock,
+      GatewaySenderAttributes attrs) {
     this.cache = cache;
     this.statisticsClock = statisticsClock;
     this.id = attrs.getId();
@@ -293,6 +293,11 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   @Override
   public GatewaySenderStats getStatistics() {
     return statistics;
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 
   public void initProxy() {
@@ -1267,7 +1272,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         @Override
         public CachePerfStats getCachePerfStats() {
           return new CachePerfStats(cache.getDistributedSystem(), META_DATA_REGION_NAME,
-              cache.getStatisticsClock());
+              sender.statisticsClock);
         }
       };
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/InternalGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/InternalGatewaySender.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.RegionQueue;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public interface InternalGatewaySender extends GatewaySender {
 
@@ -32,6 +33,8 @@ public interface InternalGatewaySender extends GatewaySender {
   boolean isPrimary();
 
   GatewaySenderStats getStatistics();
+
+  StatisticsClock getStatisticsClock();
 
   boolean waitUntilFlushed(long timeout, TimeUnit unit) throws InterruptedException;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -84,6 +84,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderStats;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingExecutors;
 import org.apache.geode.internal.size.SingleObjectSizer;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.StoppableCondition;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantLock;
 import org.apache.geode.management.ManagementService;
@@ -359,7 +360,8 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
         }
 
         ParallelGatewaySenderQueueMetaRegion meta =
-            new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender);
+            new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender,
+                sender.getStatisticsClock());
 
         try {
           prQ = (PartitionedRegion) cache.createVMRegion(prQName, ra,
@@ -1789,13 +1791,14 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     AbstractGatewaySender sender = null;
 
     public ParallelGatewaySenderQueueMetaRegion(String regionName, RegionAttributes attrs,
-        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender pgSender) {
+        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender pgSender,
+        StatisticsClock statisticsClock) {
       super(regionName, attrs, parentRegion, cache,
           new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
               .setSnapshotInputStream(null).setImageTarget(null)
               .setIsUsedForParallelGatewaySenderQueue(true)
               .setParallelGatewaySender((AbstractGatewaySender) pgSender),
-          cache.getStatisticsClock());
+          statisticsClock);
       this.sender = (AbstractGatewaySender) pgSender;
 
     }
@@ -1856,7 +1859,8 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     ParallelGatewaySenderQueueMetaRegion newMetataRegion(InternalCache cache, final String prQName,
         final RegionAttributes ra, AbstractGatewaySender sender) {
       ParallelGatewaySenderQueueMetaRegion meta =
-          new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender);
+          new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender,
+              sender.getStatisticsClock());
       return meta;
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -1794,7 +1794,8 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
           new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
               .setSnapshotInputStream(null).setImageTarget(null)
               .setIsUsedForParallelGatewaySenderQueue(true)
-              .setParallelGatewaySender((AbstractGatewaySender) pgSender));
+              .setParallelGatewaySender((AbstractGatewaySender) pgSender),
+          cache.getStatisticsClock());
       this.sender = (AbstractGatewaySender) pgSender;
 
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -1120,7 +1120,8 @@ public class SerialGatewaySenderQueue implements RegionQueue {
       super(regionName, attrs, parentRegion, cache,
           new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
               .setSnapshotInputStream(null).setImageTarget(null)
-              .setIsUsedForSerialGatewaySenderQueue(true).setSerialGatewaySender(sender));
+              .setIsUsedForSerialGatewaySenderQueue(true).setSerialGatewaySender(sender),
+          cache.getStatisticsClock());
       this.sender = sender;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -69,6 +69,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
 import org.apache.geode.internal.cache.wan.GatewaySenderStats;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.beans.AsyncEventQueueMBean;
 import org.apache.geode.management.internal.beans.GatewaySenderMBean;
@@ -876,7 +877,8 @@ public class SerialGatewaySenderQueue implements RegionQueue {
       final RegionAttributes<Long, AsyncEvent> ra = factory.create();
       try {
         SerialGatewaySenderQueueMetaRegion meta =
-            new SerialGatewaySenderQueueMetaRegion(this.regionName, ra, null, gemCache, sender);
+            new SerialGatewaySenderQueueMetaRegion(this.regionName, ra, null, gemCache, sender,
+                sender.getStatisticsClock());
         try {
           this.region = gemCache.createVMRegion(this.regionName, ra,
               new InternalRegionArguments().setInternalMetaRegion(meta).setDestroyLockFlag(true)
@@ -1116,12 +1118,13 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     AbstractGatewaySender sender = null;
 
     protected SerialGatewaySenderQueueMetaRegion(String regionName, RegionAttributes attrs,
-        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender sender) {
+        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender sender,
+        StatisticsClock statisticsClock) {
       super(regionName, attrs, parentRegion, cache,
           new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
               .setSnapshotInputStream(null).setImageTarget(null)
               .setIsUsedForSerialGatewaySenderQueue(true).setSerialGatewaySender(sender),
-          cache.getStatisticsClock());
+          statisticsClock);
       this.sender = sender;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache.xmlcache;
 import static java.lang.String.format;
 import static org.apache.geode.internal.logging.LogWriterFactory.toSecurityLogWriter;
 import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 
 import java.io.File;
 import java.io.IOException;
@@ -2429,7 +2430,7 @@ public class CacheCreation implements InternalCache {
 
   @Override
   public StatisticsClock getStatisticsClock() {
-    throw new UnsupportedOperationException("Should not be invoked");
+    return disabledClock();
   }
 
   CacheTransactionManagerCreation getCacheTransactionManagerCreation() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -157,6 +157,7 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.security.SecurityServiceFactory;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
 import org.apache.geode.pdx.JSONFormatter;
@@ -2423,6 +2424,11 @@ public class CacheCreation implements InternalCache {
 
   @Override
   public void saveCacheXmlForReconnect() {
+    throw new UnsupportedOperationException("Should not be invoked");
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
     throw new UnsupportedOperationException("Should not be invoked");
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheServerCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheServerCreation.java
@@ -34,6 +34,7 @@ import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Represents a {@link CacheServer} that is created declaratively.
@@ -307,6 +308,11 @@ public class CacheServerCreation extends AbstractCacheServer {
 
   @Override
   public String[] getCombinedGroups() {
+    throw new UnsupportedOperationException("Shouldn't be invoked");
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
     throw new UnsupportedOperationException("Shouldn't be invoked");
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelAsyncEventQueueCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelAsyncEventQueueCreation.java
@@ -35,7 +35,7 @@ public class ParallelAsyncEventQueueCreation extends AbstractGatewaySender
     implements GatewaySender {
 
   public ParallelAsyncEventQueueCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs, disabledClock());
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelAsyncEventQueueCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelAsyncEventQueueCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -33,7 +35,7 @@ public class ParallelAsyncEventQueueCreation extends AbstractGatewaySender
     implements GatewaySender {
 
   public ParallelAsyncEventQueueCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, attrs, disabledClock());
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelGatewaySenderCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelGatewaySenderCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -33,7 +35,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class ParallelGatewaySenderCreation extends AbstractGatewaySender implements GatewaySender {
 
   public ParallelGatewaySenderCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, attrs, disabledClock());
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelGatewaySenderCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelGatewaySenderCreation.java
@@ -35,7 +35,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class ParallelGatewaySenderCreation extends AbstractGatewaySender implements GatewaySender {
 
   public ParallelGatewaySenderCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs, disabledClock());
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialAsyncEventQueueCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialAsyncEventQueueCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -32,7 +34,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class SerialAsyncEventQueueCreation extends AbstractGatewaySender implements GatewaySender {
 
   public SerialAsyncEventQueueCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, attrs, disabledClock());
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialAsyncEventQueueCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialAsyncEventQueueCreation.java
@@ -34,7 +34,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class SerialAsyncEventQueueCreation extends AbstractGatewaySender implements GatewaySender {
 
   public SerialAsyncEventQueueCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs, disabledClock());
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialGatewaySenderCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialGatewaySenderCreation.java
@@ -35,7 +35,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class SerialGatewaySenderCreation extends AbstractGatewaySender implements GatewaySender {
 
   public SerialGatewaySenderCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs, disabledClock());
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialGatewaySenderCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialGatewaySenderCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -33,7 +35,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class SerialGatewaySenderCreation extends AbstractGatewaySender implements GatewaySender {
 
   public SerialGatewaySenderCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, attrs, disabledClock());
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/DisabledStatisticsClock.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/DisabledStatisticsClock.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+public class DisabledStatisticsClock implements StatisticsClock {
+
+  @Override
+  public long getTime() {
+    return 0;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/EnabledStatisticsClock.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/EnabledStatisticsClock.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import org.apache.geode.internal.NanoTimer;
+
+public class EnabledStatisticsClock implements StatisticsClock {
+
+  @Override
+  public long getTime() {
+    return NanoTimer.getTime();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClock.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClock.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+@FunctionalInterface
+public interface StatisticsClock {
+
+  /**
+   * Returns the current value of the running Java Virtual Machine's high-resolution time source,
+   * in nanoseconds.
+   *
+   * <p>
+   * See {@code java.lang.System#nanoTime()}.
+   */
+  long getTime();
+
+  /**
+   * Returns true if this clock is enabled. If disabled then {@code getTime()} will return zero.
+   *
+   * <p>
+   * Default returns {@code true}.
+   */
+  default boolean isEnabled() {
+    return true;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.LongSupplier;
+
+import org.apache.geode.annotations.Immutable;
+
+public class StatisticsClockFactory {
+
+  @Immutable
+  public static final String ENABLE_CLOCK_STATS_PROPERTY = "enableClockStats";
+
+  @Immutable
+  public static final boolean enableClockStats = Boolean.getBoolean(ENABLE_CLOCK_STATS_PROPERTY);
+
+  /**
+   * TODO: delete getTimeIfEnabled
+   */
+  @Deprecated
+  public static long getTimeIfEnabled() {
+    return enableClockStats ? getTime() : 0;
+  }
+
+  public static long getTime() {
+    return System.nanoTime();
+  }
+
+  /**
+   * Creates new {@code StatisticsClock} using {@code enableClockStats} system property.
+   */
+  public static StatisticsClock clock() {
+    return clock(Boolean.getBoolean(ENABLE_CLOCK_STATS_PROPERTY));
+  }
+
+  /**
+   * Creates new {@code StatisticsClock} using specified boolean value.
+   */
+  public static StatisticsClock clock(boolean enabled) {
+    if (enabled) {
+      return enabledClock(() -> getTime());
+    }
+    return disabledClock();
+  }
+
+  public static StatisticsClock enabledClock() {
+    return clock(() -> getTime(), () -> true);
+  }
+
+  public static StatisticsClock enabledClock(LongSupplier time) {
+    return clock(() -> time.getAsLong(), () -> true);
+  }
+
+  public static StatisticsClock disabledClock() {
+    return clock(() -> 0, () -> false);
+  }
+
+  public static StatisticsClock clock(LongSupplier time, BooleanSupplier isEnabled) {
+    return new StatisticsClock() {
+      @Override
+      public long getTime() {
+        return time.getAsLong();
+      }
+
+      @Override
+      public boolean isEnabled() {
+        return isEnabled.getAsBoolean();
+      }
+    };
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockSupplier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockSupplier.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+public interface StatisticsClockSupplier {
+
+  StatisticsClock getStatisticsClock();
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -374,7 +374,8 @@ public class FederatingManager extends Manager {
 
             // Create anonymous stats holder for Management Regions
             HasCachePerfStats monitoringRegionStats =
-                () -> new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats");
+                () -> new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats",
+                    cache.getStatisticsClock());
 
             internalRegionArguments.setCachePerfStatsHolder(monitoringRegionStats);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -31,6 +31,7 @@ import javax.management.ObjectName;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.DataPolicy;
@@ -50,6 +51,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingExecutors;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.ManagementException;
 
 /**
@@ -84,9 +86,9 @@ public class FederatingManager extends Manager {
   private final AtomicReference<Exception> latestException = new AtomicReference<>(null);
 
   FederatingManager(MBeanJMXAdapter jmxAdapter, ManagementResourceRepo repo,
-      InternalDistributedSystem system, SystemManagementService service,
-      InternalCache cache) {
-    super(repo, system, cache);
+      InternalDistributedSystem system, SystemManagementService service, InternalCache cache,
+      StatisticsFactory statisticsFactory, StatisticsClock statisticsClock) {
+    super(repo, system, cache, statisticsFactory, statisticsClock);
     this.service = service;
     proxyFactory = new MBeanProxyFactory(jmxAdapter, service);
     messenger = new MemberMessenger(jmxAdapter, system);
@@ -214,7 +216,7 @@ public class FederatingManager extends Manager {
       notificationRegion.localDestroyRegion();
     }
 
-    if (!cache.getDistributedSystem().getDistributedMember().equals(member)) {
+    if (!system.getDistributedMember().equals(member)) {
       service.memberDeparted((InternalDistributedMember) member, crashed);
     }
   }
@@ -242,7 +244,7 @@ public class FederatingManager extends Manager {
 
     List<Callable<DistributedMember>> giiTaskList = new ArrayList<>();
 
-    for (DistributedMember member : cache.getDistributionManager()
+    for (DistributedMember member : system.getDistributionManager()
         .getOtherDistributionManagerIds()) {
       giiTaskList.add(new GIITask(member));
     }
@@ -357,7 +359,6 @@ public class FederatingManager extends Manager {
         String monitoringRegionName = ManagementConstants.MONITORING_REGION + "_" + appender;
         String notificationRegionName = ManagementConstants.NOTIFICATION_REGION + "_" + appender;
 
-
         if (cache.getInternalRegion(monitoringRegionName) != null
             && cache.getInternalRegion(notificationRegionName) != null) {
           return member;
@@ -374,8 +375,7 @@ public class FederatingManager extends Manager {
 
             // Create anonymous stats holder for Management Regions
             HasCachePerfStats monitoringRegionStats =
-                () -> new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats",
-                    cache.getStatisticsClock());
+                () -> new CachePerfStats(system, "managementRegionStats", statisticsClock);
 
             internalRegionArguments.setCachePerfStatsHolder(monitoringRegionStats);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.GemFireException;
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.DataPolicy;
@@ -45,6 +46,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingExecutors;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.ManagementException;
 
 /**
@@ -72,19 +74,20 @@ public class LocalManager extends Manager {
    * This map holds all the components which are eligible for federation. Although filters might
    * prevent any of the component from getting federated.
    */
-  private Map<ObjectName, FederationComponent> federatedComponentMap;
+  private final Map<ObjectName, FederationComponent> federatedComponentMap;
 
-  private Object lock = new Object();
+  private final Object lock = new Object();
 
-  private SystemManagementService service;
+  private final SystemManagementService service;
 
   /**
    * @param repo management resource repo
    * @param system internal distributed system
    */
   public LocalManager(ManagementResourceRepo repo, InternalDistributedSystem system,
-      SystemManagementService service, InternalCache cache) {
-    super(repo, system, cache);
+      SystemManagementService service, InternalCache cache, StatisticsFactory statisticsFactory,
+      StatisticsClock statisticsClock) {
+    super(repo, system, cache, statisticsFactory, statisticsClock);
     this.service = service;
     this.federatedComponentMap = new ConcurrentHashMap<ObjectName, FederationComponent>();
   }
@@ -115,13 +118,8 @@ public class LocalManager extends Manager {
         internalArgs.setIsUsedForMetaRegion(true);
 
         // Create anonymous stats holder for Management Regions
-        final HasCachePerfStats monitoringRegionStats = new HasCachePerfStats() {
-          @Override
-          public CachePerfStats getCachePerfStats() {
-            return new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats",
-                cache.getStatisticsClock());
-          }
-        };
+        final HasCachePerfStats monitoringRegionStats =
+            () -> new CachePerfStats(system, "managementRegionStats", statisticsClock);
 
         internalArgs.setCachePerfStatsHolder(monitoringRegionStats);
 
@@ -145,8 +143,7 @@ public class LocalManager extends Manager {
         RegionAttributes<NotificationKey, Notification> notifRegionAttrs =
             notificationRegionAttributeFactory.create();
 
-        String appender = MBeanJMXAdapter
-            .getUniqueIDForMember(cache.getDistributedSystem().getDistributedMember());
+        String appender = MBeanJMXAdapter.getUniqueIDForMember(system.getDistributedMember());
 
         boolean monitoringRegionCreated = false;
         boolean notifRegionCreated = false;
@@ -192,7 +189,7 @@ public class LocalManager extends Manager {
         managementTask.run();
         // All local resources are created for the ManagementTask
         // Now Management tasks can proceed.
-        int updateRate = cache.getInternalDistributedSystem().getConfig().getJmxManagerUpdateRate();
+        int updateRate = system.getConfig().getJmxManagerUpdateRate();
         singleThreadFederationScheduler.scheduleAtFixedRate(managementTask, updateRate, updateRate,
             TimeUnit.MILLISECONDS);
 
@@ -296,7 +293,7 @@ public class LocalManager extends Manager {
    */
   private class ManagementTask implements Runnable {
 
-    private Map<String, FederationComponent> replicaMap;
+    private final Map<String, FederationComponent> replicaMap;
 
     public ManagementTask(Map<ObjectName, FederationComponent> federatedComponentMap)
         throws ManagementException {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
@@ -118,7 +118,8 @@ public class LocalManager extends Manager {
         final HasCachePerfStats monitoringRegionStats = new HasCachePerfStats() {
           @Override
           public CachePerfStats getCachePerfStats() {
-            return new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats");
+            return new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats",
+                cache.getStatisticsClock());
           }
         };
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/Manager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/Manager.java
@@ -14,9 +14,11 @@
  */
 package org.apache.geode.management.internal;
 
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * The Manager is a 7.0 JMX Agent which is hosted within a GemFire process. Only one instance is
@@ -27,7 +29,7 @@ import org.apache.geode.internal.cache.InternalCacheForClientAccess;
  */
 public abstract class Manager {
 
-  protected InternalCacheForClientAccess cache;
+  protected final InternalCacheForClientAccess cache;
 
   /**
    * depicts whether this node is a Managing node or not
@@ -42,18 +44,24 @@ public abstract class Manager {
   /**
    * This is a single window to manipulate region resources for management
    */
-  protected ManagementResourceRepo repo;
+  protected final ManagementResourceRepo repo;
 
   /**
    * The concrete implementation of DistributedSystem that provides internal-only functionality.
    */
-  protected InternalDistributedSystem system;
+  protected final InternalDistributedSystem system;
+
+  protected final StatisticsFactory statisticsFactory;
+
+  protected final StatisticsClock statisticsClock;
 
   public Manager(ManagementResourceRepo repo, InternalDistributedSystem system,
-      InternalCache cache) {
+      InternalCache cache, StatisticsFactory statisticsFactory, StatisticsClock statisticsClock) {
     this.repo = repo;
     this.cache = cache.getCacheForProcessingClientRequests();
     this.system = system;
+    this.statisticsFactory = statisticsFactory;
+    this.statisticsClock = statisticsClock;
   }
 
   public abstract boolean isRunning();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
@@ -153,7 +153,8 @@ public class QueryDataFunction implements Function, InternalEntity {
             for (BucketRegion bRegion : localPrimaryBucketRegions) {
               localPrimaryBucketSet.add(bRegion.getId());
             }
-            LocalDataSet lds = new LocalDataSet(parRegion, localPrimaryBucketSet);
+            LocalDataSet lds =
+                new LocalDataSet(parRegion, localPrimaryBucketSet, parRegion.getStatisticsClock());
             DefaultQuery query = (DefaultQuery) cache.getQueryService().newQuery(queryString);
             final ExecutionContext executionContext = new QueryExecutionContext(null, cache, query);
             results = lds.executeQuery(query, executionContext, null, localPrimaryBucketSet);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
@@ -154,7 +154,7 @@ public class QueryDataFunction implements Function, InternalEntity {
               localPrimaryBucketSet.add(bRegion.getId());
             }
             LocalDataSet lds =
-                new LocalDataSet(parRegion, localPrimaryBucketSet, parRegion.getStatisticsClock());
+                new LocalDataSet(parRegion, localPrimaryBucketSet);
             DefaultQuery query = (DefaultQuery) cache.getQueryService().newQuery(queryString);
             final ExecutionContext executionContext = new QueryExecutionContext(null, cache, query);
             results = lds.executeQuery(query, executionContext, null, localPrimaryBucketSet);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractDistributedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractDistributedRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -33,6 +34,7 @@ import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.fake.Fakes;
 
 public abstract class AbstractDistributedRegionJUnitTest {
@@ -96,7 +98,8 @@ public abstract class AbstractDistributedRegionJUnitTest {
   protected abstract void setInternalRegionArguments(InternalRegionArguments ira);
 
   protected abstract DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
-      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache);
+      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache,
+      StatisticsClock statisticsClock);
 
   protected abstract void verifyDistributeUpdate(DistributedRegion region, EntryEventImpl event,
       int cnt);
@@ -121,7 +124,8 @@ public abstract class AbstractDistributedRegionJUnitTest {
     setInternalRegionArguments(ira);
 
     // create a region object
-    DistributedRegion region = createAndDefineRegion(isConcurrencyChecksEnabled, ra, ira, cache);
+    DistributedRegion region =
+        createAndDefineRegion(isConcurrencyChecksEnabled, ra, ira, cache, disabledClock());
     if (isConcurrencyChecksEnabled) {
       region.enableConcurrencyChecks();
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.enabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -114,7 +115,8 @@ public class AbstractRegionJUnitTest {
     when(regionAttributes.getDiskWriteAttributes()).thenReturn(diskWriteAttributes);
     RegionMapConstructor regionMapConstructor = mock(RegionMapConstructor.class);
     AbstractRegion region = new LocalRegion("regionName", regionAttributes, null, Fakes.cache(),
-        new InternalRegionArguments(), null, regionMapConstructor, null, null, null);
+        new InternalRegionArguments(), null, regionMapConstructor, null, null, null,
+        enabledClock());
     return region;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
 
@@ -51,8 +52,9 @@ public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
 
   @Override
   protected DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
-      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache) {
-    BucketRegion br = new BucketRegion("testRegion", ra, null, cache, ira);
+      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache,
+      StatisticsClock statisticsClock) {
+    BucketRegion br = new BucketRegion("testRegion", ra, null, cache, ira, statisticsClock);
     // it is necessary to set the event tracker to initialized, since initialize() in not being
     // called on the instantiated region
     br.getEventTracker().setInitialized();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -113,7 +114,7 @@ public class BucketRegionTest {
   public void waitUntilLockedThrowsIfFoundLockAndPartitionedRegionIsClosing() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     Integer[] keys = {1};
     doReturn(mock(LockObject.class)).when(bucketRegion).searchAndLock(keys);
     doThrow(regionDestroyedException).when(partitionedRegion)
@@ -126,7 +127,7 @@ public class BucketRegionTest {
   public void waitUntilLockedReturnsTrueIfNoOtherThreadLockedKeys() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     Integer[] keys = {1};
     doReturn(null).when(bucketRegion).searchAndLock(keys);
 
@@ -137,7 +138,7 @@ public class BucketRegionTest {
   public void basicPutEntryDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.basicPutEntry(event, 1);
@@ -149,7 +150,7 @@ public class BucketRegionTest {
   public void basicPutEntryReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(mock(AbstractRegionMap.class)).when(bucketRegion).getRegionMap();
 
@@ -162,7 +163,7 @@ public class BucketRegionTest {
   public void virtualPutDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.virtualPut(event, false, true, null, false, 1, true);
@@ -174,7 +175,7 @@ public class BucketRegionTest {
   public void virtualPutReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
 
@@ -187,7 +188,7 @@ public class BucketRegionTest {
   public void basicDestroyDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.basicDestroy(event, false, null);
@@ -199,7 +200,7 @@ public class BucketRegionTest {
   public void basicDestroyReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
 
@@ -212,7 +213,7 @@ public class BucketRegionTest {
   public void basicUpdateEntryVersionDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
     when(event.getRegion()).thenReturn(bucketRegion);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
@@ -227,7 +228,7 @@ public class BucketRegionTest {
   public void basicUpdateEntryVersionReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     when(event.getRegion()).thenReturn(bucketRegion);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
@@ -242,7 +243,7 @@ public class BucketRegionTest {
   public void basicInvalidateDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.basicInvalidate(event, false, false);
@@ -254,7 +255,7 @@ public class BucketRegionTest {
   public void basicInvalidateReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
 
@@ -267,7 +268,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryReturnFalseIfDoesNotNeedWriteLock() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).needWriteLock(event);
 
     assertThat(bucketRegion.lockKeysAndPrimary(event)).isFalse();
@@ -277,7 +278,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryThrowsIfWaitUntilLockedThrows() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(keys).when(bucketRegion).getKeysToBeLocked(event);
     doThrow(regionDestroyedException).when(bucketRegion).waitUntilLocked(keys);
 
@@ -288,7 +289,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryReleaseLockHeldIfDoLockForPrimaryThrows() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(keys).when(bucketRegion).getKeysToBeLocked(event);
     doReturn(true).when(bucketRegion).waitUntilLocked(keys);
     doThrow(new PrimaryBucketException()).when(bucketRegion).doLockForPrimary(false);
@@ -302,7 +303,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryReleaseLockHeldIfDoesNotLockForPrimary() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(keys).when(bucketRegion).getKeysToBeLocked(event);
     doReturn(true).when(bucketRegion).waitUntilLocked(keys);
     doReturn(true).when(bucketRegion).doLockForPrimary(false);
@@ -317,7 +318,7 @@ public class BucketRegionTest {
 
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
 
     Map regionGCVersions = new HashMap();
     Set keysRemoved = new HashSet();
@@ -333,7 +334,7 @@ public class BucketRegionTest {
   public void testDoNotNotifyClientsOfTombstoneGCNoProxy() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
 
     Map regionGCVersions = new HashMap();
     Set keysRemoved = new HashSet();
@@ -356,7 +357,7 @@ public class BucketRegionTest {
   public void testNotifyClientsOfTombstoneGC() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
 
     Map regionGCVersions = new HashMap();
     Set keysRemoved = new HashSet();
@@ -384,7 +385,7 @@ public class BucketRegionTest {
   public void invokeTXCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -398,7 +399,7 @@ public class BucketRegionTest {
   public void invokeTXCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -414,7 +415,7 @@ public class BucketRegionTest {
   public void invokeTXCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();
@@ -431,7 +432,7 @@ public class BucketRegionTest {
   public void invokeDestroyCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -445,7 +446,7 @@ public class BucketRegionTest {
   public void invokeDestroyCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -461,7 +462,7 @@ public class BucketRegionTest {
   public void invokeDestroyCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();
@@ -478,7 +479,7 @@ public class BucketRegionTest {
   public void invokeInvalidateCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -492,7 +493,7 @@ public class BucketRegionTest {
   public void invokeInvalidateCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -508,7 +509,7 @@ public class BucketRegionTest {
   public void invokeInvalidateCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();
@@ -525,7 +526,7 @@ public class BucketRegionTest {
   public void invokePutCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -539,7 +540,7 @@ public class BucketRegionTest {
   public void invokePutCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -555,7 +556,7 @@ public class BucketRegionTest {
   public void invokePutCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
@@ -51,6 +51,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.fake.Fakes;
 
 public class BucketRegionTest {
@@ -343,8 +344,8 @@ public class BucketRegionTest {
     doReturn(mock(SystemTimer.class)).when(cache).getCCPTimer();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     bucketRegion.notifyClientsOfTombstoneGC(regionGCVersions, keysRemoved, eventID, routing);
     verify(bucketRegion, never()).getFilterProfile();
@@ -366,8 +367,8 @@ public class BucketRegionTest {
     doReturn(mock(SystemTimer.class)).when(cache).getCCPTimer();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     doReturn(mock(ClientProxyMembershipID.class)).when(proxy).getProxyID();
     ccn.addClientProxyToMap(proxy);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -56,7 +56,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -89,13 +88,7 @@ public class CachePerfStatsTest {
     when(statisticsFactory.createAtomicStatistics(eq(statisticsType), eq(TEXT_ID)))
         .thenReturn(statistics);
 
-    CachePerfStats.enableClockStats = true;
     cachePerfStats = new CachePerfStats(statisticsFactory, TEXT_ID, () -> CLOCK_TIME);
-  }
-
-  @After
-  public void tearDown() {
-    CachePerfStats.enableClockStats = false;
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CacheServerImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CacheServerImplTest.java
@@ -43,6 +43,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.internal.statistics.StatisticsManager;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
@@ -88,8 +89,9 @@ public class CacheServerImplTest {
   @Test
   public void createdAcceptorIsGatewayEndpoint() throws IOException {
     OverflowAttributes overflowAttributes = mock(OverflowAttributes.class);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     Acceptor acceptor = server.createAcceptor(overflowAttributes);
@@ -99,8 +101,9 @@ public class CacheServerImplTest {
 
   @Test
   public void getGroups_returnsSpecifiedGroup() {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup = "group0";
 
@@ -112,8 +115,9 @@ public class CacheServerImplTest {
 
   @Test
   public void getGroups_returnsMultipleSpecifiedGroups() {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup1 = "group1";
     String specifiedGroup2 = "group2";
@@ -129,8 +133,9 @@ public class CacheServerImplTest {
   public void getCombinedGroups_includesMembershipGroup() {
     String membershipGroup = "group-m0";
     when(config.getGroups()).thenReturn(membershipGroup);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     assertThat(server.getCombinedGroups())
@@ -144,8 +149,9 @@ public class CacheServerImplTest {
     String membershipGroup3 = "group-m3";
     when(config.getGroups())
         .thenReturn(membershipGroup1 + "," + membershipGroup2 + "," + membershipGroup3);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     assertThat(server.getCombinedGroups())
@@ -159,8 +165,9 @@ public class CacheServerImplTest {
     String membershipGroup3 = "group-m3";
     when(config.getGroups())
         .thenReturn(membershipGroup1 + "," + membershipGroup2 + "," + membershipGroup3);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup1 = "group1";
     String specifiedGroup2 = "group2";
@@ -175,8 +182,9 @@ public class CacheServerImplTest {
 
   @Test
   public void startNotifiesResourceEventCacheServerStart() throws IOException {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     server.start();
@@ -186,8 +194,9 @@ public class CacheServerImplTest {
 
   @Test
   public void stopNotifiesResourceEventCacheServerStart() throws IOException {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     server.start();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +45,7 @@ import org.apache.geode.internal.cache.ha.ThreadIdentifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.versions.VMVersionTag;
 import org.apache.geode.internal.cache.versions.VersionTag;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class DistributedRegionJUnitTest
     extends AbstractDistributedRegionJUnitTest {
@@ -52,11 +54,11 @@ public class DistributedRegionJUnitTest
   protected void setInternalRegionArguments(InternalRegionArguments ira) {}
 
   @Override
-  protected DistributedRegion createAndDefineRegion(
-      boolean isConcurrencyChecksEnabled,
-      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache) {
+  protected DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
+      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache,
+      StatisticsClock statisticsClock) {
     DistributedRegion region = new DistributedRegion("testRegion", ra, null,
-        cache, ira);
+        cache, ira, disabledClock());
     if (isConcurrencyChecksEnabled) {
       region.enableConcurrencyChecks();
     }
@@ -222,9 +224,7 @@ public class DistributedRegionJUnitTest
     byte[] memId = {1, 2, 3};
     long threadId = 1;
     long retrySeqId = 1;
-    ThreadIdentifier tid = new ThreadIdentifier(memId, threadId);
     EventID retryEventID = new EventID(memId, threadId, retrySeqId);
-    boolean skipCallbacks = true;
 
     final EventIDHolder clientEvent = new EventIDHolder(retryEventID);
     clientEvent.setOperation(Operation.UPDATE);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -54,7 +55,8 @@ public class DistributedRegionSearchLoadJUnitTest {
 
   protected DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
       RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache) {
-    DistributedRegion region = new DistributedRegion("testRegion", ra, null, cache, ira);
+    DistributedRegion region =
+        new DistributedRegion("testRegion", ra, null, cache, ira, disabledClock());
     if (isConcurrencyChecksEnabled) {
       region.enableConcurrencyChecks();
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalDataSetTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalDataSetTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache;
 
-import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
@@ -36,7 +35,7 @@ public class LocalDataSetTest {
     PartitionedRegion pr = mock(PartitionedRegion.class);
     when(pr.isEmpty()).thenReturn(false);
     when(pr.entryCount(any())).thenReturn(0);
-    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet(), disabledClock());
+    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet());
     assertTrue(lds.isEmpty());
   }
 
@@ -45,7 +44,7 @@ public class LocalDataSetTest {
     PartitionedRegion pr = mock(PartitionedRegion.class);
     when(pr.isEmpty()).thenReturn(true);
     when(pr.entryCount(any())).thenReturn(1);
-    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet(), disabledClock());
+    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet());
     assertFalse(lds.isEmpty());
   }
 
@@ -53,7 +52,7 @@ public class LocalDataSetTest {
   public void verifyThatGetCallbackArgIsCorrectlyPassedToGetHashKey() {
     PartitionedRegion pr = mock(PartitionedRegion.class);
     when(pr.getTotalNumberOfBuckets()).thenReturn(33);
-    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet(), disabledClock());
+    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet());
     LocalDataSet spy = spy(lds);
     Object key = "key";
     Object callbackArg = "callbackArg";

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalDataSetTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalDataSetTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
@@ -35,7 +36,7 @@ public class LocalDataSetTest {
     PartitionedRegion pr = mock(PartitionedRegion.class);
     when(pr.isEmpty()).thenReturn(false);
     when(pr.entryCount(any())).thenReturn(0);
-    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet());
+    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet(), disabledClock());
     assertTrue(lds.isEmpty());
   }
 
@@ -44,7 +45,7 @@ public class LocalDataSetTest {
     PartitionedRegion pr = mock(PartitionedRegion.class);
     when(pr.isEmpty()).thenReturn(true);
     when(pr.entryCount(any())).thenReturn(1);
-    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet());
+    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet(), disabledClock());
     assertFalse(lds.isEmpty());
   }
 
@@ -52,7 +53,7 @@ public class LocalDataSetTest {
   public void verifyThatGetCallbackArgIsCorrectlyPassedToGetHashKey() {
     PartitionedRegion pr = mock(PartitionedRegion.class);
     when(pr.getTotalNumberOfBuckets()).thenReturn(33);
-    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet());
+    LocalDataSet lds = new LocalDataSet(pr, Collections.emptySet(), disabledClock());
     LocalDataSet spy = spy(lds);
     Object key = "key";
     Object callbackArg = "callbackArg";

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
@@ -52,6 +52,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class LocalRegionTest {
   private LocalRegion region;
@@ -226,8 +227,8 @@ public class LocalRegionTest {
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     doCallRealMethod().when(region).notifyClientsOfTombstoneGC(regionGCVersions, keysRemoved,
         eventID, routing);
@@ -248,8 +249,8 @@ public class LocalRegionTest {
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     when(proxy.getProxyID()).thenReturn(mock(ClientProxyMembershipID.class));
     ccn.addClientProxyToMap(proxy);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl.getSenderIdFromAsyncEventQueueId;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -73,7 +74,7 @@ public class PartitionedRegionTest {
     attributesFactory.setPartitionAttributes(
         new PartitionAttributesFactory().setTotalNumBuckets(1).setRedundantCopies(1).create());
     partitionedRegion = new PartitionedRegion("prTestRegion", attributesFactory.create(), null,
-        internalCache, mock(InternalRegionArguments.class));
+        internalCache, mock(InternalRegionArguments.class), disabledClock());
     DistributedSystem mockDistributedSystem = mock(DistributedSystem.class);
     when(internalCache.getDistributedSystem()).thenReturn(mockDistributedSystem);
     when(mockDistributedSystem.getProperties()).thenReturn(gemfireProperties);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ServerBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ServerBuilderTest.java
@@ -37,6 +37,7 @@ import org.apache.geode.distributed.internal.DistributionAdvisee;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier.CacheClientNotifierProvider;
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHealthMonitorProvider;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category(ClientServerTest.class)
@@ -47,30 +48,32 @@ public class ServerBuilderTest {
 
   private InternalCache cache;
   private SecurityService securityService;
+  private StatisticsClock statisticsClock;
 
   @Before
   public void setUp() {
     cache = mock(InternalCache.class);
     securityService = mock(SecurityService.class);
+    statisticsClock = mock(StatisticsClock.class);
   }
 
   @Test
   public void sendResourceEventsIsTrueByDefault() {
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     assertThat(builder.isSendResourceEvents()).isTrue();
   }
 
   @Test
   public void includeMemberGroupsIsTrueByDefault() {
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     assertThat(builder.isIncludeMemberGroups()).isTrue();
   }
 
   @Test
   public void socketCreatorIsForServerByDefault() {
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     assertThat(builder.getSocketCreatorSupplier()).isSameAs(SERVER.getSupplier());
   }
@@ -80,7 +83,7 @@ public class ServerBuilderTest {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.forGatewayReceiver(gatewayReceiver);
 
@@ -92,7 +95,7 @@ public class ServerBuilderTest {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.forGatewayReceiver(gatewayReceiver);
 
@@ -104,7 +107,7 @@ public class ServerBuilderTest {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.forGatewayReceiver(gatewayReceiver);
 
@@ -115,7 +118,7 @@ public class ServerBuilderTest {
   public void setCacheClientNotifierProviderReplacesCacheClientNotifierProvider() {
     CacheClientNotifierProvider cacheClientNotifierProvider =
         mock(CacheClientNotifierProvider.class);
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.setCacheClientNotifierProvider(cacheClientNotifierProvider);
 
@@ -126,7 +129,7 @@ public class ServerBuilderTest {
   public void setClientHealthMonitorProviderReplacesClientHealthMonitorProvider() {
     ClientHealthMonitorProvider clientHealthMonitorProvider =
         mock(ClientHealthMonitorProvider.class);
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.setClientHealthMonitorProvider(clientHealthMonitorProvider);
 
@@ -137,7 +140,7 @@ public class ServerBuilderTest {
   public void setCacheServerAdvisorProviderReplacesCacheServerAdvisorProvider() {
     Function<DistributionAdvisee, CacheServerAdvisor> cacheServerAdvisorProvider =
         a -> mock(CacheServerAdvisor.class);
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.setCacheServerAdvisorProvider(cacheServerAdvisorProvider);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXManagerImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXManagerImplTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -76,7 +77,7 @@ public class TXManagerImplTest {
   public void setUp() {
     cache = Fakes.cache();
     dm = mock(ClusterDistributionManager.class);
-    txMgr = new TXManagerImpl(mock(CachePerfStats.class), cache);
+    txMgr = new TXManagerImpl(mock(CachePerfStats.class), cache, disabledClock());
     txid = new TXId(null, 0);
     msg = mock(DestroyMessage.class);
     txCommitMsg = mock(TXCommitMessage.class);
@@ -95,7 +96,7 @@ public class TXManagerImplTest {
     doReturn(distributedSystem).when(spyCache).getDistributedSystem();
     when(distributedSystem.getDistributionManager()).thenReturn(dm);
     when(distributedSystem.getDistributedMember()).thenReturn(member);
-    spyTxMgr = spy(new TXManagerImpl(mock(CachePerfStats.class), spyCache));
+    spyTxMgr = spy(new TXManagerImpl(mock(CachePerfStats.class), spyCache, disabledClock()));
     timer = mock(SystemTimer.class);
     doReturn(timer).when(spyCache).getCCPTimer();
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache;
 
-import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -30,9 +29,10 @@ import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.RegionAttributes;
 
 public class UpdateOperationJUnitTest {
-  EntryEventImpl event;
-  UpdateOperation.UpdateMessage message;
-  DistributedRegion region;
+
+  private EntryEventImpl event;
+  private UpdateOperation.UpdateMessage message;
+  private DistributedRegion region;
 
   @Before
   public void setup() {
@@ -54,7 +54,7 @@ public class UpdateOperationJUnitTest {
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
     when(region.getCachePerfStats()).thenReturn(stats);
     when(region.getCache()).thenReturn(cache);
-    when(cache.getStatisticsClock()).thenReturn(disabledClock());
+    // when(cache.getStatisticsClock()).thenReturn(disabledClock());
     when(attr.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
     when(event.getOperation()).thenReturn(Operation.CREATE);
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -39,6 +40,8 @@ public class UpdateOperationJUnitTest {
     region = mock(DistributedRegion.class);
     RegionAttributes attr = mock(RegionAttributes.class);
     CachePerfStats stats = mock(CachePerfStats.class);
+    InternalCache cache = mock(InternalCache.class);
+
     when(event.isOriginRemote()).thenReturn(false);
     when(stats.endPut(anyLong(), eq(false))).thenReturn(0L);
 
@@ -50,6 +53,8 @@ public class UpdateOperationJUnitTest {
     when(region.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
     when(region.getCachePerfStats()).thenReturn(stats);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getStatisticsClock()).thenReturn(disabledClock());
     when(attr.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
     when(event.getOperation()).thenReturn(Operation.CREATE);
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueTest.java
@@ -31,6 +31,7 @@ import org.apache.geode.CancelCriterion;
 import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.HARegion;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
@@ -64,7 +65,8 @@ public class HARegionQueueTest {
     when(haRegion.getGemFireCache()).thenReturn(internalCache);
     haRegionQueue = new HARegionQueue("haRegion", haRegion, internalCache,
         new HAContainerMap(new ConcurrentHashMap()), null, (byte) 1, true,
-        mock(HARegionQueueStats.class), giiLock, rwLock, mock(CancelCriterion.class), false);
+        mock(HARegionQueueStats.class), giiLock, rwLock, mock(CancelCriterion.class), false,
+        mock(StatisticsClock.class));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/FetchKeysMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/FetchKeysMessageTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,7 +76,7 @@ public class FetchKeysMessageTest {
 
     originalTxManager = TXManagerImpl.getCurrentInstanceForTest();
     // The constructor sets the new tx manager as currentInstance
-    txManager = spy(new TXManagerImpl(mock(CachePerfStats.class), cache));
+    txManager = spy(new TXManagerImpl(mock(CachePerfStats.class), cache, disabledClock()));
     txManager.setTXState(txStateProxy);
     txManager.setDistributed(false);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionMessageTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -127,7 +128,7 @@ public class PartitionMessageTest {
 
   @Test
   public void noNewTxProcessingAfterTXManagerImplClosed() throws Exception {
-    txMgr = new TXManagerImpl(null, cache);
+    txMgr = new TXManagerImpl(null, cache, disabledClock());
     when(msg.getPartitionedRegion()).thenReturn(pr);
     when(msg.getStartPartitionMessageProcessingTime(pr)).thenReturn(startTime);
     when(msg.getTXManagerImpl(cache)).thenReturn(txMgr);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilderTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier.CacheCli
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHealthMonitorProvider;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category(ClientServerTest.class)
@@ -288,6 +289,18 @@ public class AcceptorBuilderTest {
   }
 
   @Test
+  public void forServerSetsStatisticsClockFromServer() {
+    InternalCacheServer server = mock(InternalCacheServer.class);
+    StatisticsClock statisticsClock = mock(StatisticsClock.class);
+    when(server.getStatisticsClock()).thenReturn(statisticsClock);
+    AcceptorBuilder builder = new AcceptorBuilder();
+
+    builder.forServer(server);
+
+    assertThat(builder.getStatisticsClock()).isEqualTo(statisticsClock);
+  }
+
+  @Test
   public void setCacheReplacesCacheFromServer() {
     InternalCacheServer server = mock(InternalCacheServer.class);
     InternalCache cacheFromServer = mock(InternalCache.class, "fromServer");
@@ -375,5 +388,19 @@ public class AcceptorBuilderTest {
 
     assertThat(builder.getClientHealthMonitorProvider())
         .isEqualTo(clientHealthMonitorProviderFromSetter);
+  }
+
+  @Test
+  public void setStatisticsClockReplacesStatisticsClockFromServer() {
+    InternalCacheServer server = mock(InternalCacheServer.class);
+    StatisticsClock statisticsClockFromServer = mock(StatisticsClock.class, "fromServer");
+    when(server.getStatisticsClock()).thenReturn(statisticsClockFromServer);
+    AcceptorBuilder builder = new AcceptorBuilder();
+    builder.forServer(server);
+    StatisticsClock statisticsClockFromSetter = mock(StatisticsClock.class, "fromSetter");
+
+    builder.setStatisticsClock(statisticsClockFromSetter);
+
+    assertThat(builder.getStatisticsClock()).isEqualTo(statisticsClockFromSetter);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
@@ -14,10 +14,12 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static java.util.Collections.emptyList;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_SOCKET_BUFFER_SIZE;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_TCP_NO_DELAY;
 import static org.apache.geode.internal.cache.tier.sockets.AcceptorImpl.MINIMUM_MAX_CONNECTIONS;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -29,7 +31,6 @@ import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 import java.net.ServerSocket;
 import java.net.SocketAddress;
-import java.util.Collections;
 import java.util.Properties;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -96,8 +97,8 @@ public class AcceptorImplTest {
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,
         CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
         null, DEFAULT_TCP_NO_DELAY, serverConnectionFactory, 1000, securityService,
-        () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
-        (a, b, c) -> clientHealthMonitor, false, Collections.emptyList());
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
+        (a, b, c) -> clientHealthMonitor, false, emptyList(), disabledClock());
 
     assertThat(acceptor.isGatewayReceiver()).isFalse();
   }
@@ -114,8 +115,8 @@ public class AcceptorImplTest {
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,
         CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
         null, DEFAULT_TCP_NO_DELAY, serverConnectionFactory, 1000, securityService,
-        () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
-        (a, b, c) -> clientHealthMonitor, true, Collections.emptyList());
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
+        (a, b, c) -> clientHealthMonitor, true, emptyList(), disabledClock());
 
     assertThat(acceptor.isGatewayReceiver()).isTrue();
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.junit.Assert.assertFalse;
@@ -48,9 +47,11 @@ import org.apache.geode.internal.cache.FilterProfile;
 import org.apache.geode.internal.cache.FilterRoutingInfo;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheEvent;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.fake.Fakes;
 
 public class CacheClientNotifierTest {
+
   @Test
   public void eventsInClientRegistrationQueueAreSentToClientAfterRegistrationIsComplete()
       throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
@@ -63,11 +64,13 @@ public class CacheClientNotifierTest {
     CacheClientProxy cacheClientProxy = mock(CacheClientProxy.class);
     ClientUpdateMessageImpl clientUpdateMessage = mock(ClientUpdateMessageImpl.class);
     ClientRegistrationMetadata clientRegistrationMetadata = mock(ClientRegistrationMetadata.class);
+    StatisticsClock statisticsClock = mock(StatisticsClock.class);
+
     when(clientRegistrationMetadata.getClientProxyMembershipID()).thenReturn(
         clientProxyMembershipID);
 
     CacheClientNotifier cacheClientNotifier = CacheClientNotifier.getInstance(internalCache,
-        cacheServerStats, 0, 0, connectionListener, null, false);
+        statisticsClock, cacheServerStats, 0, 0, connectionListener, null, false);
     final CacheClientNotifier cacheClientNotifierSpy = spy(cacheClientNotifier);
 
     CountDownLatch waitForEventDispatchCountdownLatch = new CountDownLatch(1);
@@ -188,8 +191,8 @@ public class CacheClientNotifierTest {
     InternalCache internalCache = Fakes.cache();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(internalCache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(internalCache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     assertFalse(CacheClientNotifier.singletonHasClientProxies());
     ccn.shutdown(111);
@@ -202,8 +205,8 @@ public class CacheClientNotifierTest {
     CacheClientProxy proxy = mock(CacheClientProxy.class);
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(internalCache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(internalCache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     when(proxy.getProxyID()).thenReturn(mock(ClientProxyMembershipID.class));
     ccn.addClientProxy(proxy);
@@ -221,8 +224,8 @@ public class CacheClientNotifierTest {
     CacheClientProxy proxy = mock(CacheClientProxy.class);
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(internalCache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(internalCache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     when(proxy.getProxyID()).thenReturn(mock(ClientProxyMembershipID.class));
     ccn.addClientInitProxy(proxy);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/TXFailoverCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/TXFailoverCommandTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets.command;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
@@ -54,7 +55,7 @@ public class TXFailoverCommandTest {
 
     int uniqueId = 1;
     TXId txId = new TXId(client, uniqueId);
-    TXStateProxyImpl proxy = new TXStateProxyImpl(cache, txManager, txId, null);
+    TXStateProxyImpl proxy = new TXStateProxyImpl(cache, txManager, txId, null, disabledClock());
 
     when(cache.getCacheTransactionManager()).thenReturn(txManager);
     when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderHelper.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderHelper.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.wan.parallel;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -149,7 +150,7 @@ public class ParallelGatewaySenderHelper {
 
     // Create BucketRegionQueue
     return new BucketRegionQueue(
-        queueRegion.getBucketName(bucketId), attributes, parentRegion, cache, ira);
+        queueRegion.getBucketName(bucketId), attributes, parentRegion, cache, ira, disabledClock());
   }
 
   public static String getRegionQueueName(String gatewaySenderId) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.wan.parallel;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
@@ -97,7 +98,8 @@ public class ParallelQueueRemovalMessageJUnitTest {
     when(this.queueRegion.getParallelGatewaySender()).thenReturn(this.sender);
     when(this.sender.getQueues()).thenReturn(null);
     when(this.sender.getDispatcherThreads()).thenReturn(1);
-    stats = new GatewaySenderStats(new DummyStatisticsFactory(), "ln");
+    stats = new GatewaySenderStats(new DummyStatisticsFactory(), "gatewaySenderStats-", "ln",
+        disabledClock());
     when(this.sender.getStatistics()).thenReturn(stats);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/StatisticsClockFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/StatisticsClockFactoryTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.ENABLE_CLOCK_STATS_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.LongSupplier;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+public class StatisticsClockFactoryTest {
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Test
+  public void clock_createsEnabledClockIfPropertyIsTrue() {
+    System.setProperty(ENABLE_CLOCK_STATS_PROPERTY, "true");
+
+    StatisticsClock clock = StatisticsClockFactory.clock();
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void clock_createsDisabledClockIfPropertyIsFalse() {
+    System.setProperty(ENABLE_CLOCK_STATS_PROPERTY, "false");
+
+    StatisticsClock clock = StatisticsClockFactory.clock();
+
+    assertThat(clock.isEnabled()).isFalse();
+  }
+
+  @Test
+  public void clock_boolean_createsEnabledClockIfParameterIsTrue() {
+    StatisticsClock clock = StatisticsClockFactory.clock(true);
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void clock_boolean_createsEnabledClockIfParameterIsFalse() {
+    StatisticsClock clock = StatisticsClockFactory.clock(false);
+
+    assertThat(clock.isEnabled()).isFalse();
+  }
+
+  @Test
+  public void enabledClock_usesProvidedLongSupplierForGetTime() {
+    StatisticsClock clock = StatisticsClockFactory.enabledClock(() -> 42);
+
+    assertThat(clock.getTime()).isEqualTo(42);
+  }
+
+  @Test
+  public void enabledClock_createsEnabledClock() {
+    StatisticsClock clock = StatisticsClockFactory.enabledClock(() -> 24);
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void disabledClock_usesZeroForGetTime() {
+    StatisticsClock clock = StatisticsClockFactory.disabledClock();
+
+    assertThat(clock.getTime()).isZero();
+  }
+
+  @Test
+  public void disabledClock_createsDisabledClock() {
+    StatisticsClock clock = StatisticsClockFactory.disabledClock();
+
+    assertThat(clock.isEnabled()).isFalse();
+  }
+
+  @Test
+  public void clock_usesProvidedLongSupplierForGetTime() {
+    StatisticsClock clock = StatisticsClockFactory.clock(() -> 100, () -> true);
+
+    assertThat(clock.getTime()).isEqualTo(100);
+  }
+
+  @Test
+  public void clock_usesProvidedBooleanSupplierForIsEnabled() {
+    StatisticsClock clock = StatisticsClockFactory.clock(() -> 100, () -> true);
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void clock_getTime_delegatesToLongSupplier() {
+    LongSupplier time = mock(LongSupplier.class);
+    StatisticsClock clock = StatisticsClockFactory.clock(time, mock(BooleanSupplier.class));
+
+    clock.getTime();
+
+    verify(time).getAsLong();
+  }
+
+  @Test
+  public void clock_isEnabled_delegatesToBooleanSupplier() {
+    BooleanSupplier isEnabled = mock(BooleanSupplier.class);
+    StatisticsClock clock = StatisticsClockFactory.clock(mock(LongSupplier.class), isEnabled);
+
+    clock.isEnabled();
+
+    verify(isEnabled).getAsBoolean();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/bean/stats/MemberLevelStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/bean/stats/MemberLevelStatsTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.bean.stats;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -68,7 +69,6 @@ public class MemberLevelStatsTest {
   @Before
   public void setUp() throws Exception {
     DistributionStats.enableClockStats = true;
-    CachePerfStats.enableClockStats = true;
 
     StatisticsManager statisticsManager = new StatisticsRegistry("TestStatisticsRegistry", 1);
     InternalDistributedSystem system = mock(InternalDistributedSystem.class);
@@ -115,7 +115,7 @@ public class MemberLevelStatsTest {
     partitionedRegionStatsArray = new PartitionedRegionStats[4];
     for (int i = 0; i < 4; i++) {
       PartitionedRegionStats stats = new PartitionedRegionStats(
-          statisticsManager, name.getMethodName() + i);
+          statisticsManager, name.getMethodName() + i, disabledClock());
       partitionedRegionStatsArray[i] = stats;
       memberMBeanBridge.addPartitionedRegionStats(stats);
     }
@@ -127,7 +127,6 @@ public class MemberLevelStatsTest {
   @After
   public void tearDown() throws Exception {
     DistributionStats.enableClockStats = true;
-    CachePerfStats.enableClockStats = false;
     statSampler.stop();
   }
 

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestBlockingHARegionQueue.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestBlockingHARegionQueue.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Test class for Blocking HA region queue functionalities
@@ -43,9 +44,10 @@ public class TestBlockingHARegionQueue extends HARegionQueue.TestOnlyHARegionQue
 
   boolean takeWhenPeekInProgress = false;
 
-  public TestBlockingHARegionQueue(String regionName, InternalCache cache)
+  public TestBlockingHARegionQueue(String regionName, InternalCache cache,
+      StatisticsClock statisticsClock)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    super(regionName, cache);
+    super(regionName, cache, statisticsClock);
   }
 
   /**

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestBlockingHARegionQueue.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestBlockingHARegionQueue.java
@@ -32,7 +32,7 @@ import org.apache.geode.internal.statistics.StatisticsClock;
 
 // TODO:Asif: Modify the test to allow working with the new class containing
 // ReadWrite lock functionality
-public class TestBlockingHARegionQueue extends HARegionQueue.TestOnlyHARegionQueue {
+public class TestBlockingHARegionQueue extends TestOnlyHARegionQueue {
   private static final Logger logger = LogService.getLogger();
 
   /**

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestOnlyHARegionQueue.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestOnlyHARegionQueue.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.ha;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.geode.cache.CacheException;
+import org.apache.geode.cache.ExpirationAction;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.tier.sockets.Handshake;
+import org.apache.geode.internal.statistics.StatisticsClock;
+
+/**
+ * A static class which is created only for for testing purposes as some existing tests extend the
+ * HARegionQueue. Since the constructors of HARegionQueue are private , this class can act as a
+ * bridge between the user defined HARegionQueue class & the actual class. This class object will
+ * be buggy as it will tend to publish the Object o QRM thread & the expiry thread before the
+ * complete creation of the HARegionQueue instance
+ */
+class TestOnlyHARegionQueue extends HARegionQueue {
+
+  TestOnlyHARegionQueue(String regionName, InternalCache cache, StatisticsClock statisticsClock)
+      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
+    this(regionName, cache, HARegionQueueAttributes.DEFAULT_HARQ_ATTRIBUTES, new HashMap(),
+        Handshake.CONFLATION_DEFAULT, false, statisticsClock);
+  }
+
+  TestOnlyHARegionQueue(String regionName, InternalCache cache, HARegionQueueAttributes hrqa,
+      Map haContainer, byte clientConflation, boolean isPrimary, StatisticsClock statisticsClock)
+      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
+    super(regionName, cache, haContainer, null, clientConflation, isPrimary, statisticsClock);
+    ExpirationAttributes expirationAttributes =
+        new ExpirationAttributes(hrqa.getExpiryTime(), ExpirationAction.LOCAL_INVALIDATE);
+    region.setOwner(this);
+    region.getAttributesMutator().setEntryTimeToLive(expirationAttributes);
+    initialized.set(true);
+  }
+
+  /**
+   * Overloaded constructor to pass an {@code HashMap} instance as a haContainer.
+   *
+   * @since GemFire 5.7
+   */
+  TestOnlyHARegionQueue(String regionName, InternalCache cache, HARegionQueueAttributes hrqa,
+      StatisticsClock statisticsClock)
+      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
+    this(regionName, cache, hrqa, new HashMap(), Handshake.CONFLATION_DEFAULT, false,
+        statisticsClock);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
@@ -45,6 +45,7 @@ import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsManager;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.internal.TypeRegistry;
@@ -108,6 +109,8 @@ public class Fakes {
     when(cache.getQueryMonitor()).thenReturn(queryMonitor);
     when(cache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
+    when(cache.getStatisticsClock()).thenReturn(mock(StatisticsClock.class));
+
     when(system.getDistributedMember()).thenReturn(member);
     when(system.getConfig()).thenReturn(config);
     when(system.getDistributionManager()).thenReturn(distributionManager);

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/WANFactoryImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/WANFactoryImpl.java
@@ -46,7 +46,7 @@ public class WANFactoryImpl implements WANFactory {
 
   @Override
   public GatewaySenderFactory createGatewaySenderFactory(InternalCache cache) {
-    return new GatewaySenderFactoryImpl(cache);
+    return new GatewaySenderFactoryImpl(cache, cache.getStatisticsClock());
   }
 
   @Override

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
@@ -40,7 +40,7 @@ public abstract class AbstractRemoteGatewaySender extends AbstractGatewaySender 
   protected int proxyFailureTries = 0;
 
   public AbstractRemoteGatewaySender(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, attrs, cache.getStatisticsClock());
   }
 
   @Override

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
@@ -32,6 +32,7 @@ import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public abstract class AbstractRemoteGatewaySender extends AbstractGatewaySender {
   private static final Logger logger = LogService.getLogger();
@@ -39,8 +40,9 @@ public abstract class AbstractRemoteGatewaySender extends AbstractGatewaySender 
   /** used to reduce warning logs in case remote locator is down (#47634) */
   protected int proxyFailureTries = 0;
 
-  public AbstractRemoteGatewaySender(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs, cache.getStatisticsClock());
+  public AbstractRemoteGatewaySender(InternalCache cache, StatisticsClock statisticsClock,
+      GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
   }
 
   @Override

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderImpl.java
@@ -36,6 +36,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAdvisor.GatewaySenderPro
 import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * @since GemFire 7.0
@@ -44,8 +45,9 @@ public class ParallelGatewaySenderImpl extends AbstractRemoteGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public ParallelGatewaySenderImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+  public ParallelGatewaySenderImpl(InternalCache cache, StatisticsClock statisticsClock,
+      GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
   }
 
   @Override

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderImpl.java
@@ -37,6 +37,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 import org.apache.geode.internal.cache.wan.GatewaySenderConfigurationException;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * @since GemFire 7.0
@@ -45,8 +46,9 @@ public class SerialGatewaySenderImpl extends AbstractRemoteGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public SerialGatewaySenderImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+  public SerialGatewaySenderImpl(InternalCache cache, StatisticsClock statisticsClock,
+      GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
   }
 
   @Override


### PR DESCRIPTION
GEODE-7010: Replace static globals in CachePerfStats with StatisticsClock

* Create StatisticsClock during Cache creation
* Configure isEnabled() using "enable-time-statistics" config property
* Inject StatisticsClock dependency via constructor in classes that use it

I plan to make a second pass to hopefully inject StatisticsClock dependency
into more classes and remove getStatisticsClock methods from Cache and
Region.
