### PR TITLE
GEODE-7374: Fix class cast exception

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/MemberCommandService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/remote/MemberCommandService.java
@@ -21,6 +21,8 @@ import org.apache.geode.management.cli.CommandService;
 import org.apache.geode.management.cli.CommandServiceException;
 import org.apache.geode.management.cli.CommandStatement;
 import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.result.CommandResult;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
 
 /**
  * @deprecated since 1.3 use OnlineCommandProcessor directly
@@ -49,7 +51,8 @@ public class MemberCommandService extends CommandService {
 
   @Override
   public Result processCommand(String commandString, Map<String, String> env) {
-    return (Result) onlineCommandProcessor.executeCommand(commandString, env, null);
+    ResultModel resultModel = onlineCommandProcessor.executeCommand(commandString, env, null);
+    return new CommandResult(resultModel);
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/remote/MemberCommandServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/remote/MemberCommandServiceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.remote;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.management.cli.Result;
+
+public class MemberCommandServiceTest {
+  private InternalCache cache;
+
+  @Before
+  public void init() {
+    cache = mock(InternalCache.class);
+    DistributedSystem distributedSystem = mock(DistributedSystem.class);
+    SecurityService securityService = mock(SecurityService.class);
+    Properties cacheProperties = new Properties();
+
+    when(cache.getDistributedSystem()).thenReturn(distributedSystem);
+    when(cache.isClosed()).thenReturn(true);
+    when(cache.getSecurityService()).thenReturn(securityService);
+    when(distributedSystem.getProperties()).thenReturn(cacheProperties);
+  }
+
+  @Test
+  public void processCommandError() throws Exception {
+    MemberCommandService memberCommandService = new MemberCommandService(cache);
+
+    Result result = memberCommandService.processCommand("fake command");
+
+    assertThat(result.getStatus()).isEqualTo(Result.Status.ERROR);
+  }
+}


### PR DESCRIPTION
Authored-by: Joris Melchior <joris.melchior@gmail.com>

Added test to replicate the issue and fixed code so that `ResultModel` is wrapped in `CommandResult` to fix the issue

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
