### PR TITLE
GEODE-7084: Prevent CancelException in FederatingManager

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -32,6 +32,7 @@ import javax.management.ObjectName;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.CancelException;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.AttributesFactory;
@@ -321,23 +322,27 @@ public class FederatingManager extends Manager {
     if (!cache.isClosed()) {
       try {
         proxyFactory.removeAllProxies(member, monitoringRegion);
-      } catch (RegionDestroyedException ignore) {
+      } catch (CancelException | RegionDestroyedException ignore) {
         // ignored
       }
       try {
         monitoringRegion.localDestroyRegion();
-      } catch (RegionDestroyedException ignore) {
+      } catch (CancelException | RegionDestroyedException ignore) {
         // ignored
       }
       try {
         notificationRegion.localDestroyRegion();
-      } catch (RegionDestroyedException ignore) {
+      } catch (CancelException | RegionDestroyedException ignore) {
         // ignored
       }
     }
 
     if (!system.getDistributedMember().equals(member)) {
-      service.memberDeparted((InternalDistributedMember) member, crashed);
+      try {
+        service.memberDeparted((InternalDistributedMember) member, crashed);
+      } catch (CancelException | RegionDestroyedException ignore) {
+        // ignored
+      }
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.net.InetAddress;
+import java.util.concurrent.ExecutorService;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -31,15 +32,16 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.alerting.internal.spi.AlertLevel;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
 import org.apache.geode.internal.cache.InternalRegionArguments;
-import org.apache.geode.internal.logging.LoggingExecutors;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.test.junit.categories.JMXTest;
@@ -49,7 +51,10 @@ public class FederatingManagerTest {
 
   private InternalCache cache;
   private InternalCacheForClientAccess cacheForClientAccess;
+  private ExecutorService executorService;
   private MBeanJMXAdapter jmxAdapter;
+  private MBeanProxyFactory proxyFactory;
+  private MemberMessenger messenger;
   private ManagementResourceRepo repo;
   private SystemManagementService service;
   private StatisticsFactory statisticsFactory;
@@ -60,7 +65,10 @@ public class FederatingManagerTest {
   public void setUp() throws Exception {
     cache = mock(InternalCache.class);
     cacheForClientAccess = mock(InternalCacheForClientAccess.class);
+    executorService = mock(ExecutorService.class);
     jmxAdapter = mock(MBeanJMXAdapter.class);
+    messenger = mock(MemberMessenger.class);
+    proxyFactory = mock(MBeanProxyFactory.class);
     repo = mock(ManagementResourceRepo.class);
     service = mock(SystemManagementService.class);
     statisticsClock = mock(StatisticsClock.class);
@@ -84,11 +92,7 @@ public class FederatingManagerTest {
   @Test
   public void addMemberArtifactsCreatesMonitoringRegion() throws Exception {
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
     federatingManager.startManager();
 
     federatingManager.addMemberArtifacts(member(1, 20));
@@ -100,11 +104,7 @@ public class FederatingManagerTest {
   @Test
   public void addMemberArtifactsCreatesMonitoringRegionWithHasOwnStats() throws Exception {
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
     federatingManager.startManager();
 
     federatingManager.addMemberArtifacts(member(2, 40));
@@ -121,11 +121,7 @@ public class FederatingManagerTest {
   @Test
   public void addMemberArtifactsCreatesNotificationRegion() throws Exception {
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
     federatingManager.startManager();
 
     federatingManager.addMemberArtifacts(member(3, 60));
@@ -137,11 +133,7 @@ public class FederatingManagerTest {
   @Test
   public void addMemberArtifactsCreatesNotificationRegionWithHasOwnStats() throws Exception {
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
     federatingManager.startManager();
 
     federatingManager.addMemberArtifacts(member(4, 80));
@@ -167,11 +159,7 @@ public class FederatingManagerTest {
     when(system.getDistributedMember())
         .thenReturn(member);
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
 
     federatingManager.removeMemberArtifacts(member, false);
 
@@ -190,11 +178,7 @@ public class FederatingManagerTest {
     when(system.getDistributedMember())
         .thenReturn(member);
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
 
     federatingManager.removeMemberArtifacts(member, false);
 
@@ -215,11 +199,7 @@ public class FederatingManagerTest {
     when(system.getDistributedMember())
         .thenReturn(member);
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
 
     federatingManager.removeMemberArtifacts(member, false);
 
@@ -240,11 +220,7 @@ public class FederatingManagerTest {
     when(system.getDistributedMember())
         .thenReturn(member);
     FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
-        statisticsFactory, statisticsClock,
-        new MBeanProxyFactory(jmxAdapter, service),
-        new MemberMessenger(jmxAdapter, system),
-        LoggingExecutors.newFixedThreadPool("FederatingManager", true,
-            Runtime.getRuntime().availableProcessors()));
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
 
     federatingManager.removeMemberArtifacts(member, false);
 
@@ -254,7 +230,156 @@ public class FederatingManagerTest {
 
   @Test
   public void removeMemberArtifactsDoesNotThrowIfMBeanProxyFactoryThrowsRegionDestroyedException() {
+    InternalDistributedMember member = member();
+    Region monitoringRegion = mock(Region.class);
+    MBeanProxyFactory proxyFactory = mock(MBeanProxyFactory.class);
+    doThrow(new RegionDestroyedException("test", "monitoringRegion"))
+        .when(proxyFactory).removeAllProxies(member, monitoringRegion);
+    when(repo.getEntryFromMonitoringRegionMap(eq(member)))
+        .thenReturn(monitoringRegion);
+    when(repo.getEntryFromNotifRegionMap(eq(member)))
+        .thenReturn(mock(Region.class));
+    when(system.getDistributedMember())
+        .thenReturn(member);
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
 
+    federatingManager.removeMemberArtifacts(member, false);
+
+    verify(proxyFactory)
+        .removeAllProxies(member, monitoringRegion);
+  }
+
+  // ----------
+
+  @Test
+  public void removeMemberArtifactsProxyFactoryDoesNotThrowIfCacheClosed() {
+    InternalDistributedMember member = member();
+    Region monitoringRegion = mock(Region.class);
+    MBeanProxyFactory proxyFactory = mock(MBeanProxyFactory.class);
+    doThrow(new CacheClosedException("test"))
+        .when(proxyFactory).removeAllProxies(member, monitoringRegion);
+    when(repo.getEntryFromMonitoringRegionMap(eq(member)))
+        .thenReturn(monitoringRegion);
+    when(repo.getEntryFromNotifRegionMap(eq(member)))
+        .thenReturn(mock(Region.class));
+    when(system.getDistributedMember())
+        .thenReturn(member);
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
+
+    federatingManager.removeMemberArtifacts(member, false);
+
+    verify(proxyFactory)
+        .removeAllProxies(member, monitoringRegion);
+  }
+
+  @Test
+  public void removeMemberArtifactsNotificationRegionDoesNotThrowIfCacheClosed() {
+    InternalDistributedMember member = member();
+    Region notificationRegion = mock(Region.class);
+    doThrow(new CacheClosedException("test"))
+        .when(notificationRegion).localDestroyRegion();
+    when(repo.getEntryFromMonitoringRegionMap(eq(member)))
+        .thenReturn(mock(Region.class));
+    when(repo.getEntryFromNotifRegionMap(eq(member)))
+        .thenReturn(notificationRegion);
+    when(system.getDistributedMember())
+        .thenReturn(member);
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
+
+    federatingManager.removeMemberArtifacts(member, false);
+
+    verify(notificationRegion)
+        .localDestroyRegion();
+  }
+
+  @Test
+  public void removeMemberArtifactsMonitoringRegionDoesNotThrowIfCacheClosed() {
+    InternalDistributedMember member = member();
+    Region monitoringRegion = mock(Region.class);
+    doThrow(new CacheClosedException("test"))
+        .when(monitoringRegion).localDestroyRegion();
+    when(repo.getEntryFromMonitoringRegionMap(eq(member)))
+        .thenReturn(monitoringRegion);
+    when(repo.getEntryFromNotifRegionMap(eq(member)))
+        .thenReturn(mock(Region.class));
+    when(system.getDistributedMember())
+        .thenReturn(member);
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
+
+    federatingManager.removeMemberArtifacts(member, false);
+
+    verify(monitoringRegion)
+        .localDestroyRegion();
+  }
+
+  // ----------
+
+  @Test
+  public void removeMemberArtifactsProxyFactoryDoesNotThrowIfSystemDisconnected() {
+    InternalDistributedMember member = member();
+    Region monitoringRegion = mock(Region.class);
+    MBeanProxyFactory proxyFactory = mock(MBeanProxyFactory.class);
+    doThrow(new DistributedSystemDisconnectedException("test"))
+        .when(proxyFactory).removeAllProxies(member, monitoringRegion);
+    when(repo.getEntryFromMonitoringRegionMap(eq(member)))
+        .thenReturn(monitoringRegion);
+    when(repo.getEntryFromNotifRegionMap(eq(member)))
+        .thenReturn(mock(Region.class));
+    when(system.getDistributedMember())
+        .thenReturn(member);
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
+
+    federatingManager.removeMemberArtifacts(member, false);
+
+    verify(proxyFactory)
+        .removeAllProxies(member, monitoringRegion);
+  }
+
+  @Test
+  public void removeMemberArtifactsNotificationRegionDoesNotThrowIfSystemDisconnected() {
+    InternalDistributedMember member = member();
+    Region notificationRegion = mock(Region.class);
+    doThrow(new DistributedSystemDisconnectedException("test"))
+        .when(notificationRegion).localDestroyRegion();
+    when(repo.getEntryFromMonitoringRegionMap(eq(member)))
+        .thenReturn(mock(Region.class));
+    when(repo.getEntryFromNotifRegionMap(eq(member)))
+        .thenReturn(notificationRegion);
+    when(system.getDistributedMember())
+        .thenReturn(member);
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
+
+    federatingManager.removeMemberArtifacts(member, false);
+
+    verify(notificationRegion)
+        .localDestroyRegion();
+  }
+
+  @Test
+  public void removeMemberArtifactsMonitoringRegionDoesNotThrowIfSystemDisconnected() {
+    InternalDistributedMember member = member();
+    Region monitoringRegion = mock(Region.class);
+    doThrow(new DistributedSystemDisconnectedException("test"))
+        .when(monitoringRegion).localDestroyRegion();
+    when(repo.getEntryFromMonitoringRegionMap(eq(member)))
+        .thenReturn(monitoringRegion);
+    when(repo.getEntryFromNotifRegionMap(eq(member)))
+        .thenReturn(mock(Region.class));
+    when(system.getDistributedMember())
+        .thenReturn(member);
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorService);
+
+    federatingManager.removeMemberArtifacts(member, false);
+
+    verify(monitoringRegion)
+        .localDestroyRegion();
   }
 
   private InternalDistributedMember member() {


### PR DESCRIPTION
* Catch and ignore CancelException in removeMemberArtifacts
* Add try-catch around call to memberDeparted
* Handle both CancelException and RegionDestroyedException
* Fix unfinished test in FederatingManagerTest
* Add more test cases to FederatingManagerTest

Please review @aaronlindsey 