### PR TITLE
GEODE-7001: Add region entry count gauge

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/ServerStartupNotificationTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/ServerStartupNotificationTest.java
@@ -87,7 +87,7 @@ public class ServerStartupNotificationTest {
 
   @Test
   public void startupWithFailingAsyncTask() {
-    String serviceJarPath = serviceJarRule.createJarFor("ServerLauncherCacheProvider.jar",
+    Path serviceJarPath = serviceJarRule.createJarFor("ServerLauncherCacheProvider.jar",
         ServerLauncherCacheProvider.class, Failing.class);
 
     String startServerCommand = String.join(" ",
@@ -115,7 +115,7 @@ public class ServerStartupNotificationTest {
 
   @Test
   public void startupWithMultipleFailingAsyncTasks() {
-    String serviceJarPath = serviceJarRule.createJarFor("ServerLauncherCacheProvider.jar",
+    Path serviceJarPath = serviceJarRule.createJarFor("ServerLauncherCacheProvider.jar",
         ServerLauncherCacheProvider.class, MultipleFailing.class);
 
     String startServerCommand = String.join(" ",
@@ -143,7 +143,7 @@ public class ServerStartupNotificationTest {
 
   @Test
   public void startupWithCompletingAndFailingAsyncTasks() {
-    String serviceJarPath = serviceJarRule.createJarFor("ServerLauncherCacheProvider.jar",
+    Path serviceJarPath = serviceJarRule.createJarFor("ServerLauncherCacheProvider.jar",
         ServerLauncherCacheProvider.class, CompletingAndFailing.class);
 
     String startServerCommand = String.join(" ",

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -118,7 +119,7 @@ public class GatewayReceiverMetricsTest {
         "--server-port=" + senderServerPort,
         "--J=-Dgemfire.distributed-system-id=" + senderSystemId);
 
-    String serviceJarPath = serviceJarRule.createJarFor("metrics-publishing-service.jar",
+    Path serviceJarPath = serviceJarRule.createJarFor("metrics-publishing-service.jar",
         MetricsPublishingService.class, SimpleMetricsPublishingService.class);
 
     String startReceiverServerCommand = String.join(GFSH_COMMAND_SEPARATOR,

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/RegionEntriesGaugeTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/RegionEntriesGaugeTest.java
@@ -261,7 +261,6 @@ public class RegionEntriesGaugeTest {
     int expectedNumberOfEntries = numberOfEntries * totalNumberOfCopies;
 
     await()
-        .atMost(10, TimeUnit.SECONDS)
         .untilAsserted(() -> {
           GfshExecution execution =
               gfshRule.execute(connectToLocatorCommand, getGaugeValueCommand);

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/RegionEntriesGaugeTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/RegionEntriesGaugeTest.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.metrics;
+
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.geode.cache.RegionShortcut.LOCAL;
+import static org.apache.geode.cache.RegionShortcut.PARTITION;
+import static org.apache.geode.cache.RegionShortcut.PARTITION_REDUNDANT;
+import static org.apache.geode.cache.RegionShortcut.REPLICATE;
+import static org.apache.geode.cache.client.ClientRegionShortcut.PROXY;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import io.micrometer.core.instrument.Gauge;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.client.PoolManager;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.rules.ServiceJarRule;
+import org.apache.geode.test.compiler.ClassBuilder;
+import org.apache.geode.test.junit.categories.MetricsTest;
+import org.apache.geode.test.junit.rules.gfsh.GfshExecution;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+
+@Category(MetricsTest.class)
+public class RegionEntriesGaugeTest {
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public ServiceJarRule serviceJarRule = new ServiceJarRule();
+
+  private ClientCache clientCache;
+  private String connectToLocatorCommand;
+  private String locatorString;
+  private Pool server1Pool;
+  private Path serviceJarPath;
+
+  @Before
+  public void startMembers() throws Exception {
+    serviceJarPath = serviceJarRule.createJarFor("metrics-publishing-service.jar",
+        MetricsPublishingService.class, SimpleMetricsPublishingService.class);
+    int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(3);
+    int locatorPort = availablePorts[0];
+    int serverPort1 = availablePorts[1];
+    int serverPort2 = availablePorts[2];
+
+    locatorString = "localhost[" + locatorPort + "]";
+
+    File folderForLocator = temporaryFolder.newFolder("locator");
+    File folderForServer1 = temporaryFolder.newFolder("server1");
+    File folderForServer2 = temporaryFolder.newFolder("server2");
+
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + "locator",
+        "--dir=" + folderForLocator.getAbsolutePath(),
+        "--port=" + locatorPort);
+
+    String startServer1Command = startServerCommand("server1", serverPort1, folderForServer1);
+    String startServer2Command = startServerCommand("server2", serverPort2, folderForServer2);
+
+    gfshRule.execute(startLocatorCommand, startServer1Command, startServer2Command);
+
+    connectToLocatorCommand = "connect --locator=" + locatorString;
+
+    Path functionJarPath =
+        temporaryFolder.getRoot().toPath().resolve("function.jar").toAbsolutePath();
+    new ClassBuilder()
+        .writeJarFromClass(GetMemberRegionEntriesGaugeFunction.class, functionJarPath.toFile());
+    String deployCommand = "deploy --jar=" + functionJarPath.toAbsolutePath();
+    String listFunctionsCommand = "list functions";
+
+    gfshRule.execute(connectToLocatorCommand, deployCommand, listFunctionsCommand);
+
+    clientCache = new ClientCacheFactory().addPoolLocator("localhost", locatorPort).create();
+
+    server1Pool = PoolManager.createFactory()
+        .addServer("localhost", serverPort1)
+        .create("server1pool");
+  }
+
+
+  @After
+  public void stopMembers() {
+    clientCache.close();
+    server1Pool.destroy();
+
+    String shutdownCommand = String.join(" ",
+        "shutdown",
+        "--include-locators=true");
+    gfshRule.execute(connectToLocatorCommand, shutdownCommand);
+  }
+
+  @Test
+  public void regionEntriesGaugeShowsCountOfLocalRegionValuesInServer() {
+    String regionName = "localRegion";
+    Region<String, String> region = createRegionInGroup(LOCAL.name(), regionName, "server1");
+
+    List<String> keys = asList("a", "b", "c", "d", "e", "f", "g", "h");
+    for (String key : keys) {
+      region.put(key, key);
+    }
+    region.destroy(keys.get(0));
+    int expectedNumberOfEntries = keys.size() - 1;
+
+    String getGaugeValueCommand = memberRegionEntryGaugeValueCommand(regionName);
+
+    await()
+        .untilAsserted(() -> {
+          GfshExecution execution = gfshRule.execute(connectToLocatorCommand, getGaugeValueCommand);
+          OptionalInt server1EntryCount = linesOf(execution.getOutputText())
+              .filter(s -> s.startsWith("server1"))
+              .mapToInt(RegionEntriesGaugeTest::extractEntryCount)
+              .findFirst();
+
+          assertThat(server1EntryCount)
+              .as("Number of entries reported by server1")
+              .hasValue(expectedNumberOfEntries);
+
+          String server2Response = linesOf(execution.getOutputText())
+              .filter(s -> s.startsWith("server2"))
+              .findFirst()
+              .orElse("No response from server2");
+
+          assertThat(server2Response)
+              .as("server2 response from entry count function")
+              .endsWith("[Meter not found.]");
+        });
+  }
+
+  @Test
+  public void regionEntriesGaugeShowsCountOfReplicateRegionValuesInServer() {
+    Region<String, String> otherRegion = createRegion(REPLICATE.name(), "otherRegionName");
+    otherRegion.put("other-region-key", "other-region-value");
+
+    String regionName = "replicateRegion";
+    Region<String, String> regionOfInterest = createRegion(REPLICATE.name(), regionName);
+
+    List<String> keys = asList("a", "b", "c", "d", "e", "f", "g", "h");
+    for (String key : keys) {
+      regionOfInterest.put(key, key);
+    }
+    regionOfInterest.destroy(keys.get(0));
+    int expectedNumberOfEntries = keys.size() - 1;
+
+    String getGaugeValueCommand = memberRegionEntryGaugeValueCommand(regionName);
+
+    await().untilAsserted(() -> {
+      GfshExecution execution = gfshRule.execute(connectToLocatorCommand, getGaugeValueCommand);
+      List<Integer> entryCounts = linesOf(execution.getOutputText())
+          .filter(s -> s.startsWith("server"))
+          .map(RegionEntriesGaugeTest::extractEntryCount)
+          .collect(toList());
+
+      assertThat(entryCounts)
+          .as("Number of entries reported by each server")
+          .allMatch(i -> i == expectedNumberOfEntries, "equals " + expectedNumberOfEntries);
+    });
+  }
+
+  @Test
+  public void regionEntriesGaugeShowsCountOfPartitionedRegionValuesInEachServer() {
+    String regionName = "partitionedRegion";
+
+    Region<String, String> region = createRegion(PARTITION.name(), regionName);
+
+    List<String> keys = asList("a", "b", "c", "d", "e", "f", "g", "h");
+    for (String key : keys) {
+      region.put(key, key);
+    }
+
+    region.destroy(keys.get(0));
+
+    int expectedNumberOfEntries = keys.size() - 1;
+
+    String getGaugeValueCommand = memberRegionEntryGaugeValueCommand(regionName);
+
+    await().untilAsserted(() -> {
+      GfshExecution execution = gfshRule.execute(connectToLocatorCommand, getGaugeValueCommand);
+      int sum = linesOf(execution.getOutputText())
+          .filter(s -> s.startsWith("server"))
+          .mapToInt(RegionEntriesGaugeTest::extractEntryCount)
+          .sum();
+
+      assertThat(sum)
+          .as("total number of entries on all servers")
+          .isEqualTo(expectedNumberOfEntries);
+    });
+  }
+
+  @Test
+  public void regionEntriesGaugeShowsCountOfPartitionedRedundantRegionValuesInEachServer()
+      throws IOException {
+    int numberOfRedundantCopies = 1;
+    String regionName = "partitionedRegion";
+
+    int server3Port = AvailablePortHelper.getRandomAvailableTCPPort();
+
+    File folderForServer3 = temporaryFolder.newFolder("server3");
+
+    String startServer3Command = startServerCommand("server3", server3Port, folderForServer3);
+    gfshRule.execute(connectToLocatorCommand, startServer3Command);
+
+    Region<String, String> region =
+        createPartitionedRegionWithRedundancy(regionName, numberOfRedundantCopies);
+
+    List<String> keys = asList("a", "b", "c", "d", "e", "f", "g", "h");
+    for (String key : keys) {
+      region.put(key, key);
+    }
+
+    region.destroy(keys.get(0));
+
+    String getGaugeValueCommand = memberRegionEntryGaugeValueCommand(regionName);
+
+    int numberOfEntries = keys.size() - 1;
+    int totalNumberOfCopies = numberOfRedundantCopies + 1;
+    int expectedNumberOfEntries = numberOfEntries * totalNumberOfCopies;
+
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .untilAsserted(() -> {
+          GfshExecution execution =
+              gfshRule.execute(connectToLocatorCommand, getGaugeValueCommand);
+          int totalEntryCount = linesOf(execution.getOutputText())
+              .filter(s -> s.startsWith("server"))
+              .mapToInt(RegionEntriesGaugeTest::extractEntryCount)
+              .sum();
+
+          assertThat(totalEntryCount)
+              .as("total number of entries on all servers")
+              .isEqualTo(expectedNumberOfEntries);
+        });
+  }
+
+  private static int extractEntryCount(String serverEntryCountLine) {
+    String entryCountExtractor = ".*\\[(\\d+).*].*";
+    Pattern entryCountPattern = Pattern.compile(entryCountExtractor);
+    Matcher matcher = entryCountPattern.matcher(serverEntryCountLine);
+    assertThat(matcher.matches())
+        .as(serverEntryCountLine)
+        .withFailMessage("does not match " + entryCountExtractor)
+        .isTrue();
+    String matchedGroup = matcher.group(1);
+    return parseInt(matchedGroup);
+  }
+
+  private static Stream<String> linesOf(String text) {
+    return new BufferedReader(new StringReader(text)).lines();
+  }
+
+  private Region<String, String> createPartitionedRegionWithRedundancy(String regionName,
+      int numberOfRedundantCopies) {
+
+    String createRegionCommand = String.join(" ",
+        "create region",
+        "--name=" + regionName,
+        "--redundant-copies=" + numberOfRedundantCopies,
+        "--type=" + PARTITION_REDUNDANT.name());
+
+    gfshRule.execute(connectToLocatorCommand, createRegionCommand);
+
+    return clientCache.<String, String>createClientRegionFactory(PROXY).create(regionName);
+  }
+
+  private Region<String, String> createRegion(String regionType, String regionName) {
+
+    String createRegionCommand = String.join(" ",
+        "create region",
+        "--name=" + regionName,
+        "--type=" + regionType);
+
+    gfshRule.execute(connectToLocatorCommand, createRegionCommand);
+
+    return clientCache.<String, String>createClientRegionFactory(PROXY).create(regionName);
+  }
+
+  private Region<String, String> createRegionInGroup(String regionType, String regionName,
+      String groupName) {
+    String createRegionCommand = String.join(" ",
+        "create region",
+        "--name=" + regionName,
+        "--type=" + regionType,
+        "--groups=" + groupName);
+
+    gfshRule.execute(connectToLocatorCommand, createRegionCommand);
+
+    return clientCache.<String, String>createClientRegionFactory(PROXY)
+        .setPoolName(server1Pool.getName())
+        .create(regionName);
+  }
+
+  private String startServerCommand(String serverName, int serverPort, File folderForServer) {
+    System.out.println("DHE: Assigning port " + serverPort + " to server " + serverName);
+    return String.join(" ",
+        "start server",
+        "--name=" + serverName,
+        "--groups=" + serverName,
+        "--dir=" + folderForServer.getAbsolutePath(),
+        "--server-port=" + serverPort,
+        "--locators=" + locatorString,
+        "--classpath=" + serviceJarPath);
+  }
+
+  private static String memberRegionEntryGaugeValueCommand(String regionName) {
+    return String.join(" ",
+        "execute function",
+        "--id=" + GetMemberRegionEntriesGaugeFunction.ID,
+        "--arguments=" + regionName);
+  }
+
+  public static class GetMemberRegionEntriesGaugeFunction implements Function<String[]> {
+
+    private static final String ID = "GetMemberRegionEntriesGaugeFunction";
+
+    @Override
+    public void execute(FunctionContext<String[]> context) {
+      String regionName = context.getArguments()[0];
+
+      Gauge memberRegionEntriesGauge = SimpleMetricsPublishingService.getRegistry()
+          .find("member.region.entries")
+          .tag("region.name", regionName)
+          .gauge();
+
+      Object result = memberRegionEntriesGauge == null
+          ? "Meter not found."
+          : memberRegionEntriesGauge.value();
+
+      context.getResultSender().lastResult(result);
+    }
+
+    @Override
+    public String getId() {
+      return ID;
+    }
+  }
+}

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/RegionEntriesGaugeTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/RegionEntriesGaugeTest.java
@@ -33,7 +33,6 @@ import java.io.StringReader;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.OptionalInt;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/rules/ServiceJarRule.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/rules/ServiceJarRule.java
@@ -47,10 +47,10 @@ public class ServiceJarRule extends ExternalResource {
     temporaryFolder.after();
   }
 
-  public <S> String createJarFor(String jarName, Class<S> serviceClass,
+  public <S> Path createJarFor(String jarName, Class<S> serviceClass,
       Class<? extends S> providerClass) {
     try {
-      return newJar(jarName, serviceClass.getName(), providerClass).toAbsolutePath().toString();
+      return newJar(jarName, serviceClass.getName(), providerClass).toAbsolutePath();
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/CopyOnReadIndexDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/CopyOnReadIndexDUnitTest.java
@@ -258,8 +258,9 @@ public class CopyOnReadIndexDUnitTest extends JUnit4CacheTestCase {
           // We had to deserialized the results from the other data nodes when we iterated through
           // the results as well as our own
           GeodeAwaitility.await()
-              .untilAsserted(verifyPortfolioCount((int) ((PartitionedRegion) region).getLocalSize()
-                  + numExpectedResults + numPortfoliosPerVM));
+              .untilAsserted(
+                  verifyPortfolioCount((int) ((PartitionedRegion) region).getLocalSizeForTest()
+                      + numExpectedResults + numPortfoliosPerVM));
         }
         return null;
       }
@@ -273,11 +274,11 @@ public class CopyOnReadIndexDUnitTest extends JUnit4CacheTestCase {
           // After vm0 executed the query, we already had the values deserialized in our cache
           // So it's the same total as before
           GeodeAwaitility.await().untilAsserted(verifyPortfolioCount(
-              (int) ((PartitionedRegion) region).getLocalSize() + numPortfoliosPerVM));
+              (int) ((PartitionedRegion) region).getLocalSizeForTest() + numPortfoliosPerVM));
         } else {
           // After vm0 executed the query, we had to deserialize the values in our vm
           GeodeAwaitility.await().untilAsserted(verifyPortfolioCount(
-              (int) ((PartitionedRegion) region).getLocalSize() + numPortfoliosPerVM));
+              (int) ((PartitionedRegion) region).getLocalSizeForTest() + numPortfoliosPerVM));
         }
         return null;
       }
@@ -320,9 +321,10 @@ public class CopyOnReadIndexDUnitTest extends JUnit4CacheTestCase {
           // Because we have no index, we have to again deserialize all the values that this vm is
           // hosting
           GeodeAwaitility.await()
-              .untilAsserted(verifyPortfolioCount((int) (((PartitionedRegion) region).getLocalSize()
-                  + ((PartitionedRegion) region).getLocalSize() + numExpectedResults
-                  + numExpectedResults + numPortfoliosPerVM)));
+              .untilAsserted(
+                  verifyPortfolioCount((int) (((PartitionedRegion) region).getLocalSizeForTest()
+                      + ((PartitionedRegion) region).getLocalSizeForTest() + numExpectedResults
+                      + numExpectedResults + numPortfoliosPerVM)));
         }
         return null;
       }

--- a/geode-core/src/distributedTest/java/org/apache/geode/disttx/DistTXDebugDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/disttx/DistTXDebugDUnitTest.java
@@ -253,8 +253,9 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
           @Override
           public Object call() throws CacheException {
             PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
-            LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSize());
-            assertEquals(0, pr1.getLocalSize());
+            LogWriterUtils.getLogWriter()
+                .info(" calling pr.getLocalSize " + pr1.getLocalSizeForTest());
+            assertEquals(0, pr1.getLocalSizeForTest());
             return null;
           }
         };
@@ -334,8 +335,9 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
       public Object call() throws CacheException {
         PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
         Region rr1 = basicGetCache().getRegion("rregion1");
-        LogWriterUtils.getLogWriter().info(" calling pr1.getLocalSize " + pr1.getLocalSize());
-        assertEquals(2, pr1.getLocalSize());
+        LogWriterUtils.getLogWriter()
+            .info(" calling pr1.getLocalSize " + pr1.getLocalSizeForTest());
+        assertEquals(2, pr1.getLocalSizeForTest());
         LogWriterUtils.getLogWriter().info(" calling rr1.size " + rr1.size());
         assertEquals(3, rr1.size());
         return null;
@@ -409,8 +411,8 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() throws CacheException {
         PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
-        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSize());
-        assertEquals(2, pr1.getLocalSize());
+        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSizeForTest());
+        assertEquals(2, pr1.getLocalSizeForTest());
 
         Region rr1 = basicGetCache().getRegion("rregion1");
         LogWriterUtils.getLogWriter().info(" calling rr.getLocalSize " + rr1.size());
@@ -469,8 +471,8 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
       public Object call() throws CacheException {
         PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
         CacheTransactionManager ctx = basicGetCache().getCacheTransactionManager();
-        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSize());
-        assertEquals(2, pr1.getLocalSize());
+        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSizeForTest());
+        assertEquals(2, pr1.getLocalSizeForTest());
         return null;
       }
     };
@@ -566,8 +568,8 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
         assertEquals(3, rr1.size());
 
         PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
-        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSize());
-        assertEquals(2, pr1.getLocalSize());
+        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSizeForTest());
+        assertEquals(2, pr1.getLocalSizeForTest());
         return null;
       }
     };
@@ -630,8 +632,8 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
         assertEquals(3, rr1.size());
 
         PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
-        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSize());
-        assertEquals(2, pr1.getLocalSize());
+        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSizeForTest());
+        assertEquals(2, pr1.getLocalSizeForTest());
         return null;
       }
     };
@@ -685,8 +687,8 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() throws CacheException {
         PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
-        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSize());
-        assertEquals(2, pr1.getLocalSize());
+        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSizeForTest());
+        assertEquals(2, pr1.getLocalSizeForTest());
         return null;
       }
     };
@@ -807,8 +809,8 @@ public class DistTXDebugDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() throws CacheException {
         PartitionedRegion pr1 = (PartitionedRegion) basicGetCache().getRegion("pregion1");
-        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSize());
-        assertEquals(0, pr1.getLocalSize());
+        LogWriterUtils.getLogWriter().info(" calling pr.getLocalSize " + pr1.getLocalSizeForTest());
+        assertEquals(0, pr1.getLocalSizeForTest());
         return null;
       }
     };

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionStatsDUnitTest.java
@@ -264,7 +264,8 @@ public class PartitionedRegionStatsDUnitTest extends CacheTestCase {
     CachePerfStats cachePerfStats = region.getCachePerfStats();
 
     assertThat(stats.getDataStoreEntryCount()).isEqualTo(expectedCount);
-    assertThat(cachePerfStats.getEntries()).isEqualTo(expectedCount);
+    long actualCount = cachePerfStats.stats.getLong(CachePerfStats.entryCountId);
+    assertThat(actualCount).isEqualTo(expectedCount);
   }
 
   private void validateTotalNumBucketsCount(final String regionName, final int expectedCount) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -22,14 +22,9 @@ import org.apache.geode.distributed.internal.PoolStatHelper;
  */
 public class DummyCachePerfStats extends CachePerfStats {
 
-  // ////////////////////// Constructors ////////////////////////
-
-  /**
-   * Creates a new <code>DummyCachePerfStats</code>
-   */
-  public DummyCachePerfStats() {}
-
-  // //////////////////// Accessing Stats //////////////////////
+  DummyCachePerfStats() {
+    super(null);
+  }
 
   @Override
   public int getLoadsCompleted() {
@@ -328,10 +323,10 @@ public class DummyCachePerfStats extends CachePerfStats {
   @Override
   public void txRollback(long opTime, long txLifeTime, int txChanges) {}
 
-  // //// Special Instance Methods /////
-
   @Override
-  void close() {}
+  protected void close() {
+    // nothing
+  }
 
   @Override
   public boolean isClosed() {
@@ -357,11 +352,6 @@ public class DummyCachePerfStats extends CachePerfStats {
 
   @Override
   public void incEntryCount(int delta) {}
-
-  @Override
-  public long getEntries() {
-    return 0;
-  }
 
   @Override
   public void incRetries() {}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -69,6 +69,8 @@ import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
 public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryContext,
     RegionAttributes, HasDiskRegion, RegionMapOwner, DiskExceptionHandler, DiskRecoveryStore {
 
+  int getLocalSize();
+
   @Override
   CachePerfStats getCachePerfStats();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -597,9 +597,10 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         cachePerfStats = cache.getCachePerfStats();
       } else {
         hasOwnStats = true;
-        cachePerfStats = new RegionPerfStats(
-            cache.getInternalDistributedSystem().getStatisticsManager(), cache.getCachePerfStats(),
-            regionName);
+        cachePerfStats =
+            new RegionPerfStats(cache.getInternalDistributedSystem().getStatisticsManager(),
+                "RegionStats-" + regionName, cache.getCachePerfStats(),
+                this, cache.getMeterRegistry());
       }
     }
 
@@ -8255,6 +8256,11 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         unlockRIReadLock();
       }
     }
+  }
+
+  @Override
+  public int getLocalSize() {
+    return getRegionMap().size() - tombstoneCount.get();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -4838,7 +4838,7 @@ public class PartitionedRegion extends LocalRegion
   /**
    * Test Method: Get the number of entries in the local data store.
    */
-  public long getLocalSize() {
+  public long getLocalSizeForTest() {
     if (this.dataStore == null) {
       return 0L;
     }
@@ -6598,6 +6598,13 @@ public class PartitionedRegion extends LocalRegion
   @Override
   public int getRegionSize() {
     return entryCount(null);
+  }
+
+  @Override
+  public int getLocalSize() {
+    return dataStore.getLocalBucket2RegionMap().values().stream()
+        .mapToInt(BucketRegion::getLocalSize)
+        .sum();
   }
 
   public int entryCount(boolean localOnly) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -204,7 +204,9 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
     // this.bucketStats = new CachePerfStats(pr.getSystem(), "partition-" + pr.getName());
     this.bucketStats =
         new RegionPerfStats(pr.getCache().getInternalDistributedSystem().getStatisticsManager(),
-            pr.getCachePerfStats(), "partition-" + pr.getName());
+            "RegionStats-partition-" + pr.getName(), pr.getCachePerfStats(),
+            pr,
+            pr.getCache().getMeterRegistry());
     this.keysOfInterest = new ConcurrentHashMap();
   }
 
@@ -2438,7 +2440,6 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
     }
     return sizeOfLocal;
   }
-
 
   /**
    * Interface for visiting buckets

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
@@ -268,7 +268,7 @@ public class PartitionedRegionHelper {
       final HasCachePerfStats prMetaStatsHolder = new HasCachePerfStats() {
         @Override
         public CachePerfStats getCachePerfStats() {
-          return new CachePerfStats(cache.getDistributedSystem(), "partitionMetaData");
+          return new CachePerfStats(cache.getDistributedSystem(), "RegionStats-partitionMetaData");
         }
       };
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionStatus.java
@@ -31,14 +31,6 @@ public class PartitionedRegionStatus extends RegionStatus {
     initialize(region);
   }
 
-  public int getNumberOfLocalEntries() {
-    return this.numberOfLocalEntries;
-  }
-
-  protected void setNumberOfLocalEntries(int numberOfLocalEntries) {
-    this.numberOfLocalEntries = numberOfLocalEntries;
-  }
-
   @Override
   public long getHeapSize() {
     return this.heapSize;
@@ -55,14 +47,10 @@ public class PartitionedRegionStatus extends RegionStatus {
     // in this VM), get the number of entries and heap size. Else,
     // set these to 0.
     PartitionedRegionDataStore ds = region.getDataStore();
-    int numLocalEntries = 0;
     long heapSize = 0;
     if (ds != null) {
-      CachePerfStats cpStats = ds.getCachePerfStats();
-      numLocalEntries = (int) cpStats.getEntries();
       heapSize = ds.currentAllocatedMemory();
     }
-    setNumberOfLocalEntries(numLocalEntries);
     setHeapSize(heapSize);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -1256,7 +1256,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       final HasCachePerfStats statsHolder = new HasCachePerfStats() {
         @Override
         public CachePerfStats getCachePerfStats() {
-          return new CachePerfStats(cache.getDistributedSystem(), META_DATA_REGION_NAME);
+          return new CachePerfStats(cache.getDistributedSystem(),
+              "RegionStats-" + META_DATA_REGION_NAME);
         }
       };
 

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/CallbackSampler.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/CallbackSampler.java
@@ -64,7 +64,7 @@ public class CallbackSampler {
     try {
       for (Statistics stats : statisticsManager.getStatsList()) {
         StatisticsImpl statistics = (StatisticsImpl) stats;
-        errors += statistics.invokeSuppliers();
+        errors += statistics.updateSuppliedValues();
         suppliers += statistics.getSupplierCount();
       }
     } catch (VirtualMachineError e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsImpl.java
@@ -40,12 +40,12 @@ import org.apache.geode.internal.util.concurrent.CopyOnWriteHashMap;
  *
  * @since GemFire 3.0
  */
-public abstract class StatisticsImpl implements Statistics {
+public abstract class StatisticsImpl implements SuppliableStatistics {
 
   private static final Logger logger = LogService.getLogger();
 
   /** The type of this statistics instance */
-  protected final StatisticsTypeImpl type;
+  protected final ValidatingStatisticsType type;
 
   /** The display name of this statistics instance */
   private final String textId;
@@ -127,7 +127,7 @@ public abstract class StatisticsImpl implements Statistics {
    */
   StatisticsImpl(StatisticsType type, String textId, long numericId, long uniqueId,
       int osStatFlags, StatisticsManager statisticsManager, StatisticsLogger statisticsLogger) {
-    this.type = (StatisticsTypeImpl) type;
+    this.type = (ValidatingStatisticsType) type;
     this.textId = StringUtils.isEmpty(textId) ? statisticsManager.getName() : textId;
     this.numericId = numericId == 0 ? statisticsManager.getPid() : numericId;
     this.uniqueId = uniqueId;
@@ -504,13 +504,8 @@ public abstract class StatisticsImpl implements Statistics {
     // nothing needed in this impl.
   }
 
-  /**
-   * Invoke sample suppliers to retrieve the current value for the suppler controlled sets and
-   * update the stats to reflect the supplied values.
-   *
-   * @return the number of callback errors that occurred while sampling stats
-   */
-  int invokeSuppliers() {
+  @Override
+  public int updateSuppliedValues() {
     int errors = 0;
     for (Map.Entry<Integer, IntSupplier> entry : intSuppliers.entrySet()) {
       try {

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsTypeImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsTypeImpl.java
@@ -32,7 +32,7 @@ import org.apache.geode.annotations.Immutable;
  * @since GemFire 3.0
  */
 @Immutable
-public class StatisticsTypeImpl implements StatisticsType {
+public class StatisticsTypeImpl implements ValidatingStatisticsType {
 
   /** The name of this statistics type */
   private final String name;
@@ -221,10 +221,12 @@ public class StatisticsTypeImpl implements StatisticsType {
     return true;
   }
 
+  @Override
   public boolean isValidLongId(int id) {
     return id < longStatCount;
   }
 
+  @Override
   public boolean isValidDoubleId(int id) {
     return longStatCount <= id && id < longStatCount + doubleStatCount;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/SuppliableStatistics.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/SuppliableStatistics.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import org.apache.geode.Statistics;
+
+public interface SuppliableStatistics extends Statistics {
+
+  /**
+   * Cast {@code Statistics} to {@code SuppliableStatistics}.
+   */
+  static SuppliableStatistics toSuppliableStatistics(Statistics statistics) {
+    return (SuppliableStatistics) statistics;
+  }
+
+  /**
+   * Invoke sample suppliers to retrieve the current value for the supplier controlled sets and
+   * update the stats to reflect the supplied values.
+   *
+   * @return the number of callback errors that occurred while sampling stats
+   */
+  int updateSuppliedValues();
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/ValidatingStatisticsType.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/ValidatingStatisticsType.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import org.apache.geode.StatisticsType;
+
+public interface ValidatingStatisticsType extends StatisticsType {
+
+  boolean isValidLongId(int id);
+
+  boolean isValidDoubleId(int id);
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -374,7 +374,8 @@ public class FederatingManager extends Manager {
 
             // Create anonymous stats holder for Management Regions
             HasCachePerfStats monitoringRegionStats =
-                () -> new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats");
+                () -> new CachePerfStats(cache.getDistributedSystem(),
+                    "RegionStats-managementRegionStats");
 
             internalRegionArguments.setCachePerfStatsHolder(monitoringRegionStats);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
@@ -118,7 +118,8 @@ public class LocalManager extends Manager {
         final HasCachePerfStats monitoringRegionStats = new HasCachePerfStats() {
           @Override
           public CachePerfStats getCachePerfStats() {
-            return new CachePerfStats(cache.getDistributedSystem(), "managementRegionStats");
+            return new CachePerfStats(cache.getDistributedSystem(),
+                "RegionStats-managementRegionStats");
           }
         };
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -26,6 +26,7 @@ import static org.apache.geode.internal.cache.CachePerfStats.deltaUpdatesId;
 import static org.apache.geode.internal.cache.CachePerfStats.deltasPreparedId;
 import static org.apache.geode.internal.cache.CachePerfStats.deltasSentId;
 import static org.apache.geode.internal.cache.CachePerfStats.destroysId;
+import static org.apache.geode.internal.cache.CachePerfStats.entryCountId;
 import static org.apache.geode.internal.cache.CachePerfStats.evictorJobsCompletedId;
 import static org.apache.geode.internal.cache.CachePerfStats.evictorJobsStartedId;
 import static org.apache.geode.internal.cache.CachePerfStats.getInitialImagesCompletedId;
@@ -53,7 +54,6 @@ import static org.apache.geode.internal.cache.CachePerfStats.updatesId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import org.junit.After;
@@ -84,13 +84,13 @@ public class CachePerfStatsTest {
     StatisticsManager statisticsManager = mock(StatisticsManager.class);
     StatisticsFactory statisticsFactory = mock(StatisticsFactory.class);
 
-    statistics = spy(new StripedStatisticsImpl(statisticsType, TEXT_ID, 1, 1, statisticsManager));
+    statistics = new StripedStatisticsImpl(statisticsType, TEXT_ID, 1, 1, statisticsManager);
 
     when(statisticsFactory.createAtomicStatistics(eq(statisticsType), eq(TEXT_ID)))
         .thenReturn(statistics);
 
     CachePerfStats.enableClockStats = true;
-    cachePerfStats = new CachePerfStats(statisticsFactory, TEXT_ID, () -> CLOCK_TIME);
+    cachePerfStats = new CachePerfStats(statisticsFactory, () -> CLOCK_TIME);
   }
 
   @After
@@ -1124,5 +1124,19 @@ public class CachePerfStatsTest {
     cachePerfStats.incDeltaFullValuesRequested();
 
     assertThat(cachePerfStats.getDeltaFullValuesRequested()).isNegative();
+  }
+
+  @Test
+  public void incEntryCount_whenDeltaIsPositive_increasesTheEntryCountStat() {
+    cachePerfStats.incEntryCount(2);
+
+    assertThat(statistics.getLong(entryCountId)).isEqualTo(2);
+  }
+
+  @Test
+  public void incEntryCount_whenDeltaIsNegative_decreasesTheEntryCountStat() {
+    cachePerfStats.incEntryCount(-2);
+
+    assertThat(statistics.getLong(entryCountId)).isEqualTo(-2);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
@@ -16,35 +16,172 @@ package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
 
+import java.util.function.LongSupplier;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
+import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
+import org.apache.geode.cache.DataPolicy;
 
 public class RegionPerfStatsTest {
 
-  private StatisticsFactory statisticsFactory;
+  private static final String REGION_NAME = "region1";
+  private static final String TEXT_ID = "textId";
+  private static final DataPolicy DATA_POLICY = DataPolicy.PERSISTENT_REPLICATE;
+
+  private MeterRegistry meterRegistry;
   private CachePerfStats cachePerfStats;
+  private InternalRegion region;
+
+  private RegionPerfStats regionPerfStats;
+  private RegionPerfStats regionPerfStats2;
+  private Statistics statistics;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(STRICT_STUBS);
 
   @Before
   public void setUp() {
-    statisticsFactory = mock(StatisticsFactory.class);
+    meterRegistry = new SimpleMeterRegistry();
     cachePerfStats = mock(CachePerfStats.class);
+    StatisticsFactory statisticsFactory = mock(StatisticsFactory.class);
+    statistics = mock(Statistics.class);
+    region = mock(InternalRegion.class);
+    when(region.getName()).thenReturn(REGION_NAME);
+    when(region.getDataPolicy()).thenReturn(DATA_POLICY);
+
+    when(statisticsFactory.createAtomicStatistics(any(), any())).thenReturn(statistics);
+
+    regionPerfStats =
+        new RegionPerfStats(statisticsFactory, TEXT_ID, cachePerfStats,
+            region, meterRegistry);
+  }
+
+  @After
+  public void closeStats() {
+    if (regionPerfStats != null) {
+      regionPerfStats.close();
+    }
+    if (regionPerfStats2 != null) {
+      regionPerfStats2.close();
+    }
   }
 
   @Test
-  public void textIdIsRegionStatsHyphenRegionName() throws Exception {
-    String theRegionName = "TheRegionName";
+  public void createsStatisticsUsingTextId() {
+    StatisticsFactory statisticsFactory = mock(StatisticsFactory.class);
+    when(statisticsFactory.createAtomicStatistics(any(), any())).thenReturn(mock(Statistics.class));
 
-    new RegionPerfStats(statisticsFactory, cachePerfStats, theRegionName, () -> 0);
+    new RegionPerfStats(statisticsFactory, TEXT_ID, cachePerfStats,
+        region, meterRegistry);
 
-    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
-    verify(statisticsFactory).createAtomicStatistics(any(), captor.capture());
+    verify(statisticsFactory).createAtomicStatistics(any(), eq(TEXT_ID));
+  }
 
-    assertThat(captor.getValue()).isEqualTo("RegionStats-" + theRegionName);
+  @Test
+  public void constructor_createsEntriesGauge_taggedWithRegionName() {
+    Gauge entriesGauge = meterRegistry
+        .find("member.region.entries")
+        .gauge();
+
+    assertThat(entriesGauge.getId().getTag("region.name"))
+        .as("region.name tag")
+        .isEqualTo(REGION_NAME);
+  }
+
+  @Test
+  public void constructor_createsEntriesGauge_taggedWithDataPolicy() {
+    Gauge entriesGauge = meterRegistry
+        .find("member.region.entries")
+        .gauge();
+    assertThat(entriesGauge.getId().getTag("data.policy"))
+        .as("data.policy tag")
+        .isEqualTo(DATA_POLICY.toString());
+  }
+
+  @Test
+  public void suppliesEntryCountStatWithRegionLocalSize() {
+    ArgumentCaptor<LongSupplier> supplierCaptor = ArgumentCaptor.forClass(LongSupplier.class);
+
+    verify(statistics).setLongSupplier(eq(RegionPerfStats.entryCountId), supplierCaptor.capture());
+
+    when(region.getLocalSize()).thenReturn(92);
+
+    assertThat(supplierCaptor.getValue().getAsLong())
+        .as("Accumulated value of supplier")
+        .isEqualTo(92);
+  }
+
+  @Test
+  public void incEntryCount_incrementsCachePerfStatsEntryCount() {
+    regionPerfStats.incEntryCount(2);
+
+    verify(cachePerfStats).incEntryCount(2);
+  }
+
+  @Test
+  public void entryCountGaugeFetchesValueFromRegionLocalSize() {
+    when(region.getLocalSize()).thenReturn(3);
+
+    Gauge entriesGauge = meterRegistry
+        .find("member.region.entries")
+        .tag("region.name", REGION_NAME)
+        .gauge();
+    assertThat(entriesGauge.value()).isEqualTo(3);
+  }
+
+  @Test
+  public void close_removesItsOwnMetersFromTheRegistry() {
+    assertThat(meterNamed("member.region.entries"))
+        .as("entries gauge before closing the stats")
+        .isNotNull();
+
+    regionPerfStats.close();
+
+    assertThat(meterNamed("member.region.entries"))
+        .as("entries gauge after closing the stats")
+        .isNull();
+
+    regionPerfStats = null;
+  }
+
+  @Test
+  public void close_doesNotRemoveMetersItDoesNotOwn() {
+    String foreignMeterName = "some.meter.not.created.by.the.gateway.receiver.stats";
+
+    Timer.builder(foreignMeterName)
+        .register(meterRegistry);
+
+    regionPerfStats.close();
+
+    assertThat(meterNamed(foreignMeterName))
+        .as("foreign meter after closing the stats")
+        .isNotNull();
+
+    regionPerfStats = null;
+  }
+
+  private Meter meterNamed(String meterName) {
+    return meterRegistry
+        .find(meterName)
+        .meter();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/CallbackSamplerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/CallbackSamplerTest.java
@@ -61,8 +61,8 @@ public class CallbackSamplerTest {
 
     StatisticsImpl stats1 = mock(StatisticsImpl.class);
     StatisticsImpl stats2 = mock(StatisticsImpl.class);
-    when(stats1.invokeSuppliers()).thenReturn(3);
-    when(stats2.invokeSuppliers()).thenReturn(2);
+    when(stats1.updateSuppliedValues()).thenReturn(3);
+    when(stats2.updateSuppliedValues()).thenReturn(2);
     when(stats1.getSupplierCount()).thenReturn(7);
     when(stats2.getSupplierCount()).thenReturn(8);
     when(statisticsManager.getStatsList()).thenReturn(Arrays.asList(stats1, stats2));

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/StatisticsImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/StatisticsImplTest.java
@@ -69,7 +69,7 @@ public class StatisticsImplTest {
     IntSupplier intSupplier = mock(IntSupplier.class);
     when(intSupplier.getAsInt()).thenReturn(23);
     statistics.setIntSupplier(4, intSupplier);
-    assertThat(statistics.invokeSuppliers()).isEqualTo(0);
+    assertThat(statistics.updateSuppliedValues()).isEqualTo(0);
 
     verify(intSupplier).getAsInt();
     assertThat(statistics.getInt(4)).isEqualTo(23);
@@ -80,7 +80,7 @@ public class StatisticsImplTest {
     LongSupplier longSupplier = mock(LongSupplier.class);
     when(longSupplier.getAsLong()).thenReturn(23L);
     statistics.setLongSupplier(4, longSupplier);
-    assertThat(statistics.invokeSuppliers()).isEqualTo(0);
+    assertThat(statistics.updateSuppliedValues()).isEqualTo(0);
 
     verify(longSupplier).getAsLong();
     assertThat(statistics.getLong(4)).isEqualTo(23L);
@@ -91,7 +91,7 @@ public class StatisticsImplTest {
     DoubleSupplier doubleSupplier = mock(DoubleSupplier.class);
     when(doubleSupplier.getAsDouble()).thenReturn(23.3);
     statistics.setDoubleSupplier(4, doubleSupplier);
-    assertThat(statistics.invokeSuppliers()).isEqualTo(0);
+    assertThat(statistics.updateSuppliedValues()).isEqualTo(0);
 
     verify(doubleSupplier).getAsDouble();
     assertThat(statistics.getDouble(4)).isEqualTo(23.3);
@@ -109,7 +109,7 @@ public class StatisticsImplTest {
     IntSupplier throwingSupplier = mock(IntSupplier.class);
     when(throwingSupplier.getAsInt()).thenThrow(NullPointerException.class);
     statistics.setIntSupplier(4, throwingSupplier);
-    assertThat(statistics.invokeSuppliers()).isEqualTo(1);
+    assertThat(statistics.updateSuppliedValues()).isEqualTo(1);
 
     verify(throwingSupplier).getAsInt();
   }
@@ -123,13 +123,13 @@ public class StatisticsImplTest {
     IntSupplier throwingSupplier = mock(IntSupplier.class);
     when(throwingSupplier.getAsInt()).thenThrow(NullPointerException.class);
     statistics.setIntSupplier(4, throwingSupplier);
-    assertThat(statistics.invokeSuppliers()).isEqualTo(1);
+    assertThat(statistics.updateSuppliedValues()).isEqualTo(1);
 
     // String message, Object p0, Object p1, Object p2
     verify(statisticsLogger).logWarning(anyString(), isNull(), anyInt(),
         isA(NullPointerException.class));
 
-    assertThat(statistics.invokeSuppliers()).isEqualTo(1);
+    assertThat(statistics.updateSuppliedValues()).isEqualTo(1);
 
     // Make sure the logger isn't invoked again
     verify(statisticsLogger).logWarning(anyString(), isNull(), anyInt(),

--- a/geode-core/src/test/java/org/apache/geode/management/bean/stats/MemberLevelStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/bean/stats/MemberLevelStatsTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.bean.stats;
 
+import static org.apache.geode.internal.statistics.SuppliableStatistics.toSuppliableStatistics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -86,7 +87,7 @@ public class MemberLevelStatsTest {
 
     statSampler.start();
 
-    cachePerfStats = new CachePerfStats(statisticsManager, "cachePerfStats", clockTime::get);
+    cachePerfStats = new CachePerfStats(statisticsManager, clockTime::get);
     funcServiceStats = new FunctionServiceStats(statisticsManager, "FunctionExecution",
         clockTime::get);
     distributionStats =
@@ -340,6 +341,7 @@ public class MemberLevelStatsTest {
   }
 
   private void sampleStats() {
+    toSuppliableStatistics(cachePerfStats.getStats()).updateSuppliedValues();
     statSampler.getSampleCollector().sample(clockTime.get());
   }
 


### PR DESCRIPTION
Add 'member.region.entries' gauge in `RegionPerfStats`:
- Add region.name and data.policy tags
- Configure the member.region.entries gauge to fetch from new `getLocalSize()` method (see below).
- Configure the 'entryCount' stat to be supplied by new `getLocalSize()` method.

Add `getLocalSize()` method to `InternalRegion`, and implement it in `LocalRegion` and `PartitionedRegion`
- In `LocalRegion`, the method returns the region map size minus the number of tombstones.
- In `PartitionedRegion`, the method sums the local sizes of all local bucket regions.

Also refactored the following:
- Reorganize `CachePerfStats`/`RegionPerfStats` constructors
- Remove `CachePerfStats.getEntries()`
- Remove use of `CachePerfStats.getEntries()` from `PartitionedRegionStatus`.
- Add `@Override` to `ValidatingStatisticsType` methods in `StatisticsTypeImpl`
- Extracted `invokeSuppliers()` to new `SuppliableStatistics` interface and rename as `updateSuppliedValues()`
- Move responsibility to prepend 'RegionStats-' onto region statistics textID into the classes that create `RegionPerfStats` and `CachePerfStats`.

Co-authored-by: Michael Oleske <moleske@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>
Co-Authored-By: Mark Hanson <mhanson@pivotal.io>
Co-Authored-By: Aaron Lindsey <alindsey@pivotal.io>

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?
