### PR TITLE
GEODE-7273: Able to detect not colocated transaction

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -1599,7 +1599,7 @@ public class TXState implements TXStateInterface {
   public Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
       boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
       boolean returnTombstones, boolean retainResult, boolean createIfAbsent) {
-    TXEntryState tx = proxy.txReadEntry(keyInfo, localRegion, true, createIfAbsent);
+    TXEntryState tx = txReadEntry(keyInfo, localRegion, true, createIfAbsent);
     if (tx != null) {
       Object v = tx.getValue(keyInfo, localRegion, preferCD);
       if (!disableCopyOnRead) {
@@ -2151,5 +2151,9 @@ public class TXState implements TXStateInterface {
 
   boolean isClosed() {
     return closed;
+  }
+
+  public boolean hasPerformedAnyOperation() {
+    return regions.size() != 0;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -70,6 +70,8 @@ public class TXStateProxyImpl implements TXStateProxy {
    */
   private Map<Integer, Boolean> buckets = new HashMap<Integer, Boolean>();
 
+  private boolean firstOperationOnPartitionedRegion = false;
+
   protected volatile TXStateInterface realDeal;
 
   protected boolean inProgress = true;
@@ -164,6 +166,11 @@ public class TXStateProxyImpl implements TXStateProxy {
         logger.debug("Built a new TXState: {} me:{}", this.realDeal, this.txMgr.getDM().getId());
       }
     }
+    if (isRealDealLocal() && !((TXState) realDeal).hasPerformedAnyOperation()) {
+      if (r != null && (r instanceof PartitionedRegion || r.isUsedForPartitionedRegionBucket())) {
+        firstOperationOnPartitionedRegion = true;
+      }
+    }
     return this.realDeal;
   }
 
@@ -237,7 +244,7 @@ public class TXStateProxyImpl implements TXStateProxy {
     }
   }
 
-  private TransactionException getTransactionException(KeyInfo keyInfo, GemFireException e) {
+  TransactionException getTransactionException(KeyInfo keyInfo, GemFireException e) {
     if (isRealDealLocal() && !buckets.isEmpty() && !buckets.containsKey(keyInfo.getBucketId())) {
       TransactionException ex = new TransactionDataNotColocatedException(
           String.format("Key %s is not colocated with transaction",
@@ -248,6 +255,14 @@ public class TXStateProxyImpl implements TXStateProxy {
     Throwable ex = e;
     while (ex != null) {
       if (ex instanceof PrimaryBucketException) {
+        if (isRealDealLocal() && !firstOperationOnPartitionedRegion) {
+          return new TransactionDataNotColocatedException(
+              String.format(
+                  "Key %s is not colocated with transaction. First operation in a transaction "
+                      + "should be on a partitioned region when there are operations on both "
+                      + "partitioned regions and replicate regions.",
+                  keyInfo.getKey()));
+        }
         return new TransactionDataRebalancedException(
             "Transactional data moved, due to rebalancing.");
       }
@@ -263,12 +278,17 @@ public class TXStateProxyImpl implements TXStateProxy {
       boolean retVal = getRealDeal(keyInfo, region).containsValueForKey(keyInfo, region);
       trackBucketForTx(keyInfo);
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(keyInfo, re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(keyInfo, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(keyInfo, primaryBucketException);
     }
   }
 
-  private void trackBucketForTx(KeyInfo keyInfo) {
+  void trackBucketForTx(KeyInfo keyInfo) {
     if (keyInfo.getBucketId() >= 0) {
       if (logger.isDebugEnabled()) {
         logger.debug("adding bucket:{} for tx:{}", keyInfo.getBucketId(), getTransactionId());
@@ -287,8 +307,13 @@ public class TXStateProxyImpl implements TXStateProxy {
       getRealDeal(event.getKeyInfo(), event.getRegion()).destroyExistingEntry(event, cacheWrite,
           expectedOldValue);
       trackBucketForTx(event.getKeyInfo());
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(event.getKeyInfo(), re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
   }
 
@@ -312,14 +337,24 @@ public class TXStateProxyImpl implements TXStateProxy {
   public Object getDeserializedValue(KeyInfo keyInfo, LocalRegion localRegion, boolean updateStats,
       boolean disableCopyOnRead, boolean preferCD, EntryEventImpl clientEvent,
       boolean returnTombstones, boolean retainResult, boolean createIfAbsent) {
-    Object val = getRealDeal(keyInfo, localRegion).getDeserializedValue(keyInfo, localRegion,
-        updateStats, disableCopyOnRead, preferCD, null, false, retainResult, createIfAbsent);
-    if (val != null) {
-      // fixes bug 51057: TXStateStub on client always returns null, so do not increment
-      // the operation count it will be incremented in findObject()
-      this.operationCount++;
+    try {
+      Object val = getRealDeal(keyInfo, localRegion).getDeserializedValue(keyInfo, localRegion,
+          updateStats, disableCopyOnRead, preferCD, null, false, retainResult, createIfAbsent);
+      trackBucketForTx(keyInfo);
+      if (val != null) {
+        // fixes bug 51057: TXStateStub on client always returns null, so do not increment
+        // the operation count it will be incremented in findObject()
+        this.operationCount++;
+      }
+      return val;
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(keyInfo, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(keyInfo, primaryBucketException);
     }
-    return val;
   }
 
   @Override
@@ -329,8 +364,13 @@ public class TXStateProxyImpl implements TXStateProxy {
       Entry retVal = getRealDeal(keyInfo, region).getEntry(keyInfo, region, allowTombstones);
       trackBucketForTx(keyInfo);
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(keyInfo, re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(keyInfo, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(keyInfo, primaryBucketException);
     }
   }
 
@@ -365,8 +405,13 @@ public class TXStateProxyImpl implements TXStateProxy {
       getRealDeal(event.getKeyInfo(), event.getRegion()).invalidateExistingEntry(event,
           invokeCallbacks, forceNewEntry);
       trackBucketForTx(event.getKeyInfo());
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(event.getKeyInfo(), re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
   }
 
@@ -422,8 +467,13 @@ public class TXStateProxyImpl implements TXStateProxy {
           .txPutEntry(event, ifNew, requireOldValue, checkResources, expectedOldValue);
       trackBucketForTx(event.getKeyInfo());
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(event.getKeyInfo(), re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
   }
 
@@ -436,8 +486,13 @@ public class TXStateProxyImpl implements TXStateProxy {
           rememberRead, createTxEntryIfAbsent);
       trackBucketForTx(keyInfo);
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(keyInfo, re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(keyInfo, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(keyInfo, primaryBucketException);
     }
   }
 
@@ -485,8 +540,13 @@ public class TXStateProxyImpl implements TXStateProxy {
       boolean retVal = getRealDeal(keyInfo, localRegion).containsKey(keyInfo, localRegion);
       trackBucketForTx(keyInfo);
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(keyInfo, re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(keyInfo, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(keyInfo, primaryBucketException);
     }
   }
 
@@ -531,8 +591,13 @@ public class TXStateProxyImpl implements TXStateProxy {
           disableCopyOnRead, preferCD, requestingClient, clientEvent, false);
       trackBucketForTx(key);
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(key, re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(key, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(key, primaryBucketException);
     }
   }
 
@@ -627,8 +692,13 @@ public class TXStateProxyImpl implements TXStateProxy {
           ifOld, expectedOldValue, requireOldValue, lastModified, overwriteDestroyed);
       trackBucketForTx(event.getKeyInfo());
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(event.getKeyInfo(), re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
   }
 
@@ -647,8 +717,20 @@ public class TXStateProxyImpl implements TXStateProxy {
       ClientProxyMembershipID requestingClient, EntryEventImpl clientEvent,
       boolean returnTombstones) throws DataLocationException {
     this.operationCount++;
-    return getRealDeal(key, localRegion).getSerializedValue(localRegion, key, doNotLockEntry,
-        requestingClient, clientEvent, returnTombstones);
+    try {
+      Object retVal =
+          getRealDeal(key, localRegion).getSerializedValue(localRegion, key, doNotLockEntry,
+              requestingClient, clientEvent, returnTombstones);
+      trackBucketForTx(key);
+      return retVal;
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(key, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(key, primaryBucketException);
+    }
   }
 
   @Override
@@ -658,8 +740,19 @@ public class TXStateProxyImpl implements TXStateProxy {
     this.operationCount++;
     TXStateInterface tx = getRealDeal(event.getKeyInfo(), event.getRegion());
     assert (tx instanceof TXState) : tx.getClass().getSimpleName();
-    return tx.putEntryOnRemote(event, ifNew, ifOld, expectedOldValue, requireOldValue, lastModified,
-        overwriteDestroyed);
+    try {
+      boolean retVal = tx.putEntryOnRemote(event, ifNew, ifOld, expectedOldValue, requireOldValue,
+          lastModified, overwriteDestroyed);
+      trackBucketForTx(event.getKeyInfo());
+      return retVal;
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(event.getKeyInfo(), primaryBucketException);
+    }
   }
 
   @Override
@@ -673,7 +766,17 @@ public class TXStateProxyImpl implements TXStateProxy {
     this.operationCount++;
     TXStateInterface tx = getRealDeal(event.getKeyInfo(), event.getRegion());
     assert (tx instanceof TXState);
-    tx.destroyOnRemote(event, cacheWrite, expectedOldValue);
+    try {
+      tx.destroyOnRemote(event, cacheWrite, expectedOldValue);
+      trackBucketForTx(event.getKeyInfo());
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(event.getKeyInfo(), primaryBucketException);
+    }
   }
 
   @Override
@@ -682,7 +785,17 @@ public class TXStateProxyImpl implements TXStateProxy {
     this.operationCount++;
     TXStateInterface tx = getRealDeal(event.getKeyInfo(), event.getRegion());
     assert (tx instanceof TXState);
-    tx.invalidateOnRemote(event, invokeCallbacks, forceNewEntry);
+    try {
+      tx.invalidateOnRemote(event, invokeCallbacks, forceNewEntry);
+      trackBucketForTx(event.getKeyInfo());
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(event.getKeyInfo(), primaryBucketException);
+    }
   }
 
   @Override
@@ -728,7 +841,16 @@ public class TXStateProxyImpl implements TXStateProxy {
     this.operationCount++;
     TXStateInterface tx = getRealDeal(keyInfo, localRegion);
     assert (tx instanceof TXState);
-    return tx.getEntryOnRemote(keyInfo, localRegion, allowTombstones);
+    try {
+      return tx.getEntryOnRemote(keyInfo, localRegion, allowTombstones);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(keyInfo, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(keyInfo, primaryBucketException);
+    }
   }
 
   public void forceLocalBootstrap() {
@@ -893,8 +1015,13 @@ public class TXStateProxyImpl implements TXStateProxy {
       Entry retVal = getRealDeal(keyInfo, region).accessEntry(keyInfo, region);
       trackBucketForTx(keyInfo);
       return retVal;
-    } catch (TransactionDataRebalancedException | PrimaryBucketException re) {
-      throw getTransactionException(keyInfo, re);
+    } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
+      if (isRealDealLocal()) {
+        throw getTransactionException(keyInfo, transactionDataRebalancedException);
+      }
+      throw transactionDataRebalancedException;
+    } catch (PrimaryBucketException primaryBucketException) {
+      throw getTransactionException(keyInfo, primaryBucketException);
     }
   }
 
@@ -1004,4 +1131,7 @@ public class TXStateProxyImpl implements TXStateProxy {
     return onBehalfOfClientMember;
   }
 
+  void setFirstOperationOnPartitionedRegion(boolean firstOperationOnPartitionedRegion) {
+    this.firstOperationOnPartitionedRegion = firstOperationOnPartitionedRegion;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -279,13 +279,18 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(keyInfo);
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(keyInfo, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(keyInfo, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(keyInfo, primaryBucketException);
     }
+  }
+
+  private TransactionException handleTransactionDataRebalancedException(KeyInfo keyInfo,
+      TransactionDataRebalancedException transactionDataRebalancedException) {
+    if (isRealDealLocal()) {
+      return getTransactionException(keyInfo, transactionDataRebalancedException);
+    }
+    return transactionDataRebalancedException;
   }
 
   void trackBucketForTx(KeyInfo keyInfo) {
@@ -308,10 +313,8 @@ public class TXStateProxyImpl implements TXStateProxy {
           expectedOldValue);
       trackBucketForTx(event.getKeyInfo());
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(event.getKeyInfo(),
+          transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
@@ -348,10 +351,7 @@ public class TXStateProxyImpl implements TXStateProxy {
       }
       return val;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(keyInfo, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(keyInfo, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(keyInfo, primaryBucketException);
     }
@@ -365,10 +365,7 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(keyInfo);
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(keyInfo, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(keyInfo, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(keyInfo, primaryBucketException);
     }
@@ -406,10 +403,8 @@ public class TXStateProxyImpl implements TXStateProxy {
           invokeCallbacks, forceNewEntry);
       trackBucketForTx(event.getKeyInfo());
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(event.getKeyInfo(),
+          transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
@@ -468,10 +463,8 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(event.getKeyInfo());
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(event.getKeyInfo(),
+          transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
@@ -487,10 +480,7 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(keyInfo);
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(keyInfo, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(keyInfo, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(keyInfo, primaryBucketException);
     }
@@ -541,10 +531,7 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(keyInfo);
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(keyInfo, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(keyInfo, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(keyInfo, primaryBucketException);
     }
@@ -592,10 +579,7 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(key);
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(key, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(key, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(key, primaryBucketException);
     }
@@ -693,10 +677,8 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(event.getKeyInfo());
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(event.getKeyInfo(),
+          transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
@@ -724,10 +706,7 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(key);
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(key, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(key, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(key, primaryBucketException);
     }
@@ -746,10 +725,8 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(event.getKeyInfo());
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(event.getKeyInfo(),
+          transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
@@ -770,10 +747,8 @@ public class TXStateProxyImpl implements TXStateProxy {
       tx.destroyOnRemote(event, cacheWrite, expectedOldValue);
       trackBucketForTx(event.getKeyInfo());
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(event.getKeyInfo(),
+          transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
@@ -789,10 +764,8 @@ public class TXStateProxyImpl implements TXStateProxy {
       tx.invalidateOnRemote(event, invokeCallbacks, forceNewEntry);
       trackBucketForTx(event.getKeyInfo());
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(event.getKeyInfo(), transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(event.getKeyInfo(),
+          transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(event.getKeyInfo(), primaryBucketException);
     }
@@ -844,10 +817,7 @@ public class TXStateProxyImpl implements TXStateProxy {
     try {
       return tx.getEntryOnRemote(keyInfo, localRegion, allowTombstones);
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(keyInfo, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(keyInfo, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(keyInfo, primaryBucketException);
     }
@@ -1016,10 +986,7 @@ public class TXStateProxyImpl implements TXStateProxy {
       trackBucketForTx(keyInfo);
       return retVal;
     } catch (TransactionDataRebalancedException transactionDataRebalancedException) {
-      if (isRealDealLocal()) {
-        throw getTransactionException(keyInfo, transactionDataRebalancedException);
-      }
-      throw transactionDataRebalancedException;
+      throw handleTransactionDataRebalancedException(keyInfo, transactionDataRebalancedException);
     } catch (PrimaryBucketException primaryBucketException) {
       throw getTransactionException(keyInfo, primaryBucketException);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStub.java
@@ -77,10 +77,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     try {
       pr.destroyRemotely(state.getTarget(), event.getKeyInfo().getBucketId(), event,
           expectedOldValue);
-    } catch (TransactionException e) {
-      RuntimeException re = getTransactionException(event.getKeyInfo(), e);
-      re.initCause(e.getCause());
-      throw re;
     } catch (PrimaryBucketException e) {
       RuntimeException re = getTransactionException(event.getKeyInfo(), e);
       re.initCause(e);
@@ -104,7 +100,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
   }
 
 
-  private RuntimeException getTransactionException(KeyInfo keyInfo, Throwable cause) {
+  RuntimeException getTransactionException(KeyInfo keyInfo, Throwable cause) {
     region.getCancelCriterion().checkCancelInProgress(cause); // fixes bug 44567
     Throwable ex = cause;
     while (ex != null) {
@@ -151,7 +147,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
   /**
    * wait to retry after getting a ForceReattemptException
    */
-  private void waitToRetry() {
+  void waitToRetry() {
     // this is what PR operations do. The 2000ms is not used
     (new RetryTimeKeeper(2000)).waitForBucketsRecovery();
   }
@@ -167,10 +163,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
       return e;
     } catch (EntryNotFoundException enfe) {
       return null;
-    } catch (TransactionException e) {
-      RuntimeException re = getTransactionException(keyInfo, e);
-      re.initCause(e.getCause());
-      throw re;
     } catch (PrimaryBucketException e) {
       RuntimeException re = getTransactionException(keyInfo, e);
       re.initCause(e);
@@ -193,7 +185,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
   }
 
 
-  private void trackBucketForTx(KeyInfo keyInfo) {
+  void trackBucketForTx(KeyInfo keyInfo) {
     if (region.getCache().getLogger().fineEnabled()) {
       region.getCache().getLogger()
           .fine("adding bucket:" + keyInfo.getBucketId() + " for tx:" + state.getTransactionId());
@@ -210,10 +202,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     PartitionedRegion pr = (PartitionedRegion) event.getRegion();
     try {
       pr.invalidateRemotely(state.getTarget(), event.getKeyInfo().getBucketId(), event);
-    } catch (TransactionException e) {
-      RuntimeException re = getTransactionException(event.getKeyInfo(), e);
-      re.initCause(e.getCause());
-      throw re;
     } catch (PrimaryBucketException e) {
       RuntimeException re = getTransactionException(event.getKeyInfo(), e);
       re.initCause(e);
@@ -244,10 +232,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
           keyInfo.getBucketId(), keyInfo.getKey());
       trackBucketForTx(keyInfo);
       return retVal;
-    } catch (TransactionException e) {
-      RuntimeException re = getTransactionException(keyInfo, e);
-      re.initCause(e.getCause());
-      throw re;
     } catch (PrimaryBucketException e) {
       RuntimeException re = getTransactionException(keyInfo, e);
       re.initCause(e);
@@ -272,7 +256,7 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
   /**
    * @return true if the cause of the FRE is a BucketNotFoundException
    */
-  private boolean isBucketNotFoundException(ForceReattemptException e) {
+  boolean isBucketNotFoundException(ForceReattemptException e) {
     ForceReattemptException fre = e;
     while (fre.getCause() != null && fre.getCause() instanceof ForceReattemptException) {
       fre = (ForceReattemptException) fre.getCause();
@@ -288,10 +272,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
           (InternalDistributedMember) state.getTarget(), keyInfo.getBucketId(), keyInfo.getKey());
       trackBucketForTx(keyInfo);
       return retVal;
-    } catch (TransactionException e) {
-      RuntimeException re = getTransactionException(keyInfo, e);
-      re.initCause(e.getCause());
-      throw re;
     } catch (PrimaryBucketException e) {
       RuntimeException re = getTransactionException(keyInfo, e);
       re.initCause(e);
@@ -312,7 +292,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     }
   }
 
-
   @Override
   public Object findObject(KeyInfo keyInfo, boolean isCreate, boolean generateCallbacks,
       Object value, boolean peferCD, ClientProxyMembershipID requestingClient,
@@ -324,10 +303,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
       retVal =
           region.getRemotely((InternalDistributedMember) state.getTarget(), keyInfo.getBucketId(),
               key, callbackArgument, peferCD, requestingClient, clientEvent, false);
-    } catch (TransactionException e) {
-      RuntimeException re = getTransactionException(keyInfo, e);
-      re.initCause(e.getCause());
-      throw re;
     } catch (PrimaryBucketException e) {
       RuntimeException re = getTransactionException(keyInfo, e);
       re.initCause(e);
@@ -369,10 +344,6 @@ public class PartitionedTXRegionStub extends AbstractPeerTXRegionStub {
     try {
       retVal =
           pr.putRemotely(state.getTarget(), event, ifNew, ifOld, expectedOldValue, requireOldValue);
-    } catch (TransactionException e) {
-      RuntimeException re = getTransactionException(event.getKeyInfo(), e);
-      re.initCause(e.getCause());
-      throw re;
     } catch (PrimaryBucketException e) {
       RuntimeException re = getTransactionException(event.getKeyInfo(), e);
       re.initCause(e);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStubTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tx/PartitionedTXRegionStubTest.java
@@ -1,0 +1,562 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tx;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.TransactionDataNodeHasDepartedException;
+import org.apache.geode.cache.TransactionDataRebalancedException;
+import org.apache.geode.cache.TransactionException;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.EntryEventImpl;
+import org.apache.geode.internal.cache.EntrySnapshot;
+import org.apache.geode.internal.cache.ForceReattemptException;
+import org.apache.geode.internal.cache.KeyInfo;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.TXStateStub;
+
+public class PartitionedTXRegionStubTest {
+  private TXStateStub txStateStub;
+  private PartitionedRegion partitionedRegion;
+  private EntryEventImpl event;
+  private Object expectedObject;
+  private TransactionException expectedException;
+  private DistributedMember remoteTransactionHost;
+  private KeyInfo keyInfo;
+  private Object key;
+
+  @Before
+  public void setup() {
+    txStateStub = mock(TXStateStub.class);
+    partitionedRegion = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
+    event = mock(EntryEventImpl.class);
+    expectedObject = new Object();
+    expectedException = new TransactionException();
+    remoteTransactionHost = mock(InternalDistributedMember.class);
+    keyInfo = mock(KeyInfo.class);
+    key = new Object();
+    when(txStateStub.getTarget()).thenReturn(remoteTransactionHost);
+    when(event.getKeyInfo()).thenReturn(keyInfo);
+    when(keyInfo.getKey()).thenReturn(key);
+    when(keyInfo.getBucketId()).thenReturn(1);
+  }
+
+  @Test
+  public void destroyExistingEntryTracksBucketForTx() {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+
+    stub.destroyExistingEntry(event, true, expectedObject);
+
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void destroyExistingEntryThrowsTransactionExceptionFromRemoteHost() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    doThrow(expectedException).when(partitionedRegion).destroyRemotely(remoteTransactionHost, 1,
+        event, expectedObject);
+
+    Throwable caughtException = catchThrowable(() -> stub.destroyExistingEntry(event, true,
+        expectedObject));
+
+    assertThat(caughtException).isSameAs(expectedException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void destroyExistingEntryThrowsTransactionDataRebalancedExceptionIfIsBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(true).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion).destroyRemotely(remoteTransactionHost,
+        1, event, expectedObject);
+
+    Throwable caughtException = catchThrowable(() -> stub.destroyExistingEntry(event, false,
+        expectedObject));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataRebalancedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void destroyExistingEntryThrowsTransactionDataNodeHasDepartedExceptionIfIsNotBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(false).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion).destroyRemotely(remoteTransactionHost,
+        1, event, expectedObject);
+
+    Throwable caughtException = catchThrowable(() -> stub.destroyExistingEntry(event, true,
+        expectedObject));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataNodeHasDepartedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void getEntryReturnsEntryGotFromRemote() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    EntrySnapshot entry = mock(EntrySnapshot.class);
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion.getEntryRemotely((InternalDistributedMember) remoteTransactionHost, 1,
+        key, false, true)).thenReturn((entry));
+
+    assertThat(stub.getEntry(keyInfo, true)).isEqualTo(entry);
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void getEntryThrowsTransactionExceptionFromRemoteHost() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    doThrow(expectedException).when(partitionedRegion)
+        .getEntryRemotely((InternalDistributedMember) remoteTransactionHost, 1, key, false, true);
+
+    Throwable caughtException = catchThrowable(() -> stub.getEntry(keyInfo, true));
+
+    assertThat(caughtException).isSameAs(expectedException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void getEntryThrowsTransactionDataRebalancedExceptionIfIsBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(true).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion)
+        .getEntryRemotely((InternalDistributedMember) remoteTransactionHost, 1, key, false, true);
+
+    Throwable caughtException = catchThrowable(() -> stub.getEntry(keyInfo, true));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataRebalancedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void getEntryThrowsTransactionDataNodeHasDepartedExceptionIfIsNotBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(false).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion)
+        .getEntryRemotely((InternalDistributedMember) remoteTransactionHost, 1, key, false, false);
+
+    Throwable caughtException = catchThrowable(() -> stub.getEntry(keyInfo, false));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataNodeHasDepartedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void invalidateExistingEntryTracksBucketForTx() {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+
+    stub.invalidateExistingEntry(event, true, false);
+
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void invalidateExistingEntryThrowsTransactionExceptionFromRemoteHost() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(keyInfo.getBucketId()).thenReturn(1);
+    doThrow(expectedException).when(partitionedRegion).invalidateRemotely(remoteTransactionHost, 1,
+        event);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.invalidateExistingEntry(event, false, false));
+
+    assertThat(caughtException).isSameAs(expectedException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void invalidateExistingEntryThrowsTransactionDataRebalancedExceptionIfIsBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(keyInfo.getBucketId()).thenReturn(1);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(true).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion)
+        .invalidateRemotely(remoteTransactionHost, 1, event);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.invalidateExistingEntry(event, false, false));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataRebalancedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void invalidateExistingEntryThrowsTransactionDataNodeHasDepartedExceptionIfIsNotBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(keyInfo.getBucketId()).thenReturn(1);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(false).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion)
+        .invalidateRemotely(remoteTransactionHost, 1, event);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.invalidateExistingEntry(event, false, false));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataNodeHasDepartedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsKeyReturnsTrueIfContainsKeyRemotelyReturnsTrue() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion.containsKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1,
+        key)).thenReturn(true);
+
+    assertThat(stub.containsKey(keyInfo)).isTrue();
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsKeyReturnsFalseIfContainsKeyRemotelyReturnsFalse() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion.containsKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1,
+        key)).thenReturn(false);
+
+    assertThat(stub.containsKey(keyInfo)).isFalse();
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsKeyThrowsTransactionExceptionFromRemoteHost() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion.containsKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1,
+        key)).thenThrow(expectedException);
+
+    Throwable caughtException = catchThrowable(() -> stub.containsKey(keyInfo));
+
+    assertThat(caughtException).isSameAs(expectedException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsKeyThrowsTransactionExceptionIfIsBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(true).when(stub).isBucketNotFoundException(forceReattemptException);
+    when(partitionedRegion.containsKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1,
+        key)).thenThrow(forceReattemptException);
+    doReturn(expectedException).when(stub).getTransactionException(keyInfo,
+        forceReattemptException);
+
+    Throwable caughtException = catchThrowable(() -> stub.containsKey(keyInfo));
+
+    assertThat(caughtException).isInstanceOf(TransactionException.class);
+    verify(stub).getTransactionException(keyInfo, forceReattemptException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsKeyThrowsTransactionDataNodeHasDepartedExceptionIfIsNotBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doNothing().when(stub).waitToRetry();
+    doReturn(false).when(stub).isBucketNotFoundException(forceReattemptException);
+    when(partitionedRegion.containsKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1,
+        key)).thenThrow(forceReattemptException);
+
+    Throwable caughtException = catchThrowable(() -> stub.containsKey(keyInfo));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataNodeHasDepartedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsValueForKeyReturnsTrueIfContainsKeyRemotelyReturnsTrue() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion
+        .containsValueForKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1, key))
+            .thenReturn(true);
+
+    assertThat(stub.containsValueForKey(keyInfo)).isTrue();
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsValueForKeyRemotelyReturnsFalseIfContainsKeyRemotelyReturnsFalse()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion
+        .containsValueForKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1, key))
+            .thenReturn(false);
+
+    assertThat(stub.containsValueForKey(keyInfo)).isFalse();
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsValueForKeyThrowsTransactionExceptionFromRemoteHost() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion
+        .containsValueForKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1, key))
+            .thenThrow(expectedException);
+
+    Throwable caughtException = catchThrowable(() -> stub.containsValueForKey(keyInfo));
+
+    assertThat(caughtException).isSameAs(expectedException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsValueForKeyThrowsTransactionExceptionIfIsBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(true).when(stub).isBucketNotFoundException(forceReattemptException);
+    doReturn(expectedException).when(stub).getTransactionException(keyInfo,
+        forceReattemptException);
+    when(partitionedRegion
+        .containsValueForKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1, key))
+            .thenThrow(forceReattemptException);
+
+    Throwable caughtException = catchThrowable(() -> stub.containsValueForKey(keyInfo));
+
+    assertThat(caughtException).isInstanceOf(TransactionException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void containsValueForKeyThrowsTransactionDataNodeHasDepartedExceptionIfIsNotBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doNothing().when(stub).waitToRetry();
+    doReturn(false).when(stub).isBucketNotFoundException(forceReattemptException);
+    when(partitionedRegion
+        .containsValueForKeyRemotely((InternalDistributedMember) remoteTransactionHost, 1, key))
+            .thenThrow(forceReattemptException);
+
+    Throwable caughtException = catchThrowable(() -> stub.containsValueForKey(keyInfo));
+
+    assertThat(caughtException).isInstanceOf(TransactionDataNodeHasDepartedException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void findObjectReturnsObjectFoundFromRemote() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    EntrySnapshot entry = mock(EntrySnapshot.class);
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion.getRemotely((InternalDistributedMember) remoteTransactionHost, 1,
+        key, null, true, null, event, false)).thenReturn((expectedObject));
+
+    assertThat(stub.findObject(keyInfo, false, false, null, true, null, event))
+        .isEqualTo(expectedObject);
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void findObjectThrowsTransactionExceptionFromRemoteHost() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub,
+        partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    doThrow(expectedException).when(partitionedRegion).getRemotely(
+        (InternalDistributedMember) remoteTransactionHost, 1, key, null, true, null, event, false);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.findObject(keyInfo, false, false, null, true, null, event));
+
+    assertThat(caughtException).isSameAs(expectedException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void findObjectThrowsTransactionExceptionIfIsBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub,
+        partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(true).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion)
+        .getRemotely((InternalDistributedMember) remoteTransactionHost, 1, key, null, true, null,
+            event, false);
+    doReturn(expectedException).when(stub).getTransactionException(keyInfo,
+        forceReattemptException);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.findObject(keyInfo, false, false, null, true, null, event));
+
+    assertThat(caughtException).isInstanceOf(TransactionException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void findObjectThrowsTransactionExceptionIfIsNotBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub,
+        partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(false).when(stub).isBucketNotFoundException(forceReattemptException);
+    doNothing().when(stub).waitToRetry();
+    doThrow(forceReattemptException).when(partitionedRegion)
+        .getRemotely((InternalDistributedMember) remoteTransactionHost, 1, key, null, true, null,
+            event, false);
+    doReturn(expectedException).when(stub).getTransactionException(keyInfo,
+        forceReattemptException);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.findObject(keyInfo, false, false, null, true, null, event));
+
+    assertThat(caughtException).isInstanceOf(TransactionException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void putEntryReturnsTrueIfPutRemotelyReturnsTrue() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion
+        .putRemotely((InternalDistributedMember) remoteTransactionHost, event, false, false,
+            expectedObject, true))
+                .thenReturn(true);
+
+    assertThat(stub.putEntry(event, false, false, expectedObject, true, 1, false)).isTrue();
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void putEntryReturnsFalseIfPutRemotelyReturnsFalse()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion
+        .putRemotely((InternalDistributedMember) remoteTransactionHost, event, false, false,
+            expectedObject, true))
+                .thenReturn(false);
+
+    assertThat(stub.putEntry(event, false, false, expectedObject, true, 1, false)).isFalse();
+    verify(stub).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void putEntryThrowsTransactionExceptionFromRemoteHost() throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    when(partitionedRegion
+        .putRemotely((InternalDistributedMember) remoteTransactionHost, event, true, false,
+            expectedObject, true))
+                .thenThrow(expectedException);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.putEntry(event, true, false, expectedObject, true, 1, false));
+
+    assertThat(caughtException).isSameAs(expectedException);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void putEntryThrowsTransactionExceptionIfIsBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doReturn(true).when(stub).isBucketNotFoundException(forceReattemptException);
+    doReturn(expectedException).when(stub).getTransactionException(keyInfo,
+        forceReattemptException);
+    when(partitionedRegion
+        .putRemotely((InternalDistributedMember) remoteTransactionHost, event, true, false,
+            expectedObject, true))
+                .thenThrow(forceReattemptException);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.putEntry(event, true, false, expectedObject, true, 1, false));
+
+    assertThat(caughtException).isInstanceOf(TransactionException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+  @Test
+  public void putEntryThrowsTransactionExceptionIfIsNotBucketNotFoundException()
+      throws Exception {
+    PartitionedTXRegionStub stub = spy(new PartitionedTXRegionStub(txStateStub, partitionedRegion));
+    when(event.getRegion()).thenReturn(partitionedRegion);
+
+    ForceReattemptException forceReattemptException = mock(ForceReattemptException.class);
+    doNothing().when(stub).waitToRetry();
+    doReturn(false).when(stub).isBucketNotFoundException(forceReattemptException);
+    doReturn(expectedException).when(stub).getTransactionException(keyInfo,
+        forceReattemptException);
+    when(partitionedRegion
+        .putRemotely((InternalDistributedMember) remoteTransactionHost, event, true, false,
+            expectedObject, true))
+                .thenThrow(forceReattemptException);
+
+    Throwable caughtException =
+        catchThrowable(() -> stub.putEntry(event, true, false, expectedObject, true, 1, false));
+
+    assertThat(caughtException).isInstanceOf(TransactionException.class);
+    verify(stub, never()).trackBucketForTx(keyInfo);
+  }
+
+}


### PR DESCRIPTION
  * Able to detect not colocated transaction if it is caused by the first operation on a
    replicate region and then on a partitioned region.
  * Make sure transaction host can detect this and throw TransactionDataNotColocatedException.
  * Transaction host will throw appropriate TransactionException based on the operations
    exectued.
  * Remote non host will rely on the TransactionException thrown from the tx host.

