### PR TITLE
GEODE-7185: Partial revert of a7e0b2edefc6f52315ce92ea3b8cd29d5be3fd1c.

### DIFF
--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -25,7 +25,6 @@ evaluationDependsOn(":geode-core")
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
-  implementation(project(':geode-common'))
   implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   integrationTestCompile(project(':extensions:geode-modules-test')) {

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -207,7 +207,6 @@ dependencies {
   integrationTestRuntime('io.swagger:swagger-annotations')
 
 
-  distributedTestImplementation(project(':geode-common'))
   distributedTestImplementation(project(':geode-serialization'))
   distributedTestCompile(project(':geode-core'))
   distributedTestCompile(project(':geode-dunit')){

--- a/geode-assembly/geode-assembly-test/build.gradle
+++ b/geode-assembly/geode-assembly-test/build.gradle
@@ -23,7 +23,6 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compileOnly(project(':extensions:geode-modules-test'))
-  compileOnly(project(':geode-common'))
   compileOnly(project(':geode-core'))
   compileOnly(project(':geode-pulse'))
   compileOnly('com.fasterxml.jackson.core:jackson-databind')

--- a/geode-connectors/build.gradle
+++ b/geode-connectors/build.gradle
@@ -48,7 +48,6 @@ task downloadJdbcJars(type:Copy) {
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':geode-common'))
   implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   testCompile(project(':geode-junit')) {

--- a/geode-connectors/src/test/resources/expected-pom.xml
+++ b/geode-connectors/src/test/resources/expected-pom.xml
@@ -48,11 +48,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -330,7 +330,7 @@ dependencies {
   implementation('com.healthmarketscience.rmiio:rmiio')
 
   //Geode-common has annotations and other pieces used geode-core
-  implementation(project(':geode-common'))
+  api(project(':geode-common'))
   implementation(project(':geode-unsafe'))
   implementation(project(':geode-serialization'))
 

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -103,6 +103,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
       <artifactId>geode-management</artifactId>
       <scope>compile</scope>
     </dependency>
@@ -253,11 +258,6 @@
     <dependency>
       <groupId>com.healthmarketscience.rmiio</groupId>
       <artifactId>rmiio</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/geode-cq/build.gradle
+++ b/geode-cq/build.gradle
@@ -23,7 +23,6 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
   compile(project(':geode-core'))
-  implementation(project(':geode-common'))
   implementation(project(':geode-serialization'))
   testCompile(project(':geode-junit')) {
     exclude module: 'geode-core'

--- a/geode-cq/src/test/resources/expected-pom.xml
+++ b/geode-cq/src/test/resources/expected-pom.xml
@@ -58,11 +58,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-serialization</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/geode-dunit/build.gradle
+++ b/geode-dunit/build.gradle
@@ -22,7 +22,6 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
-  implementation(project(':geode-common'))
   implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
 

--- a/geode-dunit/src/test/resources/expected-pom.xml
+++ b/geode-dunit/src/test/resources/expected-pom.xml
@@ -172,11 +172,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-serialization</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 
   compileOnly(project(':geode-core'))
   compileOnly(project(':geode-serialization'))
-  compileOnly(project(':geode-common'))
   compileOnly(project(':geode-unsafe'))
 
   compile('com.fasterxml.jackson.core:jackson-annotations')

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -53,7 +53,6 @@ dependencies {
   }
   implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
-  compile(project(':geode-common'))
   compile('org.apache.lucene:lucene-analyzers-common')
   compile('org.apache.lucene:lucene-queryparser') {
     exclude module: 'lucene-sandbox'

--- a/geode-lucene/src/test/resources/expected-pom.xml
+++ b/geode-lucene/src/test/resources/expected-pom.xml
@@ -104,11 +104,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
       <scope>compile</scope>

--- a/geode-memcached/build.gradle
+++ b/geode-memcached/build.gradle
@@ -21,7 +21,6 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
   implementation(platform(project(':boms:geode-all-bom')))
-  implementation(project(':geode-common'))
   implementation(project(':geode-core'))
   implementation('org.apache.logging.log4j:log4j-api')
   implementation('com.github.stephenc.findbugs:findbugs-annotations')

--- a/geode-memcached/src/test/resources/expected-pom.xml
+++ b/geode-memcached/src/test/resources/expected-pom.xml
@@ -48,11 +48,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/geode-protobuf/build.gradle
+++ b/geode-protobuf/build.gradle
@@ -22,7 +22,6 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':geode-common'))
   implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   compile(project(':geode-protobuf-messages'))

--- a/geode-protobuf/geode-protobuf-test/build.gradle
+++ b/geode-protobuf/geode-protobuf-test/build.gradle
@@ -22,7 +22,6 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':geode-common'))
   compile(project(':geode-core'))
   compileOnly(project(':geode-protobuf'))
 

--- a/geode-protobuf/src/test/resources/expected-pom.xml
+++ b/geode-protobuf/src/test/resources/expected-pom.xml
@@ -48,11 +48,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/geode-rebalancer/build.gradle
+++ b/geode-rebalancer/build.gradle
@@ -22,7 +22,6 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':geode-common'))
   compile(project(':geode-core'))
   implementation(project(':geode-serialization'))
   integrationTestCompile(project(':geode-junit')) {

--- a/geode-rebalancer/src/test/resources/expected-pom.xml
+++ b/geode-rebalancer/src/test/resources/expected-pom.xml
@@ -48,11 +48,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
       <scope>compile</scope>
     </dependency>

--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -21,7 +21,6 @@ apply from: "${project.projectDir}/../gradle/publish.gradle"
 
 dependencies {
   compile(platform(project(':boms:geode-all-bom')))
-  implementation(project(':geode-common'))
   implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
   compile('com.github.davidmoten:geo')

--- a/geode-redis/src/test/resources/expected-pom.xml
+++ b/geode-redis/src/test/resources/expected-pom.xml
@@ -68,11 +68,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-serialization</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     // See GEODE-6128 -- ignore xml-apis in linter to avoid changes with every run.
     upgradeTestCompile('xml-apis:xml-apis:1.4.01')
   }
-  implementation(project(':geode-common'))
   implementation(project(':geode-serialization'))
   compile(project(':geode-core'))
 

--- a/geode-wan/src/test/resources/expected-pom.xml
+++ b/geode-wan/src/test/resources/expected-pom.xml
@@ -53,11 +53,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-serialization</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/geode-web-api/build.gradle
+++ b/geode-web-api/build.gradle
@@ -27,7 +27,6 @@ dependencies {
   compileOnly(platform(project(':boms:geode-all-bom')))
 
   compileOnly(project(':geode-core'))
-  compileOnly(project(':geode-common'))
   compileOnly(project(':geode-serialization'))
 
   compileOnly('javax.servlet:javax.servlet-api')

--- a/geode-web-management/build.gradle
+++ b/geode-web-management/build.gradle
@@ -48,7 +48,6 @@ dependencies {
   compile(platform(project(':boms:geode-all-bom'))) {
     exclude module: "jackson-annotations"
   }
-  compileOnly(project(':geode-common'))
   compileOnly(project(':geode-serialization'))
   compileOnly(project(':geode-core'))
 

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -29,7 +29,6 @@ dependencies {
   //transitive dependencies from geode-web.war. Since geode-web.war is ony run within
   //a container that has geode-core on the classpath, is prevents duplicating jars. geode-core
   //in particular should not be duplicated in the war.
-  providedCompile(project(':geode-common'))
   providedCompile(project(path: ':geode-core')) {
     //spring-web is excluded from the providedCompile configuration to ensure
     //that it is included as part of the war. spring-web must be loaded with the war's

--- a/geode-web/src/test/resources/expected-pom.xml
+++ b/geode-web/src/test/resources/expected-pom.xml
@@ -48,11 +48,6 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.geode</groupId>
-      <artifactId>geode-common</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
       <artifactId>geode-core</artifactId>
       <scope>compile</scope>
       <exclusions>


### PR DESCRIPTION
Fixes transitive API dependency on geode-common. Some classes in the
geode-core API extend classes in the geode-common module, thus making
geode-common API as well.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
