### PR TITLE
GEODE-7237: Fix race condition in GfshRule

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandAcceptanceTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assume.assumeFalse;
 
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -60,7 +59,6 @@ public class ConnectCommandAcceptanceTest {
         .contains("gfsh client to connect to this cluster.");
   }
 
-  @Ignore("Re-enable after GEODE-7237 is fixed")
   @Test
   public void invalidHostname() {
     GfshExecution connect = GfshScript

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/GfshRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/GfshRule.java
@@ -117,9 +117,10 @@ public class GfshRule extends ExternalResource {
   public GfshExecution execute(GfshScript gfshScript) {
     System.out.println("Executing " + gfshScript);
     try {
-      File workingDir = temporaryFolder.newFolder(gfshScript.getName());
-      int debugPort = gfshScript.getDebugPort();
+      File workingDir = new File(temporaryFolder.getRoot(), gfshScript.getName());
+      workingDir.mkdirs();
 
+      int debugPort = gfshScript.getDebugPort();
       Process process = toProcessBuilder(gfshScript, gfsh, workingDir, debugPort).start();
 
       GfshExecution gfshExecution = new GfshExecution(process, workingDir);

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/ProcessLogger.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/ProcessLogger.java
@@ -14,32 +14,62 @@
  */
 package org.apache.geode.test.junit.rules.gfsh.internal;
 
+import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
-import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.internal.logging.LogService;
 
-public class ProcessLogger {
+public class ProcessLogger implements AutoCloseable {
 
   private final Logger logger;
-  private final Queue<OutputLine> outputLines = new ConcurrentLinkedQueue<>();
+  private final Queue<OutputLine> outputLines;
+  private final StreamGobbler stdoutGobbler;
+  private final StreamGobbler stderrGobbler;
 
   public ProcessLogger(Process process, String name) {
     logger = LogService.getLogger(name);
+    outputLines = new ConcurrentLinkedQueue<>();
+    stdoutGobbler = new StreamGobbler(process.getInputStream(), this::consumeInfoMessage);
+    stderrGobbler = new StreamGobbler(process.getErrorStream(), this::consumeErrorMessage);
+  }
 
-    StreamGobbler stdOutGobbler =
-        new StreamGobbler(process.getInputStream(), this::consumeInfoMessage);
-    StreamGobbler stdErrGobbler =
-        new StreamGobbler(process.getErrorStream(), this::consumeErrorMessage);
+  public void start() {
+    stdoutGobbler.start();
+    stderrGobbler.start();
+  }
 
-    stdOutGobbler.startInNewThread();
-    stdErrGobbler.startInNewThread();
+  public String getOutputText() {
+    return outputLines.stream()
+        .map(OutputLine::getLine)
+        .collect(joining(lineSeparator()));
+  }
+
+  @Override
+  public void close() {
+    stdoutGobbler.close();
+    stderrGobbler.close();
+  }
+
+  /**
+   * Blocks until the ProcessLogger finishes collecting the process's output
+   *
+   * @throws InterruptedException if the ProcessLogger's threads are interrupted
+   * @throws ExecutionException if the ProcessLogger's threads throw
+   * @throws TimeoutException if the ProcessLogger does not finish collecting output before the
+   *         timeout
+   */
+  public void awaitTermination(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    stdoutGobbler.awaitTermination(timeout, unit);
+    stderrGobbler.awaitTermination(timeout, unit);
   }
 
   private void consumeInfoMessage(String message) {
@@ -50,27 +80,5 @@ public class ProcessLogger {
   private void consumeErrorMessage(String message) {
     logger.error(message);
     outputLines.add(OutputLine.fromStdErr(message));
-  }
-
-  public List<String> getStdOutLines() {
-    return getOutputLines(OutputLine.OutputSource.STD_OUT);
-  }
-
-  public List<String> getStdErrLines() {
-    return getOutputLines(OutputLine.OutputSource.STD_ERR);
-  }
-
-  public List<String> getOutputLines() {
-    return outputLines.stream().map(OutputLine::getLine).collect(toList());
-  }
-
-  public String getOutputText() {
-    return outputLines.stream().map(OutputLine::getLine)
-        .collect(joining(System.lineSeparator()));
-  }
-
-  private List<String> getOutputLines(OutputLine.OutputSource source) {
-    return outputLines.stream().filter(line -> line.getSource().equals(source))
-        .map(OutputLine::getLine).collect(toList());
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/StreamGobbler.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/internal/StreamGobbler.java
@@ -14,32 +14,64 @@
  */
 package org.apache.geode.test.junit.rules.gfsh.internal;
 
+import static java.util.concurrent.Executors.newSingleThreadExecutor;
+
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
-class StreamGobbler implements Runnable {
-  private InputStream inputStream;
-  private Consumer<String> consumeInputLine;
+class StreamGobbler implements AutoCloseable {
+  private final InputStream inputStream;
+  private final Consumer<String> consumeInputLine;
+  private final ExecutorService executorService;
 
-  public StreamGobbler(InputStream inputStream, Consumer<String> consumeInputLine) {
+  private Future<?> processInputTask;
+
+  StreamGobbler(InputStream inputStream, Consumer<String> consumeInputLine) {
     this.inputStream = inputStream;
     this.consumeInputLine = consumeInputLine;
+
+    executorService = newSingleThreadExecutor();
+  }
+
+  public void start() {
+    processInputTask = executorService.submit(this::processInputStream);
   }
 
   @Override
-  public void run() {
-    try {
-      new BufferedReader(new InputStreamReader(inputStream)).lines().forEach(consumeInputLine);
-    } catch (UncheckedIOException ignored) {
-      // If this gobbler is reading the System.out stream from a process that gets killed,
-      // we will occasionally see an exception here than can be ignored.
+  public void close() {
+    executorService.shutdown();
+  }
+
+  /**
+   * Blocks until the StreamGobbler finishes processing the input stream
+   *
+   * @throws InterruptedException if the StreamGobbler thread was interrupted
+   * @throws ExecutionException if the StreamGobbler thread threw an exception
+   * @throws TimeoutException if the StreamGobbler does not finish processing input before the
+   *         timeout
+   */
+  public void awaitTermination(long timeout, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    if (processInputTask != null) {
+      processInputTask.get(timeout, unit);
     }
   }
 
-  public void startInNewThread() {
-    new Thread(this).start();
+  private void processInputStream() {
+    try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream))) {
+      bufferedReader.lines().forEach(consumeInputLine);
+    } catch (UncheckedIOException | IOException ignored) {
+      // If this gobbler is reading the System.out stream from a process that gets killed,
+      // we will occasionally see an exception here than can be ignored.
+    }
   }
 }


### PR DESCRIPTION
`GfshRule.execute()` now blocks while the ProcessLogger is still collecting output from the GFSH process. This fixes a race condition that causes `ConnectCommandAcceptanceTest.invalidHostname()` to fail intermittently.

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>