### PR TITLE
GEODE-6982: standardize/improve CMS status/error messages

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GatewayReceiverManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GatewayReceiverManagementDUnitTest.java
@@ -68,7 +68,7 @@ public class GatewayReceiverManagementDUnitTest {
     receiver.setGroup("group1");
     List<RealizationResult> results =
         assertManagementResult(cms.create(receiver)).isSuccessful()
-            .containsStatusMessage("Successfully updated config for group1")
+            .containsStatusMessage("Successfully updated configuration for group1.")
             .getMemberStatus();
     assertThat(results).hasSize(1);
     assertThat(results.get(0).isSuccess()).isTrue();
@@ -78,20 +78,22 @@ public class GatewayReceiverManagementDUnitTest {
     receiver.setStartPort("5001");
     receiver.setGroup("group1");
     assertThatThrownBy(() -> cms.create(receiver))
-        .hasMessageContaining("ENTITY_EXISTS: Member(s) server-1 already has this element created");
+        .hasMessageContaining(
+            "ENTITY_EXISTS: GatewayReceiverConfig 'group1' already exists on member(s) server-1.");
 
     // try create another GWR on another group but has no server
     receiver.setStartPort("5002");
     receiver.setGroup("group2");
     assertManagementResult(cms.create(receiver)).isSuccessful()
-        .containsStatusMessage("Successfully updated config for group2")
+        .containsStatusMessage("Successfully updated configuration for group2.")
         .hasMemberStatus().hasSize(0);
 
     // try create another GWR on another group but has a common member in another group
     receiver.setStartPort("5003");
     receiver.setGroup(null);
     assertThatThrownBy(() -> cms.create(receiver))
-        .hasMessageContaining("ENTITY_EXISTS: Member(s) server-1 already has this element created");
+        .hasMessageContaining(
+            "ENTITY_EXISTS: GatewayReceiverConfig 'cluster' already exists on member(s) server-1.");
 
     ClusterManagementListResultAssert<GatewayReceiverConfig, GatewayReceiverInfo> listAssert =
         assertManagementListResult(cms.list(new GatewayReceiverConfig())).isSuccessful();

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RegionManagementDunitTest.java
@@ -146,7 +146,7 @@ public class RegionManagementDunitTest {
 
   @Test
   public void noNameInConfig() throws Exception {
-    IgnoredException.addIgnoredException("Name of the region has to be specified");
+    IgnoredException.addIgnoredException("Region name is required.");
     String json = "{\"type\": \"REPLICATE\"}";
 
     ClusterManagementResult result =
@@ -197,11 +197,11 @@ public class RegionManagementDunitTest {
     assertThatThrownBy(() -> cms.create(regionConfig)).hasMessageContaining("ENTITY_EXISTS")
         .hasMessageContaining("server-2")
         .hasMessageContaining("server-3")
-        .hasMessageContaining("already has this element created");
+        .hasMessageContaining("already exists on member(s)");
 
     regionConfig.setGroup("group3");
     assertThatThrownBy(() -> cms.create(regionConfig)).hasMessageContaining("ENTITY_EXISTS")
-        .hasMessageContaining("Member(s) server-3 already has this element created");
+        .hasMessageContaining("already exists on member(s) server-3.");
   }
 
   @Test

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/DisabledClusterConfigTest.java
@@ -48,6 +48,6 @@ public class DisabledClusterConfigTest {
             .getClusterManagementResult();
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusMessage())
-        .isEqualTo("Cluster configuration service needs to be enabled");
+        .isEqualTo("Cluster configuration service needs to be enabled.");
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
@@ -16,6 +16,7 @@
  */
 package org.apache.geode.internal.cache;
 
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CacheRealizationFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CacheRealizationFunction.java
@@ -109,29 +109,31 @@ public class CacheRealizationFunction implements InternalFunction<List> {
     result.setMemberName(context.getMemberName());
 
     if (realizer == null) {
-      return result.setMessage(
-          "Server needs to be restarted for this configuration change to be realized.");
+      return result.setMessage("Server '" + context.getMemberName()
+          + "' needs to be restarted for this configuration change to be realized.");
     }
 
     switch (operation) {
       case CREATE:
         if (realizer.exists(cacheElement, cache)) {
-          return result.setMessage(
-              "Element with id=" + cacheElement.getId() + " already exists. Skipp creation.");
+          return result.setMessage(cacheElement.getClass().getSimpleName() + " '"
+              + cacheElement.getId() + "' already exists. Skipped creation.");
         }
         result = realizer.create(cacheElement, cache);
         break;
       case DELETE:
         if (!realizer.exists(cacheElement, cache)) {
           return result.setMessage(
-              "Element with id=" + cacheElement.getId() + " does not exist.");
+              cacheElement.getClass().getSimpleName() + " '" + cacheElement.getId()
+                  + "' does not exist.");
         }
         result = realizer.delete(cacheElement, cache);
         break;
       case UPDATE:
         if (!realizer.exists(cacheElement, cache)) {
           return result.setSuccess(false).setMessage(
-              "Element with id=" + cacheElement.getId() + " does not exist.");
+              cacheElement.getClass().getSimpleName() + " '" + cacheElement.getId()
+                  + "' does not exist.");
         }
         result = realizer.update(cacheElement, cache);
         break;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
@@ -193,7 +193,7 @@ public class CommandExecutor {
                 .addLine("Cluster configuration for group '" + group + "' is not updated.");
           }
         } catch (Exception e) {
-          String message = "Failed to update cluster config for " + group;
+          String message = "Failed to update cluster configuration for " + group + ".";
           logger.error(message, e);
           // for now, if one cc update failed, we will set this flag. Will change this when we can
           // add lines to the result returned by the command

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigManager.java
@@ -74,22 +74,24 @@ public class RegionConfigManager implements ConfigurationManager<RegionConfig> {
 
     // one has to be the proxy of the other's main type
     if (!incoming.getType().contains("PROXY") && !existing.getType().contains("PROXY")) {
-      throw new IllegalArgumentException(getDescription(incoming) + " is not compatible with "
-          + group + "'s existing regionConfig "
-          + getDescription(existing));
+      raiseIncompatibilityError(incoming, group, existing);
     }
 
     // the beginning part of the type has to be the same
     String incomingType = incoming.getType().split("_")[0];
     String existingType = existing.getType().split("_")[0];
     if (!incomingType.equals(existingType)) {
-      throw new IllegalArgumentException(
-          getDescription(incoming) + " is not compatible with " + group + "'s existing "
-              + getDescription(existing));
+      raiseIncompatibilityError(incoming, group, existing);
     }
   }
 
+  private void raiseIncompatibilityError(RegionConfig incoming, String group,
+      RegionConfig existing) {
+    throw new IllegalArgumentException(getDescription(incoming) + " is not compatible with " + group
+        + "'s existing " + getDescription(existing) + ".");
+  }
+
   private String getDescription(RegionConfig regionConfig) {
-    return "Region " + regionConfig.getName() + " of type " + regionConfig.getType();
+    return "Region '" + regionConfig.getName() + "' of type '" + regionConfig.getType() + "'";
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidator.java
@@ -28,7 +28,8 @@ public class CacheElementValidator implements ConfigurationValidator<CacheElemen
   public void validate(CacheElementOperation operation, CacheElement config)
       throws IllegalArgumentException {
     if (StringUtils.isBlank(config.getId())) {
-      throw new IllegalArgumentException("id cannot be null or blank");
+      throw new IllegalArgumentException(
+          config.getClass().getSimpleName() + " identifier is required.");
     }
 
     switch (operation) {
@@ -44,7 +45,8 @@ public class CacheElementValidator implements ConfigurationValidator<CacheElemen
 
   private void validateCreate(CacheElement config) {
     if (config.getGroups().size() > 1) {
-      throw new IllegalArgumentException("Can only create element in one group at a time.");
+      throw new IllegalArgumentException(
+          "Can only create " + config.getClass().getSimpleName() + " in one group at a time.");
     }
 
     String group = config.getGroup();
@@ -58,7 +60,7 @@ public class CacheElementValidator implements ConfigurationValidator<CacheElemen
     }
     String id = config.getId();
     if (id.contains("/")) {
-      throw new IllegalArgumentException("Id should not contain slash.");
+      throw new IllegalArgumentException("Identifier should not contain slash.");
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/GatewayReceiverConfigValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/GatewayReceiverConfigValidator.java
@@ -46,7 +46,7 @@ public class GatewayReceiverConfigValidator
 
       if (Integer.parseInt(config.getStartPort()) > Integer.parseInt(config.getEndPort())) {
         throw new IllegalArgumentException("Start port " + config.getStartPort()
-            + " must be less than the end port " + config.getEndPort());
+            + " must be less than the end port " + config.getEndPort() + ".");
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/MemberValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/MemberValidator.java
@@ -61,7 +61,8 @@ public class MemberValidator {
       String members =
           intersection.stream().map(DistributedMember::getName).collect(Collectors.joining(", "));
       throw new EntityExistsException(
-          "Member(s) " + members + " already has this element created.");
+          config.getClass().getSimpleName() + " '" + config.getId()
+              + "' already exists on member(s) " + members + ".");
     }
 
     // if there is no common member, we still need to verify if the new config is compatible with

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidator.java
@@ -54,13 +54,13 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
   private void validateDelete(CacheElement config) {
     if (StringUtils.isNotBlank(config.getGroup())) {
       throw new IllegalArgumentException(
-          "group is an invalid option when deleting region.");
+          "Group is an invalid option when deleting region.");
     }
   }
 
   private void validateCreate(RegionConfig config) {
     if (config.getType() == null) {
-      throw new IllegalArgumentException("Type of the region has to be specified.");
+      throw new IllegalArgumentException("Region type is required.");
     }
 
     // validate if the type is a valid RegionType. Only types defined in RegionType are supported
@@ -69,7 +69,7 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
       RegionType.valueOf(config.getType());
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
-          String.format("Type %s is not supported in Management V2 API.", config.getType()));
+          String.format("Region type '%s' is not supported.", config.getType()));
     }
 
     RegionNameValidation.validate(config.getName());
@@ -223,7 +223,7 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
         break;
       }
       default:
-        throw new IllegalArgumentException("invalid type " + type);
+        throw new IllegalArgumentException("Invalid type " + type + ".");
     }
   }
 
@@ -235,7 +235,7 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
     }
     String existing = regionAttributes.getPartitionAttributes().getLocalMaxMemory();
     if (!existing.equals(maxMemory)) {
-      throw new IllegalArgumentException("Invalid local max memory: " + existing);
+      throw new IllegalArgumentException("Invalid local max memory: " + existing + ".");
     }
   }
 
@@ -250,7 +250,8 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
     EnumActionDestroyOverflow existing =
         regionAttributes.getEvictionAttributes().getLruHeapPercentage().getAction();
     if (existing != evictionAction) {
-      throw new IllegalArgumentException("Conflicting eviction action " + existing.toString());
+      throw new IllegalArgumentException(
+          "Conflicting eviction action " + existing.toString() + ".");
     }
   }
 
@@ -260,7 +261,7 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
     if (existing == null) {
       regionAttributes.setScope(scope);
     } else if (existing != scope) {
-      throw new IllegalArgumentException("Conflicting scope " + existing.toString());
+      throw new IllegalArgumentException("Conflicting scope " + existing.toString() + ".");
     }
   }
 
@@ -271,7 +272,7 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
       regionAttributes.setDataPolicy(policy);
     } else if (existing != policy) {
       throw new IllegalArgumentException("Conflicting data policy "
-          + existing.toString());
+          + existing.toString() + ".");
     }
   }
 
@@ -286,7 +287,7 @@ public class RegionConfigValidator implements ConfigurationValidator<RegionConfi
         regionAttributes.getPartitionAttributes();
     if ("0".equals(partitionAttributes.getRedundantCopies())) {
       throw new IllegalArgumentException(
-          "Conflicting redundant copy when region type is REDUNDANT");
+          "Conflicting redundant copy when region type is REDUNDANT.");
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/operation/OperationManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/operation/OperationManager.java
@@ -64,7 +64,7 @@ public class OperationManager implements AutoCloseable {
 
     BiFunction<Cache, A, V> performer = getPerformer(op);
     if (performer == null) {
-      throw new IllegalArgumentException(String.format("Operation type %s is not supported",
+      throw new IllegalArgumentException(String.format("%s is not supported.",
           op.getClass().getSimpleName()));
     }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/ClusterManagementResultTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/ClusterManagementResultTest.java
@@ -31,7 +31,9 @@ import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.management.api.ClusterManagementListResult;
 import org.apache.geode.management.api.ClusterManagementRealizationResult;
 import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.api.ClusterManagementResult.StatusCode;
 import org.apache.geode.management.api.ConfigurationResult;
+import org.apache.geode.management.api.RealizationResult;
 import org.apache.geode.management.runtime.RuntimeRegionInfo;
 import org.apache.geode.util.internal.GeodeJsonMapper;
 
@@ -46,43 +48,45 @@ public class ClusterManagementResultTest {
   @Test
   public void failsWhenNotAppliedOnAllMembers() {
     ClusterManagementRealizationResult result = new ClusterManagementRealizationResult();
-    result.addMemberStatus("member-1", true, "msg-1");
-    result.addMemberStatus("member-2", false, "msg-2");
-    result.setStatus(true, "message");
+    result.addMemberStatus(new RealizationResult().setMemberName("member-1")
+        .setSuccess(true).setMessage("msg-1"));
+    result.addMemberStatus(new RealizationResult().setMemberName("member-2")
+        .setSuccess(false).setMessage("msg-2"));
     assertThat(result.isSuccessful()).isFalse();
   }
 
   @Test
   public void successfulOnlyWhenResultIsSuccessfulOnAllMembers() {
     ClusterManagementRealizationResult result = new ClusterManagementRealizationResult();
-    result.addMemberStatus("member-1", true, "msg-1");
-    result.addMemberStatus("member-2", true, "msg-2");
-    result.setStatus(true, "message");
+    result.addMemberStatus(new RealizationResult().setMemberName("member-1")
+        .setSuccess(true).setMessage("msg-1"));
+    result.addMemberStatus(new RealizationResult().setMemberName("member-2")
+        .setSuccess(true).setMessage("msg-2"));
     assertThat(result.isSuccessful()).isTrue();
   }
 
   @Test
   public void emptyMemberStatus() {
     assertThat(result.isSuccessful()).isTrue();
-    assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
+    assertThat(result.getStatusCode()).isEqualTo(StatusCode.OK);
   }
 
 
   @Test
   public void failsWhenNotPersisted() {
-    result.setStatus(false, "msg-1");
+    result.setStatus(StatusCode.ERROR, "msg-1");
     assertThat(result.isSuccessful()).isFalse();
   }
 
   @Test
   public void whenNoMembersExists() {
-    result.setStatus(false, "msg-1");
+    result.setStatus(StatusCode.ERROR, "msg-1");
     assertThat(result.isSuccessful()).isFalse();
   }
 
   @Test
   public void whenNoMemberExists2() {
-    result.setStatus(true, "msg-1");
+    result.setStatus(StatusCode.OK, "msg-1");
     assertThat(result.isSuccessful()).isTrue();
   }
 
@@ -97,27 +101,29 @@ public class ClusterManagementResultTest {
 
   @Test
   public void onlyUnsuccessfulResultHasErrorCode() {
-    result = new ClusterManagementResult(true, "message");
-    assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
+    result = new ClusterManagementResult(StatusCode.OK, "message");
+    assertThat(result.getStatusCode()).isEqualTo(StatusCode.OK);
 
-    result = new ClusterManagementResult(false, "message");
+    result = new ClusterManagementResult(StatusCode.ERROR, "message");
     assertThat(result.getStatusCode()).isEqualTo(ERROR);
 
     result = new ClusterManagementResult();
-    result.setStatus(false, "message");
+    result.setStatus(StatusCode.ERROR, "message");
     assertThat(result.getStatusCode()).isEqualTo(ERROR);
 
     result = new ClusterManagementResult();
-    result.setStatus(true, "message");
-    assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.OK);
+    result.setStatus(StatusCode.OK, "message");
+    assertThat(result.getStatusCode()).isEqualTo(StatusCode.OK);
   }
 
   @Test
   public void unsuccessfulMemeberStatusSetsErrorCode() {
     ClusterManagementRealizationResult result =
-        new ClusterManagementRealizationResult(true, "message");
-    result.addMemberStatus("member-1", true, "message-1");
-    result.addMemberStatus("member-2", false, "message-2");
+        new ClusterManagementRealizationResult(StatusCode.OK, "message");
+    result.addMemberStatus(new RealizationResult().setMemberName("member-1")
+        .setSuccess(true).setMessage("message-1"));
+    result.addMemberStatus(new RealizationResult().setMemberName("member-2")
+        .setSuccess(false).setMessage("message-2"));
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusCode()).isEqualTo(ERROR);
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -163,7 +163,7 @@ public class LocatorClusterManagementServiceTest {
     when(persistenceService.getCacheConfig("cluster", true)).thenReturn(new CacheConfig());
     regionConfig.setName("test");
     assertThatThrownBy(() -> service.create(regionConfig))
-        .hasMessageContaining("Failed to apply the update on all members");
+        .hasMessageContaining("Failed to create on all members");
   }
 
   @Test
@@ -193,7 +193,7 @@ public class LocatorClusterManagementServiceTest {
   public void create_non_supportedConfigObject() {
     MemberConfig config = new MemberConfig();
     assertThatThrownBy(() -> service.create(config)).isInstanceOf(ClusterManagementException.class)
-        .hasMessageContaining("ILLEGAL_ARGUMENT: Configuration type MemberConfig is not supported");
+        .hasMessageContaining("ILLEGAL_ARGUMENT: MemberConfig is not supported.");
   }
 
   @Test
@@ -239,7 +239,7 @@ public class LocatorClusterManagementServiceTest {
     doReturn(new String[] {}).when(memberValidator).findGroupsWithThisElement(any(), any());
     assertThatThrownBy(() -> service.delete(config))
         .isInstanceOf(ClusterManagementException.class)
-        .hasMessage("ENTITY_NOT_FOUND: Cache element 'unknown' does not exist");
+        .hasMessage("ENTITY_NOT_FOUND: RegionConfig 'unknown' does not exist.");
   }
 
   @Test
@@ -249,7 +249,7 @@ public class LocatorClusterManagementServiceTest {
     config.setGroup("group1");
     assertThatThrownBy(() -> service.delete(config))
         .isInstanceOf(ClusterManagementException.class)
-        .hasMessage("ILLEGAL_ARGUMENT: group is an invalid option when deleting region.");
+        .hasMessage("ILLEGAL_ARGUMENT: Group is an invalid option when deleting region.");
   }
 
   @Test
@@ -274,7 +274,7 @@ public class LocatorClusterManagementServiceTest {
     result = service.delete(regionConfig);
     assertThat(result.isSuccessful()).isFalse();
     assertThat(result.getStatusMessage())
-        .contains("Failed to apply the update on all members");
+        .contains("Failed to delete on all members.");
 
     assertThat(config.getRegions()).hasSize(1);
   }
@@ -321,7 +321,8 @@ public class LocatorClusterManagementServiceTest {
     verify(regionManager).delete(eq(regionConfig), any());
     assertThat(result.isSuccessful()).isTrue();
     assertThat(result.getMemberStatuses()).hasSize(0);
-    assertThat(result.getStatusMessage()).contains("Successfully removed config for [cluster]");
+    assertThat(result.getStatusMessage())
+        .contains("Successfully removed configuration for [cluster]");
   }
 
   @Test
@@ -334,7 +335,7 @@ public class LocatorClusterManagementServiceTest {
     ClusterManagementOperationResult<?> result = service.start(operation);
     assertThat(result.getUri()).isEqualTo("/management/experimental" + URI + "/42");
     assertThat(result.getStatusCode()).isEqualTo(ClusterManagementResult.StatusCode.ACCEPTED);
-    assertThat(result.getStatusMessage()).contains("async operation started");
+    assertThat(result.getStatusMessage()).contains("Operation started");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigManagerTest.java
@@ -86,7 +86,7 @@ public class RegionConfigManagerTest {
     assertThatThrownBy(() -> manager.checkCompatibility(config1, "group", config2))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Region test of type PARTITION_PROXY is not compatible with group's existing Region test of type REPLICATE");
+            "Region 'test' of type 'PARTITION_PROXY' is not compatible with group's existing Region 'test' of type 'REPLICATE'");
   }
 
   @Test
@@ -96,7 +96,7 @@ public class RegionConfigManagerTest {
     assertThatThrownBy(() -> manager.checkCompatibility(config1, "group", config2))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Region test of type PARTITION is not compatible with group's existing regionConfig Region test of type REPLICATE");
+            "Region 'test' of type 'PARTITION' is not compatible with group's existing Region 'test' of type 'REPLICATE'");
   }
 
   @Test
@@ -106,6 +106,6 @@ public class RegionConfigManagerTest {
     assertThatThrownBy(() -> manager.checkCompatibility(config1, "group", config2))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
-            "Region test of type PARTITION is not compatible with group's existing regionConfig Region test of type PARTITION_PERSISTEN");
+            "Region 'test' of type 'PARTITION' is not compatible with group's existing Region 'test' of type 'PARTITION_PERSISTENT'");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/CacheElementValidatorTest.java
@@ -39,12 +39,12 @@ public class CacheElementValidatorTest {
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config)).isInstanceOf(
         IllegalArgumentException.class)
         .hasMessageContaining(
-            "id cannot be null or blank");
+            "identifier is required.");
 
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.DELETE, config)).isInstanceOf(
         IllegalArgumentException.class)
         .hasMessageContaining(
-            "id cannot be null or blank");
+            "identifier is required.");
   }
 
   @Test
@@ -75,6 +75,6 @@ public class CacheElementValidatorTest {
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config)).isInstanceOf(
         IllegalArgumentException.class)
         .hasMessageContaining(
-            "Can only create element in one group at a time");
+            "Can only create RegionConfig in one group at a time.");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/MemberValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/MemberValidatorTest.java
@@ -133,7 +133,7 @@ public class MemberValidatorTest {
     assertThatThrownBy(() -> validator.validateCreate(regionConfig, regionManager))
         .isInstanceOf(EntityExistsException.class)
         .hasMessageContaining("member4").hasMessageContaining("member2")
-        .hasMessageContaining("already has this element created");
+        .hasMessageContaining("already exists on member(s)");
   }
 
   @Test
@@ -144,7 +144,7 @@ public class MemberValidatorTest {
     regionConfig.setGroup("group2");
     assertThatThrownBy(() -> validator.validateCreate(regionConfig, regionManager))
         .isInstanceOf(EntityExistsException.class)
-        .hasMessageContaining("Member(s) member4 already has this element created");
+        .hasMessageContaining("already exists on member(s) member4.");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidatorTest.java
@@ -83,7 +83,7 @@ public class RegionConfigValidatorTest {
     config.setType("LOCAL");
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Type LOCAL is not supported in Management V2 API.");
+        .hasMessage("Region type 'LOCAL' is not supported.");
   }
 
   @Test
@@ -111,7 +111,7 @@ public class RegionConfigValidatorTest {
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config)).isInstanceOf(
         IllegalArgumentException.class)
         .hasMessageContaining(
-            "Type of the region has to be specified");
+            "Region type is required.");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/operation/OperationManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/operation/OperationManagerTest.java
@@ -91,8 +91,8 @@ public class OperationManagerTest {
   public void submitRogueOperation() {
     TestOperation operation = mock(TestOperation.class);
     assertThatThrownBy(() -> executorManager.submit(operation))
-        .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Operation type")
-        .hasMessageContaining(" not supported");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(" is not supported.");
   }
 
   static class TestOperation implements ClusterManagementOperation<TestOperationResult> {

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementListResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementListResult.java
@@ -43,8 +43,8 @@ public class ClusterManagementListResult<T extends CacheElement & CorrespondWith
   /**
    * for internal use only
    */
-  public ClusterManagementListResult(boolean success, String message) {
-    super(success, message);
+  public ClusterManagementListResult(StatusCode statusCode, String message) {
+    super(statusCode, message);
   }
 
   // Override the mapper setting so that we always show result

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationResult.java
@@ -37,16 +37,8 @@ public class ClusterManagementRealizationResult extends ClusterManagementResult 
   /**
    * for internal use only
    */
-  public ClusterManagementRealizationResult(boolean success, String message) {
-    super(success, message);
-  }
-
-  /**
-   * for internal use only
-   */
-  public void addMemberStatus(String member, boolean success, String message) {
-    addMemberStatus(new RealizationResult().setMemberName(member)
-        .setSuccess(success).setMessage(message));
+  public ClusterManagementRealizationResult(StatusCode statusCode, String message) {
+    super(statusCode, message);
   }
 
   /**

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementResult.java
@@ -73,13 +73,6 @@ public class ClusterManagementResult {
   /**
    * for internal use only
    */
-  public ClusterManagementResult(boolean success, String message) {
-    setStatus(success, message);
-  }
-
-  /**
-   * for internal use only
-   */
   public ClusterManagementResult(StatusCode statusCode, String message) {
     this.statusCode = statusCode;
     this.statusMessage = message;
@@ -92,16 +85,6 @@ public class ClusterManagementResult {
     this.statusCode = copyFrom.statusCode;
     this.statusMessage = copyFrom.statusMessage;
     this.uri = copyFrom.uri;
-  }
-
-  /**
-   * for internal use only
-   */
-  public void setStatus(boolean success, String message) {
-    if (!success) {
-      statusCode = StatusCode.ERROR;
-    }
-    this.statusMessage = message;
   }
 
   /**

--- a/geode-management/src/main/java/org/apache/geode/management/api/RealizationResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/RealizationResult.java
@@ -30,15 +30,12 @@ import org.apache.geode.annotations.Experimental;
 public class RealizationResult implements Serializable {
   private String memberName;
   private boolean success = true;
-  private String message = "success";
+  private String message = "Success.";
 
   /**
    * for internal use only
    */
-  public RealizationResult() {
-    setSuccess(true);
-    setMessage("success");
-  }
+  public RealizationResult() {}
 
   /**
    * returns optional information to supplement {@link #isSuccess()}

--- a/geode-management/src/test/java/org/apache/geode/management/api/ClusterManagementOperationResultTest.java
+++ b/geode-management/src/test/java/org/apache/geode/management/api/ClusterManagementOperationResultTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.management.api.ClusterManagementResult.StatusCode;
 import org.apache.geode.management.runtime.OperationResult;
 import org.apache.geode.util.internal.GeodeJsonMapper;
 
@@ -39,7 +40,7 @@ public class ClusterManagementOperationResultTest {
     CompletableFuture<TestOperationResult> operationResult =
         new CompletableFuture<>();
     ClusterManagementResult result1 = new ClusterManagementResult();
-    result1.setStatus(true, "success!!");
+    result1.setStatus(StatusCode.OK, "success!!");
     ClusterManagementOperationResult<TestOperationResult> result =
         new ClusterManagementOperationResult<>(result1, operationResult, new Date(),
             new CompletableFuture<>(), "operator");

--- a/geode-management/src/test/java/org/apache/geode/management/api/RealizationResultTest.java
+++ b/geode-management/src/test/java/org/apache/geode/management/api/RealizationResultTest.java
@@ -37,7 +37,7 @@ public class RealizationResultTest {
   public void defaultConstructor() {
     assertThat(result.isSuccess()).isTrue();
     assertThat(result.getMemberName()).isNull();
-    assertThat(result.getMessage()).isEqualTo("success");
+    assertThat(result.getMessage()).isEqualTo("Success.");
   }
 
   @Test

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ClientClusterManagementServiceDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ClientClusterManagementServiceDUnitTest.java
@@ -151,7 +151,8 @@ public class ClientClusterManagementServiceDUnitTest {
     // creating the same region on group2 will not be successful because they have a common member
     region.setGroup("group2");
     assertThatThrownBy(() -> client.create(region))
-        .hasMessageContaining("ENTITY_EXISTS: Member(s) server-3 already has this element created");
+        .hasMessageContaining(
+            "ENTITY_EXISTS: RegionConfig 'test' already exists on member(s) server-3.");
   }
 
   @Test
@@ -198,7 +199,7 @@ public class ClientClusterManagementServiceDUnitTest {
         .containsExactlyInAnyOrder("server-1", "server-3");
 
     assertThatThrownBy(() -> client.delete(region))
-        .hasMessageContaining("ILLEGAL_ARGUMENT: group is an invalid option when deleting region");
+        .hasMessageContaining("ILLEGAL_ARGUMENT: Group is an invalid option when deleting region");
   }
 
   @Test

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ConfigurePDXDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/ConfigurePDXDUnitTest.java
@@ -90,7 +90,7 @@ public class ConfigurePDXDUnitTest {
 
     RealizationResult status = result.getMemberStatuses().get(0);
     assertThat(status.getMemberName()).isEqualTo("server-1");
-    assertThat(status.getMessage())
-        .contains("Server needs to be restarted for this configuration change to be realized");
+    assertThat(status.getMessage()).contains(
+        "Server 'server-1' needs to be restarted for this configuration change to be realized.");
   }
 }

--- a/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/MemberManagementServiceDUnitTest.java
+++ b/geode-web-management/src/distributedTest/java/org/apache/geode/management/client/MemberManagementServiceDUnitTest.java
@@ -163,6 +163,6 @@ public class MemberManagementServiceDUnitTest {
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.statusCode", is("ENTITY_NOT_FOUND")))
         .andExpect(jsonPath("$.statusMessage",
-            is("Member with id = server not found.")));
+            is("Member 'server' does not exist.")));
   }
 }

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/ClusterManagementSecurityRestIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/ClusterManagementSecurityRestIntegrationTest.java
@@ -155,7 +155,7 @@ public class ClusterManagementSecurityRestIntegrationTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.statusCode", is("OK")))
         .andExpect(jsonPath("$.statusMessage",
-            is("Successfully updated config for cluster")));
+            is("Successfully updated configuration for cluster.")));
   }
 
   private static class TestContext {

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/PdxManagementTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/PdxManagementTest.java
@@ -63,7 +63,8 @@ public class PdxManagementTest {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("$.memberStatuses").doesNotExist())
         .andExpect(
-            jsonPath("$.statusMessage", containsString("Successfully updated config for cluster")))
+            jsonPath("$.statusMessage",
+                containsString("Successfully updated configuration for cluster.")))
         .andExpect(jsonPath("$.statusCode", is("OK")))
         .andExpect(jsonPath("$.uri", is("/management/experimental/configurations/pdx")));
   }

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RebalanceIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RebalanceIntegrationTest.java
@@ -77,7 +77,8 @@ public class RebalanceIntegrationTest {
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.statusCode", Matchers.is("ENTITY_NOT_FOUND")))
         .andExpect(
-            jsonPath("$.statusMessage", Matchers.containsString("Operation id = abc not found")));
+            jsonPath("$.statusMessage",
+                Matchers.containsString("Operation 'abc' does not exist.")));
   }
 
   @Test

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RebalanceIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RebalanceIntegrationTest.java
@@ -68,7 +68,7 @@ public class RebalanceIntegrationTest {
         .andExpect(
             jsonPath("$.uri",
                 Matchers.containsString("/management/experimental/operations/rebalance/")))
-        .andExpect(jsonPath("$.statusMessage", Matchers.containsString("async operation started")));
+        .andExpect(jsonPath("$.statusMessage", Matchers.containsString("Operation started")));
   }
 
   @Test

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementIntegrationTest.java
@@ -79,7 +79,7 @@ public class RegionManagementIntegrationTest {
 
     assertThatThrownBy(() -> client.create(regionConfig))
         .hasMessageContaining(
-            "ILLEGAL_ARGUMENT: Type LOCAL is not supported in Management V2 API.");
+            "ILLEGAL_ARGUMENT: Region type 'LOCAL' is not supported.");
   }
 
   @Test

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/ManagementControllerAdvice.java
@@ -85,23 +85,20 @@ public class ManagementControllerAdvice {
   @ExceptionHandler({AuthenticationFailedException.class, AuthenticationException.class})
   public ResponseEntity<ClusterManagementResult> unauthorized(Exception e) {
     return new ResponseEntity<>(
-        new ClusterManagementResult(StatusCode.UNAUTHENTICATED,
-            e.getMessage()),
+        new ClusterManagementResult(StatusCode.UNAUTHENTICATED, e.getMessage()),
         HttpStatus.UNAUTHORIZED);
   }
 
   @ExceptionHandler({NotAuthorizedException.class, SecurityException.class})
   public ResponseEntity<ClusterManagementResult> forbidden(Exception e) {
-    return new ResponseEntity<>(new ClusterManagementResult(
-        StatusCode.UNAUTHORIZED, e.getMessage()),
-        HttpStatus.FORBIDDEN);
+    return new ResponseEntity<>(
+        new ClusterManagementResult(StatusCode.UNAUTHORIZED, e.getMessage()), HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler({IllegalArgumentException.class, HttpMessageNotReadableException.class})
   public ResponseEntity<ClusterManagementResult> badRequest(final Exception e) {
     return new ResponseEntity<>(
-        new ClusterManagementResult(StatusCode.ILLEGAL_ARGUMENT,
-            e.getMessage()),
+        new ClusterManagementResult(StatusCode.ILLEGAL_ARGUMENT, e.getMessage()),
         HttpStatus.BAD_REQUEST);
   }
 

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
@@ -48,7 +48,7 @@ public class MemberManagementController extends AbstractManagementController {
         clusterManagementService.list(config);
     if (result.getRuntimeResult().size() == 0) {
       throw new ClusterManagementException(new ClusterManagementResult(StatusCode.ENTITY_NOT_FOUND,
-          "Member with id = " + config.getId() + " not found."));
+          "Member '" + config.getId() + "' does not exist."));
     }
 
     return new ResponseEntity<>(result,

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
@@ -151,13 +151,13 @@ public class RegionManagementController extends AbstractManagementController {
     List<ConfigurationResult<RegionConfig.Index, RuntimeInfo>> indexList = result.getResult();
 
     if (indexList.size() == 0) {
-      throw new ClusterManagementException(
-          new ClusterManagementResult(StatusCode.ENTITY_NOT_FOUND, "Index " + id + " not found."));
+      throw new ClusterManagementException(new ClusterManagementResult(StatusCode.ENTITY_NOT_FOUND,
+          "Index '" + id + "' does not exist in region '" + regionName + "'."));
     }
 
     if (indexList.size() > 1) {
       throw new ClusterManagementException(
-          new ClusterManagementResult(StatusCode.ERROR, "More than one entity found."));
+          new ClusterManagementResult(StatusCode.ERROR, "More than one index found."));
     }
 
     result.setResult(indexList);


### PR DESCRIPTION
Consistently follow these principles:
- Start with capital letter.
- End with a period.
- Spell out configuration.
- mention specific type rather than "element" or "CacheElement" 
- use active language like "is required" and "does not exist"
- use region names without leading /
- include real server name in “server needs to be restarted”