### PR TITLE
 GEODE-7001: Prevent potential NPE in LocalRegion

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionJUnitTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Set;
+import java.util.function.Function;
 
 import org.junit.Test;
 
@@ -113,8 +114,11 @@ public class AbstractRegionJUnitTest {
     DiskWriteAttributes diskWriteAttributes = mock(DiskWriteAttributes.class);
     when(regionAttributes.getDiskWriteAttributes()).thenReturn(diskWriteAttributes);
     RegionMapConstructor regionMapConstructor = mock(RegionMapConstructor.class);
+    Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory =
+        (localRegion) -> mock(RegionPerfStats.class);
     AbstractRegion region = new LocalRegion("regionName", regionAttributes, null, Fakes.cache(),
-        new InternalRegionArguments(), null, regionMapConstructor, null, null, null);
+        new InternalRegionArguments(), null, regionMapConstructor, null, null, null,
+        regionPerfStatsFactory);
     return region;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionPartialMockTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionPartialMockTest.java
@@ -53,7 +53,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 
-public class LocalRegionTest {
+public class LocalRegionPartialMockTest {
   private LocalRegion region;
   private EntryEventImpl event;
   private ServerRegionProxy serverRegionProxy;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.DiskWriteAttributes;
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.distributed.internal.DSClock;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.AbstractRegion.PoolFinder;
+import org.apache.geode.internal.cache.LocalRegion.RegionMapConstructor;
+import org.apache.geode.internal.cache.LocalRegion.ServerRegionProxyConstructor;
+
+public class LocalRegionTest {
+
+  private RegionAttributes regionAttributes;
+  private InternalCache cache;
+  private InternalRegionArguments internalRegionArguments;
+  private InternalDataView internalDataView;
+  private RegionMapConstructor regionMapConstructor;
+  private ServerRegionProxyConstructor serverRegionProxyConstructor;
+  private EntryEventFactory entryEventFactory;
+  private PoolFinder poolFinder;
+
+  @Before
+  public void setup() {
+    cache = mock(InternalCache.class);
+    entryEventFactory = mock(EntryEventFactory.class);
+    internalDataView = mock(InternalDataView.class);
+    internalRegionArguments = mock(InternalRegionArguments.class);
+    poolFinder = mock(PoolFinder.class);
+    regionAttributes = mock(RegionAttributes.class);
+    regionMapConstructor = mock(RegionMapConstructor.class);
+    serverRegionProxyConstructor = mock(ServerRegionProxyConstructor.class);
+
+    DiskWriteAttributes diskWriteAttributes = mock(DiskWriteAttributes.class);
+    EvictionAttributes evictionAttributes = mock(EvictionAttributes.class);
+    ExpirationAttributes expirationAttributes = mock(ExpirationAttributes.class);
+    InternalDistributedSystem internalDistributedSystem = mock(InternalDistributedSystem.class);
+
+    when(cache.getInternalDistributedSystem()).thenReturn(internalDistributedSystem);
+    when(evictionAttributes.getAction()).thenReturn(EvictionAction.NONE);
+    when(internalDistributedSystem.getClock()).thenReturn(mock(DSClock.class));
+    when(regionAttributes.getDataPolicy()).thenReturn(DataPolicy.DEFAULT);
+    when(regionAttributes.getDiskWriteAttributes()).thenReturn(diskWriteAttributes);
+    when(regionAttributes.getEntryIdleTimeout()).thenReturn(expirationAttributes);
+    when(regionAttributes.getEntryTimeToLive()).thenReturn(expirationAttributes);
+    when(regionAttributes.getEvictionAttributes()).thenReturn(evictionAttributes);
+    when(regionAttributes.getRegionIdleTimeout()).thenReturn(expirationAttributes);
+    when(regionAttributes.getRegionTimeToLive()).thenReturn(expirationAttributes);
+    when(regionMapConstructor.create(any(), any(), any())).thenReturn(mock(RegionMap.class));
+  }
+
+  @Test
+  public void getLocalSizeDoesNotThrowNullPointerExceptionDuringConstruction() {
+    Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory = (localRegion) -> {
+      localRegion.getLocalSize();
+      return mock(RegionPerfStats.class);
+    };
+
+    assertThatCode(() -> new LocalRegion("region", regionAttributes, null, cache,
+        internalRegionArguments, internalDataView, regionMapConstructor,
+        serverRegionProxyConstructor, entryEventFactory, poolFinder, regionPerfStatsFactory))
+            .doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
Prevent potential NPE during LocalRegion construction when stat sampling is enabled. Specifically, if getLocalSize() is invoked by the callback sampler before the RegionMap inside LocalRegion is created then it will throw an NPE.

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
