### PR TITLE
GEODE-7012: Execute the StartupMessage in the waiting pool

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupMessage.java
@@ -40,7 +40,7 @@ import org.apache.geode.internal.net.SocketCreator;
 /**
  * A message that is sent to all other distribution manager when a distribution manager starts up.
  */
-public class StartupMessage extends HighPriorityDistributionMessage implements AdminMessageType {
+public class StartupMessage extends DistributionMessage implements AdminMessageType {
   private static final Logger logger = LogService.getLogger();
 
   private String version = GemFireVersion.getGemFireVersion(); // added for bug 29005
@@ -302,6 +302,11 @@ public class StartupMessage extends HighPriorityDistributionMessage implements A
     if (myMcastHostAddr == null)
       return false;
     return myMcastHostAddr.equals(otherMcastHostAddr);
+  }
+
+  @Override
+  public int getProcessorType() {
+    return ClusterDistributionManager.WAITING_POOL_EXECUTOR;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/StartupResponseMessage.java
@@ -35,7 +35,7 @@ import org.apache.geode.internal.logging.log4j.LogMarker;
 /**
  * A message that is sent to all other distribution manager when a distribution manager starts up.
  */
-public class StartupResponseMessage extends HighPriorityDistributionMessage
+public class StartupResponseMessage extends DistributionMessage
     implements AdminMessageType {
   private static final Logger logger = LogService.getLogger();
 
@@ -118,6 +118,11 @@ public class StartupResponseMessage extends HighPriorityDistributionMessage
   @Override
   public boolean getInlineProcess() {
     return true;
+  }
+
+  @Override
+  public int getProcessorType() {
+    return ClusterDistributionManager.WAITING_POOL_EXECUTOR;
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageJUnitTest.java
@@ -82,4 +82,19 @@ public class StartupMessageJUnitTest {
         .isInstanceOf(ReplyException.class)
         .hasCauseInstanceOf(IllegalStateException.class);
   }
+
+  @Test
+  public void startupMessageGetProcessorTypeIsWaitingPool() {
+    ClusterDistributionManager distributionManager = mock(ClusterDistributionManager.class);
+
+    InternalDistributedMember id = mock(InternalDistributedMember.class);
+    when(distributionManager.getId()).thenReturn(id);
+
+    StartupMessage startupMessage = new StartupMessage();
+    startupMessage.setSender(id);
+    startupMessage.process(distributionManager);
+
+    assertThat(
+        startupMessage.getProcessorType() == ClusterDistributionManager.WAITING_POOL_EXECUTOR);
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/StartupMessageJUnitTest.java
@@ -97,4 +97,20 @@ public class StartupMessageJUnitTest {
     assertThat(
         startupMessage.getProcessorType() == ClusterDistributionManager.WAITING_POOL_EXECUTOR);
   }
+
+  @Test
+  public void startupResponseMessageGetProcessorTypeIsWaitingPool() {
+    ClusterDistributionManager distributionManager = mock(ClusterDistributionManager.class);
+
+    InternalDistributedMember id = mock(InternalDistributedMember.class);
+    when(distributionManager.getId()).thenReturn(id);
+
+    StartupResponseMessage startupResponseMessage = new StartupResponseMessage();
+    startupResponseMessage.setSender(id);
+    startupResponseMessage.process(distributionManager);
+
+    assertThat(
+        startupResponseMessage
+            .getProcessorType() == ClusterDistributionManager.WAITING_POOL_EXECUTOR);
+  }
 }


### PR DESCRIPTION
Until we get a response to a StartupMessage, we end up blocking up high
priority thread pool threads. So the StartupMessage should be processed
in a different, unbounded threadpool to avoid a distributed deadlock.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
