### PR TITLE
GEODE-3780 suspected member is never watched again after passing final check

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -707,7 +707,7 @@ public class GMSJoinLeaveJUnitTest {
         D = mockMembers[2],
         E = mockMembers[3];
     prepareAndInstallView(C, createMemberList(A, B, C, D, E));
-    when(healthMonitor.getMembersFailingAvailabilityCheck()).thenReturn(Collections.singleton(A));
+    when(healthMonitor.getSuspectedMembers()).thenReturn(Collections.singleton(A));
     LeaveRequestMessage msg = new LeaveRequestMessage(B, C, "leaving for test");
     msg.setSender(C);
     gmsJoinLeave.processMessage(msg);
@@ -730,7 +730,7 @@ public class GMSJoinLeaveJUnitTest {
         D = mockMembers[2],
         E = mockMembers[3];
     prepareAndInstallView(C, createMemberList(A, B, C, D));
-    when(healthMonitor.getMembersFailingAvailabilityCheck()).thenReturn(Collections.singleton(A));
+    when(healthMonitor.getSuspectedMembers()).thenReturn(Collections.singleton(A));
     E.setVmViewId(1);
     gmsJoinLeave.processMessage(new JoinRequestMessage(B, E, null, 1, 1));
     LeaveRequestMessage msg = new LeaveRequestMessage(B, C, "leaving for test");

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -733,11 +733,6 @@ public class GMSJoinLeaveJUnitTest {
 
     prepareAndInstallView(C, createMemberList(A, B, C, D));
 
-    gmsJoinLeave.recordViewRequest(new LeaveRequestMessage(B, A, "removing for test"));
-
-    E.setVmViewId(2);
-    gmsJoinLeave.processMessage(new JoinRequestMessage(B, E, null, 1, 1));
-
     // have the Messenger acknowledge all membership view messages so no-one is kicked out for
     // failure to respond
     when(messenger.send(isA(InstallViewMessage.class), isA(GMSMembershipView.class)))
@@ -753,8 +748,14 @@ public class GMSJoinLeaveJUnitTest {
           return null;
         });
 
+    E.setVmViewId(2);
+
+    gmsJoinLeave.recordViewRequest(new LeaveRequestMessage(B, C, "removing for test"));
+
+    gmsJoinLeave.processMessage(new JoinRequestMessage(B, E, null, 1, 1));
+
     RemoveMemberMessage msg = new RemoveMemberMessage(B, A, "crashed for test");
-    msg.setSender(C);
+    msg.setSender(D);
     gmsJoinLeave.processMessage(msg);
 
     await().until(() -> gmsJoinLeave.isCoordinator() && gmsJoinLeave.getViewRequests().isEmpty());

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -1414,7 +1414,7 @@ public class GMSHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public Collection<GMSMember> getMembersFailingAvailabilityCheck() {
+  public Collection<GMSMember> getSuspectedMembers() {
     return Collections.unmodifiableCollection(this.suspectedMemberIds.keySet());
   }
 
@@ -1436,8 +1436,9 @@ public class GMSHealthMonitor implements HealthMonitor {
       recipients = currentView.getMembers();
     }
 
-    logger.trace("Sending suspect messages to {}", recipients);
+    logger.debug("Sending suspect messages to {}", recipients);
     SuspectMembersMessage smm = new SuspectMembersMessage(recipients, requests);
+    smm.setSender(localAddress);
     Set<GMSMember> failedRecipients;
     try {
       failedRecipients = services.getMessenger().send(smm);
@@ -1447,8 +1448,10 @@ public class GMSHealthMonitor implements HealthMonitor {
     }
 
     if (failedRecipients != null && failedRecipients.size() > 0) {
-      logger.trace("Unable to send suspect message to {}", failedRecipients);
+      logger.debug("Unable to send suspect message to {}", failedRecipients);
     }
+    logger.debug("Processing suspect message locally");
+    processMessage(smm);
   }
 
   private static class ConnectTimeoutTask extends TimerTask implements ConnectionWatcher {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -1413,11 +1413,6 @@ public class GMSHealthMonitor implements HealthMonitor {
     return this.socketPort;
   }
 
-  @Override
-  public Collection<GMSMember> getSuspectedMembers() {
-    return Collections.unmodifiableCollection(this.suspectedMemberIds.keySet());
-  }
-
   private void sendSuspectRequest(final List<SuspectRequest> requests) {
     logger.debug("Sending suspect request for members {}", requests);
     List<GMSMember> recipients;
@@ -1436,7 +1431,7 @@ public class GMSHealthMonitor implements HealthMonitor {
       recipients = currentView.getMembers();
     }
 
-    logger.debug("Sending suspect messages to {}", recipients);
+    logger.trace("Sending suspect messages to {}", recipients);
     SuspectMembersMessage smm = new SuspectMembersMessage(recipients, requests);
     smm.setSender(localAddress);
     Set<GMSMember> failedRecipients;
@@ -1448,9 +1443,9 @@ public class GMSHealthMonitor implements HealthMonitor {
     }
 
     if (failedRecipients != null && failedRecipients.size() > 0) {
-      logger.debug("Unable to send suspect message to {}", failedRecipients);
+      logger.trace("Unable to send suspect message to {}", failedRecipients);
     }
-    logger.debug("Processing suspect message locally");
+    logger.trace("Processing suspect message locally");
     processMessage(smm);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.interfaces;
 
-import java.util.Collection;
 
 import org.apache.geode.distributed.internal.membership.gms.GMSMember;
 
@@ -51,10 +50,5 @@ public interface HealthMonitor extends Service {
    * Returns the failure detection port for this member, or -1 if there is no such port
    */
   int getFailureDetectionPort();
-
-  /**
-   * Returns the set of members under suspicion by the health monitor
-   */
-  Collection<GMSMember> getSuspectedMembers();
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -53,8 +53,8 @@ public interface HealthMonitor extends Service {
   int getFailureDetectionPort();
 
   /**
-   * Returns the set of members declared dead by the health monitor
+   * Returns the set of members under suspicion by the health monitor
    */
-  Collection<GMSMember> getMembersFailingAvailabilityCheck();
+  Collection<GMSMember> getSuspectedMembers();
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -621,7 +621,7 @@ public class GMSJoinLeave implements JoinLeave {
         check.removeAll(leftMembers);
       }
       Collection<GMSMember> suspectMembers =
-          services.getHealthMonitor().getMembersFailingAvailabilityCheck();
+          services.getHealthMonitor().getSuspectedMembers();
       check.removeAll(suspectMembers);
       logger.info("View with removed and left members removed is {}", check);
       if (check.getCoordinator().equals(localAddress)) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -45,6 +45,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.SystemConnectException;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
@@ -609,7 +610,8 @@ public class GMSJoinLeave implements JoinLeave {
     }
 
     if (!isCoordinator && !isStopping && !services.getCancelCriterion().isCancelInProgress()) {
-      logger.info("Checking to see if I should become coordinator");
+      logger.info("Checking to see if I should become coordinator.  My address is {}",
+          localAddress);
       GMSMembershipView check = new GMSMembershipView(v, v.getViewId() + 1);
       check.remove(mbr);
       synchronized (removedMembers) {
@@ -620,15 +622,17 @@ public class GMSJoinLeave implements JoinLeave {
         leftMembers.add(mbr);
         check.removeAll(leftMembers);
       }
-      Collection<GMSMember> suspectMembers =
-          services.getHealthMonitor().getSuspectedMembers();
-      check.removeAll(suspectMembers);
-      logger.info("View with removed and left members removed is {}", check);
-      if (check.getCoordinator().equals(localAddress)) {
-        for (GMSMember suspect : suspectMembers) {
-          recordViewRequest(
-              new RemoveMemberMessage(localAddress, suspect, "Failed availability check"));
-        }
+      // Collection<GMSMember> suspectMembers =
+      // services.getHealthMonitor().getSuspectedMembers();
+      // check.removeAll(suspectMembers);
+      GMSMember coordinator = check.getCoordinator();
+      logger.info("View with removed and left members removed is {} and coordinator would be {}",
+          check, coordinator);
+      if (coordinator.equals(localAddress)) {
+        // for (GMSMember suspect : suspectMembers) {
+        // recordViewRequest(
+        // new RemoveMemberMessage(localAddress, suspect, "Failed availability check"));
+        // }
         synchronized (viewInstallationLock) {
           becomeCoordinator(mbr);
         }
@@ -724,7 +728,8 @@ public class GMSJoinLeave implements JoinLeave {
     }
   }
 
-  private void recordViewRequest(AbstractGMSMessage request) {
+  @VisibleForTesting
+  void recordViewRequest(AbstractGMSMessage request) {
     try {
       synchronized (viewRequests) {
         logger.debug("Recording the request to be processed in the next membership view");

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -622,17 +622,10 @@ public class GMSJoinLeave implements JoinLeave {
         leftMembers.add(mbr);
         check.removeAll(leftMembers);
       }
-      // Collection<GMSMember> suspectMembers =
-      // services.getHealthMonitor().getSuspectedMembers();
-      // check.removeAll(suspectMembers);
       GMSMember coordinator = check.getCoordinator();
       logger.info("View with removed and left members removed is {} and coordinator would be {}",
           check, coordinator);
       if (coordinator.equals(localAddress)) {
-        // for (GMSMember suspect : suspectMembers) {
-        // recordViewRequest(
-        // new RemoveMemberMessage(localAddress, suspect, "Failed availability check"));
-        // }
         synchronized (viewInstallationLock) {
           becomeCoordinator(mbr);
         }


### PR DESCRIPTION
After passing a "final check" a member will be subject to suspect
processing again but we weren't processing the suspect message locally.
This caused JoinLeave to never be notified of the suspect so that
removal could be initiated.

I also noticed that a method in HealthMonitor was misnamed.  It claimed
to return the set of members that had failed availability checks but
instead it was returning a set of members currently under suspicion.  Looking
at the uses of this method I think it could cause members to be kicked out
that were only late in sending heartbeats.  They should go through full availability
checks before being kicked out.  The new code ensures that this happens
and that RemoveMemberMessages will be processed locally after performing those
checks.

@Bill 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
