### PR TITLE
GEODE-2888: Remove 'gemfire-api' from REST doc

### DIFF
--- a/geode-book/master_middleman/source/subnavs/geode-subnav.erb
+++ b/geode-book/master_middleman/source/subnavs/geode-subnav.erb
@@ -1451,46 +1451,46 @@ limitations under the License.
                                 <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/rest_regions.html">Region Endpoints</a>
                                 <ul>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_regions.html">GET /gemfire-api/v1</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_regions.html">GET /geode/v1</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_data.html">GET /gemfire-api/v1/{region}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_data.html">GET /geode/v1/{region}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_keys.html">GET /gemfire-api/v1/{region}/keys</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_keys.html">GET /geode/v1/{region}/keys</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_key_data.html">GET /gemfire-api/v1/{region}/{key}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_key_data.html">GET /geode/v1/{region}/{key}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_data_for_multiple_keys.html">GET /gemfire-api/v1/{region}/{key1},{key2},...,{keyN}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_region_data_for_multiple_keys.html">GET /geode/v1/{region}/{key1},{key2},...,{keyN}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/head_region_size.html">HEAD /gemfire-api/v1/{region}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/head_region_size.html">HEAD /geode/v1/{region}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_if_absent_data.html">POST /gemfire-api/v1/{region}?key=&lt;key&gt;</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_if_absent_data.html">POST /geode/v1/{region}?key=&lt;key&gt;</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_update_data.html">PUT /gemfire-api/v1/{region}/{key}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_update_data.html">PUT /geode/v1/{region}/{key}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_multiple_values_for_keys.html">PUT /gemfire-api/v1/{region}/{key1},{key2},...{keyN}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_multiple_values_for_keys.html">PUT /geode/v1/{region}/{key1},{key2},...{keyN}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_replace_data.html">PUT /gemfire-api/v1/{region}/{key}?op=REPLACE</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_replace_data.html">PUT /geode/v1/{region}/{key}?op=REPLACE</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_update_cas_data.html">PUT /gemfire-api/v1/{region}/{key}?op=CAS</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_update_cas_data.html">PUT /geode/v1/{region}/{key}?op=CAS</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_all_data.html">DELETE /gemfire-api/v1/{region}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_all_data.html">DELETE /geode/v1/{region}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_data_for_key.html">DELETE /gemfire-api/v1/{region}/{key}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_data_for_key.html">DELETE /geode/v1/{region}/{key}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_data_for_multiple_keys.html">DELETE /gemfire-api/v1/{region}/{key1},{key2},...{keyN}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_data_for_multiple_keys.html">DELETE /geode/v1/{region}/{key1},{key2},...{keyN}</a>
                                     </li>
                                 </ul>
                             </li>
@@ -1498,22 +1498,22 @@ limitations under the License.
                                 <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/rest_queries.html">Query Endpoints</a>
                                 <ul>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_queries.html">GET /gemfire-api/v1/queries</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_queries.html">GET /geode/v1/queries</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_create_query.html">POST /gemfire-api/v1/queries?id=&lt;queryId&gt;&amp;q=&lt;OQL-statement&gt;</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_create_query.html">POST /geode/v1/queries?id=&lt;queryId&gt;&amp;q=&lt;OQL-statement&gt;</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_execute_query.html">POST /gemfire-api/v1/queries/{queryId}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_execute_query.html">POST /geode/v1/queries/{queryId}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_update_query.html">PUT /gemfire-api/v1/queries/{queryId}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/put_update_query.html">PUT /geode/v1/queries/{queryId}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_named_query.html">DELETE /gemfire-api/v1/queries/{queryId}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/delete_named_query.html">DELETE /geode/v1/queries/{queryId}</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_execute_adhoc_query.html">GET /gemfire-api/v1/queries/adhoc?q=&lt;OQL-statement&gt;</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_execute_adhoc_query.html">GET /geode/v1/queries/adhoc?q=&lt;OQL-statement&gt;</a>
                                     </li>
                                 </ul>
                             </li>
@@ -1521,10 +1521,10 @@ limitations under the License.
                                 <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/rest_functions.html">Function Endpoints</a>
                                 <ul>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_functions.html">GET /gemfire-api/v1/functions</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_functions.html">GET /geode/v1/functions</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_execute_functions.html">POST /gemfire-api/v1/functions/{functionId}</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/post_execute_functions.html">POST /geode/v1/functions/{functionId}</a>
                                     </li>
                                 </ul>
                             </li>
@@ -1532,10 +1532,10 @@ limitations under the License.
                                 <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/rest_admin.html">Administrative Endpoints</a>
                                 <ul>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/ping_service.html">[HEAD | GET] /gemfire-api/v1/ping</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/ping_service.html">[HEAD | GET] /geode/v1/ping</a>
                                     </li>
                                     <li>
-                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_servers.html">GET /gemfire-api/v1/servers</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/rest_apps/get_servers.html">GET /geode/v1/servers</a>
                                     </li>
                                 </ul>
                             </li>

--- a/geode-docs/rest_apps/delete_all_data.html.md.erb
+++ b/geode-docs/rest_apps/delete_all_data.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  DELETE /gemfire-api/v1/{region}
+title:  DELETE /geode/v1/{region}
 ---
 
 <!--
@@ -25,7 +25,7 @@ Limited to replicated regions only; not available for partitioned regions.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}
 ```
 
 ## Parameters
@@ -36,7 +36,7 @@ None.
 
 ``` pre
 Request Payload: null
-DELETE /gemfire-api/v1/orders
+DELETE /geode/v1/orders
 Accept: application/json
 ```
 

--- a/geode-docs/rest_apps/delete_data_for_key.html.md.erb
+++ b/geode-docs/rest_apps/delete_data_for_key.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  DELETE /gemfire-api/v1/{region}/{key}
+title:  DELETE /geode/v1/{region}/{key}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Delete entry for specified key in the region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key}
 ```
 
 ## Parameters
@@ -35,7 +35,7 @@ None.
 
 ``` pre
 Request Payload: null
-DELETE /gemfire-api/v1/orders/11
+DELETE /geode/v1/orders/11
 Accept: application/json
 ```
 

--- a/geode-docs/rest_apps/delete_data_for_multiple_keys.html.md.erb
+++ b/geode-docs/rest_apps/delete_data_for_multiple_keys.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  DELETE /gemfire-api/v1/{region}/{key1},{key2},...{keyN}
+title:  DELETE /geode/v1/{region}/{key1},{key2},...{keyN}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Delete entries for multiple keys in the region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key1},{key2},...{keyN}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key1},{key2},...{keyN}
 ```
 
 ## Parameters
@@ -35,7 +35,7 @@ None.
 
 ``` pre
 Request Payload: null
-DELETE /gemfire-api/v1/orders/12,13
+DELETE /geode/v1/orders/12,13
 Accept: application/json
 ```
 

--- a/geode-docs/rest_apps/delete_named_query.html.md.erb
+++ b/geode-docs/rest_apps/delete_named_query.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  DELETE /gemfire-api/v1/queries/{queryId}
+title:  DELETE /geode/v1/queries/{queryId}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Delete the specified named query.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/queries/{query}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/queries/{query}
 ```
 
 ## Parameters
@@ -36,7 +36,7 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 ## Example Request
 
 ``` pre
-DELETE /gemfire-api/v1/queries/selectOrders
+DELETE /geode/v1/queries/selectOrders
 
 Accept: application/json
 Content-Type: application/json

--- a/geode-docs/rest_apps/develop_rest_apps.html.md.erb
+++ b/geode-docs/rest_apps/develop_rest_apps.html.md.erb
@@ -47,12 +47,12 @@ You cannot create or delete the regions themselves with the REST APIs, but you c
 
 ## Listing Available Regions
 
-The main resource endpoint to the <%=vars.product_name%> API is [GET /gemfire-api/v1](get_regions.html#topic_itv_mg5_m4). Use this endpoint to discover which regions are available in your cluster.
+The main resource endpoint to the <%=vars.product_name%> API is [GET /geode/v1](get_regions.html#topic_itv_mg5_m4). Use this endpoint to discover which regions are available in your cluster.
 
 Example call:
 
 ``` pre
-curl -i http://localhost:7070/gemfire-api/v1
+curl -i http://localhost:7070/geode/v1
 ```
 
 Example response:
@@ -63,7 +63,7 @@ Response Payload: application/json
 
 200 OK
 Server: Apache-Coyote/1.1
-Location: http://localhost:7070/gemfire-api/v1
+Location: http://localhost:7070/geode/v1
 Content-Type: application/json
 Transfer-Encoding: chunked
 Date: Sat, 18 Jan 2014 20:05:47 GMT
@@ -116,35 +116,35 @@ If no resources (regions) are available in the cluster, the call returns a 404 N
 
 You can read data from a region by using any of the following REST-enabled mechanisms:
 
--   **GET /gemfire-api/v1/{region}?limit=ALL** - Read all entries in a region
--   **GET /gemfire-api/v1/{region}?limit=*N*** - Read a limited number of entries in a region
--   **GET /gemfire-api/v1/{region}/keys** - List all keys in a region
--   **GET /gemfire-api/v1/{region}/{keys}** - Read data for specific key or keys in a region
+-   **GET /geode/v1/{region}?limit=ALL** - Read all entries in a region
+-   **GET /geode/v1/{region}?limit=*N*** - Read a limited number of entries in a region
+-   **GET /geode/v1/{region}/keys** - List all keys in a region
+-   **GET /geode/v1/{region}/{keys}** - Read data for specific key or keys in a region
 
 **Reading Entries**
 
 To read entries in a region, use the following REST endpoint:
 
 ``` pre
-GET /gemfire-api/v1/{region}?[limit={<number>|ALL}]
+GET /geode/v1/{region}?[limit={<number>|ALL}]
 ```
 
 For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/items
+http://localhost:7070/geode/v1/items
 ```
 
 To read all entries in the region, specify instead:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/items?limit=ALL
+http://localhost:7070/geode/v1/items?limit=ALL
 ```
 
 To read 80 entries from the region, specify:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/items?limit=80
+http://localhost:7070/geode/v1/items?limit=80
 ```
 
 Setting the limit parameter is optional. If you do not specify a limit, the request will return 50 results by default. The returned order of the results is not guaranteed; however, the response values (JSON) are specified in the same order as the list of comma-separated keys returned in the "Content-location" header.
@@ -154,13 +154,13 @@ Setting the limit parameter is optional. If you do not specify a limit, the requ
 To list all keys in a region, use the following endpoint:
 
 ``` pre
-/gemfire-api/v1/{region}/keys
+/geode/v1/{region}/keys
 ```
 
 For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/items/keys
+http://localhost:7070/geode/v1/items/keys
 ```
 
 You can use the returned key to perform additional operations on the keys such as read, update or delete their values.
@@ -170,13 +170,13 @@ You can use the returned key to perform additional operations on the keys such a
 To obtain data for a specific key or set of keys, use the following endpoints:
 
 ``` pre
-GET /gemfire-api/v1/{region}/{key1}
+GET /geode/v1/{region}/{key1}
 ```
 
 or
 
 ``` pre
-GET /gemfire-api/v1/{region}/{key1},{key2},...,{keyN}
+GET /geode/v1/{region}/{key1},{key2},...,{keyN}
 ```
 
 where you specify keys in a comma-delimited list.
@@ -184,9 +184,9 @@ where you specify keys in a comma-delimited list.
 For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/items/1
+http://localhost:7070/geode/v1/items/1
 
-http://localhost:7070/gemfire-api/v1/items/1,3,5
+http://localhost:7070/geode/v1/items/1,3,5
 ```
 
 If one or more of the keys you provide in the list of keys is missing from the region, you will receive a 400 BAD STATUS error response.
@@ -194,7 +194,7 @@ If one or more of the keys you provide in the list of keys is missing from the r
 If you are providing multiple keys, you can also use the `ignoreMissingKey=true` parameter to prevent 400 errors. Any non-existing keys will instead return a null response. For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/items/1,3,5?ignoreMissingKey=true
+http://localhost:7070/geode/v1/items/1,3,5?ignoreMissingKey=true
 ```
 
 ## Adding or Modifying Region Data
@@ -212,7 +212,7 @@ To add data to a region, you have several options:
 To add a new key and value to a region, you can use the following endpoint:
 
 ``` pre
-POST /gemfire-api/v1/{region}?key=<key>
+POST /geode/v1/{region}?key=<key>
 ```
 
 This endpoint only puts the entry into the region **if the specified key does not already exist**. If the key already exists, the request will fail with a 409 CONFLICT error.
@@ -223,12 +223,12 @@ If you do not specify a key for this request, a String representation of a numer
 Specify the value for the new entry in the request body. For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/orders?key=2
+http://localhost:7070/geode/v1/orders?key=2
 ```
 
 ``` pre
 Request Payload: application/json
-POST /gemfire-api/v1/orders?key=2
+POST /geode/v1/orders?key=2
 
 Accept: application/json
 Content-Type: application/json
@@ -273,12 +273,12 @@ PUT /gemfire/v1/{region}/{key}
 This endpoint will add the entry if the key does not exist. If the key already exists, the operation will update the entry.
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/orders/2
+http://localhost:7070/geode/v1/orders/2
 ```
 
 ``` pre
 Request Payload: application/json
-PUT /gemfire-api/v1/orders/2
+PUT /geode/v1/orders/2
 Request Payload: application/json
 Content-Type: application/json
 Accept: application/json
@@ -318,25 +318,25 @@ PUT /gemfire/v1{region}/{key}?op=CAS
 If you do not specify a parameter to the PUT operation, the request which will add or update the entry regardless of whether the key already exists in the region. See the example above.
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/orders/2
+http://localhost:7070/geode/v1/orders/2
 ```
 
 If you specify the op=REPLACE parameter, the request which will explicitly perform a Cache replace operation and will verify that the key exists before replacing the value. If the key does not exist in the specified region, you will receive a 404 NOT FOUND error. This operation is idempotent, meaning multiple identical requests will have the same effect as the initial request.
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/orders/2?op=REPLACE
+http://localhost:7070/geode/v1/orders/2?op=REPLACE
 ```
 
-If you specify the op=CAS parameter, the value will only be replaced with the `@new` value only if the specified `@old` value matches the current value of the key in the region. If the `@old` value does not match the current value, then a 409 CONFLICT error is thrown. If you receive a 409 CONFLICT error, you can call the `GET /gemfire-api/v1/{region}/{key}` endpoint to get an updated copy of the value. This operation is not idempotent and multiple identical requests will not have the same effect as the initial request. You can use this type of REST call to achieve a similar effect as optimistic locking.
+If you specify the op=CAS parameter, the value will only be replaced with the `@new` value only if the specified `@old` value matches the current value of the key in the region. If the `@old` value does not match the current value, then a 409 CONFLICT error is thrown. If you receive a 409 CONFLICT error, you can call the `GET /geode/v1/{region}/{key}` endpoint to get an updated copy of the value. This operation is not idempotent and multiple identical requests will not have the same effect as the initial request. You can use this type of REST call to achieve a similar effect as optimistic locking.
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/orders/2?op=REPLACE
+http://localhost:7070/geode/v1/orders/2?op=REPLACE
 ```
 
 ``` pre
 Request Payload: application/json
 
-PUT /gemfire-api/v1/orders/2?op=CAS
+PUT /geode/v1/orders/2?op=CAS
 
 Accept: application/json
 Content-Type: application/json
@@ -391,7 +391,7 @@ Content-Type: application/json
 To update multiple values for keys, use:
 
 ``` pre
-PUT /gemfire-api/v1/{region}/{key1},{key2},...,{keyN}
+PUT /geode/v1/{region}/{key1},{key2},...,{keyN}
 ```
 
 This REST call will update any keys that already exist and insert values for any keys that do not exist in the region.
@@ -409,13 +409,13 @@ There are three options for deleting data in a region using REST APIs:
 To delete all data in the region, use the following endpoint:
 
 ``` pre
-DELETE /gemfire-api/v1/{region}
+DELETE /geode/v1/{region}
 ```
 
 For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/items
+http://localhost:7070/geode/v1/items
 ```
 
 Note that this does not delete the region itself, but instead all the entries in the region.
@@ -425,13 +425,13 @@ Note that this does not delete the region itself, but instead all the entries in
 Use:
 
 ``` pre
-DELETE /gemfire-api/v1/{region}/{key}
+DELETE /geode/v1/{region}/{key}
 ```
 
 or
 
 ``` pre
-DELETE /gemfire-api/v1/{region}/{key}{key1},{key2},...{keyN}
+DELETE /geode/v1/{region}/{key}{key1},{key2},...{keyN}
 ```
 
 If any of the supplied keys are not found in the region, the request will fail and return a 404 NOT FOUND ERROR.
@@ -445,7 +445,7 @@ If any of the supplied keys are not found in the region, the request will fail a
 To find out which predefined and named queries are available in your deployment, use the following endpoint:
 
 ``` pre
-GET /gemfire-api/v1/queries
+GET /geode/v1/queries
 ```
 
 All queries that have been predefined and assigned IDs in <%=vars.product_name%> are listed.
@@ -455,13 +455,13 @@ All queries that have been predefined and assigned IDs in <%=vars.product_name%>
 To create a query, use the following endpoint:
 
 ``` pre
-POST /gemfire-api/v1/queries?id=<queryId>&q=<OQL-statement>
+POST /geode/v1/queries?id=<queryId>&q=<OQL-statement>
 ```
 
 Here are some examples:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/queries?id=selectOffers&q="SELECT DISTINCT c FROM /customers c, /orders o WHERE o.totalprice < $1 AND c.customerId = o.customerId"
+http://localhost:7070/geode/v1/queries?id=selectOffers&q="SELECT DISTINCT c FROM /customers c, /orders o WHERE o.totalprice < $1 AND c.customerId = o.customerId"
 ```
 
 **Note:**
@@ -476,18 +476,18 @@ To update this query at a later time, use the [PUT operation](#topic_fcn_g25_m4_
 To run a prepared query, use:
 
 ``` pre
-POST /gemfire-api/v1/queries/{queryId}
+POST /geode/v1/queries/{queryId}
 ```
 
 Specify the queryId in the URL. All query argument must be passed in the request body. For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/queries/selectOrders
+http://localhost:7070/geode/v1/queries/selectOrders
 ```
 
 ``` pre
 Request Payload: OQL bind parameter values HTTP message body of media type application/json
-POST /gemfire-api/v1/queries/selectOrders
+POST /geode/v1/queries/selectOrders
 Accept: application/json
 Content-Type: application/json
 
@@ -547,12 +547,12 @@ Content-Type: application/json
 Another example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/queries/selectOrders
+http://localhost:7070/geode/v1/queries/selectOrders
 ```
 
 ``` pre
 Request Payload: OQL bind parameter values HTTP message body of media type application/json
-POST /gemfire-api/v1/queries/selectCustomer
+POST /geode/v1/queries/selectCustomer
 Accept: application/json
 Content-Type: application/json
 {
@@ -584,13 +584,13 @@ Content-Type: application/json
 To modify an existing prepared query, use the following endpoint:
 
 ``` pre
-PUT /gemfire-api/v1/queries/{queryId}
+PUT /geode/v1/queries/{queryId}
 ```
 
 Here are some examples:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/queries/selectOffers&q="SELECT DISTINCT c FROM /customers c, /orders o WHERE o.totalprice < $1 AND c.customerId = o.customerId"
+http://localhost:7070/geode/v1/queries/selectOffers&q="SELECT DISTINCT c FROM /customers c, /orders o WHERE o.totalprice < $1 AND c.customerId = o.customerId"
 ```
 
 You can specify query bind parameters ($1) in your predefined queries, and then pass in values at runtime.
@@ -602,7 +602,7 @@ A PUT operation will only succeed if the specified queryId already exists (for e
 To delete an existing prepared query, use the following endpoint:
 
 ``` pre
-DELETE /gemfire-api/v1/queries/{queryId}
+DELETE /geode/v1/queries/{queryId}
 ```
 
 ## <a id="topic_fcn_g25_m4__section_wbk_b5p_y4" class="no-quick-link"></a>Executing an Ad-Hoc Query
@@ -610,7 +610,7 @@ DELETE /gemfire-api/v1/queries/{queryId}
 To run an unnamed query, use the following endpoint:
 
 ``` pre
-GET /gemfire-api/v1/queries/adhoc?q=<OQL-statement>
+GET /geode/v1/queries/adhoc?q=<OQL-statement>
 ```
 
 Provide the OQL query string directly in the URL enclosed in single quotes.
@@ -618,7 +618,7 @@ Provide the OQL query string directly in the URL enclosed in single quotes.
 For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/queries/adhoc?q="SELECT * FROM /customers"
+http://localhost:7070/geode/v1/queries/adhoc?q="SELECT * FROM /customers"
 ```
 
 ## <a id="topic_rbc_h25_m4" class="no-quick-link"></a>Working with Functions
@@ -637,7 +637,7 @@ You can do the following with functions:
 To list all functions that are currently registered and deployed in the <%=vars.product_name%> cluster, use the following endpoint:
 
 ``` pre
-GET /gemfire-api/v1/functions
+GET /geode/v1/functions
 ```
 
 The list of returned functions includes the functionId, which you can use to execute the function as described in the next section.
@@ -647,7 +647,7 @@ The list of returned functions includes the functionId, which you can use to exe
 To execute a function on a <%=vars.product_name%> cluster, use the following endpoint:
 
 ``` pre
-POST /gemfire-api/v1/functions/{functionId}?[&onRegion=regionname|&onMembers=member1,member2,...,memberN|&onGroups=group1,group2,...,groupN]
+POST /geode/v1/functions/{functionId}?[&onRegion=regionname|&onMembers=member1,member2,...,memberN|&onGroups=group1,group2,...,groupN]
 ```
 
 You have the option to target a specific region and members or member groups when executing your function. If you do not specify these parameters, the function will execute on all members that are hosting data in the entire cluster by default. Function arguments are passed in the request body.
@@ -655,12 +655,12 @@ You have the option to target a specific region and members or member groups whe
 For example:
 
 ``` pre
-http://localhost:7070/gemfire-api/v1/functions/AddFreeItemToOrders
+http://localhost:7070/geode/v1/functions/AddFreeItemToOrders
 ```
 
 ``` pre
 Request Payload: application/json
-POST /gemfire-api/v1/functions/AddFreeItemToOrders
+POST /geode/v1/functions/AddFreeItemToOrders
 Accept: application/json
 Content-Type: application/json
 

--- a/geode-docs/rest_apps/get_execute_adhoc_query.html.md.erb
+++ b/geode-docs/rest_apps/get_execute_adhoc_query.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/queries/adhoc?q=&lt;OQL-statement&gt;
+title:  GET /geode/v1/queries/adhoc?q=&lt;OQL-statement&gt;
 ---
 
 <!--
@@ -24,7 +24,7 @@ Run an unnamed (unidentified), ad-hoc query passed as a URL parameter.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/queries/adhoc?q=<OQL-statement>
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/queries/adhoc?q=<OQL-statement>
 ```
 
 ## Parameters
@@ -61,7 +61,7 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 ## Example Request
 
 ``` pre
-curl -i "http://localhost:8080/gemfire-api/v1/queries/adhoc?q=select%20*%20%20from%20/customers"
+curl -i "http://localhost:8080/geode/v1/queries/adhoc?q=select%20*%20%20from%20/customers"
 ```
 
 ## Example Success Response

--- a/geode-docs/rest_apps/get_functions.html.md.erb
+++ b/geode-docs/rest_apps/get_functions.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/functions
+title:  GET /geode/v1/functions
 ---
 
 <!--
@@ -24,7 +24,7 @@ List all registered <%=vars.product_name%> functions in the cluster.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/functions
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/functions
 ```
 
 ## Parameters
@@ -34,7 +34,7 @@ None.
 ## Example Request
 
 ``` pre
-GET /gemfire-api/v1/functions
+GET /geode/v1/functions
 Accept: application/json
 ```
 
@@ -46,7 +46,7 @@ Response Payload: application/json
 200 OK
 Content-Length: <#-of-bytes>
 Content-Type: application/json
-Location: https://localhost:8080/gemfire-api/v1/functions
+Location: https://localhost:8080/geode/v1/functions
 
 {
     "functions": [

--- a/geode-docs/rest_apps/get_queries.html.md.erb
+++ b/geode-docs/rest_apps/get_queries.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/queries
+title:  GET /geode/v1/queries
 ---
 
 <!--
@@ -24,7 +24,7 @@ List all parameterized queries by ID or name.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/queries
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/queries
 ```
 
 ## Parameters
@@ -35,7 +35,7 @@ None
 
 ``` pre
 Request Payload: null
-GET /gemfire-api/v1/queries/
+GET /geode/v1/queries/
 Accept: application/json
 ```
 
@@ -47,7 +47,7 @@ Response Payload: application/json
 
 200 OK
 Content-Type: application/json
-Location: http://localhost:8080/gemfire-api/v1/queries
+Location: http://localhost:8080/geode/v1/queries
 
 {
     "queries": [

--- a/geode-docs/rest_apps/get_region_data.html.md.erb
+++ b/geode-docs/rest_apps/get_region_data.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/{region}
+title:  GET /geode/v1/{region}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Read data for the region. The optional limit URL query parameter specifies the n
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}?[limit={<number>|ALL}]
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}?[limit={<number>|ALL}]
 ```
 
 ## Parameters
@@ -56,7 +56,7 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 ## Example Request
 
 ``` pre
-GET /gemfire-api/v1/orders/
+GET /geode/v1/orders/
 Accept: application/json
 ```
 
@@ -67,7 +67,7 @@ Response Payload: application/json
 
 200 OK
 Server: Apache-Coyote/1.1
-Content-Location: http://localhost:8080/gemfire-api/v1/orders/3,1
+Content-Location: http://localhost:8080/geode/v1/orders/3,1
 Content-Type: application/json
 Transfer-Encoding: chunked
 Date: Sat, 18 Jan 2014 21:03:08 GMT

--- a/geode-docs/rest_apps/get_region_data_for_multiple_keys.html.md.erb
+++ b/geode-docs/rest_apps/get_region_data_for_multiple_keys.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/{region}/{key1},{key2},...,{keyN}
+title:  GET /geode/v1/{region}/{key1},{key2},...,{keyN}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Read data for multiple keys in the region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/queries[?ignoreMissingKey=true]
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/queries[?ignoreMissingKey=true]
 ```
 
 ## Parameters
@@ -55,12 +55,12 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 ## Example Requests
 
 ``` pre
-GET /gemfire-api/v1/orders/1,2,13,4,5?ignoreMissingKey=true
+GET /geode/v1/orders/1,2,13,4,5?ignoreMissingKey=true
 Request Payload: null
 Accept: application/json
 
 
-GET /gemfire-api/v1/orders/1,3
+GET /geode/v1/orders/1,3
 Request Payload: null
 Accept: application/json
 ```
@@ -72,7 +72,7 @@ Response Payload: application/json
 
 200 OK
 Server: Apache-Coyote/1.1
-Content-Location: http://localhost:8080/gemfire-api/v1/orders/13,2,1,5,4
+Content-Location: http://localhost:8080/geode/v1/orders/13,2,1,5,4
 Content-Type: application/json
 Transfer-Encoding: chunked
 Date: Sat, 18 Jan 2014 21:39:04 GMT
@@ -152,7 +152,7 @@ Date: Sat, 18 Jan 2014 21:39:04 GMT
 
 200 OK
 Server: Apache-Coyote/1.1
-Content-Location: http://localhost:8080/gemfire-api/v1/orders/3,1
+Content-Location: http://localhost:8080/geode/v1/orders/3,1
 Content-Type: application/json
 Transfer-Encoding: chunked
 Date: Sat, 18 Jan 2014 21:39:04 GMT
@@ -218,7 +218,7 @@ Date: Sat, 18 Jan 2014 21:39:04 GMT
 ## Example Error Response
 
 ``` pre
-GET /gemfire-api/v1/orders/1,2,13,4,5
+GET /geode/v1/orders/1,2,13,4,5
 Request Payload: null
 Accept: application/json
 Response Payload: application/json

--- a/geode-docs/rest_apps/get_region_key_data.html.md.erb
+++ b/geode-docs/rest_apps/get_region_key_data.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/{region}/{key}
+title:  GET /geode/v1/{region}/{key}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Read data for a specific key in the region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key}
 ```
 
 ## Parameters
@@ -34,7 +34,7 @@ None.
 ## Example Request
 
 ``` pre
-GET /gemfire-api/v1/orders/1
+GET /geode/v1/orders/1
 
 Request Payload: null
 Accept: application/json
@@ -47,7 +47,7 @@ Response Payload: application/json
 
 200 OK
 Server: Apache-Coyote/1.1
-Content-Location: http: //localhost:8080/gemfire-api/v1/orders/1
+Content-Location: http: //localhost:8080/geode/v1/orders/1
 Content-Type: application/json
 Transfer-Encoding: chunked
 Date: Sat, 18 Jan 2014 21:27:59 GMT

--- a/geode-docs/rest_apps/get_region_keys.html.md.erb
+++ b/geode-docs/rest_apps/get_region_keys.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/{region}/keys
+title:  GET /geode/v1/{region}/keys
 ---
 
 <!--
@@ -24,7 +24,7 @@ List all keys for the specified region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{keys}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{keys}
 ```
 
 ## Parameters
@@ -34,7 +34,7 @@ None.
 ## Example Request
 
 ``` pre
-GET /gemfire-api/v1/orders/keys
+GET /geode/v1/orders/keys
 ```
 
 ## Example Success Response
@@ -44,7 +44,7 @@ Response Payload: application/json
 
 200 OK
 Server: Apache-Coyote/1.1
-Location: http://localhost:8080/gemfire-api/v1/orders/keys
+Location: http://localhost:8080/geode/v1/orders/keys
 Content-Type: application/json
 Transfer-Encoding: chunked
 Date: Sat, 18 Jan 2014 21:20:05 GMT

--- a/geode-docs/rest_apps/get_regions.html.md.erb
+++ b/geode-docs/rest_apps/get_regions.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1
+title:  GET /geode/v1
 ---
 
 <!--
@@ -24,7 +24,7 @@ List all available resources (regions) in the <%=vars.product_name%> cluster.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1
 ```
 
 ## Parameters
@@ -45,7 +45,7 @@ Response Payload: application/json
 
 200 OK
 Server: Apache-Coyote/1.1
-Location: http://localhost:8080/gemfire-api/v1
+Location: http://localhost:8080/geode/v1
 Content-Type: application/json
 Transfer-Encoding: chunked 
 Date: Sat, 18 Jan 2014 20:05:47 GMT

--- a/geode-docs/rest_apps/get_servers.html.md.erb
+++ b/geode-docs/rest_apps/get_servers.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  GET /gemfire-api/v1/servers
+title:  GET /geode/v1/servers
 ---
 
 <!--
@@ -24,7 +24,7 @@ Mechanism to obtain a list of all members in the cluster that are running the RE
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/servers
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/servers
 ```
 
 ## Parameters
@@ -35,7 +35,7 @@ None.
 
 ``` pre
 Request Payload: null
-Request: GET /gemfire-api/v1/servers
+Request: GET /geode/v1/servers
 Response Payload: application/json
 ```
 

--- a/geode-docs/rest_apps/head_region_size.html.md.erb
+++ b/geode-docs/rest_apps/head_region_size.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  HEAD /gemfire-api/v1/{region}
+title:  HEAD /geode/v1/{region}
 ---
 
 <!--
@@ -24,7 +24,7 @@ An HTTP HEAD request that returns region's size (number of entries) within the H
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}
 ```
 
 ## Parameters
@@ -35,7 +35,7 @@ None.
 
 ``` pre
 Request Payload: null
-HEAD /gemfire-api/v1/customers
+HEAD /geode/v1/customers
 Response Payload: null
 ```
 

--- a/geode-docs/rest_apps/ping_service.html.md.erb
+++ b/geode-docs/rest_apps/ping_service.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  \[HEAD | GET\] /gemfire-api/v1/ping
+title:  \[HEAD | GET\] /geode/v1/ping
 ---
 
 <!--
@@ -24,7 +24,7 @@ Mechanism to check for REST API server and service availability.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/ping
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/ping
 ```
 
 ## Parameters

--- a/geode-docs/rest_apps/post_create_query.html.md.erb
+++ b/geode-docs/rest_apps/post_create_query.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  POST /gemfire-api/v1/queries?id=&lt;queryId&gt;&q=&lt;OQL-statement&gt;
+title:  POST /geode/v1/queries?id=&lt;queryId&gt;&q=&lt;OQL-statement&gt;
 ---
 
 <!--
@@ -24,7 +24,7 @@ Create (prepare) the specified parameterized query and assign the corresponding 
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/queries?id=<queryId>&q="<OQL-statement>"
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/queries?id=<queryId>&q="<OQL-statement>"
 ```
 
 ## Parameters
@@ -62,7 +62,7 @@ For this release, you cannot specify the query string inside the request body (a
 ## Example Request
 
 ``` pre
-POST /gemfire-api/v1/queries?id=selectOrders&q="SELECT o FROM /orders o WHERE o.quantity > $1 AND o.totalprice > $2"
+POST /geode/v1/queries?id=selectOrders&q="SELECT o FROM /orders o WHERE o.quantity > $1 AND o.totalprice > $2"
 Accept: application/json
 ```
 
@@ -72,7 +72,7 @@ Accept: application/json
 Response Payload: null
 
 201 CREATED
-Location: http://localhost:8080/gemfire-api/v1/queries/selectOrders
+Location: http://localhost:8080/geode/v1/queries/selectOrders
 ```
 
 ## Error Codes

--- a/geode-docs/rest_apps/post_execute_functions.html.md.erb
+++ b/geode-docs/rest_apps/post_execute_functions.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  POST /gemfire-api/v1/functions/{functionId}
+title:  POST /geode/v1/functions/{functionId}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Execute <%=vars.product_name%> function on entire cluster or on a specified regi
 ## Resource URL
 
 ``` pre
-/gemfire-api/v1/functions/{functionId}?[&onRegion=regionname|&onMembers=member1,member2,...,memberN|&onGroups=group1,group2,...,groupN]
+/geode/v1/functions/{functionId}?[&onRegion=regionname|&onMembers=member1,member2,...,memberN|&onGroups=group1,group2,...,groupN]
 ```
 
 ## Parameters
@@ -62,7 +62,7 @@ Execute <%=vars.product_name%> function on entire cluster or on a specified regi
 
 ``` pre
 Request Payload: application/json
-POST /gemfire-api/v1/functions/AddFreeItemToOrders
+POST /geode/v1/functions/AddFreeItemToOrders
 Accept: application/json
 Content-Type: application/json
 
@@ -87,7 +87,7 @@ Another example:
 ``` pre
 Request Payload: null
 
-POST /gemfire-api/v1/functions/getDeliveredOrders
+POST /geode/v1/functions/getDeliveredOrders
 Accept: application/json
 ```
 
@@ -96,7 +96,7 @@ Accept: application/json
 ``` pre
 Response Payload: null
 200 OK
-Location:http: //localhost:8080/gemfire-api/v1/functions/AddFreeItemToOrders
+Location:http: //localhost:8080/geode/v1/functions/AddFreeItemToOrders
 ```
 
 Another example response:
@@ -107,7 +107,7 @@ Response Payload: application/json
 200 OK
 Content-Length: 316
 Content-Type: application/json
-Location: http://localhost:8080/gemfire-api/v1/functions/getDeliveredOrders
+Location: http://localhost:8080/geode/v1/functions/getDeliveredOrders
 [
     {
          "purchaseOrderNo":  "1121",

--- a/geode-docs/rest_apps/post_execute_query.html.md.erb
+++ b/geode-docs/rest_apps/post_execute_query.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  POST /gemfire-api/v1/queries/{queryId}
+title:  POST /geode/v1/queries/{queryId}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Execute the specified named query passing in scalar values for query parameters 
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/queries/{queryId}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/queries/{queryId}
 ```
 
 ## Parameters
@@ -71,7 +71,7 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 ## Example Request
 
 ``` pre
-POST /gemfire-api/v1/queries/selectOrders
+POST /geode/v1/queries/selectOrders
 Accept: application/json
 Content-Type: application/json
 

--- a/geode-docs/rest_apps/post_if_absent_data.html.md.erb
+++ b/geode-docs/rest_apps/post_if_absent_data.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  POST /gemfire-api/v1/{region}?key=&lt;key&gt;
+title:  POST /geode/v1/{region}?key=&lt;key&gt;
 ---
 
 <!--
@@ -24,7 +24,7 @@ Create (put-if-absent) data in region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}?key=<key>
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}?key=<key>
 ```
 
 ## Parameters
@@ -56,7 +56,7 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 
 ``` pre
 Request Payload: application/json
-POST /gemfire-api/v1/orders?key=2
+POST /geode/v1/orders?key=2
 
 Accept: application/json
 Content-Type: application/json
@@ -95,7 +95,7 @@ Content-Type: application/json
 ``` pre
 Response Payload: null
 201 CREATED
-Location: http://localhost:8080/gemfire-api/v1/orders/2
+Location: http://localhost:8080/geode/v1/orders/2
 ```
 
 ## Error Codes
@@ -111,7 +111,7 @@ Location: http://localhost:8080/gemfire-api/v1/orders/2
 
 ``` pre
 409 Conflict
-Location:http://localhost:8080/gemfire-api/v1/orders/2
+Location:http://localhost:8080/geode/v1/orders/2
 Content-Type: application/json
 
 {

--- a/geode-docs/rest_apps/put_multiple_values_for_keys.html.md.erb
+++ b/geode-docs/rest_apps/put_multiple_values_for_keys.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  PUT /gemfire-api/v1/{region}/{key1},{key2},...{keyN}
+title:  PUT /geode/v1/{region}/{key1},{key2},...{keyN}
 ---
 
 <!--
@@ -24,19 +24,19 @@ Update or insert (put) data for multiple keys in the region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key},{key2},...{keyN}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key},{key2},...{keyN}
 ```
 
 ## Parameters
 
-See [PUT /gemfire-api/v1/{region}/{key}?op=REPLACE](put_replace_data.html#topic_itv_mg5_m4) and [PUT /gemfire-api/v1/{region}/{key}?op=CAS](put_update_cas_data.html#topic_itv_mg5_m4).
+See [PUT /geode/v1/{region}/{key}?op=REPLACE](put_replace_data.html#topic_itv_mg5_m4) and [PUT /geode/v1/{region}/{key}?op=CAS](put_update_cas_data.html#topic_itv_mg5_m4).
 
 ## Example Request
 
 ``` pre
 Request Payload: application/json
 
-PUT /gemfire-api/v1/orders/4,5
+PUT /geode/v1/orders/4,5
 
 Accept: application/json
 Content-Type: application/json

--- a/geode-docs/rest_apps/put_replace_data.html.md.erb
+++ b/geode-docs/rest_apps/put_replace_data.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  PUT /gemfire-api/v1/{region}/{key}?op=REPLACE
+title:  PUT /geode/v1/{region}/{key}?op=REPLACE
 ---
 
 <!--
@@ -24,8 +24,8 @@ Update (replace) data with key(s) if and only if the key(s) exists in region. Th
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key}?op=REPLACE
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key1},{key2},...{keyN}?op=REPLACE
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key}?op=REPLACE
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key1},{key2},...{keyN}?op=REPLACE
 ```
 
 ## Parameters
@@ -39,7 +39,7 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 
 ``` pre
 Request Payload: application/json
-PUT //gemfire-api/v1/orders/2?op=REPLACE
+PUT //geode/v1/orders/2?op=REPLACE
 
 Accept: application/json
 Content-Type: application/json

--- a/geode-docs/rest_apps/put_update_cas_data.html.md.erb
+++ b/geode-docs/rest_apps/put_update_cas_data.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  PUT /gemfire-api/v1/{region}/{key}?op=CAS
+title:  PUT /geode/v1/{region}/{key}?op=CAS
 ---
 
 <!--
@@ -24,8 +24,8 @@ Update (compare-and-set) value having key with a new value if and only if the "@
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key}?op=CAS
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key1},{key2},...{keyN}?op=CAS
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key}?op=CAS
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key1},{key2},...{keyN}?op=CAS
 ```
 
 ## Parameters
@@ -112,7 +112,7 @@ http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v
 ``` pre
 Request Payload: application/json
 
-PUT /gemfire-api/v1/orders/2?op=CAS
+PUT /geode/v1/orders/2?op=CAS
 
 Accept: application/json
 Content-Type: application/json
@@ -212,4 +212,4 @@ Content-Type: application/json
 
 If the "@old" value sent by the client in the HTTP request, along with the "@new" value, does not match the existing value having key in region, then a 409 - CONFLICT error is returned indicating the mismatch in expected state. The "@old" and current value must match in order for the key to be assigned the "@new" value.
 
-If a "CONFLICT" occurs, it is a simple matter for the client to issue a HTTP GET request for the Key (GET /gemfire-api/v1/orders/222) to get a updated copy of the value. CAS is similar to optimistic locking (as opposed to optimistic locking assuming the value will change between the time a client requests a value and subsequently updates the value) in that it assumes the client's state is up-to-date when the client tries to update, but if not then fail, hence the 409 - CONFLICT.
+If a "CONFLICT" occurs, it is a simple matter for the client to issue a HTTP GET request for the Key (GET /geode/v1/orders/222) to get a updated copy of the value. CAS is similar to optimistic locking (as opposed to optimistic locking assuming the value will change between the time a client requests a value and subsequently updates the value) in that it assumes the client's state is up-to-date when the client tries to update, but if not then fail, hence the 409 - CONFLICT.

--- a/geode-docs/rest_apps/put_update_data.html.md.erb
+++ b/geode-docs/rest_apps/put_update_data.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  PUT /gemfire-api/v1/{region}/{key}
+title:  PUT /geode/v1/{region}/{key}
 ---
 
 <!--
@@ -24,17 +24,17 @@ Update or insert (put) data for key in region.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/{region}/{key}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/{region}/{key}
 ```
 
 ## Parameters
 
-See [PUT /gemfire-api/v1/{region}/{key}?op=REPLACE](put_replace_data.html#topic_itv_mg5_m4) and [PUT /gemfire-api/v1/{region}/{key}?op=CAS](put_update_cas_data.html#topic_itv_mg5_m4).
+See [PUT /geode/v1/{region}/{key}?op=REPLACE](put_replace_data.html#topic_itv_mg5_m4) and [PUT /geode/v1/{region}/{key}?op=CAS](put_update_cas_data.html#topic_itv_mg5_m4).
 
 ## Example Request
 
 ``` pre
-PUT /gemfire-api/v1/orders/2
+PUT /geode/v1/orders/2
 Request Payload: application/json
 Content-Type: application/json
 Accept: application/json

--- a/geode-docs/rest_apps/put_update_query.html.md.erb
+++ b/geode-docs/rest_apps/put_update_query.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title:  PUT /gemfire-api/v1/queries/{queryId}
+title:  PUT /geode/v1/queries/{queryId}
 ---
 
 <!--
@@ -24,7 +24,7 @@ Update a named, parameterized query.
 ## Resource URL
 
 ``` pre
-http://<hostname_or_http-service-bind-address>:<http-service-port>/gemfire-api/v1/queries/{queryId}
+http://<hostname_or_http-service-bind-address>:<http-service-port>/geode/v1/queries/{queryId}
 ```
 
 ## Parameters
@@ -57,7 +57,7 @@ For this release, you cannot specify the query string inside the request body (a
 ## Example Request
 
 ``` pre
-PUT /gemfire-api/v1/queries/selectOrders?q="SELECT DISTINCT from /customers where lastName=$1"
+PUT /geode/v1/queries/selectOrders?q="SELECT DISTINCT from /customers where lastName=$1"
 
 Accept: application/json
 Content-Length: <#-of-bytes>

--- a/geode-docs/rest_apps/rest_admin.html.md.erb
+++ b/geode-docs/rest_apps/rest_admin.html.md.erb
@@ -21,11 +21,11 @@ limitations under the License.
 
 Administrative endpoints provide management and monitoring functionality for the REST API interface.
 
--   **[\[HEAD | GET\] /gemfire-api/v1/ping](ping_service.html)**
+-   **[\[HEAD | GET\] /geode/v1/ping](ping_service.html)**
 
     Mechanism to check for REST API server and service availability.
 
--   **[GET /gemfire-api/v1/servers](get_servers.html)**
+-   **[GET /geode/v1/servers](get_servers.html)**
 
     Mechanism to obtain a list of all members in the cluster that are running the REST API service.
 

--- a/geode-docs/rest_apps/rest_examples.html.md.erb
+++ b/geode-docs/rest_apps/rest_examples.html.md.erb
@@ -92,7 +92,7 @@ package org.apache.geode.restclient;
     HttpEntity< String> entity =  new HttpEntity< String>(PERSON1_AS_JSON, headers);
      try {
       ResponseEntity< String> result = RestClientUtils.getRestTemplate().exchange(
-             "http://localhost:8080/gemfire-api/v1/People?key=1" , HttpMethod.POST,
+             "http://localhost:8080/geode/v1/People?key=1" , HttpMethod.POST,
             entity,  String.class);
 
        System.out.println( "STATUS_CODE = " + result.getStatusCode().value());
@@ -216,7 +216,6 @@ package org.apache.geode.util;
  import java.util.List;
  import org.springframework.http.converter.ByteArrayHttpMessageConverter;
  import org.springframework.http.converter.HttpMessageConverter;
- //import  org.springframework.http.converter.ResourceHttpMessageConverter;
  import org.springframework.http.converter.StringHttpMessageConverter;
  import org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean;
  import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -226,10 +225,10 @@ package org.apache.geode.util;
  public class RestClientUtils {
 
    public static final String BASE_URL =  "http://192.0.2.0:8080" ;
- public static final String GEMFIRE_REST_API_CONTEXT =  "/gemfire-api";
-   public static final String GEMFIRE_REST_API_VERSION =  "/v1";
-   public static final URI GEMFIRE_REST_API_WEB_SERVICE_URL = URI
-      .create(BASE_URL + GEMFIRE_REST_API_CONTEXT + GEMFIRE_REST_API_VERSION);
+   public static final String GEODE_REST_API_CONTEXT =  "/geode";
+   public static final String GEODE_REST_API_VERSION =  "/v1";
+   public static final URI GEODE_REST_API_WEB_SERVICE_URL = URI
+      .create(BASE_URL + GEODE_REST_API_CONTEXT + GEODE_REST_API_VERSION);
 
    public static RestTemplate restTemplate;
    public static RestTemplate getRestTemplate() {
@@ -238,10 +237,8 @@ package org.apache.geode.util;
        final List<HttpMessageConverter<?>> messageConverters =  new ArrayList<HttpMessageConverter<?>>();
 
       messageConverters.add( new ByteArrayHttpMessageConverter());
-       //messageConverters.add(new  ResourceHttpMessageConverter());
       messageConverters.add( new StringHttpMessageConverter());
       messageConverters.add(createMappingJackson2HttpMessageConverter());
-       // messageConverters.add(createMarshallingHttpMessageConverter());
 
       restTemplate.setMessageConverters(messageConverters);
     }
@@ -268,7 +265,7 @@ package org.apache.geode.util;
   }
 
    public static URI toUri( final String... pathSegments) {
-     return toUri(GEMFIRE_REST_API_WEB_SERVICE_URL, pathSegments);
+     return toUri(GEODE_REST_API_WEB_SERVICE_URL, pathSegments);
   }
 
    public static URI toUri( final URI baseUrl,  final String... pathSegments) {
@@ -565,7 +562,7 @@ if __FILE__ == $0
   #puts p.inspect
   #puts p.to_json
 
-  uri = URI("http://localhost:8080/gemfire-api/v1/People/1");
+  uri = URI("http://localhost:8080/geode/v1/People/1");
 
   personJson = Net::HTTP::get(uri);
 
@@ -636,7 +633,7 @@ import uuid
 import requests
 
 REGION = "demoRegion"
-BASE_URI = "http://localhost:8080/gemfire-api/v1"
+BASE_URI = "http://localhost:8080/geode/v1"
 
 headers = {'content-type': 'application/json'}
 

--- a/geode-docs/rest_apps/rest_functions.html.md.erb
+++ b/geode-docs/rest_apps/rest_functions.html.md.erb
@@ -21,11 +21,11 @@ limitations under the License.
 
 <%=vars.product_name%> functions allows you to write and execute server-side transactions and data operations. These may include anything ranging from initializing components or third-party services or aggregating data.
 
--   **[GET /gemfire-api/v1/functions](get_functions.html)**
+-   **[GET /geode/v1/functions](get_functions.html)**
 
     List all registered <%=vars.product_name%> functions in the cluster.
 
--   **[POST /gemfire-api/v1/functions/{functionId}](post_execute_functions.html)**
+-   **[POST /geode/v1/functions/{functionId}](post_execute_functions.html)**
 
     Execute <%=vars.product_name%> function on entire cluster or on a specified region, members and member groups.
 

--- a/geode-docs/rest_apps/rest_prereqs.html.md.erb
+++ b/geode-docs/rest_apps/rest_prereqs.html.md.erb
@@ -25,7 +25,7 @@ Before development, it is important to understand the prerequisites and limitati
 
 -   All domain objects, functions and function-arg classes must be properly configured and registered in the <%=vars.product_name%> deployment. Any functions that you wish to execute through the REST API must be available on the target member’s CLASSPATH.
 -   The current implementation supports only the **application/json** MIME type. Other return types (XML, objects, and so on) are not supported. Plain text is supported as a return type for some error messages.
--   Keys are strictly of type String. For example, the request `PUT http://localhost:8080/gemfire-api/v1/customers/123.456` will add an entry for key ("123.456") of type String.
+-   Keys are strictly of type String. For example, the request `PUT http://localhost:8080/geode/v1/customers/123.456` will add an entry for key ("123.456") of type String.
 -   Some special formats of JSON documents are not supported in <%=vars.product_name%> REST. See [Key Types and JSON Support](troubleshooting.html#concept_gsv_zd5_m4) for examples.
 -   To achieve interoperability between <%=vars.product_name%> Java clients (or <%=vars.product_name%> native clients) and REST clients, the following rules must be followed:
     -   All <%=vars.product_name%> Java and native client classes operating on data also accessed by the REST interface must be PDX serialized, either via PDX autoserialization or by implementing `PdxSerializable`.

--- a/geode-docs/rest_apps/rest_queries.html.md.erb
+++ b/geode-docs/rest_apps/rest_queries.html.md.erb
@@ -21,27 +21,27 @@ limitations under the License.
 
 <%=vars.product_name%> uses a query syntax based on OQL (Object Query Language) to query region data. Since <%=vars.product_name%> regions are key-value stores, values can range from simple byte arrays to complex nested objects.
 
--   **[GET /gemfire-api/v1/queries](get_queries.html)**
+-   **[GET /geode/v1/queries](get_queries.html)**
 
     List all parameterized queries by ID or name.
 
--   **[POST /gemfire-api/v1/queries?id=&lt;queryId&gt;&q=&lt;OQL-statement&gt;](post_create_query.html)**
+-   **[POST /geode/v1/queries?id=&lt;queryId&gt;&q=&lt;OQL-statement&gt;](post_create_query.html)**
 
     Create (prepare) the specified parameterized query and assign the corresponding ID for lookup.
 
--   **[POST /gemfire-api/v1/queries/{queryId}](post_execute_query.html)**
+-   **[POST /geode/v1/queries/{queryId}](post_execute_query.html)**
 
     Execute the specified named query passing in scalar values for query parameters in the POST body.
 
--   **[PUT /gemfire-api/v1/queries/{queryId}](put_update_query.html)**
+-   **[PUT /geode/v1/queries/{queryId}](put_update_query.html)**
 
     Update a named, parameterized query.
 
--   **[DELETE /gemfire-api/v1/queries/{queryId}](delete_named_query.html)**
+-   **[DELETE /geode/v1/queries/{queryId}](delete_named_query.html)**
 
     Delete the specified named query.
 
--   **[GET /gemfire-api/v1/queries/adhoc?q=&lt;OQL-statement&gt;](get_execute_adhoc_query.html)**
+-   **[GET /geode/v1/queries/adhoc?q=&lt;OQL-statement&gt;](get_execute_adhoc_query.html)**
 
     Run an unnamed (unidentified), ad-hoc query passed as a URL parameter.
 

--- a/geode-docs/rest_apps/rest_regions.html.md.erb
+++ b/geode-docs/rest_apps/rest_regions.html.md.erb
@@ -23,59 +23,59 @@ A <%=vars.product_name%> region is how <%=vars.product_name%> logically groups d
 
 See also [Data Regions](../basic_config/data_regions/chapter_overview.html#data_regions) for more information on working with regions.
 
--   **[GET /gemfire-api/v1](get_regions.html)**
+-   **[GET /geode/v1](get_regions.html)**
 
     List all available resources (regions) in the <%=vars.product_name%> cluster.
 
--   **[GET /gemfire-api/v1/{region}](get_region_data.html)**
+-   **[GET /geode/v1/{region}](get_region_data.html)**
 
     Read data for the region. The optional limit URL query parameter specifies the number of values from the Region that will be returned. The default limit is 50. If the user specifies a limit of “ALL”, then all entry values for the region will be returned.
 
--   **[GET /gemfire-api/v1/{region}/keys](get_region_keys.html)**
+-   **[GET /geode/v1/{region}/keys](get_region_keys.html)**
 
     List all keys for the specified region.
 
--   **[GET /gemfire-api/v1/{region}/{key}](get_region_key_data.html)**
+-   **[GET /geode/v1/{region}/{key}](get_region_key_data.html)**
 
     Read data for a specific key in the region.
 
--   **[GET /gemfire-api/v1/{region}/{key1},{key2},...,{keyN}](get_region_data_for_multiple_keys.html)**
+-   **[GET /geode/v1/{region}/{key1},{key2},...,{keyN}](get_region_data_for_multiple_keys.html)**
 
     Read data for multiple keys in the region.
 
--   **[HEAD /gemfire-api/v1/{region}](head_region_size.html)**
+-   **[HEAD /geode/v1/{region}](head_region_size.html)**
 
     An HTTP HEAD request that returns region's size (number of entries) within the HEADERS, which is a response without the content-body. Region size is specified in the pre-defined header named "Resource-Count".
 
--   **[POST /gemfire-api/v1/{region}?key=&lt;key&gt;](post_if_absent_data.html)**
+-   **[POST /geode/v1/{region}?key=&lt;key&gt;](post_if_absent_data.html)**
 
     Create (put-if-absent) data in region.
 
--   **[PUT /gemfire-api/v1/{region}/{key}](put_update_data.html)**
+-   **[PUT /geode/v1/{region}/{key}](put_update_data.html)**
 
     Update or insert (put) data for key in region.
 
--   **[PUT /gemfire-api/v1/{region}/{key1},{key2},...{keyN}](put_multiple_values_for_keys.html)**
+-   **[PUT /geode/v1/{region}/{key1},{key2},...{keyN}](put_multiple_values_for_keys.html)**
 
     Update or insert (put) data for multiple keys in the region.
 
--   **[PUT /gemfire-api/v1/{region}/{key}?op=REPLACE](put_replace_data.html)**
+-   **[PUT /geode/v1/{region}/{key}?op=REPLACE](put_replace_data.html)**
 
     Update (replace) data with key(s) if and only if the key(s) exists in region. The Key(s) must be present in the Region for the update to occur.
 
--   **[PUT /gemfire-api/v1/{region}/{key}?op=CAS](put_update_cas_data.html)**
+-   **[PUT /geode/v1/{region}/{key}?op=CAS](put_update_cas_data.html)**
 
     Update (compare-and-set) value having key with a new value if and only if the "@old" value sent matches the current value having key in region.
 
--   **[DELETE /gemfire-api/v1/{region}](delete_all_data.html)**
+-   **[DELETE /geode/v1/{region}](delete_all_data.html)**
 
     Delete all entries in the region.
 
--   **[DELETE /gemfire-api/v1/{region}/{key}](delete_data_for_key.html)**
+-   **[DELETE /geode/v1/{region}/{key}](delete_data_for_key.html)**
 
     Delete entry for specified key in the region.
 
--   **[DELETE /gemfire-api/v1/{region}/{key1},{key2},...{keyN}](delete_data_for_multiple_keys.html)**
+-   **[DELETE /geode/v1/{region}/{key1},{key2},...{keyN}](delete_data_for_multiple_keys.html)**
 
     Delete entries for multiple keys in the region.
 

--- a/geode-docs/rest_apps/troubleshooting.html.md.erb
+++ b/geode-docs/rest_apps/troubleshooting.html.md.erb
@@ -27,12 +27,12 @@ This section provides troubleshooting guidance and frequently asked questions ab
 
 Use the ping endpoint to verify whether the REST API server is available.
 
-Use the `/gemfire-api/v1/ping` endpoint to check REST API server availability:
+Use the `/geode/v1/ping` endpoint to check REST API server availability:
 
 For example:
 
 ``` pre
-curl -i http://localhost:7070/gemfire-api/v1/ping 
+curl -i http://localhost:7070/geode/v1/ping 
 ```
 
 Example success response:


### PR DESCRIPTION
Now the name of the rest api is defined by the rest_api_name variable
added in geode-book/config.yml.
For gemfire documentation generation, that variable should be changed
to "gemfire-api".
I had to apply a workaround for the page titles that contain the rest
api endpoint due to the set_title function appends all its parameters
separated by spaces, generating the endpoints as "/ geode /v1".
So the endpoint name has to be defined before calling the set_title
function.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
