### PR TITLE
GEODE-7202 Add null check before closing GatewayReceiverServers

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemfireCacheImplDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemfireCacheImplDUnitTest.java
@@ -30,6 +30,7 @@ public class GemfireCacheImplDUnitTest {
 
   @Test
   public void inAbsenceOfGatewayReceiverServerEmergencyCloseWillCloseCache() {
+
     VM node = VM.getVM(0);
 
     node.invoke(() -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemfireCacheImplDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemfireCacheImplDUnitTest.java
@@ -16,21 +16,33 @@ package org.apache.geode.internal.cache;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedRule;
 
+public class GemfireCacheImplDUnitTest {
 
-public class GemFireCacheImplIntegrationTest {
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
 
   @Test
   public void inAbsenceOfGatewayReceiverServerEmergencyCloseWillCloseCache() {
+    VM node = VM.getVM(0);
 
-    GemFireCacheImpl gemFireCacheImpl = (GemFireCacheImpl) new CacheFactory().create();
+    node.invoke(() -> {
+      GemFireCacheImpl gemFireCacheImpl = (GemFireCacheImpl) new CacheFactory().create();
 
-    gemFireCacheImpl.emergencyClose();
+      gemFireCacheImpl.emergencyClose();
 
-    assertThat(gemFireCacheImpl.isClosed()).isTrue();
+      assertThat(gemFireCacheImpl.isClosed()).isTrue();
+    });
+
+    // This is to close the resources that are left over after
+    // GemfireCacheImpl.emergencyClose().
+    node.bounceForcibly();
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -1656,11 +1656,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       }
     }
 
-    InternalCacheServer receiverServer = cache.gatewayReceiverServer.get();
-    Acceptor acceptor = receiverServer.getAcceptor();
-    if (acceptor != null) {
-      acceptor.emergencyClose();
-    }
+    closeGateWayReceiverServers(cache);
 
     PoolManagerImpl.emergencyClose();
 
@@ -1671,6 +1667,16 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     // partitionedRegions is intentionally *not* synchronized, The
     // implementation of clear() does not currently allocate objects.
     cache.partitionedRegions.clear();
+  }
+
+  private static void closeGateWayReceiverServers(GemFireCacheImpl cache) {
+    InternalCacheServer receiverServer = cache.gatewayReceiverServer.get();
+    if (receiverServer != null) {
+      Acceptor acceptor = receiverServer.getAcceptor();
+      if (acceptor != null) {
+        acceptor.emergencyClose();
+      }
+    }
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplIntegrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplIntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.CacheFactory;
+
+
+public class GemFireCacheImplIntegrationTest {
+
+  @Test
+  public void inAbsenceOfGatewayReceiverServerEmergencyCloseWillCloseCache() {
+
+    GemFireCacheImpl gemFireCacheImpl = (GemFireCacheImpl) new CacheFactory().create();
+
+    gemFireCacheImpl.emergencyClose();
+
+    assertThat(gemFireCacheImpl.isClosed()).isTrue();
+  }
+
+}


### PR DESCRIPTION
Add null check before closing GatewayReceiverServers in emergencyClose()

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [Y] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [Y] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [Y] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [Y] Have you written or updated unit tests to verify your changes?

- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
