### PR TITLE
Feature/geode 7168

### DIFF
--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
@@ -89,6 +89,12 @@ public class TomcatInstall extends ContainerInstall {
     }
   }
 
+  /**
+   * If you update this list method to return different dependencies, please also update
+   * the Tomcat module documentation!
+   * The documentation can be found here:
+   * geode-docs/tools_modules/http_session_mgmt/tomcat_installing_the_module.html.md.erb
+   */
   private static final String[] tomcatRequiredJars =
       {"antlr", "commons-io", "commons-lang", "commons-validator", "fastutil", "geode-common",
           "geode-core", "geode-management", "geode-serialization", "javax.transaction-api",

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandAcceptanceTest.java
@@ -30,12 +30,11 @@ import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.gfsh.GfshExecution;
 import org.apache.geode.test.junit.rules.gfsh.GfshRule;
 import org.apache.geode.test.junit.rules.gfsh.GfshScript;
-import org.apache.geode.test.version.VersionManager;
 
 @Category(GfshTest.class)
 public class ConnectCommandAcceptanceTest {
   @Rule
-  public GfshRule gfsh130 = new GfshRule(VersionManager.GEODE_130);
+  public GfshRule gfsh130 = new GfshRule("1.3.0");
 
   @Rule
   public GfshRule gfshDefault = new GfshRule();

--- a/geode-assembly/src/test/java/org/apache/geode/test/junit/rules/GfshRuleTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/test/junit/rules/GfshRuleTest.java
@@ -25,13 +25,12 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.gfsh.GfshRule;
-import org.apache.geode.test.version.VersionManager;
 
 @Category({GfshTest.class})
 public class GfshRuleTest {
 
   @Rule
-  public GfshRule gfsh130 = new GfshRule(VersionManager.GEODE_130);
+  public GfshRule gfsh130 = new GfshRule("1.3.0");
 
   @Rule
   public GfshRule gfshDefault = new GfshRule();

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
@@ -20,7 +20,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
@@ -36,6 +38,7 @@ import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.internal.UniquePortSupplier;
+import org.apache.geode.internal.Version;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;
@@ -57,12 +60,20 @@ public class Tomcat8ClientServerRollingUpgradeTest {
   private String locatorDir;
   private String server1Dir;
   private String server2Dir;
+  private static Map<String, Version> versionMap = new HashMap<>();
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> data() {
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
     int minimumVersion = SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9) ? 180 : 170;
     result.removeIf(s -> Integer.parseInt(s) < minimumVersion);
+    Version.getAllVersions().forEach(v -> {
+      result.forEach(r -> {
+        if (r.equals(v.getName().replace(".", ""))) {
+          versionMap.put(r, v);
+        }
+      });
+    });
     return result;
   }
 
@@ -140,12 +151,9 @@ public class Tomcat8ClientServerRollingUpgradeTest {
             ContainerInstall.ConnectionType.CLIENT_SERVER,
             portSupplier::getAvailablePort);
 
-    classPathTomcat8AndOldModules = tomcat8AndOldModules.getHome() + "/lib/*" + File.pathSeparator
-        + tomcat8AndOldModules.getHome() + "/bin/*";
+    classPathTomcat8AndOldModules = getClassPathTomcat8AndOldModules();
 
-    classPathTomcat8AndCurrentModules =
-        tomcat8AndCurrentModules.getHome() + "/lib/*" + File.pathSeparator
-            + tomcat8AndCurrentModules.getHome() + "/bin/*";
+    classPathTomcat8AndCurrentModules = getClassPathTomcat8AndCurrentModules();
 
     // Get available port for the locator
     locatorPort = portSupplier.getAvailablePort();
@@ -290,4 +298,67 @@ public class Tomcat8ClientServerRollingUpgradeTest {
     }
   }
 
+  /**
+   * If this test breaks due to a change in required jars, please update the
+   * "Setting up the Module" section of the Tomcat module documentation!
+   *
+   * Returns the jars required on the classpath for the old modules. This list may
+   * differ from the list required by the current modules at some point in the future, hence the
+   * duplication of the requiredClasspathJars array.
+   *
+   * @return Paths to required jars
+   */
+  private String getClassPathTomcat8AndOldModules() {
+    String oldVersion = versionMap.get(this.oldVersion).getName();
+
+    final String[] requiredClasspathJars = {
+        "/lib/geode-modules-" + oldVersion + ".jar",
+        "/lib/geode-modules-tomcat8-" + oldVersion + ".jar",
+        "/lib/servlet-api.jar",
+        "/lib/catalina.jar",
+        "/lib/tomcat-util.jar",
+        "/bin/tomcat-juli.jar"
+    };
+
+    return getRequiredClasspathJars(tomcat8AndOldModules.getHome(), requiredClasspathJars);
+  }
+
+  /**
+   * If this test breaks due to a change in required jars, please update the
+   * "Setting up the Module" section of the Tomcat module documentation!
+   *
+   * Returns the jars required on the classpath for the current modules. This list may
+   * differ from the list required by the old modules at some point in the future, hence the
+   * duplication of the requiredClasspathJars array.
+   *
+   * @return Paths to required jars
+   */
+  private String getClassPathTomcat8AndCurrentModules() {
+    String currentVersion = Version.CURRENT.getName();
+
+    final String[] requiredClasspathJars = {
+        "/lib/geode-modules-" + currentVersion + "-SNAPSHOT.jar",
+        "/lib/geode-modules-tomcat8-" + currentVersion + "-SNAPSHOT.jar",
+        "/lib/servlet-api.jar",
+        "/lib/catalina.jar",
+        "/lib/tomcat-util.jar",
+        "/bin/tomcat-juli.jar"
+    };
+
+    return getRequiredClasspathJars(tomcat8AndCurrentModules.getHome(), requiredClasspathJars);
+  }
+
+  private String getRequiredClasspathJars(final String tomcat8AndRequiredModules,
+      final String[] requiredClasspathJars) {
+    StringBuilder completeJarList = new StringBuilder();
+    for (String requiredJar : requiredClasspathJars) {
+      completeJarList.append(tomcat8AndRequiredModules)
+          .append(requiredJar)
+          .append(File.pathSeparator);
+    }
+
+    completeJarList.deleteCharAt(completeJarList.length() - 1);
+
+    return completeJarList.toString();
+  }
 }

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
@@ -36,7 +36,7 @@ import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.internal.UniquePortSupplier;
-import org.apache.geode.internal.Version;
+import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
@@ -20,9 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
@@ -60,20 +58,13 @@ public class Tomcat8ClientServerRollingUpgradeTest {
   private String locatorDir;
   private String server1Dir;
   private String server2Dir;
-  private static Map<String, Version> versionMap = new HashMap<>();
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> data() {
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
-    int minimumVersion = SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9) ? 180 : 170;
-    result.removeIf(s -> Integer.parseInt(s) < minimumVersion);
-    Version.getAllVersions().forEach(v -> {
-      result.forEach(r -> {
-        if (r.equals(v.getName().replace(".", ""))) {
-          versionMap.put(r, v);
-        }
-      });
-    });
+    String minimumVersion =
+        SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9) ? "1.8.0" : "1.7.0";
+    result.removeIf(s -> s.compareTo(minimumVersion) < 0);
     return result;
   }
 
@@ -309,8 +300,6 @@ public class Tomcat8ClientServerRollingUpgradeTest {
    * @return Paths to required jars
    */
   private String getClassPathTomcat8AndOldModules() {
-    String oldVersion = versionMap.get(this.oldVersion).getName();
-
     final String[] requiredClasspathJars = {
         "/lib/geode-modules-" + oldVersion + ".jar",
         "/lib/geode-modules-tomcat8-" + oldVersion + ".jar",

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTestBase.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTestBase.java
@@ -52,7 +52,7 @@ public abstract class TomcatSessionBackwardsCompatibilityTestBase {
   @Parameterized.Parameters
   public static Collection<String> data() {
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
-    result.removeIf(s -> Integer.parseInt(s) < 120);
+    result.removeIf(s -> Integer.parseInt(VersionManager.getInstance().versionWithNoDots(s)) < 120);
     if (result.size() < 1) {
       throw new RuntimeException("No older versions of Geode were found to test against");
     }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverWithMixedVersionServersDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverWithMixedVersionServersDistributedTest.java
@@ -96,7 +96,7 @@ public class ClientServerTransactionFailoverWithMixedVersionServersDistributedTe
   @Before
   public void setup() throws Exception {
     host = Host.getHost(0);
-    String startingVersion = "160";
+    String startingVersion = "1.6.0";
     server1 = host.getVM(startingVersion, 0);
     server2 = host.getVM(startingVersion, 1);
     server3 = host.getVM(startingVersion, 2);

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
@@ -86,7 +86,7 @@ public class ClientAuthDUnitTest {
 
     // for older version of client when we did not implement lazy initialization of the pool, the
     // authentication error will happen at this step.
-    if (Arrays.asList("1.0.0", "1.1.0", "1.1.1", "1.2.0", "1.3.0", "1.4.0")
+    if (Arrays.asList("1.0.0-incubating", "1.1.0", "1.1.1", "1.2.0", "1.3.0", "1.4.0")
         .contains(clientVersion)) {
       assertThatThrownBy(
           () -> lsRule.startClientVM(0, clientVersion,

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientAuthDUnitTest.java
@@ -86,7 +86,8 @@ public class ClientAuthDUnitTest {
 
     // for older version of client when we did not implement lazy initialization of the pool, the
     // authentication error will happen at this step.
-    if (Arrays.asList("100", "110", "111", "120", "130", "140").contains(clientVersion)) {
+    if (Arrays.asList("1.0.0", "1.1.0", "1.1.1", "1.2.0", "1.3.0", "1.4.0")
+        .contains(clientVersion)) {
       assertThatThrownBy(
           () -> lsRule.startClientVM(0, clientVersion,
               c -> c.withCredential("test", "invalidPassword")

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
@@ -98,7 +98,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     // We want the cluster VMs to be super-users for ease of testing / remote invocation.
     Properties clusterMemberProperties = getVMPropertiesWithPermission("cluster,data");
 
-    int version = Integer.parseInt(clientVersion);
+    int version = Integer.parseInt(VersionManager.getInstance().versionWithNoDots(clientVersion));
     if (version == 0 || version >= 140) {
       clusterMemberProperties.setProperty(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
           "org.apache.geode.security.templates.UsernamePrincipal");
@@ -145,7 +145,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
   @Test
   public void dataWriteCannotGet() throws Exception {
     Properties props = getVMPropertiesWithPermission("dataWrite");
-    int version = Integer.parseInt(clientVersion);
+    int version = Integer.parseInt(VersionManager.getInstance().versionWithNoDots(clientVersion));
     if (version == 0 || version >= 140) {
       props.setProperty(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
           "org.apache.geode.security.templates.UsernamePrincipal");
@@ -206,7 +206,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
   @Test
   public void dataReadCannotPut() throws Exception {
     Properties props = getVMPropertiesWithPermission("dataRead");
-    int version = Integer.parseInt(clientVersion);
+    int version = Integer.parseInt(VersionManager.getInstance().versionWithNoDots(clientVersion));
     if (version == 0 || version >= 140) {
       props.setProperty(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
           "org.apache.geode.security.templates.UsernamePrincipal");

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityDUnitTest.java
@@ -258,7 +258,7 @@ public class ClientDataAuthorizationUsingLegacySecurityDUnitTest {
     // We can't sent the object filter property versions before 1.4.0 because
     // it's not a valid property, but we must set it in 140 and above to allow
     // serialization of UsernamePrincipal
-    if (clientVersion.compareTo("140") >= 0) {
+    if (clientVersion.compareTo("1.4.0") >= 0) {
       props.setProperty(SERIALIZABLE_OBJECT_FILTER, UsernamePrincipal.class.getCanonicalName());
     }
     return props;

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
@@ -428,7 +428,7 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
     // We can't sent the object filter property versions before 1.4.0 because
     // it's not a valid property, but we must set it in 140 and above to allow
     // serialization of UsernamePrincipal
-    if (clientVersion.compareTo("140") >= 0) {
+    if (clientVersion.compareTo("1.4.0") >= 0) {
       props.setProperty(SERIALIZABLE_OBJECT_FILTER, UsernamePrincipal.class.getCanonicalName());
     }
     return props;

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest.java
@@ -131,7 +131,7 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
   @Before
   public void setup() throws Exception {
     Properties clusterMemberProperties = getVMPropertiesWithPermission("cluster,data");
-    int version = Integer.parseInt(clientVersion);
+    int version = Integer.parseInt(VersionManager.getInstance().versionWithNoDots(clientVersion));
     if (version == 0 || version >= 140) {
       clusterMemberProperties.setProperty(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
           "org.apache.geode.security.templates.UsernamePrincipal");
@@ -317,7 +317,7 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
   @Test
   public void dataWriterCannotRegisterInterestAcrossFailover() throws Exception {
     Properties props = getVMPropertiesWithPermission("dataWrite");
-    int version = Integer.parseInt(clientVersion);
+    int version = Integer.parseInt(VersionManager.getInstance().versionWithNoDots(clientVersion));
     if (version == 0 || version >= 140) {
       props.setProperty(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
           "org.apache.geode.security.templates.UsernamePrincipal");
@@ -378,7 +378,7 @@ public class ClientDataAuthorizationUsingLegacySecurityWithFailoverDUnitTest {
 
     Properties props = getVMPropertiesWithPermission(withPermission);
 
-    int version = Integer.parseInt(clientVersion);
+    int version = Integer.parseInt(VersionManager.getInstance().versionWithNoDots(clientVersion));
     if (version == 0 || version >= 140) {
       props.setProperty(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
           "org.apache.geode.security.templates.UsernamePrincipal");

--- a/geode-docs/tools_modules/http_session_mgmt/tomcat_installing_the_module.html.md.erb
+++ b/geode-docs/tools_modules/http_session_mgmt/tomcat_installing_the_module.html.md.erb
@@ -31,12 +31,15 @@ This topic describes how to install the HTTP session management module for Tomca
     -   commons-lang jar
     -   commons-validator jar
     -   fastutil jar
+    -   geode-commons jar
     -   geode-core jar
+    -   geode-management jar
     -   javax.transaction-api jar
     -   jgroups jar
     -   log4j-api jar
     -   log4j-core jar
     -   log4j-jul jar
+    -   micrometer-core jar
     -   shiro-core jar
 
 

--- a/geode-docs/tools_modules/http_session_mgmt/tomcat_setting_up_the_module.html.md.erb
+++ b/geode-docs/tools_modules/http_session_mgmt/tomcat_setting_up_the_module.html.md.erb
@@ -107,19 +107,18 @@ For Tomcat 9.0:
 The application server operates as a <%=vars.product_name%> client in this configuration. With a similar environment to this example that is for a client/server set up,
 
 ``` pre
-TC_VER=tomcat-8.0.30.C.RELEASE
-INSTANCE=geode-cs
-CLASSPATH=$PWD/$INSTANCE/lib/geode-modules-1.0.0.jar:\
-$PWD/$INSTANCE/lib/geode-modules-tomcat8-1.0.0.jar:\
-$PWD/$TC_VER/lib/servlet-api.jar:\
-$PWD/$TC_VER/lib/catalina.jar:\
-$PWD/$TC_VER/lib/tomcat-util.jar:\
-$PWD/$TC_VER/bin/tomcat-juli.jar
+CLASSPATH=$PWD/lib/geode-modules-<%=vars.product_version%>.0.jar:\
+$PWD/lib/geode-modules-tomcat8-<%=vars.product_version%>.0.jar:\
+$PWD/lib/servlet-api.jar:\
+$PWD/lib/catalina.jar:\
+$PWD/lib/tomcat-util.jar:\
+$PWD/bin/tomcat-juli.jar
 ```
 
-Start the server using `gfsh`:
+Start the locator and server using `gfsh`:
 
 ``` pre
+$ gfsh start locator --name=locator1 --classpath=$CLASSPATH
 $ gfsh start server --name=server1 --locators=localhost[10334] --server-port=0 \
   --classpath=$CLASSPATH
 ```

--- a/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
+++ b/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
@@ -70,6 +70,7 @@ To modify your war or ear file manually, make the following updates:
     -   geode-core jar
     -   geode-json jar
     -   geode-management jar
+    -   geode-serialization jar
     -   javax.transaction-api jar
     -   jgroups jar
     -   log4j-api jar

--- a/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
+++ b/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
@@ -62,14 +62,21 @@ To modify your war or ear file manually, make the following updates:
     -   slf4j-jdk14 jar
 -   Add the following jar files from the `$GEODE/lib` directory to the `WEB-INF/lib` directory of the war, where `$GEODE` is set to the <%=vars.product_name%> product installation:
     -   antlr jar
+    -   commons-io jar
+    -   commons-lang jar
+    -   commons-validator jar
     -   fastutil jar
+    -   geode-commons jar
     -   geode-core jar
     -   geode-json jar
+    -   geode-management jar
     -   javax.transaction-api jar
     -   jgroups jar
     -   log4j-api jar
     -   log4j-core jar
     -   log4j-jul jar
+    -   micrometer-core jar
+    -   shiro-core jar
 
 If you are deploying an ear file:
 

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
@@ -86,6 +86,9 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
 
   private static String getDottedVersionString(String vmVersionShorthand) throws Exception {
     if (vmVersionShorthand.contains(".")) {
+      if (vmVersionShorthand.equals("1.0.0")) {
+        return "1.0.0-incubating";
+      }
       return vmVersionShorthand;
     }
     if (vmVersionShorthand.equals("100")) {

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest.java
@@ -85,6 +85,9 @@ public class ClusterStartupRuleCanSpecifyOlderVersionsDUnitTest {
   }
 
   private static String getDottedVersionString(String vmVersionShorthand) throws Exception {
+    if (vmVersionShorthand.contains(".")) {
+      return vmVersionShorthand;
+    }
     if (vmVersionShorthand.equals("100")) {
       return "1.0.0-incubating";
     } else {

--- a/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
@@ -826,6 +826,7 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
             } catch (NoSuchMethodException e) {
               // running an old version of Geode
             }
+
             SecurityTestUtils.createCacheClientWithDynamicRegion(authInit, clientProps, javaProps,
                 0, setupDynamicRegionFactory, NO_EXCEPTION);
           });

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
@@ -192,6 +192,7 @@ class ProcessManager implements ChildVMLauncher {
     for (String module : modules) {
       classpath = removeModuleFromGradlePath(classpath, module);
       classpath = removeModuleFromEclipsePath(classpath, module);
+      classpath = removeModuleFromIntelliJPath(classpath, module);
     }
     return classpath;
   }
@@ -200,6 +201,21 @@ class ProcessManager implements ChildVMLauncher {
     String buildDir = File.separator + module + File.separator + "out" + File.separator;
 
     String mainClasses = buildDir + "production";
+    if (!classpath.contains(mainClasses)) {
+      return classpath;
+    }
+
+    classpath = removeFromPath(classpath, mainClasses);
+    return classpath;
+  }
+
+  private String removeModuleFromIntelliJPath(String classpath, String module) {
+    String mainClasses = File.separator + "out" + File.separator + "production"
+        + File.separator + "org.apache.geode." + module + ".main";
+
+    if (!classpath.contains(mainClasses)) {
+      return classpath;
+    }
 
     classpath = removeFromPath(classpath, mainClasses);
     return classpath;

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -129,9 +129,16 @@ public class VersionManager {
    */
   public String versionWithNoDots(String s) {
     StringBuilder b = new StringBuilder(10);
-    for (int i = 0; i < s.length(); i++) {
-      if (s.charAt(i) != '.')
+    int length = s.length();
+    for (int i = 0; i < length; i++) {
+      char ch = s.charAt(i);
+      if (ch != '.') {
+        // leave off any trailing stuff like "-incubating"
+        if (!Character.isDigit(ch)) {
+          break;
+        }
         b.append(s.charAt(i));
+      }
     }
     return b.toString();
   }
@@ -163,13 +170,13 @@ public class VersionManager {
     readVersionsFile(fileName, (version, path) -> {
       Optional<String> parsedVersion = parseVersion(version);
       if (parsedVersion.isPresent()) {
-        if (parsedVersion.get().equals("140")
+        if (parsedVersion.get().equals("1.4.0")
             && SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
           // Serialization filtering was added in 140, but the support for them in java 9+ was added
-          // in 150. As a result, 140 servers and clients will fail categorically when run in
+          // in 1.5.0. As a result, 1.4.0 servers and clients will fail categorically when run in
           // Java 9+ even with the additional libs (jaxb and activation) in the classpath
           System.err.println(
-              "Geode version 140 is incompatible with Java 9 and higher.  Skipping this version.");
+              "Geode version 1.4.0 is incompatible with Java 9 and higher.  Skipping this version.");
         } else {
           classPaths.put(parsedVersion.get(), path);
           testVersions.add(parsedVersion.get());
@@ -192,12 +199,12 @@ public class VersionManager {
     String parsedVersion = null;
     if (version.length() > 0 && Character.isDigit(version.charAt(0))
         && version.length() >= "1.2.3".length()) {
-      for (int i = 1; i < version.length(); i++) {
-        char character = version.charAt(i);
-        if (!Character.isDigit(character) && character != '.') {
-          return Optional.ofNullable(parsedVersion);
-        }
-      }
+      // for (int i = 1; i < version.length(); i++) {
+      // char character = version.charAt(i);
+      // if (!Character.isDigit(character) && character != '.') {
+      // return Optional.ofNullable(parsedVersion);
+      // }
+      // }
       parsedVersion = version;
     }
     return Optional.ofNullable(parsedVersion);

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -30,8 +30,6 @@ import java.util.function.BiConsumer;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
 
-import org.apache.geode.internal.serialization.Version;
-
 /**
  * VersionManager loads the class-paths for all of the releases of Geode configured for
  * backward-compatibility testing in the geode-core build.gradle file.
@@ -265,24 +263,5 @@ public class VersionManager {
           "Unable to retrieve Version.java's CURRENT_ORDINAL field in order to establlish the product's serialization version",
           e);
     }
-  }
-
-  /**
-   * map a VersionManager version string (like "180) to the actual name of the corresponding
-   * Version
-   */
-  public String getVersionName(String oldVersion) {
-    if (oldVersion.equals(CURRENT_VERSION)) {
-      return Version.CURRENT.getName();
-    }
-    if (!this.testVersions.contains(oldVersion)) {
-      throw new IllegalArgumentException("Unknown version of Geode: " + oldVersion);
-    }
-    for (Version v : Version.getAllVersions()) {
-      if (oldVersion.equals(v.getName().replace(".", ""))) {
-        return v.getName();
-      }
-    }
-    throw new IllegalArgumentException("Unknown version of Geode: " + oldVersion);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -125,6 +125,18 @@ public class VersionManager {
   }
 
   /**
+   * Remove the dots from a version string.  "1.2.0" -> "120"
+   */
+  public String versionWithNoDots(String s) {
+    StringBuilder b = new StringBuilder(10);
+    for (int i = 0; i < s.length(); i++) {
+      if (s.charAt(i) != '.')
+        b.append(s.charAt(i));
+    }
+    return b.toString();
+  }
+
+  /**
    * Returns a list of older versions available for testing
    */
   public List<String> getVersions() {

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -125,7 +125,7 @@ public class VersionManager {
   }
 
   /**
-   * Remove the dots from a version string.  "1.2.0" -> "120"
+   * Remove the dots from a version string. "1.2.0" -> "120"
    */
   public String versionWithNoDots(String s) {
     StringBuilder b = new StringBuilder(10);

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -41,11 +41,9 @@ import org.apache.geode.internal.serialization.Version;
  * see Host.getVM(String, int)
  */
 public class VersionManager {
-  public static final String CURRENT_VERSION = "000";
-  public static final String GEODE_110 = "110";
-  public static final String GEODE_120 = "120";
-  public static final String GEODE_130 = "130";
-  public static final String GEODE_140 = "140";
+  public static final String CURRENT_VERSION = "0.0.0";
+  public static final String GEODE_130 = "1.3.0";
+  public static final String GEODE_140 = "1.4.0";
 
   private static VersionManager instance;
 
@@ -180,12 +178,15 @@ public class VersionManager {
 
   private Optional<String> parseVersion(String version) {
     String parsedVersion = null;
-    if (version.startsWith("test") && version.length() >= "test".length()) {
-      if (version.equals("test")) {
-        parsedVersion = CURRENT_VERSION;
-      } else {
-        parsedVersion = version.substring("test".length());
+    if (version.length() > 0 && Character.isDigit(version.charAt(0))
+        && version.length() >= "1.2.3".length()) {
+      for (int i = 1; i < version.length(); i++) {
+        char character = version.charAt(i);
+        if (!Character.isDigit(character) && character != '.') {
+          return Optional.ofNullable(parsedVersion);
+        }
       }
+      parsedVersion = version;
     }
     return Optional.ofNullable(parsedVersion);
   }

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -40,8 +40,6 @@ import org.apache.commons.lang3.SystemUtils;
  */
 public class VersionManager {
   public static final String CURRENT_VERSION = "0.0.0";
-  public static final String GEODE_130 = "1.3.0";
-  public static final String GEODE_140 = "1.4.0";
 
   private static VersionManager instance;
 
@@ -135,7 +133,7 @@ public class VersionManager {
         if (!Character.isDigit(ch)) {
           break;
         }
-        b.append(s.charAt(i));
+        b.append(ch);
       }
     }
     return b.toString();
@@ -197,12 +195,6 @@ public class VersionManager {
     String parsedVersion = null;
     if (version.length() > 0 && Character.isDigit(version.charAt(0))
         && version.length() >= "1.2.3".length()) {
-      // for (int i = 1; i < version.length(); i++) {
-      // char character = version.charAt(i);
-      // if (!Character.isDigit(character) && character != '.') {
-      // return Optional.ofNullable(parsedVersion);
-      // }
-      // }
       parsedVersion = version;
     }
     return Optional.ofNullable(parsedVersion);

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
@@ -82,7 +82,7 @@ public abstract class LuceneSearchWithRollingUpgradeDUnit extends JUnit4Distribu
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
     // Lucene Compatibility checks start with Apache Geode v1.2.0
     // Removing the versions older than v1.2.0
-    result.removeIf(s -> Integer.parseInt(s) < 120);
+    result.removeIf(s -> Integer.parseInt(VersionManager.getInstance().versionWithNoDots(s)) < 120);
     if (result.size() < 1) {
       throw new RuntimeException("No older versions of Geode were found to test against");
     } else {

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -49,7 +49,7 @@ subprojects {
     compile "org.apache.geode:geode-rebalancer:${oldGeodeVersion}"
   }
 
-  parent.ext.versions.setProperty(projSrcName, sourceSets.main.runtimeClasspath.asPath)
+  parent.ext.versions.setProperty(oldGeodeVersion, sourceSets.main.runtimeClasspath.asPath)
 
   def unpackDest = project.buildDir.toPath().resolve('apache-geode-'.concat(oldGeodeVersion))
 
@@ -58,7 +58,7 @@ subprojects {
   if (downloadInstall) {
     project.dependencies.add "oldInstall", "org.apache.geode:apache-geode:${oldGeodeVersion}@${archiveType}"
 
-    parent.ext.installs.setProperty(projSrcName, unpackDest.toString())
+    parent.ext.installs.setProperty(oldGeodeVersion, unpackDest.toString())
   }
   project.task("downloadAndUnzipFile") {
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeMultipleReceiversDefinedInClusterConfiguration.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeMultipleReceiversDefinedInClusterConfiguration.java
@@ -95,7 +95,7 @@ public class WANRollingUpgradeMultipleReceiversDefinedInClusterConfiguration
     // saved in cluster configuration and multiple receivers are not supported starting in 140.
     // Note: This comparison works because '130' < '140'.
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
-    result.removeIf(version -> (version.compareTo(VersionManager.GEODE_140) >= 0));
+    result.removeIf(version -> (version.compareTo("1.4.0") >= 0));
     if (result.size() < 1) {
       throw new RuntimeException("No older versions of Geode were found to test against");
     }


### PR DESCRIPTION
This modifies geode-old-versions to use the dot-notation product version when building the classpath and install property files.  VersionManager.java and tests are altered to use dot-notation, too.  This lets TomcatInstall forego looking up Version instances in order to get the dot-notation product version string when it builds a classpath to launch a server.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
