### PR TITLE
GEODE-6986: Implement UnrestrictedMethodAuthorizer

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -493,6 +493,7 @@ javadoc/org/apache/geode/cache/query/package-summary.html
 javadoc/org/apache/geode/cache/query/package-tree.html
 javadoc/org/apache/geode/cache/query/security/MethodInvocationAuthorizer.html
 javadoc/org/apache/geode/cache/query/security/RestrictedMethodAuthorizer.html
+javadoc/org/apache/geode/cache/query/security/UnrestrictedMethodAuthorizer.html
 javadoc/org/apache/geode/cache/query/security/package-frame.html
 javadoc/org/apache/geode/cache/query/security/package-summary.html
 javadoc/org/apache/geode/cache/query/security/package-tree.html

--- a/geode-core/src/main/java/org/apache/geode/cache/query/security/RestrictedMethodAuthorizer.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/security/RestrictedMethodAuthorizer.java
@@ -37,9 +37,13 @@ import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.security.ResourcePermission;
 
 /**
- * The default, immutable and thread-safe method invocation authorizer used by Geode to determine
- * whether a {@link java.lang.reflect.Method} is allowed to be executed on a specific
+ * The default, immutable and thread-safe {@link MethodInvocationAuthorizer} used by Geode to
+ * determine whether a {@link java.lang.reflect.Method} is allowed to be executed on a specific
  * {@link java.lang.Object} instance.
+ * <p/>
+ *
+ * This authorizer addresses the four known security risks: {@code Java Reflection},
+ * {@code Cache Modification}, {@code Region Modification} and {@code Region Entry Modification}.
  * <p/>
  *
  * Custom applications can delegate to this class and use it as the starting point for providing
@@ -82,6 +86,12 @@ public final class RestrictedMethodAuthorizer implements MethodInvocationAuthori
 
   private static Map<String, Set<Class>> createGeodeAcceptanceList() {
     Map<String, Set<Class>> acceptanceListMap = new HashMap<>();
+
+    Set<Class> objectCallers = new HashSet<>();
+    objectCallers.add(Object.class);
+    objectCallers = Collections.unmodifiableSet(objectCallers);
+    acceptanceListMap.put("equals", objectCallers);
+    acceptanceListMap.put("toString", objectCallers);
 
     Set<Class> entryCallers = new HashSet<>();
     entryCallers.add(Region.Entry.class);
@@ -134,7 +144,6 @@ public final class RestrictedMethodAuthorizer implements MethodInvocationAuthori
     dateCallers = Collections.unmodifiableSet(dateCallers);
     acceptanceListMap.put("after", dateCallers);
     acceptanceListMap.put("before", dateCallers);
-    acceptanceListMap.put("getNanos", dateCallers);
     acceptanceListMap.put("getTime", dateCallers);
 
     Set<Class> timestampCallers = new HashSet<>();

--- a/geode-core/src/main/java/org/apache/geode/cache/query/security/UnrestrictedMethodAuthorizer.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/security/UnrestrictedMethodAuthorizer.java
@@ -60,7 +60,7 @@ public final class UnrestrictedMethodAuthorizer implements MethodInvocationAutho
   private final RestrictedMethodAuthorizer restrictedMethodAuthorizer;
 
   /**
-   * Creates a {@code GeodeBasedMethodAuthorizer} object and initializes it so it can be safely
+   * Creates a {@code UnrestrictedMethodAuthorizer} object and initializes it so it can be safely
    * used in a multi-threaded environment.
    * <p/>
    *
@@ -76,7 +76,7 @@ public final class UnrestrictedMethodAuthorizer implements MethodInvocationAutho
   }
 
   /**
-   * Creates a {@code GeodeBasedMethodAuthorizer} object and initializes it so it can be safely
+   * Creates a {@code UnrestrictedMethodAuthorizer} object and initializes it so it can be safely
    * used in a multi-threaded environment.
    * <p/>
    *

--- a/geode-core/src/main/java/org/apache/geode/cache/query/security/UnrestrictedMethodAuthorizer.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/security/UnrestrictedMethodAuthorizer.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.security;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Declarable;
+import org.apache.geode.cache.Region;
+
+/**
+ * An immutable and thread-safe {@link MethodInvocationAuthorizer} that allows any method execution
+ * as long as the target object does not belong to a Geode package, or does belong but it's marked
+ * as safe (see {@link RestrictedMethodAuthorizer#isAllowedGeodeMethod(Method, Object)}).
+ * <p/>
+ *
+ * Some known dangerous methods, like {@link Object#getClass()}, are also rejected by this
+ * authorizer implementation, no matter whether the target object belongs to Geode or not
+ * (see {@link RestrictedMethodAuthorizer#isKnownDangerousMethod(Method, Object)}).
+ * <p/>
+ *
+ * This authorizer implementation addresses only three of the four known security risks:
+ * {@code Java Reflection}, {@code Cache Modification} and {@code Region Modification}.
+ * <p/>
+ *
+ * The {@code Region Entry Modification} security risk still exists: users with the
+ * {@code DATA:READ:RegionName} privilege will be able to execute ANY method (even mutators) on the
+ * objects stored within the region and on instances used as bind parameters of the OQL, so this
+ * authorizer implementation must be used with extreme care.
+ * <p/>
+ *
+ * Usage of this authorizer implementation is only recommended for secured clusters on which only
+ * trusted users and applications have access to the OQL engine. It might also be used on clusters
+ * on which the entries stored are immutable.
+ * <p/>
+ *
+ * @see org.apache.geode.cache.Cache
+ * @see org.apache.geode.cache.query.security.MethodInvocationAuthorizer
+ * @see org.apache.geode.cache.query.security.RestrictedMethodAuthorizer
+ */
+public final class UnrestrictedMethodAuthorizer implements MethodInvocationAuthorizer {
+  static final String NULL_CACHE_MESSAGE = "Cache should be provided to configure the authorizer.";
+  static final String NULL_AUTHORIZER_MESSAGE =
+      "RestrictedMethodAuthorizer should be provided to create this authorizer.";
+  private static final String GEODE_BASE_PACKAGE = "org.apache.geode";
+  private final RestrictedMethodAuthorizer restrictedMethodAuthorizer;
+
+  /**
+   * Creates a {@code GeodeBasedMethodAuthorizer} object and initializes it so it can be safely
+   * used in a multi-threaded environment.
+   * <p/>
+   *
+   * Applications can use this constructor as part of the initialization for custom authorizers
+   * (see {@link Declarable#initialize(Cache, Properties)}), when using a declarative approach.
+   *
+   * @param cache the {@code Cache} instance that owns this authorizer, required in order to
+   *        configure the default {@link RestrictedMethodAuthorizer}.
+   */
+  public UnrestrictedMethodAuthorizer(Cache cache) {
+    Objects.requireNonNull(cache, NULL_CACHE_MESSAGE);
+    this.restrictedMethodAuthorizer = new RestrictedMethodAuthorizer(cache);
+  }
+
+  /**
+   * Creates a {@code GeodeBasedMethodAuthorizer} object and initializes it so it can be safely
+   * used in a multi-threaded environment.
+   * <p/>
+   *
+   * @param restrictedMethodAuthorizer the default {@code RestrictedMethodAuthorizer} to use.
+   */
+  public UnrestrictedMethodAuthorizer(RestrictedMethodAuthorizer restrictedMethodAuthorizer) {
+    Objects.requireNonNull(restrictedMethodAuthorizer, NULL_AUTHORIZER_MESSAGE);
+    this.restrictedMethodAuthorizer = restrictedMethodAuthorizer;
+  }
+
+  /**
+   * Executes the authorization logic to determine whether the {@code method} is allowed to be
+   * executed on the {@code target} object instance.
+   * If the {@code target} object is an instance of {@link Region}, this methods also ensures that
+   * the user has the {@code DATA:READ} permission granted for the target {@link Region}.
+   * <p/>
+   *
+   * @param method the {@link Method} that should be authorized.
+   * @param target the {@link Object} on which the {@link Method} will be executed.
+   * @return {@code true} if the {@code method} can be executed on on the {@code target} instance,
+   *         {@code false} otherwise.
+   *
+   * @see org.apache.geode.cache.query.security.MethodInvocationAuthorizer
+   */
+  @Override
+  public boolean authorize(Method method, Object target) {
+    // Return false for known dangerous methods.
+    if (restrictedMethodAuthorizer.isKnownDangerousMethod(method, target)) {
+      return false;
+    }
+
+    // Return true for non Geode classes.
+    String packageName = target.getClass().getPackage().getName().toLowerCase();
+    if (!packageName.startsWith(GEODE_BASE_PACKAGE)) {
+      return true;
+    }
+
+    // Delegate to the default authorizer.
+    return restrictedMethodAuthorizer.isAllowedGeodeMethod(method, target);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/query/security/UnrestrictedMethodAuthorizerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/security/UnrestrictedMethodAuthorizerTest.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.security;
+
+import static org.apache.geode.cache.query.security.UnrestrictedMethodAuthorizer.NULL_AUTHORIZER_MESSAGE;
+import static org.apache.geode.cache.query.security.UnrestrictedMethodAuthorizer.NULL_CACHE_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.query.internal.QRegion;
+import org.apache.geode.cache.query.internal.index.DummyQRegion;
+import org.apache.geode.cache.wan.GatewayQueueEvent;
+import org.apache.geode.internal.cache.EntrySnapshot;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.NonTXEntry;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionDataStore;
+import org.apache.geode.internal.cache.ha.HAContainerMap;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.security.NotAuthorizedException;
+import org.apache.geode.security.ResourcePermission;
+import org.apache.geode.test.junit.categories.SecurityTest;
+
+@Category(SecurityTest.class)
+public class UnrestrictedMethodAuthorizerTest {
+  private SecurityService mockSecurityService;
+  private UnrestrictedMethodAuthorizer unrestrictedMethodAuthorizer;
+
+  @Before
+  public void setUp() {
+    InternalCache mockCache = mock(InternalCache.class);
+    mockSecurityService = mock(SecurityService.class);
+    when(mockCache.getSecurityService()).thenReturn(mockSecurityService);
+    unrestrictedMethodAuthorizer =
+        new UnrestrictedMethodAuthorizer(new RestrictedMethodAuthorizer(mockCache));
+  }
+
+  @Test
+  public void constructorShouldThrowExceptionWhenCacheIsNull() {
+    assertThatThrownBy(() -> new UnrestrictedMethodAuthorizer((Cache) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(NULL_CACHE_MESSAGE);
+  }
+
+  @Test
+  public void constructorShouldThrowExceptionWhenRestrictedMethodAuthorizerIsNull() {
+    assertThatThrownBy(() -> new UnrestrictedMethodAuthorizer((RestrictedMethodAuthorizer) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(NULL_AUTHORIZER_MESSAGE);
+  }
+
+  @Test
+  public void authorizeShouldReturnFalseForKnownDangerousMethods() throws Exception {
+    TestBean testBean = new TestBean();
+    List<Method> dangerousMethods = new ArrayList<>();
+    dangerousMethods.add(TestBean.class.getMethod("getClass"));
+    dangerousMethods.add(TestBean.class.getMethod("readResolve"));
+    dangerousMethods.add(TestBean.class.getMethod("readObjectNoData"));
+    dangerousMethods.add(TestBean.class.getMethod("readObject", ObjectInputStream.class));
+    dangerousMethods.add(TestBean.class.getMethod("writeReplace"));
+    dangerousMethods.add(TestBean.class.getMethod("writeObject", ObjectOutputStream.class));
+
+    dangerousMethods.forEach(
+        method -> assertThat(unrestrictedMethodAuthorizer.authorize(method, testBean)).isFalse());
+  }
+
+  @Test
+  public void authorizeShouldReturnTrueForNonGeodeMethodsThatAreNotFlaggedAsDangerous()
+      throws Exception {
+    Map<Method, Object> nonGeodeMutatorMethods = new HashMap<>();
+    nonGeodeMutatorMethods.put(Date.class.getMethod("setYear", int.class), mock(Date.class));
+    nonGeodeMutatorMethods.put(Map.class.getMethod("remove", Object.class), mock(Map.class));
+    nonGeodeMutatorMethods.put(Map.class.getMethod("put", Object.class, Object.class),
+        mock(Map.class));
+    nonGeodeMutatorMethods.put(Map.Entry.class.getMethod("setValue", Object.class),
+        mock(Map.Entry.class));
+
+    Map<Method, Object> nonGeodeAccessorMethods = new HashMap<>();
+    nonGeodeAccessorMethods.put(Date.class.getMethod("getDay"), mock(Date.class));
+    nonGeodeAccessorMethods.put(Map.class.getMethod("entrySet"), mock(Map.class));
+    nonGeodeAccessorMethods.put(Map.class.getMethod("get", Object.class), mock(Map.class));
+    nonGeodeAccessorMethods.put(Map.Entry.class.getMethod("getValue"), mock(Map.Entry.class));
+
+    nonGeodeMutatorMethods.forEach((method,
+        object) -> assertThat(unrestrictedMethodAuthorizer.authorize(method, object)).isTrue());
+    nonGeodeAccessorMethods.forEach((method,
+        object) -> assertThat(unrestrictedMethodAuthorizer.authorize(method, object)).isTrue());
+  }
+
+  @Test
+  public void authorizeShouldReturnTrueForAllowedMethodsOnQRegionInstances() throws Exception {
+    QRegion qRegionInstance = mock(QRegion.class);
+    DummyQRegion dummyQRegionInstance = mock(DummyQRegion.class);
+
+    List<Method> methods = new ArrayList<>();
+    methods.add(Map.class.getMethod("containsKey", Object.class));
+    methods.add(Map.class.getMethod("entrySet"));
+    methods.add(Map.class.getMethod("get", Object.class));
+    methods.add(Map.class.getMethod("keySet"));
+    methods.add(Map.class.getMethod("values"));
+    methods.add(QRegion.class.getMethod("getEntries"));
+    methods.add(QRegion.class.getMethod("getValues"));
+    methods.add(Object.class.getMethod("toString"));
+    methods.add(Object.class.getMethod("equals", Object.class));
+
+    methods.forEach(method -> {
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, qRegionInstance)).isTrue();
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, dummyQRegionInstance)).isTrue();
+    });
+  }
+
+  @Test
+  public void authorizeShouldReturnTrueForMapMethodsOnRegionInstancesWheneverTheSecurityServiceAllowsOperationsOnTheRegion()
+      throws Exception {
+    Region region = mock(Region.class);
+    Region localRegion = mock(LocalRegion.class);
+    PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
+
+    List<Method> methods = new ArrayList<>();
+    methods.add(Map.class.getMethod("containsKey", Object.class));
+    methods.add(Map.class.getMethod("entrySet"));
+    methods.add(Map.class.getMethod("get", Object.class));
+    methods.add(Map.class.getMethod("keySet"));
+    methods.add(Map.class.getMethod("values"));
+    methods.add(Object.class.getMethod("toString"));
+    methods.add(Object.class.getMethod("equals", Object.class));
+
+    methods.forEach(method -> {
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, region)).isTrue();
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, localRegion)).isTrue();
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, partitionedRegion)).isTrue();
+    });
+  }
+
+  @Test
+  public void authorizeShouldReturnFalseWheneverTheSecurityServiceDoesNotAllowOperationsOnTheRegion()
+      throws Exception {
+    doThrow(new NotAuthorizedException("Mock Exception")).when(mockSecurityService).authorize(
+        ResourcePermission.Resource.DATA, ResourcePermission.Operation.READ, "testRegion");
+    Region region = mock(Region.class);
+    when(region.getName()).thenReturn("testRegion");
+    PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
+    when(partitionedRegion.getName()).thenReturn("testRegion");
+
+    List<Method> methods = new ArrayList<>();
+    methods.add(Map.class.getMethod("containsKey", Object.class));
+    methods.add(Map.class.getMethod("entrySet"));
+    methods.add(Map.class.getMethod("get", Object.class));
+    methods.add(Map.class.getMethod("keySet"));
+    methods.add(Map.class.getMethod("values"));
+
+    methods.forEach(method -> {
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, region)).isFalse();
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, partitionedRegion)).isFalse();
+    });
+  }
+
+  @Test
+  public void authorizeShouldReturnFalseForGeodeObjectsThatAreNotInstanceOfRegionAndRegionEntry()
+      throws Exception {
+    EntryEvent entryEvent = mock(EntryEvent.class);
+    HAContainerMap haContainerMap = mock(HAContainerMap.class);
+    GatewayQueueEvent gatewayQueueEvent = mock(GatewayQueueEvent.class);
+    PartitionedRegionDataStore partitionedRegionDataStore = mock(PartitionedRegionDataStore.class);
+
+    List<Method> queueRegionMethods = new ArrayList<>();
+    queueRegionMethods.add(QRegion.class.getMethod("getEntries"));
+    queueRegionMethods.add(QRegion.class.getMethod("getValues"));
+
+    List<Method> regionEntryMethods = new ArrayList<>();
+    regionEntryMethods.add(Region.Entry.class.getMethod("getKey"));
+    regionEntryMethods.add(Region.Entry.class.getMethod("getValue"));
+
+    List<Method> regionMethods = new ArrayList<>();
+    regionMethods.add(Region.class.getMethod("containsKey", Object.class));
+    regionMethods.add(Region.class.getMethod("entrySet"));
+    regionMethods.add(Region.class.getMethod("get", Object.class));
+    regionMethods.add(Region.class.getMethod("keySet"));
+    regionMethods.add(Region.class.getMethod("values"));
+
+    regionEntryMethods.forEach(method -> {
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, entryEvent)).isFalse();
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, gatewayQueueEvent)).isFalse();
+    });
+
+    regionMethods.forEach(method -> {
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, haContainerMap)).isFalse();
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, partitionedRegionDataStore))
+          .isFalse();
+    });
+
+    queueRegionMethods.forEach(method -> {
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, haContainerMap)).isFalse();
+      assertThat(unrestrictedMethodAuthorizer.authorize(method, partitionedRegionDataStore))
+          .isFalse();
+    });
+  }
+
+  @Test
+  public void authorizeShouldReturnTrueForRegionEntryMethods() throws Exception {
+    List<Region.Entry> regionEntryInstances = new ArrayList<>();
+    regionEntryInstances.add(mock(NonTXEntry.class));
+    regionEntryInstances.add(mock(Region.Entry.class));
+    regionEntryInstances.add(mock(EntrySnapshot.class));
+    Method getKeyMethod = Region.Entry.class.getMethod("getKey");
+    Method getValueMethod = Region.Entry.class.getMethod("getValue");
+    Method toStringMethod = Object.class.getMethod("toString");
+    Method equalsMethod = Object.class.getMethod("equals", Object.class);
+
+    regionEntryInstances.forEach((regionEntry) -> {
+      assertThat(unrestrictedMethodAuthorizer.authorize(getKeyMethod, regionEntry)).isTrue();
+      assertThat(unrestrictedMethodAuthorizer.authorize(getValueMethod, regionEntry)).isTrue();
+      assertThat(unrestrictedMethodAuthorizer.authorize(equalsMethod, regionEntry)).isTrue();
+      assertThat(unrestrictedMethodAuthorizer.authorize(toStringMethod, regionEntry)).isTrue();
+    });
+  }
+
+  @SuppressWarnings("unused")
+  private static class TestBean implements Serializable {
+    public Object writeReplace() throws ObjectStreamException {
+      return new TestBean();
+    }
+
+    public void writeObject(ObjectOutputStream stream) throws IOException {
+      throw new IOException();
+    }
+
+    public Object readResolve() throws ObjectStreamException {
+      return new TestBean();
+    }
+
+    public void readObjectNoData() throws ObjectStreamException {}
+
+    public void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+      if (new Random().nextBoolean()) {
+        throw new IOException();
+      } else {
+        throw new ClassNotFoundException();
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Made the class final, immutable and thread safe.
- Added comprehensive javadocs to the class and its methods.
- Added several unit tests for the class and all public methods.
- Improved javadocs for 'RestrictedMethodAuthorizer' and
  'MethodInvocationAuthorizer'.
- Fixed 'RestrictedMethodAuthorizer.isAllowedGeodeMethod()' to allow
  the execution of 'toString' and 'equals' on Geode objects.
- Removed 'getNanos' from the accepted methods for 'java.lang.Date' in
  'RestrictedMethodAuthorizer' (the method belong to 
  'java.sql.Timestamp' instead).

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
