### PR TITLE
GEODE-7038: After auto-reconnect a server's multicat communications a…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedMulticastRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedMulticastRegionDUnitTest.java
@@ -14,21 +14,26 @@
  */
 package org.apache.geode.cache30;
 
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_TIME_STATISTICS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
+import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_TTL;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_ARCHIVE_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLING_ENABLED;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.cache.AttributesFactory;
@@ -40,11 +45,15 @@ import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.cache.CachedDeserializableFactory;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.pdx.PdxReader;
 import org.apache.geode.pdx.PdxSerializable;
 import org.apache.geode.pdx.PdxSerializationException;
 import org.apache.geode.pdx.PdxWriter;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.SerializableCallable;
@@ -55,11 +64,16 @@ import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 
 public class DistributedMulticastRegionDUnitTest extends JUnit4CacheTestCase {
 
-  static int locatorVM = 3;
-  static String mcastport = "42786";
-  static String mcastttl = "0";
+  int locatorVM = 3;
+  String mcastport = "0";
+  String mcastttl = "0";
 
   private int locatorPort;
+
+  @Before
+  public void setup() {
+    mcastport = String.valueOf(AvailablePortHelper.getRandomAvailableUDPPort());
+  }
 
   @Override
   public final void preSetUp() throws Exception {
@@ -111,7 +125,50 @@ public class DistributedMulticastRegionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public void run2() throws CacheException {
         final Region region = getRootRegion().getSubregion(name);
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < 50; i++) {
+          region.put(i, i);
+        }
+      }
+    };
+
+    vm0.invoke(doPuts);
+    vm0.invoke(() -> validateMulticastOpsAfterRegionOps());
+    vm1.invoke(() -> validateMulticastOpsAfterRegionOps());
+
+    closeLocator();
+  }
+
+  @Test
+  public void testMulticastAfterReconnect() {
+    final String name = "mcastRegion";
+    SerializableRunnable create = new CacheSerializableRunnable("Create Region") {
+      @Override
+      public void run2() throws CacheException {
+        createRegion(name, getRegionAttributes());
+      }
+    };
+
+    locatorPort = startLocator();
+    Host host = Host.getHost(0);
+    final VM vm0 = host.getVM(0);
+    final VM vm1 = host.getVM(1);
+    // 1. start locator with mcast port
+    vm0.invoke(create);
+    vm1.invoke(create);
+    // There is possibility that you may get this packet from other tests
+    /*
+     * SerializableRunnable validateMulticastBeforeRegionOps = new
+     * CacheSerializableRunnable("validateMulticast before region ops") { public void run2() throws
+     * CacheException { validateMulticastOpsBeforeRegionOps(); } };
+     *
+     * vm0.invoke(validateMulticastBeforeRegionOps); vm1.invoke(validateMulticastBeforeRegionOps);
+     */
+
+    SerializableRunnable doPuts = new CacheSerializableRunnable("do put") {
+      @Override
+      public void run2() throws CacheException {
+        final Region region = getRootRegion().getSubregion(name);
+        for (int i = 0; i < 50; i++) {
           region.put(i, i);
         }
       }
@@ -119,16 +176,23 @@ public class DistributedMulticastRegionDUnitTest extends JUnit4CacheTestCase {
 
     vm0.invoke(doPuts);
 
-    SerializableRunnable validateMulticastAfterRegionOps =
-        new CacheSerializableRunnable("validateMulticast after region ops") {
-          @Override
-          public void run2() throws CacheException {
-            validateMulticastOpsAfterRegionOps();
-          }
-        };
+    DistributedTestUtils.crashDistributedSystem(vm1);
+    vm0.invoke(doPuts);
+    vm1.invoke(() -> {
+      basicGetCache().waitUntilReconnected(30, TimeUnit.SECONDS);
+      assertNotNull(basicGetCache().getReconnectedCache());
+      cache = (InternalCache) basicGetCache().getReconnectedCache();
+      system = cache.getInternalDistributedSystem();
+    });
+    vm0.invoke(doPuts);
+    vm0.invoke(() -> {
+      GeodeAwaitility.await().until(() -> {
+        getCache().close();
+        return true;
+      });
+    });
 
-    vm0.invoke(validateMulticastAfterRegionOps);
-    vm1.invoke(validateMulticastAfterRegionOps);
+    vm1.invoke(() -> validateMulticastOpsAfterRegionOps());
 
     closeLocator();
   }
@@ -220,8 +284,10 @@ public class DistributedMulticastRegionDUnitTest extends JUnit4CacheTestCase {
   @Override
   public Properties getDistributedSystemProperties() {
     Properties p = new Properties();
+    p.put(DISABLE_AUTO_RECONNECT, "false");
+    p.put(MAX_WAIT_TIME_RECONNECT, "20");
     p.put(STATISTIC_SAMPLING_ENABLED, "true");
-    p.put(STATISTIC_ARCHIVE_FILE, "multicast");
+    p.put(STATISTIC_ARCHIVE_FILE, "multicast" + OSProcess.getId());
     p.put(ENABLE_TIME_STATISTICS, "true");
     p.put(MCAST_PORT, mcastport);
     p.put(MCAST_TTL, mcastttl);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
@@ -81,6 +81,10 @@ public class ServiceConfig {
     return memberWeight;
   }
 
+  public boolean isMulticastEnabled() {
+    return transport.isMcastEnabled();
+  }
+
   public boolean isNetworkPartitionDetectionEnabled() {
     return networkPartitionDetectionEnabled;
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/ServiceConfig.java
@@ -85,6 +85,10 @@ public class ServiceConfig {
     return networkPartitionDetectionEnabled;
   }
 
+  public boolean isUDPSecurityEnabled() {
+    return !dconfig.getSecurityUDPDHAlgo().isEmpty();
+  }
+
   public boolean areLocatorsPreferredAsCoordinators() {
     boolean locatorsAreCoordinators;
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1379,7 +1380,7 @@ public class GMSHealthMonitor implements HealthMonitor {
         } else {
           logger.info(
               "Availability check failed but detected recent message traffic for suspect member "
-                  + mbr);
+                  + mbr + " at time " + new Date(ts.getTime()));
           failed = false;
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -2464,7 +2464,7 @@ public class GMSJoinLeave implements JoinLeave {
                 joinReqs.add(mbr);
                 joinPorts.put(mbr, port);
                 if (!jmsg.isResponseSent()
-                    && services.getConfig().getTransport().isMcastEnabled()) {
+                    && services.getConfig().isMulticastEnabled()) {
                   // send a join response so the new member can get the multicast messaging digest.
                   JoinResponseMessage response = new JoinResponseMessage(jmsg.getSender(),
                       services.getMessenger().getClusterSecretKey(), jmsg.getRequestId());

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -730,18 +730,6 @@ public class GMSJoinLeave implements JoinLeave {
   private void recordViewRequest(DistributionMessage request) {
     try {
       synchronized (viewRequests) {
-        if (request instanceof JoinRequestMessage) {
-          if (isCoordinator
-              && services.getConfig().isUDPSecurityEnabled()) {
-            services.getMessenger().initClusterKey();
-            JoinRequestMessage jreq = (JoinRequestMessage) request;
-            // this will inform about cluster-secret key, as we have authenticated at this point
-            JoinResponseMessage response = new JoinResponseMessage(jreq.getSender(),
-                services.getMessenger().getClusterSecretKey(), jreq.getRequestId());
-            services.getMessenger().send(response);
-            jreq.setResponseSent();
-          }
-        }
         logger.debug("Recording the request to be processed in the next membership view");
         viewRequests.add(request);
         viewRequests.notifyAll();
@@ -749,28 +737,6 @@ public class GMSJoinLeave implements JoinLeave {
     } catch (RuntimeException | Error t) {
       logger.warn("unable to record a membership view request due to this exception", t);
       throw t;
-    }
-  }
-
-  private void sendDHKeys() {
-    if (isCoordinator
-        && services.getConfig().isUDPSecurityEnabled()) {
-      synchronized (viewRequests) {
-        for (DistributionMessage request : viewRequests) {
-          if (request instanceof JoinRequestMessage) {
-
-            services.getMessenger().initClusterKey();
-            JoinRequestMessage jreq = (JoinRequestMessage) request;
-            if (!jreq.isResponseSent()) {
-              // this will inform about cluster-secret key, as we have authenticated at this point
-              JoinResponseMessage response = new JoinResponseMessage(jreq.getSender(),
-                  services.getMessenger().getClusterSecretKey(), jreq.getRequestId());
-              services.getMessenger().send(response);
-              jreq.setResponseSent();
-            }
-          }
-        }
-      }
     }
   }
 
@@ -824,7 +790,6 @@ public class GMSJoinLeave implements JoinLeave {
     if (locator != null) {
       locator.setIsCoordinator(true);
     }
-    sendDHKeys();
     if (currentView == null) {
       // create the initial membership view
       NetView newView = new NetView(this.localAddress);
@@ -2463,13 +2428,13 @@ public class GMSJoinLeave implements JoinLeave {
               } else {
                 joinReqs.add(mbr);
                 joinPorts.put(mbr, port);
-                if (!jmsg.isResponseSent()
-                    && services.getConfig().isMulticastEnabled()) {
-                  // send a join response so the new member can get the multicast messaging digest.
+                if (services.getConfig().isUDPSecurityEnabled() ||
+                    services.getConfig().isMulticastEnabled()) {
+                  // send a join response so the new member can get the multicast messaging digest
+                  // and cluster key
                   JoinResponseMessage response = new JoinResponseMessage(jmsg.getSender(),
                       services.getMessenger().getClusterSecretKey(), jmsg.getRequestId());
                   services.getMessenger().send(response);
-                  jmsg.setResponseSent();
                 }
               }
             }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/JoinRequestMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/JoinRequestMessage.java
@@ -30,7 +30,6 @@ public class JoinRequestMessage extends HighPriorityDistributionMessage {
   private Object credentials;
   private int failureDetectionPort = -1;
   private int requestId;
-  private transient boolean responseSent;
 
   public JoinRequestMessage(InternalDistributedMember coord, InternalDistributedMember id,
       Object credentials, int fdPort, int requestId) {
@@ -133,13 +132,5 @@ public class JoinRequestMessage extends HighPriorityDistributionMessage {
     if (requestId != other.requestId)
       return false;
     return true;
-  }
-
-  public void setResponseSent() {
-    responseSent = true;
-  }
-
-  public boolean isResponseSent() {
-    return responseSent;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/JoinRequestMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/JoinRequestMessage.java
@@ -30,6 +30,7 @@ public class JoinRequestMessage extends HighPriorityDistributionMessage {
   private Object credentials;
   private int failureDetectionPort = -1;
   private int requestId;
+  private transient boolean responseSent;
 
   public JoinRequestMessage(InternalDistributedMember coord, InternalDistributedMember id,
       Object credentials, int fdPort, int requestId) {
@@ -132,5 +133,13 @@ public class JoinRequestMessage extends HighPriorityDistributionMessage {
     if (requestId != other.requestId)
       return false;
     return true;
+  }
+
+  public void setResponseSent() {
+    responseSent = true;
+  }
+
+  public boolean isResponseSent() {
+    return responseSent;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/JoinResponseMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messages/JoinResponseMessage.java
@@ -174,5 +174,4 @@ public class JoinResponseMessage extends HighPriorityDistributionMessage {
     return true;
   }
 
-
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -1196,8 +1196,6 @@ public class JGroupsMessenger implements Messenger {
             this.myChannel.getProtocolStack().getTopProtocol()
                 .down(new Event(Event.MERGE_DIGEST, digest));
             jrsp.setMessengerData(null);
-            digest = (Digest) this.myChannel.getProtocolStack().getTopProtocol()
-                .down(Event.GET_DIGEST_EVT);
           } catch (Exception e) {
             logger.fatal("Unable to read JGroups messaging digest", e);
           }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -1161,7 +1161,7 @@ public class JGroupsMessenger implements Messenger {
         JoinResponseMessage jrsp = (JoinResponseMessage) m;
 
         if (jrsp.getRejectionMessage() == null
-            && services.getConfig().getTransport().isMcastEnabled()) {
+            && services.getConfig().isMulticastEnabled()) {
           // get the multicast message digest and pass it with the join response
           Digest digest = (Digest) this.myChannel.getProtocolStack().getTopProtocol()
               .down(Event.GET_DIGEST_EVT);
@@ -1185,7 +1185,7 @@ public class JGroupsMessenger implements Messenger {
         JoinResponseMessage jrsp = (JoinResponseMessage) m;
 
         if (jrsp.getRejectionMessage() == null
-            && services.getConfig().getTransport().isMcastEnabled()) {
+            && services.getConfig().isMulticastEnabled()) {
           byte[] serializedDigest = jrsp.getMessengerData();
           ByteArrayInputStream bis = new ByteArrayInputStream(serializedDigest);
           DataInputStream dis = new DataInputStream(bis);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -412,7 +412,7 @@ public class JGroupsMessenger implements Messenger {
 
   @Override
   public void started() {
-    if (queuedMessagesFromReconnect != null) {
+    if (queuedMessagesFromReconnect != null && !services.getConfig().isUDPSecurityEnabled()) {
       logger.info("Delivering {} messages queued by quorum checker",
           queuedMessagesFromReconnect.size());
       for (Message message : queuedMessagesFromReconnect) {
@@ -1196,6 +1196,8 @@ public class JGroupsMessenger implements Messenger {
             this.myChannel.getProtocolStack().getTopProtocol()
                 .down(new Event(Event.MERGE_DIGEST, digest));
             jrsp.setMessengerData(null);
+            digest = (Digest) this.myChannel.getProtocolStack().getTopProtocol()
+                .down(Event.GET_DIGEST_EVT);
           } catch (Exception e) {
             logger.fatal("Unable to read JGroups messaging digest", e);
           }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/mgr/GMSMembershipManager.java
@@ -2180,7 +2180,7 @@ public class GMSMembershipManager implements MembershipManager, Manager {
     }
     services.getMessenger().waitForMessageState((InternalDistributedMember) otherMember, state);
 
-    if (services.getConfig().getTransport().isMcastEnabled()
+    if (services.getConfig().isMulticastEnabled()
         && !services.getConfig().getDistributionConfig().getDisableTcp()) {
       // GEODE-2865: wait for scheduled multicast messages to be applied to the cache
       waitForSerialMessageProcessing((InternalDistributedMember) otherMember);


### PR DESCRIPTION
…ren't working correctly

Ensure that a JoinResponseMessage is sent if multicast is enabled.  This
allows JGroupsMessenger to piggy-back a multicast message digest on the
response that the new process can install in its JGroups stack to ensure
that multicast messaging is properly initialized.

I've also replaced complex checks for whether UDP security is enabled
with a simpler check on ServiceConfig.  When UDP security is enabled we
are already sending a JoinResponseMessage and so we don't need to send
another one if multicast is enabled.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
