### PR TITLE
GEODE-7123: Add create disk-store command option, stage-configuration

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -44,6 +44,7 @@ import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.functions.CreateDiskStoreFunction;
 import org.apache.geode.management.internal.cli.functions.ListDiskStoresFunction;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
+import org.apache.geode.management.internal.cli.result.model.InfoResultModel;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
@@ -89,7 +90,10 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
           help = CliStrings.CREATE_DISK_STORE__DISK_USAGE_WARNING_PCT__HELP) float diskUsageWarningPercentage,
       @CliOption(key = CliStrings.CREATE_DISK_STORE__DISK_USAGE_CRITICAL_PCT,
           unspecifiedDefaultValue = "99",
-          help = CliStrings.CREATE_DISK_STORE__DISK_USAGE_CRITICAL_PCT__HELP) float diskUsageCriticalPercentage) {
+          help = CliStrings.CREATE_DISK_STORE__DISK_USAGE_CRITICAL_PCT__HELP) float diskUsageCriticalPercentage,
+      @CliOption(key = CliStrings.CREATE_DISK_STORE__STAGE_CONFIGURATION,
+          specifiedDefaultValue = "true", unspecifiedDefaultValue = "false",
+          help = CliStrings.CREATE_DISK_STORE__STAGE_CONFIGURATION__HELP) boolean stageDiskStoreConfig) {
 
     DiskStoreAttributes diskStoreAttributes = new DiskStoreAttributes();
     diskStoreAttributes.allowForceCompaction = allowForceCompaction;
@@ -122,7 +126,11 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
     Set<DistributedMember> targetMembers = findMembers(groups, null);
 
     if (targetMembers.isEmpty()) {
-      return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      if (!stageDiskStoreConfig) {
+        return ResultModel.createError(CliStrings.NO_MEMBERS_FOUND_MESSAGE);
+      } else {
+        targetMembers = findMembersIncludingLocators(groups, null);
+      }
     }
 
     Pair<Boolean, String> validationResult =
@@ -131,15 +139,23 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
       return ResultModel.createError(validationResult.getRight());
     }
 
-    List<CliFunctionResult> functionResults = executeAndGetFunctionResult(
-        new CreateDiskStoreFunction(), new Object[] {name, diskStoreAttributes}, targetMembers);
+    ResultModel result;
+    DiskStoreType diskStoreType = createDiskStoreType(name, diskStoreAttributes);
+    if (stageDiskStoreConfig) {
+      result = new ResultModel();
+      InfoResultModel infoSection = result.addInfo();
+      result.setConfigObject(diskStoreType);
+    } else {
+      List<CliFunctionResult> functionResults = executeAndGetFunctionResult(
+          new CreateDiskStoreFunction(), new Object[] {name, diskStoreAttributes}, targetMembers);
 
-    ResultModel result = ResultModel.createMemberStatusResult(functionResults);
-    result.setConfigObject(createDiskStoreType(name, diskStoreAttributes));
+      result = ResultModel.createMemberStatusResult(functionResults);
+      result.setConfigObject(diskStoreType);
 
-    if (!waitForDiskStoreMBeanCreation(name, targetMembers)) {
-      result.addInfo()
-          .addLine("Did not complete waiting for Disk Store MBean proxy creation");
+      if (!waitForDiskStoreMBeanCreation(name, targetMembers)) {
+        result.addInfo()
+            .addLine("Did not complete waiting for Disk Store MBean proxy creation");
+      }
     }
 
     return result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -717,10 +717,6 @@ public class CliStrings {
       "disk-usage-critical-percentage";
   public static final String CREATE_DISK_STORE__DISK_USAGE_CRITICAL_PCT__HELP =
       "Critical percentage for disk volume usage.";
-  public static final String CREATE_DISK_STORE__STAGE_CONFIGURATION =
-      "stage-configuration";
-  public static final String CREATE_DISK_STORE__STAGE_CONFIGURATION__HELP =
-      "Only create the cluster configuration element for the disk-store. The disk-store will be created on any future servers to join the cluster.";
   public static final String CREATE_DISK_STORE__ERROR_WHILE_CREATING_REASON_0 =
       "An error occurred while creating the disk store: \"{0}\"";
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/i18n/CliStrings.java
@@ -717,6 +717,10 @@ public class CliStrings {
       "disk-usage-critical-percentage";
   public static final String CREATE_DISK_STORE__DISK_USAGE_CRITICAL_PCT__HELP =
       "Critical percentage for disk volume usage.";
+  public static final String CREATE_DISK_STORE__STAGE_CONFIGURATION =
+      "stage-configuration";
+  public static final String CREATE_DISK_STORE__STAGE_CONFIGURATION__HELP =
+      "Only create the cluster configuration element for the disk-store. The disk-store will be created on any future servers to join the cluster.";
   public static final String CREATE_DISK_STORE__ERROR_WHILE_CREATING_REASON_0 =
       "An error occurred while creating the disk store: \"{0}\"";
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
@@ -81,7 +81,7 @@ public class CreateDiskStoreCommandTest {
   }
 
   @Test
-  public void stageConfiguration_doesNotExecuteCreateDiskStoreFunction() {
+  public void createWithNoServerMembers_persistsConfigWithoutExecutingCreateDiskStoreFunction() {
     doReturn(Collections.emptySet()).when(command).findMembers(any(),
         any());
     doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
@@ -92,15 +92,14 @@ public class CreateDiskStoreCommandTest {
 
     ResultModel resultModel =
         gfsh.executeAndAssertThat(command,
-            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            "create disk-store --name=pdx --dir=./pdx/persist")
             .statusIsSuccess().getResultModel();
     verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
-
     verify(command, never()).executeAndGetFunctionResult(any(), any(), any());
   }
 
   @Test
-  public void stageConfiguration_noServers_persistsConfig() {
+  public void createWithNoServers_isIdempotent() {
     doReturn(Collections.emptySet()).when(command).findMembers(any(),
         any());
     doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
@@ -111,50 +110,14 @@ public class CreateDiskStoreCommandTest {
 
     ResultModel resultModel =
         gfsh.executeAndAssertThat(command,
-            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
-            .statusIsSuccess().getResultModel();
-    verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
-  }
-
-  @Test
-  public void stageConfiguration_withServers_persistsConfig() {
-    doReturn(Collections.emptySet()).when(command).findMembers(any(),
-        any());
-    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
-        .findMembersIncludingLocators(any(),
-            any());
-    doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
-        any());
-
-    ResultModel resultModel =
-        gfsh.executeAndAssertThat(command,
-            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
-            .statusIsSuccess().getResultModel();
-    verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
-  }
-
-  @Test
-  public void stageConfiguration_isIdempotent() {
-    doReturn(Collections.emptySet()).when(command).findMembers(any(),
-        any());
-    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
-        .findMembersIncludingLocators(any(),
-            any());
-    doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
-        any());
-
-    ResultModel resultModel =
-        gfsh.executeAndAssertThat(command,
-            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            "create disk-store --name=ds1 --dir=./pdx/persist")
             .statusIsSuccess().getResultModel();
 
     verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
-    DiskStoreType diskStoreType;
-    DiskDirType diskDirType;
 
     resultModel =
         gfsh.executeAndAssertThat(command,
-            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            "create disk-store --name=ds1 --dir=./pdx/persist")
             .statusIsSuccess().getResultModel();
     verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommandTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 
@@ -59,10 +61,7 @@ public class CreateDiskStoreCommandTest {
     ResultModel resultModel =
         gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=./data/persist")
             .getResultModel();
-    DiskStoreType diskStoreType = (DiskStoreType) resultModel.getConfigObject();
-
-    DiskDirType diskDirType = diskStoreType.getDiskDirs().get(0);
-    assertThat(diskDirType.getContent().replace('\\', '/')).isEqualTo("./data/persist");
+    verifyDiskStoreDirConfig(resultModel, "./data/persist");
   }
 
   @Test
@@ -77,9 +76,93 @@ public class CreateDiskStoreCommandTest {
     ResultModel resultModel =
         gfsh.executeAndAssertThat(command, "create disk-store --name=ds1 --dir=/data/persist")
             .getResultModel();
+    verifyDiskStoreDirConfig(resultModel, "/data/persist");
+
+  }
+
+  @Test
+  public void stageConfiguration_doesNotExecuteCreateDiskStoreFunction() {
+    doReturn(Collections.emptySet()).when(command).findMembers(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
+            any());
+    doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
+        any());
+
+    ResultModel resultModel =
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
+    verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
+
+    verify(command, never()).executeAndGetFunctionResult(any(), any(), any());
+  }
+
+  @Test
+  public void stageConfiguration_noServers_persistsConfig() {
+    doReturn(Collections.emptySet()).when(command).findMembers(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
+            any());
+    doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
+        any());
+
+    ResultModel resultModel =
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
+    verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
+  }
+
+  @Test
+  public void stageConfiguration_withServers_persistsConfig() {
+    doReturn(Collections.emptySet()).when(command).findMembers(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
+            any());
+    doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
+        any());
+
+    ResultModel resultModel =
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
+    verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
+  }
+
+  @Test
+  public void stageConfiguration_isIdempotent() {
+    doReturn(Collections.emptySet()).when(command).findMembers(any(),
+        any());
+    doReturn(Collections.singleton(mock(DistributedMember.class))).when(command)
+        .findMembersIncludingLocators(any(),
+            any());
+    doReturn(Pair.of(Boolean.TRUE, null)).when(command).validateDiskstoreAttributes(any(),
+        any());
+
+    ResultModel resultModel =
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
+
+    verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
+    DiskStoreType diskStoreType;
+    DiskDirType diskDirType;
+
+    resultModel =
+        gfsh.executeAndAssertThat(command,
+            "create disk-store --name=ds1 --dir=./pdx/persist --stage-configuration=true")
+            .statusIsSuccess().getResultModel();
+    verifyDiskStoreDirConfig(resultModel, "./pdx/persist");
+  }
+
+  private void verifyDiskStoreDirConfig(ResultModel resultModel, String expectedDir) {
     DiskStoreType diskStoreType = (DiskStoreType) resultModel.getConfigObject();
 
     DiskDirType diskDirType = diskStoreType.getDiskDirs().get(0);
-    assertThat(diskDirType.getContent().replace('\\', '/')).isEqualTo("/data/persist");
+    assertThat(diskDirType.getContent().replace('\\', '/')).isEqualTo(expectedDir);
   }
 }


### PR DESCRIPTION
The new option, --stage-configuration, to the create disk-store command
provides the capability to define a disk-store in the cluster configuration
prior to any server members have joined the cluster. Using this option
will only update the cluster-configuration, disk-stores will not be
created on any current server members.

Servers joining the cluster (or restarting) will then inherit the new
disk-store configuration and create the appropriate directory and
disk-store files.

This is useful for persisting the PDX types to a disk-store other than
DEFAULT. When starting a cluster, the disk-store for pdx can be added to
the configuration after the locators are started and before any servers
are started. Next, PDX persistence is then configured to use the disk-store,
and finally the servers are started.

Authored-by: Ken Howe <khowe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
