### PR TITLE
GEODE-7024: raise a Java exception on non-success response from REST API

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/client/CreateRegionWithDiskstoreAndSecurityDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/client/CreateRegionWithDiskstoreAndSecurityDUnitTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.management.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 
@@ -84,10 +85,8 @@ public class CreateRegionWithDiskstoreAndSecurityDUnitTest {
         ClusterManagementServiceBuilder.buildWithHostAddress()
             .setHostAddress("localhost", locator.getHttpPort())
             .setCredentials("user", "user").build();
-    ClusterManagementResult result = client.create(regionConfig);
-    assertThat(result.isSuccessful()).isFalse();
-    assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.UNAUTHORIZED);
-    assertThat(result.getStatusMessage()).isEqualTo("user not authorized for DATA:MANAGE");
+    assertThatThrownBy(() -> client.create(regionConfig))
+        .hasMessageContaining("UNAUTHORIZED: user not authorized for DATA:MANAGE");
   }
 
   @Test
@@ -109,10 +108,8 @@ public class CreateRegionWithDiskstoreAndSecurityDUnitTest {
         ClusterManagementServiceBuilder.buildWithHostAddress()
             .setHostAddress("localhost", locator.getHttpPort())
             .setCredentials("data", "data").build();
-    ClusterManagementResult result = client.create(regionConfig);
-    assertThat(result.isSuccessful()).isFalse();
-    assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.UNAUTHORIZED);
-    assertThat(result.getStatusMessage()).isEqualTo("data not authorized for CLUSTER:WRITE:DISK");
+    assertThatThrownBy(() -> client.create(regionConfig))
+        .hasMessageContaining("UNAUTHORIZED: data not authorized for CLUSTER:WRITE:DISK");
   }
 
   @Test

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementSSLTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementSSLTest.java
@@ -91,7 +91,7 @@ public class ClientClusterManagementSSLTest {
   }
 
   @Test
-  public void createRegion_Successful() throws Exception {
+  public void createRegion_Successful() {
     RegionConfig region = new RegionConfig();
     region.setName("customer");
     region.setType(RegionType.PARTITION);
@@ -115,7 +115,7 @@ public class ClientClusterManagementSSLTest {
   }
 
   @Test
-  public void createRegion_NoSsl() throws Exception {
+  public void createRegion_NoSsl() {
     RegionConfig region = new RegionConfig();
     region.setName("customer");
     region.setType(RegionType.PARTITION);
@@ -132,7 +132,7 @@ public class ClientClusterManagementSSLTest {
   }
 
   @Test
-  public void createRegion_WrongPassword() throws Exception {
+  public void createRegion_WrongPassword() {
     RegionConfig region = new RegionConfig();
     region.setName("customer");
     region.setType(RegionType.PARTITION);
@@ -152,7 +152,7 @@ public class ClientClusterManagementSSLTest {
   }
 
   @Test
-  public void createRegion_NoUser() throws Exception {
+  public void createRegion_NoUser() {
     RegionConfig region = new RegionConfig();
     region.setName("customer");
     region.setType(RegionType.PARTITION);
@@ -173,7 +173,7 @@ public class ClientClusterManagementSSLTest {
   }
 
   @Test
-  public void createRegion_NoPassword() throws Exception {
+  public void createRegion_NoPassword() {
     RegionConfig region = new RegionConfig();
     region.setName("customer");
     region.setType(RegionType.PARTITION);
@@ -193,7 +193,7 @@ public class ClientClusterManagementSSLTest {
   }
 
   @Test
-  public void createRegion_NoPrivilege() throws Exception {
+  public void createRegion_NoPrivilege() {
     RegionConfig region = new RegionConfig();
     region.setName("customer");
     region.setType(RegionType.PARTITION);
@@ -213,7 +213,7 @@ public class ClientClusterManagementSSLTest {
   }
 
   @Test
-  public void invokeFromServer() throws Exception {
+  public void invokeFromServer() {
     server.invoke(() -> {
       // when getting the service from the server, we don't need to provide the host information
       ClusterManagementService cmsClient = buildWithCache()

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementSSLTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementSSLTest.java
@@ -147,10 +147,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .setCredentials("dataManage", "wrongPassword").build();
 
-      ClusterManagementResult result = cmsClient.create(region);
-      assertThat(result.isSuccessful()).isFalse();
-      assertThat(result.getStatusCode())
-          .isEqualTo(ClusterManagementResult.StatusCode.UNAUTHENTICATED);
+      assertThatThrownBy(() -> cmsClient.create(region)).hasMessageContaining("UNAUTHENTICATED");
     });
   }
 
@@ -171,10 +168,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .build();
 
-      ClusterManagementResult result = cmsClient.create(region);
-      assertThat(result.isSuccessful()).isFalse();
-      assertThat(result.getStatusCode())
-          .isEqualTo(ClusterManagementResult.StatusCode.UNAUTHENTICATED);
+      assertThatThrownBy(() -> cmsClient.create(region)).hasMessageContaining("UNAUTHENTICATED");
     });
   }
 
@@ -194,10 +188,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .setCredentials("dataManage", null).build();
 
-      ClusterManagementResult result = cmsClient.create(region);
-      assertThat(result.isSuccessful()).isFalse();
-      assertThat(result.getStatusCode())
-          .isEqualTo(ClusterManagementResult.StatusCode.UNAUTHENTICATED);
+      assertThatThrownBy(() -> cmsClient.create(region)).hasMessageContaining("UNAUTHENTICATED");
     });
   }
 
@@ -217,9 +208,7 @@ public class ClientClusterManagementSSLTest {
           .setHostnameVerifier(hostnameVerifier)
           .setCredentials("dataRead", "dataRead").build();
 
-      ClusterManagementResult result = cmsClient.create(region);
-      assertThat(result.isSuccessful()).isFalse();
-      assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.UNAUTHORIZED);
+      assertThatThrownBy(() -> cmsClient.create(region)).hasMessageContaining("UNAUTHORIZED");
     });
   }
 

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementServiceDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementServiceDunitTest.java
@@ -69,9 +69,7 @@ public class ClientClusterManagementServiceDunitTest {
     assertThat(result.getMemberStatuses()).extracting(RealizationResult::getMemberName)
         .containsExactlyInAnyOrder("server-1", "server-2");
 
-    result = cmsClient.create(region);
-    assertThat(result.isSuccessful()).isFalse();
-    assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.ENTITY_EXISTS);
+    assertThatThrownBy(() -> cmsClient.create(region)).hasMessageContaining("ENTITY_EXISTS");
   }
 
   @Test
@@ -94,10 +92,7 @@ public class ClientClusterManagementServiceDunitTest {
     RegionConfig region = new RegionConfig();
     region.setName("__test");
 
-    ClusterManagementResult result = cmsClient.create(region);
-    assertThat(result.isSuccessful()).isFalse();
-    assertThat(result.getStatusCode())
-        .isEqualTo(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT);
+    assertThatThrownBy(() -> cmsClient.create(region)).hasMessageContaining("ILLEGAL_ARGUMENT");
   }
 
   @Test

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementServiceDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ClientClusterManagementServiceDunitTest.java
@@ -88,7 +88,7 @@ public class ClientClusterManagementServiceDunitTest {
 
 
   @Test
-  public void createRegionWithInvalidName() throws Exception {
+  public void createRegionWithInvalidName() {
     RegionConfig region = new RegionConfig();
     region.setName("__test");
 

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GatewayReceiverManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GatewayReceiverManagementDUnitTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.management.internal.rest;
 import static org.apache.geode.test.junit.assertions.ClusterManagementListResultAssert.assertManagementListResult;
 import static org.apache.geode.test.junit.assertions.ClusterManagementRealizationResultAssert.assertManagementResult;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -27,7 +28,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.apache.geode.cache.configuration.GatewayReceiverConfig;
-import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.api.ConfigurationResult;
 import org.apache.geode.management.api.RealizationResult;
@@ -77,9 +77,8 @@ public class GatewayReceiverManagementDUnitTest {
     // try create another GWR on the same group
     receiver.setStartPort("5001");
     receiver.setGroup("group1");
-    assertManagementResult(cms.create(receiver)).failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ENTITY_EXISTS)
-        .containsStatusMessage("Member(s) server-1 already has this element created");
+    assertThatThrownBy(() -> cms.create(receiver))
+        .hasMessageContaining("ENTITY_EXISTS: Member(s) server-1 already has this element created");
 
     // try create another GWR on another group but has no server
     receiver.setStartPort("5002");
@@ -91,9 +90,8 @@ public class GatewayReceiverManagementDUnitTest {
     // try create another GWR on another group but has a common member in another group
     receiver.setStartPort("5003");
     receiver.setGroup(null);
-    assertManagementResult(cms.create(receiver)).failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ENTITY_EXISTS)
-        .containsStatusMessage("Member(s) server-1 already has this element created");
+    assertThatThrownBy(() -> cms.create(receiver))
+        .hasMessageContaining("ENTITY_EXISTS: Member(s) server-1 already has this element created");
 
     ClusterManagementListResultAssert<GatewayReceiverConfig, GatewayReceiverInfo> listAssert =
         assertManagementListResult(cms.list(new GatewayReceiverConfig())).isSuccessful();

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.management.internal.rest;
 
-import static org.apache.geode.test.junit.assertions.ClusterManagementListResultAssert.assertManagementListResult;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -29,7 +28,6 @@ import org.junit.Test;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.cache.configuration.RegionType;
 import org.apache.geode.management.api.ClusterManagementListResult;
-import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
 import org.apache.geode.management.runtime.RuntimeInfo;
@@ -99,8 +97,7 @@ public class ListIndexManagementDUnitTest {
   @Test
   public void getNonExistRegion() {
     regionConfig.setName("notExist");
-    assertManagementListResult(cms.get(regionConfig)).failed().hasStatusCode(
-        ClusterManagementResult.StatusCode.ENTITY_NOT_FOUND);
+    assertThatThrownBy(() -> cms.get(regionConfig)).hasMessageContaining("ENTITY_NOT_FOUND");
   }
 
   @Test
@@ -163,8 +160,7 @@ public class ListIndexManagementDUnitTest {
     RegionConfig.Index index = new RegionConfig.Index();
     index.setRegionName("region1");
     index.setName("index333");
-    assertManagementListResult(cms.get(index)).failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ENTITY_NOT_FOUND);
+    assertThatThrownBy(() -> cms.get(index)).hasMessageContaining("ENTITY_NOT_FOUND");
   }
 
   @Test

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
@@ -194,16 +194,14 @@ public class RegionManagementDunitTest {
     regionConfig.setType(RegionType.REPLICATE);
     assertManagementResult(cms.create(regionConfig)).isSuccessful();
 
-    assertManagementResult(cms.create(regionConfig)).failed().hasStatusCode(
-        ClusterManagementResult.StatusCode.ENTITY_EXISTS)
-        .containsStatusMessage("server-2")
-        .containsStatusMessage("server-3")
-        .containsStatusMessage("already has this element created");
+    assertThatThrownBy(() -> cms.create(regionConfig)).hasMessageContaining("ENTITY_EXISTS")
+        .hasMessageContaining("server-2")
+        .hasMessageContaining("server-3")
+        .hasMessageContaining("already has this element created");
 
     regionConfig.setGroup("group3");
-    assertManagementResult(cms.create(regionConfig)).failed().hasStatusCode(
-        ClusterManagementResult.StatusCode.ENTITY_EXISTS)
-        .containsStatusMessage("Member(s) server-3 already has this element created");
+    assertThatThrownBy(() -> cms.create(regionConfig)).hasMessageContaining("ENTITY_EXISTS")
+        .hasMessageContaining("Member(s) server-3 already has this element created");
   }
 
   @Test
@@ -217,8 +215,7 @@ public class RegionManagementDunitTest {
     regionConfig.setName("incompatible");
     regionConfig.setGroup("group5");
     regionConfig.setType(RegionType.PARTITION);
-    assertManagementResult(cms.create(regionConfig)).failed().hasStatusCode(
-        ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT);
+    assertThatThrownBy(() -> cms.create(regionConfig)).hasMessageContaining("ILLEGAL_ARGUMENT");
 
     regionConfig.setName("incompatible");
     regionConfig.setGroup("group5");

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
@@ -48,6 +48,6 @@ public class DisabledClusterConfigTest {
             .getClusterManagementResult();
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusMessage())
-        .isEqualTo("Cluster configuration service needs to be enabled");
+        .contains("Cluster configuration service needs to be enabled");
   }
 }

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
@@ -48,6 +48,6 @@ public class DisabledClusterConfigTest {
             .getClusterManagementResult();
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusMessage())
-        .contains("Cluster configuration service needs to be enabled");
+        .isEqualTo("Cluster configuration service needs to be enabled");
   }
 }

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -677,12 +677,14 @@ javadoc/org/apache/geode/management/PersistentMemberDetails.html
 javadoc/org/apache/geode/management/RegionAttributesData.html
 javadoc/org/apache/geode/management/RegionMXBean.html
 javadoc/org/apache/geode/management/ServerLoadData.html
+javadoc/org/apache/geode/management/api/ClusterManagementException.html
 javadoc/org/apache/geode/management/api/ClusterManagementListOperationsResult.html
 javadoc/org/apache/geode/management/api/ClusterManagementListResult.html
 javadoc/org/apache/geode/management/api/ClusterManagementOperation.html
 javadoc/org/apache/geode/management/api/ClusterManagementOperationResult.html
 javadoc/org/apache/geode/management/api/ClusterManagementResult.StatusCode.html
 javadoc/org/apache/geode/management/api/ClusterManagementResult.html
+javadoc/org/apache/geode/management/api/ClusterManagementRealizationException.html
 javadoc/org/apache/geode/management/api/ClusterManagementRealizationResult.html
 javadoc/org/apache/geode/management/api/ClusterManagementService.html
 javadoc/org/apache/geode/management/api/ConfigurationResult.html

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -68,8 +68,8 @@ org/apache/geode/internal/shared/TCPSocketOptions
 org/apache/geode/internal/statistics/platform/LinuxProcFsStatistics$CPU
 org/apache/geode/internal/tcp/VersionedByteBufferInputStream
 org/apache/geode/internal/util/concurrent/StoppableReadWriteLock
-org/apache/geode/management/internal/ClientClusterManagementService$RemoteClusterManagementException
-org/apache/geode/management/internal/api/LocatorClusterManagementService$LocalClusterManagementException
+org/apache/geode/management/api/ClusterManagementException
+org/apache/geode/management/api/ClusterManagementRealizationException
 org/apache/geode/management/internal/cli/commands/ShowMetricsCommand$Category
 org/apache/geode/management/internal/cli/exceptions/UserErrorException
 org/apache/geode/management/internal/cli/json/AbstractJSONFormatter$PreventReserializationModule

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -69,6 +69,7 @@ org/apache/geode/internal/statistics/platform/LinuxProcFsStatistics$CPU
 org/apache/geode/internal/tcp/VersionedByteBufferInputStream
 org/apache/geode/internal/util/concurrent/StoppableReadWriteLock
 org/apache/geode/management/internal/ClientClusterManagementService$RemoteClusterManagementException
+org/apache/geode/management/internal/api/LocatorClusterManagementService$LocalClusterManagementException
 org/apache/geode/management/internal/cli/commands/ShowMetricsCommand$Category
 org/apache/geode/management/internal/cli/exceptions/UserErrorException
 org/apache/geode/management/internal/cli/json/AbstractJSONFormatter$PreventReserializationModule

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -68,6 +68,7 @@ org/apache/geode/internal/shared/TCPSocketOptions
 org/apache/geode/internal/statistics/platform/LinuxProcFsStatistics$CPU
 org/apache/geode/internal/tcp/VersionedByteBufferInputStream
 org/apache/geode/internal/util/concurrent/StoppableReadWriteLock
+org/apache/geode/management/internal/ClientClusterManagementService$RemoteClusterManagementException
 org/apache/geode/management/internal/cli/commands/ShowMetricsCommand$Category
 org/apache/geode/management/internal/cli/exceptions/UserErrorException
 org/apache/geode/management/internal/cli/json/AbstractJSONFormatter$PreventReserializationModule

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -150,9 +150,9 @@ public class LocatorClusterManagementService implements ClusterManagementService
       memberValidator.validateCreate(config, configurationManager);
       // execute function on all members
     } catch (EntityExistsException e) {
-      raise(ENTITY_EXISTS, e.getMessage());
+      raise(ENTITY_EXISTS, e);
     } catch (IllegalArgumentException e) {
-      raise(ILLEGAL_ARGUMENT, e.getMessage());
+      raise(ILLEGAL_ARGUMENT, e);
     }
 
     Set<DistributedMember> targetedMembers = memberValidator.findServers(group);
@@ -214,7 +214,7 @@ public class LocatorClusterManagementService implements ClusterManagementService
         validator.validate(CacheElementOperation.DELETE, config);
       }
     } catch (IllegalArgumentException e) {
-      raise(ILLEGAL_ARGUMENT, e.getMessage());
+      raise(ILLEGAL_ARGUMENT, e);
     }
 
     String[] groupsWithThisElement =
@@ -496,6 +496,11 @@ public class LocatorClusterManagementService implements ClusterManagementService
 
   private static void raise(StatusCode statusCode, String statusMessage) {
     throw new ClusterManagementException(new ClusterManagementResult(statusCode, statusMessage));
+  }
+
+  private static void raise(StatusCode statusCode, Exception e) {
+    throw new ClusterManagementException(new ClusterManagementResult(statusCode, e.getMessage()),
+        e);
   }
 
   public boolean isConnected() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -17,6 +17,7 @@
 
 package org.apache.geode.management.internal.api;
 
+import static org.apache.geode.management.api.ClusterManagementResult.StatusCode.ENTITY_EXISTS;
 import static org.apache.geode.management.api.ClusterManagementResult.StatusCode.ENTITY_NOT_FOUND;
 import static org.apache.geode.management.api.ClusterManagementResult.StatusCode.ERROR;
 import static org.apache.geode.management.api.ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT;
@@ -78,6 +79,7 @@ import org.apache.geode.management.internal.configuration.validators.Configurati
 import org.apache.geode.management.internal.configuration.validators.GatewayReceiverConfigValidator;
 import org.apache.geode.management.internal.configuration.validators.MemberValidator;
 import org.apache.geode.management.internal.configuration.validators.RegionConfigValidator;
+import org.apache.geode.management.internal.exceptions.EntityExistsException;
 import org.apache.geode.management.internal.operation.OperationHistoryManager;
 import org.apache.geode.management.internal.operation.OperationHistoryManager.OperationInstance;
 import org.apache.geode.management.internal.operation.OperationManager;
@@ -147,6 +149,8 @@ public class LocatorClusterManagementService implements ClusterManagementService
       // check if this config already exists on all/some members of this group
       memberValidator.validateCreate(config, configurationManager);
       // execute function on all members
+    } catch (EntityExistsException e) {
+      raise(ENTITY_EXISTS, e.getMessage());
     } catch (IllegalArgumentException e) {
       raise(ILLEGAL_ARGUMENT, e.getMessage());
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -53,6 +53,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.config.JAXBService;
+import org.apache.geode.management.api.ClusterManagementException;
 import org.apache.geode.management.api.ClusterManagementOperation;
 import org.apache.geode.management.api.ClusterManagementOperationResult;
 import org.apache.geode.management.api.ClusterManagementRealizationResult;
@@ -68,7 +69,6 @@ import org.apache.geode.management.internal.configuration.validators.CacheElemen
 import org.apache.geode.management.internal.configuration.validators.ConfigurationValidator;
 import org.apache.geode.management.internal.configuration.validators.MemberValidator;
 import org.apache.geode.management.internal.configuration.validators.RegionConfigValidator;
-import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
 import org.apache.geode.management.internal.operation.OperationHistoryManager.OperationInstance;
 import org.apache.geode.management.internal.operation.OperationManager;
 import org.apache.geode.management.runtime.OperationResult;
@@ -192,8 +192,8 @@ public class LocatorClusterManagementServiceTest {
   @Test
   public void create_non_supportedConfigObject() {
     MemberConfig config = new MemberConfig();
-    assertThatThrownBy(() -> service.create(config)).isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Configuration type MemberConfig is not supported");
+    assertThatThrownBy(() -> service.create(config)).isInstanceOf(ClusterManagementException.class)
+        .hasMessageContaining("ILLEGAL_ARGUMENT: Configuration type MemberConfig is not supported");
   }
 
   @Test
@@ -238,8 +238,8 @@ public class LocatorClusterManagementServiceTest {
     config.setName("unknown");
     doReturn(new String[] {}).when(memberValidator).findGroupsWithThisElement(any(), any());
     assertThatThrownBy(() -> service.delete(config))
-        .isInstanceOf(EntityNotFoundException.class)
-        .hasMessage("Cache element 'unknown' does not exist");
+        .isInstanceOf(ClusterManagementException.class)
+        .hasMessage("ENTITY_NOT_FOUND: Cache element 'unknown' does not exist");
   }
 
   @Test
@@ -248,8 +248,8 @@ public class LocatorClusterManagementServiceTest {
     config.setName("test");
     config.setGroup("group1");
     assertThatThrownBy(() -> service.delete(config))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("group is an invalid option when deleting region.");
+        .isInstanceOf(ClusterManagementException.class)
+        .hasMessage("ILLEGAL_ARGUMENT: group is an invalid option when deleting region.");
   }
 
   @Test
@@ -340,7 +340,7 @@ public class LocatorClusterManagementServiceTest {
   @Test
   public void checkStatusForNotFound() {
     assertThatThrownBy(() -> service.checkStatus("123"))
-        .isInstanceOf(EntityNotFoundException.class);
+        .isInstanceOf(ClusterManagementException.class);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -119,16 +119,14 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void create_persistenceIsNull() throws Exception {
+  public void create_persistenceIsNull() {
     service = new LocatorClusterManagementService(cache, null);
-    result = service.create(regionConfig);
-    assertThat(result.isSuccessful()).isFalse();
-    assertThat(result.getStatusMessage())
-        .contains("Cluster configuration service needs to be enabled");
+    assertThatThrownBy(() -> service.create(regionConfig))
+        .hasMessageContaining("Cluster configuration service needs to be enabled");
   }
 
   @Test
-  public void create_validatorIsCalledCorrectly() throws Exception {
+  public void create_validatorIsCalledCorrectly() {
     doReturn(Collections.emptySet()).when(memberValidator).findServers(anyString());
     doNothing().when(persistenceService).updateCacheConfig(any(), any());
     service.create(regionConfig);
@@ -138,7 +136,7 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void delete_validatorIsCalledCorrectly() throws Exception {
+  public void delete_validatorIsCalledCorrectly() {
     doReturn(Collections.emptySet()).when(memberValidator).findServers(anyString());
     doReturn(new String[] {"cluster"}).when(memberValidator).findGroupsWithThisElement(
         regionConfig.getId(),
@@ -152,7 +150,7 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void create_partialFailureOnMembers() throws Exception {
+  public void create_partialFailureOnMembers() {
     List<RealizationResult> functionResults = new ArrayList<>();
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(
@@ -164,14 +162,12 @@ public class LocatorClusterManagementServiceTest {
 
     when(persistenceService.getCacheConfig("cluster", true)).thenReturn(new CacheConfig());
     regionConfig.setName("test");
-    result = service.create(regionConfig);
-    assertThat(result.isSuccessful()).isFalse();
-    assertThat(result.getStatusMessage())
-        .contains("Failed to apply the update on all members");
+    assertThatThrownBy(() -> service.create(regionConfig))
+        .hasMessageContaining("Failed to apply the update on all members");
   }
 
   @Test
-  public void create_succeedsOnAllMembers() throws Exception {
+  public void create_succeedsOnAllMembers() {
     List<RealizationResult> functionResults = new ArrayList<>();
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(new RealizationResult().setMemberName("member2"));
@@ -194,14 +190,14 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void create_non_supportedConfigObject() throws Exception {
+  public void create_non_supportedConfigObject() {
     MemberConfig config = new MemberConfig();
     assertThatThrownBy(() -> service.create(config)).isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Configuration type MemberConfig is not supported");
   }
 
   @Test
-  public void list_oneGroup() throws Exception {
+  public void list_oneGroup() {
     regionConfig.setGroup("cluster");
     doReturn(Sets.newHashSet("cluster", "group1")).when(persistenceService).getGroups();
 
@@ -213,7 +209,7 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void list_aRegionInClusterAndGroup1() throws Exception {
+  public void list_aRegionInClusterAndGroup1() {
     doReturn(Sets.newHashSet("cluster", "group1")).when(persistenceService).getGroups();
     RegionConfig region1 = new RegionConfig();
     region1.setName("region1");
@@ -257,7 +253,7 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void delete_partialFailureOnMembers() throws Exception {
+  public void delete_partialFailureOnMembers() {
     List<RealizationResult> functionResults = new ArrayList<>();
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(
@@ -284,7 +280,7 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void delete_succeedsOnAllMembers() throws Exception {
+  public void delete_succeedsOnAllMembers() {
     List<RealizationResult> functionResults = new ArrayList<>();
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(new RealizationResult().setMemberName("member2"));
@@ -311,7 +307,7 @@ public class LocatorClusterManagementServiceTest {
   }
 
   @Test
-  public void deleteWithNoMember() throws Exception {
+  public void deleteWithNoMember() {
     // region exists in cluster configuration
     doReturn(new String[] {"cluster"}).when(memberValidator).findGroupsWithThisElement(any(),
         any());

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementException.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.api;
+
+/**
+ * Base class of all exceptions thrown by {@link ClusterManagementService} implementations.
+ */
+public class ClusterManagementException extends RuntimeException {
+  protected final ClusterManagementResult result;
+
+  public ClusterManagementException(ClusterManagementResult result) {
+    super(result.getStatusCode()
+        + (org.springframework.util.StringUtils.isEmpty(result.getStatusMessage()) ? ""
+            : (": " + result.getStatusMessage())));
+    this.result = result;
+  }
+
+  public ClusterManagementResult getResult() {
+    return result;
+  }
+
+  public ClusterManagementResult.StatusCode getStatusCode() {
+    return result.getStatusCode();
+  }
+
+  public String getStatusMessage() {
+    return result.getStatusMessage();
+  }
+}

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementException.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementException.java
@@ -14,27 +14,46 @@
  */
 package org.apache.geode.management.api;
 
+
 /**
  * Base class of all exceptions thrown by {@link ClusterManagementService} implementations.
  */
 public class ClusterManagementException extends RuntimeException {
-  protected final ClusterManagementResult result;
+  private final ClusterManagementResult result;
 
+  /**
+   * for internal use only
+   */
   public ClusterManagementException(ClusterManagementResult result) {
-    super(result.getStatusCode()
-        + (org.springframework.util.StringUtils.isEmpty(result.getStatusMessage()) ? ""
-            : (": " + result.getStatusMessage())));
+    super(result.toString());
     this.result = result;
   }
 
+  /**
+   * for internal use only
+   */
+  public ClusterManagementException(ClusterManagementResult result, Throwable cause) {
+    super(result.toString(), cause);
+    this.result = result;
+  }
+
+  /**
+   * for internal use only
+   */
   public ClusterManagementResult getResult() {
     return result;
   }
 
+  /**
+   * get the status code of the unsuccessful result
+   */
   public ClusterManagementResult.StatusCode getStatusCode() {
     return result.getStatusCode();
   }
 
+  /**
+   * get the status message of the unsuccessful result, if available
+   */
   public String getStatusMessage() {
     return result.getStatusMessage();
   }

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationException.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationException.java
@@ -23,19 +23,14 @@ import org.apache.geode.cache.configuration.CacheElement;
  * which have a possibility of "partial" failure.
  */
 public class ClusterManagementRealizationException extends ClusterManagementException {
+  private final ClusterManagementRealizationResult result;
+
   /**
    * for internal use only
    */
   public ClusterManagementRealizationException(ClusterManagementRealizationResult result) {
     super(result);
-  }
-
-  /**
-   * get the underlying result (not usually necessary since {@link #getStatusCode()},
-   * {@link #getStatusMessage()}, or {@link #getMemberStatuses() provide more direct access}
-   */
-  public ClusterManagementRealizationResult getRealizationResult() {
-    return (ClusterManagementRealizationResult) result;
+    this.result = result;
   }
 
   /**
@@ -43,6 +38,6 @@ public class ClusterManagementRealizationException extends ClusterManagementExce
    * only some. This will return the per-member status.
    */
   public List<RealizationResult> getMemberStatuses() {
-    return getRealizationResult().getMemberStatuses();
+    return result.getMemberStatuses();
   }
 }

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationException.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.api;
+
+import java.util.List;
+
+import org.apache.geode.cache.configuration.CacheElement;
+
+/**
+ * Thrown by {@link ClusterManagementService#create(CacheElement)}, update, and delete operations
+ * which have a possibility of "partial" failure.
+ */
+public class ClusterManagementRealizationException extends ClusterManagementException {
+  /**
+   * for internal use only
+   */
+  public ClusterManagementRealizationException(ClusterManagementRealizationResult result) {
+    super(result);
+  }
+
+  /**
+   * get the underlying result (not usually necessary since {@link #getStatusCode()},
+   * {@link #getStatusMessage()}, or {@link #getMemberStatuses() provide more direct access}
+   */
+  public ClusterManagementRealizationResult getRealizationResult() {
+    return (ClusterManagementRealizationResult) result;
+  }
+
+  /**
+   * A {@link ClusterManagementService#create(CacheElement)} operation may fail on all members or
+   * only some. This will return the per-member status.
+   */
+  public List<RealizationResult> getMemberStatuses() {
+    return getRealizationResult().getMemberStatuses();
+  }
+}

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.api;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.apache.geode.annotations.Experimental;
@@ -146,5 +148,17 @@ public class ClusterManagementResult {
    */
   public StatusCode getStatusCode() {
     return statusCode;
+  }
+
+  /**
+   * Returns the status code and message
+   */
+  @Override
+  public String toString() {
+    if (isBlank(getStatusMessage())) {
+      return getStatusCode().toString();
+    } else {
+      return getStatusCode() + ": " + getStatusMessage();
+    }
   }
 }

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
@@ -35,7 +35,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param config this holds the configuration attributes of the element to be created on the
    *        cluster, as well as the group this config belongs to
    * @return a {@link ClusterManagementRealizationResult} indicating the success of the creation
-   * @throws RuntimeException if unsuccessful
+   * @throws ClusterManagementRealizationException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement> ClusterManagementRealizationResult create(T config);
@@ -47,8 +47,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param config this holds the configuration attributes of the element to be deleted on the
    *        cluster
    * @return a {@link ClusterManagementRealizationResult} indicating the success of the deletion
-   * @throws IllegalArgumentException, NoMemberException, EntityExistsException
-   * @throws RuntimeException if unsuccessful
+   * @throws ClusterManagementRealizationException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement> ClusterManagementRealizationResult delete(T config);
@@ -60,8 +59,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param config this holds the configuration attributes of the element to be updated on the
    *        cluster
    * @return a {@link ClusterManagementRealizationResult} indicating the success of the update
-   * @throws IllegalArgumentException, NoMemberException, EntityExistsException
-   * @throws RuntimeException if unsuccessful
+   * @throws ClusterManagementRealizationException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement> ClusterManagementRealizationResult update(T config);
@@ -74,7 +72,7 @@ public interface ClusterManagementService extends AutoCloseable {
    *        for individual element types to see if they support filtering by addition attributes)
    * @return a {@link ClusterManagementListResult} holding a list of matching instances in
    *         {@link ClusterManagementListResult#getResult()}
-   * @throws RuntimeException if unsuccessful
+   * @throws ClusterManagementException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> list(
@@ -88,8 +86,8 @@ public interface ClusterManagementService extends AutoCloseable {
    *        supplying the name (id) of the desired config element
    * @return a {@link ClusterManagementListResult} holding a single element in
    *         {@link ClusterManagementListResult#getResult()}
-   * @throws RuntimeException if no matching element is found or multiple matches are found
-   * @throws RuntimeException if unsuccessful
+   * @throws ClusterManagementException if unsuccesful or, no matching element is found, or multiple
+   *         matches are found
    * @see CacheElement
    */
   <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> get(
@@ -103,7 +101,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param <V> the return type of the operation
    * @return a {@link ClusterManagementOperationResult} holding a {@link CompletableFuture} (if the
    *         operation was launched successfully) or an error code otherwise.
-   * @throws RuntimeException if unsuccessful
+   * @throws ClusterManagementException if unsuccessful
    */
   <A extends ClusterManagementOperation<V>, V extends OperationResult> ClusterManagementOperationResult<V> start(
       A op);
@@ -116,7 +114,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param <V> the return type of the operation
    * @param opType the operation type to list
    * @return a list of {@link ClusterManagementOperationResult}
-   * @throws RuntimeException if unsuccessful
+   * @throws ClusterManagementException if unsuccessful
    */
   <A extends ClusterManagementOperation<V>, V extends OperationResult> ClusterManagementListOperationsResult<V> list(
       A opType);

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementService.java
@@ -35,6 +35,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param config this holds the configuration attributes of the element to be created on the
    *        cluster, as well as the group this config belongs to
    * @return a {@link ClusterManagementRealizationResult} indicating the success of the creation
+   * @throws RuntimeException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement> ClusterManagementRealizationResult create(T config);
@@ -47,6 +48,7 @@ public interface ClusterManagementService extends AutoCloseable {
    *        cluster
    * @return a {@link ClusterManagementRealizationResult} indicating the success of the deletion
    * @throws IllegalArgumentException, NoMemberException, EntityExistsException
+   * @throws RuntimeException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement> ClusterManagementRealizationResult delete(T config);
@@ -59,6 +61,7 @@ public interface ClusterManagementService extends AutoCloseable {
    *        cluster
    * @return a {@link ClusterManagementRealizationResult} indicating the success of the update
    * @throws IllegalArgumentException, NoMemberException, EntityExistsException
+   * @throws RuntimeException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement> ClusterManagementRealizationResult update(T config);
@@ -71,6 +74,7 @@ public interface ClusterManagementService extends AutoCloseable {
    *        for individual element types to see if they support filtering by addition attributes)
    * @return a {@link ClusterManagementListResult} holding a list of matching instances in
    *         {@link ClusterManagementListResult#getResult()}
+   * @throws RuntimeException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> list(
@@ -85,6 +89,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @return a {@link ClusterManagementListResult} holding a single element in
    *         {@link ClusterManagementListResult#getResult()}
    * @throws RuntimeException if no matching element is found or multiple matches are found
+   * @throws RuntimeException if unsuccessful
    * @see CacheElement
    */
   <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> get(
@@ -98,6 +103,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param <V> the return type of the operation
    * @return a {@link ClusterManagementOperationResult} holding a {@link CompletableFuture} (if the
    *         operation was launched successfully) or an error code otherwise.
+   * @throws RuntimeException if unsuccessful
    */
   <A extends ClusterManagementOperation<V>, V extends OperationResult> ClusterManagementOperationResult<V> start(
       A op);
@@ -110,6 +116,7 @@ public interface ClusterManagementService extends AutoCloseable {
    * @param <V> the return type of the operation
    * @param opType the operation type to list
    * @return a list of {@link ClusterManagementOperationResult}
+   * @throws RuntimeException if unsuccessful
    */
   <A extends ClusterManagementOperation<V>, V extends OperationResult> ClusterManagementListOperationsResult<V> list(
       A opType);

--- a/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.HttpMethod;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 import org.apache.geode.cache.configuration.CacheElement;
@@ -72,9 +73,9 @@ public class ClientClusterManagementService implements ClusterManagementService 
   public <T extends CacheElement> ClusterManagementRealizationResult create(T config) {
     String endPoint = getEndpoint(config);
     // the response status code info is represented by the ClusterManagementResult.errorCode already
-    return restTemplate
+    return assertSuccessful(restTemplate
         .postForEntity(endPoint, config, ClusterManagementRealizationResult.class)
-        .getBody();
+        .getBody());
   }
 
   @Override
@@ -82,13 +83,13 @@ public class ClientClusterManagementService implements ClusterManagementService 
   public <T extends CacheElement> ClusterManagementRealizationResult delete(
       T config) {
     String uri = getIdentityEndPoint(config);
-    return restTemplate
+    return assertSuccessful(restTemplate
         .exchange(uri + "?group={group}",
             HttpMethod.DELETE,
             null,
             ClusterManagementRealizationResult.class,
             config.getGroup())
-        .getBody();
+        .getBody());
   }
 
   @Override
@@ -102,19 +103,19 @@ public class ClientClusterManagementService implements ClusterManagementService 
   public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> list(
       T config) {
     String endPoint = getEndpoint(config);
-    return restTemplate
+    return assertSuccessful(restTemplate
         .getForEntity(endPoint + "/?id={id}&group={group}",
             ClusterManagementListResult.class, config.getId(), config.getGroup())
-        .getBody();
+        .getBody());
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public <T extends CacheElement & CorrespondWith<R>, R extends RuntimeInfo> ClusterManagementListResult<T, R> get(
       T config) {
-    return restTemplate
+    return assertSuccessful(restTemplate
         .getForEntity(getIdentityEndPoint(config), ClusterManagementListResult.class)
-        .getBody();
+        .getBody());
   }
 
   @Override
@@ -124,8 +125,9 @@ public class ClientClusterManagementService implements ClusterManagementService 
     final ClusterManagementOperationResult result;
 
     // make the REST call to start the operation
-    result = restTemplate.postForEntity(RestfulEndpoint.URI_VERSION + op.getEndpoint(), op,
-        ClusterManagementOperationResult.class).getBody();
+    result =
+        assertSuccessful(restTemplate.postForEntity(RestfulEndpoint.URI_VERSION + op.getEndpoint(),
+            op, ClusterManagementOperationResult.class).getBody());
 
     // our restTemplate requires the url to be modified to start from "/experimental"
     return reAnimate(result);
@@ -152,8 +154,9 @@ public class ClientClusterManagementService implements ClusterManagementService 
     final ClusterManagementListOperationsResult<V> result;
 
     // make the REST call to list in-progress operations
-    result = restTemplate.getForEntity(RestfulEndpoint.URI_VERSION + opType.getEndpoint(),
-        ClusterManagementListOperationsResult.class).getBody();
+    result = assertSuccessful(
+        restTemplate.getForEntity(RestfulEndpoint.URI_VERSION + opType.getEndpoint(),
+            ClusterManagementListOperationsResult.class).getBody());
 
     return new ClusterManagementListOperationsResult<>(
         result.getResult().stream().map(this::reAnimate).collect(Collectors.toList()));
@@ -194,9 +197,32 @@ public class ClientClusterManagementService implements ClusterManagementService 
     }
   }
 
+  private <T extends ClusterManagementResult> T assertSuccessful(T result) {
+    if (!result.isSuccessful()) {
+      throw new RemoteClusterManagementException(result);
+    }
+    return result;
+  }
+
   public boolean isConnected() {
-    return restTemplate.getForEntity(RestfulEndpoint.URI_VERSION + "/ping", String.class)
-        .getBody().equals("pong");
+    try {
+      return restTemplate.getForEntity(RestfulEndpoint.URI_VERSION + "/ping", String.class)
+          .getBody().equals("pong");
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
+  /**
+   * not public because user code should *not* try to catch this exception by name, since other
+   * implementations of {@link ClusterManagementService} will throw different subtypes of
+   * RuntimeException
+   */
+  private static class RemoteClusterManagementException extends RuntimeException {
+    public RemoteClusterManagementException(ClusterManagementResult result) {
+      super(result.getStatusCode() + (StringUtils.isEmpty(result.getStatusMessage()) ? ""
+          : (": " + result.getStatusMessage())));
+    }
   }
 
   @Override

--- a/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
+++ b/geode-management/src/main/java/org/apache/geode/management/internal/ClientClusterManagementService.java
@@ -24,10 +24,10 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.HttpMethod;
-import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.management.api.ClusterManagementException;
 import org.apache.geode.management.api.ClusterManagementListOperationsResult;
 import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementOperation;
@@ -199,7 +199,7 @@ public class ClientClusterManagementService implements ClusterManagementService 
 
   private <T extends ClusterManagementResult> T assertSuccessful(T result) {
     if (!result.isSuccessful()) {
-      throw new RemoteClusterManagementException(result);
+      throw new ClusterManagementException(result);
     }
     return result;
   }
@@ -210,18 +210,6 @@ public class ClientClusterManagementService implements ClusterManagementService 
           .getBody().equals("pong");
     } catch (Exception e) {
       return false;
-    }
-  }
-
-  /**
-   * not public because user code should *not* try to catch this exception by name, since other
-   * implementations of {@link ClusterManagementService} will throw different subtypes of
-   * RuntimeException
-   */
-  private static class RemoteClusterManagementException extends RuntimeException {
-    public RemoteClusterManagementException(ClusterManagementResult result) {
-      super(result.getStatusCode() + (StringUtils.isEmpty(result.getStatusMessage()) ? ""
-          : (": " + result.getStatusMessage())));
     }
   }
 

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ClientClusterManagementServiceDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ClientClusterManagementServiceDUnitTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.management.client;
 import static org.apache.geode.test.junit.assertions.ClusterManagementListResultAssert.assertManagementListResult;
 import static org.apache.geode.test.junit.assertions.ClusterManagementRealizationResultAssert.assertManagementResult;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -149,9 +150,8 @@ public class ClientClusterManagementServiceDUnitTest {
 
     // creating the same region on group2 will not be successful because they have a common member
     region.setGroup("group2");
-    assertManagementResult(client.create(region)).failed().hasStatusCode(
-        ClusterManagementResult.StatusCode.ENTITY_EXISTS)
-        .containsStatusMessage("Member(s) server-3 already has this element created");
+    assertThatThrownBy(() -> client.create(region))
+        .hasMessageContaining("ENTITY_EXISTS: Member(s) server-3 already has this element created");
   }
 
   @Test
@@ -170,8 +170,7 @@ public class ClientClusterManagementServiceDUnitTest {
 
     // creating the same region on group2 will not be successful because they have a common member
     region.setGroup("group2");
-    assertManagementResult(client.create(region)).failed().hasStatusCode(
-        ClusterManagementResult.StatusCode.ENTITY_EXISTS);
+    assertThatThrownBy(() -> client.create(region)).hasMessageContaining("ENTITY_EXISTS");
 
     region.setGroup(null);
     ClusterManagementRealizationResult deleteResult = client.delete(region);
@@ -198,9 +197,8 @@ public class ClientClusterManagementServiceDUnitTest {
         .extracting(RealizationResult::getMemberName)
         .containsExactlyInAnyOrder("server-1", "server-3");
 
-    assertManagementResult(client.delete(region)).failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT)
-        .containsStatusMessage("group is an invalid option when deleting region");
+    assertThatThrownBy(() -> client.delete(region))
+        .hasMessageContaining("ILLEGAL_ARGUMENT: group is an invalid option when deleting region");
   }
 
   @Test
@@ -209,9 +207,7 @@ public class ClientClusterManagementServiceDUnitTest {
     RegionConfig region = new RegionConfig();
     region.setName("unknown");
 
-    ClusterManagementRealizationResult result = client.delete(region);
-    assertManagementResult(result).failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ENTITY_NOT_FOUND);
+    assertThatThrownBy(() -> client.delete(region)).hasMessageContaining("ENTITY_NOT_FOUND");
   }
 
   @Test

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GatewayManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GatewayManagementIntegrationTest.java
@@ -16,7 +16,7 @@
 package org.apache.geode.management.internal.rest;
 
 
-import static org.apache.geode.test.junit.assertions.ClusterManagementRealizationResultAssert.assertManagementResult;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 import java.util.List;
@@ -33,7 +33,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.apache.geode.cache.configuration.GatewayReceiverConfig;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.management.api.ClusterManagementListResult;
-import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.api.ConfigurationResult;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
@@ -110,16 +109,12 @@ public class GatewayManagementIntegrationTest {
   @Test
   public void createWithBindAddress() throws Exception {
     receiver.setBindAddress("test-mbpro");
-    assertManagementResult(client.create(receiver)).failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT)
-        .containsStatusMessage("");
+    assertThatThrownBy(() -> client.create(receiver)).hasMessageContaining("ILLEGAL_ARGUMENT");
   }
 
   @Test
   public void createWithHostName() throws Exception {
     receiver.setHostnameForSenders("test-mbpro");
-    assertManagementResult(client.create(receiver)).failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT)
-        .containsStatusMessage("");
+    assertThatThrownBy(() -> client.create(receiver)).hasMessageContaining("ILLEGAL_ARGUMENT");
   }
 }

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
@@ -78,7 +78,8 @@ public class RegionManagementIntegrationTest {
     regionConfig.setType("LOCAL");
 
     assertThatThrownBy(() -> client.create(regionConfig))
-        .hasMessage("ILLEGAL_ARGUMENT: Type LOCAL is not supported in Management V2 API.");
+        .hasMessageContaining(
+            "ILLEGAL_ARGUMENT: Type LOCAL is not supported in Management V2 API.");
   }
 
   @Test
@@ -88,7 +89,7 @@ public class RegionManagementIntegrationTest {
     regionConfig.setGroup("cluster");
 
     assertThatThrownBy(() -> client.create(regionConfig))
-        .hasMessage("ILLEGAL_ARGUMENT: 'cluster' is a reserved group name");
+        .hasMessageContaining("ILLEGAL_ARGUMENT: 'cluster' is a reserved group name");
   }
 
   @Test

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
@@ -59,7 +59,7 @@ public class RegionManagementIntegrationTest {
 
   @Test
   @WithMockUser
-  public void sanityCheck() throws Exception {
+  public void sanityCheck() {
     RegionConfig regionConfig = new RegionConfig();
     regionConfig.setName("customers");
     regionConfig.setType(RegionType.REPLICATE);
@@ -72,7 +72,7 @@ public class RegionManagementIntegrationTest {
 
   @Test
   @WithMockUser
-  public void invalidType() throws Exception {
+  public void invalidType() {
     RegionConfig regionConfig = new RegionConfig();
     regionConfig.setName("customers");
     regionConfig.setType("LOCAL");
@@ -83,7 +83,7 @@ public class RegionManagementIntegrationTest {
   }
 
   @Test
-  public void invalidGroup() throws Exception {
+  public void invalidGroup() {
     RegionConfig regionConfig = new RegionConfig();
     regionConfig.setName("customers");
     regionConfig.setGroup("cluster");

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.management.internal.rest;
 
 import static org.apache.geode.test.junit.assertions.ClusterManagementRealizationResultAssert.assertManagementResult;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
@@ -76,10 +77,8 @@ public class RegionManagementIntegrationTest {
     regionConfig.setName("customers");
     regionConfig.setType("LOCAL");
 
-    assertManagementResult(client.create(regionConfig))
-        .failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT)
-        .containsStatusMessage("Type LOCAL is not supported in Management V2 API.");
+    assertThatThrownBy(() -> client.create(regionConfig))
+        .hasMessage("ILLEGAL_ARGUMENT: Type LOCAL is not supported in Management V2 API.");
   }
 
   @Test
@@ -88,10 +87,8 @@ public class RegionManagementIntegrationTest {
     regionConfig.setName("customers");
     regionConfig.setGroup("cluster");
 
-    assertManagementResult(client.create(regionConfig))
-        .failed()
-        .hasStatusCode(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT)
-        .containsStatusMessage("'cluster' is a reserved group name");
+    assertThatThrownBy(() -> client.create(regionConfig))
+        .hasMessage("ILLEGAL_ARGUMENT: 'cluster' is a reserved group name");
   }
 
   @Test

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
@@ -29,8 +29,6 @@ import org.apache.geode.management.api.ClusterManagementRealizationException;
 import org.apache.geode.management.api.ClusterManagementRealizationResult;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementResult.StatusCode;
-import org.apache.geode.management.internal.exceptions.EntityExistsException;
-import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
 import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.NotAuthorizedException;
 
@@ -77,31 +75,11 @@ public class ManagementControllerAdvice {
         return HttpStatus.CONFLICT;
       case ENTITY_NOT_FOUND:
         return HttpStatus.NOT_FOUND;
-      case UNAUTHENTICATED:
-        return HttpStatus.UNAUTHORIZED;
-      case UNAUTHORIZED:
-        return HttpStatus.FORBIDDEN;
       case ILLEGAL_ARGUMENT:
         return HttpStatus.BAD_REQUEST;
       default:
         return HttpStatus.INTERNAL_SERVER_ERROR;
     }
-  }
-
-  @ExceptionHandler(EntityExistsException.class)
-  public ResponseEntity<ClusterManagementResult> entityExists(final Exception e) {
-    return new ResponseEntity<>(
-        new ClusterManagementResult(StatusCode.ENTITY_EXISTS,
-            e.getMessage()),
-        HttpStatus.CONFLICT);
-  }
-
-  @ExceptionHandler(EntityNotFoundException.class)
-  public ResponseEntity<ClusterManagementResult> entityNotFound(final Exception e) {
-    return new ResponseEntity<>(
-        new ClusterManagementResult(StatusCode.ENTITY_NOT_FOUND,
-            e.getMessage()),
-        HttpStatus.NOT_FOUND);
   }
 
   @ExceptionHandler({AuthenticationFailedException.class, AuthenticationException.class})

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.management.internal.rest.controllers;
 
-
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +24,11 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import org.apache.geode.internal.logging.LogService;
+import org.apache.geode.management.api.ClusterManagementException;
+import org.apache.geode.management.api.ClusterManagementRealizationException;
+import org.apache.geode.management.api.ClusterManagementRealizationResult;
 import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementResult.StatusCode;
 import org.apache.geode.management.internal.exceptions.EntityExistsException;
 import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
 import org.apache.geode.security.AuthenticationFailedException;
@@ -39,7 +42,7 @@ public class ManagementControllerAdvice {
   public ResponseEntity<ClusterManagementResult> internalError(final Exception e) {
     logger.error(e.getMessage(), e);
     return new ResponseEntity<>(
-        new ClusterManagementResult(ClusterManagementResult.StatusCode.ERROR,
+        new ClusterManagementResult(StatusCode.ERROR,
             cleanup(e.getMessage())),
         HttpStatus.INTERNAL_SERVER_ERROR);
   }
@@ -54,10 +57,41 @@ public class ManagementControllerAdvice {
     }
   }
 
+  @ExceptionHandler(ClusterManagementException.class)
+  public ResponseEntity<ClusterManagementResult> clusterManagementException(final Exception e) {
+    ClusterManagementResult result = ((ClusterManagementException) e).getResult();
+    return new ResponseEntity<>(result, mapToHttpStatus(result.getStatusCode()));
+  }
+
+  @ExceptionHandler(ClusterManagementRealizationException.class)
+  public ResponseEntity<ClusterManagementRealizationResult> clusterManagementRealizationException(
+      final Exception e) {
+    ClusterManagementRealizationResult result =
+        (ClusterManagementRealizationResult) ((ClusterManagementException) e).getResult();
+    return new ResponseEntity<>(result, mapToHttpStatus(result.getStatusCode()));
+  }
+
+  private HttpStatus mapToHttpStatus(StatusCode statusCode) {
+    switch (statusCode) {
+      case ENTITY_EXISTS:
+        return HttpStatus.CONFLICT;
+      case ENTITY_NOT_FOUND:
+        return HttpStatus.NOT_FOUND;
+      case UNAUTHENTICATED:
+        return HttpStatus.UNAUTHORIZED;
+      case UNAUTHORIZED:
+        return HttpStatus.FORBIDDEN;
+      case ILLEGAL_ARGUMENT:
+        return HttpStatus.BAD_REQUEST;
+      default:
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+  }
+
   @ExceptionHandler(EntityExistsException.class)
   public ResponseEntity<ClusterManagementResult> entityExists(final Exception e) {
     return new ResponseEntity<>(
-        new ClusterManagementResult(ClusterManagementResult.StatusCode.ENTITY_EXISTS,
+        new ClusterManagementResult(StatusCode.ENTITY_EXISTS,
             e.getMessage()),
         HttpStatus.CONFLICT);
   }
@@ -65,7 +99,7 @@ public class ManagementControllerAdvice {
   @ExceptionHandler(EntityNotFoundException.class)
   public ResponseEntity<ClusterManagementResult> entityNotFound(final Exception e) {
     return new ResponseEntity<>(
-        new ClusterManagementResult(ClusterManagementResult.StatusCode.ENTITY_NOT_FOUND,
+        new ClusterManagementResult(StatusCode.ENTITY_NOT_FOUND,
             e.getMessage()),
         HttpStatus.NOT_FOUND);
   }
@@ -73,7 +107,7 @@ public class ManagementControllerAdvice {
   @ExceptionHandler({AuthenticationFailedException.class, AuthenticationException.class})
   public ResponseEntity<ClusterManagementResult> unauthorized(Exception e) {
     return new ResponseEntity<>(
-        new ClusterManagementResult(ClusterManagementResult.StatusCode.UNAUTHENTICATED,
+        new ClusterManagementResult(StatusCode.UNAUTHENTICATED,
             e.getMessage()),
         HttpStatus.UNAUTHORIZED);
   }
@@ -81,18 +115,17 @@ public class ManagementControllerAdvice {
   @ExceptionHandler({NotAuthorizedException.class, SecurityException.class})
   public ResponseEntity<ClusterManagementResult> forbidden(Exception e) {
     return new ResponseEntity<>(new ClusterManagementResult(
-        ClusterManagementResult.StatusCode.UNAUTHORIZED, e.getMessage()),
+        StatusCode.UNAUTHORIZED, e.getMessage()),
         HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler({IllegalArgumentException.class, HttpMessageNotReadableException.class})
   public ResponseEntity<ClusterManagementResult> badRequest(final Exception e) {
     return new ResponseEntity<>(
-        new ClusterManagementResult(ClusterManagementResult.StatusCode.ILLEGAL_ARGUMENT,
+        new ClusterManagementResult(StatusCode.ILLEGAL_ARGUMENT,
             e.getMessage()),
         HttpStatus.BAD_REQUEST);
   }
-
 
   /**
    * Handles an AccessDenied Exception thrown by a REST API web service endpoint, HTTP request
@@ -106,9 +139,8 @@ public class ManagementControllerAdvice {
   public ResponseEntity<ClusterManagementResult> handleException(
       final AccessDeniedException cause) {
     return new ResponseEntity<>(
-        new ClusterManagementResult(ClusterManagementResult.StatusCode.UNAUTHORIZED,
+        new ClusterManagementResult(StatusCode.UNAUTHORIZED,
             cause.getMessage()),
         HttpStatus.FORBIDDEN);
   }
-
 }

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
@@ -28,9 +28,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import org.apache.geode.management.api.ClusterManagementException;
 import org.apache.geode.management.api.ClusterManagementListResult;
+import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementResult.StatusCode;
 import org.apache.geode.management.configuration.MemberConfig;
-import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
 import org.apache.geode.management.runtime.MemberInformation;
 
 @Controller("members")
@@ -45,8 +47,8 @@ public class MemberManagementController extends AbstractManagementController {
     ClusterManagementListResult<MemberConfig, MemberInformation> result =
         clusterManagementService.list(config);
     if (result.getRuntimeResult().size() == 0) {
-      throw new EntityNotFoundException(
-          "Member with id = " + config.getId() + " not found.");
+      throw new ClusterManagementException(new ClusterManagementResult(StatusCode.ENTITY_NOT_FOUND,
+          "Member with id = " + config.getId() + " not found."));
     }
 
     return new ResponseEntity<>(result,

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
@@ -39,10 +39,11 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.management.api.ClusterManagementException;
 import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementResult.StatusCode;
 import org.apache.geode.management.api.ConfigurationResult;
-import org.apache.geode.management.internal.exceptions.EntityNotFoundException;
 import org.apache.geode.management.runtime.RuntimeInfo;
 import org.apache.geode.management.runtime.RuntimeRegionInfo;
 import org.apache.geode.security.ResourcePermission.Operation;
@@ -150,11 +151,13 @@ public class RegionManagementController extends AbstractManagementController {
     List<ConfigurationResult<RegionConfig.Index, RuntimeInfo>> indexList = result.getResult();
 
     if (indexList.size() == 0) {
-      throw new EntityNotFoundException("Index " + id + " not found.");
+      throw new ClusterManagementException(
+          new ClusterManagementResult(StatusCode.ENTITY_NOT_FOUND, "Index " + id + " not found."));
     }
 
     if (indexList.size() > 1) {
-      throw new IllegalStateException("More than one entity found.");
+      throw new ClusterManagementException(
+          new ClusterManagementResult(StatusCode.ERROR, "More than one entity found."));
     }
 
     result.setResult(indexList);


### PR DESCRIPTION
Before:
the server-side and client-side implementations of `ClusterManagementService` reported errors differently (by throwing various exceptions on the server side, but returning a status code on the client side).

After:
The goal is to be able to code to the `ClusterManagementService` interface without regard to server vs client environment. To make that possible, `ClientClusterManagementService` now raises `ClusterManagemementException` for any non-successful status, and `LocatorClusterManagementService` now wraps throw exceptions in `ClusterManagemementException` where necessary to be consistent with the client side.  REST clients should continue to receive the same status codes as they always did.