### PR TITLE
GEODE-7179: alter async queue command to change state of event proces…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
@@ -68,6 +68,9 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
   static final String BATCH_TIME_INTERVAL_HELP = CREATE_ASYNC_EVENT_QUEUE__BATCHTIMEINTERVAL__HELP;
   static final String MAXIMUM_QUEUE_MEMORY_HELP =
       CREATE_ASYNC_EVENT_QUEUE__MAXIMUM_QUEUE_MEMORY__HELP;
+  static final String PAUSE_EVENT_PROCESSING = "pause-event-processing";
+  static final String PAUSE_EVENT_PROCESSING_HELP =
+      "Pause event processing when the async event queue is created";
 
   @CliCommand(value = COMMAND_NAME, help = COMMAND_HELP)
   @CliMetaData(
@@ -80,7 +83,10 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
           help = BATCH_TIME_INTERVAL_HELP) Integer batchTimeInterval,
       @CliOption(key = MAX_QUEUE_MEMORY, help = MAXIMUM_QUEUE_MEMORY_HELP) Integer maxQueueMemory,
       @CliOption(key = IFEXISTS, help = IFEXISTS_HELP, specifiedDefaultValue = "true",
-          unspecifiedDefaultValue = "false") boolean ifExists)
+          unspecifiedDefaultValue = "false") boolean ifExists,
+      @CliOption(key = PAUSE_EVENT_PROCESSING, help = PAUSE_EVENT_PROCESSING_HELP,
+          specifiedDefaultValue = "true",
+          unspecifiedDefaultValue = "false") boolean pauseEventProcessing)
       throws IOException, SAXException, ParserConfigurationException, TransformerException,
       EntityNotFoundException {
 
@@ -98,6 +104,7 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
 
     CacheConfig.AsyncEventQueue aeqConfiguration = new CacheConfig.AsyncEventQueue();
     aeqConfiguration.setId(id);
+    aeqConfiguration.setPauseEventProcessing(pauseEventProcessing);
 
     if (batchSize != null) {
       aeqConfiguration.setBatchSize(batchSize + "");
@@ -162,6 +169,9 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
 
         if (StringUtils.isNotBlank(aeqConfiguration.getMaximumQueueMemory())) {
           queue.setMaximumQueueMemory(aeqConfiguration.getMaximumQueueMemory());
+        }
+        if (aeqConfiguration.isPauseEventProcessing() != null) {
+          queue.setPauseEventProcessing(aeqConfiguration.isPauseEventProcessing());
         }
         aeqConfigsHaveBeenUpdated = true;
       }


### PR DESCRIPTION
…sor during creation.

	* Alter the state of the event processor during the creation of the AEQ
	* The state can be changed to paused from not paused and vice versa.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
