### PR TITLE
GEODE-7063: Add basic assertions for meters

### DIFF
--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -43,6 +43,7 @@ dependencies {
   compile('org.awaitility:awaitility')
   compile('org.bouncycastle:bcpkix-jdk15on')
   compile('org.hamcrest:hamcrest-all')
+  compile('io.micrometer:micrometer-core')
   compile('org.mockito:mockito-core')
   compile('org.skyscreamer:jsonassert')
 

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/AbstractMeterAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/AbstractMeterAssert.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import java.util.Objects;
+
+import io.micrometer.core.instrument.Meter;
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * Assertions applicable to all {@link Meter} types.
+ *
+ * @param <A> the concrete type of this assertion object
+ * @param <M> the type of meter to evaluate
+ */
+public class AbstractMeterAssert<A extends AbstractMeterAssert<A, M>, M extends Meter>
+    extends AbstractAssert<A, M> {
+
+  private final Meter.Id meterId;
+
+  /**
+   * Creates an assertion to evaluate the given meter.
+   *
+   * @param meter the meter to evaluate
+   * @param selfType the concrete type of the assertion object
+   */
+  AbstractMeterAssert(M meter, Class<A> selfType) {
+    super(meter, selfType);
+    meterId = meter.getId();
+  }
+
+  /**
+   * Verifies that the meter has the given name.
+   *
+   * @param expectedName the expected name
+   * @return this assertion object
+   * @throws AssertionError if the meter is {@code null}
+   * @throws AssertionError if the meter's name is not equal to the given name
+   */
+  public A hasName(String expectedName) {
+    isNotNull();
+    String meterName = meterId.getName();
+    if (!Objects.equals(meterName, expectedName)) {
+      failWithMessage("Expected meter to have name <%s> but name was <%s>", expectedName,
+          meterName);
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the meter has a tag with the given key.
+   *
+   * @param key the expected tag key
+   * @return this assertion object
+   * @throws AssertionError if the meter is {@code null}
+   * @throws AssertionError if the meter has no tag with the given key
+   */
+  public A hasTag(String key) {
+    isNotNull();
+    if (meterId.getTag(key) == null) {
+      failWithMessage("Expected meter to have tag with key <%s>"
+          + " but meter had no tag with that key in <%s>",
+          key, meterId.getTags());
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the meter has a tag with the given key and value.
+   *
+   * @param key the tag key
+   * @param expectedValue the expected value of the tag with the given key
+   * @return this assertion object
+   * @throws AssertionError if the meter is {@code null}
+   * @throws AssertionError if the meter has no tag with the given key
+   * @throws AssertionError if the tag with the given key does not have the given value
+   */
+  public A hasTag(String key, String expectedValue) {
+    hasTag(key);
+    String tagValue = meterId.getTag(key);
+    if (!Objects.equals(tagValue, expectedValue)) {
+      failWithMessage("Expected meter's <%s> tag to have value <%s>"
+          + " but value was <%s>",
+          key, expectedValue, tagValue);
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the meter has the given base unit.
+   *
+   * @param expectedBaseUnit the expected base unit
+   * @return this assertion object
+   * @throws AssertionError if the meter is {@code null}
+   * @throws AssertionError if the meter does not have the given base unit
+   */
+  public A hasBaseUnit(String expectedBaseUnit) {
+    isNotNull();
+    String meterBaseUnit = meterId.getBaseUnit();
+    if (!Objects.equals(meterBaseUnit, expectedBaseUnit)) {
+      failWithMessage("Expected meter to have base unit <%s> but base unit was <%s>",
+          expectedBaseUnit, meterBaseUnit);
+    }
+    return myself;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/CounterAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/CounterAssert.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import io.micrometer.core.instrument.Counter;
+import org.assertj.core.api.Condition;
+
+/**
+ * Assertions for {@link Counter}s.
+ */
+public class CounterAssert extends AbstractMeterAssert<CounterAssert, Counter> {
+
+  /**
+   * Creates an assertion to evaluate the given counter.
+   *
+   * @param counter the counter to evaluate
+   */
+  CounterAssert(Counter counter) {
+    super(counter, CounterAssert.class);
+  }
+
+  /**
+   * Verifies that the counter has a count that satisfies the given condition.
+   *
+   * @param condition the criteria against which to evaluate the counter's count
+   * @return this assertion object
+   * @throws AssertionError if the counter is {@code null}
+   * @throws AssertionError if the condition rejects the counter's count
+   */
+  public CounterAssert hasCount(Condition<? super Double> condition) {
+    isNotNull();
+    double count = actual.count();
+    if (!condition.matches(count)) {
+      failWithMessage("Expected counter to have count <%s> but count was <%s>", condition, count);
+    }
+    return myself;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/GaugeAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/GaugeAssert.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import io.micrometer.core.instrument.Gauge;
+import org.assertj.core.api.Condition;
+
+/**
+ * Assertions for {@link Gauge}s.
+ */
+public class GaugeAssert extends AbstractMeterAssert<GaugeAssert, Gauge> {
+  /**
+   * Creates an assertion to evaluate the given gauge.
+   *
+   * @param gauge the gauge to evaluate
+   */
+  GaugeAssert(Gauge gauge) {
+    super(gauge, GaugeAssert.class);
+  }
+
+  /**
+   * Verifies that the gauge has a value that satisfies the given condition.
+   *
+   * @param condition the criteria against which to evaluate the gauge's count
+   * @return this assertion object
+   * @throws AssertionError if the gauge is {@code null}
+   * @throws AssertionError if the condition rejects the gauge's value
+   */
+  public GaugeAssert hasValue(Condition<? super Double> condition) {
+    double value = actual.value();
+    if (!condition.matches(value)) {
+      failWithMessage("Expected gauge to have value <%s> but value was <%s>", condition, value);
+    }
+    return myself;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/MeterAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/MeterAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import io.micrometer.core.instrument.Meter;
+
+/**
+ * Assertions for {@code Meter}s.
+ */
+public class MeterAssert extends AbstractMeterAssert<MeterAssert, Meter> {
+  /**
+   * Creates an assertion to evaluate the given meter.
+   *
+   * @param meter the meter to evaluate
+   */
+  MeterAssert(Meter meter) {
+    super(meter, MeterAssert.class);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/MicrometerAssertions.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/MicrometerAssertions.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information
+ * regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2
+ * .0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
+
+/**
+ * Entry point for assertions for Micrometer meters.
+ */
+public class MicrometerAssertions {
+
+  /**
+   * Creates an assertion to evaluate the given meter.
+   *
+   * @param meter the meter to evaluate
+   * @return the created assertion object
+   */
+  public static MeterAssert assertThat(Meter meter) {
+    return new MeterAssert(meter);
+  }
+
+  /**
+   * Creates an assertion to evaluate the given counter.
+   *
+   * @param counter the counter to evaluate
+   * @return the created assertion object
+   */
+  public static CounterAssert assertThat(Counter counter) {
+    return new CounterAssert(counter);
+  }
+
+  /**
+   * Creates an assertion to evaluate the given gauge.
+   *
+   * @param gauge the gauge to evaluate
+   * @return the created assertion object
+   */
+  public static GaugeAssert assertThat(Gauge gauge) {
+    return new GaugeAssert(gauge);
+  }
+
+  /**
+   * Creates an assertion to evaluate the given timer.
+   *
+   * @param timer the timer to evaluate
+   * @return the created assertion object
+   */
+  public static TimerAssert assertThat(Timer timer) {
+    return new TimerAssert(timer);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/TimerAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/TimerAssert.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.Timer;
+import org.assertj.core.api.Condition;
+
+/**
+ * Assertions for {@link Timer}s.
+ */
+public class TimerAssert extends AbstractMeterAssert<TimerAssert, Timer> {
+  /**
+   * Creates an assertion to evaluate the given timer.
+   *
+   * @param timer the timer to evaluate
+   */
+  TimerAssert(Timer timer) {
+    super(timer, TimerAssert.class);
+  }
+
+  /**
+   * Verifies that the timer's count satisfies the given condition.
+   *
+   * @param condition the criteria against which to evaluate the timer's count
+   * @return this assertion object
+   * @throws AssertionError if the timer is {@code null}
+   * @throws AssertionError if the condition rejects the timer's count
+   */
+  public TimerAssert hasCount(Condition<? super Long> condition) {
+    isNotNull();
+    long count = actual.count();
+    if (!condition.matches(count)) {
+      failWithMessage("Expected timer to have count <%s> but count was <%s>", condition, count);
+    }
+    return myself;
+  }
+
+  /**
+   * Verifies that the timer's total time satisfies the given condition.
+   *
+   * @param timeUnit the time unit to which to convert the total time before evaluating
+   * @param condition the criteria against which to evaluate the timer's total time
+   * @return this assertion object
+   * @throws AssertionError if the timer is {@code null}
+   * @throws AssertionError if the condition rejects the timer's total time
+   */
+  public TimerAssert hasTotalTime(TimeUnit timeUnit, Condition<? super Double> condition) {
+    isNotNull();
+    double totalTime = actual.totalTime(timeUnit);
+    if (!condition.matches(totalTime)) {
+      failWithMessage("Expected timer to have total time (%s) <%s> but total time was <%s>",
+          timeUnit, condition, totalTime);
+    }
+    return myself;
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/micrometer/CounterAssertTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/micrometer/CounterAssertTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import static org.apache.geode.test.micrometer.MicrometerAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Counter;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+public class CounterAssertTest {
+  @SuppressWarnings("unchecked")
+  private final Condition<Double> countCondition = mock(Condition.class, "count condition");
+  private final Counter counter = mock(Counter.class);
+
+  @Test
+  public void hasCount_doesNotThrow_ifConditionAcceptsCount() {
+    double acceptableCount = 92.0;
+
+    when(counter.count()).thenReturn(acceptableCount);
+    when(countCondition.matches(acceptableCount)).thenReturn(true);
+
+    assertThatCode(() -> assertThat(counter).hasCount(countCondition))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasCount_failsDescriptively_ifConditionRejectsCount() {
+    double unacceptableCount = 92.0;
+
+    when(counter.count()).thenReturn(unacceptableCount);
+    when(countCondition.matches(unacceptableCount)).thenReturn(false);
+
+    assertThatThrownBy(() -> assertThat(counter).hasCount(countCondition))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(countCondition.toString())
+        .hasMessageContaining(String.valueOf(unacceptableCount));
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/micrometer/GaugeAssertTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/micrometer/GaugeAssertTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import static org.apache.geode.test.micrometer.MicrometerAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Gauge;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+public class GaugeAssertTest {
+  @SuppressWarnings("unchecked")
+  private final Condition<Double> valueCondition = mock(Condition.class, "value condition");
+  private final Gauge gauge = mock(Gauge.class);
+
+  @Test
+  public void hasValue_doesNotThrow_ifConditionAcceptsValue() {
+    double acceptableCount = 92.0;
+
+    when(gauge.value()).thenReturn(acceptableCount);
+    when(valueCondition.matches(acceptableCount)).thenReturn(true);
+
+    assertThatCode(() -> assertThat(gauge).hasValue(valueCondition))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasValue_failsDescriptively_ifConditionRejectsValue() {
+    double unacceptableCount = 92.0;
+
+    when(gauge.value()).thenReturn(unacceptableCount);
+    when(valueCondition.matches(unacceptableCount)).thenReturn(false);
+
+    assertThatThrownBy(() -> assertThat(gauge).hasValue(valueCondition))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(valueCondition.toString())
+        .hasMessageContaining(String.valueOf(unacceptableCount));
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/micrometer/MeterAssertTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/micrometer/MeterAssertTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import static java.util.Arrays.asList;
+import static org.apache.geode.test.micrometer.MicrometerAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import org.junit.Test;
+
+public class MeterAssertTest {
+  private final Meter meter = mock(Meter.class, RETURNS_DEEP_STUBS);
+
+  @Test
+  public void hasName_doesNotThrow_ifMeterHasGivenName() {
+    String expectedName = "expected-name";
+
+    when(meter.getId().getName()).thenReturn(expectedName);
+
+    assertThatCode(() -> assertThat(meter).hasName(expectedName))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasName_failsDescriptively_ifMeterDoesNotHaveGivenName() {
+    String expectedName = "expected-name";
+    String actualName = "actual-name";
+
+    when(meter.getId().getName()).thenReturn(actualName);
+
+    assertThatThrownBy(() -> assertThat(meter).hasName(expectedName))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(expectedName)
+        .hasMessageContaining(actualName);
+  }
+
+  @Test
+  public void hasTagWithKey_doesNotThrow_ifMeterHasTagWithGivenKey() {
+    String expectedKey = "expected-key";
+
+    when(meter.getId().getTag(expectedKey)).thenReturn("some-non-null-value");
+
+    assertThatCode(() -> assertThat(meter).hasTag(expectedKey))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasTagWithKey_failsDescriptively_ifMeterHasNoTagWithGivenKey() {
+    String expectedKey = "expected-key";
+
+    when(meter.getId().getTag(expectedKey)).thenReturn(null);
+
+    Tag actualTag1 = mock(Tag.class, "actual-tag-1");
+    Tag actualTag2 = mock(Tag.class, "actual-tag-2");
+    when(meter.getId().getTags()).thenReturn(asList(actualTag1, actualTag2));
+
+    assertThatThrownBy(() -> assertThat(meter).hasTag(expectedKey))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(expectedKey)
+        .hasMessageContaining(actualTag1.toString())
+        .hasMessageContaining(actualTag2.toString());
+  }
+
+  @Test
+  public void hasTagWithKeyAndValue_doesNotThrow_ifMeterHasTagWithGivenKeyAndValue() {
+    String expectedKey = "expected-key";
+    String expectedValue = "expected-value";
+
+    when(meter.getId().getTag(expectedKey)).thenReturn(expectedValue);
+
+    assertThatCode(() -> assertThat(meter).hasTag(expectedKey, expectedValue))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasTagWithKeyAndValue_failsDescriptively_ifMeterHasNoTagWithGivenKey() {
+    String expectedKey = "expected-key";
+
+    when(meter.getId().getTag(expectedKey)).thenReturn(null);
+
+    Tag actualTag1 = mock(Tag.class, "actual-tag-1");
+    Tag actualTag2 = mock(Tag.class, "actual-tag-2");
+    when(meter.getId().getTags()).thenReturn(asList(actualTag1, actualTag2));
+
+    assertThatThrownBy(() -> assertThat(meter).hasTag(expectedKey, "expected-value"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(expectedKey)
+        .hasMessageContaining(actualTag1.toString())
+        .hasMessageContaining(actualTag2.toString());
+  }
+
+  @Test
+  public void hasTagWithKeyAndValue_failsDescriptively_ifMeterHasWrongValueForTagWithGivenKey() {
+    String expectedKey = "expected-key";
+    String expectedValue = "expected-value";
+    String wrongValue = "actual-value";
+
+    when(meter.getId().getTag(expectedKey)).thenReturn(wrongValue);
+
+    assertThatThrownBy(() -> assertThat(meter).hasTag(expectedKey, expectedValue))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(expectedKey)
+        .hasMessageContaining(expectedValue)
+        .hasMessageContaining(wrongValue);
+  }
+
+  @Test
+  public void hasBaseUnit_doesNotThrow_ifMeterHasGivenBaseUnit() {
+    String expectedBaseUnit = "expected-base_unit";
+
+    when(meter.getId().getBaseUnit()).thenReturn(expectedBaseUnit);
+
+    assertThatCode(() -> assertThat(meter).hasBaseUnit(expectedBaseUnit))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasBaseUnit_failsDescriptively_ifMeterDoesNotHaveGivenBaseUnit() {
+    String expectedBaseUnit = "expected-base-unit";
+    String wrongBaseUnit = "actual-base-unit";
+
+    when(meter.getId().getBaseUnit()).thenReturn(wrongBaseUnit);
+
+    assertThatThrownBy(() -> assertThat(meter).hasBaseUnit(expectedBaseUnit))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(expectedBaseUnit)
+        .hasMessageContaining(wrongBaseUnit);
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/micrometer/TimerAssertTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/micrometer/TimerAssertTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.micrometer;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.geode.test.micrometer.MicrometerAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.Timer;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+public class TimerAssertTest {
+  @SuppressWarnings("unchecked")
+  private final Condition<Long> countCondition = mock(Condition.class, "count condition");
+  @SuppressWarnings("unchecked")
+  private final Condition<Double> totalTimeCondition = mock(Condition.class, "time condition");
+  private final Timer timer = mock(Timer.class);
+
+  @Test
+  public void hasCount_doesNotThrow_ifConditionAcceptsCount() {
+    long acceptableCount = 92L;
+
+    when(timer.count()).thenReturn(acceptableCount);
+    when(countCondition.matches(acceptableCount)).thenReturn(true);
+
+    assertThatCode(() -> assertThat(timer).hasCount(countCondition))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasCount_failsDescriptively_ifConditionRejectsCount() {
+    long unacceptableCount = 92L;
+
+    when(timer.count()).thenReturn(unacceptableCount);
+    when(countCondition.matches(unacceptableCount)).thenReturn(false);
+
+    assertThatThrownBy(() -> assertThat(timer).hasCount(countCondition))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(countCondition.toString())
+        .hasMessageContaining(String.valueOf(unacceptableCount));
+  }
+
+  @Test
+  public void hasTotalTime_doesNotThrow_ifConditionAcceptsTotalTime() {
+    double acceptableCount = 92.0;
+    TimeUnit timeUnit = SECONDS;
+
+    when(timer.totalTime(timeUnit)).thenReturn(acceptableCount);
+    when(totalTimeCondition.matches(acceptableCount)).thenReturn(true);
+
+    assertThatCode(() -> assertThat(timer).hasTotalTime(timeUnit, totalTimeCondition))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void hasTotalTime_failsDescriptively_ifConditionRejectsTotalTime() {
+    double unacceptableCount = 92.0;
+    TimeUnit timeUnit = SECONDS;
+
+    when(timer.totalTime(timeUnit)).thenReturn(unacceptableCount);
+    when(totalTimeCondition.matches(unacceptableCount)).thenReturn(false);
+
+    assertThatThrownBy(() -> assertThat(timer).hasTotalTime(timeUnit, totalTimeCondition))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContaining(totalTimeCondition.toString())
+        .hasMessageContaining(String.valueOf(timeUnit))
+        .hasMessageContaining(String.valueOf(unacceptableCount));
+  }
+}

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -129,6 +129,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
- `MeterAssert` for assertions common to all meters (assertions about name, tags, and base unit)
- `CounterAssert` for assertions a counter's count
- `GaugeAssert` for assertions a gauge's value
- `TimerAssert` for assertions about a timer's count and total time

The assertions for counters, gauges, and timers each take a `Condition<T>`
that evaluates the relevant value.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

@aaronlindsey please review