### PR TITLE
GEODE-7360: Fix Flaky Cq Security Test

### DIFF
--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/internal/CqSecurityExecutionContextTamperingDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/internal/CqSecurityExecutionContextTamperingDistributedTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.cache.query.cq.internal;
 import static org.apache.geode.cache.RegionShortcut.PARTITION;
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
@@ -128,10 +129,12 @@ public class CqSecurityExecutionContextTamperingDistributedTest implements Seria
     });
 
     client.invoke(() -> {
-      assertThat(CqSecurityExecutionContextTamperingDistributedTest.cqListener.getNumEvents())
-          .isEqualTo(0);
-      assertThat(CqSecurityExecutionContextTamperingDistributedTest.cqListener.getNumErrors())
-          .isEqualTo(1);
+      await().untilAsserted(() -> assertThat(
+          CqSecurityExecutionContextTamperingDistributedTest.cqListener.getNumEvents())
+              .isEqualTo(0));
+      await().untilAsserted(() -> assertThat(
+          CqSecurityExecutionContextTamperingDistributedTest.cqListener.getNumErrors())
+              .isEqualTo(1));
     });
   }
 }


### PR DESCRIPTION
- Use 'await().untilAsserted()' instead of direct assertion when
  checking amount of events and errors received by the CQListerer.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
