### PR TITLE
GEODE-7091: Add tests for Micrometer binders

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/MicrometerBinderTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/MicrometerBinderTest.java
@@ -14,9 +14,7 @@
  */
 package org.apache.geode.metrics;
 
-import static org.apache.geode.internal.lang.SystemUtils.isWindows;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -25,7 +23,6 @@ import java.util.List;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
-import io.micrometer.core.instrument.binder.system.FileDescriptorMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import org.junit.After;
@@ -171,22 +168,6 @@ public class MicrometerBinderTest {
 
     assertThat(results)
         .as("Meter from %s binder should exist", UptimeMetrics.class.getSimpleName())
-        .containsOnly(true);
-  }
-
-  @Test
-  public void fileDescriptorMetricsBinderExists() {
-    assumeThat(isWindows()).isFalse();
-
-    String meterNameToCheck = "process.files.open";
-
-    List<Boolean> results = functionExecution
-        .setArguments(meterNameToCheck)
-        .execute(CheckIfMeterExistsFunction.ID)
-        .getResult();
-
-    assertThat(results)
-        .as("Meter from %s binder should exist", FileDescriptorMetrics.class.getSimpleName())
         .containsOnly(true);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryBindersTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryBindersTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.TimeGauge;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CacheMeterRegistryFactoryBindersTest {
+
+  private CompositeMeterRegistry registry;
+
+  @Before
+  public void before() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+
+    registry = factory.create(42, "member-name", "host-name");
+    registry.add(new SimpleMeterRegistry());
+  }
+
+  @Test
+  public void verifyThatJvmMemoryBinderMetersExist() {
+    assertThatMeterExists(Gauge.class, "jvm.buffer.count");
+    assertThatMeterExists(Gauge.class, "jvm.buffer.memory.used");
+    assertThatMeterExists(Gauge.class, "jvm.buffer.total.capacity");
+    assertThatMeterExists(Gauge.class, "jvm.memory.used");
+    assertThatMeterExists(Gauge.class, "jvm.memory.committed");
+    assertThatMeterExists(Gauge.class, "jvm.memory.max");
+  }
+
+  @Test
+  public void verifyThatJvmThreadBinderMetersExist() {
+    assertThatMeterExists(Gauge.class, "jvm.threads.peak");
+    assertThatMeterExists(Gauge.class, "jvm.threads.daemon");
+    assertThatMeterExists(Gauge.class, "jvm.threads.live");
+    assertThatMeterExists(Gauge.class, "jvm.threads.states",
+        Tag.of("state", getTagValue(Thread.State.BLOCKED)));
+    assertThatMeterExists(Gauge.class, "jvm.threads.states",
+        Tag.of("state", getTagValue(Thread.State.NEW)));
+    assertThatMeterExists(Gauge.class, "jvm.threads.states",
+        Tag.of("state", getTagValue(Thread.State.RUNNABLE)));
+    assertThatMeterExists(Gauge.class, "jvm.threads.states",
+        Tag.of("state", getTagValue(Thread.State.WAITING)));
+    assertThatMeterExists(Gauge.class, "jvm.threads.states",
+        Tag.of("state", getTagValue(Thread.State.TIMED_WAITING)));
+    assertThatMeterExists(Gauge.class, "jvm.threads.states",
+        Tag.of("state", getTagValue(Thread.State.TERMINATED)));
+  }
+
+  @Test
+  public void verifyThatJvmGcBinderMetersExist() {
+    assertThatMeterExists(Gauge.class, "jvm.gc.max.data.size");
+    assertThatMeterExists(Gauge.class, "jvm.gc.live.data.size");
+    assertThatMeterExists(Counter.class, "jvm.gc.memory.promoted");
+    assertThatMeterExists(Counter.class, "jvm.gc.memory.allocated");
+  }
+
+  @Test
+  public void verifyThatProcessorBinderMetersExist() {
+    assertThatMeterExists(Gauge.class, "system.cpu.count");
+  }
+
+  @Test
+  public void verifyThatUptimeBinderMetersExist() {
+    assertThatMeterExists(TimeGauge.class, "process.uptime");
+    assertThatMeterExists(TimeGauge.class, "process.start.time");
+  }
+
+  private static String getTagValue(Thread.State state) {
+    return state.name().toLowerCase().replace("_", "-");
+  }
+
+  private <T extends Meter> void assertThatMeterExists(Class<T> type, String name, Tag... tags) {
+    Collection<Meter> meters = registry
+        .find(name)
+        .tags(Arrays.asList(tags))
+        .meters();
+
+    assertThat(meters).isNotEmpty();
+    assertThat(meters).first().isInstanceOf(type);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
@@ -14,17 +14,11 @@
  */
 package org.apache.geode.internal.metrics;
 
-import static org.apache.geode.internal.lang.SystemUtils.isWindows;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.util.Collection;
-
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 
 public class CacheMeterRegistryFactoryTest {
@@ -81,107 +75,5 @@ public class CacheMeterRegistryFactoryTest {
 
     assertThat(meter.getId().getTags())
         .contains(Tag.of("host.name", theHostName));
-  }
-
-  @Test
-  public void addsGaugesForHeapMemory() {
-    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
-
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
-    registry.add(new SimpleMeterRegistry());
-
-    Collection<Gauge> heapGauges = registry
-        .find("jvm.memory.used")
-        .tag("area", "heap")
-        .gauges();
-
-    assertThat(heapGauges).isNotEmpty();
-  }
-
-  @Test
-  public void addsGaugesForNonHeapUsedMemory() {
-    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
-
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
-    registry.add(new SimpleMeterRegistry());
-
-    Collection<Gauge> nonheapGauges = registry
-        .find("jvm.memory.used")
-        .tag("area", "nonheap")
-        .gauges();
-
-    assertThat(nonheapGauges).isNotEmpty();
-  }
-
-  @Test
-  public void addsMetersForJvmThreadMetricsBinder() {
-    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
-
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
-    registry.add(new SimpleMeterRegistry());
-
-    Collection<Meter> meters = registry
-        .find("jvm.threads.peak")
-        .meters();
-
-    assertThat(meters).isNotEmpty();
-  }
-
-  @Test
-  public void addsMetersForJvmGcMetricsBinder() {
-    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
-
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
-    registry.add(new SimpleMeterRegistry());
-
-    Collection<Meter> meters = registry
-        .find("jvm.gc.max.data.size")
-        .meters();
-
-    assertThat(meters).isNotEmpty();
-  }
-
-  @Test
-  public void addsMetersForProcessorMetricsBinder() {
-    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
-
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
-    registry.add(new SimpleMeterRegistry());
-
-    Collection<Meter> meters = registry
-        .find("system.cpu.count")
-        .meters();
-
-    assertThat(meters).isNotEmpty();
-  }
-
-  @Test
-  public void addsMetersForUptimeMetricsBinder() {
-    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
-
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
-    registry.add(new SimpleMeterRegistry());
-
-    Collection<Meter> meters = registry
-        .find("process.uptime")
-        .meters();
-
-    assertThat(meters).isNotEmpty();
-  }
-
-  @Test
-  public void addsMetersForFileDescriptorMetricsBinder() {
-    assumeThat(isWindows()).isFalse();
-
-    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
-
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME);
-    registry.add(new SimpleMeterRegistry());
-
-    Collection<Meter> meters = registry
-        .find("process.files.open")
-        .meters();
-
-    assertThat(meters).isNotEmpty();
   }
 }


### PR DESCRIPTION
- Verify meters from binders exist
- Remove file descriptor binder tests because they depend on JVM type
- Move binder meter tests to separate class

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Mark Hanson <mhanson@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
