### PR TITLE
GEODE-7281: UpdatePassingTokens only moves git sha forward.

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -379,20 +379,26 @@ jobs:
       run:
         path: bash
         args:
-        - -ecx
+        - -cx
         - |-
           pushd geode
             GEODE_SHA=$(git rev-parse HEAD)
           popd
           GEODE_SEMVER=$(cat geode-build-version/number)
 
-          cat > geode-passing-tokens/passing-build-tokens.json <<JSON
+          GS_PATH=gs://((artifact-bucket))/semvers/((pipeline-prefix))((geode-build-branch))/passing-build-tokens.json
+          CURRENT_PASSING_SHA=$(gsutil cat ${GS_PATH} | jq -r .ref)
+          set -e
+          # Check that the incoming GEODE_SHA is a descendent of the currently stored value.
+          # Keeps us from winding back the repository in the case of an out-of-order pipeline pass
+          if [ -z "${CURRENT_PASSING_SHA}" ] || (cd geode; git merge-base --is-ancestor ${CURRENT_PASSING_SHA} ${GEODE_SHA}); then
+            cat > geode-passing-tokens/passing-build-tokens.json <<JSON
           {
             "ref": "${GEODE_SHA}",
             "semver": "${GEODE_SEMVER}"
           }
           JSON
-          echo "${GEODE_SHA}" > geode-passing-tokens/sha
+          fi
   - aggregate:
     - put: geode-passing-tokens
       params:

--- a/ci/scripts/attach_sha_to_branch.sh
+++ b/ci/scripts/attach_sha_to_branch.sh
@@ -23,6 +23,6 @@ DESIRED_BRANCH=${2:--}
 
 pushd ${REPO_DIR}
   DESIRED_SHA=$(git rev-parse HEAD)
-  git checkout ${DESIRED_BRANCH}
+  git checkout --force ${DESIRED_BRANCH}
   git reset --hard ${DESIRED_SHA}
 popd


### PR DESCRIPTION
Use `git merge-base --is-ancestor <old> <new>` to check that the SHA we
publish as 'passing' is moving forward in git history.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
