### PR TITLE
GEODE-7348: Removing dependencies on core god classes from TcpServer

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -68,10 +68,10 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.PoolStatHelper;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
-import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.PoolStats;
@@ -402,7 +402,7 @@ public class AutoConnectionSourceImplJUnitTest {
     Thread.sleep(500);
   }
 
-  protected static class FakeHandler implements TcpHandler {
+  protected static class FakeHandler implements RestartableTcpHandler {
     volatile ClientConnectionResponse nextConnectionResponse;
     volatile LocatorListResponse nextLocatorListResponse;
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
@@ -41,6 +41,7 @@ import org.apache.geode.cache.ssl.CertificateMaterial;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.PoolStatHelper;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
@@ -103,7 +104,7 @@ public class TCPClientSSLIntegrationTest {
     localhost = InetAddress.getLocalHost();
     port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
 
-    TcpHandler tcpHandler = Mockito.mock(TcpHandler.class);
+    RestartableTcpHandler tcpHandler = Mockito.mock(RestartableTcpHandler.class);
     when(tcpHandler.processRequest(any())).thenReturn("Running!");
 
     server = new FakeTcpServer(port, localhost, sslProperties, null,
@@ -196,9 +197,10 @@ public class TCPClientSSLIntegrationTest {
     private DistributionConfig distributionConfig;
 
     public FakeTcpServer(int port, InetAddress bind_address, Properties sslConfig,
-        DistributionConfigImpl cfg, TcpHandler handler, PoolStatHelper poolHelper,
+        DistributionConfigImpl cfg, RestartableTcpHandler handler, PoolStatHelper poolHelper,
         String threadName) {
-      super(port, bind_address, sslConfig, cfg, handler, poolHelper, threadName, null, null);
+      super(port, bind_address, sslConfig, cfg, handler, poolHelper, threadName,
+          (socket, input, firstByte) -> false);
       if (cfg == null) {
         cfg = new DistributionConfigImpl(sslConfig);
       }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.PoolStatHelper;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.net.DummySocketCreator;
@@ -77,7 +78,7 @@ public class TCPServerSSLJUnitTest {
     port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
 
     server = new DummyTcpServer(port, localhost, sslProperties, null,
-        Mockito.mock(TcpHandler.class), Mockito.mock(PoolStatHelper.class),
+        Mockito.mock(RestartableTcpHandler.class), Mockito.mock(PoolStatHelper.class),
         "server thread");
     server.start();
   }
@@ -138,9 +139,10 @@ public class TCPServerSSLJUnitTest {
     private List<Integer> recordedSocketsTimeouts = new ArrayList<>();
 
     public DummyTcpServer(int port, InetAddress bind_address, Properties sslConfig,
-        DistributionConfigImpl cfg, TcpHandler handler, PoolStatHelper poolHelper,
+        DistributionConfigImpl cfg, RestartableTcpHandler handler, PoolStatHelper poolHelper,
         String threadName) {
-      super(port, bind_address, sslConfig, cfg, handler, poolHelper, threadName, null, null);
+      super(port, bind_address, sslConfig, cfg, handler, poolHelper, threadName,
+          (socket, input, firstByte) -> false);
       if (cfg == null) {
         cfg = new DistributionConfigImpl(sslConfig);
       }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -44,11 +44,9 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import org.apache.geode.DataSerializable;
-import org.apache.geode.cache.GemFireCache;
-import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.distributed.internal.PoolStatHelper;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -164,7 +162,7 @@ public class TcpServerJUnitTest {
       ClassNotFoundException, InterruptedException {
     // Initially mock the handler to throw a SocketException. We want to verify that the server
     // can recover and serve new client requests after a SocketException is thrown.
-    TcpHandler mockTcpHandler = mock(TcpHandler.class);
+    RestartableTcpHandler mockTcpHandler = mock(RestartableTcpHandler.class);
     doThrow(SocketException.class).when(mockTcpHandler).processRequest(any(Object.class));
     start(mockTcpHandler);
 
@@ -249,10 +247,6 @@ public class TcpServerJUnitTest {
     }
 
     @Override
-    public void restarting(DistributedSystem ds, GemFireCache cache,
-        InternalConfigurationPersistenceService sharedConfig) {}
-
-    @Override
     public void endRequest(Object request, long startTime) {}
 
     @Override
@@ -286,10 +280,6 @@ public class TcpServerJUnitTest {
 
     @Override
     public void shutDown() {}
-
-    @Override
-    public void restarting(DistributedSystem ds, GemFireCache cache,
-        InternalConfigurationPersistenceService sharedConfig) {}
 
     @Override
     public void endRequest(Object request, long startTime) {}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1158,7 +1158,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       internalCache = null;
 
       logger.info("Locator restart: initializing TcpServer peer location services");
-      server.restarting(null, null, null);
+      handler.restarting(null, null, null);
+      server.restarting();
 
       if (productUseLog.isClosed()) {
         productUseLog.reopen();
@@ -1185,7 +1186,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     logger.info("Locator restart: initializing TcpServer");
 
     try {
-      server.restarting(newSystem, newCache, configurationPersistenceService);
+      handler.restarting(newSystem, newCache, configurationPersistenceService);
+      server.restarting();
     } catch (CancelException e) {
       internalDistributedSystem = null;
       internalCache = null;
@@ -1215,7 +1217,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     endStartLocator(internalDistributedSystem);
     logger.info("Locator restart completed");
 
-    server.restartCompleted(newSystem);
+    handler.restartCompleted(newSystem);
   }
 
   public ClusterManagementService getClusterManagementService() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/PrimaryHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/PrimaryHandler.java
@@ -32,14 +32,14 @@ import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.logging.LogService;
 
-public class PrimaryHandler implements TcpHandler {
+public class PrimaryHandler implements RestartableTcpHandler {
   private static final Logger logger = LogService.getLogger();
 
   private final LocatorMembershipListener locatorListener;
   private final InternalLocator internalLocator;
 
-  private volatile Map<Class, TcpHandler> handlerMapping = new HashMap<>();
-  private volatile Set<TcpHandler> allHandlers = new HashSet<>();
+  private volatile Map<Class, RestartableTcpHandler> handlerMapping = new HashMap<>();
+  private volatile Set<RestartableTcpHandler> allHandlers = new HashSet<>();
 
   private TcpServer tcpServer;
 
@@ -66,7 +66,7 @@ public class PrimaryHandler implements TcpHandler {
   public void restarting(DistributedSystem ds, GemFireCache cache,
       InternalConfigurationPersistenceService sharedConfig) {
     if (ds != null) {
-      for (TcpHandler handler : allHandlers) {
+      for (RestartableTcpHandler handler : allHandlers) {
         handler.restarting(ds, cache, sharedConfig);
       }
     }
@@ -75,7 +75,7 @@ public class PrimaryHandler implements TcpHandler {
   @Override
   public void restartCompleted(DistributedSystem ds) {
     if (ds != null) {
-      for (TcpHandler handler : allHandlers) {
+      for (RestartableTcpHandler handler : allHandlers) {
         handler.restartCompleted(ds);
       }
     }
@@ -137,9 +137,9 @@ public class PrimaryHandler implements TcpHandler {
     return handlerMapping.containsKey(clazz);
   }
 
-  public synchronized void addHandler(Class clazz, TcpHandler handler) {
-    Map<Class, TcpHandler> tmpHandlerMapping = new HashMap<>(handlerMapping);
-    Set<TcpHandler> tmpAllHandlers = new HashSet<>(allHandlers);
+  public synchronized void addHandler(Class clazz, RestartableTcpHandler handler) {
+    Map<Class, RestartableTcpHandler> tmpHandlerMapping = new HashMap<>(handlerMapping);
+    Set<RestartableTcpHandler> tmpAllHandlers = new HashSet<>(allHandlers);
     tmpHandlerMapping.put(clazz, handler);
     if (tmpAllHandlers.add(handler) && tcpServer != null) {
       handler.init(tcpServer);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ProtocolCheckerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ProtocolCheckerImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.cache.IncompatibleVersionException;
+import org.apache.geode.distributed.internal.tcpserver.ProtocolChecker;
+import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
+import org.apache.geode.internal.cache.client.protocol.ClientProtocolService;
+import org.apache.geode.internal.cache.client.protocol.ClientProtocolServiceLoader;
+import org.apache.geode.internal.cache.client.protocol.exception.ServiceLoadingFailureException;
+import org.apache.geode.internal.cache.client.protocol.exception.ServiceVersionNotFoundException;
+import org.apache.geode.internal.cache.tier.CommunicationMode;
+import org.apache.geode.internal.cache.tier.sockets.Handshake;
+import org.apache.geode.internal.logging.LogService;
+
+public class ProtocolCheckerImpl implements ProtocolChecker {
+  private static final Logger logger = LogService.getLogger();
+  public final InternalLocator internalLocator;
+  public final ClientProtocolServiceLoader clientProtocolServiceLoader;
+
+  public ProtocolCheckerImpl(
+      final InternalLocator internalLocator,
+      final ClientProtocolServiceLoader clientProtocolServiceLoader) {
+    this.internalLocator = internalLocator;
+    this.clientProtocolServiceLoader = clientProtocolServiceLoader;
+  }
+
+
+  @Override
+  public boolean checkProtocol(final Socket socket, final DataInputStream input,
+      final int firstByte) throws Exception {
+    boolean handled = false;
+    if (firstByte == CommunicationMode.ProtobufClientServerProtocol.getModeNumber()) {
+      handleProtobufConnection(socket, input);
+      handled = true;
+    } else if (CommunicationMode.isValidMode(firstByte)) {
+      socket.getOutputStream().write(Handshake.REPLY_SERVER_IS_LOCATOR);
+      throw new Exception("Improperly configured client detected - use addPoolLocator to "
+          + "configure its locators instead of addPoolServer.");
+    }
+    return handled;
+  }
+
+  public void handleProtobufConnection(Socket socket, DataInputStream input) throws Exception {
+    if (!Boolean.getBoolean("geode.feature-protobuf-protocol")) {
+      logger.warn("Incoming protobuf connection, but protobuf not enabled on this locator.");
+      socket.close();
+      return;
+    }
+
+    try {
+      ClientProtocolService clientProtocolService = clientProtocolServiceLoader.lookupService();
+      clientProtocolService.initializeStatistics("LocatorStats",
+          internalLocator.getDistributedSystem());
+      try (ClientProtocolProcessor pipeline = clientProtocolService.createProcessorForLocator(
+          internalLocator, internalLocator.getCache().getSecurityService())) {
+        while (!pipeline.socketProcessingIsFinished()) {
+          pipeline.processMessage(input, socket.getOutputStream());
+        }
+      } catch (IncompatibleVersionException e) {
+        // should not happen on the locator as there is no handshake.
+        logger.error("Unexpected exception in client message processing", e);
+      }
+    } catch (ServiceLoadingFailureException e) {
+      logger.error("There was an error looking up the client protocol service", e);
+      socket.close();
+      throw new IOException("There was an error looking up the client protocol service", e);
+    } catch (ServiceVersionNotFoundException e) {
+      logger.error("Unable to find service matching the client protocol version byte", e);
+      socket.close();
+      throw new IOException("Unable to find service matching the client protocol version byte", e);
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/RestartableTcpHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/RestartableTcpHandler.java
@@ -12,19 +12,32 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.distributed.internal.membership;
+package org.apache.geode.distributed.internal;
 
-import org.apache.geode.distributed.internal.RestartableTcpHandler;
-import org.apache.geode.distributed.internal.membership.gms.Services;
 
-public interface NetLocator extends RestartableTcpHandler {
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
+import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+
+/**
+ * A handler which responds to messages for the {@link TcpServer}
+ *
+ * @since GemFire 5.7
+ */
+public interface RestartableTcpHandler extends TcpHandler {
 
   /**
-   * This must be called after booting the membership manager so that the locator can use its
-   * services
+   * Informs the handler that TcpServer is restarting with the given distributed system and cache
    *
-   * @return true if the membership manager was accepted
+   * @param sharedConfig TODO
    */
-  boolean setServices(Services pservices);
+  void restarting(DistributedSystem ds, GemFireCache cache,
+      InternalConfigurationPersistenceService sharedConfig);
+
+  /**
+   * Informs the handler that restart has completed
+   */
+  default void restartCompleted(DistributedSystem ds) {}
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ServerLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ServerLocator.java
@@ -49,7 +49,6 @@ import org.apache.geode.cache.server.ServerLoad;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionAdvisor.Profile;
-import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.cache.CacheServerAdvisor.CacheServerProfile;
 import org.apache.geode.internal.cache.ControllerAdvisor;
@@ -64,7 +63,7 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
  *
  * @since GemFire 5.7
  */
-public class ServerLocator implements TcpHandler, DistributionAdvisee {
+public class ServerLocator implements RestartableTcpHandler, DistributionAdvisee {
   private static final Logger logger = LogService.getLogger();
 
   private final int port;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
@@ -23,14 +23,14 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.LocatorStats;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.distributed.internal.membership.NetLocator;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Locator;
 import org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator;
-import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 
-public class GMSLocatorAdapter implements TcpHandler, NetLocator {
+public class GMSLocatorAdapter implements RestartableTcpHandler, NetLocator {
 
   private final GMSLocator gmsLocator;
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/ProtocolChecker.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/ProtocolChecker.java
@@ -12,19 +12,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.distributed.internal.membership;
+package org.apache.geode.distributed.internal.tcpserver;
 
-import org.apache.geode.distributed.internal.RestartableTcpHandler;
-import org.apache.geode.distributed.internal.membership.gms.Services;
+import java.io.DataInputStream;
+import java.net.Socket;
 
-public interface NetLocator extends RestartableTcpHandler {
-
-  /**
-   * This must be called after booting the membership manager so that the locator can use its
-   * services
-   *
-   * @return true if the membership manager was accepted
-   */
-  boolean setServices(Services pservices);
-
+public interface ProtocolChecker {
+  boolean checkProtocol(Socket socket, DataInputStream input,
+      int firstByte) throws Exception;
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpHandler.java
@@ -1,30 +1,27 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the
+ * * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * * copy of the License at
+ * *
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License
+ * * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express
+ * * or implied. See the License for the specific language governing permissions and limitations
+ * under
+ * * the License.
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
  */
 package org.apache.geode.distributed.internal.tcpserver;
 
 import java.io.IOException;
 
-import org.apache.geode.cache.GemFireCache;
-import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
-
-/**
- * A handler which responds to messages for the {@link TcpServer}
- *
- * @since GemFire 5.7
- */
 public interface TcpHandler {
   /**
    * Process a request and return a response
@@ -41,19 +38,6 @@ public interface TcpHandler {
    * Perform any shutdown code in the handler after the TCP server has closed the socket.
    */
   void shutDown();
-
-  /**
-   * Informs the handler that TcpServer is restarting with the given distributed system and cache
-   *
-   * @param sharedConfig TODO
-   */
-  void restarting(DistributedSystem ds, GemFireCache cache,
-      InternalConfigurationPersistenceService sharedConfig);
-
-  /**
-   * Informs the handler that restart has completed
-   */
-  default void restartCompleted(DistributedSystem ds) {}
 
   /**
    * Initialize the handler with the TcpServer. Called before the TcpServer starts accepting

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpHandler.java
@@ -1,22 +1,16 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
  *
- * * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * * agreements. See the NOTICE file distributed with this work for additional information regarding
- * * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0
- * (the
- * * "License"); you may not use this file except in compliance with the License. You may obtain a
- * * copy of the License at
- * *
- * * http://www.apache.org/licenses/LICENSE-2.0
- * *
- * * Unless required by applicable law or agreed to in writing, software distributed under the
- * License
- * * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express
- * * or implied. See the License for the specific language governing permissions and limitations
- * under
- * * the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.apache.geode.distributed.internal.tcpserver;
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -43,23 +43,11 @@ import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.annotations.internal.MutableForTesting;
-import org.apache.geode.cache.IncompatibleVersionException;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.DistributionStats;
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.internal.GemFireVersion;
-import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
-import org.apache.geode.internal.cache.client.protocol.ClientProtocolService;
-import org.apache.geode.internal.cache.client.protocol.ClientProtocolServiceLoader;
-import org.apache.geode.internal.cache.client.protocol.exception.ServiceLoadingFailureException;
-import org.apache.geode.internal.cache.client.protocol.exception.ServiceVersionNotFoundException;
-import org.apache.geode.internal.cache.tier.CommunicationMode;
-import org.apache.geode.internal.cache.tier.sockets.Handshake;
 import org.apache.geode.internal.logging.CoreLoggingExecutors;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingThread;
@@ -105,6 +93,7 @@ public class TcpServer {
   @MutableForTesting("The map used here is mutable, because some tests modify it")
   private static final Map<Integer, Short> GOSSIP_TO_GEMFIRE_VERSION_MAP =
       createGossipToVersionMap();
+  public static final int GOSSIP_BYTE = 0;
 
   // For test purpose only
   @MutableForTesting
@@ -120,7 +109,7 @@ public class TcpServer {
       Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "TcpServer.MAX_POOL_SIZE", 100);
   private static final int POOL_IDLE_TIMEOUT = 60 * 1000;
 
-  private static final Logger log = LogService.getLogger();
+  private static final Logger logger = LogService.getLogger();
 
   // no longer static so that tests can test this system property
   private final int READ_TIMEOUT =
@@ -128,15 +117,14 @@ public class TcpServer {
   private static final int P2P_BACKLOG = Integer.getInteger("p2p.backlog", 1000);
   private static final int BACKLOG =
       Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "TcpServer.BACKLOG", P2P_BACKLOG);
+  private final ProtocolChecker protocolChecker;
 
   private int port;
   private ServerSocket srv_sock = null;
   private InetAddress bind_address;
   private volatile boolean shuttingDown = false;
   private final PoolStatHelper poolHelper;
-  private final InternalLocator internalLocator;
   private final TcpHandler handler;
-  private final ClientProtocolServiceLoader clientProtocolServiceLoader;
 
 
   private ExecutorService executor;
@@ -159,14 +147,12 @@ public class TcpServer {
 
   public TcpServer(int port, InetAddress bind_address, Properties sslConfig,
       DistributionConfigImpl cfg, TcpHandler handler, PoolStatHelper poolHelper,
-      String threadName, InternalLocator internalLocator,
-      ClientProtocolServiceLoader clientProtocolServiceLoader) {
+      String threadName, ProtocolChecker protocolChecker) {
     this.port = port;
     this.bind_address = bind_address;
     this.handler = handler;
     this.poolHelper = poolHelper;
-    this.internalLocator = internalLocator;
-    this.clientProtocolServiceLoader = clientProtocolServiceLoader;
+    this.protocolChecker = protocolChecker;
     this.executor = createExecutor(poolHelper);
     this.threadName = threadName;
 
@@ -191,19 +177,13 @@ public class TcpServer {
         MAX_POOL_SIZE, poolHelper, POOL_IDLE_TIMEOUT, new ThreadPoolExecutor.CallerRunsPolicy());
   }
 
-  public void restarting(InternalDistributedSystem ds, InternalCache cache,
-      InternalConfigurationPersistenceService sharedConfig) throws IOException {
+  public void restarting() throws IOException {
     this.shuttingDown = false;
-    this.handler.restarting(ds, cache, sharedConfig);
     startServerThread();
     this.executor = createExecutor(this.poolHelper);
-    log.info("TcpServer@" + System.identityHashCode(this)
+    logger.info("TcpServer@" + System.identityHashCode(this)
         + " restarting: completed.  Server thread=" + this.serverThread + '@'
         + System.identityHashCode(this.serverThread) + ";alive=" + this.serverThread.isAlive());
-  }
-
-  public void restartCompleted(InternalDistributedSystem ds) {
-    this.handler.restartCompleted(ds);
   }
 
   public void start() throws IOException {
@@ -233,9 +213,9 @@ public class TcpServer {
       if (this.port <= 0) {
         this.port = srv_sock.getLocalPort();
       }
-      if (log.isInfoEnabled()) {
-        log.info("Locator was created at " + new Date());
-        log.info("Listening on port " + getPort() + " bound on address " + bind_address);
+      if (logger.isInfoEnabled()) {
+        logger.info("Locator was created at " + new Date());
+        logger.info("Listening on port " + getPort() + " bound on address " + bind_address);
       }
       srv_sock.setReuseAddress(true);
     }
@@ -300,14 +280,14 @@ public class TcpServer {
           // SW: This is the case when there is a problem in locator
           // SSL configuration, so need to exit otherwise goes into an
           // infinite loop just filling the logs
-          log.error("Locator stopping due to SSL configuration problem.", ex);
+          logger.error("Locator stopping due to SSL configuration problem.", ex);
           shuttingDown = true;
           continue;
         }
         processRequest(sock);
       } catch (Exception ex) {
         if (!shuttingDown) {
-          log.error("exception=", ex);
+          logger.error("exception=", ex);
         }
         continue;
       }
@@ -317,12 +297,12 @@ public class TcpServer {
       try {
         srv_sock.close();
       } catch (java.io.IOException ex) {
-        log.warn("exception closing server socket during shutdown", ex);
+        logger.warn("exception closing server socket during shutdown", ex);
       }
     }
 
     if (shuttingDown) {
-      log.info("locator shutting down");
+      logger.info("locator shutting down");
       executor.shutdown();
       try {
         executor.awaitTermination(SHUTDOWN_WAIT_TIME, TimeUnit.MILLISECONDS);
@@ -353,24 +333,22 @@ public class TcpServer {
         } catch (StreamCorruptedException e) {
           // Some garbage can be left on the socket stream
           // if a peer disappears at exactly the wrong moment.
-          log.debug("Discarding illegal request from "
+          logger.debug("Discarding illegal request from "
               + (socket.getInetAddress().getHostAddress() + ":" + socket.getPort()), e);
           return;
         }
         // read the first byte & check for an improperly configured client pool trying
         // to contact a cache server
         int firstByte = input.readUnsignedByte();
-        if (firstByte == CommunicationMode.ReservedForGossip.getModeNumber()) {
-          processOneConnection(socket, startTime, input);
-        } else if (firstByte == CommunicationMode.ProtobufClientServerProtocol.getModeNumber()) {
-          handleProtobufConnection(socket, input);
-        } else if (CommunicationMode.isValidMode(firstByte)) {
-          socket.getOutputStream().write(Handshake.REPLY_SERVER_IS_LOCATOR);
-          throw new Exception("Improperly configured client detected - use addPoolLocator to "
-              + "configure its locators instead of addPoolServer.");
 
-        } else {
-          rejectUnknownProtocolConnection(socket, firstByte);
+        boolean handled = protocolChecker.checkProtocol(socket, input, firstByte);
+
+        if (!handled) {
+          if (firstByte == GOSSIP_BYTE) {
+            processOneConnection(socket, startTime, input);
+          } else {
+            rejectUnknownProtocolConnection(socket, firstByte);
+          }
         }
       } catch (EOFException | SocketException ignore) {
         // client went away - ignore
@@ -382,13 +360,13 @@ public class TcpServer {
           sender = socket.getInetAddress().getHostAddress();
         }
         // Do not want the full stack trace to fill up the logs
-        log.info("Exception in processing request from " + sender + ": " + ex.getMessage());
+        logger.info("Exception in processing request from " + sender + ": " + ex.getMessage());
       } catch (ClassNotFoundException ex) {
         String sender = null;
         if (socket != null) {
           sender = socket.getInetAddress().getHostAddress();
         }
-        log.info("Unable to process request from " + sender + " exception=" + ex.getMessage());
+        logger.info("Unable to process request from " + sender + " exception=" + ex.getMessage());
       } catch (Exception ex) {
         String sender = null;
         if (socket != null) {
@@ -398,10 +376,10 @@ public class TcpServer {
           // IOException could be caused by a client failure. Don't
           // log with severe.
           if (!socket.isClosed()) {
-            log.info("Exception in processing request from " + sender, ex);
+            logger.info("Exception in processing request from " + sender, ex);
           }
         } else {
-          log.fatal("Exception in processing request from " + sender, ex);
+          logger.fatal("Exception in processing request from " + sender, ex);
         }
 
       } catch (VirtualMachineError err) {
@@ -414,7 +392,7 @@ public class TcpServer {
           sender = socket.getInetAddress().getHostAddress();
         }
         try {
-          log.fatal("Exception in processing request from " + sender, ex);
+          logger.fatal("Exception in processing request from " + sender, ex);
         } catch (VirtualMachineError err) {
           SystemFailure.initiateFailure(err);
           throw err;
@@ -454,14 +432,14 @@ public class TcpServer {
         versionOrdinal = input.readShort();
       }
 
-      if (log.isDebugEnabled() && versionOrdinal != Version.CURRENT_ORDINAL) {
-        log.debug("Locator reading request from " + socket.getInetAddress() + " with version "
+      if (logger.isDebugEnabled() && versionOrdinal != Version.CURRENT_ORDINAL) {
+        logger.debug("Locator reading request from " + socket.getInetAddress() + " with version "
             + Version.fromOrdinal(versionOrdinal));
       }
       input = new VersionedDataInputStream(input, Version.fromOrdinal(versionOrdinal));
       request = DataSerializer.readObject(input);
-      if (log.isDebugEnabled()) {
-        log.debug("Locator received request " + request + " from " + socket.getInetAddress());
+      if (logger.isDebugEnabled()) {
+        logger.debug("Locator received request " + request + " from " + socket.getInetAddress());
       }
       if (request instanceof ShutdownRequest) {
         shuttingDown = true;
@@ -503,38 +481,9 @@ public class TcpServer {
       socket.getOutputStream().flush();
       socket.close();
     } catch (IOException e) {
-      log.debug("exception in sending reply to process using unknown protocol " + gossipVersion, e);
-    }
-  }
-
-  private void handleProtobufConnection(Socket socket, DataInputStream input) throws Exception {
-    if (!Boolean.getBoolean("geode.feature-protobuf-protocol")) {
-      log.warn("Incoming protobuf connection, but protobuf not enabled on this locator.");
-      socket.close();
-      return;
-    }
-
-    try {
-      ClientProtocolService clientProtocolService = clientProtocolServiceLoader.lookupService();
-      clientProtocolService.initializeStatistics("LocatorStats",
-          internalLocator.getDistributedSystem());
-      try (ClientProtocolProcessor pipeline = clientProtocolService.createProcessorForLocator(
-          internalLocator, internalLocator.getCache().getSecurityService())) {
-        while (!pipeline.socketProcessingIsFinished()) {
-          pipeline.processMessage(input, socket.getOutputStream());
-        }
-      } catch (IncompatibleVersionException e) {
-        // should not happen on the locator as there is no handshake.
-        log.error("Unexpected exception in client message processing", e);
-      }
-    } catch (ServiceLoadingFailureException e) {
-      log.error("There was an error looking up the client protocol service", e);
-      socket.close();
-      throw new IOException("There was an error looking up the client protocol service", e);
-    } catch (ServiceVersionNotFoundException e) {
-      log.error("Unable to find service matching the client protocol version byte", e);
-      socket.close();
-      throw new IOException("Unable to find service matching the client protocol version byte", e);
+      logger
+          .debug("exception in sending reply to process using unknown protocol " + gossipVersion,
+              e);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.PoolStatHelper;
+import org.apache.geode.distributed.internal.ProtocolCheckerImpl;
 import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.cache.client.protocol.ClientProtocolServiceLoader;
@@ -41,6 +42,6 @@ public class TcpServerFactory {
       String threadName, InternalLocator internalLocator) {
 
     return new TcpServer(port, bind_address, sslConfig, cfg, handler, poolHelper,
-        threadName, internalLocator, clientProtocolServiceLoader);
+        threadName, new ProtocolCheckerImpl(internalLocator, clientProtocolServiceLoader));
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocator.java
@@ -26,8 +26,8 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
@@ -37,7 +37,7 @@ import org.apache.geode.management.AlreadyRunningException;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.JmxManagerAdvisor.JmxManagerProfile;
 
-public class JmxManagerLocator implements TcpHandler {
+public class JmxManagerLocator implements RestartableTcpHandler {
   private static final Logger logger = LogService.getLogger();
 
   private InternalCacheForClientAccess cache;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/handlers/ClusterManagementServiceInfoRequestHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/handlers/ClusterManagementServiceInfoRequestHandler.java
@@ -24,7 +24,7 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
@@ -32,7 +32,7 @@ import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.management.internal.configuration.messages.ClusterManagementServiceInfo;
 import org.apache.geode.management.internal.configuration.messages.ClusterManagementServiceInfoRequest;
 
-public class ClusterManagementServiceInfoRequestHandler implements TcpHandler {
+public class ClusterManagementServiceInfoRequestHandler implements RestartableTcpHandler {
   @Override
   public Object processRequest(Object request) throws IOException {
     if (!(request instanceof ClusterManagementServiceInfoRequest)) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/handlers/SharedConfigurationStatusRequestHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/handlers/SharedConfigurationStatusRequestHandler.java
@@ -20,11 +20,11 @@ import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
+import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.management.internal.configuration.messages.SharedConfigurationStatusRequest;
 
-public class SharedConfigurationStatusRequestHandler implements TcpHandler {
+public class SharedConfigurationStatusRequestHandler implements RestartableTcpHandler {
 
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
@@ -29,21 +29,11 @@ import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.SystemFailure;
-import org.apache.geode.cache.GemFireCache;
-import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.DistributionStats;
-import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.internal.GemFireVersion;
-import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.internal.cache.client.protocol.ClientProtocolProcessor;
-import org.apache.geode.internal.cache.client.protocol.ClientProtocolService;
-import org.apache.geode.internal.cache.client.protocol.ClientProtocolServiceLoader;
-import org.apache.geode.internal.cache.tier.CommunicationMode;
 import org.apache.geode.internal.logging.CoreLoggingExecutors;
 import org.apache.geode.internal.logging.LogService;
 import org.apache.geode.internal.logging.LoggingExecutors;
@@ -80,19 +70,11 @@ public class TcpServerDependenciesTest {
               .or(type(DataSerializable.class))
 
               // TODO - TCP socket related classes
-              .or(type(CommunicationMode.class))
               .or(type(SocketCreator.class))
               .or(type(SSLConfigurationFactory.class))
               .or(type(SecurableCommunicationChannel.class))
               .or(type(SocketCreatorFactory.class))
               .or(type(SSLConfigurationFactory.class))
-
-              // TODO - client protocol service
-              .or(type(ClientProtocolServiceLoader.class))
-              .or(type(ClientProtocolService.class))
-              .or(type(ClientProtocolProcessor.class))
-
-
 
               // TODO - stats
               .or(type(DistributionStats.class))
@@ -109,12 +91,6 @@ public class TcpServerDependenciesTest {
 
 
               // TODO - god classes
-              .or(type(DistributedSystem.class))
-              .or(type(InternalConfigurationPersistenceService.class))
-              .or(type(GemFireCache.class))
-              .or(type(InternalLocator.class))
-              .or(type(InternalCache.class))
-              .or(type(InternalDistributedSystem.class))
               .or(type(SystemFailure.class))
 
               // TODO - version class? Version.java is in serialization, what is


### PR DESCRIPTION
- Removed DistributedSystem, GemFireCache,
  InternalConfiguratinPersistenceService dependencies that were used in the
  restarting method. Now there is a RestartableTcpHandler that lives inside core
  and extends TcpHandler. Core directly calls restarting on the
  RestartableTcpHandler.
- Extracted ProtocolChecker interface to remove Protobuf dependency.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
