### PR TITLE
GEODE-6973: The pdxRegion.size() should be called outside of TX conte…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
@@ -359,7 +359,7 @@ public class PeerTypeRegistration implements TypeRegistration {
     }
     lock();
     try {
-      if (reverseMap.shouldReloadFromRegion(getIdToType())) {
+      if (shouldReload()) {
         buildReverseMapsFromRegion();
       }
       reverseMap.flushPendingReverseMap();
@@ -629,6 +629,17 @@ public class PeerTypeRegistration implements TypeRegistration {
     }
   }
 
+  boolean shouldReload() {
+    boolean shouldReload = false;
+    TXStateProxy currentState = suspendTX();
+    try {
+      shouldReload = reverseMap.shouldReloadFromRegion(getIdToType());
+    } finally {
+      resumeTX(currentState);
+    }
+    return shouldReload;
+  }
+
   @Override
   public int defineEnum(final EnumInfo newInfo) {
     statistics.enumDefined();
@@ -639,7 +650,7 @@ public class PeerTypeRegistration implements TypeRegistration {
     }
     lock();
     try {
-      if (reverseMap.shouldReloadFromRegion(getIdToType())) {
+      if (shouldReload()) {
         buildReverseMapsFromRegion();
       }
       reverseMap.flushPendingReverseMap();


### PR DESCRIPTION
…xt to avoid messaging.

  Co-authored-by: Anil <agingade@pivotal.io>
  Co-authored-by: Xiaojian Zhou <gzhou@pivotal.io>
  Co-authored-by: Donal Evans <doevans@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
