### PR TITLE
GEODE-7072 CI Failure: WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
@@ -320,7 +320,8 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     final int locPort = locatorPort;
     final int secondLocPort = AvailablePortHelper.getRandomAvailableTCPPort();
 
-    DistributedTestUtils.deleteLocatorStateFile(locPort, secondLocPort);
+    Invoke
+        .invokeInEveryVM(() -> DistributedTestUtils.deleteLocatorStateFile(locPort, secondLocPort));
 
 
     final String xmlFileLoc = (new File(".")).getAbsolutePath();
@@ -473,8 +474,8 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     forceDisconnect(vm1);
     newdm = waitForReconnect(vm1);
     assertNotSame("expected a reconnect to occur in member", evenNewerdm, newdm);
-    DistributedTestUtils.deleteLocatorStateFile(locPort);
-    DistributedTestUtils.deleteLocatorStateFile(secondLocPort);
+    Invoke
+        .invokeInEveryVM(() -> DistributedTestUtils.deleteLocatorStateFile(locPort, secondLocPort));
   }
 
   private DistributedMember getDMID(VM vm) {
@@ -553,7 +554,8 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
     final int locPort = locatorPort;
     final int secondLocPort = AvailablePortHelper.getRandomAvailableTCPPort();
 
-    DistributedTestUtils.deleteLocatorStateFile(locPort, secondLocPort);
+    Invoke
+        .invokeInEveryVM(() -> DistributedTestUtils.deleteLocatorStateFile(locPort, secondLocPort));
 
     final String xmlFileLoc = (new File(".")).getAbsolutePath();
 
@@ -638,8 +640,8 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
           gfshThread = null;
         }
       });
-      DistributedTestUtils.deleteLocatorStateFile(locPort);
-      DistributedTestUtils.deleteLocatorStateFile(secondLocPort);
+      Invoke.invokeInEveryVM(
+          () -> DistributedTestUtils.deleteLocatorStateFile(locPort, secondLocPort));
     }
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -102,6 +102,7 @@ import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DUnitBlackboard;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.RMIException;
 import org.apache.geode.test.dunit.SerializableRunnable;
@@ -162,7 +163,7 @@ public class LocatorDUnitTest implements Serializable {
     port2 = ports[1];
     port3 = ports[2];
     port4 = ports[3];
-    deleteLocatorStateFile(port1, port2, port3, port4);
+    Invoke.invokeInEveryVM(() -> deleteLocatorStateFile(port1, port2, port3, port4));
   }
 
   @After
@@ -178,11 +179,13 @@ public class LocatorDUnitTest implements Serializable {
     }
 
     // delete locator state files so they don't accidentally get used by other tests
-    for (int port : new int[] {port1, port2, port3, port4}) {
-      if (port > 0) {
-        deleteLocatorStateFile(port);
+    Invoke.invokeInEveryVM(() -> {
+      for (int port : new int[] {port1, port2, port3, port4}) {
+        if (port > 0) {
+          deleteLocatorStateFile(port);
+        }
       }
-    }
+    });
   }
 
   private static DUnitBlackboard getBlackboard() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/snapshot/GFSnapshotDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/snapshot/GFSnapshotDUnitTest.java
@@ -156,7 +156,7 @@ public class GFSnapshotDUnitTest extends JUnit4DistributedTestCase {
 
   private void configureAndStartLocator(final int locatorPort, final String serverHostName,
       final Properties properties) throws IOException {
-    DistributedTestUtils.deleteLocatorStateFile();
+    DistributedTestUtils.deleteLocatorStateFile(locatorPort);
 
     final String memberName = getUniqueName() + "-locator";
     final File workingDirectory = temporaryFolder.newFolder(memberName);

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTestBase.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTestBase.java
@@ -249,7 +249,7 @@ public abstract class RollingUpgrade2DUnitTestBase extends JUnit4DistributedTest
 
     String serverHostName = NetworkUtils.getServerHostName();
     int port = AvailablePortHelper.getRandomAvailableTCPPort();
-    DistributedTestUtils.deleteLocatorStateFile(port);
+    oldServerAndLocator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(port));
     try {
       Properties props = getSystemProperties();
       props.remove(DistributionConfig.LOCATORS_NAME);

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeClients.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeClients.java
@@ -47,7 +47,7 @@ public class RollingUpgradeClients extends RollingUpgrade2DUnitTestBase {
     int[] locatorPorts = new int[] {ports[0]};
     int[] csPorts = new int[] {ports[1], ports[2]};
 
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     String hostName = NetworkUtils.getServerHostName();
     String[] hostNames = new String[] {hostName};

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeConcurrentPutsReplicated.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeConcurrentPutsReplicated.java
@@ -27,6 +27,7 @@ import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.VM;
@@ -54,7 +55,7 @@ public class RollingUpgradeConcurrentPutsReplicated extends RollingUpgrade2DUnit
     String hostName = NetworkUtils.getServerHostName();
     String locatorString = getLocatorString(locatorPorts);
 
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    Invoke.invokeInEveryVM(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     try {
       locator.invoke(invokeStartLocator(hostName, locatorPorts[0], getTestMethodName(),

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeHARegionNameOnDifferentServerVersions.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeHARegionNameOnDifferentServerVersions.java
@@ -43,7 +43,7 @@ public class RollingUpgradeHARegionNameOnDifferentServerVersions
     int[] locatorPorts = new int[] {ports[0]};
     int[] csPorts = new int[] {ports[1], ports[2]};
 
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     String hostName = NetworkUtils.getServerHostName();
     String[] hostNames = new String[] {hostName};

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeOplogMagicSeqBackwardCompactibility.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeOplogMagicSeqBackwardCompactibility.java
@@ -60,7 +60,7 @@ public class RollingUpgradeOplogMagicSeqBackwardCompactibility
     String hostName = NetworkUtils.getServerHostName();
     String locatorsString = getLocatorString(locatorPorts);
 
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     try {
       locator.invoke(invokeStartLocator(hostName, locatorPorts[0], getTestMethodName(),

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorWithTwoServers.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorWithTwoServers.java
@@ -46,7 +46,7 @@ public class RollingUpgradeRollLocatorWithTwoServers extends RollingUpgrade2DUni
     RegionShortcut shortcut = RegionShortcut.REPLICATE;
 
     int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator1.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     String hostName = NetworkUtils.getServerHostName();
     String locatorString = getLocatorString(locatorPorts);

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorsWithOldServer.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorsWithOldServer.java
@@ -40,7 +40,8 @@ public class RollingUpgradeRollLocatorsWithOldServer extends RollingUpgrade2DUni
     VM server4 = host.getVM(oldVersion, 3);
 
     int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(3);
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator1.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
+    locator2.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     String hostName = NetworkUtils.getServerHostName();
     String locatorString = getLocatorString(locatorPorts);

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollSingleLocatorWithMultipleServersReplicatedRegion.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollSingleLocatorWithMultipleServersReplicatedRegion.java
@@ -43,7 +43,7 @@ public class RollingUpgradeRollSingleLocatorWithMultipleServersReplicatedRegion
     RegionShortcut shortcut = RegionShortcut.REPLICATE;
 
     int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(1);
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts[0]);
+    locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts[0]));
 
     // configure all class loaders for each vm
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeVerifyXmlEntity.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeVerifyXmlEntity.java
@@ -45,7 +45,7 @@ public class RollingUpgradeVerifyXmlEntity extends RollingUpgrade2DUnitTestBase 
     int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(1);
     String hostName = NetworkUtils.getServerHostName();
     String locatorsString = getLocatorString(locatorPorts);
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    oldLocator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     try {
       // Start locator

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServersAreRolled.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServersAreRolled.java
@@ -45,7 +45,8 @@ public class RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServe
     String regionType = "partitionedRedundant";
 
     int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator1.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
+    locator2.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     String hostName = NetworkUtils.getServerHostName(host);
     String locatorString = getLocatorString(locatorPorts);

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOver.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOver.java
@@ -48,7 +48,7 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
     int[] locatorPorts = new int[] {ports[0]};
     int[] csPorts = new int[] {ports[1], ports[2]};
 
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     String hostName = NetworkUtils.getServerHostName(host);
     String[] hostNames = new String[] {hostName};

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
@@ -60,7 +60,7 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
     int[] locatorPorts = new int[] {ports[0]};
     int[] csPorts = new int[] {ports[1], ports[2]};
 
-    DistributedTestUtils.deleteLocatorStateFile(locatorPorts);
+    locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));
 
     String hostName = NetworkUtils.getServerHostName(host);
     String[] hostNames = new String[] {hostName};

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
@@ -43,7 +43,7 @@ public class RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentV
     RegionShortcut shortcut = RegionShortcut.PARTITION_REDUNDANT;
 
     int locatorPort = AvailablePortHelper.getRandomAvailableTCPPort();
-    DistributedTestUtils.deleteLocatorStateFile(locatorPort);
+    locator1.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPort));
 
     String hostName = NetworkUtils.getServerHostName(host);
     String locatorString = getLocatorString(locatorPort);

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeCreateGatewaySenderMixedSiteOneCurrentSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeCreateGatewaySenderMixedSiteOneCurrentSiteTwo.java
@@ -49,13 +49,13 @@ public class WANRollingUpgradeCreateGatewaySenderMixedSiteOneCurrentSiteTwo
     // Get mixed site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
     final int site1LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort));
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get current site locator properties
     final int site2LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort));
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo.java
@@ -49,19 +49,20 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo
     // Get mixed site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
     final int site1LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get current site locator properties
     final int site2LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;
 
     // Start mixed site locator
-    site1Locator.invoke(() -> startLocator(site1LocatorPort, site1DistributedSystemId,
-        site1Locators, site2Locators));
+    site1Locator.invoke(() -> {
+      DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+      startLocator(site1LocatorPort, site1DistributedSystemId,
+          site1Locators, site2Locators);
+    });
 
     // Locators before 1.4 handled configuration asynchronously.
     // We must wait for configuration configuration to be ready, or confirm that it is disabled.
@@ -72,8 +73,11 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo
                     || InternalLocator.getLocator().isSharedConfigurationRunning())));
 
     // Start current site locator
-    site2Locator.invoke(() -> startLocator(site2LocatorPort, site2DistributedSystemId,
-        site2Locators, site1Locators));
+    site2Locator.invoke(() -> {
+      DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+      startLocator(site2LocatorPort, site2DistributedSystemId,
+          site2Locators, site1Locators);
+    });
 
     // Start and configure mixed site servers
     String regionName = getName() + "_region";

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo.java
@@ -49,13 +49,13 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo
     String hostName = NetworkUtils.getServerHostName(host);
     final int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
     final int site1LocatorPort = availablePorts[0];
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort));
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get old site locator properties
     final int site2LocatorPort = availablePorts[1];
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort));
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingOldSiteOneCurrentSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingOldSiteOneCurrentSiteTwo.java
@@ -50,13 +50,13 @@ public class WANRollingUpgradeEventProcessingOldSiteOneCurrentSiteTwo
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
     final int site1LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort));
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get current site locator properties
     final int site2LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort));
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeNewSenderProcessOldEvent.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeNewSenderProcessOldEvent.java
@@ -73,12 +73,12 @@ public class WANRollingUpgradeNewSenderProcessOldEvent
     String hostName = NetworkUtils.getServerHostName(host);
     final int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
     site1LocatorPort = availablePorts[0];
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort));
     site1Locators = hostName + "[" + site1LocatorPort + "]";
 
     // Get old site locator properties
     site2LocatorPort = availablePorts[1];
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort));
     site2Locators = hostName + "[" + site2LocatorPort + "]";
 
     // Start mixed site locator

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailover.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailover.java
@@ -47,13 +47,13 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMembe
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
     final int site1LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort));
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get current site locator properties
     final int site2LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort));
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailoverWithOldClient.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailoverWithOldClient.java
@@ -50,13 +50,13 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMembe
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
     final int site1LocatorPort = locatorPorts[0];
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort));
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get current site locator properties
     final int site2LocatorPort = locatorPorts[1];
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort));
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterOldSiteMemberFailover.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterOldSiteMemberFailover.java
@@ -47,13 +47,13 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterOldSiteMemberFai
     // Get old site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
     final int site1LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort);
+    site1Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site1LocatorPort));
     final String site1Locators = hostName + "[" + site1LocatorPort + "]";
     final int site1DistributedSystemId = 0;
 
     // Get current site locator properties
     final int site2LocatorPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort);
+    site2Locator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(site2LocatorPort));
     final String site2Locators = hostName + "[" + site2LocatorPort + "]";
     final int site2DistributedSystemId = 1;
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewayReceiverDoesNotSendRemoveCacheServerProfileToMembersOlderThan1dot5.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewayReceiverDoesNotSendRemoveCacheServerProfileToMembersOlderThan1dot5.java
@@ -40,7 +40,7 @@ public class WANRollingUpgradeVerifyGatewayReceiverDoesNotSendRemoveCacheServerP
 
     // Start locator
     final int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(port);
+    oldLocator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(port));
     final String locators = NetworkUtils.getServerHostName(host) + "[" + port + "]";
     oldLocator.invoke(() -> startLocator(port, 0, locators, ""));
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewaySenderProfile.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewaySenderProfile.java
@@ -40,7 +40,7 @@ public class WANRollingUpgradeVerifyGatewaySenderProfile extends WANRollingUpgra
 
     // Start locator
     final int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
-    DistributedTestUtils.deleteLocatorStateFile(port);
+    oldLocator.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(port));
     final String locators = NetworkUtils.getServerHostName(host) + "[" + port + "]";
     oldLocator.invoke(() -> startLocator(port, 0, locators, ""));
 


### PR DESCRIPTION
A number of tests were attempting to delete old locator state files
containing membership views in order to ensure that artifacts from
previously run tests were not around to infect the current test.

Unfortunately the calls to DistributedTestUtils.deleteLocatorStateFile()
were being made from the wrong working directory.  Instead of looking
for the file(s) in the directory that the test's locator would use they
were looking in the unit test VMs working directory.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
