### PR TITLE
GEODE-7340: Dependency cleanup for geode-old-versions

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -223,8 +223,8 @@ jobs:
   serial: true
   plan:
   - get: geode-ci
+  - get: alpine-tools-image
   - aggregate:
-    - get: alpine-tools-image
     - get: geode
       trigger: true
     - get: geode-build-version
@@ -482,8 +482,8 @@ jobs:
   - get: geode-ci
     passed:
     - Benchmark
+  - get: alpine-tools-image
   - aggregate:
-    - get: alpine-tools-image
     - get: geode
       passed:
       - Benchmark

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -193,10 +193,10 @@ dependencies {
   testCompile(project(':geode-log4j')) {
     exclude module: 'geode-core'
   }
-  testRuntime(project(':geode-old-versions'))
+  testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
 
-  acceptanceTestRuntime(project(':geode-old-versions'))
+  acceptanceTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
 
   integrationTestCompile(project(':geode-core'))
@@ -281,7 +281,7 @@ dependencies {
   }
   upgradeTestCompile(project(':geode-assembly:geode-assembly-test'))
 
-  upgradeTestRuntime(project(':geode-old-versions'))
+  upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
   upgradeTestRuntime(project(':extensions:session-testing-war'))
   upgradeTestRuntime('org.codehaus.cargo:cargo-core-uberjar')
   upgradeTestRuntime('org.apache.httpcomponents:httpclient')

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -342,7 +342,7 @@ dependencies {
   testRuntime('commons-io:commons-io')
   testRuntime('commons-validator:commons-validator')
   testRuntime('com.pholser:junit-quickcheck-generators')
-  testRuntime(project(':geode-old-versions'))
+  testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
 
   integrationTestCompile(project(':geode-junit')) {
@@ -379,7 +379,7 @@ dependencies {
   distributedTestCompile('com.jayway.jsonpath:json-path-assert')
   distributedTestCompile('net.openhft:compiler')
 
-  distributedTestRuntime(project(':geode-old-versions'))
+  distributedTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
   distributedTestRuntime('org.apache.derby:derby')
 
 
@@ -387,7 +387,7 @@ dependencies {
     exclude module: 'geode-core'
   }
 
-  upgradeTestRuntime(project(':geode-old-versions'))
+  upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
   upgradeTestRuntime(project(':geode-log4j'))
 
 

--- a/geode-cq/build.gradle
+++ b/geode-cq/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   upgradeTestCompile('org.awaitility:awaitility')
   upgradeTestCompile('org.mockito:mockito-core')
 
-  upgradeTestRuntime(project(':geode-old-versions'))
+  upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 }
 
 ext.moduleName = group + '.cq'

--- a/geode-dunit/build.gradle
+++ b/geode-dunit/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     exclude module: 'hamcrest-core'
   }
 
-  distributedTestRuntime(project(':geode-old-versions'))
+  distributedTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 }
 
 distributedTest {

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 
   testCompile('pl.pragmatists:JUnitParams')
 
-  testRuntime(project(':geode-old-versions'))
+  testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 }
 
 test {

--- a/geode-logging/build.gradle
+++ b/geode-logging/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testCompile('junit:junit')
     testCompile('org.assertj:assertj-core')
 
-    testRuntime(project(':geode-old-versions'))
+    testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
     integrationTestCompile(project(':geode-junit')) {
         exclude module: 'geode-logging'
@@ -52,8 +52,8 @@ dependencies {
         exclude module: 'geode-logging'
     }
     distributedTestCompile('pl.pragmatists:JUnitParams')
-    distributedTestRuntime(project(':geode-old-versions'))
-    upgradeTestRuntime(project(':geode-old-versions'))
+    distributedTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+    upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
 }
 

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -90,7 +90,7 @@ dependencies {
     exclude module: 'geode-core'
   }
 
-  upgradeTestRuntime(project(':geode-old-versions'))
+  upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
 
   performanceTestCompile(project(':geode-junit')) {

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -17,13 +17,12 @@ import java.nio.file.Paths
  * limitations under the License.
  */
 
-apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
+apply from: "${rootProject.rootDir}/gradle/java.gradle"
 
 project.ext.installs = new Properties()
-project.ext.versions = new Properties()
 
 subprojects {
-  apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
+  apply plugin: 'base'
 
   def oldGeodeVersion = project.name
 
@@ -40,18 +39,6 @@ subprojects {
       .subList(0,3)
       .join(''))
 
-  project.dependencies {
-    compile "org.apache.geode:geode-common:${oldGeodeVersion}"
-    compile "org.apache.geode:geode-core:${oldGeodeVersion}"
-    compile "org.apache.geode:geode-lucene:${oldGeodeVersion}"
-    compile "org.apache.geode:geode-old-client-support:${oldGeodeVersion}"
-    compile "org.apache.geode:geode-wan:${oldGeodeVersion}"
-    compile "org.apache.geode:geode-cq:${oldGeodeVersion}"
-    compile "org.apache.geode:geode-rebalancer:${oldGeodeVersion}"
-  }
-
-  parent.ext.versions.setProperty(oldGeodeVersion, sourceSets.main.runtimeClasspath.asPath)
-
   def unpackDest = project.buildDir.toPath().resolve('apache-geode-'.concat(oldGeodeVersion))
 
   project.configurations.create("oldInstall")
@@ -60,43 +47,61 @@ subprojects {
     project.dependencies.add "oldInstall", "org.apache.geode:apache-geode:${oldGeodeVersion}@${archiveType}"
 
     parent.ext.installs.setProperty(oldGeodeVersion, unpackDest.toString())
-  }
-  project.task("downloadAndUnzipFile") {
+    project.tasks.register('downloadAndUnzipFile') {
+      onlyIf { downloadInstall }
+      inputs.files {
+        configurations.oldInstall
+      }
+      outputs.dir {
+        file(unpackDest)
+      }
 
-    inputs.files {
-      configurations.oldInstall
-    }
-    outputs.dir(unpackDest)
-
-    doLast {
-      def oldArchive = configurations."oldInstall".singleFile
-      copy {
-        from(useTgz ? tarTree(oldArchive) : zipTree(oldArchive))
-        into project.buildDir
+      doLast {
+        def oldArchive = configurations."oldInstall".singleFile
+        copy {
+          from(useTgz ? tarTree(oldArchive) : zipTree(oldArchive))
+          into project.buildDir
+        }
       }
     }
-  }
-  project.build.dependsOn(project.downloadAndUnzipFile)
-  project.downloadAndUnzipFile.onlyIf {downloadInstall}
+    project.tasks.register('enumerateArchiveContents') {
+      onlyIf { downloadInstall }
+      inputs.files {
+        downloadAndUnzipFile
+      }
+      def contentsFile = project.buildDir.toPath().resolve('contents.txt')
+      outputs.files {
+        file(contentsFile)
+      }
+      doLast {
+        new File(contentsFile.toAbsolutePath().toString()).text = file(unpackDest).listFiles()
+      }
+    }
+    project.assemble.dependsOn(project.downloadAndUnzipFile)
+    project.assemble.dependsOn(project.enumerateArchiveContents)
 
-  (project.tasks.jar as Task).onlyIf {false}
+  }
 }
 
-def generatedResources = buildDir.toPath().resolve('generated-resources').resolve('main').toString()
-task createGeodeClasspathsFile {
+def generatedResources = buildDir.toPath().resolve('generated-resources').resolve('test').toString()
+tasks.register('createGeodeClasspathsFile') {
   def classpathsFile = Paths.get(generatedResources).resolve('geodeOldVersionClasspaths.txt').toString()
   def installsFile = Paths.get(generatedResources).resolve('geodeOldVersionInstalls.txt').toString()
-  outputs.file(classpathsFile)
-  outputs.file(installsFile)
-//  outputs.cacheIf( false )
+  outputs.files {classpathsFile }
+  outputs.files {installsFile}
 
   doLast {
-    sourceSets.each { sset ->
-      project.ext.versions.setProperty(sset.name, sset.runtimeClasspath.asPath)
-    }
-
     new FileOutputStream(classpathsFile).withStream { fos ->
-      project.ext.versions.store(fos, '')
+      def cp = new Properties()
+      project.ext.installs.each {
+        File libdir = file("${it.value}/lib")
+        FileCollection libJars = layout.files(libdir.listFiles())
+          .filter { File f ->
+            f.name.endsWith('.jar')
+          }
+        cp.setProperty(it.key, libJars.join(':'))
+      }
+      cp.store(fos, '')
     }
 
     // TODO potential caching issue with implicit configuration in doLast action.
@@ -108,10 +113,11 @@ task createGeodeClasspathsFile {
 
 project.createGeodeClasspathsFile.mustRunAfter(clean)
 project.createGeodeClasspathsFile.inputs.files(getTasksByName('downloadAndUnzipFile', true))
-project.build.dependsOn(createGeodeClasspathsFile)
+project.createGeodeClasspathsFile.inputs.files(getTasksByName('enumerateArchiveContents', true))
+project.jarTest.dependsOn(createGeodeClasspathsFile)
 
 sourceSets {
-  main {
+  test {
     output.dir(generatedResources, builtBy: createGeodeClasspathsFile)
   }
 }

--- a/geode-serialization/build.gradle
+++ b/geode-serialization/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
 
-  testRuntime(project(':geode-old-versions'))
+  testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
   integrationTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'
@@ -58,8 +58,8 @@ dependencies {
     exclude module: 'geode-serialization'
   }
   distributedTestImplementation('pl.pragmatists:JUnitParams')
-  distributedTestRuntime(project(':geode-old-versions'))
-  upgradeTestRuntime(project(':geode-old-versions'))
+  distributedTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+  upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 }
 
 distributedTest {

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -72,5 +72,5 @@ dependencies {
   upgradeTestCompile('org.assertj:assertj-core')
   upgradeTestCompile('junit:junit')
 
-  upgradeTestRuntime(project(':geode-old-versions'))
+  upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 }


### PR DESCRIPTION
Use test configuration to download, unpack and enumerate geode-old-versions.

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
