### PR TITLE
GEODE-7157: SSLConfig&SSLConf..Factory thread-safe

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/LocatorSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/LocatorSSLJUnitTest.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category({ClientServerTest.class})
@@ -41,9 +40,7 @@ public class LocatorSSLJUnitTest {
           .getAbsolutePath();
 
   @After
-  public void tearDownTest() {
-    SSLConfigurationFactory.close();
-  }
+  public void tearDownTest() {}
 
   @Test
   public void canStopLocatorWithSSL() throws IOException {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
@@ -208,9 +208,9 @@ public class TCPClientSSLIntegrationTest {
     @Override
     protected SocketCreator getSocketCreator() {
       if (this.socketCreator == null) {
-        SSLConfigurationFactory.setDistributionConfig(distributionConfig);
         SSLConfig sslConfig =
-            SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.LOCATOR);
+            SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+                SecurableCommunicationChannel.LOCATOR);
         this.socketCreator = new SocketCreator(sslConfig);
       }
       return socketCreator;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
@@ -150,9 +150,9 @@ public class TCPServerSSLJUnitTest {
     @Override
     protected SocketCreator getSocketCreator() {
       if (this.socketCreator == null) {
-        SSLConfigurationFactory.setDistributionConfig(distributionConfig);
         SSLConfig sslConfig =
-            SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.LOCATOR);
+            SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+                SecurableCommunicationChannel.LOCATOR);
         this.socketCreator = new DummySocketCreator(sslConfig, recordedSocketsTimeouts);
       }
       return socketCreator;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
@@ -91,7 +91,7 @@ public class TCPServerSSLJUnitTest {
       Properties sslProperties = getSSLConfigurationProperties();
       startTimeDelayedTcpServer(sslProperties);
 
-      createTcpClientConnection();
+      createTcpClientConnection(sslProperties);
 
     } catch (LocatorCancelException e) {
       // we catching the LocatorCancelException. Expected to have the exception thrown
@@ -123,9 +123,10 @@ public class TCPServerSSLJUnitTest {
     return sslProperties;
   }
 
-  private void createTcpClientConnection() {
+  private void createTcpClientConnection(final Properties clientProperties) {
     try {
-      new TcpClient().requestToServer(localhost, port, Boolean.valueOf(false), 5 * 1000);
+      new TcpClient(clientProperties).requestToServer(localhost, port, Boolean.valueOf(false),
+          5 * 1000);
     } catch (IOException e) {
       e.printStackTrace();
     } catch (ClassNotFoundException e) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/SSLConfigIntegrationJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/SSLConfigIntegrationJUnitTest.java
@@ -24,7 +24,6 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.management.GemFireProperties;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.MemberMXBean;
@@ -38,9 +37,7 @@ import org.apache.geode.test.junit.categories.MembershipTest;
 public class SSLConfigIntegrationJUnitTest {
 
   @After
-  public void tearDownTest() {
-    SSLConfigurationFactory.close();
-  }
+  public void tearDownTest() {}
 
   @Test
   public void testIsClusterSSLRequireAuthentication() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/SSLConfigJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/SSLConfigJUnitTest.java
@@ -151,9 +151,7 @@ public class SSLConfigJUnitTest {
   }
 
   @After
-  public void tearDownTest() {
-    SSLConfigurationFactory.close();
-  }
+  public void tearDownTest() {}
 
   @Test
   public void testMCastPortWithClusterSSL() throws Exception {

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
@@ -1688,15 +1688,16 @@ public class AdminDistributedSystemImpl implements org.apache.geode.admin.AdminD
   }
 
   protected SSLConfig buildSSLConfig() {
-    SSLConfig conf = new SSLConfig();
+    SSLConfig.Builder sslConfigBuilder = new SSLConfig.Builder();
+
     if (getConfig() != null) {
-      conf.setEnabled(getConfig().isSSLEnabled());
-      conf.setProtocols(getConfig().getSSLProtocols());
-      conf.setCiphers(getConfig().getSSLCiphers());
-      conf.setRequireAuth(getConfig().isSSLAuthenticationRequired());
-      conf.setProperties(getConfig().getSSLProperties());
+      sslConfigBuilder.setEnabled(getConfig().isSSLEnabled());
+      sslConfigBuilder.setProtocols(getConfig().getSSLProtocols());
+      sslConfigBuilder.setCiphers(getConfig().getSSLCiphers());
+      sslConfigBuilder.setRequireAuth(getConfig().isSSLAuthenticationRequired());
+      sslConfigBuilder.setProperties(getConfig().getSSLProperties());
     }
-    return conf;
+    return sslConfigBuilder.build();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/SSLConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/SSLConfig.java
@@ -23,108 +23,109 @@ import java.security.KeyStore;
 import java.util.Iterator;
 import java.util.Properties;
 
+import org.apache.geode.annotations.Immutable;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.management.internal.SSLUtil;
 
 /**
  * The SSL configuration settings for a GemFire distributed system.
+ *
+ * This class is immutable and the way to construct it is by means of the
+ * the setters plus the build() method of its inner {@link SSLConfig.Build} class.
  */
+@Immutable
 public class SSLConfig {
 
-  private boolean endpointIdentification;
-  private boolean useDefaultSSLContext = DistributionConfig.DEFAULT_SSL_USE_DEFAULT_CONTEXT;
-  private boolean enabled = DistributionConfig.DEFAULT_SSL_ENABLED;
-  private String protocols = DistributionConfig.DEFAULT_SSL_PROTOCOLS;
-  private String ciphers = DistributionConfig.DEFAULT_SSL_CIPHERS;
-  private boolean requireAuth = DistributionConfig.DEFAULT_SSL_REQUIRE_AUTHENTICATION;
-  private String keystore = DistributionConfig.DEFAULT_SSL_KEYSTORE;
-  private String keystoreType = KeyStore.getDefaultType();
-  private String keystorePassword = DistributionConfig.DEFAULT_SSL_KEYSTORE_PASSWORD;
-  private String truststore = DistributionConfig.DEFAULT_SSL_TRUSTSTORE;
-  private String truststorePassword = DistributionConfig.DEFAULT_SSL_TRUSTSTORE_PASSWORD;
-  private String truststoreType = KeyStore.getDefaultType();
-  private String alias = null;
-  private SecurableCommunicationChannel securableCommunicationChannel = null;
+  private final boolean endpointIdentification;
+  private final boolean useDefaultSSLContext;
+  private final boolean enabled;
+  private final String protocols;
+  private final String ciphers;
+  private final boolean requireAuth;
+  private final String keystore;
+  private final String keystoreType;
+  private final String keystorePassword;
+  private final String truststore;
+  private final String truststorePassword;
+  private final String truststoreType;
+  private final String alias;
+  @Immutable
+  private final SecurableCommunicationChannel securableCommunicationChannel;
 
   /**
    * SSL implementation-specific key-value pairs. Each key should be prefixed with
    * <code>javax.net.ssl.</code>
    */
+  @Immutable
   private Properties properties = new Properties();
 
-  public SSLConfig() {}
+  private SSLConfig(boolean endpointIdentification,
+      boolean useDefaultSSLContext,
+      boolean enabled,
+      String protocols,
+      String ciphers,
+      boolean requireAuth,
+      String keystore,
+      String keystoreType,
+      String keystorePassword,
+      String truststore,
+      String truststorePassword,
+      String truststoreType,
+      String alias,
+      SecurableCommunicationChannel securableCommunicationChannel,
+      Properties properties) {
+    this.endpointIdentification = endpointIdentification;
+    this.useDefaultSSLContext = useDefaultSSLContext;
+    this.enabled = enabled;
+    this.protocols = protocols;
+    this.ciphers = ciphers;
+    this.requireAuth = requireAuth;
+    this.keystore = keystore;
+    this.keystoreType = keystoreType;
+    this.keystorePassword = keystorePassword;
+    this.truststore = truststore;
+    this.truststorePassword = truststorePassword;
+    this.truststoreType = truststoreType;
+    this.alias = alias;
+    this.securableCommunicationChannel = securableCommunicationChannel;
+    this.properties = properties;
+  }
 
   public String getAlias() {
     return alias;
-  }
-
-  public void setAlias(final String alias) {
-    this.alias = alias;
   }
 
   public boolean doEndpointIdentification() {
     return this.endpointIdentification;
   }
 
-  public void setEndpointIdentificationEnabled(boolean endpointIdentification) {
-    this.endpointIdentification = endpointIdentification;
-  }
-
   public String getKeystore() {
     return keystore;
-  }
-
-  public void setKeystore(final String keystore) {
-    this.keystore = keystore;
   }
 
   public String getKeystorePassword() {
     return keystorePassword;
   }
 
-  public void setKeystorePassword(final String keystorePassword) {
-    this.keystorePassword = keystorePassword;
-  }
-
   public String getKeystoreType() {
     return keystoreType;
-  }
-
-  public void setKeystoreType(final String keystoreType) {
-    this.keystoreType = keystoreType;
   }
 
   public String getTruststore() {
     return truststore;
   }
 
-  public void setTruststore(final String truststore) {
-    this.truststore = truststore;
-  }
-
   public String getTruststorePassword() {
     return truststorePassword;
-  }
-
-  public void setTruststorePassword(final String truststorePassword) {
-    this.truststorePassword = truststorePassword;
   }
 
   public boolean isEnabled() {
     return this.enabled;
   }
 
-  public void setEnabled(boolean enabled) {
-    this.enabled = enabled;
-  }
-
   public boolean useDefaultSSLContext() {
     return this.useDefaultSSLContext;
-  }
-
-  public void setUseDefaultSSLContext(boolean useDefaultSSLContext) {
-    this.useDefaultSSLContext = useDefaultSSLContext;
   }
 
   public String getProtocols() {
@@ -135,10 +136,6 @@ public class SSLConfig {
     return SSLUtil.readArray(this.protocols);
   }
 
-  public void setProtocols(String protocols) {
-    this.protocols = protocols;
-  }
-
   public String getCiphers() {
     return this.ciphers;
   }
@@ -147,46 +144,20 @@ public class SSLConfig {
     return SSLUtil.readArray(this.ciphers);
   }
 
-  public void setCiphers(String ciphers) {
-    this.ciphers = ciphers;
-  }
-
   public boolean isRequireAuth() {
     return this.requireAuth;
-  }
-
-  public void setRequireAuth(boolean requireAuth) {
-    this.requireAuth = requireAuth;
   }
 
   public String getTruststoreType() {
     return truststoreType;
   }
 
-  public void setTruststoreType(final String truststoreType) {
-    this.truststoreType = truststoreType;
-  }
-
   public Properties getProperties() {
     return this.properties;
   }
 
-  public void setProperties(Properties newProps) {
-    this.properties = new Properties();
-    for (Iterator iter = newProps.keySet().iterator(); iter.hasNext();) {
-      String key = (String) iter.next();
-      // String value = newProps.getProperty(key);
-      this.properties.setProperty(key, newProps.getProperty(key));
-    }
-  }
-
   public SecurableCommunicationChannel getSecuredCommunicationChannel() {
     return securableCommunicationChannel;
-  }
-
-  public void setSecurableCommunicationChannel(
-      final SecurableCommunicationChannel securableCommunicationChannel) {
-    this.securableCommunicationChannel = securableCommunicationChannel;
   }
 
   @Override
@@ -215,5 +186,137 @@ public class SSLConfig {
       props.setProperty(CLUSTER_SSL_REQUIRE_AUTHENTICATION, String.valueOf(this.requireAuth));
     }
   }
+
+  public static class Builder {
+    private boolean endpointIdentification;
+    private boolean useDefaultSSLContext = DistributionConfig.DEFAULT_SSL_USE_DEFAULT_CONTEXT;
+    private boolean enabled = DistributionConfig.DEFAULT_SSL_ENABLED;
+    private String protocols = DistributionConfig.DEFAULT_SSL_PROTOCOLS;
+    private String ciphers = DistributionConfig.DEFAULT_SSL_CIPHERS;
+    private boolean requireAuth = DistributionConfig.DEFAULT_SSL_REQUIRE_AUTHENTICATION;
+    private String keystore = DistributionConfig.DEFAULT_SSL_KEYSTORE;
+    private String keystoreType = KeyStore.getDefaultType();
+    private String keystorePassword = DistributionConfig.DEFAULT_SSL_KEYSTORE_PASSWORD;
+    private String truststore = DistributionConfig.DEFAULT_SSL_TRUSTSTORE;
+    private String truststorePassword = DistributionConfig.DEFAULT_SSL_TRUSTSTORE_PASSWORD;
+    private String truststoreType = KeyStore.getDefaultType();
+    private String alias = null;
+    private SecurableCommunicationChannel securableCommunicationChannel = null;
+    private Properties properties = new Properties();
+
+    public Builder() {}
+
+    public SSLConfig build() {
+      return new SSLConfig(endpointIdentification, useDefaultSSLContext, enabled,
+          protocols, ciphers, requireAuth, keystore, keystoreType, keystorePassword,
+          truststore, truststorePassword, truststoreType, alias, securableCommunicationChannel,
+          properties);
+    }
+
+    public Builder setAlias(final String alias) {
+      this.alias = alias;
+      return this;
+    }
+
+    public Builder setEndpointIdentificationEnabled(boolean endpointIdentification) {
+      this.endpointIdentification = endpointIdentification;
+      return this;
+    }
+
+    public Builder setKeystore(final String keystore) {
+      this.keystore = keystore;
+      return this;
+    }
+
+    public Builder setKeystorePassword(final String keystorePassword) {
+      this.keystorePassword = keystorePassword;
+      return this;
+    }
+
+    public Builder setKeystoreType(final String keystoreType) {
+      this.keystoreType = keystoreType;
+      return this;
+    }
+
+    public Builder setTruststore(final String truststore) {
+      this.truststore = truststore;
+      return this;
+    }
+
+    public Builder setTruststorePassword(final String truststorePassword) {
+      this.truststorePassword = truststorePassword;
+      return this;
+    }
+
+    public Builder setEnabled(boolean enabled) {
+      this.enabled = enabled;
+      return this;
+    }
+
+    public Builder setUseDefaultSSLContext(boolean useDefaultSSLContext) {
+      this.useDefaultSSLContext = useDefaultSSLContext;
+      return this;
+    }
+
+    public Builder setProtocols(String protocols) {
+      this.protocols = protocols;
+      return this;
+    }
+
+    public Builder setCiphers(String ciphers) {
+      this.ciphers = ciphers;
+      return this;
+    }
+
+    public Builder setRequireAuth(boolean requireAuth) {
+      this.requireAuth = requireAuth;
+      return this;
+    }
+
+    public Builder setTruststoreType(final String truststoreType) {
+      this.truststoreType = truststoreType;
+      return this;
+    }
+
+    public Builder setProperties(Properties newProps) {
+      this.properties = new Properties();
+      for (Iterator iter = newProps.keySet().iterator(); iter.hasNext();) {
+        String key = (String) iter.next();
+        this.properties.setProperty(key, newProps.getProperty(key));
+      }
+      return this;
+    }
+
+    public Builder setSecurableCommunicationChannel(
+        final SecurableCommunicationChannel securableCommunicationChannel) {
+      this.securableCommunicationChannel = securableCommunicationChannel;
+      return this;
+    }
+
+    public String getKeystore() {
+      return keystore;
+    }
+
+    public String getKeystoreType() {
+      return keystoreType;
+    }
+
+    public String getKeystorePassword() {
+      return keystorePassword;
+    }
+
+    public String getTruststore() {
+      return truststore;
+    }
+
+    public String getTruststorePassword() {
+      return truststorePassword;
+    }
+
+    public String getTruststoreType() {
+      return truststoreType;
+    }
+  }
+
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/SSLConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/SSLConfig.java
@@ -32,7 +32,7 @@ import org.apache.geode.management.internal.SSLUtil;
  * The SSL configuration settings for a GemFire distributed system.
  *
  * This class is immutable and the way to construct it is by means of the
- * the setters plus the build() method of its inner {@link SSLConfig.Build} class.
+ * {@link SSLConfig.Builder} class.
  */
 @Immutable
 public class SSLConfig {
@@ -58,7 +58,7 @@ public class SSLConfig {
    * <code>javax.net.ssl.</code>
    */
   @Immutable
-  private Properties properties = new Properties();
+  private final Properties properties;
 
   private SSLConfig(boolean endpointIdentification,
       boolean useDefaultSSLContext,
@@ -187,6 +187,20 @@ public class SSLConfig {
     }
   }
 
+  /**
+   * Builder class to be used to construct SSLConfig instances.
+   * In order to build an {@link SSLConfig} instance an instance of this
+   * class must be created, then the corresponding setter methods invoked
+   * and finally the build() method that returns the {@link SSLConfig} instance
+   *
+   * Example:
+   * SSLConfig sslConfInstance = new SSLConfig.Builder()
+   * .setAlias(alias)
+   * .setKeystore(keystore)
+   * ...
+   * .build();
+   *
+   */
   public static class Builder {
     private boolean endpointIdentification;
     private boolean useDefaultSSLContext = DistributionConfig.DEFAULT_SSL_USE_DEFAULT_CONTEXT;
@@ -317,6 +331,5 @@ public class SSLConfig {
       return truststoreType;
     }
   }
-
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DistributionLocatorId.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DistributionLocatorId.java
@@ -198,7 +198,7 @@ public class DistributionLocatorId implements java.io.Serializable {
 
   private SSLConfig validateSSLConfig(SSLConfig sslConfig) {
     if (sslConfig == null)
-      return new SSLConfig(); // uses defaults
+      return new SSLConfig.Builder().build(); // uses defaults
     return sslConfig;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteTransportConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteTransportConfig.java
@@ -77,7 +77,7 @@ public class RemoteTransportConfig implements TransportConfig {
     this.vmKind = vmKind;
     this.tcpPort = config.getTcpPort();
     this.membershipPortRange = getMembershipPortRangeString(config.getMembershipPortRange());
-    this.sslConfig = new SSLConfig();
+    this.sslConfig = new SSLConfig.Builder().build();
 
     String initialHosts = config.getLocators();
     if (initialHosts == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
@@ -15,14 +15,11 @@
 
 package org.apache.geode.internal.net;
 
-import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import org.apache.geode.GemFireConfigException;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
@@ -41,9 +38,6 @@ public class SSLConfigurationFactory {
 
   @MakeNotStatic
   private static SSLConfigurationFactory instance = new SSLConfigurationFactory();
-  private DistributionConfig distributionConfig = null;
-  private Map<SecurableCommunicationChannel, SSLConfig> registeredSSLConfig =
-      new ConcurrentHashMap<>();
 
   private SSLConfigurationFactory() {}
 
@@ -52,45 +46,6 @@ public class SSLConfigurationFactory {
       instance = new SSLConfigurationFactory();
     }
     return instance;
-  }
-
-  private DistributionConfig getDistributionConfig() {
-    if (distributionConfig == null) {
-      throw new GemFireConfigException("SSL Configuration requires a valid distribution config.");
-    }
-    return distributionConfig;
-  }
-
-  public static void setDistributionConfig(final DistributionConfig distributionConfig) {
-    if (distributionConfig == null) {
-      throw new GemFireConfigException("SSL Configuration requires a valid distribution config.");
-    }
-    getInstance().distributionConfig = distributionConfig;
-  }
-
-  /**
-   * @deprecated since GEODE 1.3, use #{getSSLConfigForComponent({@link DistributionConfig} ,
-   *             {@link SecurableCommunicationChannel})} instead
-   */
-  @Deprecated
-  public static SSLConfig getSSLConfigForComponent(
-      SecurableCommunicationChannel sslEnabledComponent) {
-    SSLConfig sslConfig = getInstance().getRegisteredSSLConfigForComponent(sslEnabledComponent);
-    if (sslConfig == null) {
-      sslConfig = getInstance().createSSLConfigForComponent(sslEnabledComponent);
-      getInstance().registeredSSLConfigForComponent(sslEnabledComponent, sslConfig);
-    }
-    return sslConfig;
-  }
-
-  private void registeredSSLConfigForComponent(
-      final SecurableCommunicationChannel sslEnabledComponent, final SSLConfig sslConfig) {
-    registeredSSLConfig.put(sslEnabledComponent, sslConfig);
-  }
-
-  private SSLConfig createSSLConfigForComponent(
-      final SecurableCommunicationChannel sslEnabledComponent) {
-    return createSSLConfigForComponent(getDistributionConfig(), sslEnabledComponent);
   }
 
   private SSLConfig createSSLConfigForComponent(final DistributionConfig distributionConfig,
@@ -353,20 +308,6 @@ public class SSLConfigurationFactory {
       }
     }
     return propertyValue;
-  }
-
-  private SSLConfig getRegisteredSSLConfigForComponent(
-      final SecurableCommunicationChannel sslEnabledComponent) {
-    return registeredSSLConfig.get(sslEnabledComponent);
-  }
-
-  public static void close() {
-    getInstance().clearSSLConfigForAllComponents();
-    getInstance().distributionConfig = null;
-  }
-
-  private synchronized void clearSSLConfigForAllComponents() {
-    registeredSSLConfig.clear();
   }
 
   @Deprecated

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SSLConfigurationFactory.java
@@ -15,9 +15,9 @@
 
 package org.apache.geode.internal.net;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -42,7 +42,8 @@ public class SSLConfigurationFactory {
   @MakeNotStatic
   private static SSLConfigurationFactory instance = new SSLConfigurationFactory();
   private DistributionConfig distributionConfig = null;
-  private Map<SecurableCommunicationChannel, SSLConfig> registeredSSLConfig = new HashMap<>();
+  private Map<SecurableCommunicationChannel, SSLConfig> registeredSSLConfig =
+      new ConcurrentHashMap<>();
 
   private SSLConfigurationFactory() {}
 
@@ -82,7 +83,7 @@ public class SSLConfigurationFactory {
     return sslConfig;
   }
 
-  private synchronized void registeredSSLConfigForComponent(
+  private void registeredSSLConfigForComponent(
       final SecurableCommunicationChannel sslEnabledComponent, final SSLConfig sslConfig) {
     registeredSSLConfig.put(sslEnabledComponent, sslConfig);
   }
@@ -94,98 +95,98 @@ public class SSLConfigurationFactory {
 
   private SSLConfig createSSLConfigForComponent(final DistributionConfig distributionConfig,
       final SecurableCommunicationChannel sslEnabledComponent) {
-    SSLConfig sslConfig = createSSLConfig(distributionConfig, sslEnabledComponent);
+    SSLConfig.Builder sslConfigBuilder =
+        createSSLConfigBuilder(distributionConfig, sslEnabledComponent);
     SecurableCommunicationChannel[] sslEnabledComponents =
         distributionConfig.getSecurableCommunicationChannels();
     if (sslEnabledComponents.length == 0) {
-      sslConfig = configureLegacyClusterSSL(distributionConfig, sslConfig);
+      configureLegacyClusterSSL(distributionConfig, sslConfigBuilder);
     }
-    sslConfig.setSecurableCommunicationChannel(sslEnabledComponent);
+    sslConfigBuilder.setSecurableCommunicationChannel(sslEnabledComponent);
     switch (sslEnabledComponent) {
       case ALL: {
-        // Create a SSLConfig separate for HTTP Service. As the require-authentication might differ
-        createSSLConfigForComponent(distributionConfig, SecurableCommunicationChannel.WEB);
         break;
       }
       case CLUSTER: {
         if (sslEnabledComponents.length > 0) {
-          sslConfig = setAliasForComponent(sslConfig, distributionConfig.getClusterSSLAlias());
+          setAliasForComponent(sslConfigBuilder, distributionConfig.getClusterSSLAlias());
         } else {
-          sslConfig = configureLegacyClusterSSL(distributionConfig, sslConfig);
+          configureLegacyClusterSSL(distributionConfig, sslConfigBuilder);
         }
         break;
       }
       case LOCATOR: {
         if (sslEnabledComponents.length > 0) {
-          sslConfig = setAliasForComponent(sslConfig, distributionConfig.getLocatorSSLAlias());
+          setAliasForComponent(sslConfigBuilder, distributionConfig.getLocatorSSLAlias());
         }
         break;
       }
       case SERVER: {
         if (sslEnabledComponents.length > 0) {
-          sslConfig = setAliasForComponent(sslConfig, distributionConfig.getServerSSLAlias());
+          setAliasForComponent(sslConfigBuilder, distributionConfig.getServerSSLAlias());
         } else {
-          sslConfig = configureLegacyServerSSL(distributionConfig, sslConfig);
+          configureLegacyServerSSL(distributionConfig, sslConfigBuilder);
         }
         break;
       }
       case GATEWAY: {
         if (sslEnabledComponents.length > 0) {
-          sslConfig = setAliasForComponent(sslConfig, distributionConfig.getGatewaySSLAlias());
+          setAliasForComponent(sslConfigBuilder, distributionConfig.getGatewaySSLAlias());
         } else {
-          sslConfig = configureLegacyGatewaySSL(distributionConfig, sslConfig);
+          configureLegacyGatewaySSL(distributionConfig, sslConfigBuilder);
         }
         break;
       }
       case WEB: {
         if (sslEnabledComponents.length > 0) {
-          sslConfig = setAliasForComponent(sslConfig, distributionConfig.getHTTPServiceSSLAlias());
-          sslConfig.setRequireAuth(distributionConfig.getSSLWebRequireAuthentication());
+          setAliasForComponent(sslConfigBuilder, distributionConfig.getHTTPServiceSSLAlias());
+          sslConfigBuilder.setRequireAuth(distributionConfig.getSSLWebRequireAuthentication());
         } else {
-          sslConfig = configureLegacyHttpServiceSSL(distributionConfig, sslConfig);
+          configureLegacyHttpServiceSSL(distributionConfig, sslConfigBuilder);
         }
         break;
       }
       case JMX: {
         if (sslEnabledComponents.length > 0) {
-          sslConfig = setAliasForComponent(sslConfig, distributionConfig.getJMXSSLAlias());
+          setAliasForComponent(sslConfigBuilder, distributionConfig.getJMXSSLAlias());
         } else {
-          sslConfig = configureLegacyJMXSSL(distributionConfig, sslConfig);
+          configureLegacyJMXSSL(distributionConfig, sslConfigBuilder);
         }
         break;
       }
     }
-    configureSSLPropertiesFromSystemProperties(sslConfig);
-    return sslConfig;
+    configureSSLPropertiesFromSystemProperties(sslConfigBuilder);
+    return sslConfigBuilder.build();
   }
 
-  private SSLConfig setAliasForComponent(final SSLConfig sslConfig, final String clusterSSLAlias) {
+  private SSLConfig.Builder setAliasForComponent(SSLConfig.Builder sslConfigBuilder,
+      final String clusterSSLAlias) {
     if (!StringUtils.isEmpty(clusterSSLAlias)) {
-      sslConfig.setAlias(clusterSSLAlias);
+      sslConfigBuilder.setAlias(clusterSSLAlias);
     }
-    return sslConfig;
+    return sslConfigBuilder;
   }
 
-  private SSLConfig createSSLConfig(final DistributionConfig distributionConfig,
+  private SSLConfig.Builder createSSLConfigBuilder(final DistributionConfig distributionConfig,
       final SecurableCommunicationChannel sslEnabledComponent) {
-    SSLConfig sslConfig = new SSLConfig();
-    sslConfig.setCiphers(distributionConfig.getSSLCiphers());
-    sslConfig
+    SSLConfig.Builder sslConfigBuilder = new SSLConfig.Builder();
+    sslConfigBuilder.setCiphers(distributionConfig.getSSLCiphers());
+    sslConfigBuilder
         .setEndpointIdentificationEnabled(distributionConfig.getSSLEndPointIdentificationEnabled());
-    sslConfig
+    sslConfigBuilder
         .setEnabled(determineIfSSLEnabledForSSLComponent(distributionConfig, sslEnabledComponent));
-    sslConfig.setKeystore(distributionConfig.getSSLKeyStore());
-    sslConfig.setKeystorePassword(distributionConfig.getSSLKeyStorePassword());
-    sslConfig.setKeystoreType(distributionConfig.getSSLKeyStoreType());
-    sslConfig.setTruststore(distributionConfig.getSSLTrustStore());
-    sslConfig.setTruststorePassword(distributionConfig.getSSLTrustStorePassword());
-    sslConfig.setTruststoreType(distributionConfig.getSSLTrustStoreType());
-    sslConfig.setProtocols(distributionConfig.getSSLProtocols());
-    sslConfig.setRequireAuth(distributionConfig.getSSLRequireAuthentication());
-    sslConfig.setAlias(distributionConfig.getSSLDefaultAlias());
-    sslConfig.setUseDefaultSSLContext(distributionConfig.getSSLUseDefaultContext());
+    sslConfigBuilder.setKeystore(distributionConfig.getSSLKeyStore());
+    sslConfigBuilder.setKeystorePassword(distributionConfig.getSSLKeyStorePassword());
+    sslConfigBuilder.setKeystoreType(distributionConfig.getSSLKeyStoreType());
+    sslConfigBuilder.setTruststore(distributionConfig.getSSLTrustStore());
+    sslConfigBuilder.setTruststorePassword(distributionConfig.getSSLTrustStorePassword());
+    sslConfigBuilder.setTruststoreType(distributionConfig.getSSLTrustStoreType());
+    sslConfigBuilder.setProtocols(distributionConfig.getSSLProtocols());
+    sslConfigBuilder.setRequireAuth(distributionConfig.getSSLRequireAuthentication());
+    sslConfigBuilder.setAlias(distributionConfig.getSSLDefaultAlias());
+    sslConfigBuilder.setUseDefaultSSLContext(distributionConfig.getSSLUseDefaultContext());
 
-    return sslConfig;
+    return sslConfigBuilder;
   }
 
   private boolean determineIfSSLEnabledForSSLComponent(final DistributionConfig distributionConfig,
@@ -200,136 +201,142 @@ public class SSLConfigurationFactory {
   }
 
   /**
-   * Configure a sslConfig for the cluster using the legacy configuration
+   * Configure a SSLConfig.Builder for the cluster using the legacy configuration
    *
-   * @return A sslConfig object describing the ssl config for the server component
+   * @return A SSLConfig.Builder object describing the ssl config for the server component
    * @deprecated as of Geode 1.0
    */
-  private SSLConfig configureLegacyClusterSSL(final DistributionConfig distributionConfig,
-      final SSLConfig sslConfig) {
-    sslConfig.setCiphers(distributionConfig.getClusterSSLCiphers());
-    sslConfig.setEnabled(distributionConfig.getClusterSSLEnabled());
-    sslConfig.setKeystore(distributionConfig.getClusterSSLKeyStore());
-    sslConfig.setKeystorePassword(distributionConfig.getClusterSSLKeyStorePassword());
-    sslConfig.setKeystoreType(distributionConfig.getClusterSSLKeyStoreType());
-    sslConfig.setTruststore(distributionConfig.getClusterSSLTrustStore());
-    sslConfig.setTruststorePassword(distributionConfig.getClusterSSLTrustStorePassword());
-    sslConfig.setTruststoreType(distributionConfig.getClusterSSLKeyStoreType());
-    sslConfig.setProtocols(distributionConfig.getClusterSSLProtocols());
-    sslConfig.setRequireAuth(distributionConfig.getClusterSSLRequireAuthentication());
-    return sslConfig;
+  private SSLConfig.Builder configureLegacyClusterSSL(final DistributionConfig distributionConfig,
+      SSLConfig.Builder sslConfigBuilder) {
+    sslConfigBuilder.setCiphers(distributionConfig.getClusterSSLCiphers());
+    sslConfigBuilder.setEnabled(distributionConfig.getClusterSSLEnabled());
+    sslConfigBuilder.setKeystore(distributionConfig.getClusterSSLKeyStore());
+    sslConfigBuilder.setKeystorePassword(distributionConfig.getClusterSSLKeyStorePassword());
+    sslConfigBuilder.setKeystoreType(distributionConfig.getClusterSSLKeyStoreType());
+    sslConfigBuilder.setTruststore(distributionConfig.getClusterSSLTrustStore());
+    sslConfigBuilder.setTruststorePassword(distributionConfig.getClusterSSLTrustStorePassword());
+    sslConfigBuilder.setTruststoreType(distributionConfig.getClusterSSLKeyStoreType());
+    sslConfigBuilder.setProtocols(distributionConfig.getClusterSSLProtocols());
+    sslConfigBuilder.setRequireAuth(distributionConfig.getClusterSSLRequireAuthentication());
+    return sslConfigBuilder;
   }
 
   /**
-   * Configure a sslConfig for the server using the legacy configuration
+   * Configure a SSLConfig.Builder for the server using the legacy configuration
    *
-   * @return A sslConfig object describing the ssl config for the server component
+   * @return A SSLConfig.Builder object describing the ssl config for the server component
    * @deprecated as of Geode 1.0
    */
-  private SSLConfig configureLegacyServerSSL(final DistributionConfig distributionConfig,
-      final SSLConfig sslConfig) {
-    sslConfig.setCiphers(distributionConfig.getServerSSLCiphers());
-    sslConfig.setEnabled(distributionConfig.getServerSSLEnabled());
-    sslConfig.setKeystore(distributionConfig.getServerSSLKeyStore());
-    sslConfig.setKeystorePassword(distributionConfig.getServerSSLKeyStorePassword());
-    sslConfig.setKeystoreType(distributionConfig.getServerSSLKeyStoreType());
-    sslConfig.setTruststore(distributionConfig.getServerSSLTrustStore());
-    sslConfig.setTruststorePassword(distributionConfig.getServerSSLTrustStorePassword());
-    sslConfig.setTruststoreType(distributionConfig.getServerSSLKeyStoreType());
-    sslConfig.setProtocols(distributionConfig.getServerSSLProtocols());
-    sslConfig.setRequireAuth(distributionConfig.getServerSSLRequireAuthentication());
-    return sslConfig;
+  private SSLConfig.Builder configureLegacyServerSSL(final DistributionConfig distributionConfig,
+      final SSLConfig.Builder sslConfigBuilder) {
+    sslConfigBuilder.setCiphers(distributionConfig.getServerSSLCiphers());
+    sslConfigBuilder.setEnabled(distributionConfig.getServerSSLEnabled());
+    sslConfigBuilder.setKeystore(distributionConfig.getServerSSLKeyStore());
+    sslConfigBuilder.setKeystorePassword(distributionConfig.getServerSSLKeyStorePassword());
+    sslConfigBuilder.setKeystoreType(distributionConfig.getServerSSLKeyStoreType());
+    sslConfigBuilder.setTruststore(distributionConfig.getServerSSLTrustStore());
+    sslConfigBuilder.setTruststorePassword(distributionConfig.getServerSSLTrustStorePassword());
+    sslConfigBuilder.setTruststoreType(distributionConfig.getServerSSLKeyStoreType());
+    sslConfigBuilder.setProtocols(distributionConfig.getServerSSLProtocols());
+    sslConfigBuilder.setRequireAuth(distributionConfig.getServerSSLRequireAuthentication());
+    return sslConfigBuilder;
   }
 
   /**
-   * Configure a sslConfig for the jmx using the legacy configuration
+   * Configure a SSLConfig.Builder for the jmx using the legacy configuration
    *
-   * @return A sslConfig object describing the ssl config for the jmx component
+   * @return A SSLConfig.Builder object describing the ssl config for the jmx component
    * @deprecated as of Geode 1.0
    */
-  private SSLConfig configureLegacyJMXSSL(final DistributionConfig distributionConfig,
-      final SSLConfig sslConfig) {
-    sslConfig.setCiphers(distributionConfig.getJmxManagerSSLCiphers());
-    sslConfig.setEnabled(distributionConfig.getJmxManagerSSLEnabled());
-    sslConfig.setKeystore(distributionConfig.getJmxManagerSSLKeyStore());
-    sslConfig.setKeystorePassword(distributionConfig.getJmxManagerSSLKeyStorePassword());
-    sslConfig.setKeystoreType(distributionConfig.getJmxManagerSSLKeyStoreType());
-    sslConfig.setTruststore(distributionConfig.getJmxManagerSSLTrustStore());
-    sslConfig.setTruststorePassword(distributionConfig.getJmxManagerSSLTrustStorePassword());
-    sslConfig.setTruststoreType(distributionConfig.getJmxManagerSSLKeyStoreType());
-    sslConfig.setProtocols(distributionConfig.getJmxManagerSSLProtocols());
-    sslConfig.setRequireAuth(distributionConfig.getJmxManagerSSLRequireAuthentication());
-    return sslConfig;
+  private SSLConfig.Builder configureLegacyJMXSSL(final DistributionConfig distributionConfig,
+      SSLConfig.Builder sslConfigBuilder) {
+    sslConfigBuilder.setCiphers(distributionConfig.getJmxManagerSSLCiphers());
+    sslConfigBuilder.setEnabled(distributionConfig.getJmxManagerSSLEnabled());
+    sslConfigBuilder.setKeystore(distributionConfig.getJmxManagerSSLKeyStore());
+    sslConfigBuilder.setKeystorePassword(distributionConfig.getJmxManagerSSLKeyStorePassword());
+    sslConfigBuilder.setKeystoreType(distributionConfig.getJmxManagerSSLKeyStoreType());
+    sslConfigBuilder.setTruststore(distributionConfig.getJmxManagerSSLTrustStore());
+    sslConfigBuilder.setTruststorePassword(distributionConfig.getJmxManagerSSLTrustStorePassword());
+    sslConfigBuilder.setTruststoreType(distributionConfig.getJmxManagerSSLKeyStoreType());
+    sslConfigBuilder.setProtocols(distributionConfig.getJmxManagerSSLProtocols());
+    sslConfigBuilder.setRequireAuth(distributionConfig.getJmxManagerSSLRequireAuthentication());
+    return sslConfigBuilder;
   }
 
   /**
-   * Configure a sslConfig for the gateway using the legacy configuration
+   * Configure a SSLConfig.Builder for the gateway using the legacy configuration
    *
    * @return A sslConfig object describing the ssl config for the gateway component
    * @deprecated as of Geode 1.0
    */
-  private SSLConfig configureLegacyGatewaySSL(final DistributionConfig distributionConfig,
-      final SSLConfig sslConfig) {
-    sslConfig.setCiphers(distributionConfig.getGatewaySSLCiphers());
-    sslConfig.setEnabled(distributionConfig.getGatewaySSLEnabled());
-    sslConfig.setKeystore(distributionConfig.getGatewaySSLKeyStore());
-    sslConfig.setKeystorePassword(distributionConfig.getGatewaySSLKeyStorePassword());
-    sslConfig.setKeystoreType(distributionConfig.getGatewaySSLKeyStoreType());
-    sslConfig.setTruststore(distributionConfig.getGatewaySSLTrustStore());
-    sslConfig.setTruststorePassword(distributionConfig.getGatewaySSLTrustStorePassword());
-    sslConfig.setProtocols(distributionConfig.getGatewaySSLProtocols());
-    sslConfig.setRequireAuth(distributionConfig.getGatewaySSLRequireAuthentication());
-    return sslConfig;
+  private SSLConfig.Builder configureLegacyGatewaySSL(final DistributionConfig distributionConfig,
+      SSLConfig.Builder sslConfigBuilder) {
+    sslConfigBuilder.setCiphers(distributionConfig.getGatewaySSLCiphers());
+    sslConfigBuilder.setEnabled(distributionConfig.getGatewaySSLEnabled());
+    sslConfigBuilder.setKeystore(distributionConfig.getGatewaySSLKeyStore());
+    sslConfigBuilder.setKeystorePassword(distributionConfig.getGatewaySSLKeyStorePassword());
+    sslConfigBuilder.setKeystoreType(distributionConfig.getGatewaySSLKeyStoreType());
+    sslConfigBuilder.setTruststore(distributionConfig.getGatewaySSLTrustStore());
+    sslConfigBuilder.setTruststorePassword(distributionConfig.getGatewaySSLTrustStorePassword());
+    sslConfigBuilder.setProtocols(distributionConfig.getGatewaySSLProtocols());
+    sslConfigBuilder.setRequireAuth(distributionConfig.getGatewaySSLRequireAuthentication());
+    return sslConfigBuilder;
   }
 
   /**
-   * Configure a sslConfig for the http service using the legacy configuration
+   * Configure a SSLConfig.Builder for the http service using the legacy configuration
    *
-   * @return A sslConfig object describing the ssl config for the http service component
+   * @return A SSLConfig.Builder object describing the ssl config for the http service component
    * @deprecated as of Geode 1.0
    */
-  private SSLConfig configureLegacyHttpServiceSSL(final DistributionConfig distributionConfig,
-      final SSLConfig sslConfig) {
-    sslConfig.setCiphers(distributionConfig.getHttpServiceSSLCiphers());
-    sslConfig.setEnabled(distributionConfig.getHttpServiceSSLEnabled());
-    sslConfig.setKeystore(distributionConfig.getHttpServiceSSLKeyStore());
-    sslConfig.setKeystorePassword(distributionConfig.getHttpServiceSSLKeyStorePassword());
-    sslConfig.setKeystoreType(distributionConfig.getHttpServiceSSLKeyStoreType());
-    sslConfig.setTruststore(distributionConfig.getHttpServiceSSLTrustStore());
-    sslConfig.setTruststorePassword(distributionConfig.getHttpServiceSSLTrustStorePassword());
-    sslConfig.setTruststoreType(distributionConfig.getHttpServiceSSLKeyStoreType());
-    sslConfig.setProtocols(distributionConfig.getHttpServiceSSLProtocols());
-    sslConfig.setRequireAuth(distributionConfig.getHttpServiceSSLRequireAuthentication());
-    return sslConfig;
+  private SSLConfig.Builder configureLegacyHttpServiceSSL(
+      final DistributionConfig distributionConfig,
+      SSLConfig.Builder sslConfigBuilder) {
+    sslConfigBuilder.setCiphers(distributionConfig.getHttpServiceSSLCiphers());
+    sslConfigBuilder.setEnabled(distributionConfig.getHttpServiceSSLEnabled());
+    sslConfigBuilder.setKeystore(distributionConfig.getHttpServiceSSLKeyStore());
+    sslConfigBuilder.setKeystorePassword(distributionConfig.getHttpServiceSSLKeyStorePassword());
+    sslConfigBuilder.setKeystoreType(distributionConfig.getHttpServiceSSLKeyStoreType());
+    sslConfigBuilder.setTruststore(distributionConfig.getHttpServiceSSLTrustStore());
+    sslConfigBuilder
+        .setTruststorePassword(distributionConfig.getHttpServiceSSLTrustStorePassword());
+    sslConfigBuilder.setTruststoreType(distributionConfig.getHttpServiceSSLKeyStoreType());
+    sslConfigBuilder.setProtocols(distributionConfig.getHttpServiceSSLProtocols());
+    sslConfigBuilder.setRequireAuth(distributionConfig.getHttpServiceSSLRequireAuthentication());
+    return sslConfigBuilder;
   }
 
-  private SSLConfig configureSSLPropertiesFromSystemProperties(SSLConfig sslConfig) {
-    return configureSSLPropertiesFromSystemProperties(sslConfig, null);
+  private SSLConfig.Builder configureSSLPropertiesFromSystemProperties(
+      SSLConfig.Builder sslConfigBuilder) {
+    return configureSSLPropertiesFromSystemProperties(sslConfigBuilder, null);
   }
 
-  private SSLConfig configureSSLPropertiesFromSystemProperties(SSLConfig sslConfig,
+  private SSLConfig.Builder configureSSLPropertiesFromSystemProperties(
+      SSLConfig.Builder sslConfigBuilder,
       Properties properties) {
-    if (StringUtils.isEmpty(sslConfig.getKeystore())) {
-      sslConfig.setKeystore(getValueFromSystemProperties(properties, JAVAX_KEYSTORE));
+    if (StringUtils.isEmpty(sslConfigBuilder.getKeystore())) {
+      sslConfigBuilder.setKeystore(getValueFromSystemProperties(properties, JAVAX_KEYSTORE));
     }
-    if (StringUtils.isEmpty(sslConfig.getKeystoreType())) {
-      sslConfig.setKeystoreType(getValueFromSystemProperties(properties, JAVAX_KEYSTORE_TYPE));
+    if (StringUtils.isEmpty(sslConfigBuilder.getKeystoreType())) {
+      sslConfigBuilder
+          .setKeystoreType(getValueFromSystemProperties(properties, JAVAX_KEYSTORE_TYPE));
     }
-    if (StringUtils.isEmpty(sslConfig.getKeystorePassword())) {
-      sslConfig
+    if (StringUtils.isEmpty(sslConfigBuilder.getKeystorePassword())) {
+      sslConfigBuilder
           .setKeystorePassword(getValueFromSystemProperties(properties, JAVAX_KEYSTORE_PASSWORD));
     }
-    if (StringUtils.isEmpty(sslConfig.getTruststore())) {
-      sslConfig.setTruststore(getValueFromSystemProperties(properties, JAVAX_TRUSTSTORE));
+    if (StringUtils.isEmpty(sslConfigBuilder.getTruststore())) {
+      sslConfigBuilder.setTruststore(getValueFromSystemProperties(properties, JAVAX_TRUSTSTORE));
     }
-    if (StringUtils.isEmpty(sslConfig.getTruststorePassword())) {
-      sslConfig.setTruststorePassword(
+    if (StringUtils.isEmpty(sslConfigBuilder.getTruststorePassword())) {
+      sslConfigBuilder.setTruststorePassword(
           getValueFromSystemProperties(properties, JAVAX_TRUSTSTORE_PASSWORD));
     }
-    if (StringUtils.isEmpty(sslConfig.getTruststoreType())) {
-      sslConfig.setTruststoreType(getValueFromSystemProperties(properties, JAVAX_TRUSTSTORE_TYPE));
+    if (StringUtils.isEmpty(sslConfigBuilder.getTruststoreType())) {
+      sslConfigBuilder
+          .setTruststoreType(getValueFromSystemProperties(properties, JAVAX_TRUSTSTORE_TYPE));
     }
-    return sslConfig;
+    return sslConfigBuilder;
   }
 
   private String getValueFromSystemProperties(final Properties properties, String property) {
@@ -358,7 +365,7 @@ public class SSLConfigurationFactory {
     getInstance().distributionConfig = null;
   }
 
-  private void clearSSLConfigForAllComponents() {
+  private synchronized void clearSSLConfigForAllComponents() {
     registeredSSLConfig.clear();
   }
 
@@ -366,17 +373,16 @@ public class SSLConfigurationFactory {
   public static SSLConfig getSSLConfigForComponent(final boolean useSSL,
       final boolean needClientAuth, final String protocols, final String ciphers,
       final Properties gfsecurityProps, final String alias) {
-    SSLConfig sslConfig = new SSLConfig();
-    sslConfig.setAlias(alias);
-    sslConfig.setCiphers(ciphers);
-    sslConfig.setProtocols(protocols);
-    sslConfig.setRequireAuth(needClientAuth);
-    sslConfig.setEnabled(useSSL);
+    SSLConfig.Builder sslConfigBuilder = new SSLConfig.Builder();
+    sslConfigBuilder.setAlias(alias);
+    sslConfigBuilder.setCiphers(ciphers);
+    sslConfigBuilder.setProtocols(protocols);
+    sslConfigBuilder.setRequireAuth(needClientAuth);
+    sslConfigBuilder.setEnabled(useSSL);
 
-    sslConfig =
-        getInstance().configureSSLPropertiesFromSystemProperties(sslConfig, gfsecurityProps);
+    getInstance().configureSSLPropertiesFromSystemProperties(sslConfigBuilder, gfsecurityProps);
 
-    return sslConfig;
+    return sslConfigBuilder.build();
   }
 
   public static SSLConfig getSSLConfigForComponent(DistributionConfig distributionConfig,

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreatorFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreatorFactory.java
@@ -44,7 +44,6 @@ public class SocketCreatorFactory {
     } else {
       this.distributionConfig = distributionConfig;
     }
-    SSLConfigurationFactory.setDistributionConfig(this.distributionConfig);
   }
 
   private DistributionConfig getDistributionConfig() {
@@ -69,7 +68,8 @@ public class SocketCreatorFactory {
   public static SocketCreator getSocketCreatorForComponent(
       SecurableCommunicationChannel sslEnabledComponent) {
     SSLConfig sslConfigForComponent =
-        SSLConfigurationFactory.getSSLConfigForComponent(sslEnabledComponent);
+        SSLConfigurationFactory.getSSLConfigForComponent(getInstance().getDistributionConfig(),
+            sslEnabledComponent);
     return getInstance().getOrCreateSocketCreatorForSSLEnabledComponent(sslEnabledComponent,
         sslConfigForComponent);
   }
@@ -149,7 +149,6 @@ public class SocketCreatorFactory {
     if (socketCreatorFactory != null) {
       socketCreatorFactory.clearSocketCreators();
       socketCreatorFactory.distributionConfig = null;
-      SSLConfigurationFactory.close();
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisee.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerAdvisee.java
@@ -117,7 +117,8 @@ public class JmxManagerAdvisee implements DistributionAdvisee {
       if (port != 0) {
         if (!usingJdkConfig) {
           SSLConfig jmxSSL =
-              SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.JMX);
+              SSLConfigurationFactory.getSSLConfigForComponent(dc,
+                  SecurableCommunicationChannel.JMX);
           ssl = jmxSSL.isEnabled();
           host = dc.getJmxManagerHostnameForClients();
           if (host == null || host.equals("")) {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SSLConfigurationFactoryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SSLConfigurationFactoryJUnitTest.java
@@ -59,20 +59,18 @@ public class SSLConfigurationFactoryJUnitTest {
   public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   @After
-  public void tearDownTest() {
-    SSLConfigurationFactory.close();
-  }
+  public void tearDownTest() {}
 
   @Test
   public void getNonSSLConfiguration() {
     Properties properties = new Properties();
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     for (SecurableCommunicationChannel securableComponent : SecurableCommunicationChannel
         .values()) {
       assertSSLConfig(properties,
-          SSLConfigurationFactory.getSSLConfigForComponent(securableComponent), securableComponent,
+          SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig, securableComponent),
+          securableComponent,
           distributionConfig);
     }
   }
@@ -101,7 +99,6 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(SSL_CIPHERS, "Cipher1,Cipher2");
     properties.setProperty(SSL_PROTOCOLS, "Protocol1,Protocol2");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     assertSSLConfigForChannels(properties, distributionConfig);
   }
@@ -119,7 +116,6 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(SSL_CIPHERS, "Cipher1,Cipher2");
     properties.setProperty(SSL_PROTOCOLS, "any");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     assertSSLConfigForChannels(properties, distributionConfig);
   }
@@ -137,7 +133,6 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(SSL_CIPHERS, "any");
     properties.setProperty(SSL_PROTOCOLS, "any");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     assertSSLConfigForChannels(properties, distributionConfig);
   }
@@ -155,7 +150,6 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(SSL_CIPHERS, "any");
     properties.setProperty(SSL_PROTOCOLS, "any");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     assertSSLConfigForChannels(properties, distributionConfig);
   }
@@ -174,7 +168,6 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(SSL_CIPHERS, "any");
     properties.setProperty(SSL_PROTOCOLS, "any");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     assertSSLConfigForChannels(properties, distributionConfig);
   }
@@ -194,7 +187,6 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(SSL_CIPHERS, "any");
     properties.setProperty(SSL_PROTOCOLS, "any");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     assertSSLConfigForChannels(properties, distributionConfig);
   }
@@ -211,9 +203,9 @@ public class SSLConfigurationFactoryJUnitTest {
     System.setProperty(SSLConfigurationFactory.JAVAX_TRUSTSTORE_PASSWORD, "truststorePassword");
     System.setProperty(SSLConfigurationFactory.JAVAX_TRUSTSTORE_TYPE, KeyStore.getDefaultType());
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
     SSLConfig sslConfig =
-        SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.CLUSTER);
+        SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+            SecurableCommunicationChannel.CLUSTER);
 
     assertThat(sslConfig.isEnabled()).isTrue();
     assertThat(sslConfig.getKeystore())
@@ -249,24 +241,28 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(CLUSTER_SSL_ENABLED, "true");
     properties.setProperty(MCAST_PORT, "0");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
     SSLConfig sslConfig =
-        SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.WEB);
+        SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+            SecurableCommunicationChannel.WEB);
     assertThat(sslConfig.isRequireAuth()).isFalse();
     assertThat(sslConfig.isEnabled()).isTrue();
     sslConfig =
-        SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.CLUSTER);
+        SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+            SecurableCommunicationChannel.CLUSTER);
     assertThat(sslConfig.isRequireAuth()).isTrue();
     assertThat(sslConfig.isEnabled()).isTrue();
     sslConfig =
-        SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.GATEWAY);
+        SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+            SecurableCommunicationChannel.GATEWAY);
     assertThat(sslConfig.isRequireAuth()).isTrue();
     assertThat(sslConfig.isEnabled()).isTrue();
     sslConfig =
-        SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.SERVER);
+        SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+            SecurableCommunicationChannel.SERVER);
     assertThat(sslConfig.isRequireAuth()).isTrue();
     assertThat(sslConfig.isEnabled()).isTrue();
-    sslConfig = SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.JMX);
+    sslConfig = SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+        SecurableCommunicationChannel.JMX);
     assertThat(sslConfig.isRequireAuth()).isTrue();
     assertThat(sslConfig.isEnabled()).isTrue();
   }
@@ -277,10 +273,10 @@ public class SSLConfigurationFactoryJUnitTest {
     properties.setProperty(SSL_ENABLED_COMPONENTS, "all");
     properties.setProperty(SSL_KEYSTORE, "someKeyStore");
     DistributionConfigImpl distributionConfig = new DistributionConfigImpl(properties);
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
 
     SSLConfig sslConfig =
-        SSLConfigurationFactory.getSSLConfigForComponent(SecurableCommunicationChannel.LOCATOR);
+        SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig,
+            SecurableCommunicationChannel.LOCATOR);
     assertThat(sslConfig.isEnabled()).isTrue();
     assertThat(sslConfig.getKeystore()).isEqualTo("someKeyStore");
 
@@ -323,7 +319,8 @@ public class SSLConfigurationFactoryJUnitTest {
     for (SecurableCommunicationChannel securableComponent : SecurableCommunicationChannel
         .values()) {
       assertSSLConfig(distributionConfigProperties,
-          SSLConfigurationFactory.getSSLConfigForComponent(securableComponent), securableComponent,
+          SSLConfigurationFactory.getSSLConfigForComponent(distributionConfig, securableComponent),
+          securableComponent,
           distributionConfig);
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
@@ -38,14 +38,14 @@ public class SocketCreatorJUnitTest {
 
   @Test
   public void testCreateSocketCreatorWithKeystoreUnset() throws Exception {
-    SSLConfig testSSLConfig = new SSLConfig();
-    testSSLConfig.setEnabled(true);
-    testSSLConfig.setKeystore(null);
-    testSSLConfig.setKeystorePassword("");
-    testSSLConfig.setTruststore(getSingleKeyKeystore());
-    testSSLConfig.setTruststorePassword("password");
+    SSLConfig.Builder sslConfigBuilder = new SSLConfig.Builder();
+    sslConfigBuilder.setEnabled(true);
+    sslConfigBuilder.setKeystore(null);
+    sslConfigBuilder.setKeystorePassword("");
+    sslConfigBuilder.setTruststore(getSingleKeyKeystore());
+    sslConfigBuilder.setTruststorePassword("password");
     // GEODE-3393: This would fail with java.io.FileNotFoundException: $USER_HOME/.keystore
-    new SocketCreator(testSSLConfig);
+    new SocketCreator(sslConfigBuilder.build());
 
   }
 

--- a/geode-http-service/src/test/java/org/apache/geode/management/internal/InternalHttpServiceJunitTest.java
+++ b/geode-http-service/src/test/java/org/apache/geode/management/internal/InternalHttpServiceJunitTest.java
@@ -29,7 +29,6 @@ import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalHttpService;
-import org.apache.geode.internal.net.SSLConfigurationFactory;
 
 /**
  * The InternalHttpServiceJunitTest class is a test suite of test cases testing the contract and
@@ -45,8 +44,6 @@ public class InternalHttpServiceJunitTest {
     props.setProperty(DistributionConfig.HTTP_SERVICE_PORT_NAME, "" + port);
     distributionConfig = new DistributionConfigImpl(props);
 
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
-
     InternalDistributedSystem ds = mock(InternalDistributedSystem.class);
     when(ds.getConfig()).thenReturn(distributionConfig);
 
@@ -56,9 +53,7 @@ public class InternalHttpServiceJunitTest {
   }
 
   @After
-  public void teardown() {
-    SSLConfigurationFactory.close();
-  }
+  public void teardown() {}
 
   @Test
   public void testSetPortNoBindAddress() {

--- a/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheConnectionIntegrationTest.java
+++ b/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheConnectionIntegrationTest.java
@@ -259,19 +259,19 @@ public class CacheConnectionIntegrationTest {
         createTempFileFromResource(CacheConnectionIntegrationTest.class, DEFAULT_STORE)
             .getAbsolutePath();
 
-    SSLConfig sslConfig = new SSLConfig();
-    sslConfig.setEnabled(true);
-    sslConfig.setCiphers(SSL_CIPHERS_VALUE);
-    sslConfig.setProtocols(SSL_PROTOCOLS_VALUE);
-    sslConfig.setRequireAuth(true);
-    sslConfig.setKeystoreType("jks");
-    sslConfig.setKeystore(keyStorePath);
-    sslConfig.setKeystorePassword("password");
-    sslConfig.setTruststore(trustStorePath);
-    sslConfig.setKeystorePassword("password");
-    sslConfig.setEndpointIdentificationEnabled(false);
+    SSLConfig.Builder sslConfigBuilder = new SSLConfig.Builder();
+    sslConfigBuilder.setEnabled(true);
+    sslConfigBuilder.setCiphers(SSL_CIPHERS_VALUE);
+    sslConfigBuilder.setProtocols(SSL_PROTOCOLS_VALUE);
+    sslConfigBuilder.setRequireAuth(true);
+    sslConfigBuilder.setKeystoreType("jks");
+    sslConfigBuilder.setKeystore(keyStorePath);
+    sslConfigBuilder.setKeystorePassword("password");
+    sslConfigBuilder.setTruststore(trustStorePath);
+    sslConfigBuilder.setKeystorePassword("password");
+    sslConfigBuilder.setEndpointIdentificationEnabled(false);
 
-    SocketCreator socketCreator = new SocketCreator(sslConfig);
+    SocketCreator socketCreator = new SocketCreator(sslConfigBuilder.build());
     return socketCreator.connectForClient("localhost", cacheServerPort, 5000);
   }
 }

--- a/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheOperationsJUnitTest.java
+++ b/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheOperationsJUnitTest.java
@@ -389,18 +389,18 @@ public class CacheOperationsJUnitTest {
         createTempFileFromResource(CacheOperationsJUnitTest.class, DEFAULT_STORE)
             .getAbsolutePath();
 
-    SSLConfig sslConfig = new SSLConfig();
-    sslConfig.setEnabled(true);
-    sslConfig.setCiphers(SSL_CIPHERS);
-    sslConfig.setProtocols(SSL_PROTOCOLS);
-    sslConfig.setRequireAuth(true);
-    sslConfig.setKeystoreType("jks");
-    sslConfig.setKeystore(keyStorePath);
-    sslConfig.setKeystorePassword("password");
-    sslConfig.setTruststore(trustStorePath);
-    sslConfig.setKeystorePassword("password");
+    SSLConfig.Builder sslConfigBuilder = new SSLConfig.Builder();
+    sslConfigBuilder.setEnabled(true);
+    sslConfigBuilder.setCiphers(SSL_CIPHERS);
+    sslConfigBuilder.setProtocols(SSL_PROTOCOLS);
+    sslConfigBuilder.setRequireAuth(true);
+    sslConfigBuilder.setKeystoreType("jks");
+    sslConfigBuilder.setKeystore(keyStorePath);
+    sslConfigBuilder.setKeystorePassword("password");
+    sslConfigBuilder.setTruststore(trustStorePath);
+    sslConfigBuilder.setKeystorePassword("password");
 
-    SocketCreator socketCreator = new SocketCreator(sslConfig);
+    SocketCreator socketCreator = new SocketCreator(sslConfigBuilder.build());
     return socketCreator.connectForClient("localhost", cacheServerPort, 5000);
   }
 }

--- a/geode-pulse/geode-pulse-test/src/main/java/org/apache/geode/tools/pulse/tests/rules/ServerRule.java
+++ b/geode-pulse/geode-pulse-test/src/main/java/org/apache/geode/tools/pulse/tests/rules/ServerRule.java
@@ -80,7 +80,7 @@ public class ServerRule extends ExternalResource {
 
     int httpPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
     jetty = new InternalHttpService();
-    jetty.createJettyServer(LOCALHOST, httpPort, new SSLConfig());
+    jetty.createJettyServer(LOCALHOST, httpPort, new SSLConfig.Builder().build());
     jetty.addWebApplication(PULSE_CONTEXT, getPulseWarPath(), new HashMap<>());
     pulseURL = "http://" + LOCALHOST + ":" + httpPort + PULSE_CONTEXT;
   }

--- a/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcherIntegrationTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/internal/cache/wan/GatewaySenderEventRemoteDispatcherIntegrationTest.java
@@ -46,7 +46,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.cache.PoolManagerImpl;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
-import org.apache.geode.internal.net.SSLConfigurationFactory;
+import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 
 public class GatewaySenderEventRemoteDispatcherIntegrationTest {
@@ -117,7 +117,7 @@ public class GatewaySenderEventRemoteDispatcherIntegrationTest {
     doReturn(new SecurableCommunicationChannel[] {}).when(distributionConfig)
         .getSecurableCommunicationChannels();
 
-    SSLConfigurationFactory.setDistributionConfig(distributionConfig);
+    SocketCreatorFactory.setDistributionConfig(distributionConfig);
 
     final Properties properties = new Properties();
     properties.put(DURABLE_CLIENT_ID, "1");


### PR DESCRIPTION
SSLConfig and SSLConfigFactory have been changed to be
tread-safe by means of the following:

* SSLConfig has been converted into an immutable class

* The registeredSSLConfig HashMap member of SSLConfigurationFactory
  has been changed into a ConcurrentHashMap and accesses to this
  map other than put and get has been synchronized.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
