### PR TITLE
GEODE-7085: Add dunit test of recovery with large versions

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentPartitionedRegionLargeVersionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentPartitionedRegionLargeVersionDUnitTest.java
@@ -1,0 +1,60 @@
+package org.apache.geode.internal.cache;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.internal.cache.versions.RegionVersionVector;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
+
+public class PersistentPartitionedRegionLargeVersionDUnitTest extends CacheTestCase {
+
+  /**
+   * Test that we can recover from disk files with versions larger than Integer.MAX_VALUE
+   */
+  @Test
+  public void canRecoverWithLargeGCVersionInFiles() {
+    VM vm0 = VM.getVM(0);
+    VM vm1 = VM.getVM(1);
+
+    vm0.invoke(() -> {
+      createRegion();
+      PartitionedRegion region = (PartitionedRegion) getCache().getRegion("region");
+      region.put(0, 0);
+
+      // Manually set the version in bucket 0 to be greater than Integer.MAX_VALUE
+      RegionVersionVector vectorVector = region.getBucketRegion(0).getVersionVector();
+      vectorVector.recordVersion(vectorVector.getOwnerId(), ((long) Integer.MAX_VALUE) + 10L);
+
+      // Do an update, which will pick up the large version
+      region.put(1, 0);
+
+      // Do a destroy, and a tombstone gc, which will set the gc version to the large version
+      region.destroy(1);
+      getCache().getTombstoneService().forceBatchExpirationForTests(1);
+    });
+
+    // Start a second member to copy the bucket
+    vm1.invoke(() -> {
+      createRegion();
+      getCache().getResourceManager().createRebalanceFactory().start().getResults();
+    });
+
+    // Shutdown both members
+    vm0.invoke(() -> getCache().close());
+    vm1.invoke(() -> getCache().close());
+
+    // Restart both members
+    vm1.invoke(() -> createRegion());
+    vm0.invoke(() -> createRegion());
+  }
+
+  private void createRegion() {
+    Cache cache = getCache();
+    cache.createRegionFactory(RegionShortcut.PARTITION_REDUNDANT_PERSISTENT)
+        .setPartitionAttributes(new PartitionAttributesFactory().setTotalNumBuckets(1).create())
+        .create("region");
+  }
+}


### PR DESCRIPTION
Adding a dunit test that we can recover from disk store files with a
large gc version.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
