### PR TITLE
GEODE-7278: convert transport filters

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverter.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverter.java
@@ -68,11 +68,13 @@ public class GatewayReceiverConverter
     receiver.setManualStart(configObject.isManualStart());
     receiver.setMaximumTimeBetweenPings(intToString(configObject.getMaximumTimeBetweenPings()));
     receiver.setSocketBufferSize(intToString(configObject.getSocketBufferSize()));
-    List<DeclarableType> xmlFilters = receiver.getGatewayTransportFilters();
-    for (ClassName configFilter : configObject.getGatewayTransportFilters()) {
-      String className = configFilter.getClassName();
-      Properties props = configFilter.getInitProperties();
-      xmlFilters.add(new DeclarableType(className, props));
+    if (configObject.getGatewayTransportFilters() != null) {
+      List<DeclarableType> xmlFilters = receiver.getGatewayTransportFilters();
+      for (ClassName configFilter : configObject.getGatewayTransportFilters()) {
+        String className = configFilter.getClassName();
+        Properties props = configFilter.getInitProperties();
+        xmlFilters.add(new DeclarableType(className, props));
+      }
     }
     return receiver;
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverterTest.java
@@ -62,7 +62,7 @@ public class GatewayReceiverConverterTest {
   }
 
   @Test
-  public void fromConfigWithNullTransportFilters() {
+  public void fromConfigWithNoTransportFilters() {
     GatewayReceiver config = new GatewayReceiver();
     config.setEndPort(2);
     config.setManualStart(true);
@@ -102,4 +102,38 @@ public class GatewayReceiverConverterTest {
     assertThat(configFilter.getClassName()).isEqualTo("className");
     assertThat(configFilter.getInitProperties()).isEqualTo(filterProps);
   }
+
+  @Test
+  public void fromXmlWithNoTransportFilters() {
+    GatewayReceiverConfig xml = new GatewayReceiverConfig();
+    xml.setEndPort("2");
+    xml.setManualStart(true);
+    xml.setMaximumTimeBetweenPings("1000");
+    xml.setSocketBufferSize("1024");
+    xml.setStartPort("1");
+    GatewayReceiver config = converter.fromXmlObject(xml);
+    assertThat(config.isManualStart()).isTrue();
+    assertThat(config.getEndPort()).isEqualTo(2);
+    assertThat(config.getMaximumTimeBetweenPings()).isEqualTo(1000);
+    assertThat(config.getSocketBufferSize()).isEqualTo(1024);
+    assertThat(config.getStartPort()).isEqualTo(1);
+    assertThat(config.getGatewayTransportFilters()).isNull();;
+  }
+
+  @Test
+  public void fromXmlWithBlankIntAttribute() {
+    GatewayReceiverConfig xml = new GatewayReceiverConfig();
+    xml.setEndPort("");
+    GatewayReceiver config = converter.fromXmlObject(xml);
+    assertThat(config.getEndPort()).isNull();
+  }
+
+  @Test
+  public void fromConfigWithNullIntegerAttribute() {
+    GatewayReceiver config = new GatewayReceiver();
+    config.setEndPort(null);
+    GatewayReceiverConfig xml = converter.fromConfigObject(config);
+    assertThat(xml.getEndPort()).isNull();
+  }
+
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverterTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.configuration.converters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.configuration.DeclarableType;
+import org.apache.geode.cache.configuration.GatewayReceiverConfig;
+import org.apache.geode.cache.configuration.ParameterType;
+import org.apache.geode.management.configuration.ClassName;
+import org.apache.geode.management.configuration.GatewayReceiver;
+
+public class GatewayReceiverConverterTest {
+  private GatewayReceiverConverter converter = new GatewayReceiverConverter();
+
+  @Test
+  public void fromConfig() {
+    GatewayReceiver config = new GatewayReceiver();
+    config.setEndPort(2);
+    Properties classNameProps = new Properties();
+    classNameProps.setProperty("key1", "value1");
+    config.setGatewayTransportFilters(
+        Collections.singletonList(new ClassName("className", classNameProps)));
+    config.setManualStart(true);
+    config.setMaximumTimeBetweenPings(1000);
+    config.setSocketBufferSize(1024);
+    config.setStartPort(1);
+    GatewayReceiverConfig xml = converter.fromConfigObject(config);
+    assertThat(xml.isManualStart()).isTrue();
+    assertThat(xml.getStartPort()).isEqualTo("1");
+    assertThat(xml.getEndPort()).isEqualTo("2");
+    assertThat(xml.getSocketBufferSize()).isEqualTo("1024");
+    assertThat(xml.getMaximumTimeBetweenPings()).isEqualTo("1000");
+    List<DeclarableType> xmlTransportFilters = xml.getGatewayTransportFilters();
+    assertThat(xmlTransportFilters).hasSize(1);
+    DeclarableType xmlFilter = xmlTransportFilters.get(0);
+    assertThat(xmlFilter.getClassName()).isEqualTo("className");
+    List<ParameterType> xmlFilterParams = xmlFilter.getParameters();
+    assertThat(xmlFilterParams).hasSize(1);
+    ParameterType xmlFilterParam = xmlFilterParams.get(0);
+    assertThat(xmlFilterParam.getName()).isEqualTo("key1");
+    assertThat(xmlFilterParam.getString()).isEqualTo("value1");
+  }
+
+  @Test
+  public void fromXmlObject() {
+    GatewayReceiverConfig xml = new GatewayReceiverConfig();
+    xml.setEndPort("2");
+    xml.setManualStart(true);
+    xml.setMaximumTimeBetweenPings("1000");
+    xml.setSocketBufferSize("1024");
+    xml.setStartPort("1");
+    Properties filterProps = new Properties();
+    filterProps.setProperty("key1", "value1");
+    DeclarableType filter = new DeclarableType("className", filterProps);
+    xml.getGatewayTransportFilters().add(filter);
+    GatewayReceiver config = converter.fromXmlObject(xml);
+    assertThat(config.isManualStart()).isTrue();
+    assertThat(config.getEndPort()).isEqualTo(2);
+    assertThat(config.getMaximumTimeBetweenPings()).isEqualTo(1000);
+    assertThat(config.getSocketBufferSize()).isEqualTo(1024);
+    assertThat(config.getStartPort()).isEqualTo(1);
+    List<ClassName> configFilters = config.getGatewayTransportFilters();
+    assertThat(configFilters).hasSize(1);
+    ClassName configFilter = configFilters.get(0);
+    assertThat(configFilter.getClassName()).isEqualTo("className");
+    assertThat(configFilter.getInitProperties()).isEqualTo(filterProps);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/converters/GatewayReceiverConverterTest.java
@@ -62,6 +62,23 @@ public class GatewayReceiverConverterTest {
   }
 
   @Test
+  public void fromConfigWithNullTransportFilters() {
+    GatewayReceiver config = new GatewayReceiver();
+    config.setEndPort(2);
+    config.setManualStart(true);
+    config.setMaximumTimeBetweenPings(1000);
+    config.setSocketBufferSize(1024);
+    config.setStartPort(1);
+    GatewayReceiverConfig xml = converter.fromConfigObject(config);
+    assertThat(xml.isManualStart()).isTrue();
+    assertThat(xml.getStartPort()).isEqualTo("1");
+    assertThat(xml.getEndPort()).isEqualTo("2");
+    assertThat(xml.getSocketBufferSize()).isEqualTo("1024");
+    assertThat(xml.getMaximumTimeBetweenPings()).isEqualTo("1000");
+    assertThat(xml.getGatewayTransportFilters()).isEmpty();
+  }
+
+  @Test
   public void fromXmlObject() {
     GatewayReceiverConfig xml = new GatewayReceiverConfig();
     xml.setEndPort("2");


### PR DESCRIPTION
Added unit test for GatewayReceiverConverter.
GatewayReceiverConverter now handles the transport filters.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
