### PR TITLE
GEODE-7350: Do not suspect hydra.MasterDescription.master.locators={}

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/LogConsumer.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/LogConsumer.java
@@ -25,6 +25,7 @@ import static org.apache.geode.test.greplogs.Patterns.EXCEPTION;
 import static org.apache.geode.test.greplogs.Patterns.EXCEPTION_2;
 import static org.apache.geode.test.greplogs.Patterns.EXCEPTION_3;
 import static org.apache.geode.test.greplogs.Patterns.EXCEPTION_4;
+import static org.apache.geode.test.greplogs.Patterns.HYDRA_MASTER_LOCATORS_WILDCARD;
 import static org.apache.geode.test.greplogs.Patterns.IGNORED_EXCEPTION;
 import static org.apache.geode.test.greplogs.Patterns.JAVA_LANG_ERROR;
 import static org.apache.geode.test.greplogs.Patterns.LOG_STATEMENT;
@@ -165,6 +166,7 @@ public class LogConsumer {
         JAVA_LANG_ERROR.matcher(line).find() ||
         MALFORMED_I18N_MESSAGE.matcher(line).find() ||
         MALFORMED_LOG4J_MESSAGE.matcher(line).find()) &&
+        !(HYDRA_MASTER_LOCATORS_WILDCARD.matcher(line).find()) &&
         !(WARN_OR_LESS_LOG_LEVEL.matcher(line).find() &&
             RVV_BIT_SET_MESSAGE.matcher(line).find());
   }

--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/Patterns.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/Patterns.java
@@ -56,7 +56,9 @@ public enum Patterns {
   /** RegionVersionVector bit set message */
   RVV_BIT_SET_MESSAGE(compile("RegionVersionVector.+bsv\\d+.+bs=\\{\\d+\\}")),
   /** "{}" literal which is probably unused Log4J parameter */
-  MALFORMED_LOG4J_MESSAGE(compile("\\{\\}"));
+  MALFORMED_LOG4J_MESSAGE(compile("\\{\\}")),
+  /** "{}" literal used for hydra master locators wildcard */
+  HYDRA_MASTER_LOCATORS_WILDCARD(compile("hydra\\.MasterDescription\\.master\\.locators=\\{\\}"));
 
   private final Pattern pattern;
 

--- a/geode-dunit/src/test/java/org/apache/geode/test/greplogs/LogConsumerTest.java
+++ b/geode-dunit/src/test/java/org/apache/geode/test/greplogs/LogConsumerTest.java
@@ -143,4 +143,14 @@ public class LogConsumerTest {
 
     assertThat(value).contains(line);
   }
+
+  @Test
+  public void closeReturnsNullIfLineContainsHydraMasterLocatorsWildcard() {
+    String line = "hydra.MasterDescription.master.locators={}";
+    logConsumer.consume(line);
+
+    StringBuilder value = logConsumer.close();
+
+    assertThat(value).isNull();
+  }
 }


### PR DESCRIPTION
This prevents "hydra.MasterDescription.master.locators={}" from being suspected as a malformed log4j message.