### PR TITLE
GEODE-7105: Changed Function execution HA docs

### DIFF
--- a/geode-docs/developing/function_exec/how_function_execution_works.html.md.erb
+++ b/geode-docs/developing/function_exec/how_function_execution_works.html.md.erb
@@ -65,7 +65,7 @@ When a failure (such as an execution error or member crash while executing) occu
 
 For client regions, the system retries the execution according to `org.apache.geode.cache.client.Pool` `retryAttempts`. If the function fails to run every time, the final exception is returned to the `getResult` method.
 
-The default number of retries is the total number of servers present. For member calls, if a function fails then the system will retry on each server only once or till no data remains in the system for the function to operate on. If the function fails on every server, then an exception will be returned to the user.
+The default number of retries is the total number of servers present. For member calls, if a function fails then the system will retry on each server only once or until no data remains in the system for the function to operate on. If the function fails on every server, then an exception will be returned to the user.
 
 ## <a id="how_function_execution_works__section_A0FD54B73E9A453AA38FC4A4D5282351" class="no-quick-link"></a>Function Execution Scenarios
 

--- a/geode-docs/developing/function_exec/how_function_execution_works.html.md.erb
+++ b/geode-docs/developing/function_exec/how_function_execution_works.html.md.erb
@@ -65,7 +65,7 @@ When a failure (such as an execution error or member crash while executing) occu
 
 For client regions, the system retries the execution according to `org.apache.geode.cache.client.Pool` `retryAttempts`. If the function fails to run every time, the final exception is returned to the `getResult` method.
 
-For member calls, the system retries until either it succeeds or no data remains in the system for the function to operate on.
+The default number of retries is the total number of servers present. For member calls, if a function fails then the system will retry on each server only once or till no data remains in the system for the function to operate on. If the function fails on every server, then an exception will be returned to the user.
 
 ## <a id="how_function_execution_works__section_A0FD54B73E9A453AA38FC4A4D5282351" class="no-quick-link"></a>Function Execution Scenarios
 


### PR DESCRIPTION
	* Before : the default for retries was -1 and function execution was retried infinitely.
	* After : the default behavior is now that the function will be retried on every server only once and if it fails on every one of them, then an exception will be returned to the user.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
