### PR TITLE
GEODE-7213: Initialization of arrays with size 0

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
@@ -799,13 +799,13 @@ public class DistributedSystemConfigImpl implements DistributedSystemConfig {
   @Override
   public CacheServerConfig[] getCacheServerConfigs() {
     return (CacheServerConfig[]) this.cacheServerConfigs
-        .toArray(new CacheServerConfig[this.cacheServerConfigs.size()]);
+        .toArray(new CacheServerConfig[0]);
   }
 
   @Override
   public CacheVmConfig[] getCacheVmConfigs() {
     return (CacheVmConfig[]) this.cacheServerConfigs
-        .toArray(new CacheVmConfig[this.cacheServerConfigs.size()]);
+        .toArray(new CacheVmConfig[0]);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheImpl.java
@@ -214,7 +214,7 @@ public class SystemMemberCacheImpl implements SystemMemberCache {
     for (int i = 0; i < stats.length; i++) {
       statList.add(createStatistic(stats[i]));
     }
-    this.statistics = (Statistic[]) statList.toArray(new Statistic[statList.size()]);
+    this.statistics = (Statistic[]) statList.toArray(new Statistic[0]);
   }
 
   private void updateStats() {

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentLauncher.java
@@ -289,7 +289,7 @@ public class AgentLauncher {
       commands.add(key + "=" + agentProps.get(key.toString()));
     }
 
-    return commands.toArray(new String[commands.size()]);
+    return commands.toArray(new String[0]);
   }
 
   private void printCommandLine(final String[] commandLine) {

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DynamicManagedBean.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DynamicManagedBean.java
@@ -71,7 +71,7 @@ public class DynamicManagedBean extends org.apache.commons.modeler.ManagedBean {
         }
       }
       this.attributes =
-          (AttributeInfo[]) attributesList.toArray(new AttributeInfo[attributesList.size()]);
+          (AttributeInfo[]) attributesList.toArray(new AttributeInfo[0]);
 
       /*
        * super.info should be nulled out anytime the structure is changed, such as altering the
@@ -103,7 +103,7 @@ public class DynamicManagedBean extends org.apache.commons.modeler.ManagedBean {
         }
       }
       this.operations =
-          (OperationInfo[]) operationsList.toArray(new OperationInfo[operationsList.size()]);
+          (OperationInfo[]) operationsList.toArray(new OperationInfo[0]);
 
       /*
        * super.info should be nulled out anytime the structure is changed, such as altering the

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledJunction.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledJunction.java
@@ -667,7 +667,7 @@ public class CompiledJunction extends AbstractCompiledValue implements Negatable
           if (listOrPosition instanceof List) {
             List ops = (List) listOrPosition;
             nullifiedFields += ops.size();
-            CompiledValue operands[] = (CompiledValue[]) ops.toArray(new CompiledValue[ops.size()]);
+            CompiledValue operands[] = (CompiledValue[]) ops.toArray(new CompiledValue[0]);
             rangeJunctions[numRangeJunctions++] =
                 new RangeJunction(this._operator, grpIndpndntItr, completeExpnsn, operands);
           }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/MethodDispatch.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/MethodDispatch.java
@@ -48,7 +48,7 @@ public class MethodDispatch {
       String methodName, List argTypes) throws NameResolutionException {
     _targetClass = targetClass;
     _methodName = methodName;
-    _argTypes = (Class[]) argTypes.toArray(new Class[argTypes.size()]);
+    _argTypes = (Class[]) argTypes.toArray(new Class[0]);
     _methodInvocationAuthorizer = methodInvocationAuthorizer;
 
     resolve();

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/PathUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/PathUtils.java
@@ -47,7 +47,7 @@ public class PathUtils {
     while (tokenizer.hasMoreTokens()) {
       alist.add(tokenizer.nextToken());
     }
-    return (String[]) alist.toArray(new String[alist.size()]);
+    return (String[]) alist.toArray(new String[0]);
   }
 
   public static String buildPathString(String[] path) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QCompiler.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QCompiler.java
@@ -563,7 +563,7 @@ public class QCompiler implements OQLLexerTokenTypes {
     }
 
     push(new CompiledJunction(
-        (CompiledValue[]) operands.toArray(new CompiledValue[operands.size()]), operator));
+        (CompiledValue[]) operands.toArray(new CompiledValue[0]), operator));
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -5333,6 +5333,6 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
       }
     }
     Collections.sort(atts);
-    return atts.toArray(new String[atts.size()]);
+    return atts.toArray(new String[0]);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
@@ -253,7 +253,7 @@ public abstract class DistributionMessage implements DataSerializableFixedID, Cl
           "Recipients can only be set once");
     }
     this.recipients = recipients
-        .toArray(new InternalDistributedMember[recipients.size()]);
+        .toArray(new InternalDistributedMember[0]);
   }
 
   public void resetRecipients() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceService.java
@@ -211,7 +211,7 @@ public class InternalConfigurationPersistenceService implements ConfigurationPer
       // No group is specified, so delete in every single group if it exists.
       if (groups == null) {
         Set<String> groupSet = configRegion.keySet();
-        groups = groupSet.toArray(new String[groupSet.size()]);
+        groups = groupSet.toArray(new String[0]);
       }
       for (String group : groups) {
         Configuration configuration = configRegion.get(group);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
@@ -555,7 +555,7 @@ public class DLockGrantor {
           batchList.add(batch);
         }
       }
-      return (DLockBatch[]) batchList.toArray(new DLockBatch[batchList.size()]);
+      return (DLockBatch[]) batchList.toArray(new DLockBatch[0]);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRecoverGrantorProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockRecoverGrantorProcessor.java
@@ -419,7 +419,7 @@ public class DLockRecoverGrantorProcessor extends ReplyProcessor21 {
             replyCode = DLockRecoverGrantorReplyMessage.GRANTOR_DISPUTE;
           } else {
             heldLocks =
-                (DLockRemoteToken[]) heldLockSet.toArray(new DLockRemoteToken[heldLockSet.size()]);
+                (DLockRemoteToken[]) heldLockSet.toArray(new DLockRemoteToken[0]);
           }
         }
       } catch (RuntimeException e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
@@ -184,7 +184,7 @@ public class SystemAdmin {
     }
     cmdVec.add(hostnameForClientsOption);
 
-    String[] cmd = (String[]) cmdVec.toArray(new String[cmdVec.size()]);
+    String[] cmd = (String[]) cmdVec.toArray(new String[0]);
 
     // start with a fresh log each time
     if (!logFile.delete() && logFile.exists()) {
@@ -1150,7 +1150,7 @@ public class SystemAdmin {
       StatArchiveReader reader = null;
       boolean interrupted = false;
       try {
-        reader = new StatArchiveReader((File[]) archiveNames.toArray(new File[archiveNames.size()]),
+        reader = new StatArchiveReader((File[]) archiveNames.toArray(new File[0]),
             specs, !monitor);
         // Runtime.getRuntime().gc(); System.out.println("DEBUG: heap size=" +
         // (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()));

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/StatAlertsManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/StatAlertsManager.java
@@ -250,7 +250,7 @@ public class StatAlertsManager {
         }
       } // while
     } // synchronized
-    return (StatAlert[]) alerts.toArray(new StatAlert[alerts.size()]);
+    return (StatAlert[]) alerts.toArray(new StatAlert[0]);
   }
 
   /**
@@ -312,7 +312,7 @@ public class StatAlertsManager {
       }
     } // for
 
-    return (StatAlertDefinition[]) result.toArray(new StatAlertDefinition[result.size()]);
+    return (StatAlertDefinition[]) result.toArray(new StatAlertDefinition[0]);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -2779,7 +2779,7 @@ public class DiskStoreImpl implements DiskStore {
       return null;
     }
 
-    return l.toArray(new CompactableOplog[l.size()]);
+    return l.toArray(new CompactableOplog[0]);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -738,7 +738,7 @@ public class InitialImageOperation {
           // member(s) These will either be DistributedMember IDs or DiskStore IDs
           RequestSyncMessage msg = new RequestSyncMessage();
           msg.regionPath = this.region.getFullPath();
-          msg.lostVersionSources = needsSync.toArray(new VersionSource[needsSync.size()]);
+          msg.lostVersionSources = needsSync.toArray(new VersionSource[0]);
           Set recipients = this.region.getCacheDistributionAdvisor().adviseReplicates();
           for (Iterator it = recipients.iterator(); it.hasNext();) {
             InternalDistributedMember mbr = (InternalDistributedMember) it.next();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/SearchLoadAndWriteProcessor.java
@@ -702,7 +702,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
       ArrayList list = new ArrayList(loadCandidatesSet);
       Collections.shuffle(list);
       InternalDistributedMember[] loadCandidates =
-          (InternalDistributedMember[]) list.toArray(new InternalDistributedMember[list.size()]);
+          (InternalDistributedMember[]) list.toArray(new InternalDistributedMember[0]);
       initRemainingTimeout();
 
       RegionAttributes attrs = region.getAttributes();
@@ -922,7 +922,7 @@ public class SearchLoadAndWriteProcessor implements MembershipListener {
     ArrayList list = new ArrayList(writeCandidateSet);
     Collections.shuffle(list);
     InternalDistributedMember[] writeCandidates =
-        (InternalDistributedMember[]) list.toArray(new InternalDistributedMember[list.size()]);
+        (InternalDistributedMember[]) list.toArray(new InternalDistributedMember[0]);
     initRemainingTimeout();
     int index = 0;
     do {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXManagerImpl.java
@@ -670,7 +670,7 @@ public class TXManagerImpl implements CacheTransactionManager, MembershipListene
       // After this, newly added TXStateProxy would not operate on the TXState.
       this.closed = true;
 
-      proxies = this.hostedTXStates.values().toArray(new TXStateProxy[this.hostedTXStates.size()]);
+      proxies = this.hostedTXStates.values().toArray(new TXStateProxy[0]);
     }
 
     for (TXStateProxy proxy : proxies) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
@@ -199,7 +199,7 @@ public class SnapshotPacket implements DataSerializableFixedID {
     this.windowId = windowId;
     this.packetId = UUID.randomUUID().toString();
     this.sender = sender;
-    records = recs.toArray(new SnapshotRecord[recs.size()]);
+    records = recs.toArray(new SnapshotRecord[0]);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/InternalClientMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/InternalClientMembership.java
@@ -185,7 +185,7 @@ public class InternalClientMembership {
     List<ClientMembershipListener> l = clientMembershipListeners; // volatile fetch
     // convert to an array
     ClientMembershipListener[] listeners =
-        (ClientMembershipListener[]) l.toArray(new ClientMembershipListener[l.size()]);
+        (ClientMembershipListener[]) l.toArray(new ClientMembershipListener[0]);
     return listeners;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlParser.java
@@ -1515,7 +1515,7 @@ public class CacheXmlParser extends CacheXml implements ContentHandler {
     ResumptionAction raction = ResumptionAction.fromName(raName);
 
     MembershipAttributes ra = new MembershipAttributes(
-        (String[]) roles.toArray(new String[roles.size()]), laction, raction);
+        (String[]) roles.toArray(new String[0]), laction, raction);
     RegionAttributesCreation rattrs = (RegionAttributesCreation) stack.peek();
     rattrs.setMembershipAttributes(ra);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/size/ObjectTraverser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/size/ObjectTraverser.java
@@ -126,8 +126,8 @@ public class ObjectTraverser {
       clazz = clazz.getSuperclass();
     }
 
-    return new FieldSet(staticFields.toArray(new Field[staticFields.size()]),
-        nonPrimativeFields.toArray(new Field[nonPrimativeFields.size()]));
+    return new FieldSet(staticFields.toArray(new Field[0]),
+        nonPrimativeFields.toArray(new Field[0]));
   }
 
   public interface Visitor {

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveReader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveReader.java
@@ -714,7 +714,7 @@ public class StatArchiveReader implements StatArchiveFormat, AutoCloseable {
      * Creates a ComboValue by adding all the specified values together.
      */
     ComboValue(List valueList) {
-      this((StatValue[]) valueList.toArray(new StatValue[valueList.size()]));
+      this((StatValue[]) valueList.toArray(new StatValue[0]));
     }
 
     /**

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsTypeXml.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatisticsTypeXml.java
@@ -161,7 +161,7 @@ public class StatisticsTypeXml implements EntityResolver, ErrorHandler {
       Element typeNode = (Element) typeNodes.item(i);
       types.add(extractType(typeNode, statFactory));
     }
-    return (StatisticsType[]) types.toArray(new StatisticsType[types.size()]);
+    return (StatisticsType[]) types.toArray(new StatisticsType[0]);
   }
 
   /**
@@ -179,7 +179,7 @@ public class StatisticsTypeXml implements EntityResolver, ErrorHandler {
       stats.add(extractStat(statNode, statFactory));
     }
     StatisticDescriptor[] descriptors =
-        (StatisticDescriptor[]) stats.toArray(new StatisticDescriptor[stats.size()]);
+        (StatisticDescriptor[]) stats.toArray(new StatisticDescriptor[0]);
     String description = "";
     {
       NodeList descriptionNodes = typeNode.getElementsByTagName("description");

--- a/geode-core/src/main/java/org/apache/geode/internal/stats50/VMStats50.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/stats50/VMStats50.java
@@ -247,7 +247,7 @@ public class VMStats50 implements VMStatsContract {
       sds.add(f.createLongGauge("fdsOpen", "Current number of open file descriptors", "fds"));
     }
     vmType = f.createType("VMStats", "Stats available on a 1.5 java virtual machine.",
-        sds.toArray(new StatisticDescriptor[sds.size()]));
+        sds.toArray(new StatisticDescriptor[0]));
     pendingFinalizationCountId = vmType.nameToId("pendingFinalization");
     loadedClassesId = vmType.nameToId("loadedClasses");
     unloadedClassesId = vmType.nameToId("unloadedClasses");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
@@ -652,7 +652,7 @@ public class DistributedSystemBridge {
         set.addAll(hostedLocators);
       }
 
-      return set.toArray(new String[set.size()]);
+      return set.toArray(new String[0]);
     }
     return ManagementConstants.NO_DATA_STRING;
   }
@@ -832,7 +832,7 @@ public class DistributedSystemBridge {
       listOfRegions.add(bridge.getName());
     }
 
-    return listOfRegions.toArray(new String[listOfRegions.size()]);
+    return listOfRegions.toArray(new String[0]);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/RegionMBeanBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/RegionMBeanBridge.java
@@ -233,7 +233,7 @@ public class RegionMBeanBridge<K, V> {
     for (Region<?, ?> region : subregions) {
       subregionPaths.add(region.getFullPath());
     }
-    return subregionPaths.toArray(new String[subregionPaths.size()]);
+    return subregionPaths.toArray(new String[0]);
   }
 
   public RegionMBeanBridge(CachePerfStats cachePerfStats) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJConsoleCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJConsoleCommand.java
@@ -147,6 +147,6 @@ public class StartJConsoleCommand extends OfflineGfshCommand {
       }
     }
 
-    return commandLine.toArray(new String[commandLine.size()]);
+    return commandLine.toArray(new String[0]);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJVisualVMCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartJVisualVMCommand.java
@@ -80,6 +80,6 @@ public class StartJVisualVMCommand extends OfflineGfshCommand {
       }
     }
 
-    return commandLine.toArray(new String[commandLine.size()]);
+    return commandLine.toArray(new String[0]);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartVsdCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/lifecycle/StartVsdCommand.java
@@ -84,7 +84,7 @@ public class StartVsdCommand extends OfflineGfshCommand {
     commandLine.add(getPathToVsd());
     commandLine.addAll(processStatisticsArchiveFiles(statisticsArchiveFilePathnames));
 
-    return commandLine.toArray(new String[commandLine.size()]);
+    return commandLine.toArray(new String[0]);
   }
 
   protected String getPathToVsd() {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/web/shell/support/HttpInvocationHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/web/shell/support/HttpInvocationHandler.java
@@ -84,7 +84,7 @@ public class HttpInvocationHandler implements InvocationHandler {
       return null;
     }
 
-    return signature.toArray(new String[signature.size()]);
+    return signature.toArray(new String[0]);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/pdx/ReflectionBasedAutoSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/ReflectionBasedAutoSerializer.java
@@ -120,7 +120,7 @@ public class ReflectionBasedAutoSerializer implements PdxSerializer, Declarable 
     if (l == null) {
       l = Collections.emptyList();
     }
-    return l.toArray(new String[l.size()]);
+    return l.toArray(new String[0]);
   }
 
   /**


### PR DESCRIPTION
	* Non zero size requirement for array initialization is not a requirement post JDK6
	* Zero size is considered more efficient.
	* toArray(new T[0]) is considered faster, safer and contractually cleaner.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
