### PR TITLE
GEODCE-7123: Add create disk-store command option, stage-configuration

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -93,7 +93,7 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
           help = CliStrings.CREATE_DISK_STORE__DISK_USAGE_CRITICAL_PCT__HELP) float diskUsageCriticalPercentage,
       @CliOption(key = CliStrings.CREATE_DISK_STORE__STAGE_CONFIGURATION,
           specifiedDefaultValue = "true", unspecifiedDefaultValue = "false",
-          help = CliStrings.CREATE_DISK_STORE__STAGE_CONFIGURATION__HELP) boolean diskStoreConfigOnly) {
+          help = CliStrings.CREATE_DISK_STORE__STAGE_CONFIGURATION__HELP) boolean stageDiskStoreConfig) {
 
     DiskStoreAttributes diskStoreAttributes = new DiskStoreAttributes();
     diskStoreAttributes.allowForceCompaction = allowForceCompaction;
@@ -125,13 +125,14 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
 
     Set<DistributedMember> targetMembers = findMembers(groups, null);
 
-    if (targetMembers.isEmpty() && !diskStoreConfigOnly) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+    if (targetMembers.isEmpty()) {
+      if (!stageDiskStoreConfig) {
+        return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      } else {
+        targetMembers = findMembersIncludingLocators(groups, null);
+      }
     }
 
-    if (diskStoreConfigOnly) {
-      targetMembers = findMembersIncludingLocators(groups, null);
-    }
     Pair<Boolean, String> validationResult =
         validateDiskstoreAttributes(diskStoreAttributes, targetMembers);
     if (validationResult.getLeft().equals(Boolean.FALSE)) {
@@ -140,12 +141,10 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
 
     ResultModel result;
     DiskStoreType diskStoreType = createDiskStoreType(name, diskStoreAttributes);
-    if (diskStoreConfigOnly) {
+    if (stageDiskStoreConfig) {
       result = new ResultModel();
       InfoResultModel infoSection = result.addInfo();
       result.setConfigObject(diskStoreType);
-
-
     } else {
       List<CliFunctionResult> functionResults = executeAndGetFunctionResult(
           new CreateDiskStoreFunction(), new Object[] {name, diskStoreAttributes}, targetMembers);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -717,6 +717,10 @@ public class CliStrings {
       "disk-usage-critical-percentage";
   public static final String CREATE_DISK_STORE__DISK_USAGE_CRITICAL_PCT__HELP =
       "Critical percentage for disk volume usage.";
+  public static final String CREATE_DISK_STORE__STAGE_CONFIGURATION =
+      "stage-configuration";
+  public static final String CREATE_DISK_STORE__STAGE_CONFIGURATION__HELP =
+      "Only create the cluster configuration element for the disk-store. The disk-store will be created on any future servers to join the cluster.";
   public static final String CREATE_DISK_STORE__ERROR_WHILE_CREATING_REASON_0 =
       "An error occurred while creating the disk store: \"{0}\"";
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
@@ -23,8 +23,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
-
-
 import java.util.Collections;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -85,15 +83,17 @@ public class CreateDiskStoreCommandTest {
   @Test
   public void stageConfiguration_doesNotExecuteCreateDiskStoreFunction() {
     doReturn(Collections.emptySet()).when(command).findMembers(any(),
-            any());
-    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command).findMembersIncludingLocators(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
             any());
     doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
-            any());
+        any());
 
     ResultModel resultModel =
-            gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
-                    .statusIsSuccess().getResultModel();
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
     verifyDiskStoreDir(resultModel, "./data/persist");
 
     verify(command, never()).executeAndGetFunctionResult(any(), any(), any());
@@ -102,53 +102,60 @@ public class CreateDiskStoreCommandTest {
   @Test
   public void stageConfiguration_noServers_persistsConfig() {
     doReturn(Collections.emptySet()).when(command).findMembers(any(),
-            any());
-    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command).findMembersIncludingLocators(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
             any());
     doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
-            any());
+        any());
 
     ResultModel resultModel =
-            gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
-                    .statusIsSuccess().getResultModel();
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
     verifyDiskStoreDir(resultModel, "./data/persist");
   }
 
   @Test
   public void stageConfiguration_withServers_persistsConfig() {
     doReturn(Collections.emptySet()).when(command).findMembers(any(),
-            any());
-    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command).findMembersIncludingLocators(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
             any());
     doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
-            any());
+        any());
 
     ResultModel resultModel =
-            gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
-                    .statusIsSuccess().getResultModel();
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
     verifyDiskStoreDir(resultModel, "./data/persist");
   }
 
   @Test
   public void stageConfiguration_isIdempotent() {
     doReturn(Collections.emptySet()).when(command).findMembers(any(),
-            any());
-    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command).findMembersIncludingLocators(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
             any());
     doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
-            any());
+        any());
 
     ResultModel resultModel =
-            gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
-                    .statusIsSuccess().getResultModel();
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
 
     verifyDiskStoreDir(resultModel, "./data/persist");
     DiskStoreType diskStoreType;
     DiskDirType diskDirType;
 
     resultModel =
-            gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
-                    .statusIsSuccess().getResultModel();
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./data/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
     verifyDiskStoreDir(resultModel, "./data/persist");
   }
 


### PR DESCRIPTION
The new option, --stage-configuration, to the create disk-store command
provides the capability to define a disk-store in the cluster configuration
prior to any server members have joining the cluster. Using this option
will only update the cluster-configuration, disk-stores will not be
created on any current server members.

Servers joining the cluster (or restarting) will then inherit the new
disk-store configuration and create the appropriate directory and
disk-store files.

This is useful for persisting the PDX types to a disk-store other than
DEFAULT.

Authored-by: Ken Howe <khowe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
