### PR TITLE
GEODE-6799: better gfsh error message when missing required parameters

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
@@ -46,7 +46,11 @@ public class GfshParser extends SimpleParser {
   public static final String J_ARGUMENT_DELIMITER = "" + ASCII_UNIT_SEPARATOR;
   public static final String J_OPTION_CONTEXT = "splittingRegex=" + J_ARGUMENT_DELIMITER;
 
+  private final CommandManager commandManager;
+
   public GfshParser(CommandManager commandManager) {
+    this.commandManager = commandManager;
+
     for (CommandMarker command : commandManager.getCommandMarkers()) {
       add(command);
     }
@@ -199,6 +203,12 @@ public class GfshParser extends SimpleParser {
     ParseResult result = super.parse(rawInput);
 
     if (result == null) {
+      // do a quick check for required arguments, since SimpleParser unhelpfully suggests everything
+      String missingHelp = commandManager.getHelper().getMiniHelp(userInput);
+      if (missingHelp != null) {
+        System.out.println(missingHelp);
+      }
+
       return null;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/help/Helper.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/help/Helper.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.shell.core.MethodTarget;
@@ -125,7 +126,7 @@ public class Helper {
   /**
    * get mini-help for commands entered without all required parameters
    *
-   * @returns null if unable to identify anything missing
+   * @return null if unable to identify anything missing
    */
   public String getMiniHelp(String userInput) {
     if (StringUtils.isBlank(userInput)) {
@@ -341,11 +342,11 @@ public class Helper {
     }
     optionNode.addChild(
         new HelpBlock(REQUIRED_SUB_NAME + ((cliOption.mandatory()) ? TRUE_TOKEN : FALSE_TOKEN)));
-    if (!isNullOrBlank(cliOption.specifiedDefaultValue())) {
+    if (isNotNullOrBlank(cliOption.specifiedDefaultValue())) {
       optionNode.addChild(
           new HelpBlock(SPECIFIEDDEFAULTVALUE_SUB_NAME + cliOption.specifiedDefaultValue()));
     }
-    if (!isNullOrBlank(cliOption.unspecifiedDefaultValue())) {
+    if (isNotNullOrBlank(cliOption.unspecifiedDefaultValue())) {
       optionNode.addChild(new HelpBlock(
           UNSPECIFIEDDEFAULTVALUE_VALUE_SUB_NAME + cliOption.unspecifiedDefaultValue()));
     }
@@ -391,7 +392,7 @@ public class Helper {
     StringBuilder buffer = new StringBuilder();
     buffer.append(GfshParser.LONG_OPTION_SPECIFIER).append(key0);
 
-    boolean hasSpecifiedDefault = !isNullOrBlank(cliOption.specifiedDefaultValue());
+    boolean hasSpecifiedDefault = isNotNullOrBlank(cliOption.specifiedDefaultValue());
 
     if (hasSpecifiedDefault) {
       buffer.append("(");
@@ -441,8 +442,8 @@ public class Helper {
     return synonyms;
   }
 
-  private static boolean isNullOrBlank(String value) {
-    return StringUtils.isBlank(value) || CliMetaData.ANNOTATION_NULL_VALUE.equals(value);
+  private static boolean isNotNullOrBlank(String value) {
+    return !StringUtils.isBlank(value) && !CliMetaData.ANNOTATION_NULL_VALUE.equals(value);
   }
 
   public Set<String> getCommands() {


### PR DESCRIPTION
This improves gfsh error in cases where required options are not given.

Before:
```describe offline-disk-store --name=foo```
```You should specify option (--disk-dirs, --pdx, --region) for this command```

After: 
```describe offline-disk-store --name=foo```
```You should specify option (--disk-dirs, --pdx, --region) for this command```
```  --disk-dirs=  is required```
```Use "help describe offline-disk-store" (without the quotes) to display detailed usage information.```

Note that the unhelpful first part that lists all possible options, including non-required, comes from a private method in spring shell, so there is no way to suppress it.  But hopefully the added helpful information will be enough to make the user less confused.