### PR TITLE
GEODE-7028: rename PR check status 'pending' to 'in progress'

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -84,7 +84,7 @@ jobs:
           params:
             context: {{ build_test.name }}
             path: geode
-            status: pending
+            status: "in progress"
           get_params: {skip_download: true}
       - do:
         - put: concourse-metadata-resource
@@ -225,7 +225,7 @@ jobs:
           params:
             context: {{test.name}}Test{{java_test_version.name}}
             path: geode
-            status: pending
+            status: "in progress"
           get_params: {skip_download: true}
       - do:
         - put: concourse-metadata-resource


### PR DESCRIPTION
The new LGTM PR checks use "in progress" while our existing checks use "pending". Both mean the same thing, but make it tricky to make sense of GitHub's summary e.g. 
`1 in progress, 1 pending, 2 neutral, and 7 successful checks`

This PR changes ours to also use "in progress", so the above example is a little easier to grok:
 `2 in progress, 2 neutral, and 7 successful checks`