### PR TITLE
GEODE-7088: Using ConcurrentSets for interested clients

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1822,8 +1822,8 @@ fromData,63
 toData,59
 
 org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl,2
-fromData,171
-toData,162
+fromData,172
+toData,196
 
 org/apache/geode/internal/cache/tier/sockets/HAEventWrapper,2
 fromData,440

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
@@ -103,6 +103,7 @@ import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.cache.tier.MessageType;
 import org.apache.geode.internal.cache.tier.OverflowAttributes;
 import org.apache.geode.internal.cache.versions.VersionTag;
+import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.net.SocketCloser;
@@ -769,10 +770,13 @@ public class CacheClientNotifier {
   private void incMessagesNotQueuedOriginatorStat(final InternalCacheEvent event,
       final Set<ClientProxyMembershipID> ids) {
     // don't send to member of origin
-    if (ids.remove(event.getContext())) {
-      CacheClientProxy ccp = getClientProxy(event.getContext());
-      if (ccp != null) {
-        ccp.getStatistics().incMessagesNotQueuedOriginator();
+    ClientProxyMembershipID eventOriginator = event.getContext();
+    if (eventOriginator != null) {
+      if (ids.remove(eventOriginator)) {
+        CacheClientProxy ccp = getClientProxy(eventOriginator);
+        if (ccp != null) {
+          ccp.getStatistics().incMessagesNotQueuedOriginator();
+        }
       }
     }
   }
@@ -907,7 +911,7 @@ public class CacheClientNotifier {
    * collection of non-durable identifiers of clients connected to this VM
    */
   Set<ClientProxyMembershipID> getProxyIDs(Set mixedDurableAndNonDurableIDs) {
-    Set<ClientProxyMembershipID> result = new HashSet<>();
+    Set<ClientProxyMembershipID> result = new ConcurrentHashSet<>();
     for (Object id : mixedDurableAndNonDurableIDs) {
       if (id instanceof String) {
         CacheClientProxy clientProxy = getClientProxy((String) id, true);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
@@ -171,8 +171,6 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
   public ClientUpdateMessageImpl(EnumListenerEvent operation, LocalRegion region,
       Object keyOfInterest, Object value, byte[] delta, byte valueIsObject, Object callbackArgument,
       ClientProxyMembershipID memberId, EventID eventIdentifier, VersionTag versionTag) {
-    // this._clientInterestList = new HashSet();
-    // this._clientInterestListInv = new HashSet();
     this._operation = operation;
     this._regionName = region.getFullPath();
     this._keyOfInterest = keyOfInterest;
@@ -196,8 +194,6 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
    */
   protected ClientUpdateMessageImpl(EnumListenerEvent operation, ClientProxyMembershipID memberId,
       EventID eventIdentifier) {
-    // this._clientInterestList = new HashSet();
-    // this._clientInterestListInv = new HashSet();
     this._operation = operation;
     this._membershipId = memberId;
     this._eventIdentifier = eventIdentifier;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.GemFireIOException;
 import org.apache.geode.InternalGemFireError;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.query.internal.cq.InternalCqQuery;
 import org.apache.geode.cache.util.ObjectSizer;
 import org.apache.geode.internal.ByteArrayDataInput;
@@ -46,6 +47,7 @@ import org.apache.geode.internal.cache.WrappedCallbackArgument;
 import org.apache.geode.internal.cache.ha.HAContainerRegion;
 import org.apache.geode.internal.cache.tier.MessageType;
 import org.apache.geode.internal.cache.versions.VersionTag;
+import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.size.Sizeable;
 
@@ -1129,39 +1131,7 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
     }
   }
 
-  /*
-   * private void writeCqInfo(ObjectOutput out) throws IOException { // Write Client CQ Size
-   * out.writeInt(this._clientCqs.size()); // For each client. Iterator entries =
-   * this._clientCqs.entrySet().iterator(); while (entries.hasNext()) { Map.Entry entry =
-   * (Map.Entry)entries.next();
-   *
-   * // Write ProxyId. ClientProxyMembershipID proxyId = (ClientProxyMembershipID)entry.getKey();
-   * proxyId.toData(out);
-   *
-   * HashMap cqs = (HashMap)entry.getValue(); // Write CQ size for each Client.
-   * out.writeInt(cqs.size()); Iterator clients = cqs.entrySet().iterator(); while
-   * (clients.hasNext()) { Map.Entry client = (Map.Entry)clients.next(); // Write CQ Name. String cq
-   * = (String)client.getKey(); out.writeObject(cq); // Write CQ OP. int cqOp =
-   * ((Integer)client.getValue()).intValue(); out.writeInt(cqOp); } } // while }
-   */
-
-  /*
-   * private void readCqInfo(ObjectInput in) throws IOException, ClassNotFoundException { // Read
-   * Client CQ Size int numClientIds = in.readInt(); this._clientCqs = new HashMap();
-   *
-   * // For each Client. for (int cCnt=0; cCnt < numClientIds; cCnt++){ ClientProxyMembershipID
-   * proxyId = new ClientProxyMembershipID();
-   *
-   * // Read Proxy id. proxyId.fromData(in); // read CQ size for each Client. int numCqs =
-   * in.readInt(); HashMap cqs = new HashMap();
-   *
-   * for (int cqCnt=0; cqCnt < numCqs; cqCnt++){ // Get CQ Name and CQ Op. // Read CQ Name. String
-   * cqName = (String)in.readObject(); int cqOp = in.readInt();
-   *
-   * // Read CQ Op. cqs.put(cqName, Integer.valueOf(cqOp)); } this._clientCqs.put(proxyId, cqs); } }
-   */
-
-  public void addClientInterestList(Set clientIds, boolean receiveValues) {
+  void addClientInterestList(Set<ClientProxyMembershipID> clientIds, boolean receiveValues) {
     if (receiveValues) {
       if (this._clientInterestList == null) {
         this._clientInterestList = clientIds;
@@ -1179,23 +1149,16 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
 
   public void addClientInterestList(ClientProxyMembershipID clientId, boolean receiveValues) {
     // This happens under synchronization on HAContainer.
-    HashSet<ClientProxyMembershipID> newInterests;
     if (receiveValues) {
       if (this._clientInterestList == null) {
-        newInterests = new HashSet<ClientProxyMembershipID>();
-      } else {
-        newInterests = new HashSet<ClientProxyMembershipID>(this._clientInterestList);
+        this._clientInterestList = new ConcurrentHashSet<>();
       }
-      newInterests.add(clientId);
-      this._clientInterestList = newInterests;
+      this._clientInterestList.add(clientId);
     } else {
       if (this._clientInterestListInv == null) {
-        newInterests = new HashSet<ClientProxyMembershipID>();
-      } else {
-        newInterests = new HashSet<ClientProxyMembershipID>(this._clientInterestListInv);
+        this._clientInterestListInv = new ConcurrentHashSet<>();
       }
-      newInterests.add(clientId);
-      this._clientInterestListInv = newInterests;
+      this._clientInterestListInv.add(clientId);
     }
   }
 
@@ -1211,6 +1174,16 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
 
   public boolean isClientInterestedInInvalidates(ClientProxyMembershipID clientId) {
     return (this._clientInterestListInv != null && this._clientInterestListInv.contains(clientId));
+  }
+
+  @VisibleForTesting
+  boolean hasClientsInterestedInUpdates() {
+    return this._clientInterestList != null;
+  }
+
+  @VisibleForTesting
+  boolean hasClientsInterestedInInvalidates() {
+    return this._clientInterestListInv != null;
   }
 
   protected Object deserialize(byte[] serializedBytes) {
@@ -1261,17 +1234,24 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
     }
     out.writeByte(_valueIsObject);
     DataSerializer.writeObject(_membershipId, out);
-    // DataSerializer.writeObject(_eventIdentifier,out);
     out.writeBoolean(_shouldConflate);
     out.writeBoolean(_isInterestListPassed);
     DataSerializer.writeByteArray(this.deltaBytes, out);
     out.writeBoolean(_hasCqs);
-    // if (_hasCqs) {
-    // DataSerializer.writeHashMap(this._clientCqs, out);
-    // }
     DataSerializer.writeObject(_callbackArgument, out);
-    DataSerializer.writeHashSet((HashSet) this._clientInterestList, out);
-    DataSerializer.writeHashSet((HashSet) this._clientInterestListInv, out);
+
+    HashSet<ClientProxyMembershipID> clientInterestListSnapshot =
+        this._clientInterestList != null
+            ? new HashSet<>(this._clientInterestList)
+            : null;
+    DataSerializer.writeHashSet(clientInterestListSnapshot, out);
+
+    HashSet<ClientProxyMembershipID> clientInterestListInvSnapshot =
+        this._clientInterestListInv != null
+            ? new HashSet<>(this._clientInterestListInv)
+            : null;
+    DataSerializer.writeHashSet(clientInterestListInvSnapshot, out);
+
     DataSerializer.writeObject(this.versionTag, out);
   }
 
@@ -1283,33 +1263,25 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
     this._value = DataSerializer.readByteArray(in);
     this._valueIsObject = in.readByte();
     this._membershipId = ClientProxyMembershipID.readCanonicalized(in);
-    // this._eventIdentifier = (EventID)DataSerializer.readObject(in);;
     this._shouldConflate = in.readBoolean();
     this._isInterestListPassed = in.readBoolean();
     this.deltaBytes = DataSerializer.readByteArray(in);
     this._hasCqs = in.readBoolean();
-
-    // if (this._hasCqs) {
-    // this._clientCqs = DataSerializer.readHashMap(in);
-    // }
     this._callbackArgument = DataSerializer.readObject(in);
 
     CacheClientNotifier ccn = CacheClientNotifier.getInstance();
 
-    HashSet ids = DataSerializer.readHashSet(in);
+    Set<ClientProxyMembershipID> clientInterestList = DataSerializer.readHashSet(in);
+    this._clientInterestList = ccn != null && clientInterestList != null
+        ? ccn.getProxyIDs(clientInterestList)
+        : null;
 
-    if (ccn != null && ids != null) { // use canonical IDs in servers
-      ids = (HashSet) ccn.getProxyIDs(ids);
-    }
-    this._clientInterestList = ids;
+    Set<ClientProxyMembershipID> clientInterestListInv = DataSerializer.readHashSet(in);
+    this._clientInterestListInv = ccn != null && clientInterestListInv != null
+        ? ccn.getProxyIDs(clientInterestListInv)
+        : null;
 
-    ids = DataSerializer.readHashSet(in);
-    if (ccn != null && ids != null) {
-      ids = (HashSet) ccn.getProxyIDs(ids);
-    }
-    this._clientInterestListInv = ids;
-
-    this.versionTag = (VersionTag) DataSerializer.readObject(in);
+    this.versionTag = DataSerializer.readObject(in);
   }
 
   private Object getOriginalCallbackArgument() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImplTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.Serializable;
+
+import org.junit.Test;
+
+import org.apache.geode.CopyHelper;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.DurableClientAttributes;
+import org.apache.geode.internal.cache.EnumListenerEvent;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.test.fake.Fakes;
+
+public class ClientUpdateMessageImplTest implements Serializable {
+  @Test
+  public void addInterestedClientTest() {
+    ClientUpdateMessageImpl clientUpdateMessageImpl = new ClientUpdateMessageImpl();
+    ClientProxyMembershipID clientProxyMembershipID = mock(ClientProxyMembershipID.class);
+
+    assertThat(clientUpdateMessageImpl.isClientInterestedInUpdates(clientProxyMembershipID))
+        .isFalse();
+    clientUpdateMessageImpl.addClientInterestList(clientProxyMembershipID, true);
+    assertThat(clientUpdateMessageImpl.isClientInterestedInUpdates(clientProxyMembershipID))
+        .isTrue();
+
+    assertThat(clientUpdateMessageImpl.isClientInterestedInInvalidates(clientProxyMembershipID))
+        .isFalse();
+    clientUpdateMessageImpl.addClientInterestList(clientProxyMembershipID, false);
+    assertThat(clientUpdateMessageImpl.isClientInterestedInInvalidates(clientProxyMembershipID))
+        .isTrue();
+  }
+
+  @Test
+  public void serializeClientUpdateMessageNullInterestLists() {
+    ClientUpdateMessageImpl clientUpdateMessageImpl = getTestClientUpdateMessage();
+
+    ClientUpdateMessageImpl clientUpdateMessageCopy = CopyHelper.copy(clientUpdateMessageImpl);
+
+    assertNotNull(clientUpdateMessageCopy);
+    assertThat(clientUpdateMessageCopy.hasClientsInterestedInUpdates()).isFalse();
+    assertThat(clientUpdateMessageCopy.hasClientsInterestedInInvalidates()).isFalse();
+  }
+
+  @Test
+  public void serializeClientUpdateMessageWithInterestLists() {
+    ClientUpdateMessageImpl clientUpdateMessageImpl = getTestClientUpdateMessage();
+
+    DistributedMember distributedMember =
+        mock(DistributedMember.class, withSettings().serializable());
+    when(distributedMember.getDurableClientAttributes())
+        .thenReturn(mock(DurableClientAttributes.class, withSettings().serializable()));
+
+    ClientProxyMembershipID interestedClientID = new ClientProxyMembershipID(distributedMember);
+
+    clientUpdateMessageImpl.addClientInterestList(interestedClientID, false);
+    clientUpdateMessageImpl.addClientInterestList(interestedClientID, true);
+
+    // This creates the CacheClientNotifier singleton which is null checked in
+    // ClientUpdateMessageImpl.fromData(), so we need to do this for serialization to
+    // succeed.
+    CacheClientNotifier cacheClientNotifier =
+        CacheClientNotifier.getInstance(Fakes.cache(), mock(StatisticsClock.class),
+            mock(CacheServerStats.class), 10, 10,
+            mock(ConnectionListener.class), null, true);
+
+    // Mock the deserializing side to include the cache client
+    // proxy with the interested client ID, so that the ID is added to the interest
+    // collection in the message copy
+    CacheClientProxy cacheClientProxy = mock(CacheClientProxy.class);
+    when(cacheClientProxy.getProxyID()).thenReturn(interestedClientID);
+
+    cacheClientNotifier.addClientProxy(cacheClientProxy);
+
+    ClientUpdateMessageImpl clientUpdateMessageCopy = CopyHelper.copy(clientUpdateMessageImpl);
+
+    assertNotNull(clientUpdateMessageCopy);
+    assertThat(clientUpdateMessageCopy.isClientInterestedInUpdates(interestedClientID)).isTrue();
+    assertThat(clientUpdateMessageCopy.isClientInterestedInInvalidates(interestedClientID))
+        .isTrue();
+  }
+
+  private ClientUpdateMessageImpl getTestClientUpdateMessage() {
+    LocalRegion localRegion = mock(LocalRegion.class);
+    String regionName = "regionName";
+    when(localRegion.getName()).thenReturn(regionName);
+    return new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_CREATE, null, null);
+  }
+}


### PR DESCRIPTION
This fix is to handle a very specific race condition scenario as described here:

Subscription HA is enabled and a server is providing a client queue image to a peer (serializing the queue). Meanwhile, a client is also just finished client subscription registration with that same server and is recalculating its filter info to determine if the client needs the event. Recalculating the filter info results in the client message in the HAContainer to be mutated, which causes a ConcurrentModificationException to occur in the GII provider thread.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.