### PR TITLE
GEODE-6944: separate regionType and region shortcut

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/converters/RegionConverter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/converters/RegionConverter.java
@@ -28,25 +28,18 @@ public class RegionConverter extends ConfigurationConverter<Region, RegionConfig
   protected Region fromNonNullXmlObject(RegionConfig xmlObject) {
     Region region = new Region();
     region.setName(xmlObject.getName());
-    if (xmlObject.getType() == null) {
-      // older gfsh would generate the region xml without the refid/type. we will not
-      // support showing these regions in management rest api for now.
-      region.setType(RegionType.UNSUPPORTED);
-    } else {
-      try {
-        region.setType(RegionType.valueOf(xmlObject.getType()));
-      } catch (IllegalArgumentException e) {
-        // Management rest api will not support showing regions with "LOCAL*" types or user defined
-        // refids
-        region.setType(RegionType.UNSUPPORTED);
-      }
-    }
     RegionAttributesType regionAttributes = xmlObject.getRegionAttributes();
+    region.setType(getRegionType(regionAttributes));
 
     if (regionAttributes != null) {
       region.setDiskStoreName(regionAttributes.getDiskStoreName());
       region.setKeyConstraint(regionAttributes.getKeyConstraint());
       region.setValueConstraint(regionAttributes.getValueConstraint());
+      RegionAttributesType.PartitionAttributes partitionAttributes =
+          regionAttributes.getPartitionAttributes();
+      if (partitionAttributes != null && partitionAttributes.getRedundantCopies() != null) {
+        region.setRedundantCopies(Integer.parseInt(partitionAttributes.getRedundantCopies()));
+      }
     }
     return region;
   }
@@ -68,11 +61,66 @@ public class RegionConverter extends ConfigurationConverter<Region, RegionConfig
     return region;
   }
 
+  /**
+   * Data policy to regionType is almost a 1-to-1 mapping, except in
+   * the case of DataPolicy.PARTITION, we will need to see the local max memory
+   * to determine if it's a PARTITION type or a PARTITION_PROXY type.
+   *
+   * we do our best to infer the type from the existing xml attributes. For data
+   * policies not supported by management rest api (for example, NORMAL and RELOADED)
+   * it will show as UNSUPPORTED
+   */
+  public RegionType getRegionType(RegionAttributesType regionAttributes) {
+    if (regionAttributes == null) {
+      return RegionType.UNSUPPORTED;
+    }
+    RegionAttributesDataPolicy dataPolicy = regionAttributes.getDataPolicy();
+
+    if (regionAttributes.getDataPolicy() == null) {
+      return RegionType.UNSUPPORTED;
+    }
+
+    switch (dataPolicy.name()) {
+      case "PARTITION": {
+        RegionAttributesType.PartitionAttributes partitionAttributes =
+            regionAttributes.getPartitionAttributes();
+        if (partitionAttributes != null && partitionAttributes.getLocalMaxMemory().equals("0")) {
+          return RegionType.PARTITION_PROXY;
+        }
+        return RegionType.PARTITION;
+      }
+      case "PERSISTENT_PARTITION": {
+        return RegionType.PARTITION_PERSISTENT;
+      }
+      case "PERSISTENT_REPLICATE": {
+        return RegionType.REPLICATE_PERSISTENT;
+      }
+      case "REPLICATE": {
+        return RegionType.REPLICATE;
+      }
+      case "EMPTY": {
+        return RegionType.REPLICATE_PROXY;
+      }
+    }
+    return RegionType.UNSUPPORTED;
+  }
+
+
   public RegionAttributesType createRegionAttributesByType(String type) {
     RegionAttributesType regionAttributes = new RegionAttributesType();
     switch (type) {
+      // these are supported by the management rest api
       case "PARTITION": {
         regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PARTITION);
+        break;
+      }
+      case "PARTITION_PERSISTENT": {
+        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PERSISTENT_PARTITION);
+        break;
+      }
+      case "PARTITION_PROXY": {
+        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PARTITION);
+        regionAttributes.setLocalMaxMemory("0");
         break;
       }
       case "REPLICATE": {
@@ -80,15 +128,23 @@ public class RegionConverter extends ConfigurationConverter<Region, RegionConfig
         regionAttributes.setScope(RegionAttributesScope.DISTRIBUTED_ACK);
         break;
       }
+      case "REPLICATE_PERSISTENT": {
+        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PERSISTENT_REPLICATE);
+        regionAttributes.setScope(RegionAttributesScope.DISTRIBUTED_ACK);
+        break;
+      }
+      case "REPLICATE_PROXY": {
+        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.EMPTY);
+        regionAttributes.setScope(RegionAttributesScope.DISTRIBUTED_ACK);
+        break;
+      }
+      // below can come from gfsh
       case "PARTITION_REDUNDANT": {
         regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PARTITION);
         regionAttributes.setRedundantCopy("1");
         break;
       }
-      case "PARTITION_PERSISTENT": {
-        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PERSISTENT_PARTITION);
-        break;
-      }
+
       case "PARTITION_REDUNDANT_PERSISTENT": {
         regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PERSISTENT_PARTITION);
         regionAttributes.setRedundantCopy("1");
@@ -134,19 +190,12 @@ public class RegionConverter extends ConfigurationConverter<Region, RegionConfig
             .setLruHeapPercentageEvictionAction(EnumActionDestroyOverflow.LOCAL_DESTROY);
         break;
       }
-
-      case "REPLICATE_PERSISTENT": {
-        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PERSISTENT_REPLICATE);
-        regionAttributes.setScope(RegionAttributesScope.DISTRIBUTED_ACK);
-        break;
-      }
       case "REPLICATE_OVERFLOW": {
         regionAttributes.setDataPolicy(RegionAttributesDataPolicy.REPLICATE);
         regionAttributes.setScope(RegionAttributesScope.DISTRIBUTED_ACK);
         regionAttributes
             .setLruHeapPercentageEvictionAction(EnumActionDestroyOverflow.OVERFLOW_TO_DISK);
         break;
-
       }
       case "REPLICATE_PERSISTENT_OVERFLOW": {
         regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PERSISTENT_REPLICATE);
@@ -194,22 +243,14 @@ public class RegionConverter extends ConfigurationConverter<Region, RegionConfig
             .setLruHeapPercentageEvictionAction(EnumActionDestroyOverflow.OVERFLOW_TO_DISK);
         break;
       }
-      case "PARTITION_PROXY": {
-        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PARTITION);
-        regionAttributes.setLocalMaxMemory("0");
-        break;
-      }
+
       case "PARTITION_PROXY_REDUNDANT": {
         regionAttributes.setDataPolicy(RegionAttributesDataPolicy.PARTITION);
         regionAttributes.setLocalMaxMemory("0");
         regionAttributes.setRedundantCopy("1");
         break;
       }
-      case "REPLICATE_PROXY": {
-        regionAttributes.setDataPolicy(RegionAttributesDataPolicy.EMPTY);
-        regionAttributes.setScope(RegionAttributesScope.DISTRIBUTED_ACK);
-        break;
-      }
+
       default:
         throw new IllegalArgumentException("invalid type " + type);
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/mutators/RegionConfigManagerTest.java
@@ -46,8 +46,8 @@ public class RegionConfigManagerTest {
 
   @Test
   public void compatibleWithSameType() throws Exception {
-    config1.setType(RegionType.PARTITION_HEAP_LRU);
-    config2.setType(RegionType.PARTITION_HEAP_LRU);
+    config1.setType(RegionType.PARTITION_PERSISTENT);
+    config2.setType(RegionType.PARTITION_PERSISTENT);
     manager.checkCompatibility(config1, "group", config2);
   }
 

--- a/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionType.java
+++ b/geode-management/src/main/java/org/apache/geode/cache/configuration/RegionType.java
@@ -18,34 +18,32 @@ package org.apache.geode.cache.configuration;
 import org.apache.geode.annotations.Experimental;
 
 /**
- * these are the region types supported by Cluster Management V2 API. The attributes of these
- * region types are the same as their namesakes in RegionShortcut
+ * these are the region types supported by Cluster Management V2 API.
+ * these corresponds to a subset of data policies
  */
 @Experimental
 public enum RegionType {
   PARTITION,
-  PARTITION_REDUNDANT,
   PARTITION_PERSISTENT,
-  PARTITION_REDUNDANT_PERSISTENT,
-  PARTITION_OVERFLOW,
-  PARTITION_REDUNDANT_OVERFLOW,
-  PARTITION_PERSISTENT_OVERFLOW,
-  PARTITION_REDUNDANT_PERSISTENT_OVERFLOW,
-  PARTITION_HEAP_LRU,
-  PARTITION_REDUNDANT_HEAP_LRU,
-
   PARTITION_PROXY,
-  PARTITION_PROXY_REDUNDANT,
 
   REPLICATE,
   REPLICATE_PERSISTENT,
-  REPLICATE_OVERFLOW,
-  REPLICATE_PERSISTENT_OVERFLOW,
-  REPLICATE_HEAP_LRU,
-
   REPLICATE_PROXY,
 
   // this is used to represent regions not supported by the management V2 API. For example Gfsh can
   // create regions with "LOCAL*" types
   UNSUPPORTED;
+
+  public boolean isProxy() {
+    return name().contains("PROXY");
+  }
+
+  public boolean isPersistent() {
+    return name().contains("PERSISTENT");
+  }
+
+  public boolean isReplicate() {
+    return name().contains("REPLICATE");
+  }
 }

--- a/geode-management/src/main/java/org/apache/geode/management/configuration/RegionShortcut.java
+++ b/geode-management/src/main/java/org/apache/geode/management/configuration/RegionShortcut.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.configuration;
+
+import org.apache.geode.cache.configuration.RegionType;
+
+/**
+ * these are the region shortcuts supported by Cluster Management V2 API. The attributes of these
+ * region shortcuts are the same as their namesakes in RegionShortcut
+ */
+public enum RegionShortcut {
+  PARTITION,
+  PARTITION_REDUNDANT,
+  PARTITION_PERSISTENT,
+  PARTITION_REDUNDANT_PERSISTENT,
+  PARTITION_OVERFLOW,
+  PARTITION_REDUNDANT_OVERFLOW,
+  PARTITION_PERSISTENT_OVERFLOW,
+  PARTITION_REDUNDANT_PERSISTENT_OVERFLOW,
+  PARTITION_HEAP_LRU,
+  PARTITION_REDUNDANT_HEAP_LRU,
+
+  PARTITION_PROXY,
+  PARTITION_PROXY_REDUNDANT,
+
+  REPLICATE,
+  REPLICATE_PERSISTENT,
+  REPLICATE_OVERFLOW,
+  REPLICATE_PERSISTENT_OVERFLOW,
+  REPLICATE_HEAP_LRU,
+
+  REPLICATE_PROXY;
+
+  /**
+   * @return the corresponding region type of each of these region shortcut
+   */
+  public RegionType getRegionType() {
+    if (withPartition()) {
+      if (withPersistent()) {
+        return RegionType.PARTITION_PERSISTENT;
+      }
+      if (withProxy()) {
+        return RegionType.PARTITION_PROXY;
+      }
+      return RegionType.PARTITION;
+    }
+
+    if (withReplicate()) {
+      if (withPersistent()) {
+        return RegionType.REPLICATE_PERSISTENT;
+      }
+      if (withProxy()) {
+        return RegionType.REPLICATE_PROXY;
+      }
+      return RegionType.REPLICATE;
+    }
+
+    throw new IllegalStateException("Can't reach here.");
+  }
+
+  public boolean withPartition() {
+    return name().contains("PARTITION");
+  }
+
+  public boolean withReplicate() {
+    return name().contains("REPLICATE");
+  }
+
+  public boolean withPersistent() {
+    return name().contains("PERSISTENT");
+  }
+
+  public boolean withProxy() {
+    return name().contains("PROXY");
+  }
+
+  public boolean withRedundant() {
+    return name().contains("REDUNDANT");
+  }
+
+  public boolean withOverflow() {
+    return name().contains("OVERFLOW");
+  }
+
+  public boolean withHeapLRU() {
+    return name().contains("HEAP_LRU");
+  }
+}


### PR DESCRIPTION
Co-authored-by: Darrel Schneider <dschneider@pivotal.io>

* we can create a region config object using a shortcut, but can not set it after it's created
* regionType is a more distilled enum that more corresponds to data policy now
* the converter will recognize more region types created by gfsh or cache.xml
