### PR TITLE
GEODE-7072 CI Failure: WANRollingUpgradeEventProcessingMixedSiteOneCu…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -604,6 +604,33 @@ public class GMSHealthMonitorJUnitTest {
   }
 
   @Test
+  public void testExonerationMessageIsNotSentToVersion_1_3() {
+    // versions older than 1.4 don't know about the FinalCheckPassedMessage class
+    useGMSHealthMonitorTestClass = true;
+
+    try {
+      GMSMembershipView v = installAView();
+
+      setFailureDetectionPorts(v);
+
+      GMSMember memberToCheck = gmsHealthMonitor.getNextNeighbor();
+
+      gmsHealthMonitor.setNextNeighbor(v, memberToCheck);
+      assertNotEquals(memberToCheck, gmsHealthMonitor.getNextNeighbor());
+
+      mockMembers.get(0).setVersion(Version.GEODE_1_3_0);
+      boolean retVal = gmsHealthMonitor.inlineCheckIfAvailable(mockMembers.get(0), v, true,
+          memberToCheck, "Not responding");
+
+      assertTrue("CheckIfAvailable should have return true", retVal);
+      verify(messenger, never()).send(isA(FinalCheckPassedMessage.class));
+
+    } finally {
+      useGMSHealthMonitorTestClass = false;
+    }
+  }
+
+  @Test
   public void testFinalCheckPassedMessageCanBeSerializedAndDeserialized()
       throws IOException, ClassNotFoundException {
     HeapDataOutputStream heapDataOutputStream = new HeapDataOutputStream(500, Version.CURRENT);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -1387,7 +1387,7 @@ public class GMSHealthMonitor implements HealthMonitor {
 
       if (!failed) {
         if (!isStopping && !initiator.equals(localAddress)
-            && initiator.getVersionOrdinal() >= Version.GEODE_1_3_0.ordinal()) {
+            && initiator.getVersionOrdinal() >= Version.GEODE_1_4_0.ordinal()) {
           // let the sender know that it's okay to monitor this member again
           FinalCheckPassedMessage message = new FinalCheckPassedMessage(initiator, mbr);
           services.getMessenger().send(message);


### PR DESCRIPTION
…rrentSiteTwo

The DataSerializableFixedID class FinalCheckPassedMessage (with ID -158)
wasn't added until version 1.4.  Sending this message to a member of the
cluster running v1.3 will result in a deserialization error on that
member.  The error is benign but it does expose rolling-upgrade tests to
failure if suspect-string processing sees the deserialization error in
unit test output.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
