### PR TITLE
GEODE-6959: Prevent NPE in GMSMembershipManager for null AlertAppender

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSMembershipManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSMembershipManager.java
@@ -2584,7 +2584,7 @@ public class GMSMembershipManager implements MembershipManager {
       services.setShutdownCause(shutdownCause);
       services.getCancelCriterion().cancel(reason);
 
-      AlertAppender.getInstance().stopSession();
+      AlertAppender.stopSessionIfRunning();
 
       if (!inhibitForceDisconnectLogging) {
         logger.fatal(

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/AlertAppender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/log4j/AlertAppender.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.alerting.AlertLevel;
@@ -337,7 +338,20 @@ public class AlertAppender extends AbstractAppender
     return listeners;
   }
 
-  public static AlertAppender getInstance() {
+  @VisibleForTesting
+  static AlertAppender getInstance() {
     return instanceRef.get();
+  }
+
+  @VisibleForTesting
+  static void setInstance(AlertAppender alertAppender) {
+    instanceRef.set(alertAppender);
+  }
+
+  public static void stopSessionIfRunning() {
+    AlertAppender instance = instanceRef.get();
+    if (instance != null) {
+      instance.stopSession();
+    }
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/AlertAppenderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/logging/log4j/AlertAppenderTest.java
@@ -15,9 +15,13 @@
 package org.apache.geode.internal.logging.log4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import org.apache.logging.log4j.Level;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +54,11 @@ public class AlertAppenderTest {
 
     alertAppender = new AlertAppender(testName.getMethodName(), null, null);
     asAlertingProvider = alertAppender;
+  }
+
+  @After
+  public void tearDown() {
+    AlertAppender.setInstance(null);
   }
 
   @Test
@@ -163,5 +172,22 @@ public class AlertAppenderTest {
 
     assertThat(alertAppender.getAlertListeners()).containsExactly(listener1, listener2,
         listener3);
+  }
+
+  @Test
+  public void stopSessionIfRunningDoesNotThrowIfReferenceIsNull() {
+    AlertAppender.setInstance(null);
+
+    assertThatCode(AlertAppender::stopSessionIfRunning).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void stopSessionIfRunningStopCurrentInstance() {
+    alertAppender = spy(alertAppender);
+    AlertAppender.setInstance(alertAppender);
+
+    AlertAppender.stopSessionIfRunning();
+
+    verify(alertAppender).stopSession();
   }
 }


### PR DESCRIPTION
If a custom log4j2.xml is used without specifying the Geode AlertAppender,
GMSMembershipManager may throw a NullPointerException when invoking
AlertAppender.getInstance().stopSession() during a forceDisconnect. This 
change prevents the NullPointerException allowing forceDisconnect to finish.

Users using Spring Boot with Logback are more likely to hit this bug.

Co-authored-by: Mark Hanson <mhanson@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>
