### PR TITLE
GEODE-7220 NPE in the logs on reconnect

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
@@ -114,8 +114,7 @@ public class GMSQuorumChecker {
 
 
   public void resume() {
-    channel.setReceiver(null);
-    channel.setReceiver(new QuorumCheckerReceiver());
+    JGroupsMessenger.setChannelReceiver(channel, new QuorumCheckerReceiver());
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -184,9 +184,9 @@ public class JGroupsMessenger implements Messenger {
 
   public static void setChannelReceiver(JChannel channel, Receiver r) {
     try {
-      // Channel.setReceiver() won't set a new receiver unless the field is null but that
-      // causes NPEs in receiver threads because use of the the field isn't synchronized.
-      // Attempt to use reflection to avoid having the field be null. See GEODE-7220
+      // Channel.setReceiver() will issue a warning if we try to set a new receiver
+      // and the channel already has one. Rather than set the receiver to null &
+      // then establish a new one we use reflection to set the channel receiver. See GEODE-7220
       Field receiver = Channel.class.getDeclaredField("receiver");
       receiver.setAccessible(true);
       receiver.set(channel, r);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -49,11 +49,13 @@ import java.util.stream.Collectors;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.apache.logging.log4j.Logger;
 import org.jgroups.Address;
+import org.jgroups.Channel;
 import org.jgroups.Event;
 import org.jgroups.JChannel;
 import org.jgroups.Message;
 import org.jgroups.Message.Flag;
 import org.jgroups.Message.TransientFlag;
+import org.jgroups.Receiver;
 import org.jgroups.ReceiverAdapter;
 import org.jgroups.View;
 import org.jgroups.ViewId;
@@ -69,6 +71,7 @@ import org.apache.geode.ForcedDisconnectException;
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.GemFireIOException;
 import org.apache.geode.InternalGemFireError;
+import org.apache.geode.InternalGemFireException;
 import org.apache.geode.SystemConnectException;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
@@ -178,6 +181,19 @@ public class JGroupsMessenger implements Messenger {
    * for deserializating and dispatching those messages to the appropriate handler
    */
   private JGroupsReceiver jgroupsReceiver;
+
+  public static void setChannelReceiver(JChannel channel, Receiver r) {
+    try {
+      // Channel.setReceiver() won't set a new receiver unless the field is null but that
+      // causes NPEs in receiver threads because use of the the field isn't synchronized.
+      // Attempt to use reflection to avoid having the field be null. See GEODE-7220
+      Field receiver = Channel.class.getDeclaredField("receiver");
+      receiver.setAccessible(true);
+      receiver.set(channel, r);
+    } catch (NoSuchFieldException | IllegalAccessException e) {
+      throw new InternalGemFireException("unable to establish a JGroups receiver", e);
+    }
+  }
 
   @Override
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(
@@ -358,9 +374,8 @@ public class JGroupsMessenger implements Messenger {
     nackack2HeaderId = ClassConfigurator.getProtocolId(NAKACK2.class);
 
     try {
-      myChannel.setReceiver(null);
       jgroupsReceiver = new JGroupsReceiver();
-      myChannel.setReceiver(jgroupsReceiver);
+      setChannelReceiver(myChannel, jgroupsReceiver);
       if (!reconnecting) {
         myChannel.connect("AG"); // Apache Geode
       }


### PR DESCRIPTION
Use reflection to poke a new Receiver into JGroups to avoid
synchronization problems in JGroups code.

No new tests were needed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
