### PR TITLE
GEODE-6804: Tab completion does not work when specifying path for --jar argument in gfsh

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserConverterTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserConverterTest.java
@@ -206,4 +206,28 @@ public class GfshParserConverterTest {
     result = parser.parse(command + "invalid_action");
     assertThat(result).isNull();
   }
+
+  @Test
+  public void testJarFilesPathConverter() {
+    String command = "deploy --jar=";
+    commandCandidate = parser.complete(command);
+    assertThat(commandCandidate.size()).isGreaterThan(0);
+    assertThat(commandCandidate.getCandidate(0)).isEqualTo(command + "/");
+  }
+
+  @Test
+  public void testJarFilesPathConverterWithMultiplePaths() {
+    String command = "deploy --jar=foo.jar,";
+    commandCandidate = parser.complete(command);
+    assertThat(commandCandidate.size()).isGreaterThan(0);
+    assertThat(commandCandidate.getCandidate(0)).isEqualTo(command + "/");
+  }
+
+  @Test
+  public void testJarDirPathConverter() {
+    String command = "deploy --dir=";
+    commandCandidate = parser.complete(command);
+    assertThat(commandCandidate.size()).isGreaterThan(0);
+    assertThat(commandCandidate.getCandidate(0)).isEqualTo(command + "/");
+  }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserConverterTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserConverterTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doReturn;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -212,7 +213,7 @@ public class GfshParserConverterTest {
     String command = "deploy --jar=";
     commandCandidate = parser.complete(command);
     assertThat(commandCandidate.size()).isGreaterThan(0);
-    assertThat(commandCandidate.getCandidate(0)).isEqualTo(command + "/");
+    assertCandidateEndsWithFirstRoot(commandCandidate.getCandidate(0), command);
   }
 
   @Test
@@ -220,7 +221,7 @@ public class GfshParserConverterTest {
     String command = "deploy --jar=foo.jar,";
     commandCandidate = parser.complete(command);
     assertThat(commandCandidate.size()).isGreaterThan(0);
-    assertThat(commandCandidate.getCandidate(0)).isEqualTo(command + "/");
+    assertCandidateEndsWithFirstRoot(commandCandidate.getCandidate(0), command);
   }
 
   @Test
@@ -228,6 +229,11 @@ public class GfshParserConverterTest {
     String command = "deploy --dir=";
     commandCandidate = parser.complete(command);
     assertThat(commandCandidate.size()).isGreaterThan(0);
-    assertThat(commandCandidate.getCandidate(0)).isEqualTo(command + "/");
+    assertCandidateEndsWithFirstRoot(commandCandidate.getCandidate(0), command);
+  }
+
+  private void assertCandidateEndsWithFirstRoot(String candidate, String command) {
+    File[] roots = File.listRoots();
+    assertThat(candidate).isEqualTo(command + roots[0]);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/cli/ConverterHint.java
+++ b/geode-core/src/main/java/org/apache/geode/management/cli/ConverterHint.java
@@ -45,5 +45,6 @@ public interface ConverterHint {
   String INDEX_TYPE = "geode.converter.index.type" + DISABLE_ENUM_CONVERTER;
   String GATEWAY_SENDER_ID = "geode.converter.gateway.senderid" + DISABLE_STRING_CONVERTER;
   String LOG_LEVEL = "geode.converter.log.levels" + DISABLE_STRING_CONVERTER;
-
+  String JARFILES = "geode.converter.jarfiles" + DISABLE_STRING_CONVERTER;
+  String JARDIR = "geode.converter.jardir" + DISABLE_STRING_CONVERTER;
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
@@ -78,9 +78,10 @@ public class DeployCommand extends GfshCommand {
   public ResultModel deploy(
       @CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS}, help = CliStrings.DEPLOY__GROUP__HELP,
           optionContext = ConverterHint.MEMBERGROUP) String[] groups,
-      @CliOption(key = {CliStrings.JAR, CliStrings.JARS},
+      @CliOption(key = {CliStrings.JAR, CliStrings.JARS}, optionContext = ConverterHint.JARFILES,
           help = CliStrings.DEPLOY__JAR__HELP) String[] jars,
-      @CliOption(key = {CliStrings.DEPLOY__DIR}, help = CliStrings.DEPLOY__DIR__HELP) String dir)
+      @CliOption(key = {CliStrings.DEPLOY__DIR}, optionContext = ConverterHint.JARDIR,
+          help = CliStrings.DEPLOY__DIR__HELP) String dir)
       throws IOException {
 
     ResultModel result = new ResultModel();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/converters/FilePathStringConverter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/converters/FilePathStringConverter.java
@@ -17,7 +17,9 @@ package org.apache.geode.management.internal.cli.converters;
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.shell.core.Completion;
@@ -74,21 +76,25 @@ public class FilePathStringConverter implements Converter<String> {
     } else {
       prefix = path.endsWith(File.separator) ? path : path + File.separator;
     }
-    return Arrays.stream(currentFile.list()).map(s -> prefix + s).collect(Collectors.toList());
+
+    return Stream.of(currentFile)
+        .map(File::list)
+        .filter(Objects::nonNull)
+        .flatMap(Stream::of)
+        .map(s -> prefix + s)
+        .collect(Collectors.toList());
   }
 
   @Override
   public boolean getAllPossibleValues(List<Completion> completions, Class<?> targetType,
       String existingData, String optionContext, MethodTarget target) {
     if (StringUtils.isBlank(existingData)) {
-      getRoots().stream().forEach(path -> completions.add(new Completion(path)));
+      getRoots().forEach(path -> completions.add(new Completion(path)));
       return !completions.isEmpty();
     }
 
     getSiblings(existingData).stream().filter(string -> string.startsWith(existingData))
-        .forEach(path -> {
-          completions.add(new Completion(path));
-        });
+        .forEach(path -> completions.add(new Completion(path)));
 
     return !completions.isEmpty();
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/converters/JarDirPathConverter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/converters/JarDirPathConverter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.converters;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.shell.core.Completion;
+import org.springframework.shell.core.Converter;
+import org.springframework.shell.core.MethodTarget;
+
+import org.apache.geode.management.cli.ConverterHint;
+
+public class JarDirPathConverter implements Converter<String> {
+  private FilePathStringConverter delegate;
+
+  public JarDirPathConverter() {
+    this.delegate = new FilePathStringConverter();
+  }
+
+  public void setDelegate(FilePathStringConverter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean supports(Class<?> type, String optionContext) {
+    return String.class.equals(type) && optionContext.contains(ConverterHint.JARDIR);
+  }
+
+  @Override
+  public String convertFromText(String value, Class<?> targetType, String optionContext) {
+    return value;
+  }
+
+  @Override
+  public boolean getAllPossibleValues(List<Completion> completions, Class<?> targetType,
+      String existingData, String optionContext, MethodTarget target) {
+    List<Completion> allCompletions = new ArrayList<>();
+    delegate.getAllPossibleValues(allCompletions, targetType, existingData, optionContext, target);
+    completions.addAll(allCompletions.stream()
+        .filter(JarDirPathConverter::isDirWithDirsOrDirWithJars)
+        .collect(Collectors.toList()));
+    return notAllAreJars(completions);
+  }
+
+  static boolean isDirWithDirsOrDirWithJars(Completion dir) {
+    return isDirWithDirsOrDirWithJars(dir.getValue());
+  }
+
+  static boolean isDirWithDirsOrDirWithJars(String dir) {
+    File d = new File(dir);
+    if (!d.isDirectory()) {
+      return false;
+    }
+
+    File[] listing = d.listFiles();
+    if (listing == null) {
+      return false;
+    }
+    return hasSubdirs(listing) || hasJars(listing);
+  }
+
+  private static boolean hasSubdirs(File[] listing) {
+    return Arrays.stream(listing).anyMatch(File::isDirectory);
+  }
+
+  private static boolean hasJars(File[] listing) {
+    return Arrays.stream(listing).anyMatch(f -> f.getName().endsWith(".jar"));
+  }
+
+  private static boolean notAllAreJars(List<Completion> completions) {
+    return completions.stream().anyMatch(c -> !c.getValue().endsWith(".jar"));
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/converters/JarFilesPathConverter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/converters/JarFilesPathConverter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.converters;
+
+import static org.apache.geode.management.internal.cli.converters.JarDirPathConverter.isDirWithDirsOrDirWithJars;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.shell.core.Completion;
+import org.springframework.shell.core.Converter;
+import org.springframework.shell.core.MethodTarget;
+
+import org.apache.geode.management.cli.ConverterHint;
+
+public class JarFilesPathConverter implements Converter<String[]> {
+  private FilePathStringConverter delegate;
+
+  public JarFilesPathConverter() {
+    this.delegate = new FilePathStringConverter();
+  }
+
+  public void setDelegate(FilePathStringConverter delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean supports(Class<?> type, String optionContext) {
+    return String[].class.equals(type) && optionContext.contains(ConverterHint.JARFILES);
+  }
+
+  @Override
+  public String[] convertFromText(String value, Class<?> targetType, String optionContext) {
+    return value.split(",");
+  }
+
+  @Override
+  public boolean getAllPossibleValues(List<Completion> completions, Class<?> targetType,
+      String existingData, String optionContext, MethodTarget target) {
+    // remove anything before ,
+    int comma = existingData.lastIndexOf(',') + 1;
+    String otherJars = existingData.substring(0, comma);
+    existingData = existingData.substring(comma);
+    List<Completion> allCompletions = new ArrayList<>();
+    delegate.getAllPossibleValues(allCompletions, targetType, existingData, optionContext, target);
+    completions.addAll(allCompletions.stream()
+        .map(Completion::getValue)
+        .filter(JarFilesPathConverter::isDirOrJar)
+        .map(s -> new Completion(otherJars + s))
+        .collect(Collectors.toList()));
+    return allAreJars(completions);
+  }
+
+  private static boolean isDirOrJar(String file) {
+    return isDirWithDirsOrDirWithJars(file) || file.endsWith(".jar");
+  }
+
+  private static boolean allAreJars(List<Completion> completions) {
+    return completions.stream().allMatch(c -> c.getValue().endsWith(".jar"));
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarDirPathConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarDirPathConverterTest.java
@@ -42,45 +42,45 @@ public class JarDirPathConverterTest {
 
   @Test
   public void itFindsJarDirs() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testOne", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(testDir.getPath() + "/empty", true);
-    createFileOrDir(libDir.getPath() + "/jar_one.jar", false);
-    createFileOrDir(libDir.getPath() + "/jar_two.jar", false);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testOne", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(testDir, "empty", true);
+    createFileOrDir(libDir, "jar_one.jar", false);
+    createFileOrDir(libDir, "jar_two.jar", false);
 
     JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
     List<Completion> completions = new ArrayList<>();
     jarDirPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
 
     assertThat(completions).hasSize(1);
-    assertThat(completions.get(0).getValue()).endsWith("/lib");
+    assertThat(completions.get(0).getValue()).endsWith("lib");
   }
 
   @Test
   public void itFindsDirsWithSubdirs() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "/file.txt", false);
-    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir, "nonEmpty", true);
+    createFileOrDir(nonEmptyDir, "subDirOne", true);
+    createFileOrDir(nonEmptyDir, "subDirTwo", true);
 
     JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
     List<Completion> completions = new ArrayList<>();
     jarDirPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
 
     assertThat(completions).hasSize(1);
-    assertThat(completions.get(0).getValue()).endsWith("/nonEmpty");
+    assertThat(completions.get(0).getValue()).endsWith("nonEmpty");
   }
 
   @Test
   public void itFindsDirsWithSubdirsAndJars() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "/file.jar", false);
-    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.jar", false);
+    File nonEmptyDir = createFileOrDir(testDir, "nonEmpty", true);
+    createFileOrDir(nonEmptyDir, "subDirOne", true);
+    createFileOrDir(nonEmptyDir, "subDirTwo", true);
 
     JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -93,12 +93,12 @@ public class JarDirPathConverterTest {
 
   @Test
   public void itFindsNothingWithBadSearch() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "file.txt", false);
-    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir, "nonEmpty", true);
+    createFileOrDir(nonEmptyDir, "subDirOne", true);
+    createFileOrDir(nonEmptyDir, "subDirTwo", true);
 
     JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -109,10 +109,10 @@ public class JarDirPathConverterTest {
 
   @Test
   public void itFindsNothing() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "file.txt", false);
-    createFileOrDir(testDir.getPath() + "/empty", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.txt", false);
+    createFileOrDir(testDir, "empty", true);
 
     JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -121,8 +121,8 @@ public class JarDirPathConverterTest {
     assertThat(completions).isEmpty();
   }
 
-  private File createFileOrDir(String path, boolean isDir) throws Exception {
-    File fileOrDir = new File(path);
+  private File createFileOrDir(File parent, String fileOrDirName, boolean isDir) throws Exception {
+    File fileOrDir = new File(parent, fileOrDirName);
     boolean success = fileOrDir.exists() || (isDir ? fileOrDir.mkdir() : fileOrDir.createNewFile());
     assertThat(success).isTrue();
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarDirPathConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarDirPathConverterTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.shell.core.Completion;
+
+import org.apache.geode.management.cli.ConverterHint;
+
+public class JarDirPathConverterTest {
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
+  @Test
+  public void itSupportsString() {
+    JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
+    assertThat(jarDirPathConverter.supports(String.class, ConverterHint.JARDIR)).isTrue();
+    assertThat(jarDirPathConverter.supports(String.class, ConverterHint.JARFILES)).isFalse();
+    assertThat(jarDirPathConverter.supports(Integer.class, ConverterHint.JARDIR)).isFalse();
+  }
+
+  @Test
+  public void itFindsJarDirs() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testOne", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(testDir.getPath() + "/empty", true);
+    createFileOrDir(libDir.getPath() + "/jar_one.jar", false);
+    createFileOrDir(libDir.getPath() + "/jar_two.jar", false);
+
+    JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarDirPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
+
+    assertThat(completions).hasSize(1);
+    assertThat(completions.get(0).getValue()).endsWith("/lib");
+  }
+
+  @Test
+  public void itFindsDirsWithSubdirs() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "/file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+
+    JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarDirPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
+
+    assertThat(completions).hasSize(1);
+    assertThat(completions.get(0).getValue()).endsWith("/nonEmpty");
+  }
+
+  @Test
+  public void itFindsDirsWithSubdirsAndJars() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "/file.jar", false);
+    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+
+    JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarDirPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
+
+    assertThat(completions).hasSize(2);
+    assertThat(completions).containsExactlyInAnyOrder(new Completion(nonEmptyDir.getPath()),
+        new Completion(libDir.getPath()));
+  }
+
+  @Test
+  public void itFindsNothingWithBadSearch() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+
+    JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarDirPathConverter.getAllPossibleValues(completions, null, "garbage", null, null);
+
+    assertThat(completions).isEmpty();
+  }
+
+  @Test
+  public void itFindsNothing() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "file.txt", false);
+    createFileOrDir(testDir.getPath() + "/empty", true);
+
+    JarDirPathConverter jarDirPathConverter = new JarDirPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarDirPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
+
+    assertThat(completions).isEmpty();
+  }
+
+  private File createFileOrDir(String path, boolean isDir) throws Exception {
+    File fileOrDir = new File(path);
+    boolean success = fileOrDir.exists() || (isDir ? fileOrDir.mkdir() : fileOrDir.createNewFile());
+    assertThat(success).isTrue();
+
+    return fileOrDir;
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarFilesPathConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarFilesPathConverterTest.java
@@ -42,11 +42,11 @@ public class JarFilesPathConverterTest {
 
   @Test
   public void itFindsJarDirs() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testOne", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(testDir.getPath() + "/empty", true);
-    createFileOrDir(libDir.getPath() + "/jar_one.jar", false);
-    createFileOrDir(libDir.getPath() + "/jar_two.jar", false);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testOne", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(testDir, "empty", true);
+    createFileOrDir(libDir, "jar_one.jar", false);
+    createFileOrDir(libDir, "jar_two.jar", false);
 
     JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -58,11 +58,11 @@ public class JarFilesPathConverterTest {
 
   @Test
   public void itFindsJarFiles() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testOne", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(testDir.getPath() + "/empty", true);
-    createFileOrDir(libDir.getPath() + "/jar_one.jar", false);
-    createFileOrDir(libDir.getPath() + "/jar_two.jar", false);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testOne", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(testDir, "empty", true);
+    createFileOrDir(libDir, "jar_one.jar", false);
+    createFileOrDir(libDir, "jar_two.jar", false);
 
     JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -74,12 +74,12 @@ public class JarFilesPathConverterTest {
 
   @Test
   public void itFindsDirsWithSubdirs() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "file.txt", false);
-    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir, "nonEmpty", true);
+    createFileOrDir(nonEmptyDir, "subDirOne", true);
+    createFileOrDir(nonEmptyDir, "subDirTwo", true);
 
     JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -87,18 +87,18 @@ public class JarFilesPathConverterTest {
         null, null);
 
     assertThat(completions.size()).isEqualTo(1);
-    assertThat(completions.get(0).getValue()).endsWith("/nonEmpty");
+    assertThat(completions.get(0).getValue()).endsWith("nonEmpty");
     assertThat(completions.get(0).getValue()).startsWith("garbage,");
   }
 
   @Test
   public void itFindsDirsWithSubdirsAndJars() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "/file.jar", false);
-    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.jar", false);
+    File nonEmptyDir = createFileOrDir(testDir, "nonEmpty", true);
+    createFileOrDir(nonEmptyDir, "subDirOne", true);
+    createFileOrDir(nonEmptyDir, "subDirTwo", true);
 
     JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -111,12 +111,12 @@ public class JarFilesPathConverterTest {
 
   @Test
   public void itFindsNothingWithBadSearch() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "file.txt", false);
-    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
-    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir, "nonEmpty", true);
+    createFileOrDir(nonEmptyDir, "subDirOne", true);
+    createFileOrDir(nonEmptyDir, "subDirTwo", true);
 
     JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
     List<Completion> completions = new ArrayList<>();
@@ -127,21 +127,20 @@ public class JarFilesPathConverterTest {
 
   @Test
   public void itFindsNothing() throws Exception {
-    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
-    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
-    createFileOrDir(libDir.getPath() + "file.txt", false);
-    createFileOrDir(testDir.getPath() + "/empty", true);
+    File testDir = createFileOrDir(tmpDir.getRoot(), "testTwo", true);
+    File libDir = createFileOrDir(testDir, "lib", true);
+    createFileOrDir(libDir, "file.txt", false);
+    createFileOrDir(testDir, "empty", true);
 
     JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
     List<Completion> completions = new ArrayList<>();
-    jarFilesPathConverter.getAllPossibleValues(completions, null,
-        testDir.getPath() + testDir.getPath(), null, null);
+    jarFilesPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
 
     assertThat(completions.size()).isEqualTo(0);
   }
 
-  private File createFileOrDir(String path, boolean isDir) throws Exception {
-    File fileOrDir = new File(path);
+  private File createFileOrDir(File parent, String fileOrDirName, boolean isDir) throws Exception {
+    File fileOrDir = new File(parent, fileOrDirName);
     boolean success = fileOrDir.exists() || (isDir ? fileOrDir.mkdir() : fileOrDir.createNewFile());
     assertThat(success).isTrue();
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarFilesPathConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/converters/JarFilesPathConverterTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.shell.core.Completion;
+
+import org.apache.geode.management.cli.ConverterHint;
+
+public class JarFilesPathConverterTest {
+  @Rule
+  public TemporaryFolder tmpDir = new TemporaryFolder();
+
+  @Test
+  public void itSupportsStringArray() {
+    JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
+    assertThat(jarFilesPathConverter.supports(String[].class, ConverterHint.JARFILES)).isTrue();
+    assertThat(jarFilesPathConverter.supports(String[].class, ConverterHint.JARDIR)).isFalse();
+    assertThat(jarFilesPathConverter.supports(Integer.class, ConverterHint.JARDIR)).isFalse();
+  }
+
+  @Test
+  public void itFindsJarDirs() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testOne", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(testDir.getPath() + "/empty", true);
+    createFileOrDir(libDir.getPath() + "/jar_one.jar", false);
+    createFileOrDir(libDir.getPath() + "/jar_two.jar", false);
+
+    JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarFilesPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
+
+    assertThat(completions.size()).isEqualTo(1);
+    assertThat(completions.get(0).getValue()).endsWith("lib");
+  }
+
+  @Test
+  public void itFindsJarFiles() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testOne", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(testDir.getPath() + "/empty", true);
+    createFileOrDir(libDir.getPath() + "/jar_one.jar", false);
+    createFileOrDir(libDir.getPath() + "/jar_two.jar", false);
+
+    JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarFilesPathConverter.getAllPossibleValues(completions, null, libDir.getPath(), null, null);
+
+    assertThat(completions.size()).isEqualTo(2);
+    assertThat(completions.get(0).getValue()).endsWith(".jar");
+  }
+
+  @Test
+  public void itFindsDirsWithSubdirs() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+
+    JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarFilesPathConverter.getAllPossibleValues(completions, null, "garbage," + testDir.getPath(),
+        null, null);
+
+    assertThat(completions.size()).isEqualTo(1);
+    assertThat(completions.get(0).getValue()).endsWith("/nonEmpty");
+    assertThat(completions.get(0).getValue()).startsWith("garbage,");
+  }
+
+  @Test
+  public void itFindsDirsWithSubdirsAndJars() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "/file.jar", false);
+    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+
+    JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarFilesPathConverter.getAllPossibleValues(completions, null, testDir.getPath(), null, null);
+
+    assertThat(completions).hasSize(2);
+    assertThat(completions).containsExactlyInAnyOrder(new Completion(nonEmptyDir.getPath()),
+        new Completion(libDir.getPath()));
+  }
+
+  @Test
+  public void itFindsNothingWithBadSearch() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "file.txt", false);
+    File nonEmptyDir = createFileOrDir(testDir.getPath() + "/nonEmpty", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirOne", true);
+    createFileOrDir(nonEmptyDir.getPath() + "/subDirTwo", true);
+
+    JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarFilesPathConverter.getAllPossibleValues(completions, null, "garbage", null, null);
+
+    assertThat(completions).isEmpty();
+  }
+
+  @Test
+  public void itFindsNothing() throws Exception {
+    File testDir = createFileOrDir(tmpDir.getRoot() + "/testTwo", true);
+    File libDir = createFileOrDir(testDir.getPath() + "/lib", true);
+    createFileOrDir(libDir.getPath() + "file.txt", false);
+    createFileOrDir(testDir.getPath() + "/empty", true);
+
+    JarFilesPathConverter jarFilesPathConverter = new JarFilesPathConverter();
+    List<Completion> completions = new ArrayList<>();
+    jarFilesPathConverter.getAllPossibleValues(completions, null,
+        testDir.getPath() + testDir.getPath(), null, null);
+
+    assertThat(completions.size()).isEqualTo(0);
+  }
+
+  private File createFileOrDir(String path, boolean isDir) throws Exception {
+    File fileOrDir = new File(path);
+    boolean success = fileOrDir.exists() || (isDir ? fileOrDir.mkdir() : fileOrDir.createNewFile());
+    assertThat(success).isTrue();
+
+    return fileOrDir;
+  }
+}


### PR DESCRIPTION
Previous fix had issues on Windows with tests using '/'.

@jmelchio 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
