### PR TITLE
GEODE-7160: Remove AttributesFactory in geode-wan

### DIFF
--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
@@ -40,10 +40,8 @@ import java.util.StringTokenizer;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.cache.EntryNotFoundException;
@@ -51,7 +49,8 @@ import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.Region.Entry;
-import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.internal.LocatorDiscoveryCallbackAdapter;
 import org.apache.geode.cache.wan.GatewayEventFilter;
 import org.apache.geode.cache.wan.GatewayReceiver;
@@ -495,7 +494,8 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
 
   private void createPartitionedRegion(String regionName, String senderIds, Integer redundantCopies,
       Integer totalNumBuckets) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION);
+
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -503,17 +503,19 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
         fact.addGatewaySenderId(senderId);
       }
     }
+
     PartitionAttributesFactory pFact = new PartitionAttributesFactory();
     pFact.setTotalNumBuckets(totalNumBuckets);
     pFact.setRedundantCopies(redundantCopies);
     pFact.setRecoveryDelay(0);
     fact.setPartitionAttributes(pFact.create());
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    Region r = fact.create(regionName);
     assertNotNull(r);
   }
 
   private void createReplicatedRegion(String regionName, String senderIds) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.REPLICATE);
+
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -521,9 +523,8 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
         fact.addGatewaySenderId(senderId);
       }
     }
-    fact.setDataPolicy(DataPolicy.REPLICATE);
-    fact.setScope(Scope.DISTRIBUTED_ACK);
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+
+    Region r = fact.create(regionName);
     assertNotNull(r);
   }
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/CacheClientNotifierDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/CacheClientNotifierDUnitTest.java
@@ -38,6 +38,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.server.CacheServer;
@@ -265,8 +266,9 @@ public class CacheClientNotifierDUnitTest extends WANTestBase {
       CacheServerTestUtil.enableShufflingOfEndpoints();
     }
 
-    RegionFactory factory = cache.createRegionFactory(RegionShortcut.LOCAL);
-    factory.setPoolName(p.getName());
+    RegionFactory factory = cache.createRegionFactory(RegionShortcut.LOCAL)
+        .setScope(Scope.DISTRIBUTED_NO_ACK)
+        .setPoolName(p.getName());
     region = factory.create(regionName);
     region.registerInterest("ALL_KEYS");
     assertNotNull(region);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/CacheClientNotifierDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/CacheClientNotifierDUnitTest.java
@@ -30,14 +30,14 @@ import java.util.Properties;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.EvictionAction;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.server.CacheServer;
@@ -265,11 +265,9 @@ public class CacheClientNotifierDUnitTest extends WANTestBase {
       CacheServerTestUtil.enableShufflingOfEndpoints();
     }
 
-    AttributesFactory factory = new AttributesFactory();
+    RegionFactory factory = cache.createRegionFactory(RegionShortcut.LOCAL);
     factory.setPoolName(p.getName());
-    factory.setDataPolicy(DataPolicy.NORMAL);
-    RegionAttributes attrs = factory.create();
-    region = cache.createRegion(regionName, attrs);
+    region = factory.create(regionName);
     region.registerInterest("ALL_KEYS");
     assertNotNull(region);
     if (isDurable) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -86,7 +86,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.AttributesMutator;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
@@ -99,9 +98,9 @@ import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.cache.EntryEvent;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
 import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
@@ -419,7 +418,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp2 =
         IgnoredException.addIgnoredException(GatewaySenderException.class.getName());
     try {
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.REPLICATE);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -427,10 +426,9 @@ public class WANTestBase extends DistributedTestCase {
           fact.addGatewaySenderId(senderId);
         }
       }
-      fact.setDataPolicy(DataPolicy.REPLICATE);
-      fact.setScope(Scope.DISTRIBUTED_ACK);
+
       fact.setOffHeap(offHeap);
-      Region r = cache.createRegionFactory(fact.create()).create(regionName);
+      Region r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -440,7 +438,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void createNormalRegion(String regionName, String senderIds) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.LOCAL);
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -448,15 +446,14 @@ public class WANTestBase extends DistributedTestCase {
         fact.addGatewaySenderId(senderId);
       }
     }
-    fact.setDataPolicy(DataPolicy.NORMAL);
-    fact.setScope(Scope.DISTRIBUTED_ACK);
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+
+    Region r = fact.create(regionName);
     assertNotNull(r);
   }
 
   public static void createPersistentReplicatedRegion(String regionName, String senderIds,
       Boolean offHeap) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.REPLICATE_PERSISTENT);
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -464,9 +461,9 @@ public class WANTestBase extends DistributedTestCase {
         fact.addGatewaySenderId(senderId);
       }
     }
-    fact.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+
     fact.setOffHeap(offHeap);
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    Region r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -475,7 +472,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp1 =
         IgnoredException.addIgnoredException(ForceReattemptException.class.getName());
     try {
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.REPLICATE);
       if (asyncQueueIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(asyncQueueIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -483,10 +480,9 @@ public class WANTestBase extends DistributedTestCase {
           fact.addAsyncEventQueueId(asyncQueueId);
         }
       }
-      fact.setDataPolicy(DataPolicy.REPLICATE);
+
       fact.setOffHeap(offHeap);
-      RegionFactory regionFactory = cache.createRegionFactory(fact.create());
-      Region r = regionFactory.create(regionName);
+      Region r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp1.remove();
@@ -498,7 +494,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp =
         IgnoredException.addIgnoredException(ForceReattemptException.class.getName());
     try {
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.REPLICATE);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -506,12 +502,10 @@ public class WANTestBase extends DistributedTestCase {
           fact.addGatewaySenderId(senderId);
         }
       }
-      fact.setDataPolicy(DataPolicy.REPLICATE);
-      fact.setScope(Scope.DISTRIBUTED_ACK);
+
       fact.setOffHeap(offHeap);
-      RegionFactory regionFactory = cache.createRegionFactory(fact.create());
-      regionFactory.addAsyncEventQueueId(asyncChannelId);
-      Region r = regionFactory.create(regionName);
+      fact.addAsyncEventQueueId(asyncChannelId);
+      Region r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -520,7 +514,7 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void createReplicatedRegion(String regionName, String senderIds, Scope scope,
       DataPolicy policy, Boolean offHeap) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory();
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -528,10 +522,11 @@ public class WANTestBase extends DistributedTestCase {
         fact.addGatewaySenderId(senderId);
       }
     }
+
     fact.setDataPolicy(policy);
     fact.setScope(scope);
     fact.setOffHeap(offHeap);
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    Region r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -571,7 +566,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp1 =
         IgnoredException.addIgnoredException(PartitionOfflineException.class.getName());
     try {
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -585,7 +580,7 @@ public class WANTestBase extends DistributedTestCase {
       pfact.setRecoveryDelay(0);
       fact.setPartitionAttributes(pfact.create());
       fact.setOffHeap(offHeap);
-      Region r = cache.createRegionFactory(fact.create()).create(regionName);
+      Region r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -601,7 +596,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp1 =
         IgnoredException.addIgnoredException(PartitionOfflineException.class.getName());
     try {
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION_PERSISTENT);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -614,8 +609,7 @@ public class WANTestBase extends DistributedTestCase {
       pfact.setRedundantCopies(redundantCopies);
       pfact.setRecoveryDelay(0);
       fact.setPartitionAttributes(pfact.create());
-      fact.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-      Region r = cache.createRegionFactory(fact.create()).create(regionName);
+      Region r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -630,7 +624,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp1 =
         IgnoredException.addIgnoredException(PartitionOfflineException.class.getName());
     try {
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -638,13 +632,14 @@ public class WANTestBase extends DistributedTestCase {
           fact.addGatewaySenderId(senderId);
         }
       }
+
       PartitionAttributesFactory pfact = new PartitionAttributesFactory();
       pfact.setTotalNumBuckets(totalNumBuckets);
       pfact.setRedundantCopies(redundantCopies);
       pfact.setRecoveryDelay(0);
       pfact.setColocatedWith(colocatedWith);
       fact.setPartitionAttributes(pfact.create());
-      Region r = cache.createRegionFactory(fact.create()).create(regionName);
+      Region r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -668,7 +663,7 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void createPartitionedRegionAsAccessor(String regionName, String senderIds,
       Integer redundantCopies, Integer totalNumBuckets) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION_PROXY);
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -679,15 +674,14 @@ public class WANTestBase extends DistributedTestCase {
     PartitionAttributesFactory pfact = new PartitionAttributesFactory();
     pfact.setTotalNumBuckets(totalNumBuckets);
     pfact.setRedundantCopies(redundantCopies);
-    pfact.setLocalMaxMemory(0);
     fact.setPartitionAttributes(pfact.create());
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    Region r = fact.create(regionName);
     assertNotNull(r);
   }
 
   public static void createPartitionedRegionWithSerialParallelSenderIds(String regionName,
       String serialSenderIds, String parallelSenderIds, String colocatedWith, Boolean offHeap) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION);
     if (serialSenderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(serialSenderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -706,7 +700,7 @@ public class WANTestBase extends DistributedTestCase {
     pfact.setColocatedWith(colocatedWith);
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    Region r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -719,7 +713,7 @@ public class WANTestBase extends DistributedTestCase {
         IgnoredException.addIgnoredException(PartitionOfflineException.class.getName());
     try {
 
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION_PERSISTENT);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -731,9 +725,8 @@ public class WANTestBase extends DistributedTestCase {
       pfact.setTotalNumBuckets(totalNumBuckets);
       pfact.setRedundantCopies(redundantCopies);
       fact.setPartitionAttributes(pfact.create());
-      fact.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
       fact.setOffHeap(offHeap);
-      Region r = cache.createRegionFactory(fact.create()).create(regionName);
+      Region r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -746,7 +739,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp =
         IgnoredException.addIgnoredException(ForceReattemptException.class.getName());
     try {
-      AttributesFactory fact = new AttributesFactory();
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -761,7 +754,7 @@ public class WANTestBase extends DistributedTestCase {
       fact.setPartitionAttributes(paf.create());
       fact.setOffHeap(offHeap);
       customerRegion =
-          (PartitionedRegion) cache.createRegionFactory(fact.create()).create(customerRegionName);
+          (PartitionedRegion) fact.create(customerRegionName);
       assertNotNull(customerRegion);
       logger.info("Partitioned Region CUSTOMER created Successfully :" + customerRegion.toString());
 
@@ -769,7 +762,7 @@ public class WANTestBase extends DistributedTestCase {
       paf.setRedundantCopies(redundantCopies).setTotalNumBuckets(totalNumBuckets)
           .setColocatedWith(customerRegionName)
           .setPartitionResolver(new CustomerIDPartitionResolver("CustomerIDPartitionResolver"));
-      fact = new AttributesFactory();
+      fact = cache.createRegionFactory(RegionShortcut.PARTITION);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -780,7 +773,7 @@ public class WANTestBase extends DistributedTestCase {
       fact.setPartitionAttributes(paf.create());
       fact.setOffHeap(offHeap);
       orderRegion =
-          (PartitionedRegion) cache.createRegionFactory(fact.create()).create(orderRegionName);
+          (PartitionedRegion) fact.create(orderRegionName);
       assertNotNull(orderRegion);
       logger.info("Partitioned Region ORDER created Successfully :" + orderRegion.toString());
 
@@ -788,7 +781,7 @@ public class WANTestBase extends DistributedTestCase {
       paf.setRedundantCopies(redundantCopies).setTotalNumBuckets(totalNumBuckets)
           .setColocatedWith(orderRegionName)
           .setPartitionResolver(new CustomerIDPartitionResolver("CustomerIDPartitionResolver"));
-      fact = new AttributesFactory();
+      fact = cache.createRegionFactory(RegionShortcut.PARTITION);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -799,7 +792,7 @@ public class WANTestBase extends DistributedTestCase {
       fact.setPartitionAttributes(paf.create());
       fact.setOffHeap(offHeap);
       shipmentRegion =
-          (PartitionedRegion) cache.createRegionFactory(fact.create()).create(shipmentRegionName);
+          (PartitionedRegion) fact.create(shipmentRegionName);
       assertNotNull(shipmentRegion);
       logger.info("Partitioned Region SHIPMENT created Successfully :" + shipmentRegion.toString());
     } finally {
@@ -809,7 +802,7 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void createColocatedPartitionedRegions(String regionName, String senderIds,
       Integer redundantCopies, Integer totalNumBuckets, Boolean offHeap) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION);
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -822,22 +815,22 @@ public class WANTestBase extends DistributedTestCase {
     pfact.setRedundantCopies(redundantCopies);
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    Region r = fact.create(regionName);
     assertNotNull(r);
 
     pfact.setColocatedWith(r.getName());
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r1 = cache.createRegionFactory(fact.create()).create(regionName + "_child1");
+    Region r1 = fact.create(regionName + "_child1");
     assertNotNull(r1);
 
-    Region r2 = cache.createRegionFactory(fact.create()).create(regionName + "_child2");
+    Region r2 = fact.create(regionName + "_child2");
     assertNotNull(r2);
   }
 
   public static void createColocatedPartitionedRegions2(String regionName, String senderIds,
       Integer redundantCopies, Integer totalNumBuckets, Boolean offHeap) {
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory fact = cache.createRegionFactory(RegionShortcut.PARTITION);
     if (senderIds != null) {
       StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
       while (tokenizer.hasMoreTokens()) {
@@ -850,18 +843,17 @@ public class WANTestBase extends DistributedTestCase {
     pfact.setRedundantCopies(redundantCopies);
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    Region r = fact.create(regionName);
     assertNotNull(r);
 
-
-    fact = new AttributesFactory();
+    fact = cache.createRegionFactory(RegionShortcut.PARTITION);
     pfact.setColocatedWith(r.getName());
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r1 = cache.createRegionFactory(fact.create()).create(regionName + "_child1");
+    Region r1 = fact.create(regionName + "_child1");
     assertNotNull(r1);
 
-    Region r2 = cache.createRegionFactory(fact.create()).create(regionName + "_child2");
+    Region r2 = fact.create(regionName + "_child2");
     assertNotNull(r2);
   }
 
@@ -2144,11 +2136,10 @@ public class WANTestBase extends DistributedTestCase {
   public static void createClientWithLocator(int port0, String host, String regionName) {
     createClientWithLocator(port0, host);
 
-    AttributesFactory factory = new AttributesFactory();
+    RegionFactory factory = cache.createRegionFactory(RegionShortcut.LOCAL);
     factory.setPoolName("pool");
-    factory.setDataPolicy(DataPolicy.NORMAL);
-    RegionAttributes attrs = factory.create();
-    region = cache.createRegion(regionName, attrs);
+
+    region = factory.create(regionName);
     region.registerInterest("ALL_KEYS");
     assertNotNull(region);
     logger.info("Distributed Region " + regionName + " created Successfully :" + region.toString());
@@ -3856,7 +3847,8 @@ public class WANTestBase extends DistributedTestCase {
     // of WANTestBase (instead of instances of the subclass). So we can't override
     // this method so that only the off-heap subclasses allocate off heap memory.
     Properties props = new Properties();
-    props.setProperty(OFF_HEAP_MEMORY_SIZE, "300m");
+    props.setProperty(OFF_HEAP_MEMORY_SIZE, "200m");
+
     return props;
   }
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueueOverflowDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueueOverflowDUnitTest.java
@@ -28,12 +28,12 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.wan.GatewayEventFilter;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.cache.wan.GatewaySenderFactory;
@@ -50,6 +50,7 @@ import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.junit.categories.WanTest;
+
 
 /**
  * DUnit for ParallelSenderQueue overflow operations.
@@ -434,11 +435,9 @@ public class ParallelGatewaySenderQueueOverflowDUnitTest extends WANTestBase {
     try {
       GatewaySender sender1 = fact.create("TKSender", 2);
 
-      AttributesFactory factory = new AttributesFactory();
+      RegionFactory factory = cache.createRegionFactory(RegionShortcut.PARTITION_PERSISTENT);
       factory.addGatewaySenderId(sender1.getId());
-      factory.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-      Region region = cache.createRegionFactory(factory.create())
-          .create("test_ValidateGatewaySenderAttributes");
+      Region region = factory.create("test_ValidateGatewaySenderAttributes");
       Set<GatewaySender> senders = cache.getGatewaySenders();
       assertEquals(senders.size(), 1);
       GatewaySender gatewaySender = senders.iterator().next();
@@ -488,11 +487,9 @@ public class ParallelGatewaySenderQueueOverflowDUnitTest extends WANTestBase {
     final IgnoredException ex = IgnoredException.addIgnoredException("Could not connect");
     try {
       GatewaySender sender1 = fact.create("TKSender", 2);
-      AttributesFactory factory = new AttributesFactory();
+      RegionFactory factory = cache.createRegionFactory(RegionShortcut.PARTITION);
       factory.addGatewaySenderId(sender1.getId());
-      factory.setDataPolicy(DataPolicy.PARTITION);
-      Region region = cache.createRegionFactory(factory.create())
-          .create("test_ValidateGatewaySenderAttributes");
+      Region region = factory.create("test_ValidateGatewaySenderAttributes");
       Set<GatewaySender> senders = cache.getGatewaySenders();
       assertEquals(senders.size(), 1);
       GatewaySender gatewaySender = senders.iterator().next();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPersistenceEnabledGatewaySenderDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPersistenceEnabledGatewaySenderDUnitTest.java
@@ -22,9 +22,9 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.cache.wan.GatewaySenderFactory;
 import org.apache.geode.internal.cache.ColocationHelper;
@@ -63,14 +63,14 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
       try {
         GatewaySender sender1 = fact.create("NYSender", 2);
 
-        AttributesFactory rFact = new AttributesFactory();
-        rFact.addGatewaySenderId(sender1.getId());
+        RegionFactory regionFactory = cache.createRegionFactory();
+        regionFactory.addGatewaySenderId(sender1.getId());
 
         PartitionAttributesFactory pFact = new PartitionAttributesFactory();
         pFact.setTotalNumBuckets(100);
         pFact.setRedundantCopies(1);
-        rFact.setPartitionAttributes(pFact.create());
-        Region r = cache.createRegionFactory(rFact.create()).create("MyRegion");
+        regionFactory.setPartitionAttributes(pFact.create());
+        Region r = regionFactory.create("MyRegion");
         sender1.start();
       } finally {
         ex.remove();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueueDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueueDUnitTest.java
@@ -29,12 +29,12 @@ import java.util.Set;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.wan.GatewayEventFilter;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.cache.wan.GatewaySender.OrderPolicy;
@@ -257,11 +257,9 @@ public class SerialGatewaySenderQueueDUnitTest extends WANTestBase {
     try {
       GatewaySender sender1 = fact.create("TKSender", 2);
 
-      AttributesFactory factory = new AttributesFactory();
-      factory.addGatewaySenderId(sender1.getId());
-      factory.setDataPolicy(DataPolicy.PARTITION);
-      Region region = cache.createRegionFactory(factory.create())
-          .create("test_ValidateGatewaySenderAttributes");
+      RegionFactory regionFactory = cache.createRegionFactory(RegionShortcut.PARTITION);
+      regionFactory.addGatewaySenderId(sender1.getId());
+      Region region = regionFactory.create("test_ValidateGatewaySenderAttributes");
       Set<GatewaySender> senders = cache.getGatewaySenders();
       assertEquals(senders.size(), 1);
       GatewaySender gatewaySender = senders.iterator().next();
@@ -309,12 +307,9 @@ public class SerialGatewaySenderQueueDUnitTest extends WANTestBase {
     final IgnoredException exp = IgnoredException.addIgnoredException("Could not connect");
     try {
       GatewaySender sender1 = fact.create("TKSender", 2);
-
-      AttributesFactory factory = new AttributesFactory();
-      factory.addGatewaySenderId(sender1.getId());
-      factory.setDataPolicy(DataPolicy.PARTITION);
-      Region region = cache.createRegionFactory(factory.create())
-          .create("test_ValidateGatewaySenderAttributes");
+      RegionFactory regionFactory = cache.createRegionFactory(RegionShortcut.PARTITION);
+      regionFactory.addGatewaySenderId(sender1.getId());
+      Region region = regionFactory.create("test_ValidateGatewaySenderAttributes");
       Set<GatewaySender> senders = cache.getGatewaySenders();
       assertEquals(senders.size(), 1);
       GatewaySender gatewaySender = senders.iterator().next();


### PR DESCRIPTION
- Removed references to the deprecated AttributesFactory from the
  geode-wan module.
- Reduced default configured off-heap size in WanTestBase to 128m.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
