### PR TITLE
GEODE-7221: Ensure management regions close CachePerfStats

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/CacheManagementDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/CacheManagementDUnitTest.java
@@ -355,7 +355,7 @@ public class CacheManagementDUnitTest implements Serializable {
 
       assertThat(service.getLocalManager().isRunning()).isTrue();
 
-      assertThat(service.getLocalManager().getFederationSheduler().isShutdown()).isFalse();
+      assertThat(service.getLocalManager().getFederationScheduler().isShutdown()).isFalse();
 
       ObjectName memberMBeanName = service.getMemberMBeanName(otherMember);
 
@@ -379,7 +379,7 @@ public class CacheManagementDUnitTest implements Serializable {
 
       assertThat(service.isManager()).isFalse();
       assertThat(service.getLocalManager().isRunning()).isTrue();
-      assertThat(service.getLocalManager().getFederationSheduler().isShutdown()).isFalse();
+      assertThat(service.getLocalManager().getFederationScheduler().isShutdown()).isFalse();
 
       // Check for Proxies
       Set<DistributedMember> otherMembers = this.managementTestRule.getOtherNormalMembers();

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/CacheManagementDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/CacheManagementDUnitTest.java
@@ -44,6 +44,7 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.management.internal.LocalManager;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.ManagementConstants;
@@ -618,9 +619,12 @@ public class CacheManagementDUnitTest implements Serializable {
 
   private void verifyNotificationsAndRegionSize(final VM memberVM1, final VM memberVM2,
       final VM memberVM3, final VM managerVM) {
-    DistributedMember member1 = this.managementTestRule.getDistributedMember(memberVM1);
-    DistributedMember member2 = this.managementTestRule.getDistributedMember(memberVM2);
-    DistributedMember member3 = this.managementTestRule.getDistributedMember(memberVM3);
+    InternalDistributedMember member1 =
+        (InternalDistributedMember) managementTestRule.getDistributedMember(memberVM1);
+    InternalDistributedMember member2 =
+        (InternalDistributedMember) managementTestRule.getDistributedMember(memberVM2);
+    InternalDistributedMember member3 =
+        (InternalDistributedMember) managementTestRule.getDistributedMember(memberVM3);
 
     String memberId1 = MBeanJMXAdapter.getUniqueIDForMember(member1);
     String memberId2 = MBeanJMXAdapter.getUniqueIDForMember(member2);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/JMXMBeanFederationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/JMXMBeanFederationDUnitTest.java
@@ -38,8 +38,8 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.dunit.internal.InternalBlackboard;
@@ -111,7 +111,7 @@ public class JMXMBeanFederationDUnitTest {
     locator1.waitUntilRegionIsReadyOnExactlyThisManyServers(REGION_PATH, SERVER_COUNT);
     List keyset = server3.invoke(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
-      DistributedMember member =
+      InternalDistributedMember member =
           InternalDistributedSystem.getConnectedInstance().getDistributedMember();
       String appender = MBeanJMXAdapter.getUniqueIDForMember(member);
       Region monitoringRegion =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/HasCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/HasCachePerfStats.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+@FunctionalInterface
 public interface HasCachePerfStats {
 
   CachePerfStats getCachePerfStats();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/HasCachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/HasCachePerfStats.java
@@ -18,4 +18,8 @@ package org.apache.geode.internal.cache;
 public interface HasCachePerfStats {
 
   CachePerfStats getCachePerfStats();
+
+  default boolean hasOwnStats() {
+    return false;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -604,8 +604,9 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     subregions = new ConcurrentHashMap();
 
     if (internalRegionArgs.getCachePerfStatsHolder() != null) {
-      hasOwnStats = false;
-      cachePerfStats = internalRegionArgs.getCachePerfStatsHolder().getCachePerfStats();
+      HasCachePerfStats cachePerfStatsHolder = internalRegionArgs.getCachePerfStatsHolder();
+      hasOwnStats = cachePerfStatsHolder.hasOwnStats();
+      cachePerfStats = cachePerfStatsHolder.getCachePerfStats();
     } else {
       if (attrs.getPartitionAttributes() != null || isInternalRegion()
           || internalRegionArgs.isUsedForMetaRegion()) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -380,9 +380,19 @@ public class FederatingManager extends Manager {
           internalRegionArguments.setIsUsedForMetaRegion(true);
 
           // Create anonymous stats holder for Management Regions
-          HasCachePerfStats monitoringRegionStats =
-              () -> new CachePerfStats(cache.getDistributedSystem(),
+          HasCachePerfStats monitoringRegionStats = new HasCachePerfStats() {
+
+            @Override
+            public CachePerfStats getCachePerfStats() {
+              return new CachePerfStats(cache.getDistributedSystem(),
                   "RegionStats-managementRegionStats", statisticsClock);
+            }
+
+            @Override
+            public boolean hasOwnStats() {
+              return true;
+            }
+          };
 
           internalRegionArguments.setCachePerfStatsHolder(monitoringRegionStats);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/LocalManager.java
@@ -120,9 +120,19 @@ public class LocalManager extends Manager {
       internalArgs.setIsUsedForMetaRegion(true);
 
       // Create anonymous stats holder for Management Regions
-      final HasCachePerfStats monitoringRegionStats =
-          () -> new CachePerfStats(cache.getDistributedSystem(),
+      HasCachePerfStats monitoringRegionStats = new HasCachePerfStats() {
+
+        @Override
+        public CachePerfStats getCachePerfStats() {
+          return new CachePerfStats(cache.getDistributedSystem(),
               "RegionStats-managementRegionStats", statisticsClock);
+        }
+
+        @Override
+        public boolean hasOwnStats() {
+          return true;
+        }
+      };
 
       internalArgs.setCachePerfStatsHolder(monitoringRegionStats);
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/MBeanJMXAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/MBeanJMXAdapter.java
@@ -540,17 +540,14 @@ public class MBeanJMXAdapter implements ManagementConstants {
     return this.localGemFireMBean;
   }
 
-  public static String getUniqueIDForMember(DistributedMember member) {
-
-    InternalDistributedMember iMember = (InternalDistributedMember) member;
+  public static String getUniqueIDForMember(InternalDistributedMember member) {
     final StringBuilder sb = new StringBuilder();
-    sb.append(iMember.getInetAddress().getHostAddress());
+    sb.append(member.getInetAddress().getHostAddress());
     // View ID will be 0 for Loner, but in that case no federation as well
-    sb.append("<v").append(iMember.getVmViewId()).append(">");
-    sb.append(iMember.getPort());
+    sb.append("<v").append(member.getVmViewId()).append(">");
+    sb.append(member.getPort());
     // Lower case to handle IPv6
     return makeCompliantName(sb.toString().toLowerCase());
-
   }
 
   public static boolean isAttributeAvailable(String attributeName, String objectName) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
@@ -12,58 +12,79 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.function.Function;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
 
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskWriteAttributes;
 import org.apache.geode.cache.EvictionAction;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.ExpirationAttributes;
+import org.apache.geode.cache.MembershipAttributes;
+import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.distributed.internal.DSClock;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.AbstractRegion.PoolFinder;
 import org.apache.geode.internal.cache.LocalRegion.RegionMapConstructor;
 import org.apache.geode.internal.cache.LocalRegion.ServerRegionProxyConstructor;
+import org.apache.geode.internal.cache.control.InternalResourceManager;
 
 public class LocalRegionTest {
 
-  private RegionAttributes regionAttributes;
-  private InternalCache cache;
-  private InternalRegionArguments internalRegionArguments;
-  private InternalDataView internalDataView;
-  private RegionMapConstructor regionMapConstructor;
-  private ServerRegionProxyConstructor serverRegionProxyConstructor;
   private EntryEventFactory entryEventFactory;
+  private InternalCache cache;
+  private InternalDataView internalDataView;
+  private InternalDistributedSystem internalDistributedSystem;
+  private InternalRegionArguments internalRegionArguments;
   private PoolFinder poolFinder;
+  private RegionAttributes regionAttributes;
+  private RegionMapConstructor regionMapConstructor;
+  private Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory;
+  private ServerRegionProxyConstructor serverRegionProxyConstructor;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
 
   @Before
-  public void setup() {
-    cache = mock(InternalCache.class);
+  public void setUp() {
     entryEventFactory = mock(EntryEventFactory.class);
+    cache = mock(InternalCache.class);
     internalDataView = mock(InternalDataView.class);
+    internalDistributedSystem = mock(InternalDistributedSystem.class);
     internalRegionArguments = mock(InternalRegionArguments.class);
     poolFinder = mock(PoolFinder.class);
     regionAttributes = mock(RegionAttributes.class);
     regionMapConstructor = mock(RegionMapConstructor.class);
+    regionPerfStatsFactory = localRegion -> {
+      localRegion.getLocalSize();
+      return mock(RegionPerfStats.class);
+    };
     serverRegionProxyConstructor = mock(ServerRegionProxyConstructor.class);
 
     DiskWriteAttributes diskWriteAttributes = mock(DiskWriteAttributes.class);
     EvictionAttributes evictionAttributes = mock(EvictionAttributes.class);
     ExpirationAttributes expirationAttributes = mock(ExpirationAttributes.class);
-    InternalDistributedSystem internalDistributedSystem = mock(InternalDistributedSystem.class);
 
     when(cache.getInternalDistributedSystem()).thenReturn(internalDistributedSystem);
     when(evictionAttributes.getAction()).thenReturn(EvictionAction.NONE);
@@ -80,7 +101,7 @@ public class LocalRegionTest {
 
   @Test
   public void getLocalSizeDoesNotThrowNullPointerExceptionDuringConstruction() {
-    Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory = (localRegion) -> {
+    Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory = localRegion -> {
       localRegion.getLocalSize();
       return mock(RegionPerfStats.class);
     };
@@ -90,5 +111,81 @@ public class LocalRegionTest {
             internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
             poolFinder, regionPerfStatsFactory, disabledClock()))
                 .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void destroyRegionClosesCachePerfStatsIfHasOwnStatsIsTrue() {
+    CachePerfStats cachePerfStats = mock(CachePerfStats.class);
+    HasCachePerfStats hasCachePerfStats = mock(HasCachePerfStats.class);
+    InternalRegionArguments internalRegionArguments = mock(InternalRegionArguments.class);
+
+    when(cache.getCancelCriterion())
+        .thenReturn(mock(CancelCriterion.class));
+    when(cache.getDistributedSystem())
+        .thenReturn(internalDistributedSystem);
+    when(cache.getInternalResourceManager(eq(false)))
+        .thenReturn(mock(InternalResourceManager.class));
+    when(cache.getTXMgr())
+        .thenReturn(mock(TXManagerImpl.class));
+    when(hasCachePerfStats.getCachePerfStats())
+        .thenReturn(cachePerfStats);
+    when(internalDistributedSystem.getDistributionManager())
+        .thenReturn(mock(DistributionManager.class));
+    when(internalDistributedSystem.getDistributedMember())
+        .thenReturn(mock(InternalDistributedMember.class));
+    when(internalRegionArguments.getCachePerfStatsHolder())
+        .thenReturn(hasCachePerfStats);
+    when(regionAttributes.getMembershipAttributes())
+        .thenReturn(mock(MembershipAttributes.class));
+
+    when(hasCachePerfStats.hasOwnStats())
+        .thenReturn(true);
+
+    Region region =
+        new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock());
+
+    region.destroyRegion();
+
+    verify(cachePerfStats).close();
+  }
+
+  @Test
+  public void destroyRegionDoesNotCloseCachePerfStatsIfHasOwnStatsIsFalse() {
+    CachePerfStats cachePerfStats = mock(CachePerfStats.class);
+    HasCachePerfStats hasCachePerfStats = mock(HasCachePerfStats.class);
+    InternalRegionArguments internalRegionArguments = mock(InternalRegionArguments.class);
+
+    when(cache.getCancelCriterion())
+        .thenReturn(mock(CancelCriterion.class));
+    when(cache.getDistributedSystem())
+        .thenReturn(internalDistributedSystem);
+    when(cache.getInternalResourceManager(eq(false)))
+        .thenReturn(mock(InternalResourceManager.class));
+    when(cache.getTXMgr())
+        .thenReturn(mock(TXManagerImpl.class));
+    when(hasCachePerfStats.getCachePerfStats())
+        .thenReturn(cachePerfStats);
+    when(internalDistributedSystem.getDistributionManager())
+        .thenReturn(mock(DistributionManager.class));
+    when(internalDistributedSystem.getDistributedMember())
+        .thenReturn(mock(InternalDistributedMember.class));
+    when(internalRegionArguments.getCachePerfStatsHolder())
+        .thenReturn(hasCachePerfStats);
+    when(regionAttributes.getMembershipAttributes())
+        .thenReturn(mock(MembershipAttributes.class));
+
+    when(hasCachePerfStats.hasOwnStats())
+        .thenReturn(false);
+
+    Region region =
+        new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock());
+
+    region.destroyRegion();
+
+    verify(cachePerfStats, never()).close();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.net.InetAddress;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.alerting.AlertLevel;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.management.DistributedSystemMXBean;
+
+public class FederatingManagerTest {
+
+  private MBeanJMXAdapter jmxAdapter;
+  private ManagementResourceRepo repo;
+  private InternalDistributedSystem system;
+  private SystemManagementService service;
+  private InternalCache cache;
+  private StatisticsFactory statisticsFactory;
+  private StatisticsClock statisticsClock;
+  private InternalCacheForClientAccess cacheForClientAccess;
+
+  @Before
+  public void setUp() throws Exception {
+    jmxAdapter = mock(MBeanJMXAdapter.class);
+    repo = mock(ManagementResourceRepo.class);
+    system = mock(InternalDistributedSystem.class);
+    service = mock(SystemManagementService.class);
+    cache = mock(InternalCache.class);
+    statisticsFactory = mock(StatisticsFactory.class);
+    statisticsClock = mock(StatisticsClock.class);
+    cacheForClientAccess = mock(InternalCacheForClientAccess.class);
+    DistributedSystemMXBean distributedSystemMXBean = mock(DistributedSystemMXBean.class);
+
+    when(cache.getCacheForProcessingClientRequests())
+        .thenReturn(cacheForClientAccess);
+    when(cacheForClientAccess.createInternalRegion(any(), any(), any()))
+        .thenReturn(mock(Region.class));
+    when(distributedSystemMXBean.getAlertLevel())
+        .thenReturn(AlertLevel.WARNING.name());
+    when(jmxAdapter.getDistributedSystemMXBean())
+        .thenReturn(distributedSystemMXBean);
+    when(system.getDistributionManager())
+        .thenReturn(mock(DistributionManager.class));
+  }
+
+  @Test
+  public void addMemberArtifactsCreatesMonitoringRegion() throws Exception {
+    InternalDistributedMember member = member(0, 42);
+    FederatingManager federatingManager = new FederatingManager(jmxAdapter, repo, system, service,
+        cache, statisticsFactory, statisticsClock);
+    federatingManager.startManager();
+
+    federatingManager.addMemberArtifacts(member);
+
+    verify(cacheForClientAccess).createInternalRegion(eq("_monitoringRegion_null<v0>42"), any(),
+        any());
+  }
+
+  @Test
+  public void addMemberArtifactsCreatesNotificationRegion() throws Exception {
+    InternalDistributedMember member = member(0, 42);
+    FederatingManager federatingManager = new FederatingManager(jmxAdapter, repo, system, service,
+        cache, statisticsFactory, statisticsClock);
+    federatingManager.startManager();
+
+    federatingManager.addMemberArtifacts(member);
+
+    verify(cacheForClientAccess).createInternalRegion(eq("_notificationRegion_null<v0>42"), any(),
+        any());
+  }
+
+  private InternalDistributedMember member(int viewId, int port) {
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    when(member.getInetAddress()).thenReturn(mock(InetAddress.class));
+    when(member.getVmViewId()).thenReturn(viewId);
+    when(member.getPort()).thenReturn(port);
+    return member;
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.net.InetAddress;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.alerting.AlertLevel;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.management.DistributedSystemMXBean;
+
+public class LocalManagerTest {
+
+  private ManagementResourceRepo repo;
+  private InternalDistributedSystem system;
+  private SystemManagementService service;
+  private InternalCache cache;
+  private StatisticsFactory statisticsFactory;
+  private StatisticsClock statisticsClock;
+  private InternalCacheForClientAccess cacheForClientAccess;
+
+  @Before
+  public void setUp() throws Exception {
+    repo = mock(ManagementResourceRepo.class);
+    system = mock(InternalDistributedSystem.class);
+    service = mock(SystemManagementService.class);
+    cache = mock(InternalCache.class);
+    statisticsFactory = mock(StatisticsFactory.class);
+    statisticsClock = mock(StatisticsClock.class);
+    cacheForClientAccess = mock(InternalCacheForClientAccess.class);
+    DistributedSystemMXBean distributedSystemMXBean = mock(DistributedSystemMXBean.class);
+    DistributionConfig config = mock(DistributionConfig.class);
+
+    when(cache.getCacheForProcessingClientRequests())
+        .thenReturn(cacheForClientAccess);
+    when(cacheForClientAccess.createInternalRegion(any(), any(), any()))
+        .thenReturn(mock(Region.class));
+    when(config.getJmxManagerUpdateRate())
+        .thenReturn(Integer.MAX_VALUE);
+    when(distributedSystemMXBean.getAlertLevel())
+        .thenReturn(AlertLevel.WARNING.name());
+    when(system.getConfig())
+        .thenReturn(config);
+    when(system.getDistributionManager())
+        .thenReturn(mock(DistributionManager.class));
+  }
+
+  @Test
+  public void startLocalManagementCreatesMonitoringRegion() throws Exception {
+    InternalDistributedMember member = member(1, 20);
+    when(system.getDistributedMember()).thenReturn(member);
+    LocalManager localManager =
+        new LocalManager(repo, system, service, cache, statisticsFactory, statisticsClock);
+
+    localManager.startManager();
+
+    verify(cacheForClientAccess).createInternalRegion(eq("_monitoringRegion_null<v1>20"), any(),
+        any());
+  }
+
+  @Test
+  public void addMemberArtifactsCreatesNotificationRegion() throws Exception {
+    InternalDistributedMember member = member(3, 60);
+    when(system.getDistributedMember()).thenReturn(member);
+    LocalManager localManager =
+        new LocalManager(repo, system, service, cache, statisticsFactory, statisticsClock);
+
+    localManager.startManager();
+
+    verify(cacheForClientAccess).createInternalRegion(eq("_notificationRegion_null<v3>60"), any(),
+        any());
+  }
+
+  private InternalDistributedMember member(int viewId, int port) {
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    when(member.getInetAddress()).thenReturn(mock(InetAddress.class));
+    when(member.getVmViewId()).thenReturn(viewId);
+    when(member.getPort()).thenReturn(port);
+    return member;
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -24,6 +25,7 @@ import java.net.InetAddress;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.Region;
@@ -32,8 +34,10 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.alerting.AlertLevel;
+import org.apache.geode.internal.cache.HasCachePerfStats;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
+import org.apache.geode.internal.cache.InternalRegionArguments;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.DistributedSystemMXBean;
 
@@ -87,6 +91,25 @@ public class LocalManagerTest {
   }
 
   @Test
+  public void addMemberArtifactsCreatesMonitoringRegionWithHasOwnStats() throws Exception {
+    InternalDistributedMember member = member(2, 40);
+    when(system.getDistributedMember()).thenReturn(member);
+    LocalManager localManager =
+        new LocalManager(repo, system, service, cache, statisticsFactory, statisticsClock);
+
+    localManager.startManager();
+
+    ArgumentCaptor<InternalRegionArguments> captor =
+        ArgumentCaptor.forClass(InternalRegionArguments.class);
+    verify(cacheForClientAccess).createInternalRegion(eq("_monitoringRegion_null<v2>40"), any(),
+        captor.capture());
+
+    InternalRegionArguments internalRegionArguments = captor.getValue();
+    HasCachePerfStats hasCachePerfStats = internalRegionArguments.getCachePerfStatsHolder();
+    assertThat(hasCachePerfStats.hasOwnStats()).isTrue();
+  }
+
+  @Test
   public void addMemberArtifactsCreatesNotificationRegion() throws Exception {
     InternalDistributedMember member = member(3, 60);
     when(system.getDistributedMember()).thenReturn(member);
@@ -97,6 +120,25 @@ public class LocalManagerTest {
 
     verify(cacheForClientAccess).createInternalRegion(eq("_notificationRegion_null<v3>60"), any(),
         any());
+  }
+
+  @Test
+  public void addMemberArtifactsCreatesNotificationRegionWithHasOwnStats() throws Exception {
+    InternalDistributedMember member = member(4, 80);
+    when(system.getDistributedMember()).thenReturn(member);
+    LocalManager localManager =
+        new LocalManager(repo, system, service, cache, statisticsFactory, statisticsClock);
+
+    localManager.startManager();
+
+    ArgumentCaptor<InternalRegionArguments> captor =
+        ArgumentCaptor.forClass(InternalRegionArguments.class);
+    verify(cacheForClientAccess).createInternalRegion(eq("_notificationRegion_null<v4>80"), any(),
+        captor.capture());
+
+    InternalRegionArguments internalRegionArguments = captor.getValue();
+    HasCachePerfStats hasCachePerfStats = internalRegionArguments.getCachePerfStatsHolder();
+    assertThat(hasCachePerfStats.hasOwnStats()).isTrue();
   }
 
   private InternalDistributedMember member(int viewId, int port) {


### PR DESCRIPTION
1) [Cleanup and unit test FederatingManager](https://github.com/apache/geode/pull/4072/commits/a47be7a495b8a62b5372a4ec0d2b8bcb259ea92d)
```
commit a47be7a495b8a62b5372a4ec0d2b8bcb259ea92d
Author: Kirk Lund <klund@apache.org>
Date:   Thu Sep 19 11:30:07 2019 -0700

    GEODE-7221: Cleanup and unit test FederatingManager
    
    * Move inner classes to bottom of outer class
    * Extract addMemberArtifacts from GIITask
    * Remove unnecessary code
    * Create FederatingManagerTest
```
2) [Cleanup and unit test LocalManager](https://github.com/apache/geode/pull/4072/commits/74e4467410e58f32897715a763ede0bff3020f77)
```
commit 74e4467410e58f32897715a763ede0bff3020f77
Author: Kirk Lund <klund@apache.org>
Date:   Thu Sep 19 11:47:59 2019 -0700

    GEODE-7221: Cleanup and unit test LocalManager
    
    * Move inner class to bottom of outer class
    * Remove unnecessary code
    * Extract doManagementTask from ManagementTask
    * Create LocalManagerTest
```
3) [Fix GEODE-7221 by setting hasOwnStats true for management regions](https://github.com/apache/geode/pull/4072/commits/a13a4a236de93955f0eac118bec0a93fe3ef47f9)
```
commit a13a4a236de93955f0eac118bec0a93fe3ef47f9
Author: Kirk Lund <klund@apache.org>
Date:   Thu Sep 19 13:02:00 2019 -0700

    GEODE-7221: Set hasOwnStats true for management regions
    
    Ensure that managements regions close CachePerfStats by setting
    hasOwnStats to true from FederatingManager and LocalManager.
```
