### PR TITLE
GEODE-7365: increase DistributedTest timeout by 45m (to 3h)

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -89,10 +89,10 @@ tests:
   RAM: '12'
   name: Acceptance
 - ARTIFACT_SLUG: distributedtestfiles
-  CALL_STACK_TIMEOUT: '7200'
+  CALL_STACK_TIMEOUT: '9900'
   CPUS: '96'
   DUNIT_PARALLEL_FORKS: '24'
-  EXECUTE_TEST_TIMEOUT: 2h15m
+  EXECUTE_TEST_TIMEOUT: 3h00m
   GRADLE_TASK: distributedTest
   PARALLEL_DUNIT: 'true'
   PLATFORM: linux


### PR DESCRIPTION
this will hopefully alleviate timeouts such as https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/DistributedTestOpenJDK8/builds/1231