### PR TITLE
GEODE-6805: Allow shorthand ~ to represent user home in jar deployment.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
@@ -203,6 +203,8 @@ public class GfshParser extends SimpleParser {
 
     // this tells the simpleParser not to interpret backslash as escaping character
     rawInput = rawInput.replace("\\", "\\\\");
+    // this allows the usage of home shorthand across platforms
+    rawInput = rawInput.replace("~", System.getProperty("user.home"));
     // User SimpleParser to parse the input
     ParseResult result = super.parse(rawInput);
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DeployCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/DeployCommandTest.java
@@ -57,4 +57,10 @@ public class DeployCommandTest {
   public void missingDirOrJar() {
     gfsh.executeAndAssertThat(command, "deploy").statusIsError().containsOutput("is required");
   }
+
+  @Test
+  public void convertShorthandToPathJar() {
+    gfsh.executeAndAssertThat(command, "deploy --jar=~/abc.jar").statusIsError()
+        .containsOutput(System.getProperty("user.home"));
+  }
 }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
