### PR TITLE
GEODE-7178: Check operation if instance of Byte for older native clients

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -1463,12 +1463,18 @@ public abstract class BaseCommand implements Command {
     }
 
     // Fallback for older clients.
-    final Operation operation = (Operation) operationPart.getObject();
+    final Object operation = operationPart.getObject();
     if (operation == null) {
-      // native clients may send a null since the op is java-serialized.
+      // older native clients may send a null since the op was java-serialized.
       return defaultOperation;
     }
-    return operation;
-  }
 
+    if (operation instanceof Byte) {
+      // older native clients may send Byte object.
+      return Operation.fromOrdinal((Byte) operation);
+    }
+
+    // Older java clients send operation as java-serialized
+    return (Operation) operation;
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/BaseCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/BaseCommandJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -26,6 +27,8 @@ import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.apache.geode.cache.Operation;
+import org.apache.geode.internal.cache.OpType;
 import org.apache.geode.internal.cache.execute.ServerToClientFunctionResultSender;
 import org.apache.geode.internal.cache.tier.sockets.command.ExecuteRegionFunction61;
 import org.apache.geode.internal.cache.tier.sockets.command.ExecuteRegionFunction65;
@@ -91,4 +94,79 @@ public class BaseCommandJUnitTest {
 
   }
 
+  @Test
+  public void getOperationWhenIsBytesIsFalse_whenOperationPartIsByte_thenReturnsOperation()
+      throws Exception {
+    Part operationPart = mock(Part.class);
+    when(operationPart.getObject()).thenReturn(OpType.CREATE);
+
+    Operation actualOperation = BaseCommand.getOperation(operationPart, null);
+
+    assertThat(actualOperation).isEqualTo(Operation.CREATE);
+  }
+
+  @Test
+  public void getOperationWhenIsBytesIsFalse_whenOperationPartIsNull_thenReturnsDefaultOperation()
+      throws Exception {
+    Part operationPart = mock(Part.class);
+    when(operationPart.getObject()).thenReturn(null);
+
+    Operation defaultOperation = mock(Operation.class);
+
+    Operation actualOperation = BaseCommand.getOperation(operationPart, defaultOperation);
+
+    assertThat(actualOperation).isEqualTo(defaultOperation);
+  }
+
+  @Test
+  public void getOperationWhenIsBytesIsFalse_whenOperationPartIsOperation_thenReturnsThatOperation()
+      throws Exception {
+    Part operationPart = mock(Part.class);
+    when(operationPart.getObject()).thenReturn(Operation.CREATE);
+
+    Operation actualOperation = BaseCommand.getOperation(operationPart, null);
+
+    assertThat(actualOperation).isEqualTo(Operation.CREATE);
+  }
+
+  @Test
+  public void getOperationWhenIsBytesIsTrue_whenOperationSerializedFormIsNull_thenReturnsDefaultOperation()
+      throws Exception {
+    Part operationPart = mock(Part.class);
+    when(operationPart.isBytes()).thenReturn(true);
+    when(operationPart.getSerializedForm()).thenReturn(null);
+
+    Operation defaultOperation = mock(Operation.class);
+
+    Operation actualOperation = BaseCommand.getOperation(operationPart, defaultOperation);
+
+    assertThat(actualOperation).isEqualTo(defaultOperation);
+  }
+
+  @Test
+  public void getOperationWhenIsBytesIsTrue_whenOperationSerializedFormIsLengthZero_thenReturnsDefaultOperation()
+      throws Exception {
+    Part operationPart = mock(Part.class);
+    when(operationPart.isBytes()).thenReturn(true);
+    when(operationPart.getSerializedForm()).thenReturn(new byte[0]);
+
+    Operation defaultOperation = mock(Operation.class);
+
+    Operation actualOperation = BaseCommand.getOperation(operationPart, defaultOperation);
+
+    assertThat(actualOperation).isEqualTo(defaultOperation);
+  }
+
+  @Test
+  public void getOperationWhenIsBytesIsTrue_whenOperationSerializedFormIsValid_thenReturnsOperationFromOrdinal()
+      throws Exception {
+    Part operationPart = mock(Part.class);
+    when(operationPart.isBytes()).thenReturn(true);
+    byte[] serializedForm = {OpType.CREATE};
+    when(operationPart.getSerializedForm()).thenReturn(serializedForm);
+
+    Operation actualOperation = BaseCommand.getOperation(operationPart, null);
+
+    assertThat(actualOperation).isEqualTo(Operation.CREATE);
+  }
 }


### PR DESCRIPTION
Co-authored-by: Blake Bender <bbender@pivotal.io>
Co-authored-by: Michael Oleske <moleske@pivotal.io>

Older Geode Native clients send Byte object, so it would be good to still check.
Back-filled unit tests for the getOperation

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
