### PR TITLE
GEODE-6976 org.apache.geode.internal.net.SSLSocketIntegrationTest failure

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -312,7 +312,9 @@ public class SSLSocketIntegrationTest {
     ByteBufferInputStream bbis = new ByteBufferInputStream(unwrapped);
     DataInputStream dis = new DataInputStream(bbis);
     String welcome = dis.readUTF();
-    engine.doneReading(unwrapped);
+    if (unwrapped.position() >= unwrapped.limit()) {
+      unwrapped.position(0).limit(unwrapped.capacity());
+    }
     assertThat(welcome).isEqualTo("Hello world");
     System.out.println("server read Hello World message from client");
   }


### PR DESCRIPTION
testSecuredSocketTransmissionShouldWorkUsingNIO FAILED

This test failed if the first read from the server socket happened to
read two messages instead of one.  This change lets the server thread
read the second message by leaving the decoded buffer's position
unchanged if there is more data to read.

Before this change the test failed in one out of 200 runs.  With the change it ran successfully 2000+ times.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
