### PR TITLE
Revert "GEODE-7336: Pulling failing tests during investigation."

### DIFF
--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModuleCanDoPutsTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModuleCanDoPutsTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.session.tests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -28,7 +27,6 @@ public class TomcatSessionBackwardsCompatibilityTomcat7079WithOldModuleCanDoPuts
     super(version);
   }
 
-  @Ignore // GEODE-7336 addressing failures in upgradeTests
   @Test
   public void test() throws Exception {
     startClusterWithTomcat(classPathTomcat7079);

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWithCurrentCanDoPutFromCurrentModuleTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWithCurrentCanDoPutFromCurrentModuleTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.session.tests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -29,7 +28,6 @@ public class TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWit
     super(version);
   }
 
-  @Ignore // GEODE-7336 addressing failures in upgradeTests
   @Test
   public void test() throws Exception {
     startClusterWithTomcat(classPathTomcat7079);

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWithCurrentCanDoPutFromOldModuleTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWithCurrentCanDoPutFromOldModuleTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.session.tests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -29,7 +28,6 @@ public class TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWit
     super(version);
   }
 
-  @Ignore // GEODE-7336 addressing failures in upgradeTests
   @Test
   public void test() throws Exception {
     startClusterWithTomcat(classPathTomcat7079);

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat8WithOldModuleCanDoPutsTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat8WithOldModuleCanDoPutsTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.session.tests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -28,7 +27,6 @@ public class TomcatSessionBackwardsCompatibilityTomcat8WithOldModuleCanDoPutsTes
     super(version);
   }
 
-  @Ignore // GEODE-7336 addressing failures in upgradeTests
   @Test
   public void test() throws Exception {
     startClusterWithTomcat(classPathTomcat8);

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat8WithOldModulesMixedWithCurrentCanDoPutFromCurrentModuleTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat8WithOldModulesMixedWithCurrentCanDoPutFromCurrentModuleTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.session.tests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -29,7 +28,6 @@ public class TomcatSessionBackwardsCompatibilityTomcat8WithOldModulesMixedWithCu
     super(version);
   }
 
-  @Ignore // GEODE-7336 addressing failures in upgradeTests
   @Test
   public void test() throws Exception {
     startClusterWithTomcat(classPathTomcat8);

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat8WithOldModulesMixedWithCurrentCanDoPutFromOldModuleTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat8WithOldModulesMixedWithCurrentCanDoPutFromOldModuleTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.session.tests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -29,7 +28,6 @@ public class TomcatSessionBackwardsCompatibilityTomcat8WithOldModulesMixedWithCu
     super(version);
   }
 
-  @Ignore // GEODE-7336 addressing failures in upgradeTests
   @Test
   public void test() throws Exception {
     startClusterWithTomcat(classPathTomcat8);


### PR DESCRIPTION
This reverts commit 8f829d5de0d64f06014b87fae658e480691f6b73.

