### PR TITLE
GEODE-7168: CI failure in Tomcat8 rolling upgrade test

### DIFF
--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
@@ -61,8 +61,9 @@ public class Tomcat8ClientServerRollingUpgradeTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> data() {
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
-    int minimumVersion = SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9) ? 180 : 170;
-    result.removeIf(s -> Integer.parseInt(s) < minimumVersion);
+    String minimumVersion =
+        SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9) ? "1.8.0" : "1.7.0";
+    result.removeIf(s -> s.compareTo(minimumVersion) < 0);
     return result;
   }
 
@@ -290,4 +291,65 @@ public class Tomcat8ClientServerRollingUpgradeTest {
     }
   }
 
+  /**
+   * If this test breaks due to a change in required jars, please update the
+   * "Setting up the Module" section of the Tomcat module documentation!
+   *
+   * Returns the jars required on the classpath for the old modules. This list may
+   * differ from the list required by the current modules at some point in the future, hence the
+   * duplication of the requiredClasspathJars array.
+   *
+   * @return Paths to required jars
+   */
+  private String getClassPathTomcat8AndOldModules() {
+    final String[] requiredClasspathJars = {
+        "/lib/geode-modules-" + oldVersion + ".jar",
+        "/lib/geode-modules-tomcat8-" + oldVersion + ".jar",
+        "/lib/servlet-api.jar",
+        "/lib/catalina.jar",
+        "/lib/tomcat-util.jar",
+        "/bin/tomcat-juli.jar"
+    };
+
+    return getRequiredClasspathJars(tomcat8AndOldModules.getHome(), requiredClasspathJars);
+  }
+
+  /**
+   * If this test breaks due to a change in required jars, please update the
+   * "Setting up the Module" section of the Tomcat module documentation!
+   *
+   * Returns the jars required on the classpath for the current modules. This list may
+   * differ from the list required by the old modules at some point in the future, hence the
+   * duplication of the requiredClasspathJars array.
+   *
+   * @return Paths to required jars
+   */
+  private String getClassPathTomcat8AndCurrentModules() {
+    String currentVersion = Version.CURRENT.getName();
+
+    final String[] requiredClasspathJars = {
+        "/lib/geode-modules-" + currentVersion + "-SNAPSHOT.jar",
+        "/lib/geode-modules-tomcat8-" + currentVersion + "-SNAPSHOT.jar",
+        "/lib/servlet-api.jar",
+        "/lib/catalina.jar",
+        "/lib/tomcat-util.jar",
+        "/bin/tomcat-juli.jar"
+    };
+
+    return getRequiredClasspathJars(tomcat8AndCurrentModules.getHome(), requiredClasspathJars);
+  }
+
+  private String getRequiredClasspathJars(final String tomcat8AndRequiredModules,
+      final String[] requiredClasspathJars) {
+    StringBuilder completeJarList = new StringBuilder();
+    for (String requiredJar : requiredClasspathJars) {
+      completeJarList.append(tomcat8AndRequiredModules)
+          .append(requiredJar)
+          .append(File.pathSeparator);
+    }
+
+    completeJarList.deleteCharAt(completeJarList.length() - 1);
+
+    return completeJarList.toString();
+  }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverWithMixedVersionServersDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverWithMixedVersionServersDistributedTest.java
@@ -96,7 +96,7 @@ public class ClientServerTransactionFailoverWithMixedVersionServersDistributedTe
   @Before
   public void setup() throws Exception {
     host = Host.getHost(0);
-    String startingVersion = "160";
+    String startingVersion = "1.6.0";
     server1 = host.getVM(startingVersion, 0);
     server2 = host.getVM(startingVersion, 1);
     server3 = host.getVM(startingVersion, 2);

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
@@ -86,7 +86,8 @@ public class ClientAuthDUnitTest {
 
     // for older version of client when we did not implement lazy initialization of the pool, the
     // authentication error will happen at this step.
-    if (Arrays.asList("100", "110", "111", "120", "130", "140").contains(clientVersion)) {
+    if (Arrays.asList("1.0.0", "1.1.0", "1.1.1", "1.2.0", "1.3.0", "1.4.0")
+        .contains(clientVersion)) {
       assertThatThrownBy(
           () -> lsRule.startClientVM(0, clientVersion,
               c -> c.withCredential("test", "invalidPassword")

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -38,11 +38,9 @@ import org.apache.commons.lang3.SystemUtils;
  * see Host.getVM(String, int)
  */
 public class VersionManager {
-  public static final String CURRENT_VERSION = "000";
-  public static final String GEODE_110 = "110";
-  public static final String GEODE_120 = "120";
-  public static final String GEODE_130 = "130";
-  public static final String GEODE_140 = "140";
+  public static final String CURRENT_VERSION = "0.0.0";
+  public static final String GEODE_130 = "1.3.0";
+  public static final String GEODE_140 = "1.4.0";
 
   private static VersionManager instance;
 
@@ -166,12 +164,15 @@ public class VersionManager {
 
   private Optional<String> parseVersion(String version) {
     String parsedVersion = null;
-    if (version.startsWith("test") && version.length() >= "test".length()) {
-      if (version.equals("test")) {
-        parsedVersion = CURRENT_VERSION;
-      } else {
-        parsedVersion = version.substring("test".length());
+    if (version.length() > 0 && Character.isDigit(version.charAt(0))
+        && version.length() >= "1.2.3".length()) {
+      for (int i = 1; i < version.length(); i++) {
+        char character = version.charAt(i);
+        if (!Character.isDigit(character) && character != '.') {
+          return Optional.ofNullable(parsedVersion);
+        }
       }
+      parsedVersion = version;
     }
     return Optional.ofNullable(parsedVersion);
   }

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -49,7 +49,7 @@ subprojects {
     compile "org.apache.geode:geode-rebalancer:${oldGeodeVersion}"
   }
 
-  parent.ext.versions.setProperty(projSrcName, sourceSets.main.runtimeClasspath.asPath)
+  parent.ext.versions.setProperty(oldGeodeVersion, sourceSets.main.runtimeClasspath.asPath)
 
   def unpackDest = project.buildDir.toPath().resolve('apache-geode-'.concat(oldGeodeVersion))
 
@@ -58,7 +58,7 @@ subprojects {
   if (downloadInstall) {
     project.dependencies.add "oldInstall", "org.apache.geode:apache-geode:${oldGeodeVersion}@${archiveType}"
 
-    parent.ext.installs.setProperty(projSrcName, unpackDest.toString())
+    parent.ext.installs.setProperty(oldGeodeVersion, unpackDest.toString())
   }
   project.task("downloadAndUnzipFile") {
 


### PR DESCRIPTION
The test infrastructure wasn't providing the actual version strings with
period-separators so our tomcat tests were having to do some hard work
to find those strings.  This PR alters the geode-old-versions sub-project
and VersionManager to preserve the original version strings.  This removes the
need for an old-version to have a corresponding Version instance, which
was causing NPEs in this test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
