### PR TITLE
GEODE-7010: Replace static globals in CachePerfStats with StatisticsClock

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearDuringGiiOplogWithMissingCreateRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearDuringGiiOplogWithMissingCreateRegressionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,15 +39,14 @@ import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolde
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
 
 /**
- * Bug37377 DUNIT Test: The Clear operation during a GII in progress can leave a Entry in the Oplog
+ * Regression test: The Clear operation during a GII in progress can leave a Entry in the Oplog
  * due to a race condition wherein the clearFlag getting set after the entry gets written to the
  * disk, The Test verifies the existence of the scenario.
  *
  * <p>
- * TRAC #37377: Clear operation with GII in progress may result in a deleted entry to be logged in
+ * Bug: Clear operation with GII in progress may result in a deleted entry to be logged in
  * the oplog without accompanying create
  */
-
 public class ClearDuringGiiOplogWithMissingCreateRegressionTest extends CacheTestCase {
 
   private static final int PUT_COUNT = 10000;
@@ -148,7 +148,8 @@ public class ClearDuringGiiOplogWithMissingCreateRegressionTest extends CacheTes
 
     DistributedRegion distRegion = new DistributedRegion(regionName, factory.create(), null,
         getCache(), new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
-            .setSnapshotInputStream(null).setImageTarget(null));
+            .setSnapshotInputStream(null).setImageTarget(null),
+        disabledClock());
 
     distRegion.entries.setEntryFactory(new TestableDiskRegionEntryFactory());
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GiiDiskAccessExceptionRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GiiDiskAccessExceptionRegressionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -43,12 +44,9 @@ import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
  * Tests that if a node doing GII experiences DiskAccessException, it should also not try to recover
  * from the disk
  *
- * GiiDiskAccessExceptionRegressionTest
- *
  * <p>
- * TRAC #39079: Regions with persistence remain in use after IOException have occurred
+ * Bug: Regions with persistence remain in use after IOException have occurred
  */
-
 public class GiiDiskAccessExceptionRegressionTest extends CacheTestCase {
 
   private String uniqueName;
@@ -133,7 +131,8 @@ public class GiiDiskAccessExceptionRegressionTest extends CacheTestCase {
 
     DistributedRegion distributedRegion = new DistributedRegion(uniqueName, factory.create(), null,
         getCache(), new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
-            .setSnapshotInputStream(null).setImageTarget(null));
+            .setSnapshotInputStream(null).setImageTarget(null),
+        disabledClock());
 
     distributedRegion.entries.setEntryFactory(new DiskRegionEntryThrowsFactory());
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAConflationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAConflationDUnitTest.java
@@ -130,7 +130,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
 
   /**
    * In this test do a create & then update on same key , the client should receive 2 calabcks.
-   *
    */
 
   @Test
@@ -146,7 +145,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
   /**
    * In this test do create , then update & update. The client should receive 2 callbacks , one for
    * create & one for the last update.
-   *
    */
   @Test
   public void testConflationUpdate() throws Exception {
@@ -169,7 +167,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
   /**
    * In this test do create , then update, update, invalidate. The client should receive 3
    * callbacks, one for create one for the last update and one for the invalidate.
-   *
    */
   @Test
   public void testConflationCreateUpdateInvalidate() throws Exception {
@@ -187,7 +184,6 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
   /**
    * In this test do a create , update , update & destroy. The client should receive 3 callbacks (
    * craete , conflated update & destroy).
-   *
    */
   @Test
   public void testConflationCreateUpdateDestroy() throws Exception {
@@ -348,86 +344,83 @@ public class HAConflationDUnitTest extends JUnit4CacheTestCase {
     return new Integer(server.getPort());
   }
 
-}
+  private static class HAClientCountEventListener implements CacheListener, Declarable {
 
-
-class HAClientCountEventListener implements CacheListener, Declarable {
-
-  @Override
-  public void afterCreate(EntryEvent event) {
-    String key = (String) event.getKey();
-    if (key.equals(HAConflationDUnitTest.LAST_KEY)) {
-      synchronized (HAConflationDUnitTest.LOCK) {
-        HAConflationDUnitTest.lastKeyArrived = true;
-        HAConflationDUnitTest.LOCK.notifyAll();
+    @Override
+    public void afterCreate(EntryEvent event) {
+      String key = (String) event.getKey();
+      if (key.equals(LAST_KEY)) {
+        synchronized (LOCK) {
+          lastKeyArrived = true;
+          LOCK.notifyAll();
+        }
+      } else {
+        actualNoEvents++;
       }
-    } else {
-      HAConflationDUnitTest.actualNoEvents++;
+
     }
 
-  }
+    @Override
+    public void afterUpdate(EntryEvent event) {
 
-  @Override
-  public void afterUpdate(EntryEvent event) {
+      actualNoEvents++;
 
-    HAConflationDUnitTest.actualNoEvents++;
+    }
 
-  }
+    @Override
+    public void afterInvalidate(EntryEvent event) {
 
-  @Override
-  public void afterInvalidate(EntryEvent event) {
+      actualNoEvents++;
 
-    HAConflationDUnitTest.actualNoEvents++;
+    }
 
-  }
+    @Override
+    public void afterDestroy(EntryEvent event) {
+      actualNoEvents++;
 
-  @Override
-  public void afterDestroy(EntryEvent event) {
-    HAConflationDUnitTest.actualNoEvents++;
+    }
 
-  }
+    @Override
+    public void afterRegionInvalidate(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionInvalidate(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionDestroy(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionDestroy(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionClear(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionClear(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionCreate(RegionEvent event) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void afterRegionCreate(RegionEvent event) {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void afterRegionLive(RegionEvent event) {
+      // TODO NOT Auto-generated method stub, added by vrao
 
-  @Override
-  public void afterRegionLive(RegionEvent event) {
-    // TODO NOT Auto-generated method stub, added by vrao
-
-  }
+    }
 
 
+    @Override
+    public void close() {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void close() {
-    // TODO Auto-generated method stub
+    }
 
-  }
+    @Override
+    public void init(Properties props) {
+      // TODO Auto-generated method stub
 
-  @Override
-  public void init(Properties props) {
-    // TODO Auto-generated method stub
-
+    }
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HADuplicateDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HADuplicateDUnitTest.java
@@ -275,35 +275,32 @@ public class HADuplicateDUnitTest extends JUnit4DistributedTestCase {
       cache.getDistributedSystem().disconnect();
     }
   }
-}
 
-// TODO: move these classes to be inner static classes
-
-
-// Listener class for the validation purpose
-class HAValidateDuplicateListener extends CacheListenerAdapter {
-  @Override
-  public void afterCreate(EntryEvent event) {
-    System.out.println("After Create");
-    HADuplicateDUnitTest.storeEvents.put(event.getKey(), event.getNewValue());
-  }
-
-  @Override
-  public void afterUpdate(EntryEvent event) {
-    Object value = HADuplicateDUnitTest.storeEvents.get(event.getKey());
-    if (value == null)
-      HADuplicateDUnitTest.isEventDuplicate = false;
-    synchronized (HADuplicateDUnitTest.dummyObj) {
-      try {
-        HADuplicateDUnitTest.put_counter++;
-        if (HADuplicateDUnitTest.put_counter == HADuplicateDUnitTest.NO_OF_PUTS) {
-          HADuplicateDUnitTest.waitFlag = false;
-          HADuplicateDUnitTest.dummyObj.notifyAll();
-        }
-      } catch (Exception e) {
-        e.printStackTrace();
-      }
+  // Listener class for the validation purpose
+  private static class HAValidateDuplicateListener extends CacheListenerAdapter {
+    @Override
+    public void afterCreate(EntryEvent event) {
+      System.out.println("After Create");
+      storeEvents.put(event.getKey(), event.getNewValue());
     }
 
+    @Override
+    public void afterUpdate(EntryEvent event) {
+      Object value = storeEvents.get(event.getKey());
+      if (value == null)
+        isEventDuplicate = false;
+      synchronized (dummyObj) {
+        try {
+          put_counter++;
+          if (put_counter == NO_OF_PUTS) {
+            waitFlag = false;
+            dummyObj.notifyAll();
+          }
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      }
+
+    }
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAExpiryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAExpiryDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.createRegionName;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.Properties;
@@ -60,13 +61,13 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 @Category({ClientSubscriptionTest.class})
 public class HAExpiryDUnitTest extends JUnit4DistributedTestCase {
 
-  VM vm0 = null;
+  private VM vm0 = null;
 
-  VM vm1 = null;
+  private VM vm1 = null;
 
-  VM vm2 = null;
+  private VM vm2 = null;
 
-  VM vm3 = null;
+  private VM vm3 = null;
 
   protected static InternalCache cache = null;
 
@@ -74,13 +75,7 @@ public class HAExpiryDUnitTest extends JUnit4DistributedTestCase {
 
   private static final String REGION_NAME = "HAExpiryDUnitTest_region";
 
-  static RegionQueue regionqueue = null;
-
-  protected static int regionQueueSize = -1;
-
-  public HAExpiryDUnitTest() {
-    super();
-  }
+  private static int regionQueueSize = -1;
 
   /**
    * This function creates regionqueue on 4 VMs
@@ -178,7 +173,7 @@ public class HAExpiryDUnitTest extends JUnit4DistributedTestCase {
    * This function checks the regionqueue size before expiration. size should be > 0.
    *
    */
-  public static void checkSizeBeforeExpiration() throws Exception {
+  private static void checkSizeBeforeExpiration() throws Exception {
     HARegion regionForQueue = (HARegion) cache
         .getRegion(SEPARATOR + createRegionName(regionQueueName));
     final HARegionQueue regionqueue = regionForQueue.getOwner();
@@ -205,7 +200,7 @@ public class HAExpiryDUnitTest extends JUnit4DistributedTestCase {
    * This function checks the regionqueue size After expiration. size should be = 0.
    *
    */
-  public static void checkSizeAfterExpiration() throws Exception {
+  private static void checkSizeAfterExpiration() throws Exception {
 
     HARegion regionForQueue = (HARegion) cache
         .getRegion(SEPARATOR + createRegionName(regionQueueName));
@@ -239,13 +234,13 @@ public class HAExpiryDUnitTest extends JUnit4DistributedTestCase {
     assertNotNull(cache);
   }
 
-  public static void createRegionQueue(Boolean isDurable) throws Exception {
+  private static void createRegionQueue(Boolean isDurable) throws Exception {
     new HAExpiryDUnitTest().createCache(new Properties());
     HARegionQueueAttributes hattr = new HARegionQueueAttributes();
     // setting expiry time for the regionqueue.
     hattr.setExpiryTime(4);
     RegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(regionQueueName, cache, hattr,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, isDurable.booleanValue());
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, isDurable.booleanValue(), disabledClock());
     assertNotNull(regionqueue);
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -224,7 +225,8 @@ public class HARegionDUnitTest extends JUnit4DistributedTestCase {
     when(harq.updateHAEventWrapper(any(), any(), any()))
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
 
-    HARegion.getInstance(REGION_NAME, (GemFireCacheImpl) cache, harq, factory.create());
+    HARegion.getInstance(REGION_NAME, (GemFireCacheImpl) cache, harq, factory.create(),
+        disabledClock());
   }
 
   private static HARegionQueue hrq = null;
@@ -239,7 +241,7 @@ public class HARegionDUnitTest extends JUnit4DistributedTestCase {
      * factory.setDataPolicy(DataPolicy.REPLICATE);
      */
     hrq = HARegionQueue.getHARegionQueueInstance(REGION_NAME, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     EventID id1 = new EventID(new byte[] {1}, 1, 1);
     EventID id2 = new EventID(new byte[] {1}, 1, 2);
     ConflatableObject c1 = new ConflatableObject("1", "1", id1, false, REGION_NAME);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache.ha;
 import static java.lang.Thread.yield;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.NON_BLOCKING_HA_QUEUE;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.getHARegionQueueInstance;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertNotNull;
@@ -219,7 +220,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
             hrqa.setExpiryTime(300);
             try {
               hrq = HARegionQueue.getHARegionQueueInstance("testregion1", cache, hrqa,
-                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
               // Do 1000 putand 100 take in a separate thread
               hrq.put(new ConflatableObject(new Long(1), new Long(1),
                   new EventID(new byte[] {0}, 1, 1), false, "dummy"));
@@ -281,7 +282,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
 
     HARegion.getInstance("HARegionQueueDUnitTest_region", (GemFireCacheImpl) cache, harq,
-        factory.create());
+        factory.create(), disabledClock());
   }
 
   private static void createRegionQueue() throws Exception {
@@ -292,7 +293,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
      * factory.setDataPolicy(DataPolicy.REPLICATE);
      */
     hrq = HARegionQueue.getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     EventID id1 = new EventID(new byte[] {1}, 1, 1);
     EventID id2 = new EventID(new byte[] {1}, 1, 2);
     ConflatableObject c1 =
@@ -313,7 +314,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
     HARegionQueueAttributes harqAttr = new HARegionQueueAttributes();
     harqAttr.setExpiryTime(3);
     hrq = HARegionQueue.getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache, harqAttr,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
   }
 
   private static void clearRegion() {
@@ -592,10 +593,10 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
         try {
           if (createBlockingQueue) {
             hrq = HARegionQueue.getHARegionQueueInstance("testregion1", cache, hrqa,
-                HARegionQueue.BLOCKING_HA_QUEUE, false);
+                HARegionQueue.BLOCKING_HA_QUEUE, false, disabledClock());
           } else {
             hrq = HARegionQueue.getHARegionQueueInstance("testregion1", cache, hrqa,
-                HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
           }
         } catch (Exception e) {
           throw new AssertionError(e);
@@ -777,7 +778,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
             try {
               hrq = HARegionQueue.getHARegionQueueInstance(
                   "testNPEDueToHARegionQueueEscapeInConstructor", cache, hrqa,
-                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
               // changing OP_COUNT to 20 makes no difference in test time
               final int OP_COUNT = 200;
               // Do 1000 putand 100 take in a separate thread
@@ -824,7 +825,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
             try {
               hrq = HARegionQueue.getHARegionQueueInstance(
                   "testNPEDueToHARegionQueueEscapeInConstructor", cache, hrqa,
-                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+                  HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
             } catch (Exception e) {
               throw new AssertionError(e);
             }
@@ -955,7 +956,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
     HARegionQueueAttributes attrs = new HARegionQueueAttributes();
     attrs.setExpiryTime(1);
     hrq = getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache, attrs,
-        NON_BLOCKING_HA_QUEUE, false);
+        NON_BLOCKING_HA_QUEUE, false, disabledClock());
     // wait until we have a dead
     // server
     WaitCriterion ev = new WaitCriterion() {
@@ -987,7 +988,7 @@ public class HARegionQueueDUnitTest extends JUnit4DistributedTestCase {
     cache = test.createCache();
 
     hrq = HARegionQueue.getHARegionQueueInstance("HARegionQueueDUnitTest_region", cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
 
     assertEquals(2, hrq.size());
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/HABug36738DUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/HABug36738DUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
 import static org.junit.Assert.assertEquals;
@@ -124,7 +125,7 @@ public class HABug36738DUnitTest extends JUnit4DistributedTestCase {
         .thenAnswer(AdditionalAnswers.returnsSecondArg());
 
     haRegion = HARegion.getInstance(HAREGION_NAME, (GemFireCacheImpl) cache, harq,
-        factory.createRegionAttributes());
+        factory.createRegionAttributes(), disabledClock());
   }
 
   private void checkRegionQueueSize() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImplJUnitTest.java
@@ -47,7 +47,9 @@ public class SerialAsyncEventQueueImplJUnitTest {
   public void testStopClearsStats() {
     GatewaySenderAttributes attrs = new GatewaySenderAttributes();
     attrs.id = AsyncEventQueueImpl.ASYNC_EVENT_QUEUE_PREFIX + "id";
-    SerialAsyncEventQueueImpl queue = new SerialAsyncEventQueueImpl(cache, attrs);
+    SerialAsyncEventQueueImpl queue = new SerialAsyncEventQueueImpl(cache,
+        cache.getInternalDistributedSystem().getStatisticsManager(), cache.getStatisticsClock(),
+        attrs);
     queue.getStatistics().incQueueSize(5);
     queue.getStatistics().incSecondaryQueueSize(6);
     queue.getStatistics().incTempQueueSize(10);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/LRUClearWithDiskRegionOpRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/LRUClearWithDiskRegionOpRegressionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -83,7 +84,7 @@ public class LRUClearWithDiskRegionOpRegressionTest {
         .setRecreateFlag(false).setSnapshotInputStream(null).setImageTarget(null);
 
     DistributedRegion distributedRegion =
-        new DistributedRegion(regionName, regionAttributes, null, cache, args);
+        new DistributedRegion(regionName, regionAttributes, null, cache, args, disabledClock());
 
     region = cache.createVMRegion(regionName, regionAttributes,
         new InternalRegionArguments().setInternalMetaRegion(distributedRegion)

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PRTXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PRTXJUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -88,7 +90,7 @@ public class PRTXJUnitTest extends TXJUnitTest {
 
     PRWithLocalOps(String regionName, RegionAttributes ra, LocalRegion parentRegion,
         GemFireCacheImpl cache, InternalRegionArguments internalRegionArgs) {
-      super(regionName, ra, parentRegion, cache, internalRegionArgs);
+      super(regionName, ra, parentRegion, cache, internalRegionArgs, disabledClock());
     }
 
     @Override

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionDataStoreJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionDataStoreJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -79,7 +80,7 @@ public class PartitionedRegionDataStoreJUnitTest {
     PartitionedRegion pr = null;
     pr = (PartitionedRegion) cache.createRegion("PR2", ra);
     paf.setLocalProperties(null).create();
-    /* PartitionedRegionDataStore prDS = */ new PartitionedRegionDataStore(pr);
+    /* PartitionedRegionDataStore prDS = */ new PartitionedRegionDataStore(pr, disabledClock());
     /*
      * PartitionedRegionHelper.removeGlobalMetadataForFailedNode(PartitionedRegion.node,
      * prDS.partitionedRegion.getRegionIdentifier(), prDS.partitionedRegion.cache);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ServerBuilderIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ServerBuilderIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
 import org.apache.geode.internal.cache.tier.Acceptor;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category(ClientServerTest.class)
@@ -64,8 +65,9 @@ public class ServerBuilderIntegrationTest {
 
   @Test
   public void byDefaultCreatesServerWithCacheServerAcceptor() throws IOException {
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .createServer();
     server.setPort(0);
 
     server.start();
@@ -78,9 +80,10 @@ public class ServerBuilderIntegrationTest {
   public void forGatewayReceiverCreatesServerWithGatewayReceiverAcceptor() throws IOException {
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .forGatewayReceiver(gatewayReceiver)
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .forGatewayReceiver(gatewayReceiver)
+            .createServer();
     server.setPort(0);
 
     server.start();
@@ -94,8 +97,9 @@ public class ServerBuilderIntegrationTest {
     cache.close();
     String membershipGroup = "group-m0";
     cache = (InternalCache) new CacheFactory().set(GROUPS, membershipGroup).create();
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .createServer();
 
     assertThat(server.getCombinedGroups()).containsExactly(membershipGroup);
   }
@@ -107,9 +111,10 @@ public class ServerBuilderIntegrationTest {
     cache.close();
     String membershipGroup = "group-m0";
     cache = (InternalCache) new CacheFactory().set(GROUPS, membershipGroup).create();
-    server = new ServerBuilder(cache, cache.getSecurityService())
-        .forGatewayReceiver(gatewayReceiver)
-        .createServer();
+    server = new ServerBuilder(cache, cache.getSecurityService(),
+        StatisticsClockFactory.disabledClock())
+            .forGatewayReceiver(gatewayReceiver)
+            .createServer();
 
     assertThat(server.getCombinedGroups()).doesNotContain(membershipGroup);
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQAddOperationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQAddOperationJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -51,7 +52,8 @@ public class BlockingHARQAddOperationJUnitTest extends HARQAddOperationJUnitTest
   protected HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue =
-        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false,
+            disabledClock());
     return regionqueue;
   }
 
@@ -64,7 +66,7 @@ public class BlockingHARQAddOperationJUnitTest extends HARQAddOperationJUnitTest
   protected HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.BLOCKING_HA_QUEUE, false, disabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQStatsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARQStatsJUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.io.IOException;
 
 import org.junit.experimental.categories.Category;
@@ -40,7 +42,8 @@ public class BlockingHARQStatsJUnitTest extends HARegionQueueStatsJUnitTest {
   protected HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue =
-        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.getHARegionQueueInstance(name, cache, HARegionQueue.BLOCKING_HA_QUEUE, false,
+            disabledClock());
     return regionqueue;
   }
 
@@ -55,7 +58,7 @@ public class BlockingHARQStatsJUnitTest extends HARegionQueueStatsJUnitTest {
   protected HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.BLOCKING_HA_QUEUE, false);
+        HARegionQueue.BLOCKING_HA_QUEUE, false, disabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/BlockingHARegionJUnitTest.java
@@ -18,6 +18,7 @@ import static java.lang.Thread.sleep;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.BLOCKING_HA_QUEUE;
 import static org.apache.geode.internal.cache.ha.HARegionQueue.getHARegionQueueInstance;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.dunit.ThreadUtils.join;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -72,7 +73,7 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(1);
     HARegionQueue hrq = HARegionQueue.getHARegionQueueInstance("BlockingHARegionJUnitTest_Region",
-        cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false, disabledClock());
     hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
     Thread thread1 = new DoPuts(hrq, 1000);
     Thread thread2 = new DoTake(hrq, 1000);
@@ -105,7 +106,8 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(1);
     final HARegionQueue hrq = getHARegionQueueInstance(
-        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false);
+        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false,
+        disabledClock());
     hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
     final Thread thread1 = new DoPuts(hrq, 2);
     thread1.start();
@@ -176,7 +178,8 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(10000);
     final HARegionQueue hrq = getHARegionQueueInstance(
-        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false);
+        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false,
+        disabledClock());
     hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
     Thread thread1 = new DoPuts(hrq, 20000, 1);
     Thread thread2 = new DoPuts(hrq, 20000, 2);
@@ -246,7 +249,8 @@ public class BlockingHARegionJUnitTest {
     HARegionQueueAttributes harqa = new HARegionQueueAttributes();
     harqa.setBlockingQueueCapacity(10000);
     final HARegionQueue hrq = getHARegionQueueInstance(
-        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false);
+        "BlockingHARegionJUnitTest_Region", cache, harqa, BLOCKING_HA_QUEUE, false,
+        disabledClock());
     Thread thread1 = new DoPuts(hrq, 40000, 1);
     Thread thread2 = new DoPuts(hrq, 40000, 2);
     Thread thread3 = new DoPuts(hrq, 40000, 3);
@@ -336,7 +340,8 @@ public class BlockingHARegionJUnitTest {
       harqa.setBlockingQueueCapacity(1);
       harqa.setExpiryTime(180);
       final HARegionQueue hrq = HARegionQueue.getHARegionQueueInstance(
-          "BlockingHARegionJUnitTest_Region", cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false);
+          "BlockingHARegionJUnitTest_Region", cache, harqa, HARegionQueue.BLOCKING_HA_QUEUE, false,
+          disabledClock());
       hrq.setPrimary(true);// fix for 40314 - capacity constraint is checked for primary only.
       final EventID id1 = new EventID(new byte[] {1}, 1, 2); // violation
       final EventID ignore = new EventID(new byte[] {1}, 1, 1); //

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARQAddOperationJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -111,7 +112,7 @@ public class HARQAddOperationJUnitTest {
     factory.setDataPolicy(DataPolicy.REPLICATE);
     factory.setScope(Scope.DISTRIBUTED_ACK);
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     return regionqueue;
   }
 
@@ -121,7 +122,7 @@ public class HARQAddOperationJUnitTest {
   protected HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     return regionqueue;
   }
 
@@ -891,7 +892,7 @@ public class HARQAddOperationJUnitTest {
       HARegionQueueAttributes attrs = new HARegionQueueAttributes();
       attrs.setExpiryTime(10);
       final HARegionQueue regionqueue =
-          new HARegionQueue.TestOnlyHARegionQueue("testing", cache, attrs) {
+          new TestOnlyHARegionQueue("testing", cache, attrs, disabledClock()) {
             @Override
             CacheListener createCacheListenerForHARegion() {
               return new CacheListenerAdapter() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -100,7 +101,8 @@ public class HARegionJUnitTest {
     });
     RegionAttributes ra = factory.create();
     Region region =
-        HARegion.getInstance("HARegionJUnitTest_region", (GemFireCacheImpl) cache, null, ra);
+        HARegion.getInstance("HARegionJUnitTest_region", (GemFireCacheImpl) cache, null, ra,
+            disabledClock());
     region.getAttributesMutator().setEntryTimeToLive(ea);
     return region;
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -50,8 +49,6 @@ import org.mockito.MockitoAnnotations;
 import util.TestException;
 
 import org.apache.geode.CancelCriterion;
-import org.apache.geode.Statistics;
-import org.apache.geode.StatisticsType;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -61,12 +58,7 @@ import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
-import org.apache.geode.distributed.internal.DSClock;
-import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.DistributionManager;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.SystemTimer;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.CachedDeserializable;
@@ -86,6 +78,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
 import org.apache.geode.internal.concurrent.ConcurrentHashSet;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock;
 
@@ -108,7 +101,6 @@ public class HARegionQueueIntegrationTest {
     dataRegion = createDataRegion();
     ccn = createCacheClientNotifier();
     member = createMember();
-    HAContainerWrapper haContainerWrapper = (HAContainerWrapper) ccn.getHaContainer();
   }
 
   @After
@@ -125,38 +117,11 @@ public class HARegionQueueIntegrationTest {
     return cache.createRegionFactory(RegionShortcut.REPLICATE).create("data");
   }
 
-  private InternalCache createMockInternalCache() {
-    InternalCache mockInternalCache = mock(InternalCache.class);
-    doReturn(mock(SystemTimer.class)).when(mockInternalCache).getCCPTimer();
-    doReturn(mock(CancelCriterion.class)).when(mockInternalCache).getCancelCriterion();
-
-    InternalDistributedSystem mockInteralDistributedSystem = createMockInternalDistributedSystem();
-    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getInternalDistributedSystem();
-    doReturn(mockInteralDistributedSystem).when(mockInternalCache).getDistributedSystem();
-
-    return mockInternalCache;
-  }
-
-  private InternalDistributedSystem createMockInternalDistributedSystem() {
-    InternalDistributedSystem mockInternalDistributedSystem =
-        mock(InternalDistributedSystem.class);
-    DistributionManager mockDistributionManager = mock(DistributionManager.class);
-
-    doReturn(mock(InternalDistributedMember.class)).when(mockInternalDistributedSystem)
-        .getDistributedMember();
-    doReturn(mock(Statistics.class)).when(mockInternalDistributedSystem)
-        .createAtomicStatistics(any(StatisticsType.class), any(String.class));
-    doReturn(mock(DistributionConfig.class)).when(mockDistributionManager).getConfig();
-    doReturn(mockDistributionManager).when(mockInternalDistributedSystem).getDistributionManager();
-    doReturn(mock(DSClock.class)).when(mockInternalDistributedSystem).getClock();
-
-    return mockInternalDistributedSystem;
-  }
-
   private CacheClientNotifier createCacheClientNotifier() {
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance((InternalCache) cache, mock(CacheServerStats.class),
-            100000, 100000, mock(ConnectionListener.class), null, false);
+        CacheClientNotifier.getInstance((InternalCache) cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 100000, 100000, mock(ConnectionListener.class), null,
+            false);
     return ccn;
   }
 
@@ -653,7 +618,7 @@ public class HARegionQueueIntegrationTest {
 
     return new HARegionQueue("haRegion+" + index, haRegion, (InternalCache) cache, haContainer,
         null, (byte) 1, true, mock(HARegionQueueStats.class), giiLock, rwLock,
-        mock(CancelCriterion.class), puttingGIIDataInQueue);
+        mock(CancelCriterion.class), puttingGIIDataInQueue, mock(StatisticsClock.class));
   }
 
   private HARegionQueue createHARegionQueue(Map haContainer, int index) throws Exception {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache.ha;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -188,7 +189,7 @@ public class HARegionQueueJUnitTest {
   @Test
   public void testBlockQueue() throws Exception {
     HARegionQueue regionQueue = HARegionQueue.getHARegionQueueInstance(testName.getMethodName(),
-        cache, HARegionQueue.BLOCKING_HA_QUEUE, false);
+        cache, HARegionQueue.BLOCKING_HA_QUEUE, false, disabledClock());
     Thread[] threads = new Thread[10];
     int threadsLength = threads.length;
     CyclicBarrier barrier = new CyclicBarrier(threadsLength + 1);
@@ -1075,7 +1076,8 @@ public class HARegionQueueJUnitTest {
   @Test
   public void testBlockingQueueForConcurrentPeekAndTake() throws Exception {
     TestBlockingHARegionQueue regionQueue =
-        new TestBlockingHARegionQueue("testBlockQueueForConcurrentPeekAndTake", cache);
+        new TestBlockingHARegionQueue("testBlockQueueForConcurrentPeekAndTake", cache,
+            disabledClock());
     Thread[] threads = new Thread[3];
 
     for (int i = 0; i < 3; i++) {
@@ -1136,7 +1138,8 @@ public class HARegionQueueJUnitTest {
   @Test
   public void testBlockingQueueForTakeWhenPeekInProgress() throws Exception {
     TestBlockingHARegionQueue regionQueue =
-        new TestBlockingHARegionQueue("testBlockQueueForTakeWhenPeekInProgress", cache);
+        new TestBlockingHARegionQueue("testBlockQueueForTakeWhenPeekInProgress", cache,
+            disabledClock());
     Thread[] threads = new Thread[3];
 
     for (int i = 0; i < 3; i++) {
@@ -1209,7 +1212,8 @@ public class HARegionQueueJUnitTest {
     haa.setExpiryTime(3);
 
     RegionQueue regionqueue =
-        new HARegionQueue.TestOnlyHARegionQueue(testName.getMethodName(), cache, haa) {
+        new TestOnlyHARegionQueue(testName.getMethodName(), cache, haa,
+            disabledClock()) {
           @Override
           CacheListener createCacheListenerForHARegion() {
 
@@ -1333,10 +1337,10 @@ public class HARegionQueueJUnitTest {
 
     if (createBlockingQueue) {
       return HARegionQueue.getHARegionQueueInstance(testName.getMethodName(), cache, haa,
-          HARegionQueue.BLOCKING_HA_QUEUE, false);
+          HARegionQueue.BLOCKING_HA_QUEUE, false, disabledClock());
     } else {
       return HARegionQueue.getHARegionQueueInstance(testName.getMethodName(), cache, haa,
-          HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+          HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     }
   }
 
@@ -1852,7 +1856,7 @@ public class HARegionQueueJUnitTest {
    */
   private HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType(), false);
+    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType(), false, disabledClock());
   }
 
   /**
@@ -1860,7 +1864,7 @@ public class HARegionQueueJUnitTest {
    */
   private HARegionQueue createHARegionQueue(String name, int queueType)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType, false);
+    return HARegionQueue.getHARegionQueueInstance(name, cache, queueType, false, disabledClock());
   }
 
   /**
@@ -1868,7 +1872,8 @@ public class HARegionQueueJUnitTest {
    */
   HARegionQueue createHARegionQueue(String name, HARegionQueueAttributes attrs)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    return HARegionQueue.getHARegionQueueInstance(name, cache, attrs, queueType(), false);
+    return HARegionQueue.getHARegionQueueInstance(name, cache, attrs, queueType(), false,
+        disabledClock());
   }
 
   /**
@@ -1892,11 +1897,11 @@ public class HARegionQueueJUnitTest {
   /**
    * Extends HARegionQueue for testing purposes. used by testSafeConflationRemoval
    */
-  static class HARQTestClass extends HARegionQueue.TestOnlyHARegionQueue {
+  static class HARQTestClass extends TestOnlyHARegionQueue {
 
     HARQTestClass(String regionName, InternalCache cache)
         throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      super(regionName, cache);
+      super(regionName, cache, disabledClock());
     }
 
     @Override

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStartStopJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStartStopJUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class HARegionQueueStartStopJUnitTest {
   private RegionQueue createHARegionQueue(String name, InternalCache cache)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     RegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStatsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueStatsJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -85,7 +86,7 @@ public class HARegionQueueStatsJUnitTest {
   protected HARegionQueue createHARegionQueue(String name)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     return regionqueue;
   }
 
@@ -102,7 +103,7 @@ public class HARegionQueueStatsJUnitTest {
     factory.setDataPolicy(DataPolicy.REPLICATE);
     factory.setScope(Scope.DISTRIBUTED_ACK);
     HARegionQueue regionqueue = HARegionQueue.getHARegionQueueInstance(name, cache, attrs,
-        HARegionQueue.NON_BLOCKING_HA_QUEUE, false);
+        HARegionQueue.NON_BLOCKING_HA_QUEUE, false, disabledClock());
     return regionqueue;
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.net.SocketCloser;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
@@ -49,7 +50,6 @@ public class CacheClientProxyTest {
 
   @Test
   public void closeSocketShouldBeAtomic() {
-
     final CacheServerStats stats = mock(CacheServerStats.class);
     doNothing().when(stats).incCurrentQueueConnections();
 
@@ -73,7 +73,7 @@ public class CacheClientProxyTest {
 
     CacheClientProxy proxy = new CacheClientProxy(ccn, socket, proxyID, true,
         Handshake.CONFLATION_DEFAULT, Version.CURRENT, 1L, true,
-        null, null);
+        null, null, mock(StatisticsClock.class));
 
     CompletableFuture<Void> result1 = executorServiceRule.runAsync(() -> proxy.close());
     CompletableFuture<Void> result2 = executorServiceRule.runAsync(() -> proxy.close());
@@ -93,5 +93,4 @@ public class CacheClientProxyTest {
       closeSocketShouldBeAtomic();
     }
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/AsyncEventQueueStatsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/AsyncEventQueueStatsJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.bean.stats;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -33,7 +34,7 @@ public class AsyncEventQueueStatsJUnitTest extends MBeanStatsTestCase {
 
   @Override
   public void init() {
-    asyncEventQueueStats = new AsyncEventQueueStats(system, "test");
+    asyncEventQueueStats = new AsyncEventQueueStats(system, "test", disabledClock());
 
     bridge = new AsyncEventQueueMBeanBridge();
     bridge.addAsyncEventQueueStats(asyncEventQueueStats);

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayMBeanBridgeJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/bean/stats/GatewayMBeanBridgeJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.bean.stats;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +41,7 @@ public class GatewayMBeanBridgeJUnitTest extends MBeanStatsTestCase {
 
   @Override
   public void init() {
-    senderStats = new GatewaySenderStats(system, "test");
+    senderStats = new GatewaySenderStats(system, "gatewaySenderStats-", "test", disabledClock());
 
     sender = Mockito.mock(AbstractGatewaySender.class);
     Mockito.when(sender.getStatistics()).thenReturn(senderStats);

--- a/geode-core/src/main/java/org/apache/geode/cache/DynamicRegionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/DynamicRegionFactory.java
@@ -879,7 +879,8 @@ public abstract class DynamicRegionFactory {
   // the meta data
   private class LocalMetaRegion extends LocalRegion {
     protected LocalMetaRegion(RegionAttributes attrs, InternalRegionArguments ira) {
-      super(DYNAMIC_REGION_LIST_NAME, attrs, null, DynamicRegionFactory.this.cache, ira);
+      super(DYNAMIC_REGION_LIST_NAME, attrs, null, DynamicRegionFactory.this.cache, ira,
+          DynamicRegionFactory.this.cache.getStatisticsClock());
       Assert.assertTrue(attrs.getScope().isLocal());
     }
 
@@ -989,7 +990,7 @@ public abstract class DynamicRegionFactory {
   private class DistributedMetaRegion extends DistributedRegion {
     protected DistributedMetaRegion(RegionAttributes attrs) {
       super(DYNAMIC_REGION_LIST_NAME, attrs, null, DynamicRegionFactory.this.cache,
-          new InternalRegionArguments());
+          new InternalRegionArguments(), DynamicRegionFactory.this.cache.getStatisticsClock());
     }
 
     // This is an internal uses only region

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueFactoryImpl.java
@@ -204,7 +204,9 @@ public class AsyncEventQueueFactoryImpl implements AsyncEventQueueFactory {
       if (cache instanceof CacheCreation) {
         sender = new ParallelAsyncEventQueueCreation(cache, gatewaySenderAttributes);
       } else {
-        sender = new ParallelAsyncEventQueueImpl(cache, gatewaySenderAttributes);
+        sender = new ParallelAsyncEventQueueImpl(cache,
+            cache.getInternalDistributedSystem().getStatisticsManager(), cache.getStatisticsClock(),
+            gatewaySenderAttributes);
       }
       cache.addGatewaySender(sender);
 
@@ -217,7 +219,9 @@ public class AsyncEventQueueFactoryImpl implements AsyncEventQueueFactory {
       if (cache instanceof CacheCreation) {
         sender = new SerialAsyncEventQueueCreation(cache, gatewaySenderAttributes);
       } else {
-        sender = new SerialAsyncEventQueueImpl(cache, gatewaySenderAttributes);
+        sender = new SerialAsyncEventQueueImpl(cache,
+            cache.getInternalDistributedSystem().getStatisticsManager(), cache.getStatisticsClock(),
+            gatewaySenderAttributes);
       }
       cache.addGatewaySender(sender);
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/AsyncEventQueueStats.java
@@ -19,6 +19,7 @@ import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.internal.cache.wan.GatewaySenderStats;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 public class AsyncEventQueueStats extends GatewaySenderStats {
@@ -42,7 +43,8 @@ public class AsyncEventQueueStats extends GatewaySenderStats {
    * @param asyncQueueId The id of the <code>AsyncEventQueue</code> used to generate the name of the
    *        <code>Statistics</code>
    */
-  public AsyncEventQueueStats(StatisticsFactory f, String asyncQueueId) {
-    super(f, asyncQueueId, type);
+  public AsyncEventQueueStats(StatisticsFactory f, String asyncQueueId,
+      StatisticsClock statisticsClock) {
+    super(f, "asyncEventQueueStats-", asyncQueueId, type, statisticsClock);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImpl.java
@@ -16,6 +16,7 @@ package org.apache.geode.cache.asyncqueue.internal;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.EntryOperation;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
@@ -38,18 +39,20 @@ import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySen
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class ParallelAsyncEventQueueImpl extends AbstractGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public ParallelAsyncEventQueueImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+  public ParallelAsyncEventQueueImpl(InternalCache cache, StatisticsFactory statisticsFactory,
+      StatisticsClock statisticsClock, GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
     if (!(this.cache instanceof CacheCreation)) {
       // this sender lies underneath the AsyncEventQueue. Need to have
       // AsyncEventQueueStats
-      this.statistics = new AsyncEventQueueStats(cache.getDistributedSystem(),
-          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id));
+      this.statistics = new AsyncEventQueueStats(statisticsFactory,
+          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), statisticsClock);
     }
     this.isForInternalUse = true;
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
@@ -17,6 +17,7 @@ package org.apache.geode.cache.asyncqueue.internal;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
 import org.apache.geode.distributed.DistributedLockService;
@@ -40,18 +41,20 @@ import org.apache.geode.internal.cache.wan.serial.SerialGatewaySenderQueue;
 import org.apache.geode.internal.cache.xmlcache.CacheCreation;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class SerialAsyncEventQueueImpl extends AbstractGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public SerialAsyncEventQueueImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+  public SerialAsyncEventQueueImpl(InternalCache cache, StatisticsFactory statisticsFactory,
+      StatisticsClock statisticsClock, GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
     if (!(this.cache instanceof CacheCreation)) {
       // this sender lies underneath the AsyncEventQueue. Need to have
       // AsyncEventQueueStats
-      this.statistics = new AsyncEventQueueStats(cache.getDistributedSystem(),
-          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id));
+      this.statistics = new AsyncEventQueueStats(statisticsFactory,
+          AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(id), statisticsClock);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -149,7 +149,7 @@ public class PoolImpl implements InternalPool {
 
   public static final int PRIMARY_QUEUE_NOT_AVAILABLE = -2;
   public static final int PRIMARY_QUEUE_TIMED_OUT = -1;
-  private AtomicInteger primaryQueueSize = new AtomicInteger(PRIMARY_QUEUE_NOT_AVAILABLE);
+  private final AtomicInteger primaryQueueSize = new AtomicInteger(PRIMARY_QUEUE_NOT_AVAILABLE);
 
   private final ThreadsMonitoring threadMonitoring;
 
@@ -216,7 +216,8 @@ public class PoolImpl implements InternalPool {
     subscriptionAckInterval = attributes.getSubscriptionAckInterval();
     subscriptionTimeoutMultiplier = attributes.getSubscriptionTimeoutMultiplier();
     if (subscriptionTimeoutMultiplier < 0) {
-      throw new IllegalArgumentException("The subscription timeout multipler must not be negative");
+      throw new IllegalArgumentException(
+          "The subscription timeout multiplier must not be negative");
     }
     serverGroup = attributes.getServerGroup();
     multiuserSecureModeEnabled = attributes.getMultiuserAuthentication();

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyCache.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyCache.java
@@ -127,7 +127,7 @@ public class ProxyCache implements RegionService {
         throw new IllegalStateException(
             "Region's data-policy must be EMPTY when multiuser-authentication is true");
       }
-      return new ProxyRegion(this, this.cache.getRegion(path));
+      return new ProxyRegion(this, this.cache.getRegion(path), cache.getStatisticsClock());
     }
   }
 
@@ -209,7 +209,7 @@ public class ProxyCache implements RegionService {
     Set<Region<?, ?>> rootRegions = new HashSet<>();
     for (Region<?, ?> region : this.cache.rootRegions()) {
       if (!region.getAttributes().getDataPolicy().withStorage()) {
-        rootRegions.add(new ProxyRegion(this, region));
+        rootRegions.add(new ProxyRegion(this, region, cache.getStatisticsClock()));
       }
     }
     return Collections.unmodifiableSet(rootRegions);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ProxyRegion.java
@@ -44,6 +44,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.snapshot.RegionSnapshotService;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * A wrapper class over an actual Region instance. This is used when the multiuser-authentication
@@ -56,10 +57,12 @@ public class ProxyRegion implements Region {
 
   private final ProxyCache proxyCache;
   private final Region realRegion;
+  private final StatisticsClock statisticsClock;
 
-  public ProxyRegion(ProxyCache proxyCache, Region realRegion) {
+  public ProxyRegion(ProxyCache proxyCache, Region realRegion, StatisticsClock statisticsClock) {
     this.proxyCache = proxyCache;
     this.realRegion = realRegion;
+    this.statisticsClock = statisticsClock;
   }
 
   @Override
@@ -366,7 +369,7 @@ public class ProxyRegion implements Region {
   @Override
   public Region getSubregion(String path) {
     Region region = this.realRegion.getSubregion(path);
-    return region != null ? new ProxyRegion(this.proxyCache, region) : null;
+    return region != null ? new ProxyRegion(this.proxyCache, region, statisticsClock) : null;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QRegion.java
@@ -97,8 +97,9 @@ public class QRegion implements SelectResults {
 
     ResultsCollectionWrapper res = null;
     if (context.getBucketList() != null && region instanceof PartitionedRegion) {
+      PartitionedRegion partitionedRegion = (PartitionedRegion) region;
       LocalDataSet localData =
-          new LocalDataSet(((PartitionedRegion) region), new HashSet(context.getBucketList()));
+          new LocalDataSet(partitionedRegion, new HashSet(context.getBucketList()));
       this.region = localData;
       if (includeKeys) {
         res = new ResultsCollectionWrapper(TypeUtils.getObjectType(constraint),

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndexSet.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndexSet.java
@@ -314,7 +314,7 @@ public class HashIndexSet implements Set {
 
     long start = -1L;
     if (this.cacheStats != null) {
-      start = this.cacheStats.getStatTime();
+      start = this.cacheStats.getTime();
       this.cacheStats.incQueryResultsHashCollisions();
     }
     try {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStats.java
@@ -20,7 +20,8 @@ import org.apache.geode.StatisticsFactory;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.internal.cache.CachePerfStats;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 /**
@@ -45,6 +46,8 @@ public class IndexStats {
 
   /** The Statistics object that we delegate most behavior to */
   private final Statistics stats;
+
+  private final StatisticsClock clock;
 
   static {
     StatisticsTypeFactory f = StatisticsTypeFactoryImpl.singleton();
@@ -85,11 +88,16 @@ public class IndexStats {
   }
 
   /**
-   * Creates a new <code>CachePerfStats</code> and registers itself with the given statistics
+   * Creates a new <code>IndexStats</code> and registers itself with the given statistics
    * factory.
    */
   public IndexStats(StatisticsFactory factory, String indexName) {
+    this(factory, indexName, StatisticsClockFactory.clock());
+  }
+
+  private IndexStats(StatisticsFactory factory, String indexName, StatisticsClock clock) {
     stats = factory.createAtomicStatistics(type, indexName);
+    this.clock = clock;
   }
 
   public long getNumberOfKeys() {
@@ -109,11 +117,11 @@ public class IndexStats {
   }
 
   public long getTotalUpdateTime() {
-    return CachePerfStats.enableClockStats ? stats.getLong(updateTimeId) : 0;
+    return clock.isEnabled() ? stats.getLong(updateTimeId) : 0;
   }
 
   public long getUseTime() {
-    return CachePerfStats.enableClockStats ? stats.getLong(useTimeId) : 0;
+    return clock.isEnabled() ? stats.getLong(useTimeId) : 0;
   }
 
   public int getReadLockCount() {
@@ -149,7 +157,7 @@ public class IndexStats {
   }
 
   public void incUpdateTime(long delta) {
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(updateTimeId, delta);
     }
   }
@@ -167,7 +175,7 @@ public class IndexStats {
   }
 
   public void incUseTime(long delta) {
-    if (CachePerfStats.enableClockStats) {
+    if (clock.isEnabled()) {
       this.stats.incLong(useTimeId, delta);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteBridgeServer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteBridgeServer.java
@@ -43,6 +43,7 @@ import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * A remote (serializable) implementation of <code>BridgeServer</code> that is passed between
@@ -189,6 +190,11 @@ public class RemoteBridgeServer extends AbstractCacheServer
 
   @Override
   public String[] getCombinedGroups() {
+    throw new UnsupportedOperationException("Unsupported in RemoteBridgeServer");
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
     throw new UnsupportedOperationException("Unsupported in RemoteBridgeServer");
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
@@ -42,6 +42,7 @@ import org.apache.geode.internal.cache.wan.parallel.ConcurrentParallelGatewaySen
 import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public abstract class AbstractBucketRegionQueue extends BucketRegion {
   protected static final Logger logger = LogService.getLogger();
@@ -68,8 +69,9 @@ public abstract class AbstractBucketRegionQueue extends BucketRegion {
   private final ConcurrentHashSet<Object> failedBatchRemovalMessageKeys = new ConcurrentHashSet<>();
 
   AbstractBucketRegionQueue(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     this.gatewaySenderStats =
         this.getPartitionedRegion().getParallelGatewaySender().getStatistics();
   }
@@ -348,7 +350,7 @@ public abstract class AbstractBucketRegionQueue extends BucketRegion {
     }
 
     boolean didPut = false;
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
     // Value will always be an instanceof GatewaySenderEventImpl which
     // is never stored offheap so this EntryEventImpl values will never be off-heap.
     // So the value that ends up being stored in this region is a GatewaySenderEventImpl

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
@@ -137,7 +137,7 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
         if (logger.isDebugEnabled()) {
           logger.debug("doPutOrCreate: attempting to update or create entry");
         }
-        final long startPut = CachePerfStats.getStatTime();
+        final long startPut = rgn.getCachePerfStats().getTime();
         final boolean isBucket = rgn.isUsedForPartitionedRegionBucket();
         if (isBucket) {
           BucketRegion br = (BucketRegion) rgn;
@@ -169,7 +169,7 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
       // from this message.
       if (doUpdate) {
         if (!ev.isLocalInvalid()) {
-          final long startPut = CachePerfStats.getStatTime();
+          final long startPut = rgn.getCachePerfStats().getTime();
           boolean overwriteDestroyed = ev.getOperation().isCreate();
           final boolean isBucket = rgn.isUsedForPartitionedRegionBucket();
           if (isBucket) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -93,6 +93,7 @@ import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 
 /**
@@ -223,8 +224,9 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   }
 
   public BucketRegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     if (PartitionedRegion.DISABLE_SECONDARY_BUCKET_ACK) {
       Assert.assertTrue(attrs.getScope().isDistributedNoAck());
     } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
@@ -48,6 +48,7 @@ import org.apache.geode.internal.concurrent.Atomics;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
 import org.apache.geode.internal.offheap.annotations.Released;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class BucketRegionQueue extends AbstractBucketRegionQueue {
 
@@ -73,8 +74,9 @@ public class BucketRegionQueue extends AbstractBucketRegionQueue {
   private final AtomicLong latestAcknowledgedKey = new AtomicLong();
 
   public BucketRegionQueue(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     this.keySet();
     this.indexes = new ConcurrentHashMap<Object, Long>();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -14,28 +14,22 @@
  */
 package org.apache.geode.internal.cache;
 
-import java.util.function.LongSupplier;
-
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.StatisticsType;
 import org.apache.geode.StatisticsTypeFactory;
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.annotations.VisibleForTesting;
-import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.QueueStatHelper;
 import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 
 /**
  * CachePerfStats tracks statistics about Geode cache performance and usage.
  */
 public class CachePerfStats {
-  @MakeNotStatic
-  public static boolean enableClockStats;
-
   @Immutable
   private static final StatisticsType type;
 
@@ -622,50 +616,15 @@ public class CachePerfStats {
   /** The Statistics object that we delegate most behavior to */
   protected final Statistics stats;
 
-  private final LongSupplier clock;
+  private final StatisticsClock clock;
 
-  public CachePerfStats(StatisticsFactory factory) {
-    this(factory, "cachePerfStats");
-  }
-
-  @VisibleForTesting
-  public CachePerfStats(StatisticsFactory factory, LongSupplier clock) {
+  public CachePerfStats(StatisticsFactory factory, StatisticsClock clock) {
     this(factory, "cachePerfStats", clock);
   }
 
-  public CachePerfStats(StatisticsFactory factory, String textId) {
-    this(factory, textId, createClock());
-  }
-
-  CachePerfStats(StatisticsFactory factory, String textId, LongSupplier clock) {
-    this(createStatistics(factory, textId), clock);
-  }
-
-  private CachePerfStats(Statistics stats, LongSupplier clock) {
-    this.stats = stats;
+  public CachePerfStats(StatisticsFactory factory, String textId, StatisticsClock clock) {
+    stats = factory == null ? null : factory.createAtomicStatistics(type, textId);
     this.clock = clock;
-  }
-
-  private static Statistics createStatistics(StatisticsFactory factory, String textId) {
-    if (factory == null) {
-      return null;
-    }
-    return factory.createAtomicStatistics(type, textId);
-  }
-
-  private static LongSupplier createClock() {
-    return enableClockStats ? NanoTimer::getTime : () -> 0;
-  }
-
-  /**
-   * Returns the current NanoTime or, if clock stats are disabled, zero.
-   *
-   * @since GemFire 5.0
-   * @deprecated Please use instance method {@link #getTime()} instead.
-   */
-  @Deprecated
-  public static long getStatTime() {
-    return enableClockStats ? NanoTimer.getTime() : 0;
   }
 
   public static StatisticsType getStatisticsType() {
@@ -681,8 +640,8 @@ public class CachePerfStats {
     return stats;
   }
 
-  protected long getTime() {
-    return clock.getAsLong();
+  public long getTime() {
+    return clock.getTime();
   }
 
   public int getLoadsCompleted() {
@@ -887,7 +846,7 @@ public class CachePerfStats {
   }
 
   public void endCompression(long startTime, long startSize, long endSize) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(compressionCompressTimeId, getTime() - startTime);
     }
     stats.incLong(compressionPreCompressedBytesId, startSize);
@@ -900,7 +859,7 @@ public class CachePerfStats {
   }
 
   public void endDecompression(long startTime) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(compressionDecompressTimeId, getTime() - startTime);
     }
   }
@@ -937,7 +896,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endNetload(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(netloadTimeId, getTime() - start);
     }
     stats.incInt(netloadsInProgressId, -1);
@@ -976,7 +935,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endCacheWriterCall(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(cacheWriterCallTimeId, getTime() - start);
     }
     stats.incInt(cacheWriterCallsInProgressId, -1);
@@ -1001,7 +960,7 @@ public class CachePerfStats {
    * @since GemFire 3.5
    */
   public void endCacheListenerCall(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(cacheListenerCallTimeId, getTime() - start);
     }
     stats.incInt(cacheListenerCallsInProgressId, -1);
@@ -1024,7 +983,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endGetInitialImage(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(getInitialImageTimeId, getTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
@@ -1035,7 +994,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endNoGIIDone(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(getInitialImageTimeId, getTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
@@ -1112,7 +1071,7 @@ public class CachePerfStats {
    * @param start the timestamp taken when the operation started
    */
   public void endGet(long start, boolean miss) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       long delta = getTime() - start;
       stats.incLong(getTimeId, delta);
     }
@@ -1130,13 +1089,13 @@ public class CachePerfStats {
     long total = 0;
     if (isUpdate) {
       stats.incLong(updatesId, 1L);
-      if (enableClockStats) {
+      if (clock.isEnabled()) {
         total = getTime() - start;
         stats.incLong(updateTimeId, total);
       }
     } else {
       stats.incLong(putsId, 1L);
-      if (enableClockStats) {
+      if (clock.isEnabled()) {
         total = getTime() - start;
         stats.incLong(putTimeId, total);
       }
@@ -1146,19 +1105,19 @@ public class CachePerfStats {
 
   public void endPutAll(long start) {
     stats.incInt(putAllsId, 1);
-    if (enableClockStats)
+    if (clock.isEnabled())
       stats.incLong(putAllTimeId, getTime() - start);
   }
 
   public void endRemoveAll(long start) {
     stats.incInt(removeAllsId, 1);
-    if (enableClockStats)
+    if (clock.isEnabled())
       stats.incLong(removeAllTimeId, getTime() - start);
   }
 
   public void endQueryExecution(long executionTime) {
     stats.incInt(queryExecutionsId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(queryExecutionTimeId, executionTime);
     }
   }
@@ -1168,7 +1127,7 @@ public class CachePerfStats {
   }
 
   public void endQueryResultsHashCollisionProbe(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(queryResultsHashCollisionProbeTimeId, getTime() - start);
     }
   }
@@ -1252,7 +1211,7 @@ public class CachePerfStats {
 
   void endDeltaUpdate(long start) {
     stats.incInt(deltaUpdatesId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(deltaUpdatesTimeId, getTime() - start);
     }
   }
@@ -1263,7 +1222,7 @@ public class CachePerfStats {
 
   public void endDeltaPrepared(long start) {
     stats.incInt(deltasPreparedId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(deltasPreparedTimeId, getTime() - start);
     }
   }
@@ -1476,14 +1435,14 @@ public class CachePerfStats {
 
   public void endImport(long entryCount, long start) {
     stats.incLong(importedEntriesCountId, entryCount);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(importTimeId, getTime() - start);
     }
   }
 
   public void endExport(long entryCount, long start) {
     stats.incLong(exportedEntriesCountId, entryCount);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(exportTimeId, getTime() - start);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CacheServerImpl.java
@@ -77,6 +77,7 @@ import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.membership.ClientMembership;
 import org.apache.geode.management.membership.ClientMembershipListener;
 
@@ -93,10 +94,12 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   private static final int FORCE_LOAD_UPDATE_FREQUENCY = getInteger(
       DistributionConfig.GEMFIRE_PREFIX + "BridgeServer.FORCE_LOAD_UPDATE_FREQUENCY", 10);
 
+  static final String CACHE_SERVER_BIND_ADDRESS_NOT_AVAILABLE_EXCEPTION_MESSAGE =
+      "A cache server's bind address is only available if it has been started";
+
   private final SecurityService securityService;
 
-  public static final String CACHE_SERVER_BIND_ADDRESS_NOT_AVAILABLE_EXCEPTION_MESSAGE =
-      "A cache server's bind address is only available if it has been started";
+  private final StatisticsClock statisticsClock;
 
   private final AcceptorBuilder acceptorBuilder;
 
@@ -146,6 +149,7 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
 
   CacheServerImpl(final InternalCache cache,
       final SecurityService securityService,
+      final StatisticsClock statisticsClock,
       final AcceptorBuilder acceptorBuilder,
       final boolean sendResourceEvents,
       final boolean includeMembershipGroups,
@@ -155,6 +159,7 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
       final Function<DistributionAdvisee, CacheServerAdvisor> cacheServerAdvisorProvider) {
     super(cache);
     this.securityService = securityService;
+    this.statisticsClock = statisticsClock;
     this.acceptorBuilder = acceptorBuilder;
     this.sendResourceEvents = sendResourceEvents;
     this.includeMembershipGroups = includeMembershipGroups;
@@ -167,6 +172,11 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   @Override
   public CancelCriterion getCancelCriterion() {
     return cache.getCancelCriterion();
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 
   /**
@@ -275,7 +285,6 @@ public class CacheServerImpl extends AbstractCacheServer implements Distribution
   public int getMessageTimeToLive() {
     return this.messageTimeToLive;
   }
-
 
   @Override
   public ClientSubscriptionConfig getClientSubscriptionConfig() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
@@ -337,7 +337,8 @@ public class ColocationHelper {
       PartitionedRegion region, Set<Integer> bucketSet) {
     Map<String, LocalDataSet> colocatedLocalDataSets = new HashMap<String, LocalDataSet>();
     if (region.getColocatedWith() == null && (!region.isColocatedBy())) {
-      colocatedLocalDataSets.put(region.getFullPath(), new LocalDataSet(region, bucketSet));
+      colocatedLocalDataSets.put(region.getFullPath(),
+          new LocalDataSet(region, bucketSet));
       return colocatedLocalDataSets;
     }
     Map<String, PartitionedRegion> colocatedRegions =
@@ -346,7 +347,8 @@ public class ColocationHelper {
       colocatedLocalDataSets.put(colocatedRegion.getFullPath(),
           new LocalDataSet((PartitionedRegion) colocatedRegion, bucketSet));
     }
-    colocatedLocalDataSets.put(region.getFullPath(), new LocalDataSet(region, bucketSet));
+    colocatedLocalDataSets.put(region.getFullPath(),
+        new LocalDataSet(region, bucketSet));
     return colocatedLocalDataSets;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXState.java
@@ -44,6 +44,7 @@ import org.apache.geode.internal.cache.tx.DistTxEntryEvent;
 import org.apache.geode.internal.cache.tx.DistTxKeyInfo;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.offheap.annotations.Released;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * TxState on a data node VM
@@ -59,8 +60,9 @@ public class DistTXState extends TXState {
 
   private boolean updatingTxStateDuringPreCommit = false;
 
-  public DistTXState(TXStateProxy proxy, boolean onBehalfOfRemoteStub) {
-    super(proxy, onBehalfOfRemoteStub);
+  public DistTXState(TXStateProxy proxy, boolean onBehalfOfRemoteStub,
+      StatisticsClock statisticsClock) {
+    super(proxy, onBehalfOfRemoteStub, statisticsClock);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
@@ -24,6 +24,7 @@ import org.apache.geode.cache.UnsupportedOperationInTransactionException;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
 import org.apache.geode.internal.cache.tx.DistTxEntryEvent;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * TxState on TX coordinator, created when coordinator is also a data node
@@ -38,8 +39,9 @@ public class DistTXStateOnCoordinator extends DistTXState implements DistTXCoord
   private boolean preCommitResponse = false;
   private boolean rollbackResponse = false;
 
-  public DistTXStateOnCoordinator(TXStateProxy proxy, boolean onBehalfOfRemoteStub) {
-    super(proxy, onBehalfOfRemoteStub);
+  public DistTXStateOnCoordinator(TXStateProxy proxy, boolean onBehalfOfRemoteStub,
+      StatisticsClock statisticsClock) {
+    super(proxy, onBehalfOfRemoteStub, statisticsClock);
     primaryTransactionalOperations = new ArrayList<DistTxEntryEvent>();
     secondaryTransactionalOperations = new ArrayList<DistTxEntryEvent>();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImpl.java
@@ -18,19 +18,20 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public abstract class DistTXStateProxyImpl extends TXStateProxyImpl {
 
   protected static final Logger logger = LogService.getLogger();
 
   public DistTXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember) {
-    super(cache, managerImpl, id, clientMember);
+      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, clientMember, statisticsClock);
   }
 
   public DistTXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      boolean isjta) {
-    super(cache, managerImpl, id, isjta);
+      boolean isjta, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, isjta, statisticsClock);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnCoordinator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnCoordinator.java
@@ -35,6 +35,7 @@ import org.apache.geode.internal.cache.TXEntryState.DistTxThinEntryState;
 import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
 import org.apache.geode.internal.cache.tx.DistClientTXStateStub;
 import org.apache.geode.internal.cache.tx.DistTxEntryEvent;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
 
@@ -52,13 +53,13 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
   private HashMap<String, ArrayList<DistTxThinEntryState>> txEntryEventMap = null;
 
   public DistTXStateProxyImplOnCoordinator(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember) {
-    super(cache, managerImpl, id, clientMember);
+      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, clientMember, statisticsClock);
   }
 
   public DistTXStateProxyImplOnCoordinator(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      boolean isjta) {
-    super(cache, managerImpl, id, isjta);
+      boolean isjta, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, isjta, statisticsClock);
   }
 
   /*
@@ -159,7 +160,7 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
                 DistTXCoordinatorInterface newTxStub = null;
                 if (currentNode.equals(dm)) {
                   // [DISTTX] TODO add a test case for this condition?
-                  newTxStub = new DistTXStateOnCoordinator(this, false);
+                  newTxStub = new DistTXStateOnCoordinator(this, false, getStatisticsClock());
                 } else {
                   newTxStub = new DistPeerTXStateStub(this, dm, onBehalfOfClientMember);
                 }
@@ -316,7 +317,7 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
     if (this.realDeal == null) {
       // assert (r != null);
       if (r == null) { // TODO: stop gap to get tests working
-        this.realDeal = new DistTXStateOnCoordinator(this, false);
+        this.realDeal = new DistTXStateOnCoordinator(this, false, getStatisticsClock());
         target = this.txMgr.getDM().getId();
       } else {
         // Code to keep going forward
@@ -334,7 +335,7 @@ public class DistTXStateProxyImplOnCoordinator extends DistTXStateProxyImpl {
         } else {
           // (r != null) code block above
           if (target == null || target.equals(this.txMgr.getDM().getId())) {
-            this.realDeal = new DistTXStateOnCoordinator(this, false);
+            this.realDeal = new DistTXStateOnCoordinator(this, false, getStatisticsClock());
           } else {
             this.realDeal = new DistPeerTXStateStub(this, target, onBehalfOfClientMember);
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnDatanode.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateProxyImplOnDatanode.java
@@ -22,6 +22,7 @@ import org.apache.geode.cache.UnsupportedOperationInTransactionException;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.TXEntryState.DistTxThinEntryState;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class DistTXStateProxyImplOnDatanode extends DistTXStateProxyImpl {
 
@@ -29,19 +30,19 @@ public class DistTXStateProxyImplOnDatanode extends DistTXStateProxyImpl {
   private boolean preCommitResponse = false;
 
   public DistTXStateProxyImplOnDatanode(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember) {
-    super(cache, managerImpl, id, clientMember);
+      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, clientMember, statisticsClock);
   }
 
   public DistTXStateProxyImplOnDatanode(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      boolean isjta) {
-    super(cache, managerImpl, id, isjta);
+      boolean isjta, StatisticsClock statisticsClock) {
+    super(cache, managerImpl, id, isjta, statisticsClock);
   }
 
   @Override
   public TXStateInterface getRealDeal(KeyInfo key, InternalRegion r) {
     if (this.realDeal == null) {
-      this.realDeal = new DistTXState(this, false);
+      this.realDeal = new DistTXState(this, false, getStatisticsClock());
       if (r != null) {
         // wait for the region to be initialized fixes bug 44652
         r.waitOnInitialization(r.getInitializationLatchBeforeGetInitialImage());
@@ -60,7 +61,7 @@ public class DistTXStateProxyImplOnDatanode extends DistTXStateProxyImpl {
     assert t != null;
     if (this.realDeal == null) {
       this.target = t;
-      this.realDeal = new DistTXState(this, false);
+      this.realDeal = new DistTXState(this, false, getStatisticsClock());
       if (logger.isDebugEnabled()) {
         logger.debug("Built a new DistTXState: {} me:{}", this.realDeal,
             this.txMgr.getDM().getId());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -130,6 +130,7 @@ import org.apache.geode.internal.logging.LoggingThread;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.sequencelog.RegionLogger;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
 
 @SuppressWarnings("deprecation")
@@ -197,8 +198,9 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
 
   /** Creates a new instance of DistributedRegion */
   protected DistributedRegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) {
-    super(regionName, attrs, parentRegion, cache, internalRegionArgs);
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
+    super(regionName, attrs, parentRegion, cache, internalRegionArgs, statisticsClock);
     initializationLatchAfterMemberTimeout =
         new StoppableCountDownLatch(getCancelCriterion(), 1);
     distAdvisor = createDistributionAdvisor(internalRegionArgs);
@@ -2359,7 +2361,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
     // Set eventId. Required for interested clients.
     event.setNewEventId(cache.getDistributedSystem());
 
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
     validateKey(event.getKey());
     // this next step also distributes the object to other processes, if necessary
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DummyCachePerfStats.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import org.apache.geode.Statistics;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 
@@ -23,7 +25,7 @@ import org.apache.geode.distributed.internal.PoolStatHelper;
 public class DummyCachePerfStats extends CachePerfStats {
 
   DummyCachePerfStats() {
-    super(null);
+    super(null, disabledClock());
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -1831,7 +1831,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       }
       boolean deltaBytesApplied = false;
       try {
-        long start = CachePerfStats.getStatTime();
+        long start = getRegion().getCachePerfStats().getTime();
         ((org.apache.geode.Delta) value)
             .fromDelta(new ByteArrayDataInput(getDeltaBytes()));
         getRegion().getCachePerfStats().endDeltaUpdate(start);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -158,7 +158,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.CacheTime;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionAdvisee;
 import org.apache.geode.distributed.internal.DistributionAdvisor;
@@ -233,6 +232,9 @@ import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.security.SecurityServiceFactory;
 import org.apache.geode.internal.sequencelog.SequenceLoggerImpl;
 import org.apache.geode.internal.shared.StringPrintWriter;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
+import org.apache.geode.internal.statistics.StatisticsClockSupplier;
 import org.apache.geode.internal.tcp.ConnectionTable;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.internal.util.concurrent.FutureResult;
@@ -260,7 +262,7 @@ import org.apache.geode.pdx.internal.TypeRegistry;
  */
 @SuppressWarnings("deprecation")
 public class GemFireCacheImpl implements InternalCache, InternalClientCache, HasCachePerfStats,
-    DistributionAdvisee, CacheTime {
+    DistributionAdvisee, StatisticsClockSupplier {
   private static final Logger logger = LogService.getLogger();
 
   /** The default number of seconds to wait for a distributed lock */
@@ -601,6 +603,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   private final MeterRegistry meterRegistry;
   private final Set<MeterRegistry> meterSubregistries;
 
+  private final StatisticsClock statisticsClock;
+
   static {
     // this works around jdk bug 6427854, reported in ticket #44434
     String propertyName = "sun.nio.ch.bugLevel";
@@ -843,10 +847,11 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       cqService = CqServiceProvider.create(this);
 
       // Create the CacheStatistics
-      CachePerfStats.enableClockStats = system.getConfig().getEnableTimeStatistics();
-      cachePerfStats = new CachePerfStats(internalDistributedSystem.getStatisticsManager());
+      statisticsClock = StatisticsClockFactory.clock(system.getConfig().getEnableTimeStatistics());
+      cachePerfStats = new CachePerfStats(
+          internalDistributedSystem.getStatisticsManager(), statisticsClock);
 
-      transactionManager = new TXManagerImpl(cachePerfStats, this);
+      transactionManager = new TXManagerImpl(cachePerfStats, this, statisticsClock);
       dm.addMembershipListener(transactionManager);
 
       creationDate = new Date();
@@ -2008,7 +2013,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     synchronized (heapEvictorLock) {
       stopper.checkCancelInProgress(null);
       if (heapEvictor == null) {
-        heapEvictor = new HeapEvictor(this);
+        heapEvictor = new HeapEvictor(this, statisticsClock);
       }
       return heapEvictor;
     }
@@ -2018,7 +2023,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     synchronized (offHeapEvictorLock) {
       stopper.checkCancelInProgress(null);
       if (offHeapEvictor == null) {
-        offHeapEvictor = new OffHeapEvictor(this);
+        offHeapEvictor = new OffHeapEvictor(this, statisticsClock);
       }
       return offHeapEvictor;
     }
@@ -2996,7 +3001,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
             if (internalRegionArgs.getInternalMetaRegion() != null) {
               region = internalRegionArgs.getInternalMetaRegion();
             } else if (isPartitionedRegion) {
-              region = new PartitionedRegion(name, attrs, null, this, internalRegionArgs);
+              region = new PartitionedRegion(name, attrs, null, this, internalRegionArgs,
+                  statisticsClock);
             } else {
               // Abstract region depends on the default pool existing so lazily initialize it
               // if necessary.
@@ -3004,9 +3010,11 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
                 determineDefaultPool();
               }
               if (attrs.getScope().isLocal()) {
-                region = new LocalRegion(name, attrs, null, this, internalRegionArgs);
+                region =
+                    new LocalRegion(name, attrs, null, this, internalRegionArgs, statisticsClock);
               } else {
-                region = new DistributedRegion(name, attrs, null, this, internalRegionArgs);
+                region = new DistributedRegion(name, attrs, null, this, internalRegionArgs,
+                    statisticsClock);
               }
             }
 
@@ -3750,7 +3758,8 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     throwIfClient();
     stopper.checkCancelInProgress(null);
 
-    InternalCacheServer server = new ServerBuilder(this, securityService).createServer();
+    InternalCacheServer server = new ServerBuilder(this, securityService,
+        StatisticsClockFactory.disabledClock()).createServer();
     allCacheServers.add(server);
 
     sendAddCacheServerProfileMessage();
@@ -3842,8 +3851,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     requireNonNull(gatewayReceiver.get(),
         "GatewayReceiver must be added before adding a server endpoint.");
 
-    InternalCacheServer receiverServer = new ServerBuilder(this, securityService)
-        .forGatewayReceiver(receiver).createServer();
+    InternalCacheServer receiverServer = new ServerBuilder(this, securityService,
+        StatisticsClockFactory.disabledClock())
+            .forGatewayReceiver(receiver).createServer();
     gatewayReceiverServer.set(receiverServer);
 
     sendAddCacheServerProfileMessage();
@@ -5351,4 +5361,15 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     }
   }
 
+  /**
+   * Feature factories may use this supplier to acquire the {@code StatisticsClock} which is
+   * created by the Cache as configured by {@link DistributionConfig#getEnableTimeStatistics()}.
+   *
+   * <p>
+   * Please pass the {@code StatisticsClock} through constructors where possible instead of
+   * accessing it from this supplier.
+   */
+  public StatisticsClock getStatisticsClock() {
+    return statisticsClock;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/HARegion.java
@@ -46,6 +46,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.annotations.Released;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * This region is being implemented to suppress distribution of puts and to allow localDestroys on
@@ -90,10 +91,11 @@ public class HARegion extends DistributedRegion {
   private volatile HARegionQueue owningQueue;
 
   private HARegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache) {
+      InternalCache cache, StatisticsClock statisticsClock) {
     super(regionName, attrs, parentRegion, cache,
         new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
-            .setSnapshotInputStream(null).setImageTarget(null));
+            .setSnapshotInputStream(null).setImageTarget(null),
+        statisticsClock);
     this.haRegionStats = new DummyCachePerfStats();
   }
 
@@ -244,10 +246,10 @@ public class HARegion extends DistributedRegion {
    * @throws RegionExistsException if a region of the same name exists in the same Cache
    */
   public static HARegion getInstance(String regionName, InternalCache cache, HARegionQueue hrq,
-      RegionAttributes ra)
+      RegionAttributes ra, StatisticsClock statisticsClock)
       throws TimeoutException, RegionExistsException, IOException, ClassNotFoundException {
 
-    HARegion haRegion = new HARegion(regionName, ra, null, cache);
+    HARegion haRegion = new HARegion(regionName, ra, null, cache, statisticsClock);
     haRegion.setOwner(hrq);
     Region region = cache.createVMRegion(regionName, ra,
         new InternalRegionArguments().setInternalMetaRegion(haRegion).setDestroyLockFlag(true)

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -66,6 +66,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClockSupplier;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
 import org.apache.geode.pdx.PdxInstanceFactory;
@@ -78,7 +79,8 @@ import org.apache.geode.pdx.internal.TypeRegistry;
  * @see org.apache.geode.cache.Cache
  * @since GemFire 7.0
  */
-public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, ReconnectableCache {
+public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, ReconnectableCache,
+    StatisticsClockSupplier {
 
   InternalDistributedMember getMyId();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -89,6 +89,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
 import org.apache.geode.pdx.JSONFormatter;
@@ -1255,5 +1256,10 @@ public class InternalCacheForClientAccess implements InternalCache {
   @Override
   public void saveCacheXmlForReconnect() {
     delegate.saveCacheXmlForReconnect();
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
+    return delegate.getStatisticsClock();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheServer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheServer.java
@@ -26,6 +26,7 @@ import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public interface InternalCacheServer extends CacheServer {
 
@@ -52,4 +53,6 @@ public interface InternalCacheServer extends CacheServer {
   ClientHealthMonitorProvider getClientHealthMonitorProvider();
 
   String[] getCombinedGroups();
+
+  StatisticsClock getStatisticsClock();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalDataSet.java
@@ -64,7 +64,6 @@ import org.apache.geode.internal.cache.execute.InternalRegionFunctionContext;
 import org.apache.geode.internal.cache.snapshot.RegionSnapshotServiceImpl;
 import org.apache.geode.internal.logging.LogService;
 
-
 public class LocalDataSet implements Region, QueryExecutor {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -214,6 +214,7 @@ import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.sequencelog.EntryLogger;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.CopyOnWriteHashMap;
 import org.apache.geode.internal.util.concurrent.FutureResult;
 import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
@@ -531,20 +532,24 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   }
 
   protected LocalRegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
-      InternalCache cache, InternalRegionArguments internalRegionArgs) throws DiskAccessException {
-    this(regionName, attrs, parentRegion, cache, internalRegionArgs, new LocalRegionDataView());
+      InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) throws DiskAccessException {
+    this(regionName, attrs, parentRegion, cache, internalRegionArgs, new LocalRegionDataView(),
+        statisticsClock);
   }
 
   protected LocalRegion(String regionName, RegionAttributes attrs, LocalRegion parentRegion,
       InternalCache cache, InternalRegionArguments internalRegionArgs,
-      InternalDataView internalDataView) throws DiskAccessException {
+      InternalDataView internalDataView, StatisticsClock statisticsClock)
+      throws DiskAccessException {
     this(regionName, attrs, parentRegion, cache, internalRegionArgs, internalDataView,
         RegionMapFactory::createVM, new DefaultServerRegionProxyConstructor(),
         new DefaultEntryEventFactory(), poolName -> (PoolImpl) PoolManager.find(poolName),
         (LocalRegion region) -> new RegionPerfStats(
             cache.getInternalDistributedSystem().getStatisticsManager(),
             "RegionStats-" + regionName, cache.getCachePerfStats(),
-            region, cache.getMeterRegistry()));
+            region, cache.getMeterRegistry(), statisticsClock),
+        statisticsClock);
   }
 
   @VisibleForTesting
@@ -553,9 +558,10 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       InternalDataView internalDataView, RegionMapConstructor regionMapConstructor,
       ServerRegionProxyConstructor serverRegionProxyConstructor,
       EntryEventFactory entryEventFactory, PoolFinder poolFinder,
-      java.util.function.Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory)
+      java.util.function.Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory,
+      StatisticsClock statisticsClock)
       throws DiskAccessException {
-    super(cache, attrs, regionName, internalRegionArgs, poolFinder);
+    super(cache, attrs, regionName, internalRegionArgs, poolFinder, statisticsClock);
 
     this.regionMapConstructor = regionMapConstructor;
     this.entryEventFactory = entryEventFactory;
@@ -915,21 +921,21 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
               internalRegionArgs.setUserAttribute(pr.getUserAttribute());
               if (pr.isShadowPR()) {
                 newRegion = new BucketRegionQueue(subregionName, regionAttributes, this, cache,
-                    internalRegionArgs);
+                    internalRegionArgs, getStatisticsClock());
               } else {
                 newRegion = new BucketRegion(subregionName, regionAttributes, this, cache,
-                    internalRegionArgs);
+                    internalRegionArgs, getStatisticsClock());
               }
             } else if (regionAttributes.getPartitionAttributes() != null) {
               newRegion = new PartitionedRegion(subregionName, regionAttributes, this, cache,
-                  internalRegionArgs);
+                  internalRegionArgs, getStatisticsClock());
             } else {
               boolean local = regionAttributes.getScope().isLocal();
               newRegion = local
                   ? new LocalRegion(subregionName, regionAttributes, this, cache,
-                      internalRegionArgs)
+                      internalRegionArgs, getStatisticsClock())
                   : new DistributedRegion(subregionName, regionAttributes, this, cache,
-                      internalRegionArgs);
+                      internalRegionArgs, getStatisticsClock());
             }
             Object previousValue = subregions.putIfAbsent(subregionName, newRegion);
 
@@ -1036,7 +1042,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   @Override
   public void create(Object key, Object value, Object aCallbackArgument)
       throws TimeoutException, EntryExistsException, CacheWriterException {
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
     @Released
     EntryEventImpl event = newCreateEntryEvent(key, value, aCallbackArgument);
     try {
@@ -1608,7 +1614,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   @Override
   public Object put(Object key, Object value, Object aCallbackArgument)
       throws TimeoutException, CacheWriterException {
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
     @Released
     EntryEventImpl event = newUpdateEntryEvent(key, value, aCallbackArgument);
     try {
@@ -2817,7 +2823,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     RegionEntry re = null;
     if (value != null && !isMemoryThresholdReachedForLoad()) {
 
-      long startPut = CachePerfStats.getStatTime();
+      long startPut = getStatisticsClock().getTime();
       validateKey(key);
       Operation op;
       if (isCreate) {
@@ -5046,7 +5052,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       List<EntryEventImpl> pendingCallbacks, FilterRoutingInfo filterRoutingInfo,
       ClientProxyMembershipID bridgeContext, TXEntryState txEntryState, VersionTag versionTag,
       long tailKey) {
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
     entries.txApplyPut(putOp, key, newValue, didDestroy, transactionId, event, eventId,
         aCallbackArgument, pendingCallbacks, filterRoutingInfo, bridgeContext, txEntryState,
         versionTag, tailKey);
@@ -5101,7 +5107,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     EventID eventId = clientEvent.getEventId();
     Object theCallbackArg = callbackArg;
 
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     @Released
     final EntryEventImpl event =
@@ -5169,7 +5175,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
     EventID eventID = clientEvent.getEventId();
     Object theCallbackArg = callbackArg;
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     @Released
     final EntryEventImpl event = entryEventFactory.create(this, Operation.UPDATE, key,
@@ -5249,7 +5255,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     }
 
     concurrencyConfigurationCheck(event.getVersionTag());
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     // Generate EventID as it is possible that client is a cache server
     // in hierarchical cache
@@ -8648,7 +8654,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
           // The following basicPutEntry needs to be done
           // even if we do not have storage so that the
           // correct events will be delivered to any callbacks we have.
-          long startPut = CachePerfStats.getStatTime();
+          long startPut = getStatisticsClock().getTime();
           validateKey(key);
 
           @Released
@@ -8747,7 +8753,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       ClientProxyMembershipID memberId, EventID eventId, boolean skipCallbacks, Object callbackArg)
       throws TimeoutException, CacheWriterException {
 
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     @Released
     final EntryEventImpl event =
@@ -8783,7 +8789,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       ArrayList<VersionTag> retryVersions, ClientProxyMembershipID memberId, EventID eventId,
       Object callbackArg) throws TimeoutException, CacheWriterException {
 
-    long startOp = CachePerfStats.getStatTime();
+    long startOp = getStatisticsClock().getTime();
 
     @Released
     final EntryEventImpl event =
@@ -8809,7 +8815,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   // TODO: return value is never used
   public VersionedObjectList basicImportPutAll(Map map, boolean skipCallbacks) {
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     @Released
     EntryEventImpl event = entryEventFactory.create(this, Operation.PUTALL_CREATE, null, null, null,
@@ -8832,7 +8838,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   @Override
   public void putAll(Map map, Object aCallbackArgument) {
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
     final DistributedPutAllOperation putAllOp = newPutAllOperation(map, aCallbackArgument);
     if (putAllOp != null) {
       try {
@@ -8858,7 +8864,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   @Override
   public void removeAll(Collection keys, Object aCallbackArgument) {
-    long startOp = CachePerfStats.getStatTime();
+    long startOp = getStatisticsClock().getTime();
     DistributedRemoveAllOperation operation = newRemoveAllOperation(keys, aCallbackArgument);
     if (operation != null) {
       try {
@@ -10362,7 +10368,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    * @throws PartitionedRegionStorageException if the operation could not be completed.
    */
   public Object putIfAbsent(Object key, Object value, Object callbackArgument) {
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     checkIfConcurrentMapOpsAllowed();
     validateArguments(key, value, callbackArgument);
@@ -10470,7 +10476,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       throw new NullPointerException();
     }
 
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
     validateArguments(key, newValue, callbackArg);
     checkReadiness();
     checkForLimitedOrNoAccess();
@@ -10523,7 +10529,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    * TODO: callbackArg is always null but this method is for callbacks??
    */
   private Object replaceWithCallbackArgument(Object key, Object value, Object callbackArg) {
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     checkIfConcurrentMapOpsAllowed();
 
@@ -10570,7 +10576,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       throws TimeoutException, EntryExistsException, CacheWriterException {
 
     EventID eventId = clientEvent.getEventId();
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     @Released
     final EntryEventImpl event =
@@ -10646,7 +10652,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       throws TimeoutException, EntryExistsException, CacheWriterException {
 
     EventID eventId = clientEvent.getEventId();
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     @Released
     final EntryEventImpl event =
@@ -10704,7 +10710,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       throws TimeoutException, EntryExistsException, CacheWriterException {
 
     EventID eventId = clientEvent.getEventId();
-    long startPut = CachePerfStats.getStatTime();
+    long startPut = getStatisticsClock().getTime();
 
     @Released
     final EntryEventImpl event =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -246,6 +246,7 @@ import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.sequencelog.RegionLogger;
 import org.apache.geode.internal.size.Sizeable;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.TransformUtils;
 import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
 
@@ -545,7 +546,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   public boolean remove(Object key, Object value, Object callbackArg) {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       return super.remove(key, value, callbackArg);
     } finally {
@@ -739,12 +740,14 @@ public class PartitionedRegion extends LocalRegion
    * and also by invoking Cache.createRegion(). (Cache.xml etc to be added)
    */
   public PartitionedRegion(String regionName, RegionAttributes regionAttributes,
-      LocalRegion parentRegion, InternalCache cache, InternalRegionArguments internalRegionArgs) {
+      LocalRegion parentRegion, InternalCache cache, InternalRegionArguments internalRegionArgs,
+      StatisticsClock statisticsClock) {
     super(regionName, regionAttributes, parentRegion, cache, internalRegionArgs,
-        new PartitionedRegionDataView());
+        new PartitionedRegionDataView(), statisticsClock);
 
     this.node = initializeNode();
-    this.prStats = new PartitionedRegionStats(cache.getDistributedSystem(), getFullPath());
+    this.prStats = new PartitionedRegionStats(cache.getDistributedSystem(), getFullPath(),
+        statisticsClock);
     this.regionIdentifier = getFullPath().replace('/', '#');
 
     if (logger.isDebugEnabled()) {
@@ -1327,7 +1330,8 @@ public class PartitionedRegion extends LocalRegion
   private void initializeDataStore(RegionAttributes ra) {
 
     this.dataStore =
-        PartitionedRegionDataStore.createDataStore(cache, this, ra.getPartitionAttributes());
+        PartitionedRegionDataStore.createDataStore(cache, this, ra.getPartitionAttributes(),
+            getStatisticsClock());
   }
 
   protected DistributedLockService getPartitionedRegionLockService() {
@@ -1668,7 +1672,7 @@ public class PartitionedRegion extends LocalRegion
   @Override
   protected Region.Entry<?, ?> nonTXGetEntry(KeyInfo keyInfo, boolean access,
       boolean allowTombstones) {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     final Object key = keyInfo.getKey();
     try {
       int bucketId = keyInfo.getBucketId();
@@ -2148,7 +2152,7 @@ public class PartitionedRegion extends LocalRegion
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
       boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     boolean result = false;
     final DistributedPutAllOperation putAllOp_save = event.setPutAllOperation(null);
 
@@ -2319,7 +2323,7 @@ public class PartitionedRegion extends LocalRegion
       throw cache.getCacheClosedException("Cache is shutting down");
     }
 
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     // build all the msgs by bucketid
     HashMap prMsgMap = putAllOp.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(putAllOp.putAllDataSize);
@@ -2411,7 +2415,7 @@ public class PartitionedRegion extends LocalRegion
       throw cache.getCacheClosedException("Cache is shutting down");
     }
 
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     // build all the msgs by bucketid
     HashMap<Integer, RemoveAllPRMessage> prMsgMap = op.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(op.removeAllDataSize);
@@ -3426,7 +3430,7 @@ public class PartitionedRegion extends LocalRegion
     }
     // Potentially no storage assigned, start bucket creation, be careful of race
     // conditions
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     if (isDataStore()) {
       ret = this.redundancyProvider.createBucketAtomically(bucketId, size, false,
           partitionName);
@@ -3444,7 +3448,7 @@ public class PartitionedRegion extends LocalRegion
     Object obj = null;
     final Object key = keyInfo.getKey();
     final Object aCallbackArgument = keyInfo.getCallbackArg();
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       int bucketId = keyInfo.getBucketId();
       if (bucketId == KeyInfo.UNKNOWN_BUCKET) {
@@ -5227,7 +5231,7 @@ public class PartitionedRegion extends LocalRegion
       final Object expectedOldValue)
       throws TimeoutException, EntryNotFoundException, CacheWriterException {
 
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       if (event.getEventId() == null) {
         event.setNewEventId(this.cache.getDistributedSystem());
@@ -5714,7 +5718,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   public void basicInvalidate(EntryEventImpl event) throws EntryNotFoundException {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     try {
       if (event.getEventId() == null) {
         event.setNewEventId(this.cache.getDistributedSystem());
@@ -6363,7 +6367,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   boolean nonTXContainsKey(KeyInfo keyInfo) {
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     boolean contains = false;
     try {
       int bucketId = keyInfo.getBucketId();
@@ -6537,7 +6541,7 @@ public class PartitionedRegion extends LocalRegion
     // checkClosed();
     checkReadiness();
     validateKey(key);
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = prStats.getTime();
     boolean containsValueForKey = false;
     try {
       containsValueForKey = getDataView().containsValueForKey(getKeyInfo(key), this);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
@@ -268,7 +268,8 @@ public class PartitionedRegionHelper {
       final HasCachePerfStats prMetaStatsHolder = new HasCachePerfStats() {
         @Override
         public CachePerfStats getCachePerfStats() {
-          return new CachePerfStats(cache.getDistributedSystem(), "RegionStats-partitionMetaData");
+          return new CachePerfStats(cache.getDistributedSystem(), "RegionStats-partitionMetaData",
+              cache.getStatisticsClock());
         }
       };
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
@@ -57,7 +57,7 @@ public class PoolFactoryImpl implements PoolFactory {
    */
   private PoolAttributes attributes = new PoolAttributes();
 
-  private List<HostAddress> locatorAddresses = new ArrayList<>();
+  private final List<HostAddress> locatorAddresses = new ArrayList<>();
 
   /**
    * The cache that created this factory

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionPerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionPerfStats.java
@@ -14,33 +14,32 @@
  */
 package org.apache.geode.internal.cache;
 
-import java.util.function.LongSupplier;
-
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.annotations.VisibleForTesting;
-import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
-class RegionPerfStats extends CachePerfStats {
+class RegionPerfStats extends CachePerfStats implements RegionStats {
 
   private final CachePerfStats cachePerfStats;
+  private final StatisticsClock clock;
   private final MeterRegistry meterRegistry;
   private final Gauge entriesGauge;
 
   RegionPerfStats(StatisticsFactory statisticsFactory, String textId, CachePerfStats cachePerfStats,
-      InternalRegion region,
-      MeterRegistry meterRegistry) {
-    this(statisticsFactory, textId, createClock(), cachePerfStats, region,
+      InternalRegion region, MeterRegistry meterRegistry, StatisticsClock clock) {
+    this(statisticsFactory, textId, clock, cachePerfStats, region,
         meterRegistry);
   }
 
   @VisibleForTesting
-  RegionPerfStats(StatisticsFactory statisticsFactory, String textId, LongSupplier clock,
-      CachePerfStats cachePerfStats,
-      InternalRegion region, MeterRegistry meterRegistry) {
+  RegionPerfStats(StatisticsFactory statisticsFactory, String textId, StatisticsClock clock,
+      CachePerfStats cachePerfStats, InternalRegion region,
+      MeterRegistry meterRegistry) {
     super(statisticsFactory, textId, clock);
+    this.clock = clock;
     this.cachePerfStats = cachePerfStats;
     this.meterRegistry = meterRegistry;
     entriesGauge = Gauge.builder("member.region.entries", region::getLocalSize)
@@ -50,10 +49,6 @@ class RegionPerfStats extends CachePerfStats {
         .baseUnit("entries")
         .register(meterRegistry);
     stats.setLongSupplier(entryCountId, region::getLocalSize);
-  }
-
-  private static LongSupplier createClock() {
-    return enableClockStats ? NanoTimer::getTime : () -> 0;
   }
 
   @Override
@@ -122,22 +117,16 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.incQueuedEvents(inc);
   }
 
-  /**
-   * @return the timestamp that marks the start of the operation
-   */
   @Override
   public long startLoad() {
     stats.incInt(loadsInProgressId, 1);
     return cachePerfStats.startLoad();
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   */
   @Override
   public void endLoad(long start) {
     // note that load times are used in health checks and
-    // should not be disabled by enableClockStats==false
+    // should not be disabled by clock.isEnabled()==false
 
     // don't use getStatTime so always enabled
     long ts = getTime();
@@ -149,9 +138,6 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.endLoad(start);
   }
 
-  /**
-   * @return the timestamp that marks the start of the operation
-   */
   @Override
   public long startNetload() {
     stats.incInt(netloadsInProgressId, 1);
@@ -159,12 +145,9 @@ class RegionPerfStats extends CachePerfStats {
     return getTime();
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   */
   @Override
   public void endNetload(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(netloadTimeId, getTime() - start);
     }
     stats.incInt(netloadsInProgressId, -1);
@@ -172,22 +155,16 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.endNetload(start);
   }
 
-  /**
-   * @return the timestamp that marks the start of the operation
-   */
   @Override
   public long startNetsearch() {
     stats.incInt(netsearchesInProgressId, 1);
     return cachePerfStats.startNetsearch();
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   */
   @Override
   public void endNetsearch(long start) {
     // note that netsearch is used in health checks and timings should
-    // not be disabled by enableClockStats==false
+    // not be disabled by clock.isEnabled()==false
 
     // don't use getStatTime so always enabled
     long ts = getTime();
@@ -197,9 +174,6 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.endNetsearch(start);
   }
 
-  /**
-   * @return the timestamp that marks the start of the operation
-   */
   @Override
   public long startCacheWriterCall() {
     stats.incInt(cacheWriterCallsInProgressId, 1);
@@ -207,12 +181,9 @@ class RegionPerfStats extends CachePerfStats {
     return getTime();
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   */
   @Override
   public void endCacheWriterCall(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(cacheWriterCallTimeId, getTime() - start);
     }
     stats.incInt(cacheWriterCallsInProgressId, -1);
@@ -220,10 +191,6 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.endCacheWriterCall(start);
   }
 
-  /**
-   * @return the timestamp that marks the start of the operation
-   * @since GemFire 3.5
-   */
   @Override
   public long startCacheListenerCall() {
     stats.incInt(cacheListenerCallsInProgressId, 1);
@@ -231,13 +198,9 @@ class RegionPerfStats extends CachePerfStats {
     return getTime();
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   * @since GemFire 3.5
-   */
   @Override
   public void endCacheListenerCall(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(cacheListenerCallTimeId, getTime() - start);
     }
     stats.incInt(cacheListenerCallsInProgressId, -1);
@@ -245,9 +208,6 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.endCacheListenerCall(start);
   }
 
-  /**
-   * @return the timestamp that marks the start of the operation
-   */
   @Override
   public long startGetInitialImage() {
     stats.incInt(getInitialImagesInProgressId, 1);
@@ -255,12 +215,9 @@ class RegionPerfStats extends CachePerfStats {
     return getTime();
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   */
   @Override
   public void endGetInitialImage(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(getInitialImageTimeId, getTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
@@ -268,12 +225,9 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.endGetInitialImage(start);
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   */
   @Override
   public void endNoGIIDone(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(getInitialImageTimeId, getTime() - start);
     }
     stats.incInt(getInitialImagesInProgressId, -1);
@@ -357,12 +311,9 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.incConflatedEventsCount();
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   */
   @Override
   public void endGet(long start, boolean miss) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       long totalNanos = getTime() - start;
       stats.incLong(getTimeId, totalNanos);
     }
@@ -373,22 +324,18 @@ class RegionPerfStats extends CachePerfStats {
     cachePerfStats.endGet(start, miss);
   }
 
-  /**
-   * @param start the timestamp taken when the operation started
-   * @param isUpdate true if the put was an update (origin remote)
-   */
   @Override
   public long endPut(long start, boolean isUpdate) {
     long totalNanos = 0;
     if (isUpdate) {
       stats.incLong(updatesId, 1L);
-      if (enableClockStats) {
+      if (clock.isEnabled()) {
         totalNanos = getTime() - start;
         stats.incLong(updateTimeId, totalNanos);
       }
     } else {
       stats.incLong(putsId, 1L);
-      if (enableClockStats) {
+      if (clock.isEnabled()) {
         totalNanos = getTime() - start;
         stats.incLong(putTimeId, totalNanos);
       }
@@ -400,7 +347,7 @@ class RegionPerfStats extends CachePerfStats {
   @Override
   public void endPutAll(long start) {
     stats.incInt(putAllsId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(putAllTimeId, getTime() - start);
     }
     cachePerfStats.endPutAll(start);
@@ -409,7 +356,7 @@ class RegionPerfStats extends CachePerfStats {
   @Override
   public void endQueryExecution(long executionTime) {
     stats.incInt(queryExecutionsId, 1);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(queryExecutionTimeId, executionTime);
     }
     cachePerfStats.endQueryExecution(executionTime);
@@ -417,7 +364,7 @@ class RegionPerfStats extends CachePerfStats {
 
   @Override
   public void endQueryResultsHashCollisionProbe(long start) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(queryResultsHashCollisionProbeTimeId, getTime() - start);
     }
     cachePerfStats.endQueryResultsHashCollisionProbe(start);
@@ -475,13 +422,13 @@ class RegionPerfStats extends CachePerfStats {
   }
 
   @Override
-  protected void incEventQueueThrottleTime(long nanos) {
+  public void incEventQueueThrottleTime(long nanos) {
     stats.incLong(eventQueueThrottleTimeId, nanos);
     cachePerfStats.incEventQueueThrottleTime(nanos);
   }
 
   @Override
-  protected void incEventThreads(int items) {
+  public void incEventThreads(int items) {
     stats.incInt(eventThreadsId, items);
     cachePerfStats.incEventThreads(items);
   }
@@ -560,7 +507,7 @@ class RegionPerfStats extends CachePerfStats {
   @Override
   public void endImport(long entryCount, long start) {
     stats.incLong(importedEntriesCountId, entryCount);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(importTimeId, getTime() - start);
     }
     cachePerfStats.endImport(entryCount, start);
@@ -569,7 +516,7 @@ class RegionPerfStats extends CachePerfStats {
   @Override
   public void endExport(long entryCount, long start) {
     stats.incLong(exportedEntriesCountId, entryCount);
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       stats.incLong(exportTimeId, getTime() - start);
     }
     cachePerfStats.endExport(entryCount, start);
@@ -584,7 +531,7 @@ class RegionPerfStats extends CachePerfStats {
 
   @Override
   public void endCompression(long startTime, long startSize, long endSize) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       long time = getTime() - startTime;
       stats.incLong(compressionCompressTimeId, time);
       cachePerfStats.stats.incLong(compressionCompressTimeId, time);
@@ -606,7 +553,7 @@ class RegionPerfStats extends CachePerfStats {
 
   @Override
   public void endDecompression(long startTime) {
-    if (enableClockStats) {
+    if (clock.isEnabled()) {
       long time = getTime() - startTime;
       stats.incLong(compressionDecompressTimeId, time);
       cachePerfStats.stats.incLong(compressionDecompressTimeId, time);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionStats.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+public interface RegionStats {
+
+  void incReliableQueuedOps(int inc);
+
+  void incReliableQueueSize(int inc);
+
+  void incReliableQueueMax(int inc);
+
+  void incReliableRegions(int inc);
+
+  void incReliableRegionsMissing(int inc);
+
+  void incReliableRegionsQueuing(int inc);
+
+  void incReliableRegionsMissingFullAccess(int inc);
+
+  void incReliableRegionsMissingLimitedAccess(int inc);
+
+  void incReliableRegionsMissingNoAccess(int inc);
+
+  void incQueuedEvents(int inc);
+
+  long startLoad();
+
+  void endLoad(long start);
+
+  long startNetload();
+
+  void endNetload(long start);
+
+  long startNetsearch();
+
+  void endNetsearch(long start);
+
+  long startCacheWriterCall();
+
+  void endCacheWriterCall(long start);
+
+  long startCacheListenerCall();
+
+  void endCacheListenerCall(long start);
+
+  long startGetInitialImage();
+
+  void endGetInitialImage(long start);
+
+  void endNoGIIDone(long start);
+
+  void incGetInitialImageKeysReceived();
+
+  long startIndexUpdate();
+
+  void endIndexUpdate(long start);
+
+  void incRegions(int inc);
+
+  void incPartitionedRegions(int inc);
+
+  void incDestroys();
+
+  void incCreates();
+
+  void incInvalidates();
+
+  void incTombstoneCount(int amount);
+
+  void incTombstoneGCCount();
+
+  void incClearTimeouts();
+
+  void incConflatedEventsCount();
+
+  void endGet(long start, boolean miss);
+
+  long endPut(long start, boolean isUpdate);
+
+  void endPutAll(long start);
+
+  void endQueryExecution(long executionTime);
+
+  void endQueryResultsHashCollisionProbe(long start);
+
+  void incQueryResultsHashCollisions();
+
+  void incTxConflictCheckTime(long delta);
+
+  void txSuccess(long opTime, long txLifeTime, int txChanges);
+
+  void txFailure(long opTime, long txLifeTime, int txChanges);
+
+  void txRollback(long opTime, long txLifeTime, int txChanges);
+
+  void incEventQueueSize(int items);
+
+  void incEventQueueThrottleCount(int items);
+
+  void incEventQueueThrottleTime(long nanos);
+
+  void incEventThreads(int items);
+
+  void incEntryCount(int delta);
+
+  void incRetries();
+
+  void incDiskTasksWaiting();
+
+  void decDiskTasksWaiting();
+
+  void decDiskTasksWaiting(int count);
+
+  void incEvictorJobsStarted();
+
+  void incEvictorJobsCompleted();
+
+  void incEvictorQueueSize(int delta);
+
+  void incEvictWorkTime(long delta);
+
+  void incClearCount();
+
+  void incPRQueryRetries();
+
+  void incMetaDataRefreshCount();
+
+  void endImport(long entryCount, long start);
+
+  void endExport(long entryCount, long start);
+
+  long startCompression();
+
+  void endCompression(long startTime, long startSize, long endSize);
+
+  long startDecompression();
+
+  void endDecompression(long startTime);
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ServerBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ServerBuilder.java
@@ -35,6 +35,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHe
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Builds instances of {@link InternalCacheServer}.
@@ -43,6 +44,7 @@ class ServerBuilder implements ServerFactory {
 
   private final InternalCache cache;
   private final SecurityService securityService;
+  private final StatisticsClock statisticsClock;
 
   private boolean sendResourceEvents = true;
   private boolean includeMemberGroups = true;
@@ -58,9 +60,11 @@ class ServerBuilder implements ServerFactory {
 
   private List<GatewayTransportFilter> gatewayTransportFilters = Collections.emptyList();
 
-  ServerBuilder(InternalCache cache, SecurityService securityService) {
+  ServerBuilder(InternalCache cache, SecurityService securityService,
+      StatisticsClock statisticsClock) {
     this.cache = cache;
     this.securityService = securityService;
+    this.statisticsClock = statisticsClock;
   }
 
   /**
@@ -109,8 +113,8 @@ class ServerBuilder implements ServerFactory {
     acceptorBuilder.setIsGatewayReceiver(socketCreatorType.isGateway());
     acceptorBuilder.setGatewayTransportFilters(gatewayTransportFilters);
 
-    return new CacheServerImpl(cache, securityService, acceptorBuilder, sendResourceEvents,
-        includeMemberGroups, socketCreatorSupplier, cacheClientNotifierProvider,
+    return new CacheServerImpl(cache, securityService, statisticsClock, acceptorBuilder,
+        sendResourceEvents, includeMemberGroups, socketCreatorSupplier, cacheClientNotifierProvider,
         clientHealthMonitorProvider, cacheServerAdvisorProvider);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -63,6 +63,7 @@ import org.apache.geode.internal.cache.tier.MessageType;
 import org.apache.geode.internal.cache.tier.sockets.Message;
 import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.HashEntry;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap.MapCallback;
@@ -182,11 +183,14 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
    */
   private int transactionTimeToLive;
 
+  private final StatisticsClock statisticsClock;
+
   /**
    * Constructor that implements the {@link CacheTransactionManager} interface. Only only one
    * instance per {@link org.apache.geode.cache.Cache}
    */
-  public TXManagerImpl(CachePerfStats cachePerfStats, InternalCache cache) {
+  public TXManagerImpl(CachePerfStats cachePerfStats, InternalCache cache,
+      StatisticsClock statisticsClock) {
     this.cache = cache;
     this.dm = ((InternalDistributedSystem) cache.getDistributedSystem()).getDistributionManager();
     this.distributionMgrId = this.dm.getDistributionManagerId();
@@ -199,6 +203,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     this.transactionTimeToLive = Integer
         .getInteger(DistributionConfig.GEMFIRE_PREFIX + "cacheServer.transactionTimeToLive", 180);
     currentInstance = this;
+    this.statisticsClock = statisticsClock;
   }
 
   public static TXManagerImpl getCurrentInstanceForTest() {
@@ -352,9 +357,9 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     TXId id = new TXId(this.distributionMgrId, this.uniqId.incrementAndGet());
     TXStateProxyImpl proxy = null;
     if (isDistributed()) {
-      proxy = new DistTXStateProxyImplOnCoordinator(cache, this, id, null);
+      proxy = new DistTXStateProxyImplOnCoordinator(cache, this, id, null, statisticsClock);
     } else {
-      proxy = new TXStateProxyImpl(cache, this, id, null);
+      proxy = new TXStateProxyImpl(cache, this, id, null, statisticsClock);
     }
     setTXState(proxy);
     if (logger.isDebugEnabled()) {
@@ -375,9 +380,9 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     TXStateProxy newState = null;
 
     if (isDistributed()) {
-      newState = new DistTXStateProxyImplOnCoordinator(cache, this, id, true);
+      newState = new DistTXStateProxyImplOnCoordinator(cache, this, id, true, statisticsClock);
     } else {
-      newState = new TXStateProxyImpl(cache, this, id, true);
+      newState = new TXStateProxyImpl(cache, this, id, true, statisticsClock);
     }
     setTXState(newState);
     return newState;
@@ -419,7 +424,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     tx.checkJTA(
         "Can not commit this transaction because it is enlisted with a JTA transaction, use the JTA manager to perform the commit.");
 
-    final long opStart = CachePerfStats.getStatTime();
+    final long opStart = statisticsClock.getTime();
     final long lifeTime = opStart - tx.getBeginTime();
     try {
       setTXState(null);
@@ -448,7 +453,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
   }
 
   void noteCommitFailure(long opStart, long lifeTime, TXStateInterface tx) {
-    long opEnd = CachePerfStats.getStatTime();
+    long opEnd = statisticsClock.getTime();
     this.cachePerfStats.txFailure(opEnd - opStart, lifeTime, tx.getChanges());
     TransactionListener[] listeners = getListeners();
     if (tx.isFireCallbacks() && listeners.length > 0) {
@@ -479,7 +484,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
   }
 
   void noteCommitSuccess(long opStart, long lifeTime, TXStateInterface tx) {
-    long opEnd = CachePerfStats.getStatTime();
+    long opEnd = statisticsClock.getTime();
     this.cachePerfStats.txSuccess(opEnd - opStart, lifeTime, tx.getChanges());
     TransactionListener[] listeners = getListeners();
     if (tx.isFireCallbacks() && listeners.length > 0) {
@@ -536,7 +541,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
     tx.checkJTA(
         "Can not rollback this transaction is enlisted with a JTA transaction, use the JTA manager to perform the rollback.");
 
-    final long opStart = CachePerfStats.getStatTime();
+    final long opStart = statisticsClock.getTime();
     final long lifeTime = opStart - tx.getBeginTime();
     setTXState(null);
     tx.rollback();
@@ -546,7 +551,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
   }
 
   void noteRollbackSuccess(long opStart, long lifeTime, TXStateInterface tx) {
-    long opEnd = CachePerfStats.getStatTime();
+    long opEnd = statisticsClock.getTime();
     this.cachePerfStats.txRollback(opEnd - opStart, lifeTime, tx.getChanges());
     TransactionListener[] listeners = getListeners();
     if (tx.isFireCallbacks() && listeners.length > 0) {
@@ -918,11 +923,13 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
         val = this.hostedTXStates.get(key);
         if (val == null && msg.canStartRemoteTransaction()) {
           if (msg.isTransactionDistributed()) {
-            val = new DistTXStateProxyImplOnDatanode(cache, this, key, msg.getTXOriginatorClient());
-            val.setLocalTXState(new DistTXState(val, true));
+            val = new DistTXStateProxyImplOnDatanode(cache, this, key, msg.getTXOriginatorClient(),
+                statisticsClock);
+            val.setLocalTXState(new DistTXState(val, true, statisticsClock));
           } else {
-            val = new TXStateProxyImpl(cache, this, key, msg.getTXOriginatorClient());
-            val.setLocalTXState(new TXState(val, true));
+            val = new TXStateProxyImpl(cache, this, key, msg.getTXOriginatorClient(),
+                statisticsClock);
+            val.setLocalTXState(new TXState(val, true, statisticsClock));
             val.setTarget(cache.getDistributedSystem().getDistributedMember());
           }
           this.hostedTXStates.put(key, val);
@@ -984,10 +991,10 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
           // TODO: Conditionally create object based on distributed or non-distributed tx mode
           if (msg instanceof TransactionMessage
               && ((TransactionMessage) msg).isTransactionDistributed()) {
-            val = new DistTXStateProxyImplOnDatanode(cache, this, key, memberId);
+            val = new DistTXStateProxyImplOnDatanode(cache, this, key, memberId, statisticsClock);
             // val.setLocalTXState(new DistTXState(val,true));
           } else {
-            val = new TXStateProxyImpl(cache, this, key, memberId);
+            val = new TXStateProxyImpl(cache, this, key, memberId, statisticsClock);
             // val.setLocalTXState(new TXState(val,true));
           }
           this.hostedTXStates.put(key, val);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -44,6 +44,7 @@ import org.apache.geode.internal.cache.tx.ClientTXStateStub;
 import org.apache.geode.internal.cache.tx.TransactionalOperation.ServerRegionOperation;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class TXStateProxyImpl implements TXStateProxy {
   private static final Logger logger = LogService.getLogger();
@@ -77,26 +78,34 @@ public class TXStateProxyImpl implements TXStateProxy {
 
   private final InternalCache cache;
   private long lastOperationTimeFromClient;
+  private final StatisticsClock statisticsClock;
 
   public TXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id,
-      InternalDistributedMember clientMember) {
+      InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
     this.cache = cache;
     this.txMgr = managerImpl;
     this.txId = id;
     this.isJTA = false;
     this.onBehalfOfClientMember = clientMember;
+    this.statisticsClock = statisticsClock;
   }
 
-  public TXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id, boolean isjta) {
+  public TXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id, boolean isjta,
+      StatisticsClock statisticsClock) {
     this.cache = cache;
     this.txMgr = managerImpl;
     this.txId = id;
     this.isJTA = isjta;
+    this.statisticsClock = statisticsClock;
   }
 
   @Override
   public ReentrantLock getLock() {
     return this.lock;
+  }
+
+  protected StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 
   boolean isJTA() {
@@ -124,7 +133,7 @@ public class TXStateProxyImpl implements TXStateProxy {
   public TXStateInterface getRealDeal(KeyInfo key, InternalRegion r) {
     if (this.realDeal == null) {
       if (r == null) { // TODO: stop gap to get tests working
-        this.realDeal = new TXState(this, false);
+        this.realDeal = new TXState(this, false, statisticsClock);
       } else {
         // Code to keep going forward
         if (r.hasServerProxy()) {
@@ -143,7 +152,7 @@ public class TXStateProxyImpl implements TXStateProxy {
           r.waitOnInitialization(r.getInitializationLatchBeforeGetInitialImage());
           target = r.getOwnerForKey(key);
           if (target == null || target.equals(this.txMgr.getDM().getId())) {
-            this.realDeal = new TXState(this, false);
+            this.realDeal = new TXState(this, false, statisticsClock);
           } else {
             this.realDeal = new PeerTXStateStub(this, target, onBehalfOfClientMember);
           }
@@ -161,7 +170,7 @@ public class TXStateProxyImpl implements TXStateProxy {
     if (this.realDeal == null) {
       this.target = t;
       if (target.equals(getCache().getDistributedSystem().getDistributedMember())) {
-        this.realDeal = new TXState(this, false);
+        this.realDeal = new TXState(this, false, statisticsClock);
       } else {
         /*
          * txtodo: // what to do!! We don't know if this is client or server!!!

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/OffHeapEvictor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/OffHeapEvictor.java
@@ -20,6 +20,7 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.control.InternalResourceManager.ResourceType;
 import org.apache.geode.internal.offheap.MemoryAllocator;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Triggers centralized eviction(asynchronously) when the ResourceManager sends an eviction event
@@ -33,8 +34,8 @@ public class OffHeapEvictor extends HeapEvictor {
 
   private long bytesToEvictWithEachBurst;
 
-  public OffHeapEvictor(final InternalCache cache) {
-    super(cache, EVICTOR_THREAD_NAME);
+  public OffHeapEvictor(final InternalCache cache, StatisticsClock statisticsClock) {
+    super(cache, EVICTOR_THREAD_NAME, statisticsClock);
     calculateEvictionBurst();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
@@ -49,10 +49,10 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.CancelException;
 import org.apache.geode.InternalGemFireError;
-import org.apache.geode.InternalGemFireException;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.cache.AttributesFactory;
@@ -100,6 +100,7 @@ import org.apache.geode.internal.cache.tier.sockets.Handshake;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingThread;
 import org.apache.geode.internal.logging.log4j.LogMarker;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.internal.util.concurrent.StoppableCondition;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantLock;
@@ -325,21 +326,63 @@ public class HARegionQueue implements RegionQueue {
     return regionName.replace('/', '#');
   }
 
+  /**
+   * @param isPrimary whether this is the primary queue for a client
+   */
+  protected HARegionQueue(String regionName, InternalCache cache, Map haContainer,
+      ClientProxyMembershipID clientProxyId, final byte clientConflation, boolean isPrimary,
+      StatisticsClock statisticsClock)
+      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
+
+    String processedRegionName = createRegionName(regionName);
+
+    // Initialize the statistics
+    StatisticsFactory factory = cache.getInternalDistributedSystem().getStatisticsManager();
+
+    AttributesFactory af = new AttributesFactory();
+    af.setMirrorType(MirrorType.KEYS_VALUES);
+    af.addCacheListener(createCacheListenerForHARegion());
+    af.setStatisticsEnabled(true);
+    RegionAttributes ra = af.create();
+
+    this.region = HARegion.getInstance(processedRegionName, cache, this, ra, statisticsClock);
+
+    if (this.isPrimary) {// fix for 41878
+      // since it's primary queue, we will disable the EntryExpiryTask
+      // this should be done after region creation
+      disableEntryExpiryTasks();
+    }
+
+    this.regionName = processedRegionName;
+    this.threadIdToSeqId = new MapWrapper();
+    this.idsAvailable = new LinkedHashSet();
+    setClientConflation(clientConflation);
+    this.isPrimary = isPrimary;
+    // Initialize the statistics
+    this.stats = new HARegionQueueStats(factory, processedRegionName);
+    this.haContainer = haContainer;
+    this.giiLock = new StoppableReentrantReadWriteLock(cache.getCancelCriterion());
+    this.clientProxyID = clientProxyId;
+
+    this.stopper = this.region.getCancelCriterion();
+    this.rwLock = new StoppableReentrantReadWriteLock(region.getCancelCriterion());
+    this.readLock = this.rwLock.readLock();
+    this.writeLock = this.rwLock.writeLock();
+
+    putGIIDataInRegion();
+
+    if (this.getClass() == HARegionQueue.class) {
+      initialized.set(true);
+    }
+  }
+
+  @VisibleForTesting
   HARegionQueue(String regionName, HARegion haRegion, InternalCache cache, Map haContainer,
       ClientProxyMembershipID clientProxyId, final byte clientConflation, boolean isPrimary,
       HARegionQueueStats stats, StoppableReentrantReadWriteLock giiLock,
       StoppableReentrantReadWriteLock rwLock, CancelCriterion cancelCriterion,
-      boolean puttingGIIDataInQueue)
+      boolean puttingGIIDataInQueue, StatisticsClock statisticsClock)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    initializeHARegionQueue(regionName, haRegion, haContainer, clientProxyId, clientConflation,
-        isPrimary, stats, giiLock, rwLock, cancelCriterion, puttingGIIDataInQueue);
-  }
-
-  private void initializeHARegionQueue(String regionName, HARegion haRegion, Map haContainer,
-      ClientProxyMembershipID clientProxyId, byte clientConflation, boolean isPrimary,
-      HARegionQueueStats stats, StoppableReentrantReadWriteLock giiLock,
-      StoppableReentrantReadWriteLock rwLock, CancelCriterion cancelCriterion,
-      boolean putGIIDataInQueue) throws InterruptedException {
     this.regionName = regionName;
     this.region = haRegion;
     this.threadIdToSeqId = new MapWrapper();
@@ -358,75 +401,13 @@ public class HARegionQueue implements RegionQueue {
     this.writeLock = this.rwLock.writeLock();
 
     // false specifically set in tests only
-    if (putGIIDataInQueue) {
+    if (puttingGIIDataInQueue) {
       putGIIDataInRegion();
     }
     if (this.getClass() == HARegionQueue.class) {
       initialized.set(true);
     }
   }
-
-  /**
-   * @param isPrimary whether this is the primary queue for a client
-   */
-  protected HARegionQueue(String regionName, InternalCache cache, Map haContainer,
-      ClientProxyMembershipID clientProxyId, final byte clientConflation, boolean isPrimary)
-      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-
-    String processedRegionName = createRegionName(regionName);
-
-    // Initialize the statistics
-    StatisticsFactory factory = cache.getDistributedSystem();
-    createHARegion(processedRegionName, cache);
-
-    initializeHARegionQueue(processedRegionName, this.region, haContainer, clientProxyId,
-        clientConflation, isPrimary, new HARegionQueueStats(factory, processedRegionName),
-        new StoppableReentrantReadWriteLock(cache.getCancelCriterion()),
-        new StoppableReentrantReadWriteLock(region.getCancelCriterion()),
-        this.region.getCancelCriterion(), true);
-  }
-
-  private void createHARegion(String processedRegionName, InternalCache cache)
-      throws IOException, ClassNotFoundException {
-    AttributesFactory af = new AttributesFactory();
-    af.setMirrorType(MirrorType.KEYS_VALUES);
-    af.addCacheListener(createCacheListenerForHARegion());
-    af.setStatisticsEnabled(true);
-    RegionAttributes ra = af.create();
-    this.region = HARegion.getInstance(processedRegionName, cache, this, ra);
-
-    if (isPrimary) {// fix for 41878
-      // since it's primary queue, we will disable the EntryExpiryTask
-      // this should be done after region creation
-      disableEntryExpiryTasks();
-    }
-  }
-
-  /**
-   * reinitialize the queue, presumably pulling current information from seconaries
-   */
-  public void reinitializeRegion() {
-    InternalCache cache = this.region.getCache();
-    String regionName = this.region.getName();
-    this.region.destroyRegion();
-    Exception problem = null;
-    try {
-      createHARegion(regionName, cache);
-    } catch (IOException | ClassNotFoundException e) {
-      problem = e;
-    }
-    if (problem != null) {
-      throw new InternalGemFireException("Problem recreating region queue '" + regionName + "'");
-    }
-    try {
-      this.putGIIDataInRegion();
-    } catch (InterruptedException e) {
-      cache.getCancelCriterion().checkCancelInProgress(e);
-      Thread.currentThread().interrupt();
-    }
-  }
-
-
 
   /**
    * install DACE information from an initial image provider
@@ -1964,7 +1945,7 @@ public class HARegionQueue implements RegionQueue {
    * @return an instance of HARegionQueue
    */
   public static HARegionQueue getHARegionQueueInstance(String regionName, InternalCache cache,
-      final int haRgnQType, final boolean isDurable)
+      final int haRgnQType, final boolean isDurable, StatisticsClock statisticsClock)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     Map container = null;
     if (haRgnQType == HARegionQueue.BLOCKING_HA_QUEUE) {
@@ -1977,7 +1958,7 @@ public class HARegionQueue implements RegionQueue {
 
     return getHARegionQueueInstance(regionName, cache,
         HARegionQueueAttributes.DEFAULT_HARQ_ATTRIBUTES, haRgnQType, isDurable, container, null,
-        Handshake.CONFLATION_DEFAULT, false, Boolean.FALSE);
+        Handshake.CONFLATION_DEFAULT, false, Boolean.FALSE, statisticsClock);
   }
 
   /**
@@ -1995,7 +1976,7 @@ public class HARegionQueue implements RegionQueue {
   public static HARegionQueue getHARegionQueueInstance(String regionName, InternalCache cache,
       HARegionQueueAttributes hrqa, final int haRgnQType, final boolean isDurable, Map haContainer,
       ClientProxyMembershipID clientProxyId, final byte clientConflation, boolean isPrimary,
-      boolean canHandleDelta)
+      boolean canHandleDelta, StatisticsClock statisticsClock)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
 
     HARegionQueue hrq = null;
@@ -2003,15 +1984,15 @@ public class HARegionQueue implements RegionQueue {
       case BLOCKING_HA_QUEUE:
         if (!isDurable && !canHandleDelta) {
           hrq = new BlockingHARegionQueue(regionName, cache, hrqa, haContainer, clientProxyId,
-              clientConflation, isPrimary);
+              clientConflation, isPrimary, statisticsClock);
         } else {
           hrq = new DurableHARegionQueue(regionName, cache, hrqa, haContainer, clientProxyId,
-              clientConflation, isPrimary);
+              clientConflation, isPrimary, statisticsClock);
         }
         break;
       case NON_BLOCKING_HA_QUEUE:
         hrq = new HARegionQueue(regionName, cache, haContainer, clientProxyId, clientConflation,
-            isPrimary);
+            isPrimary, statisticsClock);
         break;
       default:
         throw new IllegalArgumentException(
@@ -2036,7 +2017,8 @@ public class HARegionQueue implements RegionQueue {
    * @since GemFire 5.7
    */
   public static HARegionQueue getHARegionQueueInstance(String regionName, InternalCache cache,
-      HARegionQueueAttributes hrqa, final int haRgnQType, final boolean isDurable)
+      HARegionQueueAttributes hrqa, final int haRgnQType, final boolean isDurable,
+      StatisticsClock statisticsClock)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
     Map container = null;
     if (haRgnQType == HARegionQueue.BLOCKING_HA_QUEUE) {
@@ -2048,7 +2030,7 @@ public class HARegionQueue implements RegionQueue {
     }
 
     return getHARegionQueueInstance(regionName, cache, hrqa, haRgnQType, isDurable, container, null,
-        Handshake.CONFLATION_DEFAULT, false, Boolean.FALSE);
+        Handshake.CONFLATION_DEFAULT, false, Boolean.FALSE, statisticsClock);
   }
 
   public boolean isEmptyAckList() {
@@ -2220,9 +2202,10 @@ public class HARegionQueue implements RegionQueue {
      */
     protected BlockingHARegionQueue(String regionName, InternalCache cache,
         HARegionQueueAttributes hrqa, Map haContainer, ClientProxyMembershipID clientProxyId,
-        final byte clientConflation, boolean isPrimary)
+        final byte clientConflation, boolean isPrimary, StatisticsClock statisticsClock)
         throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      super(regionName, cache, haContainer, clientProxyId, clientConflation, isPrimary);
+      super(regionName, cache, haContainer, clientProxyId, clientConflation, isPrimary,
+          statisticsClock);
       this.capacity = hrqa.getBlockingQueueCapacity();
       this.putPermits = this.capacity;
       this.lock = new StoppableReentrantLock(this.region.getCancelCriterion());
@@ -2449,9 +2432,10 @@ public class HARegionQueue implements RegionQueue {
 
     protected DurableHARegionQueue(String regionName, InternalCache cache,
         HARegionQueueAttributes hrqa, Map haContainer, ClientProxyMembershipID clientProxyId,
-        final byte clientConflation, boolean isPrimary)
+        final byte clientConflation, boolean isPrimary, StatisticsClock statisticsClock)
         throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      super(regionName, cache, hrqa, haContainer, clientProxyId, clientConflation, isPrimary);
+      super(regionName, cache, hrqa, haContainer, clientProxyId, clientConflation, isPrimary,
+          statisticsClock);
 
       this.threadIdToSeqId.keepPrevAcks = true;
       this.durableIDsList = new LinkedHashSet();
@@ -2670,54 +2654,6 @@ public class HARegionQueue implements RegionQueue {
    */
   public void clearPeekedIDs() {
     peekedEventsContext.set(null);
-  }
-
-  /**
-   * A static class which is created only for for testing prposes as some existing tests extend the
-   * HARegionQueue. Since the constructors of HAregionQueue are private , this class can act as a
-   * bridge between the user defined HARegionQueue class & the actual class. This class object will
-   * be buggy as it will tend to publish the Object o QRM thread & the expiry thread before the
-   * complete creation of the HARegionQueue instance
-   */
-  static class TestOnlyHARegionQueue extends HARegionQueue {
-    /**
-     * Overloaded constructor to accept haContainer.
-     *
-     * @since GemFire 5.7
-     */
-    TestOnlyHARegionQueue(String regionName, InternalCache cache, Map haContainer)
-        throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      this(regionName, cache, HARegionQueueAttributes.DEFAULT_HARQ_ATTRIBUTES, haContainer,
-          Handshake.CONFLATION_DEFAULT, false);
-      this.initialized.set(true);
-    }
-
-    TestOnlyHARegionQueue(String regionName, InternalCache cache)
-        throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      this(regionName, cache, HARegionQueueAttributes.DEFAULT_HARQ_ATTRIBUTES, new HashMap(),
-          Handshake.CONFLATION_DEFAULT, false);
-    }
-
-    TestOnlyHARegionQueue(String regionName, InternalCache cache, HARegionQueueAttributes hrqa,
-        Map haContainer, final byte clientConflation, boolean isPrimary)
-        throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      super(regionName, cache, haContainer, null, clientConflation, isPrimary);
-      ExpirationAttributes ea =
-          new ExpirationAttributes(hrqa.getExpiryTime(), ExpirationAction.LOCAL_INVALIDATE);
-      this.region.setOwner(this);
-      this.region.getAttributesMutator().setEntryTimeToLive(ea);
-      this.initialized.set(true);
-    }
-
-    /**
-     * Overloaded constructor to pass an {@code HashMap} instance as a haContainer.
-     *
-     * @since GemFire 5.7
-     */
-    TestOnlyHARegionQueue(String regionName, InternalCache cache, HARegionQueueAttributes hrqa)
-        throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-      this(regionName, cache, hrqa, new HashMap(), Handshake.CONFLATION_DEFAULT, false);
-    }
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateMissingBucketsTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateMissingBucketsTask.java
@@ -18,7 +18,6 @@ import org.apache.geode.internal.cache.ColocationHelper;
 import org.apache.geode.internal.cache.PRHARedundancyProvider;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegion.RecoveryLock;
-import org.apache.geode.internal.cache.PartitionedRegionStats;
 
 /**
  * A task for creating buckets in a child colocated region that are present in the leader region.
@@ -47,7 +46,7 @@ public class CreateMissingBucketsTask extends RecoveryRunnable {
     if (parentRegion == null) {
       return;
     }
-    // Fix for 48954 - Make sure the parent region has created missing buckets
+    // Make sure the parent region has created missing buckets
     // before we create missing buckets for this child region.
     createMissingBuckets(parentRegion);
 
@@ -55,8 +54,6 @@ public class CreateMissingBucketsTask extends RecoveryRunnable {
 
       if (parentRegion.getRegionAdvisor().getBucketAdvisor(i).getBucketRedundancy() != region
           .getRegionAdvisor().getBucketAdvisor(i).getBucketRedundancy()) {
-        /* if (leaderRegion.getRegionAdvisor().isStorageAssignedForBucket(i)) { */
-        final long startTime = PartitionedRegionStats.startTime();
         region.getRedundancyProvider().createBucketAtomically(i, 0, true, null);
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/RegionSnapshotServiceImpl.java
@@ -50,7 +50,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.DSCODE;
 import org.apache.geode.internal.InternalEntity;
-import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.CachedDeserializable;
 import org.apache.geode.internal.cache.CachedDeserializableFactory;
 import org.apache.geode.internal.cache.InternalCache;
@@ -234,7 +233,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
       throws IOException, ClassNotFoundException {
     long count = 0;
     long bytes = 0;
-    long start = CachePerfStats.getStatTime();
+    long start = local.getCachePerfStats().getTime();
 
     // Would be interesting to use a PriorityQueue ordered on isDone()
     // but this is probably close enough in practice.
@@ -349,7 +348,7 @@ public class RegionSnapshotServiceImpl<K, V> implements RegionSnapshotService<K,
     }
 
     long count = 0;
-    long start = CachePerfStats.getStatTime();
+    long start = local.getCachePerfStats().getTime();
     SnapshotWriter writer =
         GFSnapshot.create(snapshot, region.getFullPath(), (InternalCache) region.getCache());
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilder.java
@@ -29,6 +29,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier.CacheCli
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHealthMonitorProvider;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Builds an instance of {@link Acceptor}.
@@ -51,6 +52,7 @@ public class AcceptorBuilder implements AcceptorFactory {
   private ServerConnectionFactory serverConnectionFactory;
   private long timeLimitMillis;
   private SecurityService securityService;
+  private StatisticsClock statisticsClock;
 
   private boolean isGatewayReceiver;
   private List<GatewayTransportFilter> gatewayTransportFilters = Collections.emptyList();
@@ -79,6 +81,7 @@ public class AcceptorBuilder implements AcceptorFactory {
     serverConnectionFactory = server.getServerConnectionFactory();
     timeLimitMillis = server.getTimeLimitMillis();
     securityService = server.getSecurityService();
+    statisticsClock = server.getStatisticsClock();
 
     socketCreatorSupplier = server.getSocketCreatorSupplier();
     cacheClientNotifierProvider = server.getCacheClientNotifierProvider();
@@ -285,6 +288,16 @@ public class AcceptorBuilder implements AcceptorFactory {
     return this;
   }
 
+  /**
+   * Sets {@code statisticsClock}. Must be invoked after or instead of
+   * {@link #forServer(InternalCacheServer)}.
+   */
+  @VisibleForTesting
+  AcceptorBuilder setStatisticsClock(StatisticsClock statisticsClock) {
+    this.statisticsClock = statisticsClock;
+    return this;
+  }
+
   @Override
   public Acceptor create(OverflowAttributes overflowAttributes) throws IOException {
     return new AcceptorImpl(port, bindAddress, notifyBySubscription, socketBufferSize,
@@ -292,7 +305,7 @@ public class AcceptorBuilder implements AcceptorFactory {
         messageTimeToLive, connectionListener, overflowAttributes, tcpNoDelay,
         serverConnectionFactory, timeLimitMillis, securityService, socketCreatorSupplier,
         cacheClientNotifierProvider, clientHealthMonitorProvider, isGatewayReceiver,
-        gatewayTransportFilters);
+        gatewayTransportFilters, statisticsClock);
   }
 
   @VisibleForTesting
@@ -393,5 +406,10 @@ public class AcceptorBuilder implements AcceptorFactory {
   @VisibleForTesting
   ClientHealthMonitorProvider getClientHealthMonitorProvider() {
     return clientHealthMonitorProvider;
+  }
+
+  @VisibleForTesting
+  StatisticsClock getStatisticsClock() {
+    return statisticsClock;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -98,6 +98,8 @@ import org.apache.geode.internal.logging.LoggingThreadFactory.ThreadInitializer;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.internal.tcp.ConnectionTable;
 import org.apache.geode.internal.util.ArrayUtils;
 
@@ -336,6 +338,7 @@ public class AcceptorImpl implements Acceptor, Runnable {
   private final boolean isGatewayReceiver;
 
   private final List<GatewayTransportFilter> gatewayTransportFilters;
+  private final StatisticsClock statisticsClock;
 
   private final SocketCreator socketCreator;
 
@@ -380,7 +383,8 @@ public class AcceptorImpl implements Acceptor, Runnable {
         internalCache, maxConnections, maxThreads, maximumMessageCount, messageTimeToLive,
         connectionListener, overflowAttributes, tcpNoDelay, serverConnectionFactory,
         timeLimitMillis, securityService, socketCreatorSupplier, cacheClientNotifierProvider,
-        clientHealthMonitorProvider, false, Collections.emptyList());
+        clientHealthMonitorProvider, false, Collections.emptyList(),
+        StatisticsClockFactory.disabledClock());
   }
 
   /**
@@ -389,6 +393,8 @@ public class AcceptorImpl implements Acceptor, Runnable {
    * <p>
    * Initializes this acceptor thread to listen for connections on the given port.
    *
+   * @param gatewayReceiver the GatewayReceiver that will use this AcceptorImpl instance
+   * @param gatewayReceiverMetrics the GatewayReceiverMetrics to use for exposing metrics
    * @param port The port on which this acceptor listens for connections. If {@code 0}, a
    *        random port will be chosen.
    * @param bindHostName The ip address or host name this acceptor listens on for connections. If
@@ -400,23 +406,24 @@ public class AcceptorImpl implements Acceptor, Runnable {
    * @param maxConnections the maximum number of connections allowed in the server pool
    * @param maxThreads the maximum number of threads allowed in the server pool
    * @param securityService the SecurityService to use for authentication and authorization
-   * @param gatewayReceiver the GatewayReceiver that will use this AcceptorImpl instance
-   * @param gatewayReceiverMetrics the GatewayReceiverMetrics to use for exposing metrics
    * @param gatewayTransportFilters List of GatewayTransportFilters
    */
   AcceptorImpl(final int port, final String bindHostName, final boolean notifyBySubscription,
       final int socketBufferSize, final int maximumTimeBetweenPings,
       final InternalCache internalCache, final int maxConnections, final int maxThreads,
       final int maximumMessageCount, final int messageTimeToLive,
-      final ConnectionListener connectionListener, final OverflowAttributes overflowAttributes,
+      final ConnectionListener connectionListener,
+      final OverflowAttributes overflowAttributes,
       final boolean tcpNoDelay, final ServerConnectionFactory serverConnectionFactory,
       final long timeLimitMillis, final SecurityService securityService,
       final Supplier<SocketCreator> socketCreatorSupplier,
       final CacheClientNotifierProvider cacheClientNotifierProvider,
       final ClientHealthMonitorProvider clientHealthMonitorProvider,
       final boolean isGatewayReceiver,
-      final List<GatewayTransportFilter> gatewayTransportFilters) throws IOException {
+      final List<GatewayTransportFilter> gatewayTransportFilters,
+      final StatisticsClock statisticsClock) throws IOException {
     this.securityService = securityService;
+    this.statisticsClock = statisticsClock;
 
     this.isGatewayReceiver = isGatewayReceiver;
     this.gatewayTransportFilters = gatewayTransportFilters;
@@ -609,8 +616,9 @@ public class AcceptorImpl implements Acceptor, Runnable {
     cache = internalCache;
     crHelper = new CachedRegionHelper(cache);
 
-    clientNotifier = cacheClientNotifierProvider.get(internalCache, stats, maximumMessageCount,
-        messageTimeToLive, this.connectionListener, overflowAttributes, isGatewayReceiver());
+    clientNotifier =
+        cacheClientNotifierProvider.get(internalCache, statisticsClock, stats, maximumMessageCount,
+            messageTimeToLive, this.connectionListener, overflowAttributes, isGatewayReceiver());
 
     this.socketBufferSize = socketBufferSize;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -100,6 +100,7 @@ import org.apache.geode.internal.logging.LoggingThread;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.security.AuthorizeRequestPP;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.security.AccessControl;
 
 /**
@@ -315,6 +316,7 @@ public class CacheClientProxy implements ClientSession {
   private final Object drainsInProgressLock = new Object();
 
   private final SecurityService securityService;
+  private final StatisticsClock statisticsClock;
 
   /**
    * Constructor.
@@ -328,7 +330,8 @@ public class CacheClientProxy implements ClientSession {
   protected CacheClientProxy(CacheClientNotifier ccn, Socket socket,
       ClientProxyMembershipID proxyID, boolean isPrimary, byte clientConflation,
       Version clientVersion, long acceptorId, boolean notifyBySubscription,
-      SecurityService securityService, Subject subject) throws CacheException {
+      SecurityService securityService, Subject subject, StatisticsClock statisticsClock)
+      throws CacheException {
 
     initializeTransientFields(socket, proxyID, isPrimary, clientConflation, clientVersion);
     this._cacheClientNotifier = ccn;
@@ -338,7 +341,8 @@ public class CacheClientProxy implements ClientSession {
     this._messageTimeToLive = ccn.getMessageTimeToLive();
     this._acceptorId = acceptorId;
     this.notifyBySubscription = notifyBySubscription;
-    StatisticsFactory factory = this._cache.getDistributedSystem();
+    StatisticsFactory factory = this._cache.getInternalDistributedSystem().getStatisticsManager();
+    this.statisticsClock = statisticsClock;
     this._statistics =
         new CacheClientProxyStats(factory, "id_" + this.proxyID.getDistributedMember().getId()
             + "_at_" + this._remoteHostAddress + ":" + this._socket.getPort());
@@ -1704,7 +1708,7 @@ public class CacheClientProxy implements ClientSession {
   }
 
   MessageDispatcher createMessageDispatcher(String name) {
-    return new MessageDispatcher(this, name);
+    return new MessageDispatcher(this, name, statisticsClock);
   }
 
   protected void startOrResumeMessageDispatcher(boolean processedMarker) {
@@ -2225,7 +2229,8 @@ public class CacheClientProxy implements ClientSession {
      *        messages
      * @param name thread name for this dispatcher
      */
-    protected MessageDispatcher(CacheClientProxy proxy, String name) throws CacheException {
+    protected MessageDispatcher(CacheClientProxy proxy, String name,
+        StatisticsClock statisticsClock) throws CacheException {
       super(name);
 
       this._proxy = proxy;
@@ -2252,7 +2257,7 @@ public class CacheClientProxy implements ClientSession {
         this._messageQueue = HARegionQueue.getHARegionQueueInstance(getProxy().getHARegionName(),
             getCache(), harq, HARegionQueue.BLOCKING_HA_QUEUE, createDurableQueue,
             proxy._cacheClientNotifier.getHaContainer(), proxy.getProxyID(),
-            this._proxy.clientConflation, this._proxy.isPrimary(), canHandleDelta);
+            this._proxy.clientConflation, this._proxy.isPrimary(), canHandleDelta, statisticsClock);
         // Check if interests were registered during HARegion GII.
         if (this._proxy.hasRegisteredInterested()) {
           this._messageQueue.setHasRegisteredInterest(true);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
@@ -40,7 +40,6 @@ import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.KeyInfo;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegion.RetryTimeKeeper;
-import org.apache.geode.internal.cache.PartitionedRegionStats;
 import org.apache.geode.internal.cache.PrimaryBucketException;
 import org.apache.geode.internal.cache.PutAllPartialResultException;
 import org.apache.geode.internal.cache.PutAllPartialResultException.PutAllPartialResult;
@@ -401,7 +400,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     }
 
     PartitionedRegion pr = (PartitionedRegion) r;
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = pr.prStats.getTime();
     // build all the msgs by bucketid
     HashMap prMsgMap = putallO.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(putallO.putAllDataSize);
@@ -461,7 +460,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     }
 
     PartitionedRegion pr = (PartitionedRegion) r;
-    final long startTime = PartitionedRegionStats.startTime();
+    final long startTime = pr.prStats.getTime();
     // build all the msgs by bucketid
     HashMap<Integer, RemoveAllPRMessage> prMsgMap = op.createPRMessages();
     PutAllPartialResult partialKeys = new PutAllPartialResult(op.removeAllDataSize);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/InternalGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/InternalGatewaySender.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.RegionQueue;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public interface InternalGatewaySender extends GatewaySender {
 
@@ -32,6 +33,8 @@ public interface InternalGatewaySender extends GatewaySender {
   boolean isPrimary();
 
   GatewaySenderStats getStatistics();
+
+  StatisticsClock getStatisticsClock();
 
   boolean waitUntilFlushed(long timeout, TimeUnit unit) throws InterruptedException;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -84,6 +84,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderStats;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingExecutors;
 import org.apache.geode.internal.size.SingleObjectSizer;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.StoppableCondition;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantLock;
 import org.apache.geode.management.ManagementService;
@@ -359,7 +360,8 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
         }
 
         ParallelGatewaySenderQueueMetaRegion meta =
-            new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender);
+            new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender,
+                sender.getStatisticsClock());
 
         try {
           prQ = (PartitionedRegion) cache.createVMRegion(prQName, ra,
@@ -1789,12 +1791,14 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     AbstractGatewaySender sender = null;
 
     public ParallelGatewaySenderQueueMetaRegion(String regionName, RegionAttributes attrs,
-        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender pgSender) {
+        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender pgSender,
+        StatisticsClock statisticsClock) {
       super(regionName, attrs, parentRegion, cache,
           new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
               .setSnapshotInputStream(null).setImageTarget(null)
               .setIsUsedForParallelGatewaySenderQueue(true)
-              .setParallelGatewaySender((AbstractGatewaySender) pgSender));
+              .setParallelGatewaySender((AbstractGatewaySender) pgSender),
+          statisticsClock);
       this.sender = (AbstractGatewaySender) pgSender;
 
     }
@@ -1855,7 +1859,8 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     ParallelGatewaySenderQueueMetaRegion newMetataRegion(InternalCache cache, final String prQName,
         final RegionAttributes ra, AbstractGatewaySender sender) {
       ParallelGatewaySenderQueueMetaRegion meta =
-          new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender);
+          new ParallelGatewaySenderQueueMetaRegion(prQName, ra, null, cache, sender,
+              sender.getStatisticsClock());
       return meta;
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -69,6 +69,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
 import org.apache.geode.internal.cache.wan.GatewaySenderStats;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.OffHeapRegionEntryHelper;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.beans.AsyncEventQueueMBean;
 import org.apache.geode.management.internal.beans.GatewaySenderMBean;
@@ -876,7 +877,8 @@ public class SerialGatewaySenderQueue implements RegionQueue {
       final RegionAttributes<Long, AsyncEvent> ra = factory.create();
       try {
         SerialGatewaySenderQueueMetaRegion meta =
-            new SerialGatewaySenderQueueMetaRegion(this.regionName, ra, null, gemCache, sender);
+            new SerialGatewaySenderQueueMetaRegion(this.regionName, ra, null, gemCache, sender,
+                sender.getStatisticsClock());
         try {
           this.region = gemCache.createVMRegion(this.regionName, ra,
               new InternalRegionArguments().setInternalMetaRegion(meta).setDestroyLockFlag(true)
@@ -1116,11 +1118,13 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     AbstractGatewaySender sender = null;
 
     protected SerialGatewaySenderQueueMetaRegion(String regionName, RegionAttributes attrs,
-        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender sender) {
+        LocalRegion parentRegion, InternalCache cache, AbstractGatewaySender sender,
+        StatisticsClock statisticsClock) {
       super(regionName, attrs, parentRegion, cache,
           new InternalRegionArguments().setDestroyLockFlag(true).setRecreateFlag(false)
               .setSnapshotInputStream(null).setImageTarget(null)
-              .setIsUsedForSerialGatewaySenderQueue(true).setSerialGatewaySender(sender));
+              .setIsUsedForSerialGatewaySenderQueue(true).setSerialGatewaySender(sender),
+          statisticsClock);
       this.sender = sender;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache.xmlcache;
 import static java.lang.String.format;
 import static org.apache.geode.internal.logging.LogWriterFactory.toSecurityLogWriter;
 import static org.apache.geode.internal.logging.LogWriterLevel.ALL;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 
 import java.io.File;
 import java.io.IOException;
@@ -157,6 +158,7 @@ import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.security.SecurityServiceFactory;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
 import org.apache.geode.pdx.JSONFormatter;
@@ -2424,6 +2426,11 @@ public class CacheCreation implements InternalCache {
   @Override
   public void saveCacheXmlForReconnect() {
     throw new UnsupportedOperationException("Should not be invoked");
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
+    return disabledClock();
   }
 
   CacheTransactionManagerCreation getCacheTransactionManagerCreation() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheServerCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheServerCreation.java
@@ -34,6 +34,7 @@ import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnectionFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Represents a {@link CacheServer} that is created declaratively.
@@ -307,6 +308,11 @@ public class CacheServerCreation extends AbstractCacheServer {
 
   @Override
   public String[] getCombinedGroups() {
+    throw new UnsupportedOperationException("Shouldn't be invoked");
+  }
+
+  @Override
+  public StatisticsClock getStatisticsClock() {
     throw new UnsupportedOperationException("Shouldn't be invoked");
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelAsyncEventQueueCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelAsyncEventQueueCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -33,7 +35,7 @@ public class ParallelAsyncEventQueueCreation extends AbstractGatewaySender
     implements GatewaySender {
 
   public ParallelAsyncEventQueueCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelGatewaySenderCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ParallelGatewaySenderCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -33,7 +35,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class ParallelGatewaySenderCreation extends AbstractGatewaySender implements GatewaySender {
 
   public ParallelGatewaySenderCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialAsyncEventQueueCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialAsyncEventQueueCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -32,7 +34,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class SerialAsyncEventQueueCreation extends AbstractGatewaySender implements GatewaySender {
 
   public SerialAsyncEventQueueCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialGatewaySenderCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/SerialGatewaySenderCreation.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.xmlcache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+
 import java.util.List;
 
 import org.apache.geode.CancelCriterion;
@@ -33,7 +35,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 public class SerialGatewaySenderCreation extends AbstractGatewaySender implements GatewaySender {
 
   public SerialGatewaySenderCreation(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+    super(cache, disabledClock(), attrs);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/DisabledStatisticsClock.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/DisabledStatisticsClock.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+public class DisabledStatisticsClock implements StatisticsClock {
+
+  @Override
+  public long getTime() {
+    return 0;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return false;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/EnabledStatisticsClock.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/EnabledStatisticsClock.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import org.apache.geode.internal.NanoTimer;
+
+public class EnabledStatisticsClock implements StatisticsClock {
+
+  @Override
+  public long getTime() {
+    return NanoTimer.getTime();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClock.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClock.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+@FunctionalInterface
+public interface StatisticsClock {
+
+  /**
+   * Returns the current value of the running Java Virtual Machine's high-resolution time source,
+   * in nanoseconds.
+   *
+   * <p>
+   * See {@code java.lang.System#nanoTime()}.
+   */
+  long getTime();
+
+  /**
+   * Returns true if this clock is enabled. If disabled then {@code getTime()} will return zero.
+   *
+   * <p>
+   * Default returns {@code true}.
+   */
+  default boolean isEnabled() {
+    return true;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.LongSupplier;
+
+import org.apache.geode.annotations.Immutable;
+
+public class StatisticsClockFactory {
+
+  @Immutable
+  public static final String ENABLE_CLOCK_STATS_PROPERTY = "enableClockStats";
+
+  @Immutable
+  public static final boolean enableClockStats = Boolean.getBoolean(ENABLE_CLOCK_STATS_PROPERTY);
+
+  /**
+   * TODO: delete getTimeIfEnabled
+   */
+  @Deprecated
+  public static long getTimeIfEnabled() {
+    return enableClockStats ? getTime() : 0;
+  }
+
+  public static long getTime() {
+    return System.nanoTime();
+  }
+
+  /**
+   * Creates new {@code StatisticsClock} using {@code enableClockStats} system property.
+   */
+  public static StatisticsClock clock() {
+    return clock(Boolean.getBoolean(ENABLE_CLOCK_STATS_PROPERTY));
+  }
+
+  /**
+   * Creates new {@code StatisticsClock} using specified boolean value.
+   */
+  public static StatisticsClock clock(boolean enabled) {
+    if (enabled) {
+      return enabledClock(() -> getTime());
+    }
+    return disabledClock();
+  }
+
+  public static StatisticsClock enabledClock() {
+    return clock(() -> getTime(), () -> true);
+  }
+
+  public static StatisticsClock enabledClock(LongSupplier time) {
+    return clock(() -> time.getAsLong(), () -> true);
+  }
+
+  public static StatisticsClock disabledClock() {
+    return clock(() -> 0, () -> false);
+  }
+
+  public static StatisticsClock clock(LongSupplier time, BooleanSupplier isEnabled) {
+    return new StatisticsClock() {
+      @Override
+      public long getTime() {
+        return time.getAsLong();
+      }
+
+      @Override
+      public boolean isEnabled() {
+        return isEnabled.getAsBoolean();
+      }
+    };
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockSupplier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsClockSupplier.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+public interface StatisticsClockSupplier {
+
+  StatisticsClock getStatisticsClock();
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/Manager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/Manager.java
@@ -14,9 +14,11 @@
  */
 package org.apache.geode.management.internal;
 
+import org.apache.geode.StatisticsFactory;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * The Manager is a 7.0 JMX Agent which is hosted within a GemFire process. Only one instance is
@@ -27,7 +29,7 @@ import org.apache.geode.internal.cache.InternalCacheForClientAccess;
  */
 public abstract class Manager {
 
-  protected InternalCacheForClientAccess cache;
+  protected final InternalCacheForClientAccess cache;
 
   /**
    * depicts whether this node is a Managing node or not
@@ -42,18 +44,24 @@ public abstract class Manager {
   /**
    * This is a single window to manipulate region resources for management
    */
-  protected ManagementResourceRepo repo;
+  protected final ManagementResourceRepo repo;
 
   /**
    * The concrete implementation of DistributedSystem that provides internal-only functionality.
    */
-  protected InternalDistributedSystem system;
+  protected final InternalDistributedSystem system;
+
+  protected final StatisticsFactory statisticsFactory;
+
+  protected final StatisticsClock statisticsClock;
 
   public Manager(ManagementResourceRepo repo, InternalDistributedSystem system,
-      InternalCache cache) {
+      InternalCache cache, StatisticsFactory statisticsFactory, StatisticsClock statisticsClock) {
     this.repo = repo;
     this.cache = cache.getCacheForProcessingClientRequests();
     this.system = system;
+    this.statisticsFactory = statisticsFactory;
+    this.statisticsClock = statisticsClock;
   }
 
   public abstract boolean isRunning();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/QueryDataFunction.java
@@ -153,7 +153,8 @@ public class QueryDataFunction implements Function, InternalEntity {
             for (BucketRegion bRegion : localPrimaryBucketRegions) {
               localPrimaryBucketSet.add(bRegion.getId());
             }
-            LocalDataSet lds = new LocalDataSet(parRegion, localPrimaryBucketSet);
+            LocalDataSet lds =
+                new LocalDataSet(parRegion, localPrimaryBucketSet);
             DefaultQuery query = (DefaultQuery) cache.getQueryService().newQuery(queryString);
             final ExecutionContext executionContext = new QueryExecutionContext(null, cache, query);
             results = lds.executeQuery(query, executionContext, null, localPrimaryBucketSet);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractDistributedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractDistributedRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -33,6 +34,7 @@ import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.fake.Fakes;
 
 public abstract class AbstractDistributedRegionJUnitTest {
@@ -96,7 +98,8 @@ public abstract class AbstractDistributedRegionJUnitTest {
   protected abstract void setInternalRegionArguments(InternalRegionArguments ira);
 
   protected abstract DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
-      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache);
+      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache,
+      StatisticsClock statisticsClock);
 
   protected abstract void verifyDistributeUpdate(DistributedRegion region, EntryEventImpl event,
       int cnt);
@@ -121,7 +124,8 @@ public abstract class AbstractDistributedRegionJUnitTest {
     setInternalRegionArguments(ira);
 
     // create a region object
-    DistributedRegion region = createAndDefineRegion(isConcurrencyChecksEnabled, ra, ira, cache);
+    DistributedRegion region =
+        createAndDefineRegion(isConcurrencyChecksEnabled, ra, ira, cache, disabledClock());
     if (isConcurrencyChecksEnabled) {
       region.enableConcurrencyChecks();
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -118,7 +119,7 @@ public class AbstractRegionJUnitTest {
         (localRegion) -> mock(RegionPerfStats.class);
     AbstractRegion region = new LocalRegion("regionName", regionAttributes, null, Fakes.cache(),
         new InternalRegionArguments(), null, regionMapConstructor, null, null, null,
-        regionPerfStatsFactory);
+        regionPerfStatsFactory, disabledClock());
     return region;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionJUnitTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
 
@@ -51,8 +52,9 @@ public class BucketRegionJUnitTest extends DistributedRegionJUnitTest {
 
   @Override
   protected DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
-      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache) {
-    BucketRegion br = new BucketRegion("testRegion", ra, null, cache, ira);
+      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache,
+      StatisticsClock statisticsClock) {
+    BucketRegion br = new BucketRegion("testRegion", ra, null, cache, ira, statisticsClock);
     // it is necessary to set the event tracker to initialized, since initialize() in not being
     // called on the instantiated region
     br.getEventTracker().setInitialized();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -50,6 +51,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.fake.Fakes;
 
 public class BucketRegionTest {
@@ -113,7 +115,7 @@ public class BucketRegionTest {
   public void waitUntilLockedThrowsIfFoundLockAndPartitionedRegionIsClosing() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     Integer[] keys = {1};
     doReturn(mock(LockObject.class)).when(bucketRegion).searchAndLock(keys);
     doThrow(regionDestroyedException).when(partitionedRegion)
@@ -126,7 +128,7 @@ public class BucketRegionTest {
   public void waitUntilLockedReturnsTrueIfNoOtherThreadLockedKeys() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     Integer[] keys = {1};
     doReturn(null).when(bucketRegion).searchAndLock(keys);
 
@@ -137,7 +139,7 @@ public class BucketRegionTest {
   public void basicPutEntryDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.basicPutEntry(event, 1);
@@ -149,7 +151,7 @@ public class BucketRegionTest {
   public void basicPutEntryReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(mock(AbstractRegionMap.class)).when(bucketRegion).getRegionMap();
 
@@ -162,7 +164,7 @@ public class BucketRegionTest {
   public void virtualPutDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.virtualPut(event, false, true, null, false, 1, true);
@@ -174,7 +176,7 @@ public class BucketRegionTest {
   public void virtualPutReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
 
@@ -187,7 +189,7 @@ public class BucketRegionTest {
   public void basicDestroyDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.basicDestroy(event, false, null);
@@ -199,7 +201,7 @@ public class BucketRegionTest {
   public void basicDestroyReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
 
@@ -212,7 +214,7 @@ public class BucketRegionTest {
   public void basicUpdateEntryVersionDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
     when(event.getRegion()).thenReturn(bucketRegion);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
@@ -227,7 +229,7 @@ public class BucketRegionTest {
   public void basicUpdateEntryVersionReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     when(event.getRegion()).thenReturn(bucketRegion);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
@@ -242,7 +244,7 @@ public class BucketRegionTest {
   public void basicInvalidateDoesNotReleaseLockIfKeysAndPrimaryNotLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doThrow(regionDestroyedException).when(bucketRegion).lockKeysAndPrimary(event);
 
     bucketRegion.basicInvalidate(event, false, false);
@@ -254,7 +256,7 @@ public class BucketRegionTest {
   public void basicInvalidateReleaseLockIfKeysAndPrimaryLocked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(true).when(bucketRegion).lockKeysAndPrimary(event);
     doReturn(true).when(bucketRegion).hasSeenEvent(event);
 
@@ -267,7 +269,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryReturnFalseIfDoesNotNeedWriteLock() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).needWriteLock(event);
 
     assertThat(bucketRegion.lockKeysAndPrimary(event)).isFalse();
@@ -277,7 +279,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryThrowsIfWaitUntilLockedThrows() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(keys).when(bucketRegion).getKeysToBeLocked(event);
     doThrow(regionDestroyedException).when(bucketRegion).waitUntilLocked(keys);
 
@@ -288,7 +290,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryReleaseLockHeldIfDoLockForPrimaryThrows() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(keys).when(bucketRegion).getKeysToBeLocked(event);
     doReturn(true).when(bucketRegion).waitUntilLocked(keys);
     doThrow(new PrimaryBucketException()).when(bucketRegion).doLockForPrimary(false);
@@ -302,7 +304,7 @@ public class BucketRegionTest {
   public void lockKeysAndPrimaryReleaseLockHeldIfDoesNotLockForPrimary() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(keys).when(bucketRegion).getKeysToBeLocked(event);
     doReturn(true).when(bucketRegion).waitUntilLocked(keys);
     doReturn(true).when(bucketRegion).doLockForPrimary(false);
@@ -317,7 +319,7 @@ public class BucketRegionTest {
 
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
 
     Map regionGCVersions = new HashMap();
     Set keysRemoved = new HashSet();
@@ -333,7 +335,7 @@ public class BucketRegionTest {
   public void testDoNotNotifyClientsOfTombstoneGCNoProxy() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
 
     Map regionGCVersions = new HashMap();
     Set keysRemoved = new HashSet();
@@ -342,8 +344,8 @@ public class BucketRegionTest {
     doReturn(mock(SystemTimer.class)).when(cache).getCCPTimer();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     bucketRegion.notifyClientsOfTombstoneGC(regionGCVersions, keysRemoved, eventID, routing);
     verify(bucketRegion, never()).getFilterProfile();
@@ -356,7 +358,7 @@ public class BucketRegionTest {
   public void testNotifyClientsOfTombstoneGC() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
 
     Map regionGCVersions = new HashMap();
     Set keysRemoved = new HashSet();
@@ -365,8 +367,8 @@ public class BucketRegionTest {
     doReturn(mock(SystemTimer.class)).when(cache).getCCPTimer();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     doReturn(mock(ClientProxyMembershipID.class)).when(proxy).getProxyID();
     ccn.addClientProxyToMap(proxy);
@@ -384,7 +386,7 @@ public class BucketRegionTest {
   public void invokeTXCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -398,7 +400,7 @@ public class BucketRegionTest {
   public void invokeTXCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -414,7 +416,7 @@ public class BucketRegionTest {
   public void invokeTXCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();
@@ -431,7 +433,7 @@ public class BucketRegionTest {
   public void invokeDestroyCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -445,7 +447,7 @@ public class BucketRegionTest {
   public void invokeDestroyCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -461,7 +463,7 @@ public class BucketRegionTest {
   public void invokeDestroyCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();
@@ -478,7 +480,7 @@ public class BucketRegionTest {
   public void invokeInvalidateCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -492,7 +494,7 @@ public class BucketRegionTest {
   public void invokeInvalidateCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -508,7 +510,7 @@ public class BucketRegionTest {
   public void invokeInvalidateCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();
@@ -525,7 +527,7 @@ public class BucketRegionTest {
   public void invokePutCallbacksDoesNotInvokeCallbacksIfEventIsNotGenerateCallbacks() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(false).when(event).isGenerateCallbacks();
 
@@ -539,7 +541,7 @@ public class BucketRegionTest {
   public void invokePutCallbacksDoesNotInvokeCallbacksIfPartitionedRegionIsNotInitialized() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(false).when(partitionedRegion).isInitialized();
@@ -555,7 +557,7 @@ public class BucketRegionTest {
   public void invokePutCallbacksIsInvoked() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
-            cache, internalRegionArgs));
+            cache, internalRegionArgs, disabledClock()));
     doReturn(false).when(bucketRegion).isInitialized();
     doReturn(true).when(event).isGenerateCallbacks();
     doReturn(true).when(partitionedRegion).isInitialized();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CachePerfStatsTest.java
@@ -56,7 +56,6 @@ import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -89,13 +88,7 @@ public class CachePerfStatsTest {
     when(statisticsFactory.createAtomicStatistics(eq(statisticsType), eq(TEXT_ID)))
         .thenReturn(statistics);
 
-    CachePerfStats.enableClockStats = true;
-    cachePerfStats = new CachePerfStats(statisticsFactory, () -> CLOCK_TIME);
-  }
-
-  @After
-  public void tearDown() {
-    CachePerfStats.enableClockStats = false;
+    cachePerfStats = new CachePerfStats(statisticsFactory, TEXT_ID, () -> CLOCK_TIME);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CacheServerImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CacheServerImplTest.java
@@ -43,6 +43,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.internal.statistics.StatisticsManager;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
@@ -88,8 +89,9 @@ public class CacheServerImplTest {
   @Test
   public void createdAcceptorIsGatewayEndpoint() throws IOException {
     OverflowAttributes overflowAttributes = mock(OverflowAttributes.class);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     Acceptor acceptor = server.createAcceptor(overflowAttributes);
@@ -99,8 +101,9 @@ public class CacheServerImplTest {
 
   @Test
   public void getGroups_returnsSpecifiedGroup() {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup = "group0";
 
@@ -112,8 +115,9 @@ public class CacheServerImplTest {
 
   @Test
   public void getGroups_returnsMultipleSpecifiedGroups() {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup1 = "group1";
     String specifiedGroup2 = "group2";
@@ -129,8 +133,9 @@ public class CacheServerImplTest {
   public void getCombinedGroups_includesMembershipGroup() {
     String membershipGroup = "group-m0";
     when(config.getGroups()).thenReturn(membershipGroup);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     assertThat(server.getCombinedGroups())
@@ -144,8 +149,9 @@ public class CacheServerImplTest {
     String membershipGroup3 = "group-m3";
     when(config.getGroups())
         .thenReturn(membershipGroup1 + "," + membershipGroup2 + "," + membershipGroup3);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     assertThat(server.getCombinedGroups())
@@ -159,8 +165,9 @@ public class CacheServerImplTest {
     String membershipGroup3 = "group-m3";
     when(config.getGroups())
         .thenReturn(membershipGroup1 + "," + membershipGroup2 + "," + membershipGroup3);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup1 = "group1";
     String specifiedGroup2 = "group2";
@@ -175,8 +182,9 @@ public class CacheServerImplTest {
 
   @Test
   public void startNotifiesResourceEventCacheServerStart() throws IOException {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     server.start();
@@ -186,8 +194,9 @@ public class CacheServerImplTest {
 
   @Test
   public void stopNotifiesResourceEventCacheServerStart() throws IOException {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        StatisticsClockFactory.disabledClock(), new AcceptorBuilder(),
+        true, true, () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     server.start();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -44,6 +45,7 @@ import org.apache.geode.internal.cache.ha.ThreadIdentifier;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.versions.VMVersionTag;
 import org.apache.geode.internal.cache.versions.VersionTag;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class DistributedRegionJUnitTest
     extends AbstractDistributedRegionJUnitTest {
@@ -52,11 +54,11 @@ public class DistributedRegionJUnitTest
   protected void setInternalRegionArguments(InternalRegionArguments ira) {}
 
   @Override
-  protected DistributedRegion createAndDefineRegion(
-      boolean isConcurrencyChecksEnabled,
-      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache) {
+  protected DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
+      RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache,
+      StatisticsClock statisticsClock) {
     DistributedRegion region = new DistributedRegion("testRegion", ra, null,
-        cache, ira);
+        cache, ira, disabledClock());
     if (isConcurrencyChecksEnabled) {
       region.enableConcurrencyChecks();
     }
@@ -222,9 +224,7 @@ public class DistributedRegionJUnitTest
     byte[] memId = {1, 2, 3};
     long threadId = 1;
     long retrySeqId = 1;
-    ThreadIdentifier tid = new ThreadIdentifier(memId, threadId);
     EventID retryEventID = new EventID(memId, threadId, retrySeqId);
-    boolean skipCallbacks = true;
 
     final EventIDHolder clientEvent = new EventIDHolder(retryEventID);
     clientEvent.setOperation(Operation.UPDATE);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionSearchLoadJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
@@ -54,7 +55,8 @@ public class DistributedRegionSearchLoadJUnitTest {
 
   protected DistributedRegion createAndDefineRegion(boolean isConcurrencyChecksEnabled,
       RegionAttributes ra, InternalRegionArguments ira, GemFireCacheImpl cache) {
-    DistributedRegion region = new DistributedRegion("testRegion", ra, null, cache, ira);
+    DistributedRegion region =
+        new DistributedRegion("testRegion", ra, null, cache, ira, disabledClock());
     if (isConcurrencyChecksEnabled) {
       region.enableConcurrencyChecks();
     }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionPartialMockTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionPartialMockTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.AFTER_INITIAL_IMAGE;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.ANY_INIT;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.BEFORE_INITIAL_IMAGE;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
@@ -226,7 +227,7 @@ public class LocalRegionPartialMockTest {
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
+        CacheClientNotifier.getInstance(cache, disabledClock(), mock(CacheServerStats.class), 10,
             10, mock(ConnectionListener.class), null, true);
 
     doCallRealMethod().when(region).notifyClientsOfTombstoneGC(regionGCVersions, keysRemoved,
@@ -248,7 +249,7 @@ public class LocalRegionPartialMockTest {
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
+        CacheClientNotifier.getInstance(cache, disabledClock(), mock(CacheServerStats.class), 10,
             10, mock(ConnectionListener.class), null, true);
 
     when(proxy.getProxyID()).thenReturn(mock(ClientProxyMembershipID.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -84,9 +85,10 @@ public class LocalRegionTest {
       return mock(RegionPerfStats.class);
     };
 
-    assertThatCode(() -> new LocalRegion("region", regionAttributes, null, cache,
-        internalRegionArguments, internalDataView, regionMapConstructor,
-        serverRegionProxyConstructor, entryEventFactory, poolFinder, regionPerfStatsFactory))
-            .doesNotThrowAnyException();
+    assertThatCode(
+        () -> new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock()))
+                .doesNotThrowAnyException();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl.getSenderIdFromAsyncEventQueueId;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -73,7 +74,7 @@ public class PartitionedRegionTest {
     attributesFactory.setPartitionAttributes(
         new PartitionAttributesFactory().setTotalNumBuckets(1).setRedundantCopies(1).create());
     partitionedRegion = new PartitionedRegion("prTestRegion", attributesFactory.create(), null,
-        internalCache, mock(InternalRegionArguments.class));
+        internalCache, mock(InternalRegionArguments.class), disabledClock());
     DistributedSystem mockDistributedSystem = mock(DistributedSystem.class);
     when(internalCache.getDistributedSystem()).thenReturn(mockDistributedSystem);
     when(mockDistributedSystem.getProperties()).thenReturn(gemfireProperties);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -71,8 +72,8 @@ public class RegionPerfStatsTest {
     when(statisticsFactory.createAtomicStatistics(any(), any())).thenReturn(statistics);
 
     regionPerfStats =
-        new RegionPerfStats(statisticsFactory, TEXT_ID, cachePerfStats,
-            region, meterRegistry);
+        new RegionPerfStats(statisticsFactory, TEXT_ID, disabledClock(), cachePerfStats, region,
+            meterRegistry);
   }
 
   @After
@@ -90,8 +91,8 @@ public class RegionPerfStatsTest {
     StatisticsFactory statisticsFactory = mock(StatisticsFactory.class);
     when(statisticsFactory.createAtomicStatistics(any(), any())).thenReturn(mock(Statistics.class));
 
-    new RegionPerfStats(statisticsFactory, TEXT_ID, cachePerfStats,
-        region, meterRegistry);
+    new RegionPerfStats(statisticsFactory, TEXT_ID, disabledClock(), cachePerfStats, region,
+        meterRegistry);
 
     verify(statisticsFactory).createAtomicStatistics(any(), eq(TEXT_ID));
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ServerBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ServerBuilderTest.java
@@ -37,6 +37,7 @@ import org.apache.geode.distributed.internal.DistributionAdvisee;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier.CacheClientNotifierProvider;
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHealthMonitorProvider;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category(ClientServerTest.class)
@@ -47,30 +48,32 @@ public class ServerBuilderTest {
 
   private InternalCache cache;
   private SecurityService securityService;
+  private StatisticsClock statisticsClock;
 
   @Before
   public void setUp() {
     cache = mock(InternalCache.class);
     securityService = mock(SecurityService.class);
+    statisticsClock = mock(StatisticsClock.class);
   }
 
   @Test
   public void sendResourceEventsIsTrueByDefault() {
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     assertThat(builder.isSendResourceEvents()).isTrue();
   }
 
   @Test
   public void includeMemberGroupsIsTrueByDefault() {
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     assertThat(builder.isIncludeMemberGroups()).isTrue();
   }
 
   @Test
   public void socketCreatorIsForServerByDefault() {
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     assertThat(builder.getSocketCreatorSupplier()).isSameAs(SERVER.getSupplier());
   }
@@ -80,7 +83,7 @@ public class ServerBuilderTest {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.forGatewayReceiver(gatewayReceiver);
 
@@ -92,7 +95,7 @@ public class ServerBuilderTest {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.forGatewayReceiver(gatewayReceiver);
 
@@ -104,7 +107,7 @@ public class ServerBuilderTest {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     when(gatewayReceiver.getGatewayTransportFilters())
         .thenReturn(singletonList(mock(GatewayTransportFilter.class)));
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.forGatewayReceiver(gatewayReceiver);
 
@@ -115,7 +118,7 @@ public class ServerBuilderTest {
   public void setCacheClientNotifierProviderReplacesCacheClientNotifierProvider() {
     CacheClientNotifierProvider cacheClientNotifierProvider =
         mock(CacheClientNotifierProvider.class);
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.setCacheClientNotifierProvider(cacheClientNotifierProvider);
 
@@ -126,7 +129,7 @@ public class ServerBuilderTest {
   public void setClientHealthMonitorProviderReplacesClientHealthMonitorProvider() {
     ClientHealthMonitorProvider clientHealthMonitorProvider =
         mock(ClientHealthMonitorProvider.class);
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.setClientHealthMonitorProvider(clientHealthMonitorProvider);
 
@@ -137,7 +140,7 @@ public class ServerBuilderTest {
   public void setCacheServerAdvisorProviderReplacesCacheServerAdvisorProvider() {
     Function<DistributionAdvisee, CacheServerAdvisor> cacheServerAdvisorProvider =
         a -> mock(CacheServerAdvisor.class);
-    ServerBuilder builder = new ServerBuilder(cache, securityService);
+    ServerBuilder builder = new ServerBuilder(cache, securityService, statisticsClock);
 
     builder.setCacheServerAdvisorProvider(cacheServerAdvisorProvider);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXManagerImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXManagerImplTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -76,7 +77,7 @@ public class TXManagerImplTest {
   public void setUp() {
     cache = Fakes.cache();
     dm = mock(ClusterDistributionManager.class);
-    txMgr = new TXManagerImpl(mock(CachePerfStats.class), cache);
+    txMgr = new TXManagerImpl(mock(CachePerfStats.class), cache, disabledClock());
     txid = new TXId(null, 0);
     msg = mock(DestroyMessage.class);
     txCommitMsg = mock(TXCommitMessage.class);
@@ -95,7 +96,7 @@ public class TXManagerImplTest {
     doReturn(distributedSystem).when(spyCache).getDistributedSystem();
     when(distributedSystem.getDistributionManager()).thenReturn(dm);
     when(distributedSystem.getDistributedMember()).thenReturn(member);
-    spyTxMgr = spy(new TXManagerImpl(mock(CachePerfStats.class), spyCache));
+    spyTxMgr = spy(new TXManagerImpl(mock(CachePerfStats.class), spyCache, disabledClock()));
     timer = mock(SystemTimer.class);
     doReturn(timer).when(spyCache).getCCPTimer();
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
@@ -29,9 +29,10 @@ import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.RegionAttributes;
 
 public class UpdateOperationJUnitTest {
-  EntryEventImpl event;
-  UpdateOperation.UpdateMessage message;
-  DistributedRegion region;
+
+  private EntryEventImpl event;
+  private UpdateOperation.UpdateMessage message;
+  private DistributedRegion region;
 
   @Before
   public void setup() {
@@ -39,6 +40,8 @@ public class UpdateOperationJUnitTest {
     region = mock(DistributedRegion.class);
     RegionAttributes attr = mock(RegionAttributes.class);
     CachePerfStats stats = mock(CachePerfStats.class);
+    InternalCache cache = mock(InternalCache.class);
+
     when(event.isOriginRemote()).thenReturn(false);
     when(stats.endPut(anyLong(), eq(false))).thenReturn(0L);
 
@@ -50,6 +53,8 @@ public class UpdateOperationJUnitTest {
     when(region.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
     when(region.getCachePerfStats()).thenReturn(stats);
+    when(region.getCache()).thenReturn(cache);
+    // when(cache.getStatisticsClock()).thenReturn(disabledClock());
     when(attr.getDataPolicy()).thenReturn(DataPolicy.REPLICATE);
     when(event.getOperation()).thenReturn(Operation.CREATE);
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/HARegionQueueTest.java
@@ -31,6 +31,7 @@ import org.apache.geode.CancelCriterion;
 import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.HARegion;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.util.concurrent.StoppableReentrantReadWriteLock;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
@@ -64,7 +65,8 @@ public class HARegionQueueTest {
     when(haRegion.getGemFireCache()).thenReturn(internalCache);
     haRegionQueue = new HARegionQueue("haRegion", haRegion, internalCache,
         new HAContainerMap(new ConcurrentHashMap()), null, (byte) 1, true,
-        mock(HARegionQueueStats.class), giiLock, rwLock, mock(CancelCriterion.class), false);
+        mock(HARegionQueueStats.class), giiLock, rwLock, mock(CancelCriterion.class), false,
+        mock(StatisticsClock.class));
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/FetchKeysMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/FetchKeysMessageTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.ArgumentMatchers.any;
@@ -75,7 +76,7 @@ public class FetchKeysMessageTest {
 
     originalTxManager = TXManagerImpl.getCurrentInstanceForTest();
     // The constructor sets the new tx manager as currentInstance
-    txManager = spy(new TXManagerImpl(mock(CachePerfStats.class), cache));
+    txManager = spy(new TXManagerImpl(mock(CachePerfStats.class), cache, disabledClock()));
     txManager.setTXState(txStateProxy);
     txManager.setDistributed(false);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionMessageTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -127,7 +128,7 @@ public class PartitionMessageTest {
 
   @Test
   public void noNewTxProcessingAfterTXManagerImplClosed() throws Exception {
-    txMgr = new TXManagerImpl(null, cache);
+    txMgr = new TXManagerImpl(null, cache, disabledClock());
     when(msg.getPartitionedRegion()).thenReturn(pr);
     when(msg.getStartPartitionMessageProcessingTime(pr)).thenReturn(startTime);
     when(msg.getTXManagerImpl(cache)).thenReturn(txMgr);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorBuilderTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier.CacheCli
 import org.apache.geode.internal.cache.tier.sockets.ClientHealthMonitor.ClientHealthMonitorProvider;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category(ClientServerTest.class)
@@ -288,6 +289,18 @@ public class AcceptorBuilderTest {
   }
 
   @Test
+  public void forServerSetsStatisticsClockFromServer() {
+    InternalCacheServer server = mock(InternalCacheServer.class);
+    StatisticsClock statisticsClock = mock(StatisticsClock.class);
+    when(server.getStatisticsClock()).thenReturn(statisticsClock);
+    AcceptorBuilder builder = new AcceptorBuilder();
+
+    builder.forServer(server);
+
+    assertThat(builder.getStatisticsClock()).isEqualTo(statisticsClock);
+  }
+
+  @Test
   public void setCacheReplacesCacheFromServer() {
     InternalCacheServer server = mock(InternalCacheServer.class);
     InternalCache cacheFromServer = mock(InternalCache.class, "fromServer");
@@ -375,5 +388,19 @@ public class AcceptorBuilderTest {
 
     assertThat(builder.getClientHealthMonitorProvider())
         .isEqualTo(clientHealthMonitorProviderFromSetter);
+  }
+
+  @Test
+  public void setStatisticsClockReplacesStatisticsClockFromServer() {
+    InternalCacheServer server = mock(InternalCacheServer.class);
+    StatisticsClock statisticsClockFromServer = mock(StatisticsClock.class, "fromServer");
+    when(server.getStatisticsClock()).thenReturn(statisticsClockFromServer);
+    AcceptorBuilder builder = new AcceptorBuilder();
+    builder.forServer(server);
+    StatisticsClock statisticsClockFromSetter = mock(StatisticsClock.class, "fromSetter");
+
+    builder.setStatisticsClock(statisticsClockFromSetter);
+
+    assertThat(builder.getStatisticsClock()).isEqualTo(statisticsClockFromSetter);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
@@ -14,10 +14,12 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static java.util.Collections.emptyList;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_SOCKET_BUFFER_SIZE;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_TCP_NO_DELAY;
 import static org.apache.geode.internal.cache.tier.sockets.AcceptorImpl.MINIMUM_MAX_CONNECTIONS;
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -29,7 +31,6 @@ import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 import java.net.ServerSocket;
 import java.net.SocketAddress;
-import java.util.Collections;
 import java.util.Properties;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -96,8 +97,8 @@ public class AcceptorImplTest {
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,
         CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
         null, DEFAULT_TCP_NO_DELAY, serverConnectionFactory, 1000, securityService,
-        () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
-        (a, b, c) -> clientHealthMonitor, false, Collections.emptyList());
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
+        (a, b, c) -> clientHealthMonitor, false, emptyList(), disabledClock());
 
     assertThat(acceptor.isGatewayReceiver()).isFalse();
   }
@@ -114,8 +115,8 @@ public class AcceptorImplTest {
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,
         CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
         null, DEFAULT_TCP_NO_DELAY, serverConnectionFactory, 1000, securityService,
-        () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
-        (a, b, c) -> clientHealthMonitor, true, Collections.emptyList());
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
+        (a, b, c) -> clientHealthMonitor, true, emptyList(), disabledClock());
 
     assertThat(acceptor.isGatewayReceiver()).isTrue();
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierTest.java
@@ -12,7 +12,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.junit.Assert.assertFalse;
@@ -48,9 +47,11 @@ import org.apache.geode.internal.cache.FilterProfile;
 import org.apache.geode.internal.cache.FilterRoutingInfo;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheEvent;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.fake.Fakes;
 
 public class CacheClientNotifierTest {
+
   @Test
   public void eventsInClientRegistrationQueueAreSentToClientAfterRegistrationIsComplete()
       throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException,
@@ -63,11 +64,13 @@ public class CacheClientNotifierTest {
     CacheClientProxy cacheClientProxy = mock(CacheClientProxy.class);
     ClientUpdateMessageImpl clientUpdateMessage = mock(ClientUpdateMessageImpl.class);
     ClientRegistrationMetadata clientRegistrationMetadata = mock(ClientRegistrationMetadata.class);
+    StatisticsClock statisticsClock = mock(StatisticsClock.class);
+
     when(clientRegistrationMetadata.getClientProxyMembershipID()).thenReturn(
         clientProxyMembershipID);
 
     CacheClientNotifier cacheClientNotifier = CacheClientNotifier.getInstance(internalCache,
-        cacheServerStats, 0, 0, connectionListener, null, false);
+        statisticsClock, cacheServerStats, 0, 0, connectionListener, null, false);
     final CacheClientNotifier cacheClientNotifierSpy = spy(cacheClientNotifier);
 
     CountDownLatch waitForEventDispatchCountdownLatch = new CountDownLatch(1);
@@ -188,8 +191,8 @@ public class CacheClientNotifierTest {
     InternalCache internalCache = Fakes.cache();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(internalCache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(internalCache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     assertFalse(CacheClientNotifier.singletonHasClientProxies());
     ccn.shutdown(111);
@@ -202,8 +205,8 @@ public class CacheClientNotifierTest {
     CacheClientProxy proxy = mock(CacheClientProxy.class);
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(internalCache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(internalCache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     when(proxy.getProxyID()).thenReturn(mock(ClientProxyMembershipID.class));
     ccn.addClientProxy(proxy);
@@ -221,8 +224,8 @@ public class CacheClientNotifierTest {
     CacheClientProxy proxy = mock(CacheClientProxy.class);
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(internalCache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(internalCache, mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     when(proxy.getProxyID()).thenReturn(mock(ClientProxyMembershipID.class));
     ccn.addClientInitProxy(proxy);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/TXFailoverCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/TXFailoverCommandTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets.command;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.doReturn;
@@ -54,7 +55,7 @@ public class TXFailoverCommandTest {
 
     int uniqueId = 1;
     TXId txId = new TXId(client, uniqueId);
-    TXStateProxyImpl proxy = new TXStateProxyImpl(cache, txManager, txId, null);
+    TXStateProxyImpl proxy = new TXStateProxyImpl(cache, txManager, txId, null, disabledClock());
 
     when(cache.getCacheTransactionManager()).thenReturn(txManager);
     when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderHelper.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderHelper.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.wan.parallel;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -149,7 +150,7 @@ public class ParallelGatewaySenderHelper {
 
     // Create BucketRegionQueue
     return new BucketRegionQueue(
-        queueRegion.getBucketName(bucketId), attributes, parentRegion, cache, ira);
+        queueRegion.getBucketName(bucketId), attributes, parentRegion, cache, ira, disabledClock());
   }
 
   public static String getRegionQueueName(String gatewaySenderId) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelQueueRemovalMessageJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.wan.parallel;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.any;
@@ -97,7 +98,8 @@ public class ParallelQueueRemovalMessageJUnitTest {
     when(this.queueRegion.getParallelGatewaySender()).thenReturn(this.sender);
     when(this.sender.getQueues()).thenReturn(null);
     when(this.sender.getDispatcherThreads()).thenReturn(1);
-    stats = new GatewaySenderStats(new DummyStatisticsFactory(), "ln");
+    stats = new GatewaySenderStats(new DummyStatisticsFactory(), "gatewaySenderStats-", "ln",
+        disabledClock());
     when(this.sender.getStatistics()).thenReturn(stats);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/StatisticsClockFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/StatisticsClockFactoryTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.statistics;
+
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.ENABLE_CLOCK_STATS_PROPERTY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.BooleanSupplier;
+import java.util.function.LongSupplier;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+public class StatisticsClockFactoryTest {
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Test
+  public void clock_createsEnabledClockIfPropertyIsTrue() {
+    System.setProperty(ENABLE_CLOCK_STATS_PROPERTY, "true");
+
+    StatisticsClock clock = StatisticsClockFactory.clock();
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void clock_createsDisabledClockIfPropertyIsFalse() {
+    System.setProperty(ENABLE_CLOCK_STATS_PROPERTY, "false");
+
+    StatisticsClock clock = StatisticsClockFactory.clock();
+
+    assertThat(clock.isEnabled()).isFalse();
+  }
+
+  @Test
+  public void clock_boolean_createsEnabledClockIfParameterIsTrue() {
+    StatisticsClock clock = StatisticsClockFactory.clock(true);
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void clock_boolean_createsEnabledClockIfParameterIsFalse() {
+    StatisticsClock clock = StatisticsClockFactory.clock(false);
+
+    assertThat(clock.isEnabled()).isFalse();
+  }
+
+  @Test
+  public void enabledClock_usesProvidedLongSupplierForGetTime() {
+    StatisticsClock clock = StatisticsClockFactory.enabledClock(() -> 42);
+
+    assertThat(clock.getTime()).isEqualTo(42);
+  }
+
+  @Test
+  public void enabledClock_createsEnabledClock() {
+    StatisticsClock clock = StatisticsClockFactory.enabledClock(() -> 24);
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void disabledClock_usesZeroForGetTime() {
+    StatisticsClock clock = StatisticsClockFactory.disabledClock();
+
+    assertThat(clock.getTime()).isZero();
+  }
+
+  @Test
+  public void disabledClock_createsDisabledClock() {
+    StatisticsClock clock = StatisticsClockFactory.disabledClock();
+
+    assertThat(clock.isEnabled()).isFalse();
+  }
+
+  @Test
+  public void clock_usesProvidedLongSupplierForGetTime() {
+    StatisticsClock clock = StatisticsClockFactory.clock(() -> 100, () -> true);
+
+    assertThat(clock.getTime()).isEqualTo(100);
+  }
+
+  @Test
+  public void clock_usesProvidedBooleanSupplierForIsEnabled() {
+    StatisticsClock clock = StatisticsClockFactory.clock(() -> 100, () -> true);
+
+    assertThat(clock.isEnabled()).isTrue();
+  }
+
+  @Test
+  public void clock_getTime_delegatesToLongSupplier() {
+    LongSupplier time = mock(LongSupplier.class);
+    StatisticsClock clock = StatisticsClockFactory.clock(time, mock(BooleanSupplier.class));
+
+    clock.getTime();
+
+    verify(time).getAsLong();
+  }
+
+  @Test
+  public void clock_isEnabled_delegatesToBooleanSupplier() {
+    BooleanSupplier isEnabled = mock(BooleanSupplier.class);
+    StatisticsClock clock = StatisticsClockFactory.clock(mock(LongSupplier.class), isEnabled);
+
+    clock.isEnabled();
+
+    verify(isEnabled).getAsBoolean();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/bean/stats/MemberLevelStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/bean/stats/MemberLevelStatsTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.bean.stats;
 
+import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.internal.statistics.SuppliableStatistics.toSuppliableStatistics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -69,7 +70,6 @@ public class MemberLevelStatsTest {
   @Before
   public void setUp() throws Exception {
     DistributionStats.enableClockStats = true;
-    CachePerfStats.enableClockStats = true;
 
     StatisticsManager statisticsManager = new StatisticsRegistry("TestStatisticsRegistry", 1);
     InternalDistributedSystem system = mock(InternalDistributedSystem.class);
@@ -116,7 +116,7 @@ public class MemberLevelStatsTest {
     partitionedRegionStatsArray = new PartitionedRegionStats[4];
     for (int i = 0; i < 4; i++) {
       PartitionedRegionStats stats = new PartitionedRegionStats(
-          statisticsManager, name.getMethodName() + i);
+          statisticsManager, name.getMethodName() + i, disabledClock());
       partitionedRegionStatsArray[i] = stats;
       memberMBeanBridge.addPartitionedRegionStats(stats);
     }
@@ -128,7 +128,6 @@ public class MemberLevelStatsTest {
   @After
   public void tearDown() throws Exception {
     DistributionStats.enableClockStats = true;
-    CachePerfStats.enableClockStats = false;
     statSampler.stop();
   }
 

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestBlockingHARegionQueue.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestBlockingHARegionQueue.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * Test class for Blocking HA region queue functionalities
@@ -31,7 +32,7 @@ import org.apache.geode.internal.logging.LogService;
 
 // TODO:Asif: Modify the test to allow working with the new class containing
 // ReadWrite lock functionality
-public class TestBlockingHARegionQueue extends HARegionQueue.TestOnlyHARegionQueue {
+public class TestBlockingHARegionQueue extends TestOnlyHARegionQueue {
   private static final Logger logger = LogService.getLogger();
 
   /**
@@ -43,9 +44,10 @@ public class TestBlockingHARegionQueue extends HARegionQueue.TestOnlyHARegionQue
 
   boolean takeWhenPeekInProgress = false;
 
-  public TestBlockingHARegionQueue(String regionName, InternalCache cache)
+  public TestBlockingHARegionQueue(String regionName, InternalCache cache,
+      StatisticsClock statisticsClock)
       throws IOException, ClassNotFoundException, CacheException, InterruptedException {
-    super(regionName, cache);
+    super(regionName, cache, statisticsClock);
   }
 
   /**

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestOnlyHARegionQueue.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/ha/TestOnlyHARegionQueue.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.ha;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.geode.cache.CacheException;
+import org.apache.geode.cache.ExpirationAction;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.tier.sockets.Handshake;
+import org.apache.geode.internal.statistics.StatisticsClock;
+
+/**
+ * A static class which is created only for for testing purposes as some existing tests extend the
+ * HARegionQueue. Since the constructors of HARegionQueue are private , this class can act as a
+ * bridge between the user defined HARegionQueue class & the actual class. This class object will
+ * be buggy as it will tend to publish the Object o QRM thread & the expiry thread before the
+ * complete creation of the HARegionQueue instance
+ */
+class TestOnlyHARegionQueue extends HARegionQueue {
+
+  TestOnlyHARegionQueue(String regionName, InternalCache cache, StatisticsClock statisticsClock)
+      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
+    this(regionName, cache, HARegionQueueAttributes.DEFAULT_HARQ_ATTRIBUTES, new HashMap(),
+        Handshake.CONFLATION_DEFAULT, false, statisticsClock);
+  }
+
+  TestOnlyHARegionQueue(String regionName, InternalCache cache, HARegionQueueAttributes hrqa,
+      Map haContainer, byte clientConflation, boolean isPrimary, StatisticsClock statisticsClock)
+      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
+    super(regionName, cache, haContainer, null, clientConflation, isPrimary, statisticsClock);
+    ExpirationAttributes expirationAttributes =
+        new ExpirationAttributes(hrqa.getExpiryTime(), ExpirationAction.LOCAL_INVALIDATE);
+    region.setOwner(this);
+    region.getAttributesMutator().setEntryTimeToLive(expirationAttributes);
+    initialized.set(true);
+  }
+
+  /**
+   * Overloaded constructor to pass an {@code HashMap} instance as a haContainer.
+   *
+   * @since GemFire 5.7
+   */
+  TestOnlyHARegionQueue(String regionName, InternalCache cache, HARegionQueueAttributes hrqa,
+      StatisticsClock statisticsClock)
+      throws IOException, ClassNotFoundException, CacheException, InterruptedException {
+    this(regionName, cache, hrqa, new HashMap(), Handshake.CONFLATION_DEFAULT, false,
+        statisticsClock);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
@@ -45,6 +45,7 @@ import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsManager;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.internal.TypeRegistry;
@@ -108,6 +109,8 @@ public class Fakes {
     when(cache.getQueryMonitor()).thenReturn(queryMonitor);
     when(cache.getMeterRegistry()).thenReturn(new SimpleMeterRegistry());
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
+    when(cache.getStatisticsClock()).thenReturn(mock(StatisticsClock.class));
+
     when(system.getDistributedMember()).thenReturn(member);
     when(system.getConfig()).thenReturn(config);
     when(system.getDistributionManager()).thenReturn(distributionManager);

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/WANFactoryImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/WANFactoryImpl.java
@@ -46,7 +46,7 @@ public class WANFactoryImpl implements WANFactory {
 
   @Override
   public GatewaySenderFactory createGatewaySenderFactory(InternalCache cache) {
-    return new GatewaySenderFactoryImpl(cache);
+    return new GatewaySenderFactoryImpl(cache, cache.getStatisticsClock());
   }
 
   @Override

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
@@ -32,6 +32,7 @@ import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public abstract class AbstractRemoteGatewaySender extends AbstractGatewaySender {
   private static final Logger logger = LogService.getLogger();
@@ -39,8 +40,9 @@ public abstract class AbstractRemoteGatewaySender extends AbstractGatewaySender 
   /** used to reduce warning logs in case remote locator is down (#47634) */
   protected int proxyFailureTries = 0;
 
-  public AbstractRemoteGatewaySender(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+  public AbstractRemoteGatewaySender(InternalCache cache, StatisticsClock statisticsClock,
+      GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
   }
 
   @Override

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderImpl.java
@@ -36,6 +36,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAdvisor.GatewaySenderPro
 import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * @since GemFire 7.0
@@ -44,8 +45,9 @@ public class ParallelGatewaySenderImpl extends AbstractRemoteGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public ParallelGatewaySenderImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+  public ParallelGatewaySenderImpl(InternalCache cache, StatisticsClock statisticsClock,
+      GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
   }
 
   @Override

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderImpl.java
@@ -37,6 +37,7 @@ import org.apache.geode.internal.cache.wan.GatewaySenderAttributes;
 import org.apache.geode.internal.cache.wan.GatewaySenderConfigurationException;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 /**
  * @since GemFire 7.0
@@ -45,8 +46,9 @@ public class SerialGatewaySenderImpl extends AbstractRemoteGatewaySender {
 
   private static final Logger logger = LogService.getLogger();
 
-  public SerialGatewaySenderImpl(InternalCache cache, GatewaySenderAttributes attrs) {
-    super(cache, attrs);
+  public SerialGatewaySenderImpl(InternalCache cache, StatisticsClock statisticsClock,
+      GatewaySenderAttributes attrs) {
+    super(cache, statisticsClock, attrs);
   }
 
   @Override


### PR DESCRIPTION
GEODE-7010: Replace static globals in CachePerfStats with StatisticsClock

Create StatisticsClock during Cache creation with isEnabled configured by
the "enable-time-statistics" config property.

Inject StatisticsClock dependency via constructor in classes that use it.

This replaces the mutable global static in CachePerfStats.