### PR TITLE
GEODE-7242: Fix AVG and SUM documentation

### DIFF
--- a/geode-docs/developing/query_select/aggregates.html.md.erb
+++ b/geode-docs/developing/query_select/aggregates.html.md.erb
@@ -210,7 +210,8 @@ For partitioned regions, each node's buckets compute a sum over that node and re
 The `SUM` function where the `DISTINCT` modifier is applied to the expression returns the summation over the set of unique (distinct) values.
 For partitioned regions, the distinct values in a node's buckets are returned to the coordinator node, which can then calculate the sum over the values that are unique across nodes, after eliminating duplicate values that come from separate nodes.
 
-The actual expression used to calculate the aggregation should be an instance of `java.lang.Number`. The `SUM` statement always returns a `java.lang.Float` or `java.lang.Double` as the result (depending on how big the value is); you should take this into consideration when executing the query: if an overflow occurs while computing the `SUM` function because the value is higher than `Double.MAX_VALUE` ((2 - 2<sup>-52</sup>) * 2<sup>1023</sup>), the result will be incorrect.
+The actual expression used to calculate the aggregation should be an instance of `java.lang.Number`.
+The `SUM` statement always returns a `java.lang.Number` as the result and, depending on how big the value is and whether it has a decimal component or not, the returned type could be an instance of `java.lang.Integer`, `java.lang.Long`, `java.lang.Float` or `java.lang.Double`; you should take this into consideration when executing the query: if an overflow occurs while computing the `SUM` function because the value is higher than `Double.MAX_VALUE` ((2 - 2<sup>-52</sup>) * 2<sup>1023</sup>), the result will be incorrect.
 
 The following are example `SUM` queries that return the summation of the entries ID.
 
@@ -279,7 +280,7 @@ The `AVG` keyword where the `DISTINCT` modifier is applied to the expression ret
 For partitioned regions, the distinct values in a node's buckets are returned to the coordinator node, which can then calculate the average over the values that are unique across nodes, after eliminating duplicate values that come from separate nodes.
 
 The actual expression used to calculate the aggregation should be an instance of `java.lang.Number`. 
-The `AVG` statement always returns a `java.lang.Float` or `java.lang.Double` as the result (depending on how big the value is); you should take this into consideration when executing the query: if an overflow occurs while computing the `AVG` function because the value is higher than `Double.MAX_VALUE` ((2 - 2<sup>-52</sup>) * 2<sup>1023</sup>), or if an overflow occurs while computing the intermediate count because the amount of elements is higher than `Long.MAX_VALUE` (2<sup>63</sup> - 1), the result will be incorrect.  
+The `AVG` statement always returns a `java.lang.Number` as the result and, depending on how big the value is and whether it has a decimal component or not, the returned type could be an instance of `java.lang.Integer`, `java.lang.Long`, `java.lang.Float` or `java.lang.Double`; you should take this into consideration when executing the query: if an overflow occurs while computing the `AVG` function because the value is higher than `Double.MAX_VALUE` ((2 - 2<sup>-52</sup>) * 2<sup>1023</sup>), or if an overflow occurs while computing the intermediate count because the amount of elements is higher than `Long.MAX_VALUE` (2<sup>63</sup> - 1), the result will be incorrect.  
 
 The following are example `AVG` queries that calculate the average of the entries ID.
 


### PR DESCRIPTION
Fixed the documentation for the aggregate functions AVG and SUM, the
result value will always be an instance of `java.lang.Number` but the
actual type might vary depending on the value size and wether it has a
decimal componen or not.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
