### PR TITLE
GEODE-7178: Check operation if instance of Byte and Destroy for older…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -1448,27 +1448,4 @@ public abstract class BaseCommand implements Command {
       appendInterestResponseKey(region, riKey, entryKey, collector, servConn);
     }
   }
-
-  protected static Operation getOperation(final Part operationPart,
-      final Operation defaultOperation) throws Exception {
-
-    if (operationPart.isBytes()) {
-      final byte[] bytes = operationPart.getSerializedForm();
-      if (null == bytes || 0 == bytes.length) {
-        // older clients can send empty bytes for default operation.
-        return defaultOperation;
-      } else {
-        return Operation.fromOrdinal(bytes[0]);
-      }
-    }
-
-    // Fallback for older clients.
-    final Operation operation = (Operation) operationPart.getObject();
-    if (operation == null) {
-      // native clients may send a null since the op is java-serialized.
-      return defaultOperation;
-    }
-    return operation;
-  }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/BaseCommandJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/BaseCommandJUnitTest.java
@@ -90,5 +90,4 @@ public class BaseCommandJUnitTest {
     verify(resultSender, times(0)).setLastResultReceived(true);
 
   }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65Test.java
@@ -37,6 +37,7 @@ import org.apache.geode.cache.operations.DestroyOperationContext;
 import org.apache.geode.internal.Version;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.OpType;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.Message;
@@ -80,6 +81,8 @@ public class Destroy65Test {
   @Mock
   private Part keyPart;
   @Mock
+  private Part operationPart;
+  @Mock
   private Part eventPart;
   @Mock
   private Part callbackArgPart;
@@ -108,7 +111,7 @@ public class Destroy65Test {
     when(this.message.getNumberOfParts()).thenReturn(6);
     when(this.message.getPart(eq(0))).thenReturn(this.regionNamePart);
     when(this.message.getPart(eq(1))).thenReturn(this.keyPart);
-    when(this.message.getPart(eq(3))).thenReturn(mock(Part.class));
+    when(this.message.getPart(eq(3))).thenReturn(operationPart);
     when(this.message.getPart(eq(4))).thenReturn(this.eventPart);
     when(this.message.getPart(eq(5))).thenReturn(this.callbackArgPart);
 
@@ -187,5 +190,70 @@ public class Destroy65Test {
 
     assertThatCode(() -> destroy65.cmdExecute(message, serverConnection, securityService, 0))
         .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void cmdExecuteWhenOperationPartIsNotBytes_whenOperationPartGetObjectIsNull_thenCallsRegionBasicBridgeDestroy()
+      throws Exception {
+    when(operationPart.getObject()).thenReturn(null);
+
+    destroy65.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(region).basicBridgeDestroy(any(), any(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  public void cmdExecuteWhenOperationPartIsNotBytes_whenOperationPartIsNotDestroyOrRemove_thenCallsRegionBasicBridgeRemove()
+      throws Exception {
+    when(operationPart.getObject()).thenReturn(org.apache.geode.cache.Operation.CREATE);
+
+    destroy65.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(region).basicBridgeRemove(any(), any(), any(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  public void cmdExecuteWhenOperationPartIsBytes_whenOperationSerializedFormIsNull_thenCallsRegionBasicBridgeDestroy()
+      throws Exception {
+    when(operationPart.isBytes()).thenReturn(true);
+    when(operationPart.getSerializedForm()).thenReturn(null);
+
+    destroy65.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(region).basicBridgeDestroy(any(), any(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  public void cmdExecuteWhenOperationPartIsBytes_whenOperationSerializedFormIsLengthZero_thenCallsRegionBasicBridgeDestroy()
+      throws Exception {
+    when(operationPart.isBytes()).thenReturn(true);
+    when(operationPart.getSerializedForm()).thenReturn(new byte[0]);
+
+    destroy65.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(region).basicBridgeDestroy(any(), any(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  public void cmdExecuteWhenIsBytesIsTrue_whenOperationSerializedFormIsValidAndIsNotDestroyOrRemove_thenCallsRegionBasicBridgeRemove()
+      throws Exception {
+    when(operationPart.isBytes()).thenReturn(true);
+    byte[] serializedForm = {OpType.CREATE};
+    when(operationPart.getSerializedForm()).thenReturn(serializedForm);
+
+    destroy65.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(region).basicBridgeRemove(any(), any(), any(), any(), anyBoolean(), any());
+  }
+
+  @Test
+  public void cmdExecuteWhenIsBytesIsFalse_whenOperationPartIsByteAndOpTypeDestroy_thenCallsRegionBasicBridgeRemove()
+      throws Exception {
+    when(message.getPart(2)).thenReturn(mock(Part.class));
+    when(operationPart.getObject()).thenReturn(OpType.DESTROY);
+
+    destroy65.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(region).basicBridgeRemove(any(), any(), any(), any(), anyBoolean(), any());
   }
 }


### PR DESCRIPTION
…… (#4041)

* GEODE-7178: Check operation if instance of Byte and Destroy for older native clients

- Move getOperation to Put65 and Destroy65

Co-authored-by: Michael Oleske <moleske@pivotal.io>
Co-authored-by: Vince Ford <vford@pivotal.io>
Co-authored-by: Jacob Barrett <jbarrett@pivotal.io>

This is a cherry pick assuming it gets approved on the dev list (https://markmail.org/message/osblnt4b5dokoey7)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
