### PR TITLE
GEODE-7081: Prevent NPE in getLocalSize()

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -6606,6 +6606,10 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   public int getLocalSize() {
+    if (dataStore == null) {
+      return 0;
+    }
+
     return dataStore.getLocalBucket2RegionMap().values().stream()
         .mapToInt(BucketRegion::getLocalSize)
         .sum();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache;
 import static org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl.getSenderIdFromAsyncEventQueueId;
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
@@ -43,6 +44,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.apache.geode.Statistics;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheLoader;
 import org.apache.geode.cache.CacheWriter;
@@ -60,7 +62,8 @@ import org.apache.geode.test.fake.Fakes;
 public class PartitionedRegionTest {
   private InternalCache internalCache;
   private PartitionedRegion partitionedRegion;
-  private Properties gemfireProperties = new Properties();
+  @SuppressWarnings("deprecation")
+  private AttributesFactory attributesFactory;
 
   @Before
   public void setup() {
@@ -69,15 +72,16 @@ public class PartitionedRegionTest {
     InternalResourceManager resourceManager =
         mock(InternalResourceManager.class, RETURNS_DEEP_STUBS);
     when(internalCache.getInternalResourceManager()).thenReturn(resourceManager);
-    @SuppressWarnings("deprecation")
-    AttributesFactory attributesFactory = new AttributesFactory();
+    attributesFactory = new AttributesFactory();
     attributesFactory.setPartitionAttributes(
         new PartitionAttributesFactory().setTotalNumBuckets(1).setRedundantCopies(1).create());
     partitionedRegion = new PartitionedRegion("prTestRegion", attributesFactory.create(), null,
         internalCache, mock(InternalRegionArguments.class), disabledClock());
     DistributedSystem mockDistributedSystem = mock(DistributedSystem.class);
     when(internalCache.getDistributedSystem()).thenReturn(mockDistributedSystem);
-    when(mockDistributedSystem.getProperties()).thenReturn(gemfireProperties);
+    when(mockDistributedSystem.getProperties()).thenReturn(new Properties());
+    when(mockDistributedSystem.createAtomicStatistics(any(), any()))
+        .thenReturn(mock(Statistics.class));
   }
 
   @SuppressWarnings("unused")
@@ -302,5 +306,13 @@ public class PartitionedRegionTest {
     assertThat(partitionedRegion.filterOutNonParallelAsyncEventQueues(
         Stream.of("parallel", "serial", "anotherParallel").collect(Collectors.toSet())))
             .isNotEmpty().containsExactly("parallel", "anotherParallel");
+  }
+
+  @Test
+  public void getLocalSizeDoesNotThrowIfRegionUninitialized() {
+    partitionedRegion = new PartitionedRegion("region", attributesFactory.create(), null,
+        internalCache, mock(InternalRegionArguments.class), disabledClock());
+
+    assertThatCode(partitionedRegion::getLocalSize).doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
Prevent PartitionedRegion's getLocalSize() from throwing a
NullPointerException if called before its internal data store is
initialized. The stats sampler uses this method to get the region's
entry count, and stats sampling may start before the internal data store
is initialized.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
