### PR TITLE
[WIP]: GEODE-7162: Remove AttributesFactory in geode-lucene

### DIFF
--- a/geode-lucene/geode-lucene-test/src/main/java/org/apache/geode/cache/lucene/test/LuceneTestUtilities.java
+++ b/geode-lucene/geode-lucene-test/src/main/java/org/apache/geode/cache/lucene/test/LuceneTestUtilities.java
@@ -34,13 +34,14 @@ import org.apache.lucene.document.FloatPoint;
 import org.apache.lucene.document.IntPoint;
 import org.apache.lucene.search.Query;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.EntryOperation;
 import org.apache.geode.cache.FixedPartitionAttributes;
 import org.apache.geode.cache.FixedPartitionResolver;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
 import org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl;
 import org.apache.geode.cache.lucene.LuceneIndex;
@@ -162,7 +163,7 @@ public class LuceneTestUtilities {
       allPartitions.add("Q2");
     }
 
-    AttributesFactory fact = new AttributesFactory();
+    RegionFactory regionFactory = cache.createRegionFactory(RegionShortcut.PARTITION);
 
     PartitionAttributesFactory pfact = new PartitionAttributesFactory();
     pfact.setTotalNumBuckets(16);
@@ -174,8 +175,8 @@ public class LuceneTestUtilities {
       }
     }
     pfact.setPartitionResolver(new MyFixedPartitionResolver(allPartitions));
-    fact.setPartitionAttributes(pfact.create());
-    Region r = cache.createRegionFactory(fact.create()).create(regionName);
+    regionFactory.setPartitionAttributes(pfact.create());
+    Region r = regionFactory.create(regionName);
     assertNotNull(r);
     return r;
   }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegion.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 
 import org.apache.geode.CancelException;
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.FixedPartitionResolver;
 import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.PartitionAttributesFactory;
@@ -45,6 +44,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.xmlcache.RegionAttributesCreation;
 
 public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
   protected Region fileAndChunkRegion;
@@ -174,12 +174,11 @@ public class LuceneIndexForPartitionedRegion extends LuceneIndexImpl {
 
     // Create AttributesFactory based on input RegionShortcut
     RegionAttributes baseAttributes = this.cache.getRegionAttributes(regionShortCut.toString());
-    AttributesFactory factory = new AttributesFactory(baseAttributes);
-    factory.setPartitionAttributes(partitionAttributesFactory.create());
+    RegionAttributesCreation attributes = new RegionAttributesCreation(baseAttributes, false);
+    attributes.setPartitionAttributes(partitionAttributesFactory.create());
     if (regionAttributes.getDataPolicy().withPersistence()) {
-      factory.setDiskStoreName(regionAttributes.getDiskStoreName());
+      attributes.setDiskStoreName(regionAttributes.getDiskStoreName());
     }
-    RegionAttributes<K, V> attributes = factory.create();
 
     return createRegion(regionName, attributes);
   }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneRegionListener.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneRegionListener.java
@@ -20,7 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.analysis.Analyzer;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.lucene.LuceneIndexDestroyedException;
@@ -29,6 +28,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.RegionListener;
+import org.apache.geode.internal.cache.xmlcache.RegionAttributesCreation;
 import org.apache.geode.internal.logging.LogService;
 
 public class LuceneRegionListener implements RegionListener {
@@ -90,9 +90,10 @@ public class LuceneRegionListener implements RegionListener {
 
       String aeqId = LuceneServiceImpl.getUniqueIndexName(this.indexName, this.regionPath);
       if (!attrs.getAsyncEventQueueIds().contains(aeqId)) {
-        AttributesFactory af = new AttributesFactory(attrs);
-        af.addAsyncEventQueueId(aeqId);
-        updatedRA = af.create();
+        RegionAttributesCreation regionAttributesCreation =
+            new RegionAttributesCreation(attrs, false);
+        regionAttributesCreation.addAsyncEventQueueId(aeqId);
+        updatedRA = regionAttributesCreation;
       }
 
       // Add index creation profile

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegionTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexForPartitionedRegionTest.java
@@ -35,7 +35,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 
-import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheListener;
 import org.apache.geode.cache.DataPolicy;
@@ -56,6 +55,7 @@ import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.extension.ExtensionPoint;
+import org.apache.geode.internal.cache.xmlcache.RegionAttributesCreation;
 import org.apache.geode.test.fake.Fakes;
 import org.apache.geode.test.junit.categories.LuceneTest;
 
@@ -222,15 +222,15 @@ public class LuceneIndexForPartitionedRegionTest {
 
   private RegionAttributes createRegionAttributes(final boolean withPersistence,
       PartitionAttributes partitionAttributes) {
-    AttributesFactory factory = new AttributesFactory();
+    RegionAttributesCreation regionAttributes = new RegionAttributesCreation();
     if (withPersistence) {
-      factory.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
+      regionAttributes.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
     } else {
-      factory.setDataPolicy(DataPolicy.PARTITION);
+      regionAttributes.setDataPolicy(DataPolicy.PARTITION);
     }
-    factory.setPartitionAttributes(partitionAttributes);
-    RegionAttributes ra = factory.create();
-    return ra;
+
+    regionAttributes.setPartitionAttributes(partitionAttributes);
+    return regionAttributes;
   }
 
   private Region initializeScenario(final boolean withPersistence, final String regionPath,


### PR DESCRIPTION
- Removed references to the deprecated AttributesFactory from the
  geode-lucene module.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
