### PR TITLE
GEODE-7296: Fix Geode release scripts

### DIFF
--- a/dev-tools/release/commit_rc.sh
+++ b/dev-tools/release/commit_rc.sh
@@ -116,7 +116,7 @@ echo "============================================================"
 cd ${GEODE}/../..
 echo "1. ${0%/*}/deploy_rc_pipeline.sh -v ${VERSION}"
 echo "2. Monitor https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-release-${VERSION//./-}-rc until all green"
-echo "3. Send the following email to announce the RC:
+echo "3. Send the following email to announce the RC:"
 echo "To: dev@geode.apache.org"
 echo "Subject: [VOTE] Apache Geode ${FULL_VERSION}"
 ${0%/*}/print_rc_email.sh -v ${FULL_VERSION} -m ${MAVEN}

--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -254,7 +254,7 @@ jobs:
               echo 'deb-src http://ftp.de.debian.org/debian/    stable main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               echo 'deb     http://security.debian.org/         stable/updates  main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               apt-get update
-              DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev
+              DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
               cd geode-native
               mkdir build
               cd build
@@ -298,7 +298,7 @@ jobs:
               echo 'deb-src http://ftp.de.debian.org/debian/    stable main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               echo 'deb     http://security.debian.org/         stable/updates  main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               apt-get update
-              DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev
+              DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
               curl -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-native-${VERSION}-src.tar.gz > src.tgz
               tar xzf src.tgz
               cd apache-geode-native*

--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -192,7 +192,15 @@ tar czf ../${NCTAR} *
 cd ..
 rm -Rf repkg-temp
 gpg --armor -u ${SIGNING_KEY} -b ${NCTAR}
-sha512sum ${NCTAR} > ${NCTAR}.sha512
+
+if which shasum >/dev/null; then
+  SHASUM=shasum
+  SHASUM_OPTS="-a 512"
+else
+  SHASUM=sha512sum
+  SHASUM_OPTS=""
+fi
+${SHASUM} ${SHASUM_OPTS} ${NCTAR} > ${NCTAR}.sha512
 set +x
 
 


### PR DESCRIPTION
- Detect SHA sum utility on Mac OS (shasum vs. sha512sum)

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
