### PR TITLE
GEODE-7357: Updating the documentation for member-timeout

### DIFF
--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -432,11 +432,13 @@ See <a href="../../configuring/cluster_config/using_member_groups.html">Using Me
 </tr>
 <tr>
 <td>member-timeout</td>
-<td><%=vars.product_name%> uses the <code class="ph codeph">member-timeout</code> server configuration, specified in milliseconds, to detect the abnormal termination of members. <%=vars.product_name%> members use a combination of UDP heartbeat messages and TCP sockets to monitor the health of other members. If a member is suspected to be unreachable, two active checks of the member are performed. Each of those checks waits a maximum of one <code class="ph codeph">member-timeout</code>. If those health checks receive a connection failure or no response within the timeout, the member is considered dead and is removed from the list of members.
+<td><%=vars.product_name%> uses the <code class="ph codeph">member-timeout</code> server configuration, specified in milliseconds, to detect unresponsive members.
+
+<%=vars.product_name%> members use a combination of UDP heartbeat messages and TCP sockets to monitor the health of other members. If a member is suspected to be unreachable, two active checks of the member are performed. Each of those checks waits a maximum of one <code class="ph codeph">member-timeout</code>. If those health checks receive a connection failure or no response within the timeout, the member is considered dead and is removed from the list of members.
 
 This setting also controls how frequently heartbeat messages are sent. They are sent at a frequency of half the <code class="ph codeph">member-timeout</code>.
 
-The total time it takes to remove a member that is not responding to any network traffic is therefore 2 to 3 times the <code class="ph codeph">member-timeout</code>. This is not the minimum time it takes to remove a member. If the Java process has crashed but the operating system can still return a connection failure response to the health checks, the crashed member may be removed immediately. 
+The total time it takes to remove a member that is not responding to any network traffic is therefore 2 to 3 times the <code class="ph codeph">member-timeout</code>. This is not the minimum time it takes to remove a member from the list of members in the cluster. If the Java process has crashed, but the operating system can still return a connection failure response to the health checks, the crashed member may be removed from the membership list immediately.
 
 <p>Valid values are in the range 1000..600000.</p></td>
 <td>S, L</td>

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -432,11 +432,11 @@ See <a href="../../configuring/cluster_config/using_member_groups.html">Using Me
 </tr>
 <tr>
 <td>member-timeout</td>
-<td><%=vars.product_name%> uses the <code class="ph codeph">member-timeout</code> server configuration, specified in milliseconds, to detect the abnormal termination of members. Geode members use a combination of UDP heartbeat messages and tcp sockets to monitor the health of other members. If a member is suspected to be unreachable two active checks of the member will be performed. Each of those checks will wait a maximum of one <code class="ph codeph">member-timeout</code>. If those health checks receive a connection failure or no response within the timeout, the member will be considered dead and removed from the list of members.
+<td><%=vars.product_name%> uses the <code class="ph codeph">member-timeout</code> server configuration, specified in milliseconds, to detect the abnormal termination of members. <%=vars.product_name%> members use a combination of UDP heartbeat messages and TCP sockets to monitor the health of other members. If a member is suspected to be unreachable, two active checks of the member are performed. Each of those checks waits a maximum of one <code class="ph codeph">member-timeout</code>. If those health checks receive a connection failure or no response within the timeout, the member is considered dead and is removed from the list of members.
 
 This setting also controls how frequently heartbeat messages are sent. They are sent at a frequency of half the <code class="ph codeph">member-timeout</code>.
 
-The total time it will take to remove a member that is not responding to any network traffic is therefore 2 to 3 times the <code class="ph codeph">member-timeout</code>. This is not the mimimum time it will take to remove a member. If the java process has crashed but the operating system can still return a connection failure response to the health checks the crashed member may be removed immediately. 
+The total time it takes to remove a member that is not responding to any network traffic is therefore 2 to 3 times the <code class="ph codeph">member-timeout</code>. This is not the minimum time it takes to remove a member. If the Java process has crashed but the operating system can still return a connection failure response to the health checks, the crashed member may be removed immediately. 
 
 <p>Valid values are in the range 1000..600000.</p></td>
 <td>S, L</td>

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -432,7 +432,12 @@ See <a href="../../configuring/cluster_config/using_member_groups.html">Using Me
 </tr>
 <tr>
 <td>member-timeout</td>
-<td><%=vars.product_name%> uses the <code class="ph codeph">member-timeout</code> server configuration, specified in milliseconds, to detect the abnormal termination of members. The configuration setting is used in two ways: 1) First it is used during the UDP heartbeat detection process. When a member detects that a heartbeat datagram is missing from the member that it is monitoring after the time interval of 2 * the value of <code class="ph codeph">member-timeout</code>, the detecting member attempts to form a TCP/IP stream-socket connection with the monitored member as described in the next case. 2) The property is then used again during the TCP/IP stream-socket connection. If the suspected process does not respond to the <em>are you alive</em> datagram within the time period specified in <code class="ph codeph">member-timeout</code>, the membership coordinator sends out a new membership view that notes the member's failure.
+<td><%=vars.product_name%> uses the <code class="ph codeph">member-timeout</code> server configuration, specified in milliseconds, to detect the abnormal termination of members. Geode members use a combination of UDP heartbeat messages and tcp sockets to monitor the health of other members. If a member is suspected to be unreachable two active checks of the member will be performed. Each of those checks will wait a maximum of one <code class="ph codeph">member-timeout</code>. If those health checks receive a connection failure or no response within the timeout, the member will be considered dead and removed from the list of members.
+
+This setting also controls how frequently heartbeat messages are sent. They are sent at a frequency of half the <code class="ph codeph">member-timeout</code>.
+
+The total time it will take to remove a member that is not responding to any network traffic is therefore 2 to 3 times the <code class="ph codeph">member-timeout</code>. This is not the mimimum time it will take to remove a member. If the java process has crashed but the operating system can still return a connection failure response to the health checks the crashed member may be removed immediately. 
+
 <p>Valid values are in the range 1000..600000.</p></td>
 <td>S, L</td>
 <td>5000</td>


### PR DESCRIPTION
Rewriting the documentation for the member-timeout property. The old
documentation did to accurately describe the health check process or the
amount of time it would take to remove an unresponsive member.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
