### PR TITLE
GEODE-7367: Unignored Tomcat7079WithOldModulesMixedWithCurrentCanDoPutFromCurrentModuleTest

### DIFF
--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWithCurrentCanDoPutFromCurrentModuleTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWithCurrentCanDoPutFromCurrentModuleTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.session.tests;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.Parameterized;
 
@@ -29,7 +28,6 @@ public class TomcatSessionBackwardsCompatibilityTomcat7079WithOldModulesMixedWit
     super(version);
   }
 
-  @Ignore // GEODE-7336 addressing failures in upgradeTests
   @Test
   public void test() throws Exception {
     startClusterWithTomcat(classPathTomcat7079);


### PR DESCRIPTION
Co-authored-by: Donal Evans <doevans@pivotal.io>
Co-authored-by: Benjamin Ross <bross@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
