### PR TITLE
GEODE:7141 Rename meter 'cache.gatewayreceiver.events.received'

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
@@ -240,7 +240,7 @@ public class GatewayReceiverMetricsTest {
     @Override
     public void execute(FunctionContext<Void> context) {
       Counter eventsReceivedCounter = SimpleMetricsPublishingService.getRegistry()
-          .find("cache.gatewayreceiver.events.received")
+          .find("geode.gateway.receiver.events")
           .counter();
 
       Object result = eventsReceivedCounter == null

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverStats.java
@@ -107,7 +107,7 @@ public class GatewayReceiverStats extends CacheServerStats {
   private int eventsReceivedId;
   private final Counter eventsReceivedCounter;
   private static final String EVENTS_RECEIVED_COUNTER_NAME =
-      "cache.gatewayreceiver.events.received";
+      "geode.gateway.receiver.events";
   private static final String EVENTS_RECEIVED_COUNTER_DESCRIPTION =
       "total number events across the batched received by this GatewayReceiver";
   private static final String EVENTS_RECEIVED_COUNTER_UNITS = "operations";

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverStatsTest.java
@@ -40,7 +40,7 @@ import org.apache.geode.StatisticsType;
 public class GatewayReceiverStatsTest {
 
   private static final String EVENTS_RECEIVED_COUNTER_NAME =
-      "cache.gatewayreceiver.events.received";
+      "geode.gateway.receiver.events";
   private static final String EVENTS_RECEIVED_STAT_NAME = "eventsReceived";
 
   private StatisticsType statisticsType;


### PR DESCRIPTION
- Rename meter 'cache.gatewayreceiver.events.received' to 'geode.gateway.receiver.events'

Authored-by: Mark Hanson <mhanson@pivotal.io>

Draft Pr to verify tests pass.