### PR TITLE
GEODE-6183: Increase await timeout for LocatorLauncher tests

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LauncherIntegrationTestCase.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LauncherIntegrationTestCase.java
@@ -15,11 +15,14 @@
 package org.apache.geode.distributed;
 
 import static java.lang.System.lineSeparator;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.AvailablePort.SOCKET;
 import static org.apache.geode.internal.AvailablePort.isPortAvailable;
 import static org.apache.geode.internal.process.ProcessUtils.identifyPid;
 import static org.apache.geode.internal.process.ProcessUtils.isProcessAlive;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -51,7 +54,6 @@ import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.process.ProcessStreamReader.InputListener;
 import org.apache.geode.internal.process.ProcessType;
 import org.apache.geode.internal.process.lang.AvailablePid;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 /**
  * Abstract base class for integration tests of both {@link LocatorLauncher} and
@@ -60,6 +62,8 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
  * @since GemFire 8.0
  */
 public abstract class LauncherIntegrationTestCase {
+
+  protected static final long AWAIT_MILLIS = getTimeout().getValueInMS() * 2;
 
   private static final int PREFERRED_FAKE_PID = 42;
 
@@ -98,7 +102,9 @@ public abstract class LauncherIntegrationTestCase {
   protected abstract ProcessType getProcessType();
 
   protected void assertDeletionOf(final File file) {
-    GeodeAwaitility.await().untilAsserted(() -> assertThat(file).doesNotExist());
+    await()
+        .atMost(AWAIT_MILLIS, MILLISECONDS)
+        .untilAsserted(() -> assertThat(file).doesNotExist());
   }
 
   protected void assertThatServerPortIsFree(final int serverPort) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorCommand.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorCommand.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.apache.geode.distributed.LocatorLauncher.Command;
 
+@SuppressWarnings("unused")
 public class LocatorCommand {
 
   private String javaPath;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherJmxManagerLocalRegressionTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherJmxManagerLocalRegressionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
@@ -104,8 +105,10 @@ public class LocatorLauncherJmxManagerLocalRegressionTest
   }
 
   private void assertThatThreadsStopped() {
-    await().untilAsserted(() -> assertThat(currentThreadCount())
-        .isLessThanOrEqualTo(initialThreadCountPlusAwaitility()));
+    await()
+        .atMost(AWAIT_MILLIS, MILLISECONDS)
+        .untilAsserted(() -> assertThat(currentThreadCount())
+            .isLessThanOrEqualTo(initialThreadCountPlusAwaitility()));
   }
 
   private int currentThreadCount() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteFileIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteFileIntegrationTest.java
@@ -44,7 +44,7 @@ public class LocatorLauncherRemoteFileIntegrationTest extends LocatorLauncherRem
   @Test
   @Override
   public void statusWithPidReturnsOnlineWithDetails() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     Throwable thrown = catchThrowable(() -> new Builder()
         .setPid(getLocatorPid())
@@ -58,7 +58,7 @@ public class LocatorLauncherRemoteFileIntegrationTest extends LocatorLauncherRem
   @Test
   @Override
   public void stopWithPidDeletesPidFile() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     Throwable thrown = catchThrowable(() -> new Builder()
         .setPid(getLocatorPid())
@@ -72,7 +72,7 @@ public class LocatorLauncherRemoteFileIntegrationTest extends LocatorLauncherRem
   @Test
   @Override
   public void stopWithPidReturnsStopped() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     Throwable thrown = catchThrowable(() -> new Builder()
         .setPid(getLocatorPid())
@@ -86,7 +86,7 @@ public class LocatorLauncherRemoteFileIntegrationTest extends LocatorLauncherRem
   @Test
   @Override
   public void stopWithPidStopsLocatorProcess() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     Throwable thrown = catchThrowable(() -> new Builder()
         .setPid(getLocatorPid())

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherRemoteIntegrationTest.java
@@ -46,21 +46,21 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void startCreatesPidFile() {
-    startLocator();
+    startLocator(withPort(0));
 
     assertThat(getPidFile()).exists();
   }
 
   @Test
   public void pidFileContainsServerPid() {
-    startLocator();
+    startLocator(withPort(0));
 
     assertThatPidIsAlive(getLocatorPid());
   }
 
   @Test
   public void startCreatesLogFile() {
-    startLocator();
+    startLocator(withPort(0));
 
     assertThat(getLogFile()).exists();
   }
@@ -71,7 +71,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
     File statusRequestFile = givenControlFile(getStatusRequestFileName());
     File statusFile = givenControlFile(getStatusFileName());
 
-    startLocator();
+    startLocator(withPort(0));
 
     assertDeletionOf(stopRequestFile);
     assertDeletionOf(statusRequestFile);
@@ -85,7 +85,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
   public void startOverwritesStalePidFile() {
     givenPidFile(fakePid);
 
-    startLocator();
+    startLocator(withPort(0));
 
     assertThat(getLocatorPid()).isNotEqualTo(fakePid);
   }
@@ -97,7 +97,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
   public void startWithForceOverwritesExistingPidFile() {
     givenPidFile(localPid);
 
-    startLocator(withForce());
+    startLocator(withForce().withPort(0));
 
     assertThatPidIsAlive(getLocatorPid());
     assertThat(getLocatorPid()).isNotEqualTo(localPid);
@@ -125,7 +125,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void statusWithPidReturnsOnlineWithDetails() throws Exception {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     LocatorState locatorState = new Builder()
         .setPid(getLocatorPid())
@@ -147,7 +147,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void statusWithWorkingDirectoryReturnsOnlineWithDetails() throws Exception {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     LocatorState locatorState = new Builder()
         .setWorkingDirectory(getWorkingDirectoryPath())
@@ -219,7 +219,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void stopWithPidReturnsStopped() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     LocatorState serverState = new Builder()
         .setPid(getLocatorPid())
@@ -231,7 +231,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void stopWithPidStopsLocatorProcess() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     new Builder().setPid(getLocatorPid())
         .build()
@@ -242,7 +242,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void stopWithPidDeletesPidFile() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     new Builder()
         .setPid(getLocatorPid())
@@ -254,7 +254,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void stopWithWorkingDirectoryReturnsStopped() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     LocatorState serverState = new Builder()
         .setWorkingDirectory(getWorkingDirectoryPath())
@@ -266,7 +266,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void stopWithWorkingDirectoryStopsLocatorProcess() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     new Builder()
         .setWorkingDirectory(getWorkingDirectoryPath())
@@ -278,7 +278,7 @@ public class LocatorLauncherRemoteIntegrationTest extends LocatorLauncherRemoteI
 
   @Test
   public void stopWithWorkingDirectoryDeletesPidFile() {
-    givenRunningLocator();
+    givenRunningLocator(withPort(0));
 
     new Builder()
         .setWorkingDirectory(getWorkingDirectoryPath())

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerCommand.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/ServerCommand.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.apache.geode.distributed.ServerLauncher.Command;
 
+@SuppressWarnings("unused")
 public class ServerCommand {
 
   private String javaPath;


### PR DESCRIPTION
* Increase await timeout (these tests fork external process)
* Set locator port to zero where possible to reduce BindExceptions
* Include statusFailedWithException details for Errors
* Fix GEODE-7026 on Windows as well

This should reduce failures caused by GEODE-6183 and GEODE-7026. It should also increase the available information for debugging by including statusFailedWithException details for Errors (so we'll see info about the Process when the ConditionTimeoutException occurs).

Please review: @aaronlindsey 