### PR TITLE
GEODE-7179: alter async queue command to change state of event proces…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommandDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueFactoryImpl.DEFAULT_BATCH_TIME_INTERVAL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Before;
@@ -23,6 +24,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.asyncqueue.AsyncEventQueue;
+import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.wan.MyAsyncEventListener;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -33,6 +35,10 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 
 @Category({AEQTest.class})
 public class AlterAsyncEventQueueCommandDUnitTest {
+
+  private static final int ALTERED_BATCH_SIZE = 200;
+  private static final int ALTERED_BATCH_TIME_INTERVAL = 300;
+  private static final int ALTERED_MAXIMUM_QUEUE_MEMORY = 400;
 
   @Rule
   public ClusterStartupRule lsRule = new ClusterStartupRule();
@@ -60,22 +66,25 @@ public class AlterAsyncEventQueueCommandDUnitTest {
     server1.invoke(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
       AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
-      assertThat(queue.getBatchSize()).isEqualTo(100);
-      assertThat(queue.getBatchTimeInterval()).isEqualTo(5);
-      assertThat(queue.getMaximumQueueMemory()).isEqualTo(100);
+      assertThat(queue.getBatchSize()).isEqualTo(GatewaySender.DEFAULT_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(DEFAULT_BATCH_TIME_INTERVAL);
+      assertThat(queue.getMaximumQueueMemory())
+          .isEqualTo(GatewaySender.DEFAULT_MAXIMUM_QUEUE_MEMORY);
     });
 
-    gfsh.executeAndAssertThat("alter async-event-queue --id=queue1 " + "--batch-size=200 "
-        + "--batch-time-interval=300 " + "--max-queue-memory=400").statusIsSuccess();
+    gfsh.executeAndAssertThat("alter async-event-queue --id=queue1 --batch-size="
+        + ALTERED_BATCH_SIZE + " --batch-time-interval=" + ALTERED_BATCH_TIME_INTERVAL
+        + " --max-queue-memory=" + ALTERED_MAXIMUM_QUEUE_MEMORY).statusIsSuccess();
 
     // verify that server1's event queue still has the default value
     // without restart
     server1.invoke(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
       AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
-      assertThat(queue.getBatchSize()).isEqualTo(100);
-      assertThat(queue.getBatchTimeInterval()).isEqualTo(5);
-      assertThat(queue.getMaximumQueueMemory()).isEqualTo(100);
+      assertThat(queue.getBatchSize()).isEqualTo(GatewaySender.DEFAULT_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(DEFAULT_BATCH_TIME_INTERVAL);
+      assertThat(queue.getMaximumQueueMemory())
+          .isEqualTo(GatewaySender.DEFAULT_MAXIMUM_QUEUE_MEMORY);
       assertThat(cache.getAsyncEventQueue("queue2")).isNull();
     });
 
@@ -89,9 +98,125 @@ public class AlterAsyncEventQueueCommandDUnitTest {
     server1.invoke(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
       AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
-      assertThat(queue.getBatchSize()).isEqualTo(200);
-      assertThat(queue.getBatchTimeInterval()).isEqualTo(300);
-      assertThat(queue.getMaximumQueueMemory()).isEqualTo(400);
+      assertThat(queue.getBatchSize()).isEqualTo(ALTERED_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(ALTERED_BATCH_TIME_INTERVAL);
+      assertThat(queue.getMaximumQueueMemory()).isEqualTo(ALTERED_MAXIMUM_QUEUE_MEMORY);
+      assertThat(cache.getAsyncEventQueue("queue2")).isNull();
+    });
+  }
+
+  @Test
+  public void whenAlterCommandUsedToChangeFromPauseToResumeThenAEQBehaviorMustChange()
+      throws Exception {
+    gfsh.executeAndAssertThat(
+        "create async-event-queue --pause-event-processing=true --id=queue1 --group=group1 --listener="
+            + MyAsyncEventListener.class.getName())
+        .statusIsSuccess();
+
+    locator.waitUntilAsyncEventQueuesAreReadyOnExactlyThisManyServers("queue1", 1);
+
+    // verify that server1's event queue has the default value
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
+      assertThat(queue.getBatchSize()).isEqualTo(GatewaySender.DEFAULT_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(DEFAULT_BATCH_TIME_INTERVAL);
+      assertThat(queue.isDispatchingPaused()).isTrue();
+      assertThat(queue.getMaximumQueueMemory())
+          .isEqualTo(GatewaySender.DEFAULT_MAXIMUM_QUEUE_MEMORY);
+    });
+
+    gfsh.executeAndAssertThat(
+        "alter async-event-queue --id=queue1 --pause-event-processing=false --batch-size="
+            + ALTERED_BATCH_SIZE + " --batch-time-interval=" + ALTERED_BATCH_TIME_INTERVAL
+            + " --max-queue-memory=" + ALTERED_MAXIMUM_QUEUE_MEMORY)
+        .statusIsSuccess();
+
+    // verify that server1's event queue still has the default value
+    // without restart
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
+      assertThat(queue.getBatchSize()).isEqualTo(GatewaySender.DEFAULT_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(DEFAULT_BATCH_TIME_INTERVAL);
+      assertThat(queue.getMaximumQueueMemory())
+          .isEqualTo(GatewaySender.DEFAULT_MAXIMUM_QUEUE_MEMORY);
+      assertThat(queue.isDispatchingPaused()).isTrue();
+      assertThat(cache.getAsyncEventQueue("queue2")).isNull();
+    });
+
+    // restart locator and server without clearing the file system
+    server1.stop(false);
+    locator.stop(false);
+
+    locator = lsRule.startLocatorVM(0);
+    server1 = lsRule.startServerVM(1, "group1", locator.getPort());
+    // verify that server1's queue is updated
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
+      assertThat(queue.getBatchSize()).isEqualTo(ALTERED_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(ALTERED_BATCH_TIME_INTERVAL);
+      assertThat(queue.getMaximumQueueMemory()).isEqualTo(ALTERED_MAXIMUM_QUEUE_MEMORY);
+      assertThat(queue.isDispatchingPaused()).isFalse();
+      assertThat(cache.getAsyncEventQueue("queue2")).isNull();
+    });
+  }
+
+  @Test
+  public void whenAlterCommandUsedToChangeFromResumeStateToPausedThenAEQBehaviorMustChange()
+      throws Exception {
+    gfsh.executeAndAssertThat(
+        "create async-event-queue --pause-event-processing=false --id=queue1 --group=group1 --listener="
+            + MyAsyncEventListener.class.getName())
+        .statusIsSuccess();
+
+    locator.waitUntilAsyncEventQueuesAreReadyOnExactlyThisManyServers("queue1", 1);
+
+    // verify that server1's event queue has the default value
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
+      assertThat(queue.getBatchSize()).isEqualTo(GatewaySender.DEFAULT_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(DEFAULT_BATCH_TIME_INTERVAL);
+      assertThat(queue.isDispatchingPaused()).isFalse();
+      assertThat(queue.getMaximumQueueMemory())
+          .isEqualTo(GatewaySender.DEFAULT_MAXIMUM_QUEUE_MEMORY);
+    });
+
+    gfsh.executeAndAssertThat(
+        "alter async-event-queue --id=queue1 --pause-event-processing=true --batch-size="
+            + ALTERED_BATCH_SIZE + " --batch-time-interval=" + ALTERED_BATCH_TIME_INTERVAL
+            + " --max-queue-memory=" + ALTERED_MAXIMUM_QUEUE_MEMORY)
+        .statusIsSuccess();
+
+    // verify that server1's event queue still has the default value
+    // without restart
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
+      assertThat(queue.getBatchSize()).isEqualTo(GatewaySender.DEFAULT_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(DEFAULT_BATCH_TIME_INTERVAL);
+      assertThat(queue.getMaximumQueueMemory())
+          .isEqualTo(GatewaySender.DEFAULT_MAXIMUM_QUEUE_MEMORY);
+      assertThat(queue.isDispatchingPaused()).isFalse();
+      assertThat(cache.getAsyncEventQueue("queue2")).isNull();
+    });
+
+    // restart locator and server without clearing the file system
+    server1.stop(false);
+    locator.stop(false);
+
+    locator = lsRule.startLocatorVM(0);
+    server1 = lsRule.startServerVM(1, "group1", locator.getPort());
+    // verify that server1's queue is updated
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      AsyncEventQueue queue = cache.getAsyncEventQueue("queue1");
+      assertThat(queue.getBatchSize()).isEqualTo(ALTERED_BATCH_SIZE);
+      assertThat(queue.getBatchTimeInterval()).isEqualTo(ALTERED_BATCH_TIME_INTERVAL);
+      assertThat(queue.getMaximumQueueMemory()).isEqualTo(ALTERED_MAXIMUM_QUEUE_MEMORY);
+      assertThat(queue.isDispatchingPaused()).isTrue();
       assertThat(cache.getAsyncEventQueue("queue2")).isNull();
     });
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterAsyncEventQueueCommand.java
@@ -68,6 +68,9 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
   static final String BATCH_TIME_INTERVAL_HELP = CREATE_ASYNC_EVENT_QUEUE__BATCHTIMEINTERVAL__HELP;
   static final String MAXIMUM_QUEUE_MEMORY_HELP =
       CREATE_ASYNC_EVENT_QUEUE__MAXIMUM_QUEUE_MEMORY__HELP;
+  static final String PAUSE_EVENT_PROCESSING = "pause-event-processing";
+  static final String PAUSE_EVENT_PROCESSING_HELP =
+      "Pause event processing when the async event queue is created";
 
   @CliCommand(value = COMMAND_NAME, help = COMMAND_HELP)
   @CliMetaData(
@@ -80,7 +83,10 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
           help = BATCH_TIME_INTERVAL_HELP) Integer batchTimeInterval,
       @CliOption(key = MAX_QUEUE_MEMORY, help = MAXIMUM_QUEUE_MEMORY_HELP) Integer maxQueueMemory,
       @CliOption(key = IFEXISTS, help = IFEXISTS_HELP, specifiedDefaultValue = "true",
-          unspecifiedDefaultValue = "false") boolean ifExists)
+          unspecifiedDefaultValue = "false") boolean ifExists,
+      @CliOption(key = PAUSE_EVENT_PROCESSING, help = PAUSE_EVENT_PROCESSING_HELP,
+          specifiedDefaultValue = "true",
+          unspecifiedDefaultValue = "false") boolean pauseEventProcessing)
       throws IOException, SAXException, ParserConfigurationException, TransformerException,
       EntityNotFoundException {
 
@@ -98,6 +104,7 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
 
     CacheConfig.AsyncEventQueue aeqConfiguration = new CacheConfig.AsyncEventQueue();
     aeqConfiguration.setId(id);
+    aeqConfiguration.setPauseEventProcessing(pauseEventProcessing);
 
     if (batchSize != null) {
       aeqConfiguration.setBatchSize(batchSize + "");
@@ -162,6 +169,9 @@ public class AlterAsyncEventQueueCommand extends SingleGfshCommand implements
 
         if (StringUtils.isNotBlank(aeqConfiguration.getMaximumQueueMemory())) {
           queue.setMaximumQueueMemory(aeqConfiguration.getMaximumQueueMemory());
+        }
+        if (aeqConfiguration.isPauseEventProcessing() != null) {
+          queue.setPauseEventProcessing(aeqConfiguration.isPauseEventProcessing());
         }
         aeqConfigsHaveBeenUpdated = true;
       }


### PR DESCRIPTION
…sor during creation

	* Alter the state of the event processor during the creation of the AEQ
	* The state can be changed to paused from not paused and vice versa.

Co-authored-by: Donal Evans <doevans@pivotal.io>
Co-authored-by: Nabarun Nag <nag@cs.wisc.edu>
Co-authored-by: Benjamin Ross <bross@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
