### PR TITLE
GEODE-7370: Upgrade ClassGraph to 4.8.52

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -202,7 +202,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.0.6</version>
+        <version>4.8.52</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -111,7 +111,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'commons-logging', name: 'commons-logging', version: '1.2')
         api(group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1')
         api(group: 'commons-validator', name: 'commons-validator', version: get('commons-validator.version'))
-        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.0.6')
+        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.52')
         api(group: 'io.micrometer', name: 'micrometer-core', version: get('micrometer.version'))
         api(group: 'io.netty', name: 'netty-all', version: '4.1.31.Final')
         api(group: 'it.unimi.dsi', name: 'fastutil', version: get('fastutil.version'))

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -938,7 +938,7 @@ lib/HdrHistogram-2.1.11.jar
 lib/HikariCP-3.2.0.jar
 lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
-lib/classgraph-4.0.6.jar
+lib/classgraph-4.8.52.jar
 lib/commons-beanutils-1.9.3.jar
 lib/commons-codec-1.10.jar
 lib/commons-collections-3.2.2.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -42,7 +42,7 @@ commons-io-2.6.jar
 spring-core-4.3.23.RELEASE.jar
 httpclient-4.5.6.jar
 commons-logging-1.2.jar
-classgraph-4.0.6.jar
+classgraph-4.8.52.jar
 micrometer-core-1.2.0.jar
 fastutil-8.2.2.jar
 javax.resource-api-1.7.1.jar


### PR DESCRIPTION
Upgrading ClassGraph from 4.0.6 to 4.8.52 fixes a memory leak that
appeared after introducing geode-log4j even though logging does not
use ClassGraph.