### PR TITLE
GEODE-7227: ClassName now has a default constructor allowing it to be serialized

### DIFF
--- a/geode-management/src/main/java/org/apache/geode/management/configuration/ClassName.java
+++ b/geode-management/src/main/java/org/apache/geode/management/configuration/ClassName.java
@@ -43,6 +43,11 @@ public class ClassName implements Serializable {
   public static ClassName EMPTY = new ClassName("");
 
   /**
+   * Default constructor used for serialization.
+   */
+  public ClassName() {}
+
+  /**
    * Object to be instantiated using the empty param constructor of the className
    *
    * @param className this class needs to have an empty param constructor

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/PdxManagementTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/PdxManagementTest.java
@@ -32,6 +32,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.web.context.WebApplicationContext;
 
+import org.apache.geode.management.configuration.ClassName;
 import org.apache.geode.management.configuration.Pdx;
 import org.apache.geode.util.internal.GeodeJsonMapper;
 
@@ -57,6 +58,10 @@ public class PdxManagementTest {
   public void success() throws Exception {
     Pdx pdx = new Pdx();
     pdx.setReadSerialized(true);
+    pdx.setIgnoreUnreadFields(true);
+    pdx.setPersistent(true);
+    pdx.setDiskStoreName("diskStoreName");
+    pdx.setPdxSerializer(new ClassName("className"));
     context.perform(post("/experimental/configurations/pdx")
         .with(httpBasic("clusterManage", "clusterManage"))
         .content(mapper.writeValueAsString(pdx)))


### PR DESCRIPTION
Changed PdxManagementTest to include a ClassName attribute which caused the test to fail.
Added default constructor to ClassName so that it can be serialized and test now passes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
