### PR TITLE
GEODE-7257: Remove unnecessary uses of log4j-core

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -230,8 +230,6 @@ dependencies {
   distributedTestCompile('org.springframework:spring-web')
   distributedTestCompile(project(':geode-management'))
   distributedTestCompile(project(':geode-web-management'))
-  distributedTestCompile('org.apache.logging.log4j:log4j-core::tests')
-  distributedTestCompile('org.apache.logging.log4j:log4j-core::test-sources')
   distributedTestCompile('com.arakelian:java-jq')
 
   distributedTestRuntime(project(':extensions:geode-modules-session-internal')) {

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDUnitTest.java
@@ -1,90 +1,160 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package org.apache.geode.management.internal.rest;
 
+import static java.nio.charset.Charset.defaultCharset;
+import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.internal.AvailablePort.SOCKET;
+import static org.apache.geode.internal.AvailablePort.getRandomAvailablePort;
+import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.List;
-import java.util.Map;
+import java.io.File;
+import java.io.Serializable;
+import java.nio.file.Path;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.test.appender.ListAppender;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
+import org.apache.geode.distributed.LocatorLauncher;
+import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.management.api.ClusterManagementResult;
 import org.apache.geode.management.api.ClusterManagementService;
 import org.apache.geode.management.client.ClusterManagementServiceBuilder;
 import org.apache.geode.management.configuration.Region;
 import org.apache.geode.management.configuration.RegionType;
-import org.apache.geode.test.dunit.rules.ClusterStartupRule;
-import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 
-public class ManagementRequestLoggingDUnitTest {
+public class ManagementRequestLoggingDUnitTest implements Serializable {
 
-  @ClassRule
-  public static ClusterStartupRule cluster = new ClusterStartupRule();
-  private static MemberVM locator, server;
-  private static ClusterManagementService service;
+  private static LocatorLauncher locatorLauncher;
+  private static ServerLauncher serverLauncher;
 
-  @BeforeClass
-  public static void beforeClass() {
-    locator = cluster.startLocatorVM(0, l -> l.withHttpService());
-    server = cluster.startServerVM(1, locator.getPort());
-    service =
-        ClusterManagementServiceBuilder.buildWithHostAddress()
-            .setHostAddress("localhost", locator.getHttpPort())
-            .build();
+  private VM locatorVM;
+  private VM serverVM;
+
+  private String locatorName;
+  private String serverName;
+  private File locatorDir;
+  private File serverDir;
+  private int httpPort;
+  private int locatorPort;
+
+  private transient ClusterManagementService service;
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @Rule
+  public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
+
+  @Before
+  public void setUp() throws Exception {
+    locatorVM = getVM(0);
+    serverVM = getVM(1);
+
+    locatorName = "locator1";
+    serverName = "server1";
+    locatorDir = temporaryFolder.newFolder(locatorName);
+    serverDir = temporaryFolder.newFolder(serverName);
+    httpPort = getRandomAvailablePort(SOCKET);
+
+    locatorPort = locatorVM.invoke(this::startLocator);
+    serverVM.invoke(this::startServer);
+
+    service = ClusterManagementServiceBuilder.buildWithHostAddress()
+        .setHostAddress("localhost", httpPort)
+        .build();
+  }
+
+  @After
+  public void tearDown() {
+    locatorVM.invoke(() -> {
+      if (locatorLauncher != null) {
+        locatorLauncher.stop();
+        locatorLauncher = null;
+      }
+    });
+
+    serverVM.invoke(() -> {
+      if (serverLauncher != null) {
+        serverLauncher.stop();
+        serverLauncher = null;
+      }
+    });
   }
 
   @Test
-  public void checkRequestsAreLogged() throws Exception {
-    locator.invoke(() -> {
-      Logger logger = (Logger) LogManager.getLogger(ManagementLoggingFilter.class);
-      ListAppender listAppender = new ListAppender("ListAppender");
-      logger.addAppender(listAppender);
-      listAppender.start();
-    });
-
+  public void checkRequestsAreLogged() {
     Region regionConfig = new Region();
     regionConfig.setName("customers");
     regionConfig.setType(RegionType.REPLICATE);
 
     ClusterManagementResult result = service.create(regionConfig);
+
     assertThat(result.isSuccessful()).isTrue();
 
-    locator.invoke(() -> {
-      Logger logger = (Logger) LogManager.getLogger(ManagementLoggingFilter.class);
-      Map<String, Appender> appenders = logger.getAppenders();
-      ListAppender listAppender = (ListAppender) appenders.get("ListAppender");
-      List<LogEvent> logEvents = listAppender.getEvents();
+    locatorVM.invoke(() -> {
+      Path logFile = locatorDir.toPath().resolve(locatorName + ".log");
+      String logContents = readFileToString(logFile.toFile(), defaultCharset());
 
-      assertThat(logEvents.size()).as("Expected LogEvents").isEqualTo(2);
-      String beforeMessage = logEvents.get(0).getMessage().getFormattedMessage();
-      assertThat(beforeMessage).startsWith("Management Request: POST");
-      assertThat(beforeMessage).contains("user=").contains("payload={")
-          .contains("customers");
-      assertThat(logEvents.get(1).getMessage().getFormattedMessage())
-          .startsWith("Management Response: ").contains("response={").contains("Status=");
+      // Note: the following is kind of fragile. Remove experimental when it goes away.
+      // Also feel free to change the following to use regex or substrings
 
-      logger.removeAppender(listAppender);
+      assertThat(logContents)
+          .containsSubsequence(
+              "Management Request:",
+              " POST[url=/management/experimental/regions];",
+              " user=null;",
+              " payload={\"class\":\"org.apache.geode.management.configuration.Region\",\"group\":null,\"name\":\"customers\",\"type\":\"REPLICATE\",\"keyConstraint\":null,\"valueConstraint\":null,\"diskStoreName\":null,\"redundantCopies\":null,\"expirations\":null,\"uri\":\"/management/experimental/regions/customers\"}")
+          .containsSubsequence(
+              "Management Response:",
+              " Status=201;",
+              " response={\"statusCode\":\"OK\",\"statusMessage\":\"Successfully updated configuration for cluster.\",\"uri\":\"/management/experimental/regions/customers\",\"memberStatuses\":[{\"memberName\":\"server1\",\"success\":true,\"message\":\"Region successfully created.\"}]}");
     });
+  }
+
+  private int startLocator() {
+    LocatorLauncher.Builder builder = new LocatorLauncher.Builder();
+    builder.setMemberName(locatorName);
+    builder.setWorkingDirectory(locatorDir.getAbsolutePath());
+    builder.setPort(0);
+    builder.set(HTTP_SERVICE_PORT, String.valueOf(httpPort));
+
+    locatorLauncher = builder.build();
+    locatorLauncher.start();
+
+    return locatorLauncher.getPort();
+  }
+
+  private void startServer() {
+    ServerLauncher.Builder builder = new ServerLauncher.Builder();
+    builder.setMemberName(serverName);
+    builder.setWorkingDirectory(serverDir.getAbsolutePath());
+    builder.setServerPort(0);
+    builder.set(LOCATORS, "localHost[" + locatorPort + "]");
+
+    serverLauncher = builder.build();
+    serverLauncher.start();
   }
 }

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
@@ -45,6 +45,7 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 
+@SuppressWarnings("serial")
 public class ManagementRequestLoggingDistributedTest implements Serializable {
 
   private static LocatorLauncher locatorLauncher;

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
@@ -45,7 +45,7 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 
-public class ManagementRequestLoggingDUnitTest implements Serializable {
+public class ManagementRequestLoggingDistributedTest implements Serializable {
 
   private static LocatorLauncher locatorLauncher;
   private static ServerLauncher serverLauncher;

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
@@ -14,13 +14,10 @@
  */
 package org.apache.geode.management.internal.cli;
 
+import static java.lang.System.lineSeparator;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.springframework.shell.core.Completion;
@@ -29,69 +26,66 @@ import org.apache.geode.cache.query.IndexType;
 import org.apache.geode.management.internal.cli.i18n.CliStrings;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshParserRule;
+import org.apache.geode.test.junit.rules.GfshParserRule.CommandCandidate;
 
 @Category(GfshTest.class)
-public class GfshParserAutoCompletionTest {
+public class GfshParserAutoCompletionIntegrationTest {
 
-  @ClassRule
-  public static GfshParserRule parser = new GfshParserRule();
-
-  private String buffer;
-  private GfshParserRule.CommandCandidate candidate;
-  private static String LINE_SEPARATOR = System.lineSeparator();
+  @Rule
+  public GfshParserRule gfshParserRule = new GfshParserRule();
 
   @Test
   public void testCompletionDescribe() {
-    buffer = "describe";
-    candidate = parser.complete(buffer);
+    String buffer = "describe";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo("describe client");
   }
 
   @Test
   public void testCompletionDescribeWithSpace() {
-    buffer = "describe ";
-    candidate = parser.complete(buffer);
+    String buffer = "describe ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo("describe client");
   }
 
   @Test
   public void testCompletionDeploy() {
-    buffer = "deploy";
-    candidate = parser.complete(buffer);
+    String buffer = "deploy";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --dir");
   }
 
   @Test
   public void testCompletionDeployWithSpace() {
-    buffer = "deploy ";
-    candidate = parser.complete(buffer);
+    String buffer = "deploy ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--dir");
   }
 
   @Test
   public void testCompleteWithRequiredOption() {
-    buffer = "describe config";
-    candidate = parser.complete(buffer);
+    String buffer = "describe config";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --member");
   }
 
   @Test
   public void testCompleteWithRequiredOptionWithSpace() {
-    buffer = "describe config ";
-    candidate = parser.complete(buffer);
+    String buffer = "describe config ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--member");
   }
 
   @Test
   public void testCompletionStart() {
-    buffer = "start";
-    candidate = parser.complete(buffer);
+    String buffer = "start";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates().size()).isEqualTo(8);
     assertThat(candidate.getCandidates().stream()
         .anyMatch(completion -> completion.getFormattedValue().contains("gateway-receiver")))
@@ -103,8 +97,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompletionStartWithSpace() {
-    buffer = "start ";
-    candidate = parser.complete(buffer);
+    String buffer = "start ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates().size()).isEqualTo(8);
     assertThat(candidate.getCandidates().stream()
         .anyMatch(completion -> completion.getFormattedValue().contains("gateway-receiver")))
@@ -116,24 +110,24 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompleteCommand() {
-    buffer = "start ser";
-    candidate = parser.complete(buffer);
+    String buffer = "start ser";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(1);
     assertThat("start server").isEqualTo(candidate.getFirstCandidate());
   }
 
   @Test
   public void testCompleteOptionWithOnlyOneCandidate() {
-    buffer = "start server --nam";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --nam";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "e");
   }
 
   @Test
   public void testCompleteOptionWithMultipleCandidates() {
-    buffer = "start server --name=jinmei --loc";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=jinmei --loc";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(3);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "ator-wait-time");
     assertThat(candidate.getCandidate(1)).isEqualTo(buffer + "ators");
@@ -142,8 +136,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompleteWithExtraSpace() {
-    buffer = "start server --name=name1  --se";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1  --se";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo("start server --name=name1  ".length());
     assertThat(candidate.getCandidates()).hasSize(3);
     assertThat(candidate.getCandidates()).contains(new Completion("--server-port"));
@@ -152,8 +146,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompleteWithDashInTheEnd() {
-    buffer = "start server --name=name1 --";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 2);
     assertThat(candidate.getCandidates()).hasSize(53);
     assertThat(candidate.getCandidates()).contains(new Completion("--properties-file"));
@@ -162,8 +156,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompleteWithSpace() {
-    buffer = "start server --name=name1 ";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 1);
     assertThat(candidate.getCandidates()).hasSize(53);
     assertThat(candidate.getCandidates()).contains(new Completion(" --properties-file"));
@@ -172,8 +166,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompleteWithOutSpace() {
-    buffer = "start server --name=name1";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
     assertThat(candidate.getCandidates()).hasSize(53);
     assertThat(candidate.getCandidates()).contains(new Completion(" --properties-file"));
@@ -182,31 +176,31 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompleteJ() {
-    buffer = "start server --name=name1 --J=";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --J=";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 3);
     assertThat(candidate.getCandidates()).hasSize(1);
   }
 
   @Test
   public void testCompleteWithValue() {
-    buffer = "start server --name=name1 --J";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --J";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 3);
     assertThat(candidate.getCandidates()).hasSize(1);
   }
 
   @Test
   public void testCompleteWithDash() {
-    buffer = "start server --name=name1 --J=-Dfoo.bar --";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --J=-Dfoo.bar --";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(52);
   }
 
   @Test
   public void testCompleteWithMultipleJ() {
-    buffer = "start server --name=name1 --J=-Dme=her --J=-Dfoo=bar --l";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --J=-Dme=her --J=-Dfoo=bar --l";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor())
         .isEqualTo("start server --name=name1 --J=-Dme=her --J=-Dfoo=bar ".length());
     assertThat(candidate.getCandidates()).hasSize(4);
@@ -215,8 +209,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testMultiJComplete() {
-    buffer = "start server --name=name1 --J=-Dtest=test1 --J=-Dfoo=bar";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --J=-Dtest=test1 --J=-Dfoo=bar";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
     assertThat(candidate.getCandidates()).hasSize(52);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --assign-buckets");
@@ -224,8 +218,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testMultiJCompleteWithDifferentOrder() {
-    buffer = "start server --J=-Dtest=test1 --J=-Dfoo=bar --name=name1";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --J=-Dtest=test1 --J=-Dfoo=bar --name=name1";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
     assertThat(candidate.getCandidates()).hasSize(52);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --assign-buckets");
@@ -233,8 +227,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testJComplete3() {
-    buffer = "start server --name=name1 --locators=localhost --J=-Dfoo=bar";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --locators=localhost --J=-Dfoo=bar";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length());
     assertThat(candidate.getCandidates()).hasSize(51);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " --assign-buckets");
@@ -242,8 +236,8 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testJComplete4() {
-    buffer = "start server --name=name1 --locators=localhost  --J=-Dfoo=bar --";
-    candidate = parser.complete(buffer);
+    String buffer = "start server --name=name1 --locators=localhost  --J=-Dfoo=bar --";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCursor()).isEqualTo(buffer.length() - 2);
     assertThat(candidate.getCandidates()).hasSize(51);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "assign-buckets");
@@ -251,128 +245,129 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testCompleteRegionType() {
-    buffer = "create region --name=test --type";
-    candidate = parser.complete(buffer);
+    String buffer = "create region --name=test --type";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(23);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "=LOCAL");
   }
 
   @Test
   public void testCompletePartialRegionType() {
-    buffer = "create region --name=test --type=LO";
-    candidate = parser.complete(buffer);
+    String buffer = "create region --name=test --type=LO";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "CAL");
   }
 
   @Test
   public void testCompleteWithRegionTypeWithNoSpace() {
-    buffer = "create region --name=test --type=REPLICATE";
-    candidate = parser.complete(buffer);
+    String buffer = "create region --name=test --type=REPLICATE";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(5);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "_HEAP_LRU");
   }
 
   @Test
   public void testCompleteWithRegionTypeWithSpace() {
-    buffer = "create region --name=test --type=REPLICATE ";
-    candidate = parser.complete(buffer);
+    String buffer = "create region --name=test --type=REPLICATE ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(45);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--async-event-queue-id");
   }
 
   @Test
   public void testCompleteLogLevel() {
-    buffer = "change loglevel --loglevel";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates())).hasSize(8);
+    String buffer = "change loglevel --loglevel";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "=ALL");
   }
 
   @Test
   public void testCompleteLogLevelWithEqualSign() {
-    buffer = "change loglevel --loglevel=";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates())).hasSize(8);
+    String buffer = "change loglevel --loglevel=";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "ALL");
   }
 
   @Test
   public void testCompleteHintNonexistemt() {
-    buffer = "hint notfound";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates())).hasSize(0);
+    String buffer = "hint notfound";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(0);
   }
 
   @Test
   public void testCompleteHintNada() {
-    buffer = "hint";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates()).size()).isGreaterThan(10);
+    String buffer = "hint";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates().size()).isGreaterThan(10);
     assertThat(candidate.getFirstCandidate()).isEqualToIgnoringCase("hint client");
   }
 
   @Test
   public void testCompleteHintSpace() {
-    buffer = "hint ";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates()).size()).isGreaterThan(10);
+    String buffer = "hint ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates().size()).isGreaterThan(10);
     assertThat(candidate.getFirstCandidate()).isEqualToIgnoringCase("hint client");
   }
 
   @Test
   public void testCompleteHintPartial() {
-    buffer = "hint d";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates())).hasSize(3);
+    String buffer = "hint d";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(3);
     assertThat(candidate.getFirstCandidate()).isEqualToIgnoringCase("hint data");
   }
 
   @Test
   public void testCompleteHintAlreadyComplete() {
-    buffer = "hint data";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates())).hasSize(1);
+    String buffer = "hint data";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualToIgnoringCase(buffer);
   }
 
   @Test
   public void testCompleteHelpFirstWord() {
-    buffer = "help start";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates())).hasSize(8);
+    String buffer = "help start";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(8);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + " gateway-receiver");
   }
 
   @Test
   public void testCompleteHelpPartialFirstWord() {
-    buffer = "help st";
-    candidate = parser.complete(buffer);
-    assertThat(removeExtendedLevels(candidate.getCandidates())).hasSize(17);
+    String buffer = "help st";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(17);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "art gateway-receiver");
   }
 
   @Test
   public void testObtainHelp() {
     String command = CliStrings.START_PULSE;
-    String helpString = "NAME" + LINE_SEPARATOR + "start pulse" + LINE_SEPARATOR + "IS AVAILABLE"
-        + LINE_SEPARATOR + "true" + LINE_SEPARATOR + "SYNOPSIS" + LINE_SEPARATOR
+    String helpString = "NAME" + lineSeparator() + "start pulse" + lineSeparator() + "IS AVAILABLE"
+        + lineSeparator() + "true" + lineSeparator() + "SYNOPSIS" + lineSeparator()
         + "Open a new window in the default Web browser with the URL for the Pulse application."
-        + LINE_SEPARATOR
-        + "SYNTAX" + LINE_SEPARATOR + "start pulse [--url=value]" + LINE_SEPARATOR + "PARAMETERS"
-        + LINE_SEPARATOR + "url" + LINE_SEPARATOR
-        + "URL of the Pulse Web application." + LINE_SEPARATOR + "Required: false" + LINE_SEPARATOR
+        + lineSeparator()
+        + "SYNTAX" + lineSeparator() + "start pulse [--url=value]" + lineSeparator() + "PARAMETERS"
+        + lineSeparator() + "url" + lineSeparator()
+        + "URL of the Pulse Web application." + lineSeparator() + "Required: false"
+        + lineSeparator()
         + "Default (if the parameter is not specified): http://localhost:7070/pulse"
-        + LINE_SEPARATOR;
-    assertThat(parser.getCommandManager().obtainHelp(command)).isEqualTo(helpString);
+        + lineSeparator();
+    assertThat(gfshParserRule.getCommandManager().obtainHelp(command)).isEqualTo(helpString);
   }
 
   @Test
   public void testObtainHelpForStart() {
     String command = "start";
-    String helpProvided = parser.getCommandManager().getHelper().getHelp(command, 1000);
-    String[] helpProvidedArray = helpProvided.split(LINE_SEPARATOR);
-    assertThat(helpProvidedArray.length).isEqualTo((8 * 2) + 3);
+    String helpProvided = gfshParserRule.getCommandManager().getHelper().getHelp(command, 1000);
+    String[] helpProvidedArray = helpProvided.split(lineSeparator());
+    assertThat(helpProvidedArray.length).isEqualTo(8 * 2 + 3);
     for (int i = 0; i < helpProvidedArray.length - 3; i++) {
       if (i % 2 != 0) {
         assertThat(helpProvidedArray[i]).startsWith("    ");
@@ -385,8 +380,8 @@ public class GfshParserAutoCompletionTest {
   @Test
   public void testObtainHintForData() {
     String hintArgument = "data";
-    String hintsProvided = parser.getCommandManager().obtainHint(hintArgument);
-    String[] hintsProvidedArray = hintsProvided.split(LINE_SEPARATOR);
+    String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
+    String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
     assertThat(hintsProvidedArray.length).isEqualTo(15);
     assertThat(hintsProvidedArray[0])
         .isEqualTo("User data as stored in regions of the Geode distributed system.");
@@ -395,8 +390,8 @@ public class GfshParserAutoCompletionTest {
   @Test
   public void testObtainHintWithoutArgument() {
     String hintArgument = "";
-    String hintsProvided = parser.getCommandManager().obtainHint(hintArgument);
-    String[] hintsProvidedArray = hintsProvided.split(LINE_SEPARATOR);
+    String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
+    String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
     assertThat(hintsProvidedArray.length).isEqualTo(21);
     assertThat(hintsProvidedArray[0]).isEqualTo(
         "Hints are available for the following topics. Use \"hint <topic-name>\" for a specific hint.");
@@ -405,8 +400,8 @@ public class GfshParserAutoCompletionTest {
   @Test
   public void testObtainHintWithNonExistingCommand() {
     String hintArgument = "fortytwo";
-    String hintsProvided = parser.getCommandManager().obtainHint(hintArgument);
-    String[] hintsProvidedArray = hintsProvided.split(LINE_SEPARATOR);
+    String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
+    String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
     assertThat(hintsProvidedArray.length).isEqualTo(1);
     assertThat(hintsProvidedArray[0]).isEqualTo(
         "Unknown topic: " + hintArgument + ". Use hint to view the list of available topics.");
@@ -415,9 +410,9 @@ public class GfshParserAutoCompletionTest {
   @Test
   public void testObtainHintWithPartialCommand() {
     String hintArgument = "d";
-    String hintsProvided = parser.getCommandManager().obtainHint(hintArgument);
+    String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
     System.out.println(hintsProvided);
-    String[] hintsProvidedArray = hintsProvided.split(LINE_SEPARATOR);
+    String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
     assertThat(hintsProvidedArray.length).isEqualTo(5);
     assertThat(hintsProvidedArray[0]).isEqualTo(
         "Hints are available for the following topics. Use \"hint <topic-name>\" for a specific hint.");
@@ -428,24 +423,9 @@ public class GfshParserAutoCompletionTest {
 
   @Test
   public void testIndexType() {
-    buffer = "create index --type=";
-    candidate = parser.complete(buffer);
+    String buffer = "create index --type=";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(IndexType.values().length);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "hash");
-  }
-
-  /**
-   * The log4j-core:tests jar contains {@code ExtendedLevels} which adds 2 levels when that jar
-   * is on the classpath for integrationTest target.
-   */
-  private List<Completion> removeExtendedLevels(List<Completion> candidates) {
-    Collection<Completion> toRemove = new HashSet<>();
-    for (Completion completion : candidates) {
-      if (completion.getValue().contains("DETAIL") || completion.getValue().contains("NOTE")) {
-        toRemove.add(completion);
-      }
-    }
-    candidates.removeAll(toRemove);
-    return candidates;
   }
 }

--- a/geode-dunit/build.gradle
+++ b/geode-dunit/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
   compile('com.jayway.jsonpath:json-path')
   compile('org.apache.logging.log4j:log4j-api')
+  compile('org.apache.logging.log4j:log4j-core')
   compile('commons-io:commons-io')
   compile('org.apache.commons:commons-lang3')
   compile('org.springframework.shell:spring-shell') {

--- a/geode-dunit/src/test/resources/expected-pom.xml
+++ b/geode-dunit/src/test/resources/expected-pom.xml
@@ -73,6 +73,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>compile</scope>

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -40,7 +40,6 @@ dependencies {
   }
   compile('org.apache.commons:commons-lang3')
   compile('org.apache.logging.log4j:log4j-api')
-  compile('org.apache.logging.log4j:log4j-core')
   compile('org.assertj:assertj-core')
   compile('org.awaitility:awaitility')
   compile('org.bouncycastle:bcpkix-jdk15on')

--- a/geode-junit/src/main/java/org/apache/geode/test/golden/GoldenTestCase.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/golden/GoldenTestCase.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.junit.After;
 import org.junit.Before;
 
@@ -40,13 +39,13 @@ public abstract class GoldenTestCase {
   protected static final String DEBUG_PROPERTY = "golden.test.DEBUG";
   protected static final boolean DEBUG = Boolean.getBoolean(DEBUG_PROPERTY);
 
-  /** The log4j2 config used within the spawned process */
-  private static final String LOG4J2_CONFIG_URL_STRING =
+  private static final String LOG4J_CONFIGURATION_FILE_PROPERTY = "log4j.configurationFile";
+  private static final String LOG4J_CONFIG_URL_STRING =
       GoldenTestCase.class.getResource("log4j2-test.xml").toString();
   private static final String[] JVM_ARGS = new String[] {
-      "-D" + ConfigurationFactory.CONFIGURATION_FILE_PROPERTY + "=" + LOG4J2_CONFIG_URL_STRING};
+      "-D" + LOG4J_CONFIGURATION_FILE_PROPERTY + "=" + LOG4J_CONFIG_URL_STRING};
 
-  private final List<ProcessWrapper> processes = new ArrayList<ProcessWrapper>();
+  private final List<ProcessWrapper> processes = new ArrayList<>();
 
   @Before
   public final void setUpGoldenTest() throws Exception {
@@ -56,12 +55,12 @@ public abstract class GoldenTestCase {
   @After
   public final void tearDownGoldenTest() throws Exception {
     try {
-      for (ProcessWrapper process : this.processes) {
+      for (ProcessWrapper process : processes) {
         process.destroy();
         printProcessOutput(process, true);
       }
     } finally {
-      this.processes.clear();
+      processes.clear();
     }
     subTearDown();
   }
@@ -86,7 +85,7 @@ public abstract class GoldenTestCase {
       final ProcessWrapper.Builder processWrapperBuilder, final Class<?> main) {
     final ProcessWrapper processWrapper =
         processWrapperBuilder.jvmArguments(JVM_ARGS).mainClass(main).build();
-    this.processes.add(processWrapper);
+    processes.add(processWrapper);
     return processWrapper;
   }
 

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -104,11 +104,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -51,7 +51,7 @@ dependencies {
   // Needed to fully use log4j instead of commons-logging.
   compile('org.apache.logging.log4j:log4j-jcl')
   compile('org.apache.logging.log4j:log4j-api')
-  compile('org.apache.logging.log4j:log4j-core')
+//  compile('org.apache.logging.log4j:log4j-core')
 
   compile('commons-beanutils:commons-beanutils')
   compile('commons-collections:commons-collections')

--- a/geode-pulse/src/test/resources/expected-pom.xml
+++ b/geode-pulse/src/test/resources/expected-pom.xml
@@ -84,11 +84,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <scope>compile</scope>

--- a/geode-serialization/build.gradle
+++ b/geode-serialization/build.gradle
@@ -30,9 +30,6 @@ dependencies {
 
   //Log4j is used everywhere
   implementation('org.apache.logging.log4j:log4j-api')
-//  implementation('org.apache.logging.log4j:log4j-core') {
-//    ext.optional = true
-//  }
 
   testImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'

--- a/geode-serialization/build.gradle
+++ b/geode-serialization/build.gradle
@@ -30,9 +30,9 @@ dependencies {
 
   //Log4j is used everywhere
   implementation('org.apache.logging.log4j:log4j-api')
-  implementation('org.apache.logging.log4j:log4j-core') {
-    ext.optional = true
-  }
+//  implementation('org.apache.logging.log4j:log4j-core') {
+//    ext.optional = true
+//  }
 
   testImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'

--- a/geode-serialization/src/test/resources/expected-pom.xml
+++ b/geode-serialization/src/test/resources/expected-pom.xml
@@ -61,11 +61,5 @@
       <artifactId>log4j-api</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Reimplement tests without using log4j-core:
* ManagementRequestLoggingDistributedTest
* GfshParserAutoCompletionIntegrationTest
* GoldenTestCase

Remove log4j-core and log4j-core:tests dependency from:
* geode-assembly
* geode-junit
* geode-pulse
* geode-serialization


Please review: @aaronlindsey 