### PR TITLE
GEODE-7051: Upgrade to log4j 2.12.0

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -562,31 +562,31 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.11.1</version>
+        <version>2.12.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.11.1</version>
+        <version>2.12.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jcl</artifactId>
-        <version>2.11.1</version>
+        <version>2.12.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jul</artifactId>
-        <version>2.11.1</version>
+        <version>2.12.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.11.1</version>
+        <version>2.12.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -40,7 +40,7 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("fastutil.version", "8.2.2")
     deps.put("javax.transaction-api.version", "1.3")
     deps.put("jgroups.version", "3.6.14.Final")
-    deps.put("log4j.version", "2.11.1")
+    deps.put("log4j.version", "2.12.0")
     deps.put("micrometer.version", "1.2.0")
     deps.put("shiro.version", "1.4.0")
     deps.put("slf4j-api.version", "1.7.25")

--- a/geode-assembly/src/acceptanceTest/resources/gradle-test-projects/management/build.gradle
+++ b/geode-assembly/src/acceptanceTest/resources/gradle-test-projects/management/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     compile("${project.group}:geode-core:${project.version}")
-    runtime('org.apache.logging.log4j:log4j-slf4j-impl:2.11.1')
+    runtime('org.apache.logging.log4j:log4j-slf4j-impl:2.12.0')
 }
 
 application {

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -979,11 +979,11 @@ lib/jgroups-3.6.14.Final.jar
 lib/jline-2.12.jar
 lib/jna-4.1.0.jar
 lib/jopt-simple-5.0.4.jar
-lib/log4j-api-2.11.1.jar
-lib/log4j-core-2.11.1.jar
-lib/log4j-jcl-2.11.1.jar
-lib/log4j-jul-2.11.1.jar
-lib/log4j-slf4j-impl-2.11.1.jar
+lib/log4j-api-2.12.0.jar
+lib/log4j-core-2.12.0.jar
+lib/log4j-jcl-2.12.0.jar
+lib/log4j-jul-2.12.0.jar
+lib/log4j-slf4j-impl-2.12.0.jar
 lib/lucene-analyzers-common-6.6.2.jar
 lib/lucene-analyzers-phonetic-6.6.2.jar
 lib/lucene-core-6.6.2.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -53,11 +53,11 @@ jgroups-3.6.14.Final.jar
 jline-2.12.jar
 jna-4.1.0.jar
 jopt-simple-5.0.4.jar
-log4j-api-2.11.1.jar
-log4j-core-2.11.1.jar
-log4j-jcl-2.11.1.jar
-log4j-jul-2.11.1.jar
-log4j-slf4j-impl-2.11.1.jar
+log4j-api-2.12.0.jar
+log4j-core-2.12.0.jar
+log4j-jcl-2.12.0.jar
+log4j-jul-2.12.0.jar
+log4j-slf4j-impl-2.12.0.jar
 lucene-analyzers-common-6.6.2.jar
 lucene-analyzers-phonetic-6.6.2.jar
 lucene-core-6.6.2.jar

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -260,7 +260,9 @@ dependencies {
 
   //Log4j is used everywhere
   implementation('org.apache.logging.log4j:log4j-api')
-  implementation('org.apache.logging.log4j:log4j-core')
+  implementation('org.apache.logging.log4j:log4j-core') {
+    ext.optional = true
+  }
 
   //Jansi is used by the CLI (maybe? it is a runtime dependency)
   runtimeOnly('org.fusesource.jansi:jansi') {

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -224,6 +224,7 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <scope>runtime</scope>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -28,7 +28,7 @@ dependencies {
   }
   compile(project(':geode-core'))
 
-  compileOnly('org.apache.logging.log4j:log4j-api:2.11.1')
+  compileOnly('org.apache.logging.log4j:log4j-api:2.12.0')
 
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'


### PR DESCRIPTION
Upgrade to log4j 2.12.0 and mark log4j-core dependency as optional in geode-core.
