### PR TITLE
GEODE-6987: Implement RegExMethodAuthorizer

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -492,6 +492,7 @@ javadoc/org/apache/geode/cache/query/package-frame.html
 javadoc/org/apache/geode/cache/query/package-summary.html
 javadoc/org/apache/geode/cache/query/package-tree.html
 javadoc/org/apache/geode/cache/query/security/MethodInvocationAuthorizer.html
+javadoc/org/apache/geode/cache/query/security/RegExMethodAuthorizer.html
 javadoc/org/apache/geode/cache/query/security/RestrictedMethodAuthorizer.html
 javadoc/org/apache/geode/cache/query/security/package-frame.html
 javadoc/org/apache/geode/cache/query/security/package-summary.html

--- a/geode-core/src/main/java/org/apache/geode/cache/query/security/RegExMethodAuthorizer.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/security/RegExMethodAuthorizer.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.security;
+
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Declarable;
+import org.apache.geode.cache.Region;
+
+/**
+ * An immutable and thread-safe {@link MethodInvocationAuthorizer} that only allows the execution of
+ * those methods matching the configured regular expression.
+ * <p/>
+ *
+ * Some known dangerous methods, like {@link Object#getClass()}, are also rejected by this
+ * authorizer implementation, no matter whether the method matches the configured regular
+ * expressions
+ * or not (see {@link RestrictedMethodAuthorizer#isKnownDangerousMethod(Method, Object)}).
+ * <p/>
+ *
+ * When correctly configured, this authorizer implementation addresses the four known security
+ * risks: {@code Java Reflection}, {@code Cache Modification}, {@code Region Modification} and
+ * {@code Region Entry Modification}.
+ * <p/>
+ *
+ * For the above statement to remain true, however, the regular expressions used must be
+ * exhaustively studied and configured so no mutator methods match. If the regular expressions are
+ * not restrictive enough, the {@code Region Entry Modification} security risk still exists: users
+ * with the {@code DATA:READ:RegionName} privileges will be able to execute methods (even those
+ * modifying the entry) on the objects stored within the region and on instances used as bind
+ * parameters of the query, so this authorizer must be used with extreme care.
+ * <p/>
+ *
+ * Usage of this authorizer implementation is only recommended for scenarios on which the user or
+ * operator knows exactly what code is deployed to the cluster, how and when; allowing a correct
+ * configuration of the regular expressions. It might also be used on clusters on which the entries
+ * stored are immutable.
+ * <p/>
+ *
+ * @see org.apache.geode.cache.Cache
+ * @see org.apache.geode.cache.query.security.MethodInvocationAuthorizer
+ * @see org.apache.geode.cache.query.security.RestrictedMethodAuthorizer
+ */
+public final class RegExMethodAuthorizer implements MethodInvocationAuthorizer {
+  private static final String GEODE_BASE_PACKAGE = "org.apache.geode";
+  static final String NULL_CACHE_MESSAGE = "Cache should be provided to configure this authorizer.";
+  static final String NULL_AUTHORIZER_MESSAGE =
+      "RestrictedMethodAuthorizer should be provided to create this authorizer.";
+  static final String NULL_REGULAR_EXPRESSIONS_MESSAGE =
+      "A set of regular expression should be provided to configure this authorizer.";
+  private final Set<String> allowedPatterns;
+  private final Set<Pattern> compiledPatterns;
+  private final RestrictedMethodAuthorizer restrictedMethodAuthorizer;
+
+  private Set<Pattern> compilePatterns() {
+    Set<Pattern> patterns = new HashSet<>();
+    allowedPatterns.forEach(regEx -> patterns.add(Pattern.compile(regEx)));
+
+    return patterns;
+  }
+
+  /**
+   * Returns an unmodifiable view of the regular expressions used to configure this authorizer.
+   * This method can be used to get "read-only" access to the set containing the regular expressions
+   * that will be used to determine whether a method is allowed or not.
+   *
+   * @return an unmodifiable view of the regular expressions used to configure this authorizer.
+   */
+  public Set<String> getAllowedPatterns() {
+    return allowedPatterns;
+  }
+
+  /**
+   * Creates a {@code RegExMethodAuthorizer} object and initializes it so it can be safely used
+   * in a multi-threaded environment.
+   * <p/>
+   *
+   * Applications can use this constructor as part of the initialization for custom authorizers
+   * (see {@link Declarable#initialize(Cache, Properties)}, when using a declarative approach.
+   *
+   * @param cache the {@code Cache} instance that owns this authorizer, required in order to
+   *        configure the default {@link RestrictedMethodAuthorizer}.
+   * @param allowedPatterns the regular expressions that will be used to determine whether a method
+   *        is authorized or not.
+   */
+  public RegExMethodAuthorizer(Cache cache, Set<String> allowedPatterns) {
+    Objects.requireNonNull(cache, NULL_CACHE_MESSAGE);
+    Objects.requireNonNull(allowedPatterns, NULL_REGULAR_EXPRESSIONS_MESSAGE);
+
+    this.allowedPatterns = Collections.unmodifiableSet(allowedPatterns);
+    this.compiledPatterns = Collections.unmodifiableSet(compilePatterns());
+    this.restrictedMethodAuthorizer = new RestrictedMethodAuthorizer(cache);
+  }
+
+  /**
+   * Creates a {@code RegExMethodAuthorizer} object and initializes it so it can be safely used
+   * in a multi-threaded environment.
+   * <p/>
+   *
+   * @param restrictedMethodAuthorizer the default {@code RestrictedMethodAuthorizer} to use.
+   * @param allowedPatterns the regular expressions that will be used to determine whether a method
+   *        is authorized or not.
+   */
+  public RegExMethodAuthorizer(RestrictedMethodAuthorizer restrictedMethodAuthorizer,
+      Set<String> allowedPatterns) {
+    Objects.requireNonNull(allowedPatterns, NULL_REGULAR_EXPRESSIONS_MESSAGE);
+    Objects.requireNonNull(restrictedMethodAuthorizer, NULL_AUTHORIZER_MESSAGE);
+
+    this.allowedPatterns = Collections.unmodifiableSet(allowedPatterns);
+    this.compiledPatterns = Collections.unmodifiableSet(compilePatterns());
+    this.restrictedMethodAuthorizer = restrictedMethodAuthorizer;
+  }
+
+  /**
+   * Executes the authorization logic to determine whether the {@code method} is allowed to be
+   * executed on the {@code target} object instance.
+   * If the {@code target} object is an instance of {@link Region}, this methods also ensures that
+   * the user has the {@code DATA:READ} permission granted for the target {@link Region}.
+   * <p/>
+   *
+   * @param method the {@link Method} that should be authorized.
+   * @param target the {@link Object} on which the {@link Method} will be executed.
+   * @return {@code true} if the {@code method} can be executed on on the {@code target} instance,
+   *         {@code false} otherwise.
+   *
+   * @see org.apache.geode.cache.query.security.MethodInvocationAuthorizer
+   */
+  @Override
+  public boolean authorize(Method method, Object target) {
+    // Return false for known dangerous methods.
+    if (restrictedMethodAuthorizer.isKnownDangerousMethod(method, target)) {
+      return false;
+    }
+
+    // If the target object belongs to Geode, make sure the method is considered safe.
+    if (target.getClass().getPackage().getName().startsWith(GEODE_BASE_PACKAGE)) {
+      return restrictedMethodAuthorizer.isAllowedGeodeMethod(method, target);
+    }
+
+    // Compare fully qualified method name against compiled expressions.
+    String fullyQualifiedMethodName = target.getClass().getName() + "." + method.getName();
+    boolean match = compiledPatterns.stream()
+        .anyMatch(pattern -> pattern.matcher(fullyQualifiedMethodName).matches());
+
+    // Return if there was a match, otherwise delegate to the default authorizer.
+    return match || restrictedMethodAuthorizer.authorize(method, target);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/query/security/RegExMethodAuthorizer.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/security/RegExMethodAuthorizer.java
@@ -158,10 +158,12 @@ public final class RegExMethodAuthorizer implements MethodInvocationAuthorizer {
 
     // Compare fully qualified method name against compiled expressions.
     String fullyQualifiedMethodName = target.getClass().getName() + "." + method.getName();
-    boolean match = compiledPatterns.stream()
-        .anyMatch(pattern -> pattern.matcher(fullyQualifiedMethodName).matches());
+    if (compiledPatterns.stream()
+        .anyMatch(pattern -> pattern.matcher(fullyQualifiedMethodName).matches())) {
+      return true;
+    }
 
-    // Return if there was a match, otherwise delegate to the default authorizer.
-    return match || restrictedMethodAuthorizer.authorize(method, target);
+    // Delegate to the default authorizer.
+    return restrictedMethodAuthorizer.authorize(method, target);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/security/RegExMethodAuthorizerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/security/RegExMethodAuthorizerTest.java
@@ -105,7 +105,7 @@ public class RegExMethodAuthorizerTest {
 
   @Test
   public void allowedPatternsShouldBeAccessibleBuNotModifiable() {
-    assertThatThrownBy(() -> geodeRegExMatchingMethodAuthorizer.getAllowedPatterns().remove(".*"))
+    assertThatThrownBy(() -> geodeRegExMatchingMethodAuthorizer.getAllowedPatterns().add(".*"))
         .isInstanceOf(UnsupportedOperationException.class);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/security/RegExMethodAuthorizerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/security/RegExMethodAuthorizerTest.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.security;
+
+import static org.apache.geode.cache.query.security.RegExMethodAuthorizer.NULL_AUTHORIZER_MESSAGE;
+import static org.apache.geode.cache.query.security.RegExMethodAuthorizer.NULL_CACHE_MESSAGE;
+import static org.apache.geode.cache.query.security.RegExMethodAuthorizer.NULL_REGULAR_EXPRESSIONS_MESSAGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.configuration.RegionConfig;
+import org.apache.geode.internal.cache.BucketDump;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.ha.HAContainerMap;
+import org.apache.geode.internal.cache.persistence.query.mock.Pair;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.util.Valuable;
+import org.apache.geode.security.NotAuthorizedException;
+import org.apache.geode.security.ResourcePermission;
+import org.apache.geode.test.junit.categories.SecurityTest;
+
+@Category(SecurityTest.class)
+public class RegExMethodAuthorizerTest {
+  private InternalCache mockCache;
+  private SecurityService mockSecurityService;
+  private RegExMethodAuthorizer geodeRegExMatchingMethodAuthorizer;
+
+  @Before
+  public void setUp() {
+    mockCache = mock(InternalCache.class);
+    mockSecurityService = mock(SecurityService.class);
+    when(mockCache.getSecurityService()).thenReturn(mockSecurityService);
+    geodeRegExMatchingMethodAuthorizer =
+        new RegExMethodAuthorizer(new RestrictedMethodAuthorizer(mockCache),
+            Collections.singleton("^org\\.apache\\.geode\\..*"));
+  }
+
+  @Test
+  public void constructorShouldThrowExceptionWhenCacheIsNull() {
+    assertThatThrownBy(() -> new RegExMethodAuthorizer((Cache) null, Collections.emptySet()))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(NULL_CACHE_MESSAGE);
+  }
+
+  @Test
+  public void constructorShouldThrowExceptionWhenRestrictedMethodAuthorizerIsNull() {
+    assertThatThrownBy(
+        () -> new RegExMethodAuthorizer((RestrictedMethodAuthorizer) null, Collections.emptySet()))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NULL_AUTHORIZER_MESSAGE);
+  }
+
+  @Test
+  public void constructorShouldThrowExceptionWhenAllowedPatternsIsNull() {
+    assertThatThrownBy(() -> new RegExMethodAuthorizer(mockCache, null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage(NULL_REGULAR_EXPRESSIONS_MESSAGE);
+
+    assertThatThrownBy(
+        () -> new RegExMethodAuthorizer(new RestrictedMethodAuthorizer(mockCache), null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage(NULL_REGULAR_EXPRESSIONS_MESSAGE);
+  }
+
+  @Test
+  public void allowedPatternsShouldBeAccessibleBuNotModifiable() {
+    assertThatThrownBy(() -> geodeRegExMatchingMethodAuthorizer.getAllowedPatterns().remove(".*"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  public void authorizeShouldReturnFalseForKnownDangerousMethods() throws Exception {
+    TestBean testBean = new TestBean();
+    List<Method> dangerousMethods = new ArrayList<>();
+    dangerousMethods.add(TestBean.class.getMethod("getClass"));
+    dangerousMethods.add(TestBean.class.getMethod("readResolve"));
+    dangerousMethods.add(TestBean.class.getMethod("readObjectNoData"));
+    dangerousMethods.add(TestBean.class.getMethod("readObject", ObjectInputStream.class));
+    dangerousMethods.add(TestBean.class.getMethod("writeReplace"));
+    dangerousMethods.add(TestBean.class.getMethod("writeObject", ObjectOutputStream.class));
+
+    dangerousMethods.forEach(method -> assertThat(
+        geodeRegExMatchingMethodAuthorizer.authorize(method, testBean)).isFalse());
+  }
+
+  @Test
+  public void authorizeShouldReturnFalseForGeodeMethodsThatAreNotConsideredSafeEvenIfTheyMatchTheUserRegEx()
+      throws Exception {
+    Set<Pair<Method, Object>> methods = new HashSet<>();
+    methods.add(new Pair<>(TestBean.class.getMethod("accessor"), new TestBean()));
+    methods.add(new Pair<>(TestBean.class.getMethod("mutator"), new TestBean()));
+    methods.add(new Pair<>(BucketDump.class.getMethod("getValues"), mock(BucketDump.class)));
+    methods.add(new Pair<>(RegionConfig.class.getMethod("getEntries"), mock(RegionConfig.class)));
+    methods.add(new Pair<>(EntryEvent.class.getMethod("getKey"), mock(EntryEvent.class)));
+    methods.add(new Pair<>(Valuable.class.getMethod("getValue"), mock(Valuable.class)));
+    methods.add(new Pair<>(HAContainerMap.class.getMethod("containsKey", Object.class),
+        mock(HAContainerMap.class)));
+    methods.add(new Pair<>(HAContainerMap.class.getMethod("entrySet"), mock(HAContainerMap.class)));
+    methods.add(new Pair<>(HAContainerMap.class.getMethod("get", Object.class),
+        mock(HAContainerMap.class)));
+    methods.add(new Pair<>(HAContainerMap.class.getMethod("keySet"), mock(HAContainerMap.class)));
+    methods.add(new Pair<>(HAContainerMap.class.getMethod("values"), mock(HAContainerMap.class)));
+
+    methods.forEach(
+        pair -> assertThat(geodeRegExMatchingMethodAuthorizer.authorize(pair.getX(), pair.getY()))
+            .as("For method: " + pair.getX().getName()).isFalse());
+  }
+
+  @Test
+  public void authorizeShouldReturnFalseWheneverTheSecurityServiceDoesNotAllowOperationsOnTheRegion()
+      throws Exception {
+    Region region = mock(Region.class);
+    Region localRegion = mock(LocalRegion.class);
+    Region partitionedRegion = mock(PartitionedRegion.class);
+    when(region.getName()).thenReturn("testRegion");
+    when(localRegion.getName()).thenReturn("testRegion");
+    when(partitionedRegion.getName()).thenReturn("testRegion");
+    doThrow(new NotAuthorizedException("Mock Exception")).when(mockSecurityService).authorize(
+        ResourcePermission.Resource.DATA, ResourcePermission.Operation.READ, "testRegion");
+
+    List<Method> methods = new ArrayList<>();
+    methods.add(Map.class.getMethod("containsKey", Object.class));
+    methods.add(Map.class.getMethod("entrySet"));
+    methods.add(Map.class.getMethod("get", Object.class));
+    methods.add(Map.class.getMethod("keySet"));
+    methods.add(Map.class.getMethod("values"));
+
+    methods.forEach(method -> {
+      assertThat(geodeRegExMatchingMethodAuthorizer.authorize(method, region)).isFalse();
+      assertThat(geodeRegExMatchingMethodAuthorizer.authorize(method, localRegion)).isFalse();
+      assertThat(geodeRegExMatchingMethodAuthorizer.authorize(method, partitionedRegion)).isFalse();
+    });
+  }
+
+  @Test
+  public void authorizeShouldReturnTrueForMapMethodsOnRegionInstancesWheneverTheSecurityServiceAllowsOperationsOnTheRegion()
+      throws Exception {
+    Region region = mock(Region.class);
+    Region localRegion = mock(LocalRegion.class);
+    Region partitionedRegion = mock(PartitionedRegion.class);
+
+    List<Method> methods = new ArrayList<>();
+    methods.add(Map.class.getMethod("containsKey", Object.class));
+    methods.add(Map.class.getMethod("entrySet"));
+    methods.add(Map.class.getMethod("get", Object.class));
+    methods.add(Map.class.getMethod("keySet"));
+    methods.add(Map.class.getMethod("values"));
+
+    methods.forEach(method -> {
+      assertThat(geodeRegExMatchingMethodAuthorizer.authorize(method, region)).isTrue();
+      assertThat(geodeRegExMatchingMethodAuthorizer.authorize(method, localRegion)).isTrue();
+      assertThat(geodeRegExMatchingMethodAuthorizer.authorize(method, partitionedRegion)).isTrue();
+    });
+  }
+
+  @Test
+  public void authorizeShouldReturnTrueForNonMatchingMethodsConsideredSafeByDefault()
+      throws Exception {
+    Set<Pair<Method, Object>> someSafeMethods = new HashSet<>();
+    someSafeMethods.add(new Pair<>(Object.class.getMethod("toString"), new Object()));
+    someSafeMethods.add(new Pair<>(Object.class.getMethod("equals", Object.class), new Object()));
+    someSafeMethods.add(
+        new Pair<>(Comparable.class.getMethod("compareTo", Object.class), mock(Comparable.class)));
+    someSafeMethods.add(new Pair<>(Number.class.getMethod("byteValue"), new Integer("0")));
+    someSafeMethods.add(new Pair<>(Date.class.getMethod("after", Date.class), new Date()));
+    someSafeMethods.add(new Pair<>(String.class.getMethod("indexOf", int.class), ""));
+    someSafeMethods.add(new Pair<>(Map.Entry.class.getMethod("getKey"), mock(Map.Entry.class)));
+    someSafeMethods
+        .add(new Pair<>(Map.class.getMethod("get", Object.class), Collections.emptyMap()));
+    RegExMethodAuthorizer authorizer = new RegExMethodAuthorizer(
+        new RestrictedMethodAuthorizer(mockCache), Collections.emptySet());
+
+    someSafeMethods.forEach(pair -> assertThat(authorizer.authorize(pair.getX(), pair.getY()))
+        .as("For method: " + pair.getX().getName()).isTrue());
+  }
+
+  @Test
+  public void authorizeShouldReturnFalseForNonMatchingMethodsThatAreNotConsideredSafeByDefault()
+      throws Exception {
+    Set<Pair<Method, Object>> someNonSafeMethods = new HashSet<>();
+    someNonSafeMethods.add(new Pair<>(Object.class.getMethod("wait"), new Object()));
+    someNonSafeMethods.add(new Pair<>(Number.class.getMethod("notify"), new Integer("0")));
+    someNonSafeMethods.add(new Pair<>(Date.class.getMethod("setYear", int.class), new Date()));
+    someNonSafeMethods.add(new Pair<>(Set.class.getMethod("add", Object.class), new HashSet<>()));
+    someNonSafeMethods.add(
+        new Pair<>(Map.Entry.class.getMethod("setValue", Object.class), mock(Map.Entry.class)));
+    someNonSafeMethods.add(
+        new Pair<>(Map.class.getMethod("put", Object.class, Object.class), Collections.emptyMap()));
+    RegExMethodAuthorizer authorizer = new RegExMethodAuthorizer(
+        new RestrictedMethodAuthorizer(mockCache), Collections.emptySet());
+
+    someNonSafeMethods.forEach(pair -> assertThat(authorizer.authorize(pair.getX(), pair.getY()))
+        .as("For method: " + pair.getX().getName()).isFalse());
+  }
+
+  @Test
+  public void authorizeShouldReturnTrueForMatchingMethods() throws Exception {
+    RestrictedMethodAuthorizer defaultAuthorizer = new RestrictedMethodAuthorizer(mockCache);
+    Set<String> regularExpressions =
+        new HashSet<>(Arrays.asList("^java\\.lang\\..*\\.(?:wait|notify)",
+            "^java\\.util\\..*\\.(?:set|put|add).*", ".*MockitoMock.*"));
+    RegExMethodAuthorizer customAuthorizer =
+        new RegExMethodAuthorizer(defaultAuthorizer, regularExpressions);
+
+    Set<Pair<Method, Object>> someNonSafeMethods = new HashSet<>();
+    someNonSafeMethods.add(new Pair<>(Object.class.getMethod("wait"), new Object()));
+    someNonSafeMethods.add(new Pair<>(Number.class.getMethod("notify"), new Integer("0")));
+    someNonSafeMethods.add(new Pair<>(Date.class.getMethod("setYear", int.class), new Date()));
+    someNonSafeMethods.add(new Pair<>(Set.class.getMethod("add", Object.class), new HashSet<>()));
+    someNonSafeMethods.add(
+        new Pair<>(Map.Entry.class.getMethod("setValue", Object.class), mock(Map.Entry.class)));
+    someNonSafeMethods
+        .add(new Pair<>(Map.class.getMethod("put", Object.class, Object.class), new HashMap<>()));
+
+    someNonSafeMethods
+        .forEach(pair -> assertThat(customAuthorizer.authorize(pair.getX(), pair.getY()))
+            .as("For method: " + pair.getX().getName()).isTrue());
+  }
+
+  @SuppressWarnings("unused")
+  private static class TestBean implements Serializable {
+    public Object writeReplace() throws ObjectStreamException {
+      return new TestBean();
+    }
+
+    public void writeObject(ObjectOutputStream stream) throws IOException {
+      throw new IOException();
+    }
+
+    public Object readResolve() throws ObjectStreamException {
+      return new TestBean();
+    }
+
+    public void readObjectNoData() throws ObjectStreamException {}
+
+    public void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+      if (new Random().nextBoolean()) {
+        throw new IOException();
+      } else {
+        throw new ClassNotFoundException();
+      }
+    }
+
+    public void mutator() {}
+
+    public void accessor() {}
+  }
+}


### PR DESCRIPTION
- Made the class final, immutable and thread safe.
- Added comprehensive javadocs to the class and its methods.
- Added several unit tests for the class and all public methods.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
