### PR TITLE
GEODE-7326: Add cache gets timers

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/CacheGetsTimerTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/CacheGetsTimerTest.java
@@ -1,0 +1,521 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.metrics;
+
+import static java.io.File.pathSeparatorChar;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.stream.Collectors.toList;
+import static org.apache.geode.cache.execute.FunctionService.onServer;
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
+import static org.apache.geode.test.compiler.ClassBuilder.writeJarFromClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import io.micrometer.core.instrument.Timer;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.rules.ServiceJarRule;
+import org.apache.geode.security.AuthInitialize;
+import org.apache.geode.security.AuthenticationFailedException;
+import org.apache.geode.security.ResourcePermission;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+
+public class CacheGetsTimerTest {
+  private int locatorPort;
+  private ClientCache clientCache;
+  private Region<Object, Object> replicateRegion;
+  private Region<Object, Object> partitionRegion;
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Rule
+  public ServiceJarRule serviceJarRule = new ServiceJarRule();
+
+  @After
+  public void tearDown() {
+    if (clientCache != null) {
+      clientCache.close();
+    }
+
+    if (locatorPort != 0) {
+      String connectToLocatorCommand = "connect --locator=localhost[" + locatorPort + "]";
+      String shutdownCommand = "shutdown --include-locators";
+      gfshRule.execute(connectToLocatorCommand, shutdownCommand);
+    }
+  }
+
+  @Test
+  public void hitTimerRecordsCountAndTotalTime_ifGetsPerformedOnReplicateRegionWithExistingKey()
+      throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    for (int i = 0; i < 5; i++) {
+      replicateRegion.put(i, i);
+      replicateRegion.get(i);
+    }
+
+    TimerValue hitTimerValue = hitTimerValueForRegion(replicateRegion);
+
+    assertThat(hitTimerValue.region)
+        .as("Cache gets hit timer region tag value")
+        .isEqualTo(replicateRegion.getName());
+
+    assertThat(hitTimerValue.result)
+        .as("Cache gets hit timer result tag value")
+        .isEqualTo("hit");
+
+    assertThat(hitTimerValue.count)
+        .as("Cache gets hit timer count for region " + replicateRegion.getName())
+        .isEqualTo(5);
+
+    assertThat(hitTimerValue.totalTime)
+        .as("Cache gets hit timer total time for region " + replicateRegion.getName())
+        .isGreaterThan(0);
+  }
+
+  @Test
+  public void missTimerRecordsCountAndTotalTime_ifGetsPerformedOnReplicateRegionWithMissingKey()
+      throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    for (int i = 0; i < 5; i++) {
+      replicateRegion.get(i);
+    }
+
+    TimerValue missTimerValue = missTimerValueForRegion(replicateRegion);
+
+    assertThat(missTimerValue.region)
+        .as("Cache gets miss timer region tag value")
+        .isEqualTo(replicateRegion.getName());
+
+    assertThat(missTimerValue.result)
+        .as("Cache gets miss timer result tag value")
+        .isEqualTo("miss");
+
+    assertThat(missTimerValue.count)
+        .as("Cache gets miss timer count for region " + replicateRegion.getName())
+        .isEqualTo(5);
+
+    assertThat(missTimerValue.totalTime)
+        .as("Cache gets miss timer total time for region " + replicateRegion.getName())
+        .isGreaterThan(0);
+  }
+
+  @Test
+  public void hitTimerRecordsCountAndTotalTime_ifGetsPerformedOnPartitionRegionWithExistingKey()
+      throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    for (int i = 0; i < 5; i++) {
+      partitionRegion.put(i, i);
+      partitionRegion.get(i);
+    }
+
+    TimerValue hitTimerValue = hitTimerValueForRegion(partitionRegion);
+
+    assertThat(hitTimerValue.region)
+        .as("Cache gets hit timer region tag value")
+        .isEqualTo(partitionRegion.getName());
+
+    assertThat(hitTimerValue.result)
+        .as("Cache gets hit timer result tag value")
+        .isEqualTo("hit");
+
+    assertThat(hitTimerValue.count)
+        .as("Cache gets hit timer count for region " + partitionRegion.getName())
+        .isEqualTo(5);
+
+    assertThat(hitTimerValue.totalTime)
+        .as("Cache gets hit timer total time for region " + partitionRegion.getName())
+        .isGreaterThan(0);
+  }
+
+  @Test
+  public void missTimerRecordsCountAndTotalTime_ifGetsPerformedOnPartitionRegionWithMissingKey()
+      throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    for (int i = 0; i < 5; i++) {
+      partitionRegion.get(i);
+    }
+
+    TimerValue missTimerValue = missTimerValueForRegion(partitionRegion);
+
+    assertThat(missTimerValue.region)
+        .as("Cache gets miss timer region tag value")
+        .isEqualTo(partitionRegion.getName());
+
+    assertThat(missTimerValue.result)
+        .as("Cache gets miss timer result tag value")
+        .isEqualTo("miss");
+
+    assertThat(missTimerValue.count)
+        .as("Cache gets miss timer count for region " + partitionRegion.getName())
+        .isEqualTo(5);
+
+    assertThat(missTimerValue.totalTime)
+        .as("Cache gets miss timer total time for region " + partitionRegion.getName())
+        .isGreaterThan(0);
+  }
+
+  @Test
+  public void timersExistWithInitialValues_ifNoGetsPerformedOnReplicateRegion() throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    assertThat(allTimerValuesForRegion(replicateRegion))
+        .as("All timer values for region " + replicateRegion.getName())
+        .hasSize(2)
+        .anyMatch(tv -> tv.result.equals("hit"))
+        .anyMatch(tv -> tv.result.equals("miss"))
+        .allMatch(tv -> tv.count == 0, "All timers have count of zero")
+        .allMatch(tv -> tv.totalTime == 0, "All timers have total time of zero");
+  }
+
+  @Test
+  public void allTimersRemoved_ifReplicateRegionDestroyed() throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    assertThat(allTimerValuesForRegion(replicateRegion))
+        .as("All timer values before destroying region " + replicateRegion.getName())
+        .hasSize(2);
+
+    replicateRegion.destroyRegion();
+
+    assertThat(allTimerValuesForRegion(replicateRegion))
+        .as("All timer values after destroying region " + replicateRegion.getName())
+        .isEmpty();
+  }
+
+  @Test
+  public void timersExistWithInitialValues_ifNoGetsPerformedOnPartitionRegion() throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    assertThat(allTimerValuesForRegion(partitionRegion))
+        .as("All timer values for region " + partitionRegion.getName())
+        .hasSize(2)
+        .anyMatch(tv -> tv.result.equals("hit"))
+        .anyMatch(tv -> tv.result.equals("miss"))
+        .allMatch(tv -> tv.count == 0, "All timers have count of zero")
+        .allMatch(tv -> tv.totalTime == 0, "All timers have total time of zero");
+  }
+
+  @Test
+  public void allTimersRemoved_ifPartitionRegionDestroyed() throws IOException {
+    startWithTimeStatisticsEnabled();
+
+    assertThat(allTimerValuesForRegion(partitionRegion))
+        .as("All timer values before destroying region " + partitionRegion.getName())
+        .hasSize(2);
+
+    partitionRegion.destroyRegion();
+
+    assertThat(allTimerValuesForRegion(partitionRegion))
+        .as("All timer values after destroying region " + partitionRegion.getName())
+        .isEmpty();
+  }
+
+  @Test
+  public void timersRecordCountForReplicateRegion_ifTimeStatisticsDisabled() throws IOException {
+    startWithTimeStatisticsDisabled();
+
+    replicateRegion.put("existing-key", "existing-value");
+    replicateRegion.get("existing-key");
+    replicateRegion.get("missing-key");
+
+    assertThat(allTimerValuesForRegion(replicateRegion))
+        .as("All timer values for region " + replicateRegion.getName())
+        .hasSize(2)
+        .anyMatch(tv -> tv.result.equals("hit"))
+        .anyMatch(tv -> tv.result.equals("miss"))
+        .allMatch(tv -> tv.count == 1, "All timers have count of one")
+        .allMatch(tv -> tv.totalTime == 0, "All timers have total time of zero");
+  }
+
+  @Test
+  public void timersRecordCountForPartitionRegion_ifTimeStatisticsDisabled() throws IOException {
+    startWithTimeStatisticsDisabled();
+
+    partitionRegion.put("existing-key", "existing-value");
+    partitionRegion.get("existing-key");
+    partitionRegion.get("missing-key");
+
+    assertThat(allTimerValuesForRegion(partitionRegion))
+        .as("All timer values for region " + partitionRegion.getName())
+        .hasSize(2)
+        .anyMatch(tv -> tv.result.equals("hit"))
+        .anyMatch(tv -> tv.result.equals("miss"))
+        .allMatch(tv -> tv.count == 1, "All timers have count of one")
+        .allMatch(tv -> tv.totalTime == 0, "All timers have total time of zero");
+  }
+
+  @Test
+  public void timersDoNotRecord_ifNotAuthorized() throws IOException {
+    startWithSecurityEnabled();
+
+    Throwable thrown =
+        catchThrowable(() -> replicateRegion.get(DenyUnauthorizedKey.UNAUTHORIZED_KEY));
+
+    assertThat(thrown)
+        .as("Exception from unauthorized GET operation")
+        .isNotNull();
+
+    assertThat(allTimerValuesForRegion(replicateRegion))
+        .as("All timer values for region " + replicateRegion.getName())
+        .hasSize(2)
+        .allMatch(tv -> tv.count == 0, "All timers have count of zero");
+  }
+
+  private void startWithTimeStatisticsEnabled() throws IOException {
+    startCluster(true, false);
+  }
+
+  private void startWithTimeStatisticsDisabled() throws IOException {
+    startCluster(false, false);
+  }
+
+  private void startWithSecurityEnabled() throws IOException {
+    startCluster(true, true);
+  }
+
+  private void startCluster(boolean enableTimeStatistics, boolean enableSecurity)
+      throws IOException {
+    int[] availablePorts = getRandomAvailableTCPPorts(2);
+
+    locatorPort = availablePorts[0];
+    int serverPort = availablePorts[1];
+
+    Path serviceJarPath = serviceJarRule.createJarFor("metrics-publishing-service.jar",
+        MetricsPublishingService.class, SimpleMetricsPublishingService.class);
+
+    Path helpersJarPath = temporaryFolder.getRoot().toPath()
+        .resolve("helpers.jar").toAbsolutePath();
+    writeJarFromClasses(helpersJarPath.toFile(), TimerValue.class,
+        FetchCacheGetsTimerValues.class, DenyUnauthorizedKey.class, ClientCacheAuthInit.class);
+
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + "locator",
+        "--dir=" + temporaryFolder.newFolder("locator").getAbsolutePath(),
+        "--port=" + locatorPort,
+        "--classpath=" + helpersJarPath);
+
+    String serverName = "server";
+    String startServerCommand = String.join(" ",
+        "start server",
+        "--name=" + serverName,
+        "--dir=" + temporaryFolder.newFolder(serverName).getAbsolutePath(),
+        "--server-port=" + serverPort,
+        "--locators=localhost[" + locatorPort + "]",
+        "--classpath=" + serviceJarPath + pathSeparatorChar + helpersJarPath);
+
+    if (enableTimeStatistics) {
+      startServerCommand += " --enable-time-statistics";
+    }
+
+    if (enableSecurity) {
+      File securityPropertiesFile = createSecurityPropertiesFile();
+      String securityPropertiesFileOption =
+          " --security-properties-file=" + securityPropertiesFile.getAbsolutePath();
+      startLocatorCommand += securityPropertiesFileOption;
+      startServerCommand += securityPropertiesFileOption;
+    }
+
+    String replicateRegionName = "ReplicateRegion";
+    String createReplicateRegionCommand = String.join(" ",
+        "create region",
+        "--type=REPLICATE",
+        "--name=" + replicateRegionName);
+
+    String partitionRegionName = "PartitionRegion";
+    String createPartitionRegionCommand = String.join(" ",
+        "create region",
+        "--type=PARTITION",
+        "--name=" + partitionRegionName);
+
+    gfshRule.execute(startLocatorCommand, startServerCommand, createReplicateRegionCommand,
+        createPartitionRegionCommand);
+
+    ClientCacheFactory clientCacheFactory = new ClientCacheFactory();
+    if (enableSecurity) {
+      clientCacheFactory.set("security-client-auth-init", ClientCacheAuthInit.class.getName());
+    }
+
+    clientCache = clientCacheFactory
+        .addPoolLocator("localhost", locatorPort)
+        .create();
+
+    replicateRegion = clientCache
+        .createClientRegionFactory(ClientRegionShortcut.PROXY)
+        .create(replicateRegionName);
+
+    partitionRegion = clientCache
+        .createClientRegionFactory(ClientRegionShortcut.PROXY)
+        .create(partitionRegionName);
+  }
+
+  private File createSecurityPropertiesFile() throws IOException {
+    Properties securityProperties = new Properties();
+    securityProperties.setProperty(SECURITY_MANAGER, DenyUnauthorizedKey.class.getName());
+    securityProperties.setProperty("security-username", DenyUnauthorizedKey.AUTHENTICATED_USER);
+    securityProperties.setProperty("security-password", DenyUnauthorizedKey.AUTHENTICATED_PASSWORD);
+
+    File securityPropertiesFile = gfshRule.getTemporaryFolder().newFile("security.properties");
+    securityProperties.store(new FileOutputStream(securityPropertiesFile), null);
+    return securityPropertiesFile;
+  }
+
+  private TimerValue hitTimerValueForRegion(Region<?, ?> region) {
+    return timerValueForRegionAndResult(region, "hit");
+  }
+
+  private TimerValue missTimerValueForRegion(Region<?, ?> region) {
+    return timerValueForRegionAndResult(region, "miss");
+  }
+
+  private TimerValue timerValueForRegionAndResult(Region<?, ?> region, String resultTagValue) {
+    List<TimerValue> cacheGetsTimerValues = allTimerValuesForRegion(region).stream()
+        .filter(tv -> tv.result.equals(resultTagValue))
+        .collect(toList());
+
+    assertThat(cacheGetsTimerValues)
+        .as("Timers for region " + region.getName() + " with result " + resultTagValue)
+        .hasSize(1);
+
+    return cacheGetsTimerValues.get(0);
+  }
+
+  private List<TimerValue> allTimerValuesForRegion(Region<?, ?> region) {
+    @SuppressWarnings("unchecked")
+    List<List<TimerValue>> timerValuesFromAllServers =
+        (List<List<TimerValue>>) onServer(clientCache)
+            .execute(new FetchCacheGetsTimerValues())
+            .getResult();
+
+    assertThat(timerValuesFromAllServers)
+        .hasSize(1);
+
+    return timerValuesFromAllServers.get(0).stream()
+        .filter(tv -> tv.region.equals(region.getName()))
+        .collect(toList());
+  }
+
+  static class TimerValue implements Serializable {
+    final long count;
+    final double totalTime;
+    final String region;
+    final String result;
+
+    TimerValue(long count, double totalTime, String region, String result) {
+      this.count = count;
+      this.totalTime = totalTime;
+      this.region = region;
+      this.result = result;
+    }
+
+    @Override
+    public String toString() {
+      return "TimerValue{" +
+          "count=" + count +
+          ", totalTime=" + totalTime +
+          ", region='" + region + '\'' +
+          ", result='" + result + '\'' +
+          '}';
+    }
+  }
+
+  static class FetchCacheGetsTimerValues implements Function<Void> {
+    private static final String ID = "FetchCacheGetsTimerValues";
+
+    @Override
+    public void execute(FunctionContext<Void> context) {
+      Collection<Timer> timers = SimpleMetricsPublishingService.getRegistry()
+          .find("geode.cache.gets")
+          .timers();
+
+      List<TimerValue> result = timers.stream()
+          .map(FetchCacheGetsTimerValues::toTimerValues)
+          .collect(toList());
+
+      context.getResultSender().lastResult(result);
+    }
+
+    @Override
+    public String getId() {
+      return ID;
+    }
+
+    private static TimerValue toTimerValues(Timer t) {
+      String region = t.getId().getTag("region");
+      String result = t.getId().getTag("result");
+
+      return new TimerValue(
+          t.count(),
+          t.totalTime(NANOSECONDS),
+          region,
+          result);
+    }
+  }
+
+  public static class DenyUnauthorizedKey implements org.apache.geode.security.SecurityManager {
+    static final String AUTHENTICATED_USER = "user";
+    static final String AUTHENTICATED_PASSWORD = "password";
+    static final String UNAUTHORIZED_KEY = "unauthorized-key";
+
+    @Override
+    public Object authenticate(Properties credentials) throws AuthenticationFailedException {
+      return AUTHENTICATED_USER;
+    }
+
+    @Override
+    public boolean authorize(Object principal, ResourcePermission permission) {
+      return !UNAUTHORIZED_KEY.equals(permission.getKey());
+    }
+  }
+
+  public static class ClientCacheAuthInit implements AuthInitialize {
+    @Override
+    public Properties getCredentials(Properties securityProps, DistributedMember server,
+        boolean isPeer) throws AuthenticationFailedException {
+      Properties properties = new Properties();
+      properties.setProperty("security-username", DenyUnauthorizedKey.AUTHENTICATED_USER);
+      properties.setProperty("security-password", DenyUnauthorizedKey.AUTHENTICATED_PASSWORD);
+      return properties;
+    }
+  }
+}

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerNoResultTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerNoResultTest.java
@@ -56,6 +56,7 @@ public class FunctionExecutionsTimerNoResultTest {
   private Region<Object, Object> replicateRegion;
   private Region<Object, Object> partitionRegion;
   private FunctionToTimeWithoutResult functionWithNoResult;
+  private Duration functionDuration;
 
   @Rule
   public GfshRule gfshRule = new GfshRule();
@@ -65,7 +66,6 @@ public class FunctionExecutionsTimerNoResultTest {
 
   @Rule
   public ServiceJarRule serviceJarRule = new ServiceJarRule();
-  private Duration functionDuration;
 
   @Before
   public void setUp() throws IOException {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/CachePerfStats.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+
 import org.apache.geode.StatisticDescriptor;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
@@ -1080,6 +1081,8 @@ public class CachePerfStats {
       stats.incLong(missesId, 1L);
     }
   }
+
+  public void endGetForClient(long start, boolean miss) {}
 
   /**
    * @param start the timestamp taken when the operation started

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -438,4 +438,5 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
 
   Set<String> getVisibleAsyncEventQueueIds();
 
+  CachePerfStats getRegionPerfStats();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -3240,6 +3240,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     return cachePerfStats;
   }
 
+  @Override
   public CachePerfStats getRegionPerfStats() {
     return cachePerfStats;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionPerfStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionPerfStats.java
@@ -14,19 +14,26 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.statistics.StatisticsClock;
 
 class RegionPerfStats extends CachePerfStats implements RegionStats {
+  private static final String HIT_TAG_VALUE = "hit";
+  private static final String MISS_TAG_VALUE = "miss";
 
   private final CachePerfStats cachePerfStats;
   private final StatisticsClock clock;
   private final MeterRegistry meterRegistry;
   private final Gauge entriesGauge;
+  private final Timer cacheGetsHitTimer;
+  private final Timer cacheGetsMissTimer;
 
   RegionPerfStats(StatisticsFactory statisticsFactory, String textId, CachePerfStats cachePerfStats,
       InternalRegion region, MeterRegistry meterRegistry, StatisticsClock clock) {
@@ -36,24 +43,40 @@ class RegionPerfStats extends CachePerfStats implements RegionStats {
 
   @VisibleForTesting
   RegionPerfStats(StatisticsFactory statisticsFactory, String textId, StatisticsClock clock,
-      CachePerfStats cachePerfStats, InternalRegion region,
-      MeterRegistry meterRegistry) {
+      CachePerfStats cachePerfStats, InternalRegion region, MeterRegistry meterRegistry) {
+    this(statisticsFactory, textId, clock, cachePerfStats, region, meterRegistry,
+        registerEntriesGauge(region, meterRegistry),
+        registerCacheGetsTimer(region, meterRegistry, HIT_TAG_VALUE),
+        registerCacheGetsTimer(region, meterRegistry, MISS_TAG_VALUE));
+  }
+
+  @VisibleForTesting
+  RegionPerfStats(StatisticsFactory statisticsFactory, String textId, StatisticsClock clock,
+      CachePerfStats cachePerfStats, InternalRegion region, MeterRegistry meterRegistry,
+      Gauge entriesGauge, Timer cacheGetsHitTimer, Timer cacheGetsMissTimer) {
     super(statisticsFactory, textId, clock);
+
     this.clock = clock;
     this.cachePerfStats = cachePerfStats;
     this.meterRegistry = meterRegistry;
-    entriesGauge = Gauge.builder("geode.cache.entries", region::getLocalSize)
-        .description("Current number of entries in the region.")
-        .tag("region", region.getName())
-        .tag("data.policy", region.getDataPolicy().toString())
-        .baseUnit("entries")
-        .register(meterRegistry);
+    this.entriesGauge = entriesGauge;
+    this.cacheGetsHitTimer = cacheGetsHitTimer;
+    this.cacheGetsMissTimer = cacheGetsMissTimer;
+
     stats.setLongSupplier(entryCountId, region::getLocalSize);
   }
 
   @Override
   protected void close() {
     meterRegistry.remove(entriesGauge);
+    entriesGauge.close();
+
+    meterRegistry.remove(cacheGetsHitTimer);
+    cacheGetsHitTimer.close();
+
+    meterRegistry.remove(cacheGetsMissTimer);
+    cacheGetsMissTimer.close();
+
     super.close();
   }
 
@@ -313,13 +336,17 @@ class RegionPerfStats extends CachePerfStats implements RegionStats {
 
   @Override
   public void endGet(long start, boolean miss) {
+    long totalNanos = 0;
     if (clock.isEnabled()) {
-      long totalNanos = getTime() - start;
+      totalNanos = getTime() - start;
       stats.incLong(getTimeId, totalNanos);
     }
     stats.incLong(getsId, 1L);
     if (miss) {
       stats.incLong(missesId, 1L);
+      cacheGetsMissTimer.record(totalNanos, NANOSECONDS);
+    } else {
+      cacheGetsHitTimer.record(totalNanos, NANOSECONDS);
     }
     cachePerfStats.endGet(start, miss);
   }
@@ -558,5 +585,23 @@ class RegionPerfStats extends CachePerfStats implements RegionStats {
       stats.incLong(compressionDecompressTimeId, time);
       cachePerfStats.stats.incLong(compressionDecompressTimeId, time);
     }
+  }
+
+  private static Gauge registerEntriesGauge(InternalRegion region, MeterRegistry meterRegistry) {
+    return Gauge.builder("geode.cache.entries", region::getLocalSize)
+        .description("Current number of entries in the region.")
+        .tag("region", region.getName())
+        .tag("data.policy", region.getDataPolicy().toString())
+        .baseUnit("entries")
+        .register(meterRegistry);
+  }
+
+  private static Timer registerCacheGetsTimer(InternalRegion region, MeterRegistry meterRegistry,
+      String resultTagValue) {
+    return Timer.builder("geode.cache.gets")
+        .description("Total time and count for GET requests from clients.")
+        .tag("region", region.getName())
+        .tag("result", resultTagValue)
+        .register(meterRegistry);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionStats.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+
 public interface RegionStats {
 
   void incReliableQueuedOps(int inc);
@@ -87,6 +88,8 @@ public interface RegionStats {
   void incConflatedEventsCount();
 
   void endGet(long start, boolean miss);
+
+  void endGetForClient(long start, boolean miss);
 
   long endPut(long start, boolean isUpdate);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Get70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Get70.java
@@ -22,7 +22,9 @@ import org.apache.geode.cache.client.internal.GetOp;
 import org.apache.geode.cache.operations.GetOperationContext;
 import org.apache.geode.cache.operations.internal.GetOperationContextImpl;
 import org.apache.geode.distributed.internal.DistributionStats;
+import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.CachedDeserializable;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.Token;
@@ -123,8 +125,7 @@ public class Get70 extends BaseCommand {
 
     Region region = serverConnection.getCache().getRegion(regionName);
     if (region == null) {
-      String reason = String.format("%s was not found during get request",
-          regionName);
+      String reason = String.format("%s was not found during get request", regionName);
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;
@@ -221,7 +222,8 @@ public class Get70 extends BaseCommand {
     }
     stats.incWriteGetResponseTime(DistributionStats.getStatTime() - start);
 
-
+    CachePerfStats regionPerfStats = ((InternalRegion) region).getRegionPerfStats();
+    regionPerfStats.endGetForClient(startparam, entry.keyNotPresent);
   }
 
   /**
@@ -306,12 +308,8 @@ public class Get70 extends BaseCommand {
     } else if (data instanceof byte[]) {
       isObject = false;
     }
-    Entry result = new Entry();
-    result.value = data;
-    result.isObject = isObject;
-    result.keyNotPresent = !wasInvalid && (data == null || data == Token.TOMBSTONE);
-    result.versionTag = versionTag;
-    return result;
+    boolean keyNotPresent = !wasInvalid && (data == null || data == Token.TOMBSTONE);
+    return new Entry(data, isObject, keyNotPresent, versionTag);
   }
 
   /**
@@ -360,20 +358,23 @@ public class Get70 extends BaseCommand {
         data = cd.getValue();
       }
     }
-    Entry result = new Entry();
-    result.value = data;
-    result.isObject = isObject;
-    result.keyNotPresent = !wasInvalid && (data == null || data == Token.TOMBSTONE);
-    result.versionTag = versionTag;
-    return result;
+    boolean keyNotPresent = !wasInvalid && (data == null || data == Token.TOMBSTONE);
+    return new Entry(data, isObject, keyNotPresent, versionTag);
   }
 
   /** this is used to return results from getValueAndIsObject */
   public static class Entry {
-    public Object value;
-    public boolean isObject;
-    public boolean keyNotPresent;
-    public VersionTag versionTag;
+    public final Object value;
+    public final boolean isObject;
+    public final boolean keyNotPresent;
+    public final VersionTag versionTag;
+
+    public Entry(Object value, boolean isObject, boolean keyNotPresent, VersionTag versionTag) {
+      this.value = value;
+      this.isObject = isObject;
+      this.keyNotPresent = keyNotPresent;
+      this.versionTag = versionTag;
+    }
 
     @Override
     public String toString() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetEntry70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GetEntry70.java
@@ -64,11 +64,6 @@ public class GetEntry70 extends Get70 {
       data = snap;
       tag = snap.getVersionTag();
     }
-    Get70.Entry result = new Get70.Entry();
-    result.value = data;
-    result.isObject = true;
-    result.keyNotPresent = false;
-    result.versionTag = tag;
-    return result;
+    return new Entry(data, true, false, tag);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
@@ -14,7 +14,9 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+import static org.apache.geode.test.micrometer.MicrometerAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -23,6 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.quality.Strictness.STRICT_STUBS;
 
+import java.util.Collection;
 import java.util.function.LongSupplier;
 
 import io.micrometer.core.instrument.Gauge;
@@ -41,48 +44,46 @@ import org.mockito.junit.MockitoRule;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class RegionPerfStatsTest {
 
   private static final String REGION_NAME = "region1";
   private static final String TEXT_ID = "textId";
   private static final DataPolicy DATA_POLICY = DataPolicy.PERSISTENT_REPLICATE;
+  private static final long CLOCK_VALUE = 5L;
 
   private MeterRegistry meterRegistry;
   private CachePerfStats cachePerfStats;
   private InternalRegion region;
-
   private RegionPerfStats regionPerfStats;
-  private RegionPerfStats regionPerfStats2;
   private Statistics statistics;
+  private StatisticsClock statisticsClock;
 
   @Rule
   public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(STRICT_STUBS);
+  private StatisticsFactory statisticsFactory;
 
   @Before
   public void setUp() {
     meterRegistry = new SimpleMeterRegistry();
     cachePerfStats = mock(CachePerfStats.class);
-    StatisticsFactory statisticsFactory = mock(StatisticsFactory.class);
     statistics = mock(Statistics.class);
     region = mock(InternalRegion.class);
     when(region.getName()).thenReturn(REGION_NAME);
     when(region.getDataPolicy()).thenReturn(DATA_POLICY);
-
+    statisticsFactory = mock(StatisticsFactory.class);
     when(statisticsFactory.createAtomicStatistics(any(), any())).thenReturn(statistics);
+    statisticsClock = mock(StatisticsClock.class);
 
-    regionPerfStats =
-        new RegionPerfStats(statisticsFactory, TEXT_ID, disabledClock(), cachePerfStats, region,
-            meterRegistry);
+    regionPerfStats = new RegionPerfStats(statisticsFactory, TEXT_ID, statisticsClock,
+        cachePerfStats, region, meterRegistry);
   }
 
   @After
   public void closeStats() {
     if (regionPerfStats != null) {
       regionPerfStats.close();
-    }
-    if (regionPerfStats2 != null) {
-      regionPerfStats2.close();
     }
   }
 
@@ -99,23 +100,30 @@ public class RegionPerfStatsTest {
 
   @Test
   public void constructor_createsEntriesGauge_taggedWithRegionName() {
-    Gauge entriesGauge = meterRegistry
-        .find("geode.cache.entries")
-        .gauge();
-
-    assertThat(entriesGauge.getId().getTag("region"))
-        .as("region tag")
-        .isEqualTo(REGION_NAME);
+    assertThat(entriesGauge())
+        .as("geode.cache.entries gauge")
+        .hasTag("region", REGION_NAME);
   }
 
   @Test
   public void constructor_createsEntriesGauge_taggedWithDataPolicy() {
-    Gauge entriesGauge = meterRegistry
-        .find("geode.cache.entries")
-        .gauge();
-    assertThat(entriesGauge.getId().getTag("data.policy"))
-        .as("data.policy tag")
-        .isEqualTo(DATA_POLICY.toString());
+    assertThat(entriesGauge())
+        .as("geode.cache.entries gauge")
+        .hasTag("data.policy", DATA_POLICY.toString());
+  }
+
+  @Test
+  public void constructor_createsCacheGetsHitTimer_taggedWithRegionName() {
+    assertThat(cacheGetsHitTimer())
+        .as("geode.cache.gets timer with tag result=hit")
+        .hasTag("region", REGION_NAME);
+  }
+
+  @Test
+  public void constructor_createsCacheGetsMissTimer_taggedWithRegionName() {
+    assertThat(cacheGetsMissTimer())
+        .as("geode.cache.gets timer with tag result=miss")
+        .hasTag("region", REGION_NAME);
   }
 
   @Test
@@ -146,20 +154,112 @@ public class RegionPerfStatsTest {
         .find("geode.cache.entries")
         .tag("region", REGION_NAME)
         .gauge();
+
     assertThat(entriesGauge.value()).isEqualTo(3);
   }
 
   @Test
-  public void close_removesItsOwnMetersFromTheRegistry() {
-    assertThat(meterNamed("geode.cache.entries"))
+  public void endGet_recordsHitTimerCountAndTotalTime_ifCacheHitAndClockEnabled() {
+    when(statisticsClock.isEnabled()).thenReturn(true);
+    when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
+
+    regionPerfStats.endGet(0, false);
+
+    assertThat(cacheGetsHitTimer())
+        .as("geode.cache.gets timer with tag result=hit")
+        .hasCount(1)
+        .hasTotalTime(NANOSECONDS, CLOCK_VALUE);
+  }
+
+  @Test
+  public void endGet_doesNotRecordMissTimerCountOrTotalTime_ifCacheHitAndClockEnabled() {
+    when(statisticsClock.isEnabled()).thenReturn(true);
+    when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
+
+    regionPerfStats.endGet(0, false);
+
+    assertThat(cacheGetsMissTimer())
+        .as("geode.cache.gets timer with tag result=miss")
+        .hasCount(0)
+        .hasTotalTime(NANOSECONDS, 0);
+  }
+
+  @Test
+  public void endGet_recordsHitTimerCountOnly_ifCacheHitAndClockDisabled() {
+    when(statisticsClock.isEnabled()).thenReturn(false);
+
+    regionPerfStats.endGet(0, false);
+
+    assertThat(cacheGetsHitTimer())
+        .as("geode.cache.gets timer with tag result=hit")
+        .hasCount(1)
+        .hasTotalTime(NANOSECONDS, 0);
+  }
+
+  @Test
+  public void endGet_recordsMissTimerCountAndTotalTime_ifCacheMissAndClockEnabled() {
+    when(statisticsClock.isEnabled()).thenReturn(true);
+    when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
+
+    regionPerfStats.endGet(0, true);
+
+    assertThat(cacheGetsMissTimer())
+        .as("geode.cache.gets timer with tag result=miss")
+        .hasCount(1)
+        .hasTotalTime(NANOSECONDS, CLOCK_VALUE);
+  }
+
+  @Test
+  public void endGet_doesNotRecordHitTimerCountOrTotalTime_ifCacheMissAndClockEnabled() {
+    when(statisticsClock.isEnabled()).thenReturn(true);
+    when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
+
+    regionPerfStats.endGet(0, true);
+
+    assertThat(cacheGetsHitTimer())
+        .as("geode.cache.gets timer with tag result=hit")
+        .hasCount(0)
+        .hasTotalTime(NANOSECONDS, 0);
+  }
+
+  @Test
+  public void endGet_recordsMissTimerCountOnly_ifCacheMissAndClockDisabled() {
+    when(statisticsClock.isEnabled()).thenReturn(false);
+
+    regionPerfStats.endGet(0, true);
+
+    assertThat(cacheGetsMissTimer())
+        .as("geode.cache.gets timer with tag result=miss")
+        .hasCount(1)
+        .hasTotalTime(NANOSECONDS, 0);
+  }
+
+  @Test
+  public void close_removesEntriesGaugeFromTheRegistry() {
+    assertThat(metersNamed("geode.cache.entries"))
         .as("entries gauge before closing the stats")
-        .isNotNull();
+        .hasSize(1);
 
     regionPerfStats.close();
 
-    assertThat(meterNamed("geode.cache.entries"))
+    assertThat(metersNamed("geode.cache.entries"))
         .as("entries gauge after closing the stats")
-        .isNull();
+        .hasSize(0);
+
+    regionPerfStats = null;
+  }
+
+  @Test
+  public void close_removesCacheGetsTimersFromTheRegistry() {
+    assertThat(metersNamed("geode.cache.gets"))
+        .as("cache gets timer before closing the stats")
+        .hasSize(2);
+
+    regionPerfStats.close();
+
+    assertThat(metersNamed("geode.cache.gets"))
+        .as("cache gets timer after closing the stats")
+        .hasSize(0);
 
     regionPerfStats = null;
   }
@@ -173,16 +273,55 @@ public class RegionPerfStatsTest {
 
     regionPerfStats.close();
 
-    assertThat(meterNamed(foreignMeterName))
+    assertThat(metersNamed(foreignMeterName))
         .as("foreign meter after closing the stats")
-        .isNotNull();
+        .hasSize(1);
 
     regionPerfStats = null;
   }
 
-  private Meter meterNamed(String meterName) {
+  @Test
+  public void close_closesMeters() {
+    Gauge entriesGauge = mock(Gauge.class);
+    Timer cacheGetsHitTimer = mock(Timer.class);
+    Timer cacheGetsMissTimer = mock(Timer.class);
+    regionPerfStats = new RegionPerfStats(statisticsFactory, TEXT_ID, statisticsClock,
+        cachePerfStats, region, mock(MeterRegistry.class), entriesGauge, cacheGetsHitTimer,
+        cacheGetsMissTimer);
+
+    regionPerfStats.close();
+
+    verify(entriesGauge).close();
+    verify(cacheGetsHitTimer).close();
+    verify(cacheGetsMissTimer).close();
+
+    regionPerfStats = null;
+  }
+
+  private Collection<Meter> metersNamed(String meterName) {
     return meterRegistry
         .find(meterName)
-        .meter();
+        .meters();
+  }
+
+  private Gauge entriesGauge() {
+    return meterRegistry
+        .find("geode.cache.entries")
+        .gauge();
+  }
+
+  private Timer cacheGetsHitTimer() {
+    return cacheGetsTimer("hit");
+  }
+
+  private Timer cacheGetsMissTimer() {
+    return cacheGetsTimer("miss");
+  }
+
+  private Timer cacheGetsTimer(String resultTagValue) {
+    return meterRegistry
+        .find("geode.cache.gets")
+        .tag("result", resultTagValue)
+        .timer();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RegionPerfStatsTest.java
@@ -159,11 +159,11 @@ public class RegionPerfStatsTest {
   }
 
   @Test
-  public void endGet_recordsHitTimerCountAndTotalTime_ifCacheHitAndClockEnabled() {
+  public void endGetForClient_recordsHitTimerCountAndTotalTime_ifCacheHitAndClockEnabled() {
     when(statisticsClock.isEnabled()).thenReturn(true);
     when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
 
-    regionPerfStats.endGet(0, false);
+    regionPerfStats.endGetForClient(0, false);
 
     assertThat(cacheGetsHitTimer())
         .as("geode.cache.gets timer with tag result=hit")
@@ -172,11 +172,11 @@ public class RegionPerfStatsTest {
   }
 
   @Test
-  public void endGet_doesNotRecordMissTimerCountOrTotalTime_ifCacheHitAndClockEnabled() {
+  public void endGetForClient_doesNotRecordMissTimerCountOrTotalTime_ifCacheHitAndClockEnabled() {
     when(statisticsClock.isEnabled()).thenReturn(true);
     when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
 
-    regionPerfStats.endGet(0, false);
+    regionPerfStats.endGetForClient(0, false);
 
     assertThat(cacheGetsMissTimer())
         .as("geode.cache.gets timer with tag result=miss")
@@ -185,10 +185,10 @@ public class RegionPerfStatsTest {
   }
 
   @Test
-  public void endGet_recordsHitTimerCountOnly_ifCacheHitAndClockDisabled() {
+  public void endGetForClient_recordsHitTimerCountOnly_ifCacheHitAndClockDisabled() {
     when(statisticsClock.isEnabled()).thenReturn(false);
 
-    regionPerfStats.endGet(0, false);
+    regionPerfStats.endGetForClient(0, false);
 
     assertThat(cacheGetsHitTimer())
         .as("geode.cache.gets timer with tag result=hit")
@@ -197,11 +197,11 @@ public class RegionPerfStatsTest {
   }
 
   @Test
-  public void endGet_recordsMissTimerCountAndTotalTime_ifCacheMissAndClockEnabled() {
+  public void endGetForClient_recordsMissTimerCountAndTotalTime_ifCacheMissAndClockEnabled() {
     when(statisticsClock.isEnabled()).thenReturn(true);
     when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
 
-    regionPerfStats.endGet(0, true);
+    regionPerfStats.endGetForClient(0, true);
 
     assertThat(cacheGetsMissTimer())
         .as("geode.cache.gets timer with tag result=miss")
@@ -210,11 +210,11 @@ public class RegionPerfStatsTest {
   }
 
   @Test
-  public void endGet_doesNotRecordHitTimerCountOrTotalTime_ifCacheMissAndClockEnabled() {
+  public void endGetForClient_doesNotRecordHitTimerCountOrTotalTime_ifCacheMissAndClockEnabled() {
     when(statisticsClock.isEnabled()).thenReturn(true);
     when(statisticsClock.getTime()).thenReturn(CLOCK_VALUE);
 
-    regionPerfStats.endGet(0, true);
+    regionPerfStats.endGetForClient(0, true);
 
     assertThat(cacheGetsHitTimer())
         .as("geode.cache.gets timer with tag result=hit")
@@ -223,10 +223,10 @@ public class RegionPerfStatsTest {
   }
 
   @Test
-  public void endGet_recordsMissTimerCountOnly_ifCacheMissAndClockDisabled() {
+  public void endGetForClient_recordsMissTimerCountOnly_ifCacheMissAndClockDisabled() {
     when(statisticsClock.isEnabled()).thenReturn(false);
 
-    regionPerfStats.endGet(0, true);
+    regionPerfStats.endGetForClient(0, true);
 
     assertThat(cacheGetsMissTimer())
         .as("geode.cache.gets timer with tag result=miss")

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Get70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Get70Test.java
@@ -14,23 +14,28 @@
  */
 package org.apache.geode.internal.cache.tier.sockets.command;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.operations.GetOperationContext;
+import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
@@ -52,7 +57,6 @@ public class Get70Test {
   private static final String REGION_NAME = "region1";
   private static final String KEY = "key1";
   private static final Object CALLBACK_ARG = "arg";
-  private static final byte[] EVENT = new byte[8];
 
   @Mock
   private SecurityService securityService;
@@ -80,95 +84,149 @@ public class Get70Test {
   private Part valuePart;
   @Mock
   private GetOperationContext getOperationContext;
-  @InjectMocks
+
   private Get70 get70;
 
   @Before
   public void setUp() throws Exception {
-    this.get70 = new Get70();
+    get70 = new Get70();
     MockitoAnnotations.initMocks(this);
 
-    when(this.authzRequest.getAuthorize(any(), any(), any())).thenReturn(this.getOperationContext);
+    when(authzRequest.getAuthorize(any(), any(), any())).thenReturn(getOperationContext);
 
-    when(this.cache.getRegion(isA(String.class))).thenReturn(this.region);
-    when(this.cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    when(cache.getRegion(isA(String.class))).thenReturn(region);
+    when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
 
-    when(this.getOperationContext.getCallbackArg()).thenReturn(CALLBACK_ARG);
+    when(getOperationContext.getCallbackArg()).thenReturn(CALLBACK_ARG);
 
-    when(this.keyPart.getStringOrObject()).thenReturn(KEY);
+    when(keyPart.getStringOrObject()).thenReturn(KEY);
 
-    when(this.message.getNumberOfParts()).thenReturn(3);
-    when(this.message.getPart(eq(0))).thenReturn(this.regionNamePart);
-    when(this.message.getPart(eq(1))).thenReturn(this.keyPart);
-    when(this.message.getPart(eq(2))).thenReturn(this.valuePart);
+    when(message.getNumberOfParts()).thenReturn(3);
+    when(message.getPart(eq(0))).thenReturn(regionNamePart);
+    when(message.getPart(eq(1))).thenReturn(keyPart);
+    when(message.getPart(eq(2))).thenReturn(valuePart);
 
-    when(this.regionNamePart.getCachedString()).thenReturn(REGION_NAME);
+    when(regionNamePart.getCachedString()).thenReturn(REGION_NAME);
 
-    when(this.serverConnection.getCache()).thenReturn(this.cache);
-    when(this.serverConnection.getCacheServerStats()).thenReturn(this.cacheServerStats);
-    when(this.serverConnection.getAuthzRequest()).thenReturn(this.authzRequest);
-    when(this.serverConnection.getResponseMessage()).thenReturn(this.responseMessage);
-    when(this.serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
-    when(this.serverConnection.getErrorResponseMessage()).thenReturn(this.errorResponseMessage);
-    when(this.serverConnection.getClientVersion()).thenReturn(Version.CURRENT);
+    when(serverConnection.getCache()).thenReturn(cache);
+    when(serverConnection.getCacheServerStats()).thenReturn(cacheServerStats);
+    when(serverConnection.getAuthzRequest()).thenReturn(authzRequest);
+    when(serverConnection.getResponseMessage()).thenReturn(responseMessage);
+    when(serverConnection.getCachedRegionHelper()).thenReturn(mock(CachedRegionHelper.class));
+    when(serverConnection.getErrorResponseMessage()).thenReturn(errorResponseMessage);
+    when(serverConnection.getClientVersion()).thenReturn(Version.CURRENT);
 
-    when(this.valuePart.getObject()).thenReturn(CALLBACK_ARG);
+    when(valuePart.getObject()).thenReturn(CALLBACK_ARG);
+
+    when(securityService.isClientSecurityRequired()).thenReturn(false);
+
+    when(region.getRegionPerfStats()).thenReturn(mock(CachePerfStats.class));
   }
 
   @Test
   public void noSecurityShouldSucceed() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(false);
+    when(securityService.isClientSecurityRequired()).thenReturn(false);
 
-    this.get70.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
-    verify(this.responseMessage).send(this.serverConnection);
+    get70.cmdExecute(message, serverConnection, securityService, 0);
+    verify(responseMessage).send(serverConnection);
   }
 
   @Test
   public void integratedSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
+    givenIntegratedSecurity();
 
-    this.get70.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    get70.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.securityService).authorize(Resource.DATA, Operation.READ, REGION_NAME, KEY);
-    verify(this.responseMessage).send(this.serverConnection);
+    verify(securityService).authorize(Resource.DATA, Operation.READ, REGION_NAME, KEY);
+    verify(responseMessage).send(serverConnection);
   }
 
   @Test
   public void integratedSecurityShouldFailIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(true);
-    doThrow(new NotAuthorizedException("")).when(this.securityService).authorize(Resource.DATA,
-        Operation.READ, REGION_NAME, KEY);
+    givenIntegratedSecurity();
+    givenIntegratedSecurityNotAuthorized();
 
-    this.get70.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    get70.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.securityService).authorize(Resource.DATA, Operation.READ, REGION_NAME, KEY);
-    verify(this.errorResponseMessage).send(eq(this.serverConnection));
+    verify(securityService).authorize(Resource.DATA, Operation.READ, REGION_NAME, KEY);
+    verify(errorResponseMessage).send(eq(serverConnection));
   }
 
   @Test
   public void oldSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
+    givenOldSecurity();
 
-    this.get70.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    get70.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.authzRequest).getAuthorize(eq(REGION_NAME), eq(KEY), eq(CALLBACK_ARG));
-    verify(this.responseMessage).send(this.serverConnection);
+    verify(authzRequest).getAuthorize(eq(REGION_NAME), eq(KEY), eq(CALLBACK_ARG));
+    verify(responseMessage).send(serverConnection);
   }
 
   @Test
   public void oldSecurityShouldFailIfNotAuthorized() throws Exception {
-    when(this.securityService.isClientSecurityRequired()).thenReturn(true);
-    when(this.securityService.isIntegratedSecurity()).thenReturn(false);
-    doThrow(new NotAuthorizedException("")).when(this.authzRequest).getAuthorize(eq(REGION_NAME),
-        eq(KEY), eq(CALLBACK_ARG));
+    givenOldSecurity();
+    givenOldSecurityNotAuthorized();
 
-    this.get70.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
+    get70.cmdExecute(message, serverConnection, securityService, 0);
 
-    verify(this.authzRequest).getAuthorize(eq(REGION_NAME), eq(KEY), eq(CALLBACK_ARG));
-    verify(this.errorResponseMessage).send(eq(this.serverConnection));
+    verify(authzRequest).getAuthorize(eq(REGION_NAME), eq(KEY), eq(CALLBACK_ARG));
+    verify(errorResponseMessage).send(eq(serverConnection));
   }
 
+  @Test
+  public void callsEndGetForClient_ifGetSucceedsWithHit() throws IOException {
+    CachePerfStats regionPerfStats = mock(CachePerfStats.class);
+    when(region.getRegionPerfStats()).thenReturn(regionPerfStats);
+    when(region.getRetained(any(), any(), anyBoolean(), anyBoolean(), any(), any(), anyBoolean()))
+        .thenReturn("data");
+
+    get70.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(regionPerfStats).endGetForClient(0, false);
+  }
+
+  @Test
+  public void callsEndGetForClient_ifGetSucceedsWithMiss() throws IOException {
+    CachePerfStats regionPerfStats = mock(CachePerfStats.class);
+    when(region.getRegionPerfStats()).thenReturn(regionPerfStats);
+    when(region.getRetained(any(), any(), anyBoolean(), anyBoolean(), any(), any(), anyBoolean()))
+        .thenReturn(null);
+
+    get70.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(regionPerfStats).endGetForClient(0, true);
+  }
+
+  @Test
+  public void doesNotCallEndGetForClient_ifGetFails() throws IOException {
+    givenIntegratedSecurity();
+    givenIntegratedSecurityNotAuthorized();
+
+    CachePerfStats regionPerfStats = mock(CachePerfStats.class);
+    when(region.getRegionPerfStats()).thenReturn(regionPerfStats);
+
+    get70.cmdExecute(message, serverConnection, securityService, 0);
+
+    verify(regionPerfStats, never()).endGetForClient(anyLong(), anyBoolean());
+  }
+
+  private void givenIntegratedSecurity() {
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
+  }
+
+  private void givenOldSecurity() {
+    when(securityService.isClientSecurityRequired()).thenReturn(true);
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
+  }
+
+  private void givenIntegratedSecurityNotAuthorized() {
+    doThrow(new NotAuthorizedException("")).when(securityService).authorize(Resource.DATA,
+        Operation.READ, REGION_NAME, KEY);
+  }
+
+  private void givenOldSecurityNotAuthorized() {
+    doThrow(new NotAuthorizedException("")).when(authzRequest).getAuthorize(eq(REGION_NAME),
+        eq(KEY), eq(CALLBACK_ARG));
+  }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/assertj/Conditions.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/assertj/Conditions.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.assertj;
+
+import org.assertj.core.api.Condition;
+
+public class Conditions {
+  public static <T> Condition<T> equalTo(T value) {
+    return new Condition<>(value::equals, value.toString());
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/AbstractMeterAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/AbstractMeterAssert.java
@@ -38,7 +38,7 @@ public class AbstractMeterAssert<A extends AbstractMeterAssert<A, M>, M extends 
    */
   AbstractMeterAssert(M meter, Class<A> selfType) {
     super(meter, selfType);
-    meterId = meter.getId();
+    meterId = meter == null ? null : meter.getId();
   }
 
   /**

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/TimerAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/TimerAssert.java
@@ -40,7 +40,7 @@ public class TimerAssert extends AbstractMeterAssert<TimerAssert, Timer> {
    * @param count the expected value of the timer's count
    * @return this assertion object
    * @throws AssertionError if the timer is {@code null}
-   * @throws AssertionError if the condition rejects the timer's count
+   * @throws AssertionError if the timer's count is not equal to the given count
    */
   public TimerAssert hasCount(long count) {
     return hasCount(equalTo(count));
@@ -70,7 +70,7 @@ public class TimerAssert extends AbstractMeterAssert<TimerAssert, Timer> {
    * @param totalTime the expected value of the timer's total time
    * @return this assertion object
    * @throws AssertionError if the timer is {@code null}
-   * @throws AssertionError if the condition rejects the timer's total time
+   * @throws AssertionError if the timer's converted total time is not equal to the given total time
    */
   public TimerAssert hasTotalTime(TimeUnit timeUnit, double totalTime) {
     return hasTotalTime(timeUnit, equalTo(totalTime));

--- a/geode-junit/src/main/java/org/apache/geode/test/micrometer/TimerAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/micrometer/TimerAssert.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.test.micrometer;
 
+import static org.apache.geode.test.assertj.Conditions.equalTo;
+
 import java.util.concurrent.TimeUnit;
 
 import io.micrometer.core.instrument.Timer;
@@ -35,6 +37,18 @@ public class TimerAssert extends AbstractMeterAssert<TimerAssert, Timer> {
   /**
    * Verifies that the timer's count satisfies the given condition.
    *
+   * @param count the expected value of the timer's count
+   * @return this assertion object
+   * @throws AssertionError if the timer is {@code null}
+   * @throws AssertionError if the condition rejects the timer's count
+   */
+  public TimerAssert hasCount(long count) {
+    return hasCount(equalTo(count));
+  }
+
+  /**
+   * Verifies that the timer's count satisfies the given condition.
+   *
    * @param condition the criteria against which to evaluate the timer's count
    * @return this assertion object
    * @throws AssertionError if the timer is {@code null}
@@ -47,6 +61,19 @@ public class TimerAssert extends AbstractMeterAssert<TimerAssert, Timer> {
       failWithMessage("Expected timer to have count <%s> but count was <%s>", condition, count);
     }
     return myself;
+  }
+
+  /**
+   * Verifies that the timer's total time satisfies the given condition.
+   *
+   * @param timeUnit the time unit to which to convert the total time before evaluating
+   * @param totalTime the expected value of the timer's total time
+   * @return this assertion object
+   * @throws AssertionError if the timer is {@code null}
+   * @throws AssertionError if the condition rejects the timer's total time
+   */
+  public TimerAssert hasTotalTime(TimeUnit timeUnit, double totalTime) {
+    return hasTotalTime(timeUnit, equalTo(totalTime));
   }
 
   /**


### PR DESCRIPTION
- Add timers to record get operations from a Java client
- Tag each timer with region name and result (hit/miss)
- Close existing entries gauge when closing `RegionPerfStats`
- Improve micrometer assertj assertions

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>