### PR TITLE
GEODE-7291: Prevent empty micrometer tags

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/CacheCommonTagsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/CacheCommonTagsTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.metrics;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.geode.distributed.ConfigurationProperties.NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.UnknownHostException;
+import java.util.List;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.net.SocketCreator;
+
+public class CacheCommonTagsTest {
+
+  private InternalCache cache;
+
+  @After
+  public void tearDown() {
+    if (cache != null) {
+      cache.close();
+    }
+  }
+
+  @Test
+  public void metersHaveHostTag() throws UnknownHostException {
+    cache = (InternalCache) new CacheFactory().create();
+    MeterRegistry meterRegistry = cache.getMeterRegistry();
+    List<Meter> meters = meterRegistry.getMeters();
+
+    assertThat(meters)
+        .isNotEmpty();
+
+    for (Meter meter : meters) {
+      Meter.Id meterId = meter.getId();
+
+      assertThat(meter.getId().getTags())
+          .as("Tags for meter with name " + meterId.getName())
+          .contains(Tag.of("host", SocketCreator.getHostName(SocketCreator.getLocalHost())));
+    }
+  }
+
+  @Test
+  public void metersHaveClusterTag() {
+    cache = (InternalCache) new CacheFactory().create();
+    MeterRegistry meterRegistry = cache.getMeterRegistry();
+    List<Meter> meters = meterRegistry.getMeters();
+
+    assertThat(meters)
+        .isNotEmpty();
+
+    for (Meter meter : meters) {
+      Meter.Id meterId = meter.getId();
+
+      assertThat(meter.getId().getTags())
+          .as("Tags for meter with name " + meterId.getName())
+          .contains(Tag.of("cluster", String.valueOf(-1)));
+    }
+  }
+
+  @Test
+  public void metersHaveMemberTagIfMemberNameExists() {
+    String memberName = "my-name";
+    cache = (InternalCache) new CacheFactory().set(NAME, memberName).create();
+    MeterRegistry meterRegistry = cache.getMeterRegistry();
+    List<Meter> meters = meterRegistry.getMeters();
+
+    assertThat(meters)
+        .isNotEmpty();
+
+    for (Meter meter : meters) {
+      Meter.Id meterId = meter.getId();
+
+      assertThat(meter.getId().getTags())
+          .as("Tags for meter with name " + meterId.getName())
+          .contains(Tag.of("member", memberName));
+    }
+  }
+
+  @Test
+  public void metersDoNotHaveMemberTagIfMemberNameIsEmpty() {
+    cache = (InternalCache) new CacheFactory().set(NAME, "").create();
+    MeterRegistry meterRegistry = cache.getMeterRegistry();
+    List<Meter> meters = meterRegistry.getMeters();
+
+    assertThat(meters)
+        .isNotEmpty();
+
+    for (Meter meter : meters) {
+      Meter.Id meterId = meter.getId();
+      List<String> tagNames = meterId.getTags().stream().map(Tag::getKey).collect(toList());
+
+      assertThat(tagNames)
+          .as("Tag names for meter with name " + meterId.getName())
+          .doesNotContain("member");
+    }
+  }
+
+  @Test
+  public void metersDoNotHaveMemberTagIfMemberNameIsMissing() {
+    cache = (InternalCache) new CacheFactory().create();
+    MeterRegistry meterRegistry = cache.getMeterRegistry();
+    List<Meter> meters = meterRegistry.getMeters();
+
+    assertThat(meters)
+        .isNotEmpty();
+
+    for (Meter meter : meters) {
+      Meter.Id meterId = meter.getId();
+      List<String> tagNames = meterId.getTags().stream().map(Tag::getKey).collect(toList());
+
+      assertThat(tagNames)
+          .as("Tag names for meter with name " + meterId.getName())
+          .doesNotContain("member");
+    }
+  }
+}

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/ClientCacheCommonTagsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/ClientCacheCommonTagsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.metrics;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import org.junit.After;
+import org.junit.Test;
+
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.internal.InternalClientCache;
+
+public class ClientCacheCommonTagsTest {
+
+  private InternalClientCache clientCache;
+
+  @After
+  public void tearDown() {
+    if (clientCache != null) {
+      clientCache.close();
+    }
+  }
+
+  @Test
+  public void metersDoNotHaveClusterTag() {
+    clientCache =
+        (InternalClientCache) new ClientCacheFactory().set(DISTRIBUTED_SYSTEM_ID, "1").create();
+    MeterRegistry meterRegistry = clientCache.getMeterRegistry();
+    List<Meter> meters = meterRegistry.getMeters();
+
+    assertThat(meters)
+        .isNotEmpty();
+
+    for (Meter meter : meters) {
+      Meter.Id meterId = meter.getId();
+      List<String> tagNames = meterId.getTags().stream().map(Tag::getKey).collect(toList());
+
+      assertThat(tagNames)
+          .as("Tag names for meter with name " + meterId.getName())
+          .doesNotContain("cluster");
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/InternalClientCache.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/InternalClientCache.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.client.internal;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionExistsException;
@@ -41,4 +43,6 @@ public interface InternalClientCache extends ClientCache {
   InternalDistributedSystem getInternalDistributedSystem();
 
   CachePerfStats getCachePerfStats();
+
+  MeterRegistry getMeterRegistry();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheBuilder.java
@@ -202,7 +202,7 @@ public class InternalCacheBuilder {
             String hostName = internalDistributedSystem.getDistributedMember().getHost();
 
             CompositeMeterRegistry compositeMeterRegistry = compositeMeterRegistryFactory
-                .create(systemId, memberName, hostName);
+                .create(systemId, memberName, hostName, isClient);
 
             for (MeterRegistry meterSubregistry : meterSubregistries) {
               compositeMeterRegistry.add(meterSubregistry);

--- a/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/metrics/CompositeMeterRegistryFactory.java
@@ -21,5 +21,5 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
  */
 public interface CompositeMeterRegistryFactory {
 
-  CompositeMeterRegistry create(int systemId, String memberName, String hostName);
+  CompositeMeterRegistry create(int systemId, String memberName, String hostName, boolean isClient);
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -570,7 +570,7 @@ public class GemFireCacheImplTest {
     gemFireCacheImpl = (GemFireCacheImpl) new InternalCacheBuilder()
         .addMeterSubregistry(subregistry)
         .setTypeRegistry(mock(TypeRegistry.class))
-        .create(Fakes.distributedSystem());
+        .create(distributedSystem());
 
     gemFireCacheImpl.close();
 
@@ -580,15 +580,21 @@ public class GemFireCacheImplTest {
   private static GemFireCacheImpl createGemFireCacheImpl() {
     return (GemFireCacheImpl) new InternalCacheBuilder()
         .setTypeRegistry(mock(TypeRegistry.class))
-        .create(Fakes.distributedSystem());
+        .create(distributedSystem());
   }
 
   private static GemFireCacheImpl createGemFireCacheWithTypeRegistry() {
-    InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
+    InternalDistributedSystem internalDistributedSystem = distributedSystem();
     TypeRegistry typeRegistry = mock(TypeRegistry.class);
     return (GemFireCacheImpl) new InternalCacheBuilder()
         .setUseAsyncEventListeners(true)
         .setTypeRegistry(typeRegistry)
         .create(internalDistributedSystem);
+  }
+
+  private static InternalDistributedSystem distributedSystem() {
+    InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
+    when(internalDistributedSystem.getName()).thenReturn("my-name");
+    return internalDistributedSystem;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/InternalCacheBuilderTest.java
@@ -150,6 +150,7 @@ public class InternalCacheBuilderTest {
     int theSystemId = 21;
     String theMemberName = "theMemberName";
     String theHostName = "theHostName";
+    boolean isClient = false;
     InternalDistributedSystem theConstructedSystem =
         systemWith("theConstructedSystem", theSystemId, theMemberName, theHostName);
     InternalCache constructedCache = constructedCache();
@@ -167,7 +168,7 @@ public class InternalCacheBuilderTest {
         .create();
 
     verify(theCompositeMeterRegistryFactory)
-        .create(eq(theSystemId), eq(theMemberName), eq(theHostName));
+        .create(eq(theSystemId), eq(theMemberName), eq(theHostName), eq(isClient));
   }
 
   @Test
@@ -178,7 +179,7 @@ public class InternalCacheBuilderTest {
     CompositeMeterRegistry theCompositeMeterRegistry = new CompositeMeterRegistry();
     CompositeMeterRegistryFactory theCompositeMeterRegistryFactory =
         mock(CompositeMeterRegistryFactory.class);
-    when(theCompositeMeterRegistryFactory.create(anyInt(), any(), any()))
+    when(theCompositeMeterRegistryFactory.create(anyInt(), any(), any(), anyBoolean()))
         .thenReturn(theCompositeMeterRegistry);
 
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(
@@ -626,7 +627,7 @@ public class InternalCacheBuilderTest {
     MeterRegistry theMeterRegistry = new SimpleMeterRegistry();
 
     CompositeMeterRegistry theCompositeMeterRegistry = new CompositeMeterRegistry();
-    when(compositeMeterRegistryFactory.create(anyInt(), any(), any()))
+    when(compositeMeterRegistryFactory.create(anyInt(), any(), any(), anyBoolean()))
         .thenReturn(theCompositeMeterRegistry);
 
     InternalCacheBuilder internalCacheBuilder = new InternalCacheBuilder(

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryBindersTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryBindersTest.java
@@ -30,17 +30,17 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class CacheMeterRegistryFactoryBindersTest {
 
   private static final String[] COMMON_TAG_KEYS = {"cluster", "member", "host"};
+
   private CompositeMeterRegistry registry;
 
   @Before
   public void before() {
     CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
 
-    registry = factory.create(42, "member-name", "host-name");
+    registry = factory.create(42, "member-name", "host-name", false);
     registry.add(new SimpleMeterRegistry());
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/metrics/CacheMeterRegistryFactoryTest.java
@@ -14,7 +14,11 @@
  */
 package org.apache.geode.internal.metrics;
 
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.util.List;
 
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
@@ -23,24 +27,26 @@ import org.junit.Test;
 
 public class CacheMeterRegistryFactoryTest {
 
-  private static final int CLUSTER_ID = 42;
-  private static final String MEMBER_NAME = "member-name";
-  private static final String HOST_NAME = "host-name";
+  private static final int CLUSTER = 42;
+  private static final String MEMBER = "member-name";
+  private static final String HOST = "host-name";
+  private static final boolean IS_CLIENT = false;
 
   @Test
   public void createsCompositeMeterRegistry() {
     CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
 
-    assertThat(factory.create(CLUSTER_ID, MEMBER_NAME, HOST_NAME))
+    assertThat(factory.create(CLUSTER, MEMBER, HOST, IS_CLIENT))
         .isInstanceOf(CompositeMeterRegistry.class);
   }
 
   @Test
-  public void addsMemberNameCommonTag() {
+  public void addsMemberCommonTag_ifHasName() {
     CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
     String theMemberName = "the-member-name";
 
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, theMemberName, HOST_NAME);
+    CompositeMeterRegistry registry =
+        factory.create(CLUSTER, theMemberName, HOST, IS_CLIENT);
 
     Meter meter = registry
         .counter("my.meter");
@@ -50,11 +56,30 @@ public class CacheMeterRegistryFactoryTest {
   }
 
   @Test
-  public void addsClusterIdCommonTag() {
+  public void doesNotAddMemberCommonTag_ifNameIsEmpty() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+    String theMemberName = "";
+
+    CompositeMeterRegistry registry =
+        factory.create(CLUSTER, theMemberName, HOST, IS_CLIENT);
+
+    Meter meter = registry
+        .counter("my.meter");
+
+    List<String> tagNames = meter.getId().getTags().stream().map(Tag::getKey).collect(toList());
+    assertThat(tagNames)
+        .as("Tag names for meter with name " + meter.getId().getName())
+        .doesNotContain("member");
+  }
+
+  @Test
+  public void addsClusterCommonTag_ifNotClient() {
     CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
     int theSystemId = 21;
+    boolean isClient = false;
 
-    CompositeMeterRegistry registry = factory.create(theSystemId, MEMBER_NAME, HOST_NAME);
+    CompositeMeterRegistry registry =
+        factory.create(theSystemId, MEMBER, HOST, isClient);
 
     Meter meter = registry
         .counter("my.meter");
@@ -64,16 +89,71 @@ public class CacheMeterRegistryFactoryTest {
   }
 
   @Test
-  public void addsHostNameCommonTag() {
+  public void doesNotAddClusterCommonTag_ifIsClient() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+    int theSystemId = 21;
+    boolean isClient = true;
+
+    CompositeMeterRegistry registry =
+        factory.create(theSystemId, MEMBER, HOST, isClient);
+
+    Meter meter = registry
+        .counter("my.meter");
+
+    List<String> tagNames = meter.getId().getTags().stream().map(Tag::getKey).collect(toList());
+    assertThat(tagNames)
+        .as("Tag names for meter with name " + meter.getId().getName())
+        .doesNotContain("cluster");
+  }
+
+  @Test
+  public void addsHostCommonTag() {
     CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
     String theHostName = "the-host-name";
 
-    CompositeMeterRegistry registry = factory.create(CLUSTER_ID, MEMBER_NAME, theHostName);
+    CompositeMeterRegistry registry =
+        factory.create(CLUSTER, MEMBER, theHostName, IS_CLIENT);
 
     Meter meter = registry
         .counter("my.meter");
 
     assertThat(meter.getId().getTags())
         .contains(Tag.of("host", theHostName));
+  }
+
+  @Test
+  public void throwsNullPointerException_ifNameIsNull() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+    String theMemberName = null;
+
+    Throwable thrown =
+        catchThrowable(() -> factory.create(CLUSTER, theMemberName, HOST, IS_CLIENT));
+
+    assertThat(thrown)
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void throwsNullPointerException_ifHostIsNull() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+    String theHostName = null;
+
+    Throwable thrown =
+        catchThrowable(() -> factory.create(CLUSTER, MEMBER, theHostName, IS_CLIENT));
+
+    assertThat(thrown)
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void throwsIllegalArgumentException_ifHostIsEmpty() {
+    CacheMeterRegistryFactory factory = new CacheMeterRegistryFactory();
+    String theHostName = "";
+
+    Throwable thrown =
+        catchThrowable(() -> factory.create(CLUSTER, MEMBER, theHostName, IS_CLIENT));
+
+    assertThat(thrown)
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }


### PR DESCRIPTION
* Do not include member meter tag if member name is missing
* Do not include cluster meter tags in a client

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>

Please review @aaronlindsey 