### PR TITLE
GEODE-7172: Move and rename marker classes

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/Region.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/Region.java
@@ -36,7 +36,6 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.snapshot.RegionSnapshotService;
-import org.apache.geode.internal.logging.EntriesCollection;
 
 /**
  * Manages subregions and cached data. Each region can contain multiple subregions and entries for
@@ -141,7 +140,7 @@ import org.apache.geode.internal.logging.EntriesCollection;
  * @since GemFire 2.0
  */
 
-public interface Region<K, V> extends ConcurrentMap<K, V>, EntriesCollection {
+public interface Region<K, V> extends ConcurrentMap<K, V> {
   /** The region name separator character. */
   char SEPARATOR_CHAR = '/';
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegion.java
@@ -106,7 +106,7 @@ import org.apache.geode.pdx.internal.PeerTypeRegistration;
  */
 @SuppressWarnings("deprecation")
 public abstract class AbstractRegion implements InternalRegion, AttributesMutator, CacheStatistics,
-    DataSerializableFixedID, Extensible<Region<?, ?>>, EvictableRegion {
+    DataSerializableFixedID, Extensible<Region<?, ?>>, EvictableRegion, EntriesCollection {
 
   private static final Logger logger = LogService.getLogger();
   private final ReentrantReadWriteLock readWriteLockForCacheLoader = new ReentrantReadWriteLock();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesCollection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesCollection.java
@@ -12,7 +12,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.internal.logging;
+package org.apache.geode.internal.cache;
 
+import org.apache.geode.cache.Region;
+
+/**
+ * Collection of data entries in a data structure such as a {@link Region}.
+ */
 public interface EntriesCollection {
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
@@ -26,7 +26,6 @@ import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.LocalRegion.IteratorType;
 import org.apache.geode.internal.cache.entries.AbstractRegionEntry;
-import org.apache.geode.internal.logging.EntriesCollection;
 
 /** Set view of entries */
 public class EntriesSet extends AbstractSet implements EntriesCollection {

--- a/geode-logging/src/main/java/org/apache/geode/internal/logging/LogWithToString.java
+++ b/geode-logging/src/main/java/org/apache/geode/internal/logging/LogWithToString.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.logging;
+
+public interface LogWithToString {
+}

--- a/geode-logging/src/main/java/org/apache/geode/internal/logging/log4j/message/GemFireParameterizedMessage.java
+++ b/geode-logging/src/main/java/org/apache/geode/internal/logging/log4j/message/GemFireParameterizedMessage.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.apache.logging.log4j.message.Message;
 
-import org.apache.geode.internal.logging.EntriesCollection;
+import org.apache.geode.internal.logging.LogWithToString;
 
 /**
  * Handles messages that consist of a format string containing '{}' to represent each replaceable
@@ -467,7 +467,7 @@ public class GemFireParameterizedMessage implements Message {
         }
         // str.append(Arrays.deepToString((Object[]) o));
       }
-    } else if (o instanceof Map && !(o instanceof EntriesCollection)) {
+    } else if (o instanceof Map && !(o instanceof LogWithToString)) {
       // GEODE: do NOT use Map handling if instanceof Geode Region
       // special handling of container Map
       final String id = identityToString(o);
@@ -493,7 +493,7 @@ public class GemFireParameterizedMessage implements Message {
         }
         str.append('}');
       }
-    } else if (o instanceof Collection && !(o instanceof EntriesCollection)) {
+    } else if (o instanceof Collection && !(o instanceof LogWithToString)) {
       // GEODE: do NOT use Collection handling if instanceof Geode EntriesSet
       // special handling of container Collection
       final String id = identityToString(o);


### PR DESCRIPTION
- EntriesCollection put back into internal.cache and AbstractRegion now implements the marker
- Formerly known as Loggable renamed to LogWithToString

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ x] Is your initial contribution a single, squashed commit?

- [ x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
