### PR TITLE
GEODE-7165: Remove networking dependency from GatewayReceiverImplTest

### DIFF
--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
@@ -74,6 +74,16 @@ public class GatewayReceiverImpl implements GatewayReceiver {
   GatewayReceiverImpl(final InternalCache cache, final int startPort, final int endPort,
       final int maximumTimeBetweenPings, final int socketBufferSize, final String bindAddress,
       final List<GatewayTransportFilter> gatewayTransportFilters, final String hostnameForSenders,
+      final boolean manualStart, final boolean isPortAvailableResult,
+      final int getRandomAvailablePortInRangeResult) {
+    this(cache, startPort, endPort, maximumTimeBetweenPings, socketBufferSize, bindAddress,
+        gatewayTransportFilters, hostnameForSenders, manualStart, port -> isPortAvailableResult,
+        portRange -> getRandomAvailablePortInRangeResult);
+  }
+
+  private GatewayReceiverImpl(final InternalCache cache, final int startPort, final int endPort,
+      final int maximumTimeBetweenPings, final int socketBufferSize, final String bindAddress,
+      final List<GatewayTransportFilter> gatewayTransportFilters, final String hostnameForSenders,
       final boolean manualStart, final Function<Integer, Boolean> isPortAvailableFunction,
       final Function<PortRange, Integer> getRandomAvailablePortInRangeFunction) {
     this.cache = cache;
@@ -279,13 +289,12 @@ public class GatewayReceiverImpl implements GatewayReceiver {
         .append("]").toString();
   }
 
-  @VisibleForTesting
-  static class PortRange {
+  private static class PortRange {
 
-    final int startPort;
-    final int endPort;
+    private final int startPort;
+    private final int endPort;
 
-    PortRange(int startPort, int endPort) {
+    private PortRange(int startPort, int endPort) {
       this.startPort = startPort;
       this.endPort = endPort;
     }

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewayReceiverImpl.java
@@ -17,20 +17,22 @@ package org.apache.geode.internal.cache.wan;
 import static org.apache.geode.internal.AvailablePort.SOCKET;
 import static org.apache.geode.internal.AvailablePort.getAddress;
 import static org.apache.geode.internal.AvailablePort.getRandomAvailablePortInRange;
+import static org.apache.geode.internal.AvailablePort.isPortAvailable;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ResourceEvent;
-import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheServer;
 import org.apache.geode.internal.logging.LogService;
@@ -52,6 +54,8 @@ public class GatewayReceiverImpl implements GatewayReceiver {
   private final boolean manualStart;
   private final List<GatewayTransportFilter> gatewayTransportFilters;
   private final String bindAddress;
+  private final Function<Integer, Boolean> isPortAvailableFunction;
+  private final Function<PortRange, Integer> getRandomAvailablePortInRangeFunction;
 
   private volatile int port;
   private volatile InternalCacheServer receiverServer;
@@ -60,6 +64,18 @@ public class GatewayReceiverImpl implements GatewayReceiver {
       final int maximumTimeBetweenPings, final int socketBufferSize, final String bindAddress,
       final List<GatewayTransportFilter> gatewayTransportFilters, final String hostnameForSenders,
       final boolean manualStart) {
+    this(cache, startPort, endPort, maximumTimeBetweenPings, socketBufferSize, bindAddress,
+        gatewayTransportFilters, hostnameForSenders, manualStart,
+        port -> isPortAvailable(port, SOCKET, getAddress(SOCKET)),
+        portRange -> getRandomAvailablePortInRange(portRange.startPort, portRange.endPort, SOCKET));
+  }
+
+  @VisibleForTesting
+  GatewayReceiverImpl(final InternalCache cache, final int startPort, final int endPort,
+      final int maximumTimeBetweenPings, final int socketBufferSize, final String bindAddress,
+      final List<GatewayTransportFilter> gatewayTransportFilters, final String hostnameForSenders,
+      final boolean manualStart, final Function<Integer, Boolean> isPortAvailableFunction,
+      final Function<PortRange, Integer> getRandomAvailablePortInRangeFunction) {
     this.cache = cache;
     this.hostnameForSenders = hostnameForSenders;
     this.startPort = startPort;
@@ -69,6 +85,8 @@ public class GatewayReceiverImpl implements GatewayReceiver {
     this.bindAddress = bindAddress;
     this.gatewayTransportFilters = gatewayTransportFilters;
     this.manualStart = manualStart;
+    this.isPortAvailableFunction = isPortAvailableFunction;
+    this.getRandomAvailablePortInRangeFunction = getRandomAvailablePortInRangeFunction;
   }
 
   @Override
@@ -138,7 +156,7 @@ public class GatewayReceiverImpl implements GatewayReceiver {
   }
 
   private boolean tryToStart(int port) {
-    if (!AvailablePort.isPortAvailable(port, SOCKET, getAddress(SOCKET))) {
+    if (!isPortAvailableFunction.apply(port)) {
       return false;
     }
 
@@ -202,7 +220,7 @@ public class GatewayReceiverImpl implements GatewayReceiver {
     if (startPort == endPort) {
       randomPort = startPort;
     } else {
-      randomPort = getRandomAvailablePortInRange(startPort, endPort, SOCKET);
+      randomPort = getRandomAvailablePortInRangeFunction.apply(new PortRange(startPort, endPort));
     }
     return randomPort;
   }
@@ -259,5 +277,17 @@ public class GatewayReceiverImpl implements GatewayReceiver {
         .append(getSocketBufferSize()).append("; isManualStart=").append(isManualStart())
         .append("; group=").append(Arrays.toString(new String[] {GatewayReceiver.RECEIVER_GROUP}))
         .append("]").toString();
+  }
+
+  @VisibleForTesting
+  static class PortRange {
+
+    final int startPort;
+    final int endPort;
+
+    PortRange(int startPort, int endPort) {
+      this.startPort = startPort;
+      this.endPort = endPort;
+    }
   }
 }

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplTest.java
@@ -62,7 +62,7 @@ public class GatewayReceiverImplTest {
   @Test
   public void getHostOnUnstartedGatewayShouldReturnLocalHostName() throws UnknownHostException {
     GatewayReceiver gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null,
-        true, port -> true, portRange -> 2000);
+        true, true, 2000);
 
     assertThat(gateway.getHost()).isEqualTo(SocketCreator.getLocalHost().getHostName());
   }
@@ -72,7 +72,7 @@ public class GatewayReceiverImplTest {
     String theExternalAddress = "theExternalAddress";
     when(receiverServer.getExternalAddress()).thenReturn(theExternalAddress);
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
-        null, true, port -> true, portRange -> 2000);
+        null, true, true, 2000);
 
     gateway.start();
 
@@ -82,7 +82,7 @@ public class GatewayReceiverImplTest {
   @Test
   public void destroyCalledOnRunningGatewayReceiverShouldThrowGatewayReceiverException() {
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
-        null, true, port -> true, portRange -> 2000);
+        null, true, true, 2000);
     when(receiverServer.isRunning()).thenReturn(true);
     gateway.start();
 
@@ -94,7 +94,7 @@ public class GatewayReceiverImplTest {
   @Test
   public void destroyCalledOnStoppedGatewayReceiverShouldRemoveReceiverFromCacheServers() {
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
-        null, true, port -> true, portRange -> 2000);
+        null, true, true, 2000);
     gateway.start();
     when(receiverServer.isRunning()).thenReturn(false);
 
@@ -108,7 +108,7 @@ public class GatewayReceiverImplTest {
   @Test
   public void destroyCalledOnStoppedGatewayReceiverShouldRemoveReceiverFromReceivers() {
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
-        null, true, port -> true, portRange -> 2000);
+        null, true, true, 2000);
     gateway.start();
     when(receiverServer.isRunning()).thenReturn(false);
 
@@ -121,7 +121,7 @@ public class GatewayReceiverImplTest {
   public void startShouldThrowGatewayReceiverExceptionIfIOExceptionIsThrown() throws IOException {
     doThrow(new SocketException("Address already in use")).when(receiverServer).start();
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2000, 5, 100, null, null,
-        null, true, port -> true, portRange -> 2000);
+        null, true, true, 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -136,7 +136,7 @@ public class GatewayReceiverImplTest {
   public void startShouldTryTwoPortsInPortRangeIfIOExceptionIsThrown() throws IOException {
     doThrow(new SocketException("Address already in use")).when(receiverServer).start();
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
-        null, true, port -> true, portRange -> 2000);
+        null, true, true, 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -153,7 +153,7 @@ public class GatewayReceiverImplTest {
     int startPort = 2000;
     int endPort = 2100;
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, startPort, endPort, 5, 100, null,
-        null, null, true, port -> true, portRange -> 2000);
+        null, null, true, true, 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -172,7 +172,7 @@ public class GatewayReceiverImplTest {
     IOException ioException = new SocketException("Address already in use");
     doThrow(ioException).doThrow(ioException).doNothing().when(receiverServer).start();
     GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2010, 5, 100, null, null,
-        null, true, port -> true, portRange -> 2000);
+        null, true, true, 2000);
 
     gateway.start();
 

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplTest.java
@@ -61,9 +61,8 @@ public class GatewayReceiverImplTest {
 
   @Test
   public void getHostOnUnstartedGatewayShouldReturnLocalHostName() throws UnknownHostException {
-    GatewayReceiver gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiver gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null,
+        true, port -> true, portRange -> 2000);
 
     assertThat(gateway.getHost()).isEqualTo(SocketCreator.getLocalHost().getHostName());
   }
@@ -72,9 +71,8 @@ public class GatewayReceiverImplTest {
   public void getHostOnRunningGatewayShouldReturnCacheServerExternalAddress() {
     String theExternalAddress = "theExternalAddress";
     when(receiverServer.getExternalAddress()).thenReturn(theExternalAddress);
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
+        null, true, port -> true, portRange -> 2000);
 
     gateway.start();
 
@@ -83,9 +81,8 @@ public class GatewayReceiverImplTest {
 
   @Test
   public void destroyCalledOnRunningGatewayReceiverShouldThrowGatewayReceiverException() {
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
+        null, true, port -> true, portRange -> 2000);
     when(receiverServer.isRunning()).thenReturn(true);
     gateway.start();
 
@@ -96,9 +93,8 @@ public class GatewayReceiverImplTest {
 
   @Test
   public void destroyCalledOnStoppedGatewayReceiverShouldRemoveReceiverFromCacheServers() {
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
+        null, true, port -> true, portRange -> 2000);
     gateway.start();
     when(receiverServer.isRunning()).thenReturn(false);
 
@@ -111,9 +107,8 @@ public class GatewayReceiverImplTest {
 
   @Test
   public void destroyCalledOnStoppedGatewayReceiverShouldRemoveReceiverFromReceivers() {
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
+        null, true, port -> true, portRange -> 2000);
     gateway.start();
     when(receiverServer.isRunning()).thenReturn(false);
 
@@ -125,9 +120,8 @@ public class GatewayReceiverImplTest {
   @Test
   public void startShouldThrowGatewayReceiverExceptionIfIOExceptionIsThrown() throws IOException {
     doThrow(new SocketException("Address already in use")).when(receiverServer).start();
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2000, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2000, 5, 100, null, null,
+        null, true, port -> true, portRange -> 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -141,9 +135,8 @@ public class GatewayReceiverImplTest {
   @Test
   public void startShouldTryTwoPortsInPortRangeIfIOExceptionIsThrown() throws IOException {
     doThrow(new SocketException("Address already in use")).when(receiverServer).start();
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null,
+        null, true, port -> true, portRange -> 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -159,9 +152,8 @@ public class GatewayReceiverImplTest {
     doThrow(new SocketException("Address already in use")).when(receiverServer).start();
     int startPort = 2000;
     int endPort = 2100;
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, startPort, endPort, 5, 100, null, null, null, true,
-            a -> true, a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, startPort, endPort, 5, 100, null,
+        null, null, true, port -> true, portRange -> 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -179,9 +171,8 @@ public class GatewayReceiverImplTest {
   public void startsSucceedsIfRandomPortInPortRangeSucceeds() throws IOException {
     IOException ioException = new SocketException("Address already in use");
     doThrow(ioException).doThrow(ioException).doNothing().when(receiverServer).start();
-    GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2010, 5, 100, null, null, null, true, a -> true,
-            a -> 2000);
+    GatewayReceiverImpl gateway = new GatewayReceiverImpl(cache, 2000, 2010, 5, 100, null, null,
+        null, true, port -> true, portRange -> 2000);
 
     gateway.start();
 

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewayReceiverImplTest.java
@@ -62,7 +62,8 @@ public class GatewayReceiverImplTest {
   @Test
   public void getHostOnUnstartedGatewayShouldReturnLocalHostName() throws UnknownHostException {
     GatewayReceiver gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
 
     assertThat(gateway.getHost()).isEqualTo(SocketCreator.getLocalHost().getHostName());
   }
@@ -72,7 +73,8 @@ public class GatewayReceiverImplTest {
     String theExternalAddress = "theExternalAddress";
     when(receiverServer.getExternalAddress()).thenReturn(theExternalAddress);
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
 
     gateway.start();
 
@@ -82,7 +84,8 @@ public class GatewayReceiverImplTest {
   @Test
   public void destroyCalledOnRunningGatewayReceiverShouldThrowGatewayReceiverException() {
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
     when(receiverServer.isRunning()).thenReturn(true);
     gateway.start();
 
@@ -94,7 +97,8 @@ public class GatewayReceiverImplTest {
   @Test
   public void destroyCalledOnStoppedGatewayReceiverShouldRemoveReceiverFromCacheServers() {
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
     gateway.start();
     when(receiverServer.isRunning()).thenReturn(false);
 
@@ -108,7 +112,8 @@ public class GatewayReceiverImplTest {
   @Test
   public void destroyCalledOnStoppedGatewayReceiverShouldRemoveReceiverFromReceivers() {
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
     gateway.start();
     when(receiverServer.isRunning()).thenReturn(false);
 
@@ -121,7 +126,8 @@ public class GatewayReceiverImplTest {
   public void startShouldThrowGatewayReceiverExceptionIfIOExceptionIsThrown() throws IOException {
     doThrow(new SocketException("Address already in use")).when(receiverServer).start();
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2000, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2000, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -136,7 +142,8 @@ public class GatewayReceiverImplTest {
   public void startShouldTryTwoPortsInPortRangeIfIOExceptionIsThrown() throws IOException {
     doThrow(new SocketException("Address already in use")).when(receiverServer).start();
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2001, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -153,7 +160,8 @@ public class GatewayReceiverImplTest {
     int startPort = 2000;
     int endPort = 2100;
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, startPort, endPort, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, startPort, endPort, 5, 100, null, null, null, true,
+            a -> true, a -> 2000);
 
     Throwable thrown = catchThrowable(() -> gateway.start());
 
@@ -172,7 +180,8 @@ public class GatewayReceiverImplTest {
     IOException ioException = new SocketException("Address already in use");
     doThrow(ioException).doThrow(ioException).doNothing().when(receiverServer).start();
     GatewayReceiverImpl gateway =
-        new GatewayReceiverImpl(cache, 2000, 2010, 5, 100, null, null, null, true);
+        new GatewayReceiverImpl(cache, 2000, 2010, 5, 100, null, null, null, true, a -> true,
+            a -> 2000);
 
     gateway.start();
 


### PR DESCRIPTION
The test was failing on machines with ports 2000 or 2001 in use.

This change replaces GatewayReceiverImpl's dependency on AvailablePort
with functions that are now injected by the unit tests.

Specifically, this test was failing for @dickcav and @onichols-pivotal.