### PR TITLE
GEODE-7106: Prevent NFE During PRid Generation

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionIntegrationTest.java
@@ -25,11 +25,13 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
+import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.test.appender.ListAppender;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -80,27 +82,32 @@ public class PartitionedRegionIntegrationTest {
 
   @Test
   // See GEODE-7106
-  public void generatePRIdShouldNotThrowNumberFormatExceptionIfAnErrorOccursWhileReleasingTheLock()
-      throws IOException {
+  public void generatePRIdShouldNotThrowNumberFormatExceptionIfAnErrorOccursWhileReleasingTheLock() {
+    ListAppender listAppender = new ListAppender("ListAppender");
+    Logger partitionRegionLogger = (Logger) LogManager.getLogger(PartitionedRegion.class);
+    partitionRegionLogger.addAppender(listAppender);
+    listAppender.start();
+
     String methodName = testName.getMethodName();
-    File customLogFile = temporaryFolder.newFile(methodName + ".log");
     DistributedLockService mockLockService = mock(DistributedLockService.class);
     doReturn(true).when(mockLockService).lock(any(), anyLong(), anyLong());
     doThrow(new RuntimeException("Mock Exception")).when(mockLockService).unlock(any());
 
-    server.withProperty("log-level", "FINE")
-        .withProperty("log-file", customLogFile.getAbsolutePath()).startServer();
+    server.withProperty("log-level", "FINE").startServer();
     PartitionedRegion region =
         spy((PartitionedRegion) server.createRegion(RegionShortcut.PARTITION, methodName));
     doReturn(mockLockService).when(region).getPartitionedRegionLockService();
 
     assertThatCode(() -> region.generatePRId(server.getCache().getInternalDistributedSystem()))
         .doesNotThrowAnyException();
-    assertThat(Files.lines(customLogFile.toPath())
-        .anyMatch(line -> line.contains("java.lang.NumberFormatException"))).isFalse();
-    assertThat(Files.lines(customLogFile.toPath())
-        .anyMatch(line -> line.contains(
+    List<LogEvent> logEvents = listAppender.getEvents();
+    assertThat(logEvents.stream().anyMatch(logEvent -> logEvent.getMessage().getFormattedMessage()
+        .contains("java.lang.NumberFormatException"))).isFalse();
+    assertThat(logEvents.stream()
+        .anyMatch(logEvent -> logEvent.getMessage().getFormattedMessage().contains(
             "releasePRIDLock: unlocking " + MAX_PARTITIONED_REGION_ID + " caught an exception")))
                 .isTrue();
+
+    partitionRegionLogger.removeAppender(listAppender);
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/PartitionedRegionIntegrationTest.java
@@ -15,25 +15,46 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.cache.PartitionedRegionHelper.MAX_PARTITIONED_REGION_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
 
 import org.apache.geode.cache.EvictionAction;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.distributed.DistributedLockService;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 public class PartitionedRegionIntegrationTest {
 
   @Rule
-  public ServerStarterRule server = new ServerStarterRule().withNoCacheServer().withAutoStart();
+  public TestName testName = new TestName();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public ServerStarterRule server = new ServerStarterRule().withNoCacheServer();
 
   @Test
   public void bucketSorterShutdownAfterRegionDestroy() {
+    server.startServer();
     PartitionedRegion region =
         (PartitionedRegion) server.createRegion(RegionShortcut.PARTITION, "PR1",
             f -> f.setEvictionAttributes(
@@ -49,10 +70,37 @@ public class PartitionedRegionIntegrationTest {
 
   @Test
   public void bucketSorterIsNotCreatedIfNoEviction() {
+    server.startServer();
     PartitionedRegion region =
         (PartitionedRegion) server.createRegion(RegionShortcut.PARTITION, "PR1",
             rf -> rf.setOffHeap(false));
     ScheduledExecutorService bucketSorter = region.getBucketSorter();
     assertThat(bucketSorter).isNull();
+  }
+
+  @Test
+  // See GEODE-7106
+  public void generatePRIdShouldNotThrowNumberFormatExceptionIfAnErrorOccursWhileReleasingTheLock()
+      throws IOException {
+    String methodName = testName.getMethodName();
+    File customLogFile = temporaryFolder.newFile(methodName + ".log");
+    DistributedLockService mockLockService = mock(DistributedLockService.class);
+    doReturn(true).when(mockLockService).lock(any(), anyLong(), anyLong());
+    doThrow(new RuntimeException("Mock Exception")).when(mockLockService).unlock(any());
+
+    server.withProperty("log-level", "FINE")
+        .withProperty("log-file", customLogFile.getAbsolutePath()).startServer();
+    PartitionedRegion region =
+        spy((PartitionedRegion) server.createRegion(RegionShortcut.PARTITION, methodName));
+    doReturn(mockLockService).when(region).getPartitionedRegionLockService();
+
+    assertThatCode(() -> region.generatePRId(server.getCache().getInternalDistributedSystem()))
+        .doesNotThrowAnyException();
+    assertThat(Files.lines(customLogFile.toPath())
+        .anyMatch(line -> line.contains("java.lang.NumberFormatException"))).isFalse();
+    assertThat(Files.lines(customLogFile.toPath())
+        .anyMatch(line -> line.contains(
+            "releasePRIDLock: unlocking " + MAX_PARTITIONED_REGION_ID + " caught an exception")))
+                .isTrue();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -4957,8 +4957,7 @@ public class PartitionedRegion extends LocalRegion
       }
     } catch (Exception es) {
       logger.warn(String.format("releasePRIDLock: unlocking %s caught an exception",
-          Integer.valueOf(PartitionedRegionHelper.MAX_PARTITIONED_REGION_ID)),
-          es);
+          PartitionedRegionHelper.MAX_PARTITIONED_REGION_ID), es);
     }
   }
 


### PR DESCRIPTION
- Added tests.
- Fixed minor warnings.
- While releasing the distributed lock acquired to generate a new
  global partitioned region ID, don't parse the String
  MAX_PARTITIONED_REGION_ID as an Integer.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
