### PR TITLE
GEODE-7150: Use Long in OQL COUNT and AVG

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/AbstractAggregator.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/AbstractAggregator.java
@@ -21,16 +21,23 @@ import org.apache.geode.cache.query.Aggregator;
  */
 public abstract class AbstractAggregator implements Aggregator {
 
+  public static Number downCast(long value) {
+    Number retVal;
+
+    if (value <= Integer.MAX_VALUE && value >= Integer.MIN_VALUE) {
+      retVal = Integer.valueOf((int) value);
+    } else {
+      retVal = value;
+    }
+
+    return retVal;
+  }
+
   public static Number downCast(double value) {
     Number retVal;
 
     if (value % 1 == 0) {
-      long longValue = (long) value;
-      if (longValue <= Integer.MAX_VALUE && longValue >= Integer.MIN_VALUE) {
-        retVal = Integer.valueOf((int) longValue);
-      } else {
-        retVal = Long.valueOf(longValue);
-      }
+      retVal = downCast((long) value);
     } else {
       if (value <= Float.MAX_VALUE && value >= Float.MIN_VALUE) {
         retVal = Float.valueOf((float) value);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/Avg.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/Avg.java
@@ -20,9 +20,9 @@ import org.apache.geode.cache.query.QueryService;
  * Computes the non distinct average for replicated region based queries
  */
 public class Avg extends Sum {
-  private int num = 0;
+  private long num = 0;
 
-  int getNum() {
+  long getNum() {
     return num;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/AvgBucketNode.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/AvgBucketNode.java
@@ -22,9 +22,9 @@ import org.apache.geode.cache.query.QueryService;
  * queries.
  */
 public class AvgBucketNode extends Sum {
-  private int count = 0;
+  private long count = 0;
 
-  int getCount() {
+  long getCount() {
     return count;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/AvgPRQueryNode.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/AvgPRQueryNode.java
@@ -19,9 +19,9 @@ package org.apache.geode.cache.query.internal.aggregate;
  * instantiated on the PR query node.
  */
 public class AvgPRQueryNode extends Sum {
-  private int count = 0;
+  private long count = 0;
 
-  int getCount() {
+  long getCount() {
     return count;
   }
 
@@ -33,7 +33,7 @@ public class AvgPRQueryNode extends Sum {
   @Override
   public void accumulate(Object value) {
     Object[] array = (Object[]) value;
-    this.count += ((Integer) array[0]);
+    this.count += ((Long) array[0]);
     super.accumulate(array[1]);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/Count.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/Count.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.query.internal.aggregate.AbstractAggregator.downCast;
+
 import org.apache.geode.cache.query.Aggregator;
 import org.apache.geode.cache.query.QueryService;
 
@@ -21,9 +23,9 @@ import org.apache.geode.cache.query.QueryService;
  * Computes the count of the non distinct rows for replicated & PR based queries.
  */
 public class Count implements Aggregator {
-  private int count = 0;
+  private long count = 0;
 
-  int getCount() {
+  long getCount() {
     return count;
   }
 
@@ -39,6 +41,6 @@ public class Count implements Aggregator {
 
   @Override
   public Object terminate() {
-    return count;
+    return downCast(count);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/CountPRQueryNode.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/aggregate/CountPRQueryNode.java
@@ -14,15 +14,17 @@
  */
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.query.internal.aggregate.AbstractAggregator.downCast;
+
 import org.apache.geode.cache.query.Aggregator;
 
 /**
  * Computes the count of the rows on the PR query node
  */
 public class CountPRQueryNode implements Aggregator {
-  private int count = 0;
+  private long count = 0;
 
-  int getCount() {
+  long getCount() {
     return count;
   }
 
@@ -34,11 +36,11 @@ public class CountPRQueryNode implements Aggregator {
    */
   @Override
   public void accumulate(Object value) {
-    this.count += ((Integer) value);
+    this.count += ((Number) value).longValue();
   }
 
   @Override
   public Object terminate() {
-    return count;
+    return downCast(count);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/aggregate/AvgBucketNodeTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/aggregate/AvgBucketNodeTest.java
@@ -68,7 +68,7 @@ public class AvgBucketNodeTest {
 
     Object result = avgBucketNode.terminate();
     assertThat(result).isInstanceOf(Object[].class);
-    assertThat(((Integer) ((Object[]) result)[0]).intValue()).isEqualTo(7);
+    assertThat(((Long) ((Object[]) result)[0]).intValue()).isEqualTo(7);
     assertThat(((Number) ((Object[]) result)[1]).intValue()).isEqualTo(28);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/aggregate/AvgPRQueryNodeTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/aggregate/AvgPRQueryNodeTest.java
@@ -29,8 +29,8 @@ public class AvgPRQueryNodeTest {
 
   @Test
   public void accumulateShouldIncreaseAccumulatedCount() {
-    avgPRQueryNode.accumulate(new Integer[] {2, 10});
-    avgPRQueryNode.accumulate(new Integer[] {3, 30});
+    avgPRQueryNode.accumulate(new Long[] {2L, 10L});
+    avgPRQueryNode.accumulate(new Long[] {3L, 30L});
 
     assertThat(avgPRQueryNode.getCount()).isEqualTo(5);
     assertThat(avgPRQueryNode.getResult()).isEqualTo(40);
@@ -38,8 +38,8 @@ public class AvgPRQueryNodeTest {
 
   @Test
   public void terminateShouldCorrectlyComputeAverageUponAccumulatedValues() {
-    avgPRQueryNode.accumulate(new Object[] {7, 43d});
-    avgPRQueryNode.accumulate(new Object[] {5, 273.86d});
+    avgPRQueryNode.accumulate(new Object[] {7L, 43d});
+    avgPRQueryNode.accumulate(new Object[] {5L, 273.86d});
 
     Object result = avgPRQueryNode.terminate();
     assertThat(avgPRQueryNode.getCount()).isEqualTo(12);


### PR DESCRIPTION
- Use 'long' instead of 'int' to compute OQL COUNT results.
- Use 'long' instead of 'int' to compute OQL AVG internal results.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
