### PR TITLE
GEODE-7234 Better Concourse image caching

### DIFF
--- a/ci/pipelines/examples/jinja.template.yml
+++ b/ci/pipelines/examples/jinja.template.yml
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-{% from 'shared_jinja.yml' import alpine_tools_config with context %}
 {% from 'shared_jinja.yml' import github_access with context %}
 {% from 'shared_jinja.yml' import init_retry with context %}
 
@@ -71,6 +70,13 @@ resources:
 - name: 24h
   type: time
   source: {interval: 24h}
+- name: alpine-tools-image
+  type: docker-image
+  source:
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
+    tag: latest
 
 jobs:
 - name: {{examples_test.name}}
@@ -79,6 +85,7 @@ jobs:
   plan:
   - get: geode-ci
   - aggregate:
+    - get: alpine-tools-image
     - get: geode-examples
       trigger: true
     - get: 24h
@@ -87,7 +94,9 @@ jobs:
       - put: concourse-metadata-resource
       {{ init_retry()|indent(6) }}
       - task: create_instance
-        {{ alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           params:
             {{ common_instance_params(examples_test) | indent(12) }}
             GEODE_BRANCH: {{repository.branch}}
@@ -106,7 +115,9 @@ jobs:
         timeout: 15m
         attempts: 10
       - task: rsync_code_up
-        {{ alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           run:
             path: geode-ci/ci/scripts/rsync_code_up.sh
           inputs:
@@ -116,7 +127,9 @@ jobs:
           - name: instance-data
         timeout: 5m
       - task: build
-        {{ alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           params:
             JAVA_BUILD_VERSION: {{ java_build_version.version }}
             GRADLE_TASK: {{ examples_test.GRADLE_TASK }}
@@ -133,7 +146,9 @@ jobs:
     ensure:
       do:
       - task: delete_instance
-        {{ alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           run:
             path: geode-ci/ci/scripts/delete_instance.sh
           inputs:

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-{% from 'shared_jinja.yml' import alpine_tools_config with context %}
 {% from 'shared_jinja.yml' import pipeline_prefix with context %}
 {% from 'shared_jinja.yml' import github_access with context %}
 {% from 'shared_jinja.yml' import init_retry with context %}
@@ -204,6 +203,13 @@ resources:
     bucket: ((version-bucket))
     json_key: ((concourse-gcp-key))
     regexp: ((pipeline-prefix))((geode-build-branch))/passing-build-tokens-(.*).json
+- name: alpine-tools-image
+  type: docker-image
+  source:
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
+    tag: latest
 
 resource_types:
 - name: concourse-metadata-resource
@@ -234,6 +240,7 @@ jobs:
   plan:
   - get: geode-ci
   - aggregate:
+    - get: alpine-tools-image
     - get: geode
       trigger: true
     - get: geode-build-version
@@ -243,7 +250,9 @@ jobs:
       - put: concourse-metadata-resource
       {{ init_retry()|indent(6) }}
       - task: create_instance
-        {{- alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           params:
             {{ common_instance_params(build_test) | indent(12) }}
             GEODE_BRANCH: {{repository.branch}}
@@ -267,7 +276,9 @@ jobs:
       params:
         file: geode-build-version/number
     - task: rsync_code_up
-      {{- alpine_tools_config()|indent(6) }}
+      image: alpine-tools-image
+      config:
+        platform: linux
         run:
           path: geode-ci/ci/scripts/rsync_code_up.sh
         inputs:
@@ -278,7 +289,9 @@ jobs:
     on_failure:
       do:
       - task: delete_instance
-        {{- alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           run:
             path: geode-ci/ci/scripts/delete_instance.sh
           inputs:
@@ -286,7 +299,9 @@ jobs:
           - name: instance-data
         timeout: 1h
   - task: build
-    {{- alpine_tools_config()|indent(4) }}
+    image: alpine-tools-image
+    config:
+      platform: linux
       params:
         JAVA_BUILD_VERSION: {{ java_build_version.version }}
         GRADLE_TASK: {{ build_test.GRADLE_TASK }}
@@ -305,7 +320,9 @@ jobs:
     ensure:
       do:
       - task: rsync_code_down
-        {{- alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           params:
             JAVA_BUILD_VERSION: {{ java_build_version.version }}
           run:
@@ -320,7 +337,9 @@ jobs:
         do:
         - aggregate:
           - task: archive_results
-            {{- alpine_tools_config()|indent(12) }}
+            image: alpine-tools-image
+            config:
+              platform: linux
               params:
                 ARTIFACT_SLUG: {{build_test.ARTIFACT_SLUG}}-{{java_build_version.name}}
                 GRADLE_TASK: {{build_test.GRADLE_TASK}}
@@ -337,7 +356,9 @@ jobs:
               - name: geode-results
             timeout: 1h
           - task: delete_instance
-            {{- alpine_tools_config()|indent(12) }}
+            image: alpine-tools-image
+            config:
+              platform: linux
               run:
                 path: geode-ci/ci/scripts/delete_instance.sh
               inputs:
@@ -350,6 +371,7 @@ jobs:
   serial: true
   plan:
   - aggregate:
+    - get: alpine-tools-image
     - get: geode
       passed: &update-token-passed-anchor
 {%- if repository.upstream_fork != "apache" or repository.branch == "develop" %}
@@ -362,7 +384,9 @@ jobs:
       trigger: true
       passed: *update-token-passed-anchor
   - task: couple-sha-and-build-id
-    {{- alpine_tools_config()|indent(4) }}
+    image: alpine-tools-image
+    config:
+      platform: linux
       inputs:
       - name: geode
       - name: geode-build-version
@@ -405,6 +429,7 @@ jobs:
     passed:
     {{ all_gating_jobs() | indent(4) }}
   - aggregate:
+    - get: alpine-tools-image
     - get: geode
       passed:
       {{ all_gating_jobs() | indent(6) }}
@@ -417,7 +442,9 @@ jobs:
   - aggregate:
     {% for ssl_var in [{'title': '_without_ssl', 'flag':''}, {'title': '_with_ssl', 'flag': '-PwithSsl'}] %}
     - task: run_benchmarks{{ ssl_var.title }}
-      {{- alpine_tools_config()|indent(6) }}
+      image: alpine-tools-image
+      config:
+        platform: linux
         params:
           AWS_ACCESS_KEY_ID: ((benchmarks-access-key-id))
           AWS_SECRET_ACCESS_KEY: ((benchmarks-secret-access-key))
@@ -441,7 +468,9 @@ jobs:
       ensure:
         do:
         - task: cleanup_benchmarks
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             params:
               AWS_ACCESS_KEY_ID: ((benchmarks-access-key-id))
               AWS_SECRET_ACCESS_KEY: ((benchmarks-secret-access-key))
@@ -468,6 +497,7 @@ jobs:
     passed:
     - Benchmark
   - aggregate:
+    - get: alpine-tools-image
     - get: geode
       passed:
       - Benchmark
@@ -479,7 +509,9 @@ jobs:
       - put: concourse-metadata-resource
       {{ init_retry()|indent(6) }}
       - task: create_instance
-        {{- alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           params:
             {{ common_instance_params(publish_artifacts) | indent(12) }}
             GEODE_BRANCH: {{repository.branch}}
@@ -499,7 +531,9 @@ jobs:
         timeout: 15m
         attempts: 10
   - task: rsync_code_up
-    {{- alpine_tools_config()|indent(4) }}
+    image: alpine-tools-image
+    config:
+      platform: linux
       run:
         path: geode-ci/ci/scripts/rsync_code_up.sh
       inputs:
@@ -508,7 +542,9 @@ jobs:
       - name: instance-data
     timeout: 5m
   - task: publish
-    {{- alpine_tools_config()|indent(4) }}
+    image: alpine-tools-image
+    config:
+      platform: linux
       params:
         MAINTENANCE_VERSION: ((geode-build-branch))
         ARTIFACT_BUCKET: ((artifact-bucket))
@@ -526,7 +562,9 @@ jobs:
     ensure:
       do:
       - task: delete_instance
-        {{- alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           run:
             path: geode-ci/ci/scripts/delete_instance.sh
           inputs:
@@ -549,11 +587,14 @@ jobs:
   - do:
     {{- plan_resource_gets(test) |indent(4) }}
       - put: concourse-metadata-resource
+      - get: alpine-tools-image
     - aggregate:
       - do:
         {{ init_retry()|indent(8) }}
         - task: create_instance-{{java_test_version.name}}
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             params:
               {{ common_instance_params(parameters) | indent(14) }}
               GEODE_BRANCH: {{repository.branch}}
@@ -575,7 +616,9 @@ jobs:
           timeout: 15m
           attempts: 10
         - task: rsync_code_up-{{java_test_version.name}}
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             run:
               path: geode-ci/ci/scripts/rsync_code_up.sh
             inputs:
@@ -586,7 +629,9 @@ jobs:
           timeout: 15m
           attempts: 10
         - task: execute_tests-{{java_test_version.name}}
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             params:
               ARTIFACT_SLUG: {{test.ARTIFACT_SLUG}}-{{java_test_version.name}}
               JAVA_BUILD_VERSION: {{ java_build_version.version }}
@@ -604,7 +649,9 @@ jobs:
         ensure:
           do:
           - task: rsync_code_down-{{java_test_version.name}}
-            {{- alpine_tools_config()|indent(12) }}
+            image: alpine-tools-image
+            config:
+              platform: linux
               params:
                 JAVA_BUILD_VERSION: {{ java_build_version.version }}
                 ARTIFACT_SLUG: {{test.ARTIFACT_SLUG}}-{{java_test_version.name}}
@@ -623,7 +670,9 @@ jobs:
             do:
             - aggregate:
               - task: archive_results-{{java_test_version.name}}
-                {{- alpine_tools_config()|indent(16) }}
+                image: alpine-tools-image
+                config:
+                  platform: linux
                   params:
                     ARTIFACT_SLUG: {{test.ARTIFACT_SLUG}}-{{java_test_version.name}}
                     GRADLE_TASK: {{test.GRADLE_TASK}}
@@ -640,7 +689,9 @@ jobs:
                     path: geode-results
                 timeout: 1h
               - task: delete_instance-{{java_test_version.name}}
-                {{- alpine_tools_config()|indent(16) }}
+                image: alpine-tools-image
+                config:
+                  platform: linux
                   run:
                     path: geode-ci/ci/scripts/delete_instance.sh
                   inputs:

--- a/ci/pipelines/metrics/jinja.template.yml
+++ b/ci/pipelines/metrics/jinja.template.yml
@@ -16,13 +16,6 @@
 #
 {% from 'shared_jinja.yml' import github_access with context %}
 ---
-image_resource: &docker-geode-build-image
-  type: docker-image
-  source:
-    username: ((!docker-username))
-    password: ((!docker-password))
-    repository: gcr.io/((gcp-project))/metric-tools
-    tag: latest
 
 resources:
 - name: once-a-day
@@ -38,23 +31,33 @@ resources:
     paths:
     - ci/*
     {{ github_access() | indent(4) }}
+- name: docker-geode-build-image
+  type: docker-image
+  source:
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: gcr.io/((gcp-project))/metric-tools
+    tag: latest
+
 
 {%- macro metrics_job(job_name) %}
 - name: Geode{{job_name}}Metrics
   serial: true
   public: true
   plan:
-  - get: geode-ci
-  - get: once-a-day
-    trigger: true
+  - aggregate:
+    - get: docker-geode-build-image
+    - get: geode-ci
+    - get: once-a-day
+      trigger: true
   - task: get_metrics
+    image: docker-geode-build-image
     config:
       inputs:
       - name: geode-ci
       outputs:
       - name: workspace
       platform: linux
-      image_resource: *docker-geode-build-image
       run:
         path: /usr/bin/python3
         args:

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-{% from 'shared_jinja.yml' import alpine_tools_config with context %}
 {% from 'shared_jinja.yml' import pipeline_prefix with context %}
 {% from 'shared_jinja.yml' import init_retry with context %}
 
@@ -51,6 +50,14 @@ resources:
 - name: concourse-metadata-resource
   type: concourse-metadata-resource
   source: {}
+- name: alpine-tools-image
+  type: docker-image
+  source:
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
+    tag: latest
+
 resource_types:
 - name: gcs-resource
   type: docker-image
@@ -73,6 +80,7 @@ jobs:
   plan:
   - do:
     - aggregate:
+      - get: alpine-tools-image
       - get: geode
         trigger: true
         version: every
@@ -90,7 +98,9 @@ jobs:
         - put: concourse-metadata-resource
         {{ init_retry()|indent(8) }}
         - task: create_instance
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             params:
               CPUS: {{build_test.CPUS}}
               RAM: {{build_test.RAM}}
@@ -114,7 +124,9 @@ jobs:
           timeout: 15m
           attempts: 10
     - task: rsync_code_up
-      {{- alpine_tools_config()|indent(6) }}
+      image: alpine-tools-image
+      config:
+        platform: linux
         run:
           path: geode-ci/ci/scripts/rsync_code_up.sh
         inputs:
@@ -123,7 +135,9 @@ jobs:
         - name: instance-data
       timeout: 5m
     - task: build
-      {{- alpine_tools_config()|indent(6) }}
+      image: alpine-tools-image
+      config:
+        platform: linux
         params:
           JAVA_BUILD_VERSION: 8
           GRADLE_TASK: {{ build_test.GRADLE_TASK }}
@@ -157,7 +171,9 @@ jobs:
     ensure:
       do:
       - task: rsync_code_down
-        {{- alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           params:
             JAVA_BUILD_VERSION: 8
             ARTIFACT_SLUG: {{build_test.ARTIFACT_SLUG}}
@@ -173,7 +189,9 @@ jobs:
       ensure:
         aggregate:
         - task: archive_results
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             params:
               ARTIFACT_SLUG: {{build_test.ARTIFACT_SLUG}}
               GRADLE_TASK: {{build_test.GRADLE_TASK}}
@@ -188,7 +206,9 @@ jobs:
             - name: geode-ci
             - name: geode-results
         - task: delete_instance
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             run:
               path: geode-ci/ci/scripts/delete_instance.sh
             inputs:
@@ -214,6 +234,7 @@ jobs:
   plan:
   - do:
     - aggregate:
+      - get: alpine-tools-image
       - get: geode
         trigger: true
         version: every
@@ -231,7 +252,9 @@ jobs:
         - put: concourse-metadata-resource
         {{ init_retry()|indent(8) }}
         - task: create_instance-{{java_test_version.name}}
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             params:
               CPUS: {{test.CPUS}}
               GEODE_BRANCH: {{repository.branch}}
@@ -255,7 +278,9 @@ jobs:
           timeout: 15m
           attempts: 10
     - task: rsync_code_up-{{java_test_version.name}}
-      {{- alpine_tools_config()|indent(6) }}
+      image: alpine-tools-image
+      config:
+        platform: linux
         run:
           path: geode-ci/ci/scripts/rsync_code_up.sh
         inputs:
@@ -264,7 +289,9 @@ jobs:
         - name: instance-data
       timeout: 5m
     - task: execute_tests-{{java_test_version.name}}
-      {{- alpine_tools_config()|indent(6) }}
+      image: alpine-tools-image
+      config:
+        platform: linux
         params:
           ARTIFACT_SLUG: {{test.ARTIFACT_SLUG}}
           JAVA_BUILD_VERSION: {{ java_build_version.version }}
@@ -306,7 +333,9 @@ jobs:
     ensure:
       do:
       - task: rsync_code_down-{{java_test_version.name}}
-        {{- alpine_tools_config()|indent(8) }}
+        image: alpine-tools-image
+        config:
+          platform: linux
           params:
             JAVA_BUILD_VERSION: 8
             ARTIFACT_SLUG: {{test.ARTIFACT_SLUG}}
@@ -322,7 +351,9 @@ jobs:
       ensure:
         aggregate:
         - task: archive-results-{{java_test_version.name}}
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             params:
               ARTIFACT_SLUG: {{test.ARTIFACT_SLUG}}
               GRADLE_TASK: {{test.GRADLE_TASK}}
@@ -337,7 +368,9 @@ jobs:
             - name: geode-ci
             - name: geode-results
         - task: delete_instance-{{java_test_version.name}}
-          {{- alpine_tools_config()|indent(10) }}
+          image: alpine-tools-image
+          config:
+            platform: linux
             run:
               path: geode-ci/ci/scripts/delete_instance.sh
             inputs:

--- a/ci/pipelines/reaper/jinja.template.yml
+++ b/ci/pipelines/reaper/jinja.template.yml
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-{% from 'shared_jinja.yml' import alpine_tools_config with context %}
 
 ---
 
@@ -50,20 +49,32 @@ resources:
   source:
     filter: 'labels.time-to-live:* AND labels.time-to-live<$(($(date +%s) - 86400)) AND status:TERMINATED'
 
+- name: alpine-tools-image
+  type: docker-image
+  source:
+    username: ((docker-username))
+    password: ((docker-password))
+    repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
+    tag: latest
+
+- name: google-cloud-sdk-image
+  type: docker-image
+  source:
+    repository: google/cloud-sdk
+    tag: alpine
+
 jobs:
 - name: stop-instance
   plan:
-  - get: stoppable-instance
-    version: every
-    trigger: true
+  - aggregate:
+    - get: google-cloud-sdk-image
+    - get: stoppable-instance
+      version: every
+      trigger: true
   - task: stop-instances
+    image: google-cloud-sdk-image
     config:
       platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: google/cloud-sdk
-          tag: alpine
       inputs:
       - name: stoppable-instance
       run:
@@ -75,17 +86,15 @@ jobs:
 
 - name: delete-instance
   plan:
-  - get: deletable-instance
-    version: every
-    trigger: true
+  - aggregate:
+    - get: google-cloud-sdk-image
+    - get: deletable-instance
+      version: every
+      trigger: true
   - task: delete-instance
+    image: google-cloud-sdk-image
     config:
       platform: linux
-      image_resource:
-        type: docker-image
-        source:
-          repository: google/cloud-sdk
-          tag: alpine
       inputs:
       - name: deletable-instance
       run:
@@ -97,11 +106,15 @@ jobs:
 
 - name: reap-benchmark-instances
   plan:
-  - get: four-times-a-day
-    trigger: true
-  - get: geode-benchmarks
+  - aggregate:
+    - get: alpine-tools-image
+    - get: four-times-a-day
+      trigger: true
+    - get: geode-benchmarks
   - task: reap-benchmark-instances
-    {{- alpine_tools_config()|indent(4) }}
+    image: alpine-tools-image
+    config:
+      platform: linux
       params:
         AWS_ACCESS_KEY_ID: ((benchmarks-access-key-id))
         AWS_SECRET_ACCESS_KEY: ((benchmarks-secret-access-key))

--- a/ci/pipelines/shared/shared_jinja.yml
+++ b/ci/pipelines/shared/shared_jinja.yml
@@ -15,21 +15,6 @@
 # limitations under the License.
 #
 
-{%- macro alpine_tools_config() %}
-{{- docker_config() }}
-{%- endmacro %}
-
-{%- macro docker_config(repository_url) %}
-config:
-  platform: linux
-  image_resource:
-    type: docker-image
-    source:
-      username: ((!docker-username))
-      password: ((!docker-password))
-      repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
-      tag: latest
-{%- endmacro %}
 
 {%- macro github_access(public) -%}
 uri: https://github.com/((geode-fork))/((geode-repo-name)).git
@@ -41,7 +26,9 @@ password: ((github-password))
 
 {%- macro init_retry() -%}
 - task: initial-output
-  {{- docker_config()|indent(2) }}
+  image: alpine-tools-image
+  config:
+    platform: linux
     outputs:
     - name: attempts-log
     run:


### PR DESCRIPTION
Use Concourse resources for better image caching, instead of downloading the runtime image in the task container itself.

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
