### PR TITLE
GEODE-3780 suspected member is never watched again after passing fina…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -500,6 +500,31 @@ public class GMSHealthMonitorJUnitTest {
     }
   }
 
+  @Test
+  public void testMemberIsExaminedAgainAfterPassingAvailabilityCheck() {
+    // use the test health monitor's availability check for the first round of suspect processing
+    // but then turn it off so that a subsequent round is performed and fails to get a heartbeat
+    useGMSHealthMonitorTestClass = true;
+
+    try {
+      NetView v = installAView();
+
+      setFailureDetectionPorts(v);
+
+      InternalDistributedMember memberToCheck = mockMembers.get(1);
+
+      boolean retVal = gmsHealthMonitor.checkIfAvailable(memberToCheck, "Not responding", true);
+      assertTrue("CheckIfAvailable should have return true", retVal);
+
+      // memberToCheck should be suspected again since it's not sending heartbeats and then
+      // it should fail an availability check and cause removal of the member
+      useGMSHealthMonitorTestClass = false;
+      await().untilAsserted(() -> verify(joinLeave, atLeastOnce()).remove(memberToCheck,
+          "Member isn't responding to heartbeat requests"));
+    } finally {
+      useGMSHealthMonitorTestClass = false;
+    }
+  }
 
   @Test
   public void testNeighborRemainsSameAfterSuccessfulFinalCheck() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -716,12 +716,13 @@ public class GMSJoinLeaveJUnitTest {
         D = mockMembers[2],
         E = mockMembers[3];
     prepareAndInstallView(C, createMemberList(A, B, C, D, E));
-    when(healthMonitor.getMembersFailingAvailabilityCheck()).thenReturn(Collections.singleton(A));
     LeaveRequestMessage msg = new LeaveRequestMessage(B, C, "leaving for test");
     msg.setSender(C);
     gmsJoinLeave.processMessage(msg);
+    RemoveMemberMessage removeMemberMessage = new RemoveMemberMessage(B, A, "removing for test");
+    removeMemberMessage.setSender(B);
+    gmsJoinLeave.processMessage(removeMemberMessage);
     assertTrue("Expected becomeCoordinator to be invoked", gmsJoinLeave.isCoordinator());
-    await().until(() -> gmsJoinLeave.getView().size() == 1);
   }
 
   /**
@@ -738,18 +739,39 @@ public class GMSJoinLeaveJUnitTest {
         C = mockMembers[1],
         D = mockMembers[2],
         E = mockMembers[3];
+
     prepareAndInstallView(C, createMemberList(A, B, C, D));
-    when(healthMonitor.getMembersFailingAvailabilityCheck()).thenReturn(Collections.singleton(A));
-    E.setVmViewId(1);
+
+    // have the Messenger acknowledge all membership view messages so no-one is kicked out for
+    // failure to respond
+    when(messenger.send(isA(InstallViewMessage.class), isA(NetView.class)))
+        .thenAnswer((request) -> {
+          InstallViewMessage installViewMessage = request.getArgument(0);
+          for (InternalDistributedMember recipient : installViewMessage.getRecipients()) {
+            ViewAckMessage viewAckMessage =
+                new ViewAckMessage(gmsJoinLeaveMemberId, installViewMessage.getView().getViewId(),
+                    installViewMessage.isPreparing());
+            viewAckMessage.setSender(recipient);
+            gmsJoinLeave.processMessage(viewAckMessage);
+          }
+          return null;
+        });
+
+    E.setVmViewId(2);
+
+    gmsJoinLeave.recordViewRequest(new LeaveRequestMessage(B, C, "removing for test"));
+
     gmsJoinLeave.processMessage(new JoinRequestMessage(B, E, null, 1, 1));
-    LeaveRequestMessage msg = new LeaveRequestMessage(B, C, "leaving for test");
-    msg.setSender(C);
+
+    RemoveMemberMessage msg = new RemoveMemberMessage(B, A, "crashed for test");
+    msg.setSender(D);
     gmsJoinLeave.processMessage(msg);
-    assertTrue("Expected becomeCoordinator to be invoked", gmsJoinLeave.isCoordinator());
-    await().until(() -> {
-      NetView preparedView = gmsJoinLeave.getPreparedView();
-      return preparedView != null && preparedView.contains(E);
-    });
+
+    await().until(() -> gmsJoinLeave.isCoordinator() && gmsJoinLeave.getViewRequests().isEmpty());
+
+    // E should have joined and retained its view ID of 2
+    await().until(() -> gmsJoinLeave.getView().contains(E));
+    assertEquals(2, E.getVmViewId());
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -1412,11 +1412,6 @@ public class GMSHealthMonitor implements HealthMonitor {
     return this.socketPort;
   }
 
-  @Override
-  public Collection<InternalDistributedMember> getMembersFailingAvailabilityCheck() {
-    return Collections.unmodifiableCollection(this.suspectedMemberIds.keySet());
-  }
-
   private void sendSuspectRequest(final List<SuspectRequest> requests) {
     logger.debug("Sending suspect request for members {}", requests);
     List<InternalDistributedMember> recipients;
@@ -1437,6 +1432,7 @@ public class GMSHealthMonitor implements HealthMonitor {
 
     logger.trace("Sending suspect messages to {}", recipients);
     SuspectMembersMessage smm = new SuspectMembersMessage(recipients, requests);
+    smm.setSender(localAddress);
     Set<InternalDistributedMember> failedRecipients;
     try {
       failedRecipients = services.getMessenger().send(smm);
@@ -1448,6 +1444,8 @@ public class GMSHealthMonitor implements HealthMonitor {
     if (failedRecipients != null && failedRecipients.size() > 0) {
       logger.trace("Unable to send suspect message to {}", failedRecipients);
     }
+    logger.trace("Processing suspect message locally");
+    processMessage(smm);
   }
 
   private static class ConnectTimeoutTask extends TimerTask implements ConnectionWatcher {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.interfaces;
 
-import java.util.Collection;
 
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -52,10 +51,5 @@ public interface HealthMonitor extends Service {
    * Returns the failure detection port for this member, or -1 if there is no such port
    */
   int getFailureDetectionPort();
-
-  /**
-   * Returns the set of members declared dead by the health monitor
-   */
-  Collection<InternalDistributedMember> getMembersFailingAvailabilityCheck();
 
 }


### PR DESCRIPTION
…l check (#3917)

* GEODE-3780 suspected member is never watched again after passing final check

After passing a "final check" a member will be subject to suspect
processing again but we weren't processing the suspect message locally.
This caused JoinLeave to never be notified of the suspect so that
removal could be initiated.

I also noticed that a method in HealthMonitor was misnamed.  It claimed
to return the set of members that had failed availability checks but
instead it was returning a set of members currently under suspicion.  I
renamed the method for clarity.

* empty commit

* removing getSuspectMembers - it could kick out a suspect member too easily

* removing unused method and commented-out code

* revising test

(cherry picked from commit 8e9b04470264983d0aa1c7900f6e9be2374549d9)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
