### PR TITLE
GEODE-7091: Add Micrometer binders to meter registry

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/MicrometerBinderTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/MicrometerBinderTest.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.metrics;
+
+import static org.apache.geode.internal.lang.SystemUtils.isWindows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.client.PoolManager;
+import org.apache.geode.cache.execute.Execution;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.rules.ServiceJarRule;
+import org.apache.geode.test.compiler.ClassBuilder;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+
+public class MicrometerBinderTest {
+
+  private Path serverFolder;
+  private ClientCache clientCache;
+  private Pool serverPool;
+  private Execution<String, Boolean, List<Boolean>> functionExecution;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Rule
+  public ServiceJarRule serviceJarRule = new ServiceJarRule();
+
+  @Before
+  public void startServer() throws IOException {
+    serverFolder = temporaryFolder.getRoot().toPath().toAbsolutePath();
+
+    int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(2);
+
+    int serverPort = ports[0];
+    int jmxRmiPort = ports[1];
+
+    Path serviceJarPath = serviceJarRule.createJarFor("metrics-publishing-service.jar",
+        MetricsPublishingService.class, SimpleMetricsPublishingService.class);
+
+    String startServerCommand = String.join(" ",
+        "start server",
+        "--name=server",
+        "--dir=" + serverFolder,
+        "--server-port=" + serverPort,
+        "--classpath=" + serviceJarPath,
+        "--J=-Dgemfire.enable-cluster-config=true",
+        "--J=-Dgemfire.jmx-manager=true",
+        "--J=-Dgemfire.jmx-manager-start=true",
+        "--J=-Dgemfire.jmx-manager-port=" + jmxRmiPort);
+
+    gfshRule.execute(startServerCommand);
+
+    Path functionJarPath = serverFolder.resolve("function.jar").toAbsolutePath();
+    new ClassBuilder().writeJarFromClass(CheckIfMeterExistsFunction.class,
+        functionJarPath.toFile());
+
+    String connectCommand = "connect --jmx-manager=localhost[" + jmxRmiPort + "]";
+    String deployCommand = "deploy --jar=" + functionJarPath.toAbsolutePath();
+
+    gfshRule.execute(connectCommand, deployCommand);
+
+    clientCache = new ClientCacheFactory().addPoolServer("localhost", serverPort).create();
+
+    serverPool = PoolManager.createFactory()
+        .addServer("localhost", serverPort)
+        .create("server-pool");
+
+    @SuppressWarnings("unchecked")
+    Execution<String, Boolean, List<Boolean>> functionExecution =
+        (Execution<String, Boolean, List<Boolean>>) FunctionService.onServer(serverPool);
+    this.functionExecution = functionExecution;
+  }
+
+  @After
+  public void stopServer() {
+    clientCache.close();
+    serverPool.destroy();
+
+    String stopServerCommand = "stop server --dir=" + serverFolder;
+    gfshRule.execute(stopServerCommand);
+  }
+
+  @Test
+  public void jvmThreadMetricsBinderExists() {
+    String meterNameToCheck = "jvm.threads.peak";
+
+    List<Boolean> results = functionExecution
+        .setArguments(meterNameToCheck)
+        .execute(CheckIfMeterExistsFunction.ID)
+        .getResult();
+
+    assertThat(results)
+        .as("Meter from %s binder should exist", JvmThreadMetrics.class.getSimpleName())
+        .containsOnly(true);
+  }
+
+  @Test
+  public void jvmGcMetricsBinderExists() {
+    String meterNameToCheck = "jvm.gc.max.data.size";
+
+    List<Boolean> results = functionExecution
+        .setArguments(meterNameToCheck)
+        .execute(CheckIfMeterExistsFunction.ID)
+        .getResult();
+
+    assertThat(results)
+        .as("Meter from %s binder should exist", JvmGcMetrics.class.getSimpleName())
+        .containsOnly(true);
+  }
+
+  @Test
+  public void processorMetricsBinderExists() {
+    String meterNameToCheck = "system.cpu.count";
+
+    List<Boolean> results = functionExecution
+        .setArguments(meterNameToCheck)
+        .execute(CheckIfMeterExistsFunction.ID)
+        .getResult();
+
+    assertThat(results)
+        .as("Meter from %s binder should exist", ProcessorMetrics.class.getSimpleName())
+        .containsOnly(true);
+  }
+
+  @Test
+  public void uptimeMetricsBinderExists() {
+    String meterNameToCheck = "process.uptime";
+
+    List<Boolean> results = functionExecution
+        .setArguments(meterNameToCheck)
+        .execute(CheckIfMeterExistsFunction.ID)
+        .getResult();
+
+    assertThat(results)
+        .as("Meter from %s binder should exist", UptimeMetrics.class.getSimpleName())
+        .containsOnly(true);
+  }
+
+  @Test
+  public void fileDescriptorMetricsBinderExists() {
+    assumeThat(isWindows()).isFalse();
+
+    String meterNameToCheck = "process.files.open";
+
+    List<Boolean> results = functionExecution
+        .setArguments(meterNameToCheck)
+        .execute(CheckIfMeterExistsFunction.ID)
+        .getResult();
+
+    assertThat(results)
+        .as("Meter from %s binder should exist", FileDescriptorMetrics.class.getSimpleName())
+        .containsOnly(true);
+  }
+
+  public static class CheckIfMeterExistsFunction implements Function<String> {
+    private static final String ID = "CheckIfMeterExistsFunction";
+
+    @Override
+    public void execute(FunctionContext<String> context) {
+      String meterName = context.getArguments();
+
+      Meter meter = SimpleMetricsPublishingService.getRegistry()
+          .find(meterName)
+          .meter();
+
+      boolean isMeterFound = meter != null;
+
+      context.<Boolean>getResultSender().lastResult(isMeterFound);
+    }
+
+    @Override
+    public String getId() {
+      return ID;
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactory.java
@@ -15,7 +15,12 @@
 package org.apache.geode.internal.metrics;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory {
@@ -30,6 +35,11 @@ public class CacheMeterRegistryFactory implements CompositeMeterRegistryFactory 
     registryConfig.commonTags("host.name", hostName == null ? "" : hostName);
 
     new JvmMemoryMetrics().bindTo(registry);
+    new JvmThreadMetrics().bindTo(registry);
+    new JvmGcMetrics().bindTo(registry);
+    new ProcessorMetrics().bindTo(registry);
+    new UptimeMetrics().bindTo(registry);
+    new FileDescriptorMetrics().bindTo(registry);
 
     return registry;
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
@@ -14,7 +14,9 @@
  */
 package org.apache.geode.internal.metrics;
 
+import static org.apache.geode.internal.lang.SystemUtils.isWindows;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Collection;
 
@@ -109,5 +111,77 @@ public class CacheMeterRegistryFactoryTest {
         .gauges();
 
     assertThat(nonheapGauges).isNotEmpty();
+  }
+
+  @Test
+  public void addsMetersForJvmThreadMetricsBinder() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+
+    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
+    registry.add(new SimpleMeterRegistry());
+
+    Collection<Meter> meters = registry
+        .find("jvm.threads.peak")
+        .meters();
+
+    assertThat(meters).isNotEmpty();
+  }
+
+  @Test
+  public void addsMetersForJvmGcMetricsBinder() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+
+    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
+    registry.add(new SimpleMeterRegistry());
+
+    Collection<Meter> meters = registry
+        .find("jvm.gc.max.data.size")
+        .meters();
+
+    assertThat(meters).isNotEmpty();
+  }
+
+  @Test
+  public void addsMetersForProcessorMetricsBinder() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+
+    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
+    registry.add(new SimpleMeterRegistry());
+
+    Collection<Meter> meters = registry
+        .find("system.cpu.count")
+        .meters();
+
+    assertThat(meters).isNotEmpty();
+  }
+
+  @Test
+  public void addsMetersForUptimeMetricsBinder() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+
+    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
+    registry.add(new SimpleMeterRegistry());
+
+    Collection<Meter> meters = registry
+        .find("process.uptime")
+        .meters();
+
+    assertThat(meters).isNotEmpty();
+  }
+
+  @Test
+  public void addsMetersForFileDescriptorMetricsBinder() {
+    assumeThat(isWindows()).isFalse();
+
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+
+    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
+    registry.add(new SimpleMeterRegistry());
+
+    Collection<Meter> meters = registry
+        .find("process.files.open")
+        .meters();
+
+    assertThat(meters).isNotEmpty();
   }
 }


### PR DESCRIPTION
Add the following Micrometer binders:
- JvmGcMetrics
- ProcessorMetrics
- JvmThreadMetrics
- UptimeMetrics
- FileDescriptorMetrics

Ignore FileDescriptorMetrics binder tests on Windows

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
