### PR TITLE
GEODE-6897: revert accidental change of apidoc's link for dev rest api.

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/DevRestSwaggerVerificationIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/DevRestSwaggerVerificationIntegrationTest.java
@@ -33,7 +33,7 @@ import org.apache.geode.test.junit.rules.RequiresGeodeHome;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 @Category({SecurityTest.class, RestAPITest.class})
-public class SwaggerVerificationIntegrationTest {
+public class DevRestSwaggerVerificationIntegrationTest {
 
   @ClassRule
   public static ServerStarterRule serverStarter = new ServerStarterRule()
@@ -52,7 +52,7 @@ public class SwaggerVerificationIntegrationTest {
 
     // Check the JSON
     JsonNode json =
-        assertResponse(client.get("/geode/experimental/api-docs")).hasStatusCode(200)
+        assertResponse(client.get("/geode/v1/api-docs")).hasStatusCode(200)
             .getJsonObject();
     assertThat(json.get("swagger").asText(), is("2.0"));
 

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/security/RestSecurityConfiguration.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/security/RestSecurityConfiguration.java
@@ -50,7 +50,7 @@ public class RestSecurityConfiguration extends WebSecurityConfigurerAdapter {
   protected void configure(HttpSecurity http) throws Exception {
     http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
         .authorizeRequests()
-        .antMatchers("/ping", "/docs/**", "/swagger-ui.html", "/experimental/api-docs/**",
+        .antMatchers("/ping", "/docs/**", "/swagger-ui.html", "/v1/api-docs/**",
             "/webjars/springfox-swagger-ui/**", "/swagger-resources/**")
         .permitAll().anyRequest().authenticated().and().csrf().disable();
 

--- a/geode-web-api/src/main/resources/swagger.properties
+++ b/geode-web-api/src/main/resources/swagger.properties
@@ -12,5 +12,4 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 #
-springfox.documentation.swagger.v2.path=/experimental/api-docs
-springfox.documentation.swagger.v1.path=/v1/api-docs
+springfox.documentation.swagger.v2.path=/v1/api-docs


### PR DESCRIPTION
we should not change the api docs link for dev rest api.