### PR TITLE
GEODE-7237: Fix race condition in GfshRule

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandAcceptanceTest.java
@@ -40,21 +40,32 @@ public class ConnectCommandAcceptanceTest {
   public GfshRule gfshDefault = new GfshRule();
 
   @Test
-  public void useCurrentGfshToConnectToOlderLocator() throws Exception {
+  public void useCurrentGfshToConnectToOlderLocator() {
     // this test can only be run with pre-9 jdk since it needs to run older version of gfsh
     assumeTrue(!SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9));
-    GfshScript.of("start locator").execute(gfsh130);
-    GfshExecution connect = GfshScript.of("connect").expectFailure().execute(gfshDefault);
+    GfshScript
+        .of("start locator")
+        .execute(gfsh130);
 
-    assertThat(connect.getOutputText()).contains("Cannot use a")
+    GfshExecution connect = GfshScript
+        .of("connect")
+        .expectFailure()
+        .execute(gfshDefault);
+
+    assertThat(connect.getOutputText())
+        .contains("Cannot use a")
         .contains("gfsh client to connect to this cluster.");
   }
 
   @Test
-  public void invalidHostname() throws Exception {
-    GfshExecution connect = GfshScript.of("connect --locator=l192.168.99.1[52326]").expectFailure()
+  public void invalidHostname() {
+    GfshExecution connect = GfshScript
+        .of("connect --locator=l192.168.99.1[52326]")
+        .expectFailure()
         .execute(gfshDefault);
-    assertThat(connect.getOutputText()).doesNotContain("UnknownHostException")
+
+    assertThat(connect.getOutputText())
+        .doesNotContain("UnknownHostException")
         .doesNotContain("nodename nor servname")
         .contains("can't be reached. Hostname or IP address could not be found.");
   }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/ProcessLogger.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/ProcessLogger.java
@@ -21,27 +21,17 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-import org.apache.commons.lang3.SystemUtils;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.Filter;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.ConsoleAppender;
-import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
-import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
-import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
-import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+
+import org.apache.geode.internal.logging.LogService;
 
 public class ProcessLogger {
-  private static final LoggerContext LOGGER_CONTEXT = createLoggerContext();
-  private final Logger logger;
 
+  private final Logger logger;
   private final Queue<OutputLine> outputLines = new ConcurrentLinkedQueue<>();
 
   public ProcessLogger(Process process, String name) {
-    this.logger = LOGGER_CONTEXT.getLogger(name);
+    logger = LogService.getLogger(name);
 
     StreamGobbler stdOutGobbler =
         new StreamGobbler(process.getInputStream(), this::consumeInfoMessage);
@@ -62,28 +52,6 @@ public class ProcessLogger {
     outputLines.add(OutputLine.fromStdErr(message));
   }
 
-  private static LoggerContext createLoggerContext() {
-    LogManager.shutdown();
-
-    ConfigurationBuilder<BuiltConfiguration> builder =
-        ConfigurationBuilderFactory.newConfigurationBuilder();
-    builder.setStatusLevel(Level.ERROR);
-    builder.add(builder.newFilter("ThresholdFilter", Filter.Result.ACCEPT, Filter.Result.NEUTRAL)
-        .addAttribute("level", Level.DEBUG));
-    AppenderComponentBuilder appenderBuilder = builder.newAppender("Stdout", "CONSOLE")
-        .addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT);
-    appenderBuilder.add(builder.newLayout("PatternLayout").addAttribute("pattern",
-        "[%-5level %d{HH:mm:ss.SSS z}] (%c): %msg%n%throwable"));
-    appenderBuilder.add(builder.newFilter("MarkerFilter", Filter.Result.DENY, Filter.Result.NEUTRAL)
-        .addAttribute("marker", "FLOW"));
-    builder.add(appenderBuilder);
-    builder.add(builder.newLogger("org.apache.logging.log4j", Level.ERROR)
-        .add(builder.newAppenderRef("Stdout")).addAttribute("additivity", false));
-    builder.add(builder.newRootLogger(Level.ERROR).add(builder.newAppenderRef("Stdout")));
-
-    return Configurator.initialize(builder.build());
-  }
-
   public List<String> getStdOutLines() {
     return getOutputLines(OutputLine.OutputSource.STD_OUT);
   }
@@ -98,7 +66,7 @@ public class ProcessLogger {
 
   public String getOutputText() {
     return outputLines.stream().map(OutputLine::getLine)
-        .collect(joining(SystemUtils.LINE_SEPARATOR));
+        .collect(joining(System.lineSeparator()));
   }
 
   private List<String> getOutputLines(OutputLine.OutputSource source) {


### PR DESCRIPTION
Creation of geode-log4j widened a race condition in GfshRule in which
the process being forked would start printing output before the
ProcessLogger had been created and started in order to intercept that
output.

The widening of that race condition resulted in CI failures of
ConnectCommandAcceptanceTest.

ProcessLogger does not appear to have any real need for manipulating
log4j-core which is what widens the race condition far enough to fail
in CI.

Removing the manipulation of log4j-core from ProcessLogger reduces
the race condition for consistent passing. The window itself is still
there but without resorting to something like MainLauncher [1], there's
no way to completely close the window.

[1] geode-junit: org.apache.geode.test.process.MainLauncher

If ConnectCommandAcceptanceTest or other tests using GfshRule fail
after this commit, then we'll need to use something like MainLauncher.

Please review: @aaronlindsey 