### PR TITLE
GEODE-7089: Each client registration thread uses its own queue

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -400,15 +400,14 @@ public class AcceptorImpl implements Acceptor, Runnable {
    * @param maxConnections the maximum number of connections allowed in the server pool
    * @param maxThreads the maximum number of threads allowed in the server pool
    * @param securityService the SecurityService to use for authentication and authorization
-   * @param gatewayReceiver the GatewayReceiver that will use this AcceptorImpl instance
-   * @param gatewayReceiverMetrics the GatewayReceiverMetrics to use for exposing metrics
    * @param gatewayTransportFilters List of GatewayTransportFilters
    */
   AcceptorImpl(final int port, final String bindHostName, final boolean notifyBySubscription,
       final int socketBufferSize, final int maximumTimeBetweenPings,
       final InternalCache internalCache, final int maxConnections, final int maxThreads,
       final int maximumMessageCount, final int messageTimeToLive,
-      final ConnectionListener connectionListener, final OverflowAttributes overflowAttributes,
+      final ConnectionListener connectionListener,
+      final OverflowAttributes overflowAttributes,
       final boolean tcpNoDelay, final ServerConnectionFactory serverConnectionFactory,
       final long timeLimitMillis, final SecurityService securityService,
       final Supplier<SocketCreator> socketCreatorSupplier,
@@ -609,8 +608,10 @@ public class AcceptorImpl implements Acceptor, Runnable {
     cache = internalCache;
     crHelper = new CachedRegionHelper(cache);
 
-    clientNotifier = cacheClientNotifierProvider.get(internalCache, stats, maximumMessageCount,
-        messageTimeToLive, this.connectionListener, overflowAttributes, isGatewayReceiver());
+    clientNotifier =
+        cacheClientNotifierProvider.get(internalCache, new ClientRegistrationEventQueueManager(),
+            stats, maximumMessageCount, messageTimeToLive, this.connectionListener,
+            overflowAttributes, isGatewayReceiver());
 
     this.socketBufferSize = socketBufferSize;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientRegistrationEventQueueManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientRegistrationEventQueueManager.java
@@ -15,12 +15,9 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
-import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.apache.logging.log4j.Logger;
 
@@ -30,6 +27,7 @@ import org.apache.geode.internal.cache.FilterProfile;
 import org.apache.geode.internal.cache.FilterRoutingInfo;
 import org.apache.geode.internal.cache.InternalCacheEvent;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.concurrent.ConcurrentHashSet;
 import org.apache.geode.internal.logging.LogService;
 
 /**
@@ -37,10 +35,10 @@ import org.apache.geode.internal.logging.LogService;
  * client is completely registered (filter info retrieved and GII complete), we will drain the
  * client's queued events and deliver them to the cache client proxy if necessary.
  */
-class ClientRegistrationEventQueueManager {
+public class ClientRegistrationEventQueueManager {
   private static final Logger logger = LogService.getLogger();
-  private final Map<ClientProxyMembershipID, ClientRegistrationEventQueue> registeringProxyEventQueues =
-      new ConcurrentHashMap<>();
+  private final Set<ClientRegistrationEventQueue> registeringProxyEventQueues =
+      new ConcurrentHashSet<>();
 
   void add(final InternalCacheEvent event,
       final Conflatable conflatable,
@@ -52,13 +50,7 @@ class ClientRegistrationEventQueueManager {
     ClientRegistrationEvent clientRegistrationEvent =
         new ClientRegistrationEvent(event, conflatable);
 
-    for (final Map.Entry<ClientProxyMembershipID, ClientRegistrationEventQueue> eventsReceivedWhileRegisteringClient : registeringProxyEventQueues
-        .entrySet()) {
-      ClientProxyMembershipID clientProxyMembershipID =
-          eventsReceivedWhileRegisteringClient.getKey();
-      ClientRegistrationEventQueue registrationEventQueue =
-          eventsReceivedWhileRegisteringClient.getValue();
-
+    for (final ClientRegistrationEventQueue registrationEventQueue : registeringProxyEventQueues) {
       registrationEventQueue.lockForPutting();
       try {
         // If this is an HAEventWrapper we need to increment the PutInProgress counter so
@@ -69,10 +61,13 @@ class ClientRegistrationEventQueueManager {
           ((HAEventWrapper) conflatable).incrementPutInProgressCounter("client registration");
         }
 
+        ClientProxyMembershipID clientProxyMembershipID =
+            registrationEventQueue.getClientProxyMembershipID();
+
         // After taking out the lock, we need to determine if the client is still actually
         // registering since there is a small race where it may have finished registering
         // after we pulled the queue out of the registeringProxyEventQueues collection
-        if (registeringProxyEventQueues.containsKey(clientProxyMembershipID)) {
+        if (registeringProxyEventQueues.contains(registrationEventQueue)) {
           // If the event value is off-heap, copy it to heap so we are guaranteed the value
           // is available when we drain the registration queue
           copyOffHeapToHeapForRegistrationQueue(event);
@@ -90,13 +85,142 @@ class ClientRegistrationEventQueueManager {
           // this event and potentially deliver the conflatable to handle the edge case where
           // the original client filter IDs generated in the "normal" put processing path did
           // not include the registering client because the filter info was not yet available.
-          processEventAndDeliverConflatable(clientProxyMembershipID, cacheClientNotifier, event,
+          CacheClientProxy cacheClientProxy =
+              cacheClientNotifier.getClientProxy(clientProxyMembershipID);
+
+          processEventAndDeliverConflatable(cacheClientProxy, cacheClientNotifier, event,
               conflatable, originalFilterClientIDs);
         }
       } finally {
         registrationEventQueue.unlockForPutting();
       }
     }
+  }
+
+  void drain(final ClientRegistrationEventQueue clientRegistrationEventQueue,
+      final CacheClientNotifier cacheClientNotifier) {
+    try {
+      ClientProxyMembershipID clientProxyMembershipID =
+          clientRegistrationEventQueue.getClientProxyMembershipID();
+
+      if (logger.isDebugEnabled()) {
+        logger.debug("Draining events from registration queue for client proxy "
+            + clientProxyMembershipID
+            + " without synchronization");
+      }
+
+      CacheClientProxy cacheClientProxy = cacheClientNotifier
+          .getClientProxy(clientProxyMembershipID);
+
+      drainEventsReceivedWhileRegisteringClient(
+          cacheClientProxy,
+          clientRegistrationEventQueue,
+          cacheClientNotifier);
+
+      // Prevents additional events from being added to the queue while we process and remove it
+      clientRegistrationEventQueue.lockForDraining();
+
+      if (logger.isDebugEnabled()) {
+        logger.debug("Draining remaining events from registration queue for client proxy "
+            + clientProxyMembershipID
+            + " with synchronization");
+      }
+
+      drainEventsReceivedWhileRegisteringClient(
+          cacheClientProxy,
+          clientRegistrationEventQueue,
+          cacheClientNotifier);
+    } finally {
+      // The queue must be removed before attempting to release the drain lock
+      // so that no additional events can be added from add threads.
+      registeringProxyEventQueues.remove(clientRegistrationEventQueue);
+
+      if (clientRegistrationEventQueue.isLockForDrainingHeld()) {
+        clientRegistrationEventQueue.unlockForDraining();
+      }
+    }
+  }
+
+  ClientRegistrationEventQueue create(
+      final ClientProxyMembershipID clientProxyMembershipID,
+      final Queue<ClientRegistrationEvent> eventQueue,
+      final ReentrantReadWriteLock eventAddDrainLock) {
+    final ClientRegistrationEventQueue clientRegistrationEventQueue =
+        new ClientRegistrationEventQueue(clientProxyMembershipID, eventQueue,
+            eventAddDrainLock);
+    registeringProxyEventQueues.add(clientRegistrationEventQueue);
+    return clientRegistrationEventQueue;
+  }
+
+  private void processEventAndDeliverConflatable(final CacheClientProxy cacheClientProxy,
+      final CacheClientNotifier cacheClientNotifier,
+      final InternalCacheEvent internalCacheEvent,
+      final Conflatable conflatable,
+      final Set<ClientProxyMembershipID> originalFilterClientIDs) {
+    try {
+      // If the cache client proxy is null, the registration was not successful and the proxy
+      // was never added to the initialized proxy collection managed by the cache client notifier.
+      // If that is the case, we can just decrement the put in progress counter on the conflatable
+      // if it is an HAEventWrapper.
+      if (cacheClientProxy != null) {
+        // The first step is to repopulate the filter info for the event to determine if
+        // the client which was registering has a matching CQ or has registered interest
+        // in the key for this event. We need to get the filter profile, filter routing info,
+        // and local filter info in order to do so. If any of these are null, then there is
+        // no need to proceed as the client is not interested.
+        FilterProfile filterProfile =
+            ((LocalRegion) internalCacheEvent.getRegion()).getFilterProfile();
+
+        if (filterProfile != null) {
+          FilterRoutingInfo filterRoutingInfo =
+              filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent);
+
+          if (filterRoutingInfo != null) {
+            FilterRoutingInfo.FilterInfo filterInfo = filterRoutingInfo.getLocalFilterInfo();
+
+            if (filterInfo != null) {
+              ClientUpdateMessageImpl clientUpdateMessage = conflatable instanceof HAEventWrapper
+                  ? (ClientUpdateMessageImpl) ((HAEventWrapper) conflatable)
+                      .getClientUpdateMessage()
+                  : (ClientUpdateMessageImpl) conflatable;
+
+              internalCacheEvent.setLocalFilterInfo(filterInfo);
+
+              Set<ClientProxyMembershipID> newFilterClientIDs =
+                  cacheClientNotifier.getFilterClientIDs(internalCacheEvent, filterProfile,
+                      filterInfo,
+                      clientUpdateMessage);
+
+              ClientProxyMembershipID proxyID = cacheClientProxy.getProxyID();
+              if (eventNotInOriginalFilterClientIDs(proxyID, newFilterClientIDs,
+                  originalFilterClientIDs) && newFilterClientIDs.contains(proxyID)) {
+                cacheClientProxy.deliverMessage(conflatable);
+              }
+            }
+          }
+        }
+      }
+    } finally {
+      // Once we have processed the conflatable, if it is an HAEventWrapper we can
+      // decrement the PutInProgress counter, allowing the ClientUpdateMessage to be
+      // set to null. See decrementPutInProgressCounter() for more details.
+      if (conflatable instanceof HAEventWrapper) {
+        ((HAEventWrapper) conflatable).decrementPutInProgressCounter();
+      }
+    }
+  }
+
+  /*
+   * This is to handle the edge case where the original filter client IDs
+   * calculated by "normal" put processing did not include the registering client
+   * because the filter info had not been received yet, but we now found that the client
+   * is interested in the event so we should deliver it.
+   */
+  private boolean eventNotInOriginalFilterClientIDs(final ClientProxyMembershipID proxyID,
+      final Set<ClientProxyMembershipID> newFilterClientIDs,
+      final Set<ClientProxyMembershipID> originalFilterClientIDs) {
+    return originalFilterClientIDs == null
+        || (!originalFilterClientIDs.contains(proxyID) && newFilterClientIDs.contains(proxyID));
   }
 
   /**
@@ -113,93 +237,54 @@ class ClientRegistrationEventQueueManager {
     }
   }
 
-  void drain(final ClientProxyMembershipID clientProxyMembershipID,
-      final CacheClientNotifier cacheClientNotifier) {
-    ClientRegistrationEventQueue registrationEventQueue =
-        registeringProxyEventQueues.get(clientProxyMembershipID);
-
-    if (registrationEventQueue != null) {
-      // It is possible that several client registration threads are active for the same
-      // ClientProxyMembershipID, in which case we only want a single drainer to drain
-      // and remove the queue.
-      registrationEventQueue.lockForSingleDrainer();
-      try {
-        // See if the queue is still available after acquiring the lock as it may have
-        // been removed from registeringProxyEventQueues by the previous thread
-        if (registeringProxyEventQueues.containsKey(clientProxyMembershipID)) {
-          // As an optimization, we drain as many events from the queue as we can
-          // before taking out a lock to drain the remaining events. When we lock for draining,
-          // it prevents additional events from being added to the queue while the queue is drained
-          // and removed.
-          if (logger.isDebugEnabled()) {
-            logger.debug("Draining events from registration queue for client proxy "
-                + clientProxyMembershipID
-                + " without synchronization");
-          }
-
-          drainEventsReceivedWhileRegisteringClient(clientProxyMembershipID, registrationEventQueue,
-              cacheClientNotifier);
-
-          // Prevents additional events from being added to the queue while we process and remove it
-          registrationEventQueue.lockForDraining();
-          try {
-            if (logger.isDebugEnabled()) {
-              logger.debug("Draining remaining events from registration queue for client proxy "
-                  + clientProxyMembershipID + " with synchronization");
-            }
-
-            drainEventsReceivedWhileRegisteringClient(clientProxyMembershipID,
-                registrationEventQueue,
-                cacheClientNotifier);
-
-            registeringProxyEventQueues.remove(clientProxyMembershipID);
-          } finally {
-            registrationEventQueue.unlockForDraining();
-          }
-        }
-      } finally {
-        registrationEventQueue.unlockForSingleDrainer();
-      }
-    }
-  }
-
-  private void drainEventsReceivedWhileRegisteringClient(final ClientProxyMembershipID proxyID,
+  private void drainEventsReceivedWhileRegisteringClient(
+      final CacheClientProxy cacheClientProxy,
       final ClientRegistrationEventQueue registrationEventQueue,
       final CacheClientNotifier cacheClientNotifier) {
     ClientRegistrationEvent queuedEvent;
     while ((queuedEvent = registrationEventQueue.poll()) != null) {
       InternalCacheEvent internalCacheEvent = queuedEvent.internalCacheEvent;
       Conflatable conflatable = queuedEvent.conflatable;
-      processEventAndDeliverConflatable(proxyID, cacheClientNotifier, internalCacheEvent,
-          conflatable, null);
+      processEventAndDeliverConflatable(cacheClientProxy,
+          cacheClientNotifier, internalCacheEvent, conflatable, null);
     }
   }
 
-  public ClientRegistrationEventQueue create(
-      final ClientProxyMembershipID clientProxyMembershipID,
-      final Queue<ClientRegistrationEvent> eventQueue,
-      final ReadWriteLock eventAddDrainLock,
-      final ReentrantLock singleDrainerLock) {
-    final ClientRegistrationEventQueue clientRegistrationEventQueue =
-        new ClientRegistrationEventQueue(eventQueue,
-            eventAddDrainLock, singleDrainerLock);
-    registeringProxyEventQueues.putIfAbsent(clientProxyMembershipID,
-        clientRegistrationEventQueue);
-    return clientRegistrationEventQueue;
+  /**
+   * Represents a conflatable and event processed while a client was registering.
+   * This needs to be queued and processed after registration is complete. The conflatable
+   * is what we will actually be delivering to the MessageDispatcher (and thereby adding
+   * to the HARegionQueue). The internal cache event is required to rehydrate the filter
+   * info and determine if the client which was registering does have a CQ that matches or
+   * has registered interest in the key.
+   */
+  private class ClientRegistrationEvent {
+    private final Conflatable conflatable;
+    private final InternalCacheEvent internalCacheEvent;
+
+    ClientRegistrationEvent(final InternalCacheEvent internalCacheEvent,
+        final Conflatable conflatable) {
+      this.conflatable = conflatable;
+      this.internalCacheEvent = internalCacheEvent;
+    }
   }
 
   class ClientRegistrationEventQueue {
+    private final ClientProxyMembershipID clientProxyMembershipID;
     private final Queue<ClientRegistrationEvent> eventQueue;
-    private final ReadWriteLock eventAddDrainLock;
-    private final ReentrantLock singleDrainerLock;
+    private final ReentrantReadWriteLock eventAddDrainLock;
 
     ClientRegistrationEventQueue(
+        final ClientProxyMembershipID clientProxyMembershipID,
         final Queue<ClientRegistrationEvent> eventQueue,
-        final ReadWriteLock eventAddDrainLock,
-        final ReentrantLock singleDrainerLock) {
+        final ReentrantReadWriteLock eventAddDrainLock) {
+      this.clientProxyMembershipID = clientProxyMembershipID;
       this.eventQueue = eventQueue;
       this.eventAddDrainLock = eventAddDrainLock;
-      this.singleDrainerLock = singleDrainerLock;
+    }
+
+    public ClientProxyMembershipID getClientProxyMembershipID() {
+      return clientProxyMembershipID;
     }
 
     boolean isEmpty() {
@@ -222,110 +307,16 @@ class ClientRegistrationEventQueueManager {
       eventAddDrainLock.writeLock().unlock();
     }
 
+    private boolean isLockForDrainingHeld() {
+      return eventAddDrainLock.writeLock().isHeldByCurrentThread();
+    }
+
     private void lockForPutting() {
       eventAddDrainLock.readLock().lock();
     }
 
     private void unlockForPutting() {
       eventAddDrainLock.readLock().unlock();
-    }
-
-    private void lockForSingleDrainer() {
-      singleDrainerLock.lock();
-    }
-
-    private void unlockForSingleDrainer() {
-      singleDrainerLock.unlock();
-    }
-  }
-
-  private void processEventAndDeliverConflatable(final ClientProxyMembershipID proxyID,
-      final CacheClientNotifier cacheClientNotifier,
-      final InternalCacheEvent internalCacheEvent,
-      final Conflatable conflatable,
-      final Set<ClientProxyMembershipID> originalFilterClientIDs) {
-    // The first step is to repopulate the filter info for the event to determine if
-    // the client which was registering has a matching CQ or has registered interest
-    // in the key for this event. We need to get the filter profile, filter routing info,
-    // and local filter info in order to do so. If any of these are null, then there is
-    // no need to proceed as the client is not interested.
-    FilterProfile filterProfile =
-        ((LocalRegion) internalCacheEvent.getRegion()).getFilterProfile();
-
-    if (filterProfile != null) {
-      FilterRoutingInfo filterRoutingInfo =
-          filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent);
-
-      if (filterRoutingInfo != null) {
-        FilterRoutingInfo.FilterInfo filterInfo = filterRoutingInfo.getLocalFilterInfo();
-
-        if (filterInfo != null) {
-          ClientUpdateMessageImpl clientUpdateMessage = conflatable instanceof HAEventWrapper
-              ? (ClientUpdateMessageImpl) ((HAEventWrapper) conflatable).getClientUpdateMessage()
-              : (ClientUpdateMessageImpl) conflatable;
-
-          internalCacheEvent.setLocalFilterInfo(filterInfo);
-
-          Set<ClientProxyMembershipID> newFilterClientIDs =
-              cacheClientNotifier.getFilterClientIDs(internalCacheEvent, filterProfile,
-                  filterInfo,
-                  clientUpdateMessage);
-
-          if (eventNotInOriginalFilterClientIDs(proxyID, newFilterClientIDs,
-              originalFilterClientIDs)) {
-            CacheClientProxy cacheClientProxy = cacheClientNotifier.getClientProxy(proxyID);
-
-            if (eventShouldBeDelivered(proxyID, newFilterClientIDs, cacheClientProxy)) {
-              cacheClientProxy.deliverMessage(conflatable);
-            }
-          }
-        }
-      }
-    }
-
-    // Once we have processed the conflatable, if it is an HAEventWrapper we can
-    // decrement the PutInProgress counter, allowing the ClientUpdateMessage to be
-    // set to null. See decrementPutInProgressCounter() for more details.
-    if (conflatable instanceof HAEventWrapper) {
-      ((HAEventWrapper) conflatable).decrementPutInProgressCounter();
-    }
-  }
-
-  private boolean eventShouldBeDelivered(final ClientProxyMembershipID proxyID,
-      final Set<ClientProxyMembershipID> filterClientIDs,
-      final CacheClientProxy cacheClientProxy) {
-    return filterClientIDs.contains(proxyID) && cacheClientProxy != null;
-  }
-
-  /*
-   * This is to handle the edge case where the original filter client IDs
-   * calculated by "normal" put processing did not include the registering client
-   * because the filter info had not been received yet, but we now found that the client
-   * is interested in the event so we should deliver it.
-   */
-  private boolean eventNotInOriginalFilterClientIDs(final ClientProxyMembershipID proxyID,
-      final Set<ClientProxyMembershipID> newFilterClientIDs,
-      final Set<ClientProxyMembershipID> originalFilterClientIDs) {
-    return originalFilterClientIDs == null
-        || (!originalFilterClientIDs.contains(proxyID) && newFilterClientIDs.contains(proxyID));
-  }
-
-  /**
-   * Represents a conflatable and event processed while a client was registering.
-   * This needs to be queued and processed after registration is complete. The conflatable
-   * is what we will actually be delivering to the MessageDispatcher (and thereby adding
-   * to the HARegionQueue). The internal cache event is required to rehydrate the filter
-   * info and determine if the client which was registering does have a CQ that matches or
-   * has registered interest in the key.
-   */
-  private class ClientRegistrationEvent {
-    private final Conflatable conflatable;
-    private final InternalCacheEvent internalCacheEvent;
-
-    ClientRegistrationEvent(final InternalCacheEvent internalCacheEvent,
-        final Conflatable conflatable) {
-      this.conflatable = conflatable;
-      this.internalCacheEvent = internalCacheEvent;
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
@@ -169,8 +169,6 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
   public ClientUpdateMessageImpl(EnumListenerEvent operation, LocalRegion region,
       Object keyOfInterest, Object value, byte[] delta, byte valueIsObject, Object callbackArgument,
       ClientProxyMembershipID memberId, EventID eventIdentifier, VersionTag versionTag) {
-    // this._clientInterestList = new HashSet();
-    // this._clientInterestListInv = new HashSet();
     this._operation = operation;
     this._regionName = region.getFullPath();
     this._keyOfInterest = keyOfInterest;
@@ -194,8 +192,6 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
    */
   protected ClientUpdateMessageImpl(EnumListenerEvent operation, ClientProxyMembershipID memberId,
       EventID eventIdentifier) {
-    // this._clientInterestList = new HashSet();
-    // this._clientInterestListInv = new HashSet();
     this._operation = operation;
     this._membershipId = memberId;
     this._eventIdentifier = eventIdentifier;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
@@ -49,6 +49,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.cache.tier.sockets.ClientRegistrationEventQueueManager;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 import org.apache.geode.test.fake.Fakes;
 
@@ -342,8 +343,9 @@ public class BucketRegionTest {
     doReturn(mock(SystemTimer.class)).when(cache).getCCPTimer();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(ClientRegistrationEventQueueManager.class),
+            mock(CacheServerStats.class), 10, 10,
+            mock(ConnectionListener.class), null, true);
 
     bucketRegion.notifyClientsOfTombstoneGC(regionGCVersions, keysRemoved, eventID, routing);
     verify(bucketRegion, never()).getFilterProfile();
@@ -365,8 +367,8 @@ public class BucketRegionTest {
     doReturn(mock(SystemTimer.class)).when(cache).getCCPTimer();
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(ClientRegistrationEventQueueManager.class),
+            mock(CacheServerStats.class), 10, 10, mock(ConnectionListener.class), null, true);
 
     doReturn(mock(ClientProxyMembershipID.class)).when(proxy).getProxyID();
     ccn.addClientProxyToMap(proxy);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/CacheServerImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/CacheServerImplTest.java
@@ -88,8 +88,9 @@ public class CacheServerImplTest {
   @Test
   public void createdAcceptorIsGatewayEndpoint() throws IOException {
     OverflowAttributes overflowAttributes = mock(OverflowAttributes.class);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     Acceptor acceptor = server.createAcceptor(overflowAttributes);
@@ -99,8 +100,9 @@ public class CacheServerImplTest {
 
   @Test
   public void getGroups_returnsSpecifiedGroup() {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup = "group0";
 
@@ -112,8 +114,9 @@ public class CacheServerImplTest {
 
   @Test
   public void getGroups_returnsMultipleSpecifiedGroups() {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup1 = "group1";
     String specifiedGroup2 = "group2";
@@ -129,8 +132,9 @@ public class CacheServerImplTest {
   public void getCombinedGroups_includesMembershipGroup() {
     String membershipGroup = "group-m0";
     when(config.getGroups()).thenReturn(membershipGroup);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     assertThat(server.getCombinedGroups())
@@ -144,8 +148,9 @@ public class CacheServerImplTest {
     String membershipGroup3 = "group-m3";
     when(config.getGroups())
         .thenReturn(membershipGroup1 + "," + membershipGroup2 + "," + membershipGroup3);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     assertThat(server.getCombinedGroups())
@@ -159,8 +164,9 @@ public class CacheServerImplTest {
     String membershipGroup3 = "group-m3";
     when(config.getGroups())
         .thenReturn(membershipGroup1 + "," + membershipGroup2 + "," + membershipGroup3);
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     String specifiedGroup1 = "group1";
     String specifiedGroup2 = "group2";
@@ -175,8 +181,9 @@ public class CacheServerImplTest {
 
   @Test
   public void startNotifiesResourceEventCacheServerStart() throws IOException {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
 
     server.start();
@@ -186,8 +193,9 @@ public class CacheServerImplTest {
 
   @Test
   public void stopNotifiesResourceEventCacheServerStart() throws IOException {
-    InternalCacheServer server = new CacheServerImpl(cache, securityService, new AcceptorBuilder(),
-        true, true, () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
+    InternalCacheServer server = new CacheServerImpl(cache, securityService,
+        new AcceptorBuilder(), true, true,
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
         (a, b, c) -> clientHealthMonitor, a -> advisor);
     server.start();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionPartialMockTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionPartialMockTest.java
@@ -51,6 +51,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.cache.tier.sockets.ClientRegistrationEventQueueManager;
 import org.apache.geode.internal.cache.tier.sockets.ConnectionListener;
 
 public class LocalRegionPartialMockTest {
@@ -226,8 +227,9 @@ public class LocalRegionPartialMockTest {
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(ClientRegistrationEventQueueManager.class),
+            mock(CacheServerStats.class), 10, 10,
+            mock(ConnectionListener.class), null, true);
 
     doCallRealMethod().when(region).notifyClientsOfTombstoneGC(regionGCVersions, keysRemoved,
         eventID, routing);
@@ -248,8 +250,9 @@ public class LocalRegionPartialMockTest {
     when(cache.getCCPTimer()).thenReturn(mock(SystemTimer.class));
 
     CacheClientNotifier ccn =
-        CacheClientNotifier.getInstance(cache, mock(CacheServerStats.class), 10,
-            10, mock(ConnectionListener.class), null, true);
+        CacheClientNotifier.getInstance(cache, mock(ClientRegistrationEventQueueManager.class),
+            mock(CacheServerStats.class), 10, 10,
+            mock(ConnectionListener.class), null, true);
 
     when(proxy.getProxyID()).thenReturn(mock(ClientProxyMembershipID.class));
     ccn.addClientProxyToMap(proxy);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImplTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static java.util.Collections.emptyList;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_SOCKET_BUFFER_SIZE;
 import static org.apache.geode.cache.server.CacheServer.DEFAULT_TCP_NO_DELAY;
@@ -29,7 +30,6 @@ import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 import java.net.ServerSocket;
 import java.net.SocketAddress;
-import java.util.Collections;
 import java.util.Properties;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -96,8 +96,8 @@ public class AcceptorImplTest {
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,
         CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
         null, DEFAULT_TCP_NO_DELAY, serverConnectionFactory, 1000, securityService,
-        () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
-        (a, b, c) -> clientHealthMonitor, false, Collections.emptyList());
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
+        (a, b, c) -> clientHealthMonitor, false, emptyList());
 
     assertThat(acceptor.isGatewayReceiver()).isFalse();
   }
@@ -114,8 +114,8 @@ public class AcceptorImplTest {
         DEFAULT_MAXIMUM_TIME_BETWEEN_PINGS, cache, MINIMUM_MAX_CONNECTIONS, 0,
         CacheServer.DEFAULT_MAXIMUM_MESSAGE_COUNT, CacheServer.DEFAULT_MESSAGE_TIME_TO_LIVE, null,
         null, DEFAULT_TCP_NO_DELAY, serverConnectionFactory, 1000, securityService,
-        () -> socketCreator, (a, b, c, d, e, f, g) -> cacheClientNotifier,
-        (a, b, c) -> clientHealthMonitor, true, Collections.emptyList());
+        () -> socketCreator, (a, b, c, d, e, f, g, h) -> cacheClientNotifier,
+        (a, b, c) -> clientHealthMonitor, true, emptyList());
 
     assertThat(acceptor.isGatewayReceiver()).isTrue();
   }


### PR DESCRIPTION
Co-authored-by: Ryan McMahon <rmcmahon@pivotal.io>
Co-authored-by: Donal Evans <doevans@pivotal.io>

(cherry picked from commit 5d0153ad4adb1612a1083673f98b1982819a6589)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
