### PR TITLE
GEODE-7161: Remove AttributesFactory in geode-redis

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -50,7 +50,6 @@ import org.apache.geode.InternalGemFireError;
 import org.apache.geode.LogWriter;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.annotations.internal.MakeNotStatic;
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.DataPolicy;
@@ -64,6 +63,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalRegionArguments;
+import org.apache.geode.internal.cache.xmlcache.RegionAttributesCreation;
 import org.apache.geode.internal.hll.HyperLogLogPlus;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
@@ -428,12 +428,13 @@ public class GeodeRedisServer {
           hLLRegion = regionFactory.create(HLL_REGION);
         }
         if ((redisMetaData = cache.getRegion(REDIS_META_DATA_REGION)) == null) {
-          AttributesFactory af = new AttributesFactory();
-          af.addCacheListener(metaListener);
-          af.setDataPolicy(DataPolicy.REPLICATE);
+          RegionAttributesCreation regionAttributesCreation = new RegionAttributesCreation();
+          regionAttributesCreation.addCacheListener(metaListener);
+          regionAttributesCreation.setDataPolicy(DataPolicy.REPLICATE);
           InternalRegionArguments ira =
               new InternalRegionArguments().setInternalRegion(true).setIsUsedForMetaRegion(true);
-          redisMetaData = gemFireCache.createVMRegion(REDIS_META_DATA_REGION, af.create(), ira);
+          redisMetaData =
+              gemFireCache.createVMRegion(REDIS_META_DATA_REGION, regionAttributesCreation, ira);
         }
       } catch (IOException | ClassNotFoundException e) {
         // only if loading snapshot, not here


### PR DESCRIPTION
- Removed references to the deprecated AttributesFactory from the
  geode-redis module.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
