### PR TITLE
GEODE-6883 refactor GMS classes

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedMulticastRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedMulticastRegionDUnitTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.cache.AttributesFactory;
@@ -133,7 +132,6 @@ public class DistributedMulticastRegionDUnitTest extends JUnit4CacheTestCase {
     closeLocator();
   }
 
-  @Ignore
   @Test
   public void testMulticastAfterReconnect() {
     final String name = "mcastRegion";
@@ -166,7 +164,7 @@ public class DistributedMulticastRegionDUnitTest extends JUnit4CacheTestCase {
 
     DistributedTestUtils.crashDistributedSystem(vm1);
     vm0.invoke(doPuts);
-    vm1.invoke(() -> {
+    vm1.invoke("wait for vm1 to reconnect", () -> {
       basicGetCache().waitUntilReconnected(30, TimeUnit.SECONDS);
       assertNotNull(basicGetCache().getReconnectedCache());
       cache = (InternalCache) basicGetCache().getReconnectedCache();
@@ -281,6 +279,7 @@ public class DistributedMulticastRegionDUnitTest extends JUnit4CacheTestCase {
   @Override
   public Properties getDistributedSystemProperties() {
     Properties p = new Properties();
+    p.put(NAME, "vm" + VM.getCurrentVMNum());
     p.put(DISABLE_AUTO_RECONNECT, "false");
     p.put(MAX_WAIT_TIME_RECONNECT, "20");
     p.put(STATISTIC_SAMPLING_ENABLED, "true");

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -174,7 +174,7 @@ public class InternalDistributedMember implements DistributedMember, Externaliza
   public InternalDistributedMember(NetMember m) {
     netMbr = m;
 
-    if (netMbr.getHostName() == null) {
+    if (netMbr.getHostName() == null || netMbr.isPartial()) {
       String hostName = SocketCreator.resolve_dns ? SocketCreator.getHostName(m.getInetAddress())
           : m.getInetAddress().getHostAddress();
       netMbr.setHostName(hostName);
@@ -187,7 +187,7 @@ public class InternalDistributedMember implements DistributedMember, Externaliza
       this.versionObj = Version.CURRENT;
     }
     cachedToString = null;
-    this.isPartial = false;
+    this.isPartial = m.isPartial();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MembershipView.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/MembershipView.java
@@ -148,6 +148,24 @@ public class MembershipView {
     return null;
   }
 
+
+  /**
+   * Returns the ID from this view that is equal to the argument. If no such ID exists the argument
+   * is returned.
+   */
+  public synchronized InternalDistributedMember getCanonicalID(InternalDistributedMember id) {
+    if (hashedMembers.contains(id)) {
+      for (InternalDistributedMember m : this.members) {
+        if (id.equals(m)) {
+          return m;
+        }
+      }
+    }
+    return id;
+  }
+
+
+
   public InternalDistributedMember getCoordinator() {
     for (InternalDistributedMember addr : members) {
       if (addr.getNetMember().preferredForCoordinator()) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/NetMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/NetMember.java
@@ -109,4 +109,7 @@ public interface NetMember extends Comparable<NetMember> {
   void setHostName(String hostName);
 
   String getHostName();
+
+  /** is this a partial ID created without full identifier information? */
+  boolean isPartial();
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSMemberAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSMemberAdapter.java
@@ -171,6 +171,11 @@ public class GMSMemberAdapter implements NetMember {
   }
 
   @Override
+  public boolean isPartial() {
+    return gmsMember.isPartial();
+  }
+
+  @Override
   public void setDurableClientAttributes(DurableClientAttributes attributes) {
     durableClientAttributes = attributes;
     if (attributes != null) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSMembershipManager.java
@@ -1151,6 +1151,7 @@ public class GMSMembershipManager implements MembershipManager {
 
     if (o.isDistributionMessage()) { // normal message
       try {
+        o.dmsg.setSender(latestView.getCanonicalID(o.dmsg.getSender()));
         dispatchMessage(o.dmsg);
       } catch (MemberShunnedException e) {
         // message from non-member - ignore

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMember.java
@@ -64,6 +64,11 @@ public class GMSMember implements DataSerializableFixedID {
   private String durableId;
   private int durableTimeout;
 
+  private boolean isPartial; // transient state - created with readEssentialData
+
+  public boolean isPartial() {
+    return isPartial;
+  }
 
   // Used only by Externalization
   public GMSMember() {}
@@ -340,10 +345,11 @@ public class GMSMember implements DataSerializableFixedID {
     StringBuilder sb = new StringBuilder(100);
     String uuid = formatUUID();
 
-    sb.append("GMSMember[addr=").append(inetAddr).append(";port=").append(udpPort)
-        .append(";kind=").append(vmKind).append(";processId=").append(";viewId=").append(vmViewId)
-        .append(processId).append(";v").append(versionOrdinal).append(";name=")
-        .append(name).append(uuid).append(";weight=").append(memberWeight)
+    sb.append("GMSMember[name=").append(name)
+        .append(";addr=").append(inetAddr).append(";port=").append(udpPort)
+        .append(";kind=").append(vmKind).append(";processId=").append(processId)
+        .append(";viewId=").append(vmViewId)
+        .append(";version=").append(versionOrdinal).append(uuid)
         .append("]");
     return sb.toString();
   }
@@ -620,6 +626,7 @@ public class GMSMember implements DataSerializableFixedID {
     if (InternalDataSerializer.getVersionForDataStream(in).compareTo(Version.GEODE_1_2_0) >= 0) {
       this.vmKind = in.readByte();
     }
+    this.isPartial = true;
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -1170,7 +1170,7 @@ public class JGroupsMessenger implements Messenger {
           try {
             Digest digest = new Digest();
             digest.readFrom(dis);
-            logger.trace("installing JGroups message digest {}", digest);
+            logger.trace("installing JGroups message digest {} from {}", digest, m);
             this.myChannel.getProtocolStack().getTopProtocol()
                 .down(new Event(Event.MERGE_DIGEST, digest));
             jrsp.setMessengerData(null);


### PR DESCRIPTION
refactoring to remove references to InternalDistributedMember or
DistributionMessage in "gms" packages caused failures when
multicast is enabled on Regions.

Queued messages received during startup have partial sender identifiers
and these need to have their isPartial bit set correctly so they won't
be treated as full identifiers.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
