### PR TITLE
GEODE-7184: Fix failing Windows acceptance tests

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerClusterTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerClusterTest.java
@@ -83,7 +83,7 @@ public class FunctionExecutionsTimerClusterTest {
     Path functionsJarPath = temporaryFolder.getRoot().toPath()
         .resolve("functions.jar").toAbsolutePath();
     writeJarFromClasses(functionsJarPath.toFile(), GetFunctionExecutionTimerValues.class,
-        FunctionToTimeWithResult.class, ExecutionsTimerValues.class);
+        FunctionToTimeWithResult.class, ExecutionsTimerValues.class, ThreadSleep.class);
 
     String startLocatorCommand = String.join(" ",
         "start locator",

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerLonerTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerLonerTest.java
@@ -89,7 +89,7 @@ public class FunctionExecutionsTimerLonerTest {
     functionHelpersJarPath =
         temporaryFolder.getRoot().toPath().resolve("function-helpers.jar").toAbsolutePath();
     writeJarFromClasses(functionHelpersJarPath.toFile(), FunctionToTimeWithResult.class,
-        GetFunctionExecutionTimerValues.class, ExecutionsTimerValues.class);
+        GetFunctionExecutionTimerValues.class, ExecutionsTimerValues.class, ThreadSleep.class);
 
     startServerCommandWithStatsEnabled = startServerCommand(false, true);
     startServerCommandWithStatsDisabled = startServerCommand(true, true);

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerNoResultTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerNoResultTest.java
@@ -81,7 +81,7 @@ public class FunctionExecutionsTimerNoResultTest {
         .resolve("functions.jar").toAbsolutePath();
     writeJarFromClasses(functionsJarPath.toFile(),
         GetFunctionExecutionTimerValues.class, FunctionToTimeWithoutResult.class,
-        ExecutionsTimerValues.class);
+        ExecutionsTimerValues.class, ThreadSleep.class);
 
     String startLocatorCommand = String.join(" ",
         "start locator",

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionToTimeWithResult.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionToTimeWithResult.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.metrics.function.executions;
 
+import static java.time.Duration.ofMillis;
+import static org.apache.geode.metrics.function.executions.ThreadSleep.sleepForAtLeast;
+
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
@@ -24,13 +27,10 @@ public class FunctionToTimeWithResult implements Function<String[]> {
   @Override
   public void execute(FunctionContext<String[]> context) {
     String[] arguments = context.getArguments();
-    long timeToSleep = Long.parseLong(arguments[0]);
+    long sleepTimeMillis = Long.parseLong(arguments[0]);
     boolean successful = Boolean.parseBoolean(arguments[1]);
 
-    try {
-      Thread.sleep(timeToSleep);
-    } catch (InterruptedException ignored) {
-    }
+    sleepForAtLeast(ofMillis(sleepTimeMillis));
 
     if (successful) {
       context.getResultSender().lastResult("OK");

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionToTimeWithoutResult.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionToTimeWithoutResult.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.metrics.function.executions;
 
+import static java.time.Duration.ofMillis;
+import static org.apache.geode.metrics.function.executions.ThreadSleep.sleepForAtLeast;
+
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
@@ -24,13 +27,10 @@ public class FunctionToTimeWithoutResult implements Function<String[]> {
   @Override
   public void execute(FunctionContext<String[]> context) {
     String[] arguments = context.getArguments();
-    long timeToSleep = Long.parseLong(arguments[0]);
+    long sleepTimeMillis = Long.parseLong(arguments[0]);
     boolean successful = Boolean.parseBoolean(arguments[1]);
 
-    try {
-      Thread.sleep(timeToSleep);
-    } catch (InterruptedException ignored) {
-    }
+    sleepForAtLeast(ofMillis(sleepTimeMillis));
 
     if (!successful) {
       throw new FunctionException("FAIL");

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/ThreadSleep.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/ThreadSleep.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.metrics.function.executions;
+
+import static java.lang.Math.max;
+import static java.lang.System.nanoTime;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import java.time.Duration;
+
+class ThreadSleep {
+  private static final Duration MIN_TIME_TO_SLEEP = Duration.ofMillis(10);
+
+  /**
+   * Replacement for {@link Thread#sleep(long)} that sleeps at least as long as the given duration
+   *
+   * @param duration duration to sleep
+   */
+  static void sleepForAtLeast(Duration duration) {
+    long sleepTimeNanos = duration.toNanos();
+    long startTimeNanos = nanoTime();
+
+    while (true) {
+      long elapsedTimeNanos = nanoTime() - startTimeNanos;
+      if (elapsedTimeNanos >= sleepTimeNanos) {
+        break;
+      }
+
+      long remainingTimeNanos = sleepTimeNanos - elapsedTimeNanos;
+      try {
+        Thread.sleep(max(MIN_TIME_TO_SLEEP.toMillis(), NANOSECONDS.toMillis(remainingTimeNanos)));
+      } catch (InterruptedException ignored) {
+      }
+    }
+  }
+}


### PR DESCRIPTION
`Thread.sleep()` is not guaranteed to sleep for the given duration. Add new method for testing which sleeps for at least as long as the given duration.

Here is an example of the type of failures that are currently happening in the Windows acceptance test jobs:
```
org.apache.geode.metrics.function.executions.FunctionExecutionsTimerClusterTest > timersRecordCountAndTotalTime_ifFunctionExecutedOnReplicateRegion FAILED
    java.lang.AssertionError: [Total time of function executions across all servers] 
    Expecting:
     <9.99305729E8>
    to be between:
     [1.0E9, 2.0E9]
        at org.apache.geode.metrics.function.executions.FunctionExecutionsTimerClusterTest.timersRecordCountAndTotalTime_ifFunctionExecutedOnReplicateRegion(FunctionExecutionsTimerClusterTest.java:171)
```
This change prevents these failures by ensuring that the function under test sleeps for as long as the test expects.

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>