### PR TITLE
GEODE-6566: Prevent MemberMXBeanAttributesDistributedTest flaky failures

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
@@ -14,217 +14,196 @@
  */
 package org.apache.geode.management;
 
-import static org.apache.geode.management.MXBeanAwaitility.getSystemManagementService;
+import static java.lang.management.ManagementFactory.getRuntimeMXBean;
+import static org.apache.geode.cache.RegionShortcut.PARTITION_REDUNDANT;
+import static org.apache.geode.cache.RegionShortcut.REPLICATE;
+import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_TIME_STATISTICS;
+import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER;
+import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_START;
+import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLE_RATE;
+import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLING_ENABLED;
+import static org.apache.geode.internal.process.ProcessUtils.identifyPidAsUnchecked;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 import java.lang.management.ManagementFactory;
+import java.util.Properties;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
-import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
-import org.apache.geode.cache.RegionShortcut;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.cache30.CacheTestCase;
 import org.apache.geode.internal.NanoTimer;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
-import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.process.ProcessUtils;
 import org.apache.geode.internal.statistics.HostStatSampler;
 import org.apache.geode.internal.statistics.SampleCollector;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.VM;
+import org.apache.geode.management.internal.SystemManagementService;
+import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 
 /**
  * Distributed tests for {@link MemberMXBean} attributes.
  */
-
-@SuppressWarnings({"serial", "unused"})
-public class MemberMXBeanAttributesDistributedTest extends ManagementTestBase {
+@SuppressWarnings("serial")
+public class MemberMXBeanAttributesDistributedTest extends CacheTestCase {
 
   private static final long BYTES_PER_MEGABYTE = 1024 * 1024;
 
-  @Test
-  public void testReplRegionAttributes() throws Exception {
-    initManagement(false);
-    setupForReplicateRegionAttributes(managedNodeList.get(0), 1);
-    setupForReplicateRegionAttributes(managedNodeList.get(1), 201);
+  @Rule
+  public DistributedRestoreSystemProperties restoreSystemProperties =
+      new DistributedRestoreSystemProperties();
 
-    sampleStatistics(managedNodeList.get(1));// Sample now
+  @Before
+  public void setUp() throws Exception {
+    createMember();
 
-    validateReplicateRegionAttributes(managedNodeList.get(1));
-  }
-
-  @Test
-  public void testPRRegionAttributes() throws Exception {
-    initManagement(false);
-    setupForPartitionedRegionAttributes(managedNodeList.get(0), 1);
-
-    sampleStatistics(managedNodeList.get(0));// Sample now
-
-    validatePartitionedRegionAttributes(managedNodeList.get(0));
+    getVM(0).invoke(() -> {
+      createManager();
+      startManager();
+    });
   }
 
   @Test
-  public void testOSAttributes() throws Exception {
-    initManagement(false);
+  public void testReplicateRegionAttributes() {
+    RegionFactory<Number, Number> regionFactory = getCache().createRegionFactory(REPLICATE);
+    regionFactory.create("testRegion1");
+    regionFactory.create("testRegion2");
+    regionFactory.create("testRegion3");
 
-    validateSystemAndOSAttributes(managedNodeList.get(0));
+    Region<Number, Number> region1 = getCache().getRegion("/testRegion1");
+    regionFactory.createSubregion(region1, "testSubRegion1");
+
+    Region<Number, Number> region2 = getCache().getRegion("/testRegion2");
+    regionFactory.createSubregion(region2, "testSubRegion2");
+
+    Region<Number, Number> region3 = getCache().getRegion("/testRegion3");
+    regionFactory.createSubregion(region3, "testSubRegion3");
+
+    for (int i = 1; i < 1 + 200; i++) {
+      region1.put(i, i);
+      region2.put(i, i);
+      region3.put(i, i);
+    }
+
+    sampleStatistics();
+
+    MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
+
+    assertThat(memberMXBean.getTotalRegionCount()).isEqualTo(6);
+    assertThat(memberMXBean.getTotalRegionEntryCount()).isEqualTo(600);
+    assertThat(memberMXBean.getRootRegionNames()).hasSize(3);
+    assertThat(memberMXBean.listRegions()).hasSize(6);
   }
 
   @Test
-  public void testConfigAttributes() throws Exception {
-    initManagement(false);
+  public void testPartitionedRegionAttributes() {
+    RegionFactory<Number, Number> regionFactory =
+        getCache().createRegionFactory(PARTITION_REDUNDANT);
 
-    validateConfigAttributes(managedNodeList.get(0));
+    regionFactory.create("testPRRegion1");
+    regionFactory.create("testPRRegion2");
+    regionFactory.create("testPRRegion3");
+
+    Region<Number, Number> region1 = getCache().getRegion("/testPRRegion1");
+    Region<Number, Number> region2 = getCache().getRegion("/testPRRegion2");
+    Region<Number, Number> region3 = getCache().getRegion("/testPRRegion3");
+
+    for (int i = 1; i < 1 + 200; i++) {
+      region1.put(i, i);
+      region2.put(i, i);
+      region3.put(i, i);
+    }
+
+    sampleStatistics();
+
+    MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
+
+    assertThat(memberMXBean.getPartitionRegionCount()).isEqualTo(3);
+    assertThat(memberMXBean.getTotalBucketCount()).isEqualTo(339);
+    assertThat(memberMXBean.getTotalPrimaryBucketCount()).isEqualTo(339);
   }
 
-  private void sampleStatistics(final VM vm) {
-    vm.invoke("sampleStatistics", () -> {
-      InternalDistributedSystem system = getInternalDistributedSystem();
-      HostStatSampler sampler = system.getStatSampler();
-      SampleCollector sampleCollector = sampler.getSampleCollector();
-      sampleCollector.sample(NanoTimer.getTime());
-    });
+  @Test
+  public void testOSAttributes() {
+    MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
+
+    await().untilAsserted(() -> assertThat(memberMXBean.getMemberUpTime()).isGreaterThan(0));
+
+    assertThat(memberMXBean.getProcessId()).isEqualTo(identifyPidAsUnchecked());
+    assertThat(memberMXBean.getClassPath()).isEqualTo(getRuntimeMXBean().getClassPath());
+    assertThat(memberMXBean.getCurrentTime()).isGreaterThan(0);
+
+    assertThat(memberMXBean.getUsedMemory()).isGreaterThan(10);
+    assertThat(memberMXBean.getCurrentHeapSize()).isGreaterThan(10);
+
+    assertThat(memberMXBean.getFreeMemory()).isGreaterThan(0);
+    assertThat(memberMXBean.getFreeHeapSize()).isGreaterThan(0);
+
+    assertThat(memberMXBean.getMaxMemory()).isEqualTo(getHeapMemoryUsageMegabytes());
+    assertThat(memberMXBean.getMaximumHeapSize()).isEqualTo(getHeapMemoryUsageMegabytes());
+
+    assertThat(memberMXBean.fetchJvmThreads().length).isGreaterThan(0);
   }
 
-  private void setupForReplicateRegionAttributes(final VM vm, final int offset) {
-    vm.invoke("setupForReplicateRegionAttributes", () -> {
-      Cache cache = getInternalCache();
+  @Test
+  public void testConfigAttributes() {
+    MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
 
-      RegionFactory regionFactory = cache.createRegionFactory(RegionShortcut.REPLICATE);
-      regionFactory.create("testRegion1");
-      regionFactory.create("testRegion2");
-      regionFactory.create("testRegion3");
-
-      Region region1 = cache.getRegion("/testRegion1");
-      regionFactory.createSubregion(region1, "testSubRegion1");
-
-      Region region2 = cache.getRegion("/testRegion2");
-      regionFactory.createSubregion(region2, "testSubRegion2");
-
-      Region region3 = cache.getRegion("/testRegion3");
-      regionFactory.createSubregion(region3, "testSubRegion3");
-
-      for (int i = offset; i < offset + 200; i++) {
-        region1.put(i, i);
-        region2.put(i, i);
-        region3.put(i, i);
-      }
-    });
+    assertThat(memberMXBean.hasGatewayReceiver()).isFalse();
+    assertThat(memberMXBean.hasGatewaySender()).isFalse();
+    assertThat(memberMXBean.isLocator()).isFalse();
+    assertThat(memberMXBean.isManager()).isFalse();
+    assertThat(memberMXBean.isServer()).isFalse();
+    assertThat(memberMXBean.isManagerCreated()).isFalse();
   }
 
-  private void setupForPartitionedRegionAttributes(final VM vm, final int offset) {
-    vm.invoke("setupForPartitionedRegionAttributes", () -> {
-      Cache cache = getInternalCache();
-      RegionFactory regionFactory = cache.createRegionFactory(RegionShortcut.PARTITION_REDUNDANT);
+  @Override
+  public Properties getDistributedSystemProperties() {
+    Properties props = new Properties();
 
-      regionFactory.create("testPRRegion1");
-      regionFactory.create("testPRRegion2");
-      regionFactory.create("testPRRegion3");
+    props.setProperty(ENABLE_TIME_STATISTICS, "true");
+    props.setProperty(STATISTIC_SAMPLING_ENABLED, "true");
+    props.setProperty(STATISTIC_SAMPLE_RATE, "60000");
 
-      Region region1 = cache.getRegion("/testPRRegion1");
-      Region region2 = cache.getRegion("/testPRRegion2");
-      Region region3 = cache.getRegion("/testPRRegion3");
-
-      for (int i = offset; i < offset + 200; i++) {
-        region1.put(i, i);
-        region2.put(i, i);
-        region3.put(i, i);
-      }
-    });
+    return props;
   }
 
-  /**
-   * This will check all the attributes which does not depend on any distribution message.
-   */
-  private void validatePartitionedRegionAttributes(final VM vm) {
-    vm.invoke("validatePartitionedRegionAttributes", () -> {
-      MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
-
-      assertEquals(3, memberMXBean.getPartitionRegionCount());
-      assertEquals(339, memberMXBean.getTotalBucketCount());
-      assertEquals(339, memberMXBean.getTotalPrimaryBucketCount());
-    });
+  private void createMember() {
+    getCache(getDistributedSystemProperties());
   }
 
-  /**
-   * This will check all the attributes which does not depend on any distribution message.
-   */
-  private void validateReplicateRegionAttributes(final VM vm) {
-    vm.invoke("validateReplicateRegionAttributes", () -> {
-      MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
+  private void createManager() {
+    Properties props = getDistributedSystemProperties();
 
-      assertEquals(6, memberMXBean.getTotalRegionCount());
-      assertEquals(1200, memberMXBean.getTotalRegionEntryCount());
+    props.setProperty(JMX_MANAGER, "true");
+    props.setProperty(JMX_MANAGER_START, "false");
+    props.setProperty(JMX_MANAGER_PORT, "0");
+    props.setProperty(HTTP_SERVICE_PORT, "0");
 
-      assertEquals(3, memberMXBean.getRootRegionNames().length);
-      assertEquals(600, memberMXBean.getInitialImageKeysReceived());
-      assertEquals(6, memberMXBean.listRegions().length);
-    });
+    getCache(props);
   }
 
-  /**
-   * This will check all the attributes which does not depend on any distribution message.
-   */
-  private void validateSystemAndOSAttributes(final VM vm) {
-    vm.invoke("validateSystemAndOSAttributes", () -> {
-      MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
-
-      assertThat(memberMXBean.getProcessId()).isEqualTo(ProcessUtils.identifyPid());
-      assertThat(memberMXBean.getClassPath()).isEqualTo(getClassPath());
-      assertThat(memberMXBean.getCurrentTime()).isGreaterThan(0);
-
-      GeodeAwaitility.await()
-          .untilAsserted(() -> assertThat(memberMXBean.getMemberUpTime()).isGreaterThan(0));
-
-      assertThat(memberMXBean.getUsedMemory()).isGreaterThan(10);
-      assertThat(memberMXBean.getCurrentHeapSize()).isGreaterThan(10);
-
-      assertThat(memberMXBean.getFreeMemory()).isGreaterThan(0);
-      assertThat(memberMXBean.getFreeHeapSize()).isGreaterThan(0);
-
-      assertThat(memberMXBean.getMaxMemory()).isEqualTo(getHeapMemoryUsageMegabytes());
-      assertThat(memberMXBean.getMaximumHeapSize()).isEqualTo(getHeapMemoryUsageMegabytes());
-
-      assertThat(memberMXBean.fetchJvmThreads().length).isGreaterThan(0);
-
-      // TODO: provide better/more validation
-      // System.out.println(" CPU Usage is "+ bean.getCpuUsage());
-      // assertTrue(bean.getCpuUsage() > 0.0f);
-
-      // bean.getFileDescriptorLimit()
-    });
+  private void startManager() {
+    SystemManagementService service = getSystemManagementService();
+    service.createManager();
+    service.startManager();
   }
 
-  private void validateConfigAttributes(final VM vm) {
-    vm.invoke("validateConfigAttributes", () -> {
-      MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
-
-      assertFalse(memberMXBean.hasGatewayReceiver());
-      assertFalse(memberMXBean.hasGatewaySender());
-      assertFalse(memberMXBean.isLocator());
-      assertFalse(memberMXBean.isManager());
-      assertFalse(memberMXBean.isServer());
-      assertFalse(memberMXBean.isManagerCreated());
-    });
-  }
-
-  private String getClassPath() {
-    return ManagementFactory.getRuntimeMXBean().getClassPath();
+  private SystemManagementService getSystemManagementService() {
+    return (SystemManagementService) ManagementService.getManagementService(getCache());
   }
 
   private long getHeapMemoryUsageMegabytes() {
     return ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax() / BYTES_PER_MEGABYTE;
   }
 
-  private InternalDistributedSystem getInternalDistributedSystem() {
-    return InternalDistributedSystem.getConnectedInstance();
-  }
-
-  private InternalCache getInternalCache() {
-    return GemFireCacheImpl.getInstance();
+  private void sampleStatistics() {
+    HostStatSampler sampler = getSystem().getStatSampler();
+    SampleCollector sampleCollector = sampler.getSampleCollector();
+    sampleCollector.sample(NanoTimer.getTime());
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
@@ -42,7 +42,7 @@ import org.apache.geode.test.dunit.VM;
  */
 
 @SuppressWarnings({"serial", "unused"})
-public class MemberMBeanAttributesDUnitTest extends ManagementTestBase {
+public class MemberMXBeanAttributesDistributedTest extends ManagementTestBase {
 
   private static final long BYTES_PER_MEGABYTE = 1024 * 1024;
 


### PR DESCRIPTION
1) [Rename MemberMBeanAttributesDUnitTest as MemberMXBeanAttributesDistributedTest](https://github.com/apache/geode/pull/4138/commits/5e389b200e80c70ac5c7659193b4f2f2705937c3)
```
commit 5e389b200e80c70ac5c7659193b4f2f2705937c3
Author: Kirk Lund <klund@apache.org>
Date:   Wed Oct 9 09:55:36 2019 -0700

    GEODE-6566: Rename to MemberMXBeanAttributesDistributedTest
    
    Rename MemberMBeanAttributesDUnitTest as MemberMXBeanAttributesDistributedTest.
```
2) [Cleanup and deflakify MemberMXBeanAttributesDistributedTest](https://github.com/apache/geode/pull/4138/commits/ad917f314eb9e7e66b30697a55ab510f0f594ca5)
```
commit ad917f314eb9e7e66b30697a55ab510f0f594ca5
Author: Kirk Lund <klund@apache.org>
Date:   Wed Oct 9 11:01:04 2019 -0700

    GEODE-6566: Prevent MemberMXBeanAttributesDistributedTest flakiness
    
    Set STATISTIC_SAMPLE_RATE to max value (60000).
    
    Additional cleanup:
    * Cleanup MemberMXBeanAttributesDistributedTest
    * Remove unnecessary VMs
    * Convert from JUnit Assert to AssertJ
    * Inline lots of methods
    * Use controller VM as the member VM
```
Please review: @aaronlindsey 

The main fix in this PR is setting the STATISTIC_SAMPLE_RATE to max value (60000) which will avoid concurrent statistic samples which is the cause of the flaky failures.