### PR TITLE
GEODE-7173: Prevent NullPointerException in AdminDistributedSystemImpl

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
@@ -967,11 +967,11 @@ public class AdminDistributedSystemImpl implements org.apache.geode.admin.AdminD
    * system.
    */
   public DistributionManager getDistributionManager() {
-    if (this.gfManagerAgent == null) {
+    GfManagerAgent agent = gfManagerAgent;
+    if (agent == null) {
       return null;
     }
-    return this.gfManagerAgent.getDM();
-
+    return agent.getDM();
   }
 
   /**


### PR DESCRIPTION
Prevent NPE in AdminDistributedSystemImpl.getDistributionManager()
during shutdown.

Fix race condition involving null volatile field by using a single
local reference.
