### PR TITLE
GEODE-5940: Disable server port in many ServerLauncher tests

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherIntegrationTestCase.java
@@ -52,6 +52,9 @@ import org.apache.geode.internal.process.ProcessType;
  */
 public abstract class ServerLauncherIntegrationTestCase extends LauncherIntegrationTestCase {
 
+  protected static final boolean DEFAULT_SERVER_NOT_NEEDED = true;
+  protected static final boolean DEFAULT_SERVER_IS_NEEDED = false;
+
   protected volatile int defaultServerPort;
   protected volatile int nonDefaultServerPort;
   protected volatile int unusedServerPort;
@@ -104,6 +107,7 @@ public abstract class ServerLauncherIntegrationTestCase extends LauncherIntegrat
    */
   protected Builder newBuilder() {
     return new Builder()
+        .setDisableDefaultServer(DEFAULT_SERVER_NOT_NEEDED)
         .setMemberName(getUniqueName())
         .setWorkingDirectory(getWorkingDirectoryPath())
         .set(DISABLE_AUTO_RECONNECT, "true");

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherLocalIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherLocalIntegrationTest.java
@@ -172,6 +172,7 @@ public class ServerLauncherLocalIntegrationTest extends ServerLauncherLocalInteg
     givenCacheXmlFileWithServerPort(cacheXmlPort);
 
     launcher = startServer(newBuilder()
+        .setDisableDefaultServer(DEFAULT_SERVER_IS_NEEDED)
         .setServerPort(startPort));
 
     // server should use --server-port instead of port in cache.xml
@@ -185,6 +186,7 @@ public class ServerLauncherLocalIntegrationTest extends ServerLauncherLocalInteg
     givenCacheXmlFile();
 
     launcher = awaitStart(newBuilder()
+        .setDisableDefaultServer(DEFAULT_SERVER_IS_NEEDED)
         .setServerPort(defaultServerPort));
 
     // verify server used --server-port instead of default
@@ -196,6 +198,7 @@ public class ServerLauncherLocalIntegrationTest extends ServerLauncherLocalInteg
   public void startWithDefaultPortInUseFailsWithBindException() {
     givenServerPortInUse(defaultServerPort);
     launcher = newBuilder()
+        .setDisableDefaultServer(DEFAULT_SERVER_IS_NEEDED)
         .build();
 
     Throwable thrown = catchThrowable(() -> launcher.start());
@@ -209,6 +212,7 @@ public class ServerLauncherLocalIntegrationTest extends ServerLauncherLocalInteg
   public void startWithServerPortInUseFailsWithBindException() {
     givenServerPortInUse(nonDefaultServerPort);
     launcher = newBuilder()
+        .setDisableDefaultServer(DEFAULT_SERVER_IS_NEEDED)
         .setServerPort(nonDefaultServerPort)
         .build();
 
@@ -233,6 +237,7 @@ public class ServerLauncherLocalIntegrationTest extends ServerLauncherLocalInteg
     String serverBindAddress = "127.0.0.1";
 
     ServerLauncher.Builder launcherBuilder = newBuilder()
+        .setDisableDefaultServer(DEFAULT_SERVER_IS_NEEDED)
         .setHostNameForClients(hostnameForClients)
         .setMaxConnections(maxConnections)
         .setMaxMessageCount(maxMessageCount)

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTestCase.java
@@ -66,7 +66,7 @@ public abstract class ServerLauncherRemoteIntegrationTestCase
   @After
   public void tearDownServerLauncherRemoteIntegrationTestCase() {
     if (process != null) {
-      process.destroy();
+      process.destroyForcibly();
       process = null;
     }
     if (processOutReader != null && processOutReader.isRunning()) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerLauncherRemoteIntegrationTestCase.java
@@ -79,7 +79,7 @@ public abstract class ServerLauncherRemoteIntegrationTestCase
 
   @Override
   public boolean getDisableDefaultServer() {
-    return false;
+    return true;
   }
 
   @Override
@@ -140,7 +140,7 @@ public abstract class ServerLauncherRemoteIntegrationTestCase
   }
 
   protected void startServerShouldFail() throws IOException, InterruptedException {
-    startServerShouldFail(serverCommand);
+    startServerShouldFail(serverCommand.disableDefaultServer(false));
   }
 
   protected void startServerShouldFail(final ServerCommand command)
@@ -152,6 +152,14 @@ public abstract class ServerLauncherRemoteIntegrationTestCase
 
   protected ServerCommand addJvmArgument(final String arg) {
     return serverCommand.addJvmArgument(arg);
+  }
+
+  protected ServerCommand withDefaultServer() {
+    return withDisableDefaultServer(false);
+  }
+
+  protected ServerCommand withDefaultServer(final boolean value) {
+    return withDisableDefaultServer(value);
   }
 
   protected ServerCommand withDisableDefaultServer() {
@@ -171,7 +179,7 @@ public abstract class ServerLauncherRemoteIntegrationTestCase
   }
 
   protected ServerCommand withServerPort(final int port) {
-    return serverCommand.withServerPort(port);
+    return serverCommand.disableDefaultServer(false).withServerPort(port);
   }
 
   private ServerLauncher awaitStart(final File workingDirectory) {


### PR DESCRIPTION
GEODE-5940: Disable server port in many ServerLauncher tests
    
Disable default server in all launcher tests that do not require it.
    
This will decrease the number of failures to launch the server caused
by an underlying BindException because a port is already in use.

GEODE-5940: Use destroyForcibly in ServerLauncherRemoteIntegrationTest tearDown
