### PR TITLE
GEODE-7087: Do not always clean up transaction if not hosted.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FindRemoteTXMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FindRemoteTXMessage.java
@@ -110,7 +110,7 @@ public class FindRemoteTXMessage extends HighPriorityDistributionMessage
             reply.isPartialCommitMessage = true;
           }
           // cleanup the local txStateProxy fixes bug 43069
-          mgr.removeHostedTXState(txId);
+          mgr.removeHostedTXState(txId, true);
         }
       }
       reply.setRecipient(getSender());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -80,6 +80,8 @@ public class TXStateProxyImpl implements TXStateProxy {
   private long lastOperationTimeFromClient;
   private final StatisticsClock statisticsClock;
 
+  private boolean removedCausedByFailover = false;
+
   public TXStateProxyImpl(InternalCache cache, TXManagerImpl managerImpl, TXId id,
       InternalDistributedMember clientMember, StatisticsClock statisticsClock) {
     this.cache = cache;
@@ -203,6 +205,14 @@ public class TXStateProxyImpl implements TXStateProxy {
     if (isJTA()) {
       throw new IllegalStateException(errmsg);
     }
+  }
+
+  boolean isRemovedCausedByFailover() {
+    return removedCausedByFailover;
+  }
+
+  void setRemovedCausedByFailover(boolean removedCausedByFailover) {
+    this.removedCausedByFailover = removedCausedByFailover;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/TXFailoverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/TXFailoverCommand.java
@@ -126,7 +126,7 @@ public class TXFailoverCommand extends BaseCommand {
           writeException(clientMessage, new TransactionDataNodeHasDepartedException(
               "Could not find transaction host for " + txId), false, serverConnection);
           serverConnection.setAsTrue(RESPONDED);
-          mgr.removeHostedTXState(txId);
+          mgr.removeHostedTXState(txId, true);
           return;
         }
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXManagerImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXManagerImplTest.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.when;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -382,7 +383,22 @@ public class TXManagerImplTest {
   }
 
   @Test
-  public void txStateCleanedUpIfRemovedFromHostedTxStatesMap() {
+  public void txStateCleanedUpIfRemovedFromHostedTxStatesMapCausedByFailover() {
+    tx1 = txMgr.getOrSetHostedTXState(txid, msg);
+    TXStateProxyImpl txStateProxy = (TXStateProxyImpl) tx1;
+    assertNotNull(txStateProxy);
+    assertFalse(txStateProxy.getLocalRealDeal().isClosed());
+    txStateProxy.setRemovedCausedByFailover(true);
+
+    txMgr.masqueradeAs(tx1);
+    // during TX failover, tx can be removed from the hostedTXStates map by FindRemoteTXMessage
+    txMgr.getHostedTXStates().remove(txid);
+    txMgr.unmasquerade(tx1);
+    assertTrue(txStateProxy.getLocalRealDeal().isClosed());
+  }
+
+  @Test
+  public void txStateDoesNotCleanUpIfRemovedFromHostedTxStatesMapNotCausedByFailover() {
     tx1 = txMgr.getOrSetHostedTXState(txid, msg);
     TXStateProxyImpl txStateProxy = (TXStateProxyImpl) tx1;
     assertNotNull(txStateProxy);
@@ -392,7 +408,7 @@ public class TXManagerImplTest {
     // during TX failover, tx can be removed from the hostedTXStates map by FindRemoteTXMessage
     txMgr.getHostedTXStates().remove(txid);
     txMgr.unmasquerade(tx1);
-    assertTrue(txStateProxy.getLocalRealDeal().isClosed());
+    assertFalse(txStateProxy.getLocalRealDeal().isClosed());
   }
 
   @Test
@@ -519,7 +535,8 @@ public class TXManagerImplTest {
     tx1 = mock(TXStateProxyImpl.class);
     ReentrantLock lock = mock(ReentrantLock.class);
     when(tx1.getLock()).thenReturn(lock);
-    doThrow(new RuntimeException()).when(spyTxMgr).cleanupTransactionIfNoLongerHost(tx1);
+    doThrow(new RuntimeException()).when(spyTxMgr)
+        .cleanupTransactionIfNoLongerHostCausedByFailover(tx1);
 
     spyTxMgr.unmasquerade(tx1);
 
@@ -533,4 +550,27 @@ public class TXManagerImplTest {
     tx = txMgr.masqueradeAs(msg);
     assertNotNull(tx.getTarget());
   }
+
+  @Test
+  public void removeHostedTXStateSetFlagIfCausedByFailover() {
+    Map<TXId, TXStateProxy> hostedTXStates = txMgr.getHostedTXStates();
+    TXStateProxyImpl txStateProxy = mock(TXStateProxyImpl.class);
+    hostedTXStates.put(txid, txStateProxy);
+
+    txMgr.removeHostedTXState(txid, true);
+
+    verify(txStateProxy).setRemovedCausedByFailover(eq(true));
+  }
+
+  @Test
+  public void removeHostedTXStateDoesNotSetFlagIfNotCausedByFailover() {
+    Map<TXId, TXStateProxy> hostedTXStates = txMgr.getHostedTXStates();
+    TXStateProxyImpl txStateProxy = mock(TXStateProxyImpl.class);
+    hostedTXStates.put(txid, txStateProxy);
+
+    txMgr.removeHostedTXState(txid);
+
+    verify(txStateProxy, never()).setRemovedCausedByFailover(eq(true));
+  }
+
 }


### PR DESCRIPTION
  * Only clean up transaction if not hosted caused by fail over.
  * unmasquerade should not clean transaction in other cases e.g. transaction
    has been committed.
