### PR TITLE
Declare dependency on  interal -serialization and -common projects

### DIFF
--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -25,6 +25,8 @@ evaluationDependsOn(":geode-core")
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
+  implementation(project(':geode-common'))
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   integrationTestCompile(project(':extensions:geode-modules-test')) {
     exclude module: 'geode-modules'

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -207,6 +207,8 @@ dependencies {
   integrationTestRuntime('io.swagger:swagger-annotations')
 
 
+  distributedTestImplementation(project(':geode-common'))
+  distributedTestImplementation(project(':geode-serialization'))
   distributedTestCompile(project(':geode-core'))
   distributedTestCompile(project(':geode-dunit')){
     exclude module: 'geode-core'

--- a/geode-assembly/geode-assembly-test/build.gradle
+++ b/geode-assembly/geode-assembly-test/build.gradle
@@ -23,6 +23,7 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compileOnly(project(':extensions:geode-modules-test'))
+  compileOnly(project(':geode-common'))
   compileOnly(project(':geode-core'))
   compileOnly(project(':geode-pulse'))
   compileOnly('com.fasterxml.jackson.core:jackson-databind')

--- a/geode-connectors/build.gradle
+++ b/geode-connectors/build.gradle
@@ -49,6 +49,7 @@ task downloadJdbcJars(type:Copy) {
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compile(project(':geode-common'))
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'

--- a/geode-connectors/src/test/resources/expected-pom.xml
+++ b/geode-connectors/src/test/resources/expected-pom.xml
@@ -123,5 +123,10 @@
       <artifactId>rmiio</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -330,13 +330,10 @@ dependencies {
   implementation('com.healthmarketscience.rmiio:rmiio')
 
   //Geode-common has annotations and other pieces used geode-core
-  //Currently it has ExpirationAction in it, which is an API dependency in core, but
-  //probably does not belong in this project
-  api(project(':geode-common'))
-  api(project(':geode-unsafe'))
+  implementation(project(':geode-common'))
+  implementation(project(':geode-unsafe'))
+  implementation(project(':geode-serialization'))
 
-  api(project(':geode-serialization'))
-  
   //geode-management currently has pieces of the public API
   //copied into it, so it is an API dependency
   api(project(':geode-management'))

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -103,21 +103,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-unsafe</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-serialization</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-management</artifactId>
       <scope>compile</scope>
     </dependency>
@@ -268,6 +253,21 @@
     <dependency>
       <groupId>com.healthmarketscience.rmiio</groupId>
       <artifactId>rmiio</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-unsafe</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/geode-cq/build.gradle
+++ b/geode-cq/build.gradle
@@ -23,7 +23,8 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compile(project(':geode-core'))
-  testCompile(project(':geode-core'))
+  implementation(project(':geode-common'))
+  implementation(project(':geode-serialization'))
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
   }

--- a/geode-cq/src/test/resources/expected-pom.xml
+++ b/geode-cq/src/test/resources/expected-pom.xml
@@ -56,5 +56,15 @@
       <artifactId>log4j-api</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-dunit/build.gradle
+++ b/geode-dunit/build.gradle
@@ -22,6 +22,8 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
+  implementation(project(':geode-common'))
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
 
   compile(project(':geode-junit')) {

--- a/geode-dunit/src/test/resources/expected-pom.xml
+++ b/geode-dunit/src/test/resources/expected-pom.xml
@@ -170,5 +170,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-experimental-driver/build.gradle
+++ b/geode-experimental-driver/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     exclude module: 'junit-dep'
   }
 
+  integrationTestImplementation(project(':geode-serialization'))
   integrationTestCompile('com.github.stefanbirkner:system-rules') {
     exclude module: 'junit-dep'
   }

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -24,6 +24,9 @@ dependencies {
   compile(platform(project(':boms:geode-all-bom')))
 
   compileOnly(project(':geode-core'))
+  compileOnly(project(':geode-serialization'))
+  compileOnly(project(':geode-common'))
+  compileOnly(project(':geode-unsafe'))
 
   compile('com.fasterxml.jackson.core:jackson-annotations')
   compile('com.fasterxml.jackson.core:jackson-databind')

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -51,6 +51,7 @@ dependencies {
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   compile(project(':geode-common'))
   compile('org.apache.lucene:lucene-analyzers-common')

--- a/geode-lucene/geode-lucene-test/build.gradle
+++ b/geode-lucene/geode-lucene-test/build.gradle
@@ -23,6 +23,7 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compile('org.apache.lucene:lucene-core')
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   compileOnly(project(':geode-lucene'))
 

--- a/geode-lucene/src/test/resources/expected-pom.xml
+++ b/geode-lucene/src/test/resources/expected-pom.xml
@@ -125,6 +125,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-phonetic</artifactId>
       <scope>runtime</scope>

--- a/geode-memcached/build.gradle
+++ b/geode-memcached/build.gradle
@@ -20,7 +20,8 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
-  api(platform(project(':boms:geode-all-bom')))
+  implementation(platform(project(':boms:geode-all-bom')))
+  implementation(project(':geode-common'))
   implementation(project(':geode-core'))
   implementation('org.apache.logging.log4j:log4j-api')
   implementation('com.github.stephenc.findbugs:findbugs-annotations')

--- a/geode-memcached/src/test/resources/expected-pom.xml
+++ b/geode-memcached/src/test/resources/expected-pom.xml
@@ -48,6 +48,11 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/geode-old-client-support/build.gradle
+++ b/geode-old-client-support/build.gradle
@@ -21,12 +21,14 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':geode-core'))
-  distributedTestCompile(project(':geode-dunit')){
+  implementation(platform(project(':boms:geode-all-bom')))
+  implementation(project(':geode-core'))
+  implementation(project(':geode-serialization'))
+  distributedTestImplementation(project(':geode-dunit')){
     exclude module: 'geode-core'
   }
 
 
-  distributedTestCompile('junit:junit')
+  distributedTestImplementation('junit:junit')
 }
+

--- a/geode-old-client-support/src/test/resources/expected-pom.xml
+++ b/geode-old-client-support/src/test/resources/expected-pom.xml
@@ -49,7 +49,12 @@
     <dependency>
       <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
-      <scope>compile</scope>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 </project>

--- a/geode-protobuf/build.gradle
+++ b/geode-protobuf/build.gradle
@@ -23,6 +23,7 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compile(project(':geode-common'))
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   compile(project(':geode-protobuf-messages'))
   testCompile(project(':geode-core'))

--- a/geode-protobuf/src/test/resources/expected-pom.xml
+++ b/geode-protobuf/src/test/resources/expected-pom.xml
@@ -76,5 +76,10 @@
       <artifactId>shiro-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-rebalancer/build.gradle
+++ b/geode-rebalancer/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compile(project(':geode-common'))
   compile(project(':geode-core'))
+  implementation(project(':geode-serialization'))
   integrationTestCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
   }

--- a/geode-rebalancer/src/test/resources/expected-pom.xml
+++ b/geode-rebalancer/src/test/resources/expected-pom.xml
@@ -80,5 +80,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -21,6 +21,8 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
+  implementation(project(':geode-common'))
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   compile('com.github.davidmoten:geo')
   compile('io.netty:netty-all')

--- a/geode-redis/src/test/resources/expected-pom.xml
+++ b/geode-redis/src/test/resources/expected-pom.xml
@@ -66,5 +66,15 @@
       <artifactId>log4j-api</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-serialization/build.gradle
+++ b/geode-serialization/build.gradle
@@ -20,12 +20,10 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-
+  implementation(platform(project(':boms:geode-all-bom')))
 
   //Geode-common has annotations and other pieces used by geode-serialization
-  api(project(':geode-common'))
-  api(project(':geode-unsafe'))
+  implementation(project(':geode-common'))
 
   //FastUtil contains optimized collections that are used in multiple places in core
   implementation('it.unimi.dsi:fastutil')
@@ -36,37 +34,35 @@ dependencies {
     ext.optional = true
   }
 
-   testCompile(project(':geode-junit')) {
+  testImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'
   }
-  testCompile(project(':geode-concurrency-test'))
+  testImplementation(project(':geode-concurrency-test'))
 
   testImplementation('com.tngtech.archunit:archunit-junit4')
-
-  testCompile('org.apache.bcel:bcel')
-  testCompile('org.mockito:mockito-core')
-  testCompile('junit:junit')
-  testCompile('org.assertj:assertj-core')
+  testImplementation('org.apache.bcel:bcel')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
 
   testRuntime(project(':geode-old-versions'))
 
-  integrationTestCompile(project(':geode-junit')) {
+  integrationTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'
   }
-  integrationTestCompile(project(':geode-dunit')) {
+  integrationTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-serialization'
   }
-  integrationTestCompile('pl.pragmatists:JUnitParams')
-  distributedTestCompile(project(':geode-junit')) {
+  integrationTestImplementation('pl.pragmatists:JUnitParams')
+  distributedTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'
   }
-  distributedTestCompile(project(':geode-dunit')) {
+  distributedTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-serialization'
   }
-  distributedTestCompile('pl.pragmatists:JUnitParams')
+  distributedTestImplementation('pl.pragmatists:JUnitParams')
   distributedTestRuntime(project(':geode-old-versions'))
   upgradeTestRuntime(project(':geode-old-versions'))
- 
 }
 
 distributedTest {

--- a/geode-serialization/src/test/resources/expected-pom.xml
+++ b/geode-serialization/src/test/resources/expected-pom.xml
@@ -49,12 +49,7 @@
     <dependency>
       <groupId>org.apache.geode</groupId>
       <artifactId>geode-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-unsafe</artifactId>
-      <scope>compile</scope>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>it.unimi.dsi</groupId>

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     // See GEODE-6128 -- ignore xml-apis in linter to avoid changes with every run.
     upgradeTestCompile('xml-apis:xml-apis:1.4.01')
   }
+  implementation(project(':geode-common'))
+  implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
 
   compileOnly('org.apache.logging.log4j:log4j-api:2.12.0')

--- a/geode-wan/src/test/resources/expected-pom.xml
+++ b/geode-wan/src/test/resources/expected-pom.xml
@@ -51,5 +51,15 @@
       <artifactId>geode-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-web-api/build.gradle
+++ b/geode-web-api/build.gradle
@@ -27,6 +27,8 @@ dependencies {
   compileOnly(platform(project(':boms:geode-all-bom')))
 
   compileOnly(project(':geode-core'))
+  compileOnly(project(':geode-common'))
+  compileOnly(project(':geode-serialization'))
 
   compileOnly('javax.servlet:javax.servlet-api')
 

--- a/geode-web-management/build.gradle
+++ b/geode-web-management/build.gradle
@@ -48,6 +48,8 @@ dependencies {
   compile(platform(project(':boms:geode-all-bom'))) {
     exclude module: "jackson-annotations"
   }
+  compileOnly(project(':geode-common'))
+  compileOnly(project(':geode-serialization'))
   compileOnly(project(':geode-core'))
 
   compileOnly('javax.servlet:javax.servlet-api')

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   //transitive dependencies from geode-web.war. Since geode-web.war is ony run within
   //a container that has geode-core on the classpath, is prevents duplicating jars. geode-core
   //in particular should not be duplicated in the war.
+  providedCompile(project(':geode-common'))
   providedCompile(project(path: ':geode-core')) {
     //spring-web is excluded from the providedCompile configuration to ensure
     //that it is included as part of the war. spring-web must be loaded with the war's

--- a/geode-web/src/test/resources/expected-pom.xml
+++ b/geode-web/src/test/resources/expected-pom.xml
@@ -48,6 +48,11 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
       <scope>compile</scope>
       <exclusions>


### PR DESCRIPTION
These subprojects declare classes that are internal to Geode and not
intended for outside development consumption. Make them 'implementation'
not 'compile' or 'api' dependencies.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Scott Jewell <sjewell@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
