### PR TITLE
GEODE-7118: Cleanup RestartOfMemberDistributedTest

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -189,6 +189,7 @@ public class ClusterStartupRule implements SerializableTestRule {
     // close suspect string at the end of tear down
     // any background thread can fill the dunit_suspect.log
     // after its been truncated if we do it before closing cache
+    IgnoredException.removeAllExpectedExceptions();
     DUnitLauncher.closeAndCheckForSuspects();
   }
 


### PR DESCRIPTION
GEODE-7118: Cleanup RestartOfMemberDistributedTest
    
Add IgnoredException.removeAllExpectedExceptions to ClusterStartupRule
    
Reduce run-time of RestartOfMemberDistributedTest
* Set MAX_WAIT_TIME_RECONNECT to 1000
* Set MEMBER_TIMEOUT to 2000