### PR TITLE
GEODE-7035 - adding a new enumInfo will check from local map, the same behavior as adding a pdxType

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
@@ -217,8 +217,6 @@ public class PeerTypeRegistration implements TypeRegistration {
     if (!getIdToType().isEmpty()) {
       verifyConfiguration();
     }
-
-    buildReverseMapsFromRegion();
   }
 
   protected DistributedLockService getLockService() {

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistrationReverseMap.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistrationReverseMap.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.pdx.internal;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.Region;
+
+public class PeerTypeRegistrationReverseMap {
+  /**
+   * When a new pdxType or a new enumInfo is added to idToType region, its
+   * listener will add the new type to the pendingTypeToId first, to make sure
+   * the distribution finished.
+   * Then any member who wants to use this new pdxType has to get the dlock to
+   * flush the pendingTypeToId map into typeToId. This design to guarantee that
+   * when using the new pdxType, it should have been distributed to all members.
+   */
+  private final Map<PdxType, Integer> pendingTypeToId =
+      Collections.synchronizedMap(new HashMap<>());
+  private final Map<EnumInfo, EnumId> pendingEnumToId =
+      Collections.synchronizedMap(new HashMap<>());
+
+  /**
+   * This map serves two purposes. It lets us look up an id based on a type, if we previously
+   * found that type in the region. And, if a type is present in this map, that means we read
+   * the type while holding the dlock, which means the type was distributed to all members.
+   */
+  private final Map<PdxType, Integer> typeToId = Collections.synchronizedMap(new HashMap<>());
+
+  private final Map<EnumInfo, EnumId> enumToId = Collections.synchronizedMap(new HashMap<>());
+
+  void save(Object key, Object value) {
+    if (value instanceof PdxType) {
+      PdxType type = (PdxType) value;
+      typeToId.put(type, (Integer) key);
+    } else if (value instanceof EnumInfo) {
+      EnumInfo info = (EnumInfo) value;
+      enumToId.put(info, (EnumId) key);
+    }
+  }
+
+  void saveToPending(Object key, Object value) {
+    if (value instanceof PdxType) {
+      PdxType type = (PdxType) value;
+      pendingTypeToId.put(type, (Integer) key);
+    } else if (value instanceof EnumInfo) {
+      EnumInfo info = (EnumInfo) value;
+      pendingEnumToId.put(info, (EnumId) key);
+    }
+  }
+
+  int typeToIdSize() {
+    return typeToId.size();
+  }
+
+  int enumToIdSize() {
+    return enumToId.size();
+  }
+
+  Integer getIdFromReverseMap(PdxType newType) {
+    return typeToId.get(newType);
+  }
+
+  EnumId getIdFromReverseMap(EnumInfo newInfo) {
+    return enumToId.get(newInfo);
+  }
+
+  // The reverse maps should only be loaded from the region if there is a mismatch in size between
+  // the region and all reverse maps, which should only occur when initializing a new
+  // PeerTypeRegistration in a system with an existing and not-empty PdxTypes region
+  boolean shouldReloadFromRegion(Region pdxRegion) {
+    if (pdxRegion == null) {
+      return false;
+    }
+    return ((typeToId.size() + pendingTypeToId.size() + enumToId.size()
+        + pendingEnumToId.size()) != pdxRegion.size());
+  }
+
+  void flushPendingReverseMap() {
+    if (!pendingTypeToId.isEmpty()) {
+      typeToId.putAll(pendingTypeToId);
+      pendingTypeToId.clear();
+    }
+    if (!pendingEnumToId.isEmpty()) {
+      enumToId.putAll(pendingEnumToId);
+      pendingEnumToId.clear();
+    }
+  }
+
+  // This should only be called prior to reloading the maps from the region
+  void clear() {
+    typeToId.clear();
+    enumToId.clear();
+    pendingTypeToId.clear();
+    pendingEnumToId.clear();
+  }
+
+  @VisibleForTesting
+  int pendingTypeToIdSize() {
+    return pendingTypeToId.size();
+  }
+
+  @VisibleForTesting
+  int pendingEnumToIdSize() {
+    return pendingEnumToId.size();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationReverseMapTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationReverseMapTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.pdx.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.Region;
+
+public class PeerTypeRegistrationReverseMapTest {
+
+  @Test
+  public void saveCorrectlyAddsOnlyToReverseMaps() {
+    PeerTypeRegistrationReverseMap map = new PeerTypeRegistrationReverseMap();
+    assertThat(map.typeToIdSize()).isEqualTo(0);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(0);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+
+    addPdxTypeToMap(map);
+
+    assertThat(map.typeToIdSize()).isEqualTo(1);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(0);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+
+    addEnumInfoToMap(map);
+
+    assertThat(map.typeToIdSize()).isEqualTo(1);
+    assertThat(map.enumToIdSize()).isEqualTo(1);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(0);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+
+    Object fakeKey = mock(Object.class);
+    Object fakeValue = mock(Object.class);
+    map.save(fakeKey, fakeValue);
+
+    assertThat(map.typeToIdSize()).isEqualTo(1);
+    assertThat(map.enumToIdSize()).isEqualTo(1);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(0);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+  }
+
+  @Test
+  public void saveToPendingCorrectlyAddsOnlyToPendingMaps() {
+    PeerTypeRegistrationReverseMap map = new PeerTypeRegistrationReverseMap();
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(0);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+    assertThat(map.typeToIdSize()).isEqualTo(0);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+
+    addPdxTypeToPendingMap(map);
+
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(1);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+    assertThat(map.typeToIdSize()).isEqualTo(0);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+
+    addEnumInfoToPendingMap(map);
+
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(1);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(1);
+    assertThat(map.typeToIdSize()).isEqualTo(0);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+
+    Object fakeKey = mock(Object.class);
+    Object fakeValue = mock(Object.class);
+    map.saveToPending(fakeKey, fakeValue);
+
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(1);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(1);
+    assertThat(map.typeToIdSize()).isEqualTo(0);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReloadFromRegionReturnsCorrectly() {
+    PeerTypeRegistrationReverseMap map = new PeerTypeRegistrationReverseMap();
+
+    assertThat(map.shouldReloadFromRegion(null)).isFalse();
+
+    Region region = mock(Region.class);
+
+    when(region.size()).thenReturn(0);
+    // When everything is empty, we do not need to reload
+    assertThat(map.shouldReloadFromRegion(region)).isFalse();
+
+    when(region.size()).thenReturn(2);
+    // Region size is 2, reverse maps size total is 0, so we should reload
+    assertThat(map.shouldReloadFromRegion(region)).isTrue();
+
+    addPdxTypeToMap(map);
+    addEnumInfoToPendingMap(map);
+    // Region size is 2, reverse maps size total is 2, so we do not need to reload
+    assertThat(map.shouldReloadFromRegion(region)).isFalse();
+
+    map.flushPendingReverseMap();
+    // Flushing should not change the result of the call
+    assertThat(map.shouldReloadFromRegion(region)).isFalse();
+
+    addPdxTypeToMap(map);
+    addEnumInfoToPendingMap(map);
+    // Region size is 2, reverse maps size total is 4, so we should reload
+    assertThat(map.shouldReloadFromRegion(region)).isTrue();
+  }
+
+  @Test
+  public void flushPendingReverseMapCorrectlyPopulatesReverseMap() {
+    PeerTypeRegistrationReverseMap map = new PeerTypeRegistrationReverseMap();
+
+    addPdxTypeToPendingMap(map);
+    addPdxTypeToPendingMap(map);
+    addEnumInfoToPendingMap(map);
+    addEnumInfoToPendingMap(map);
+
+    assertThat(map.typeToIdSize()).isEqualTo(0);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(2);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(2);
+
+    map.flushPendingReverseMap();
+
+    assertThat(map.typeToIdSize()).isEqualTo(2);
+    assertThat(map.enumToIdSize()).isEqualTo(2);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(0);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+  }
+
+  @Test
+  public void clearRemovesAllEntriesFromReverseAndPendingMaps() {
+    PeerTypeRegistrationReverseMap map = new PeerTypeRegistrationReverseMap();
+
+    addPdxTypeToMap(map);
+    addEnumInfoToMap(map);
+    addPdxTypeToPendingMap(map);
+    addEnumInfoToPendingMap(map);
+
+    assertThat(map.typeToIdSize()).isEqualTo(1);
+    assertThat(map.enumToIdSize()).isEqualTo(1);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(1);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(1);
+
+    map.clear();
+
+    assertThat(map.typeToIdSize()).isEqualTo(0);
+    assertThat(map.enumToIdSize()).isEqualTo(0);
+    assertThat(map.pendingTypeToIdSize()).isEqualTo(0);
+    assertThat(map.pendingEnumToIdSize()).isEqualTo(0);
+  }
+
+  private void addEnumInfoToMap(PeerTypeRegistrationReverseMap map) {
+    EnumId enumId = mock(EnumId.class);
+    EnumInfo enumInfo = mock(EnumInfo.class);
+    map.save(enumId, enumInfo);
+  }
+
+  private void addPdxTypeToMap(PeerTypeRegistrationReverseMap map) {
+    Integer pdxId = map.typeToIdSize();
+    PdxType pdxType = mock(PdxType.class);
+    map.save(pdxId, pdxType);
+  }
+
+  private void addEnumInfoToPendingMap(PeerTypeRegistrationReverseMap map) {
+    EnumId enumId = mock(EnumId.class);
+    EnumInfo enumInfo = mock(EnumInfo.class);
+    map.saveToPending(enumId, enumInfo);
+  }
+
+  private void addPdxTypeToPendingMap(PeerTypeRegistrationReverseMap map) {
+    Integer pdxId = map.typeToIdSize();
+    PdxType pdxType = mock(PdxType.class);
+    map.saveToPending(pdxId, pdxType);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationTest.java
@@ -18,19 +18,34 @@ package org.apache.geode.pdx.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.internal.util.reflection.FieldSetter;
 
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsType;
+import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.DistributedLockService;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.CacheConfig;
+import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.statistics.StatisticsManager;
@@ -38,42 +53,138 @@ import org.apache.geode.pdx.PdxInitializationException;
 
 public class PeerTypeRegistrationTest {
 
-  private final PeerTypeRegistration peerTypeRegistration;
+  private final InternalDistributedSystem internalDistributedSystem =
+      mock(InternalDistributedSystem.class);
+  private final DistributionManager distributionManager = mock(DistributionManager.class);
+  private final StatisticsManager statisticsManager = mock(StatisticsManager.class);
+  private final StatisticsType statisticsType = mock(StatisticsType.class);
+  private final Statistics statistics = mock(Statistics.class);
+  private final InternalCache internalCache = mock(InternalCache.class);
+  @SuppressWarnings("unchecked")
+  private final Region<Object, Object> region = mock(Region.class);
+  private final TXManagerImpl txManager = mock(TXManagerImpl.class);
+  @SuppressWarnings("deprecation")
+  private final AttributesFactory factory = mock(AttributesFactory.class);
 
-  public PeerTypeRegistrationTest() throws IOException, ClassNotFoundException {
-    final InternalDistributedSystem internalDistributedSystem =
-        mock(InternalDistributedSystem.class);
-    final DistributionManager distributionManager = mock(DistributionManager.class);
+  @Before
+  public void setUp() throws IOException, ClassNotFoundException {
     when(internalDistributedSystem.getDistributionManager()).thenReturn(distributionManager);
-    final StatisticsManager statisticsManager = mock(StatisticsManager.class);
-    final StatisticsType statisticsType = mock(StatisticsType.class);
     when(statisticsManager.createType(any(), any(), any())).thenReturn(statisticsType);
-    final Statistics statistics = mock(Statistics.class);
     when(statisticsManager.createAtomicStatistics(any(), any())).thenReturn(statistics);
     when(internalDistributedSystem.getStatisticsManager()).thenReturn(statisticsManager);
-    final InternalCache internalCache = mock(InternalCache.class);
     when(internalCache.getInternalDistributedSystem()).thenReturn(internalDistributedSystem);
-    @SuppressWarnings("unchecked")
-    final Region<Object, Object> region = mock(Region.class);
-    when(region.size()).thenReturn(1);
     when(internalCache.createVMRegion(eq(PeerTypeRegistration.REGION_NAME), any(), any()))
         .thenReturn(region);
     when(region.getRegionService()).thenReturn(internalCache);
-    final TXManagerImpl txManager = mock(TXManagerImpl.class);
     when(internalCache.getCacheTransactionManager()).thenReturn(txManager);
-    peerTypeRegistration = new PeerTypeRegistration(internalCache);
   }
 
   @Test
   public void getLocalSizeThrowsWhenNotInitialized() {
+    PeerTypeRegistration peerTypeRegistration = new PeerTypeRegistration(internalCache);
     assertThatThrownBy(peerTypeRegistration::getLocalSize)
         .isInstanceOf(PdxInitializationException.class);
   }
 
   @Test
   public void getLocalSizeReturnsValueAfterInitialized() {
+    when(region.size()).thenReturn(1);
+    PeerTypeRegistration peerTypeRegistration = new PeerTypeRegistration(internalCache);
     peerTypeRegistration.initialize();
+
     assertThat(peerTypeRegistration.getLocalSize()).isEqualTo(1);
   }
 
+  @Test
+  public void typeRegistryCacheIsFlushedWhenNotNull() {
+    TypeRegistry typeRegistry = mock(TypeRegistry.class);
+    when(internalCache.getPdxRegistry()).thenReturn(typeRegistry);
+
+    PeerTypeRegistration peerTypeRegistration = new PeerTypeRegistration(internalCache);
+    peerTypeRegistration.initialize();
+
+    verify(typeRegistry).flushCache();
+  }
+
+  @Test
+  public void pdxPersistenceIsSetWithUserDefinedDiskStore() throws NoSuchFieldException {
+    PeerTypeRegistration peerTypeRegistration = spy(new PeerTypeRegistration(internalCache));
+    doReturn(factory).when(peerTypeRegistration).getAttributesFactory();
+    when(internalCache.getPdxPersistent()).thenReturn(true);
+    CacheConfig config = mock(CacheConfig.class);
+    when(internalCache.getCacheConfig()).thenReturn(config);
+
+    FieldSetter.setField(config, config.getClass().getField("pdxDiskStoreUserSet"), true);
+    final String diskStoreName = "userDiskStore";
+    when(internalCache.getPdxDiskStore()).thenReturn(diskStoreName);
+
+    peerTypeRegistration.initialize();
+
+    verify(factory).setDiskStoreName(diskStoreName);
+    verify(factory).setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+  }
+
+  @Test
+  public void pdxPersistenceIsSetWithDefaultDiskStore() {
+    PeerTypeRegistration peerTypeRegistration = spy(new PeerTypeRegistration(internalCache));
+    doReturn(factory).when(peerTypeRegistration).getAttributesFactory();
+    when(internalCache.getPdxPersistent()).thenReturn(true);
+    CacheConfig config = mock(CacheConfig.class);
+    when(internalCache.getCacheConfig()).thenReturn(config);
+
+    DiskStoreImpl defaultDiskStore = mock(DiskStoreImpl.class);
+    when(internalCache.getOrCreateDefaultDiskStore()).thenReturn(defaultDiskStore);
+    final String diskStoreName = "defaultDiskStoreName";
+    when(defaultDiskStore.getName()).thenReturn(diskStoreName);
+
+    peerTypeRegistration.initialize();
+
+    verify(factory).setDiskStoreName(diskStoreName);
+    verify(factory).setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+  }
+
+  @Test
+  public void pdxPersistenceIsNotSetWhenPdxPersistenceIsFalse() {
+    PeerTypeRegistration peerTypeRegistration = spy(new PeerTypeRegistration(internalCache));
+    doReturn(factory).when(peerTypeRegistration).getAttributesFactory();
+
+    peerTypeRegistration.initialize();
+
+    verify(factory, times(0)).setDiskStoreName(any(String.class));
+    verify(factory).setDataPolicy(DataPolicy.REPLICATE);
+  }
+
+  @Test(expected = PdxInitializationException.class)
+  public void pdxInitializationExceptionIsThrownInInitializeWhenRegionCreationFails()
+      throws IOException, ClassNotFoundException {
+    doThrow(new IOException()).when(internalCache).createVMRegion(any(), any(), any());
+    PeerTypeRegistration peerTypeRegistration = new PeerTypeRegistration(internalCache);
+    peerTypeRegistration.initialize();
+  }
+
+  @Test
+  public void buildLocalMapsFromRegionIsNotCalledIfLocalMapsAreUpToDate() {
+    PeerTypeRegistration peerTypeRegistration = spy(new PeerTypeRegistration(internalCache));
+
+    DistributedLockService dlockService = mock(DistributedLockService.class);
+    doReturn(dlockService).when(peerTypeRegistration).getLockService();
+
+    when(dlockService.lock(anyString(), anyLong(), anyLong())).thenReturn(true);
+
+    when(internalCache.getDistributionManager()).thenReturn(distributionManager);
+    InternalDistributedSystem internalDistributedSystem = mock(InternalDistributedSystem.class);
+    when(distributionManager.getSystem()).thenReturn(internalDistributedSystem);
+    CancelCriterion cancelCriterion = mock(CancelCriterion.class);
+    when(distributionManager.getCancelCriterion()).thenReturn(cancelCriterion);
+
+    // buildReverseMapsFromRegion() is called during initialization of the PeerTypeRegistration, so
+    // we expect to see one invocation here
+    peerTypeRegistration.initialize();
+    verify(peerTypeRegistration, times(1)).buildReverseMapsFromRegion();
+
+    PdxType newType = mock(PdxType.class);
+    peerTypeRegistration.defineType(newType);
+
+    verify(peerTypeRegistration, times(1)).buildReverseMapsFromRegion();
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationTest.java
@@ -177,14 +177,11 @@ public class PeerTypeRegistrationTest {
     CancelCriterion cancelCriterion = mock(CancelCriterion.class);
     when(distributionManager.getCancelCriterion()).thenReturn(cancelCriterion);
 
-    // buildReverseMapsFromRegion() is called during initialization of the PeerTypeRegistration, so
-    // we expect to see one invocation here
     peerTypeRegistration.initialize();
-    verify(peerTypeRegistration, times(1)).buildReverseMapsFromRegion();
 
     PdxType newType = mock(PdxType.class);
     peerTypeRegistration.defineType(newType);
 
-    verify(peerTypeRegistration, times(1)).buildReverseMapsFromRegion();
+    verify(peerTypeRegistration, times(0)).buildReverseMapsFromRegion();
   }
 }


### PR DESCRIPTION
- Brought Enum behaviour in line with PdxType behaviour in PeerTypeRegistration
- Refactored ReverseMap to not be an internal class of PeerTypeRegistration
- Added unit tests for PeerTypeRegistration and PeerTypeRegistrationReverseMap

Authored-by: Donal Evans <doevans@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
