### PR TITLE
GEODE-7375: Fix metrics test port allocation

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/CacheGetsTimerTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/CacheGetsTimerTest.java
@@ -315,10 +315,11 @@ public class CacheGetsTimerTest {
 
   private void startCluster(boolean enableTimeStatistics, boolean enableSecurity)
       throws IOException {
-    int[] availablePorts = getRandomAvailableTCPPorts(2);
+    int[] availablePorts = getRandomAvailableTCPPorts(3);
 
     locatorPort = availablePorts[0];
-    int serverPort = availablePorts[1];
+    int locatorJmxPort = availablePorts[1];
+    int serverPort = availablePorts[2];
 
     Path serviceJarPath = serviceJarRule.createJarFor("metrics-publishing-service.jar",
         MetricsPublishingService.class, SimpleMetricsPublishingService.class);
@@ -333,6 +334,8 @@ public class CacheGetsTimerTest {
         "--name=" + "locator",
         "--dir=" + temporaryFolder.newFolder("locator").getAbsolutePath(),
         "--port=" + locatorPort,
+        "--http-service-port=0",
+        "--J=-Dgemfire.jmx-manager-port=" + locatorJmxPort,
         "--classpath=" + helpersJarPath);
 
     String serverName = "server";

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/GatewayReceiverMetricsTest.java
@@ -68,7 +68,7 @@ public class GatewayReceiverMetricsTest {
 
   @Before
   public void startClusters() throws IOException {
-    int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(8);
+    int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(6);
 
     receiverLocatorPort = ports[0];
     senderLocatorPort = ports[1];
@@ -76,8 +76,6 @@ public class GatewayReceiverMetricsTest {
     int receiverServerPort = ports[3];
     int senderLocatorJmxPort = ports[4];
     int receiverLocatorJmxPort = ports[5];
-    int senderLocatorHttpPort = ports[6];
-    int receiverLocatorHttpPort = ports[7];
 
     int senderSystemId = 2;
     int receiverSystemId = 1;
@@ -93,10 +91,10 @@ public class GatewayReceiverMetricsTest {
         "--dir=" + senderLocatorFolder,
         "--port=" + senderLocatorPort,
         "--locators=localhost[" + senderLocatorPort + "]",
+        "--http-service-port=0",
         "--J=-Dgemfire.remote-locators=localhost[" + receiverLocatorPort + "]",
         "--J=-Dgemfire.distributed-system-id=" + senderSystemId,
         "--J=-Dgemfire.jmx-manager-start=true",
-        "--J=-Dgemfire.jmx-manager-http-port=" + senderLocatorHttpPort,
         "--J=-Dgemfire.jmx-manager-port=" + senderLocatorJmxPort);
 
     String startReceiverLocatorCommand = String.join(GFSH_COMMAND_SEPARATOR,
@@ -105,10 +103,10 @@ public class GatewayReceiverMetricsTest {
         "--dir=" + receiverLocatorFolder,
         "--port=" + receiverLocatorPort,
         "--locators=localhost[" + receiverLocatorPort + "]",
+        "--http-service-port=0",
         "--J=-Dgemfire.remote-locators=localhost[" + senderLocatorPort + "]",
         "--J=-Dgemfire.distributed-system-id=" + receiverSystemId,
         "--J=-Dgemfire.jmx-manager-start=true ",
-        "--J=-Dgemfire.jmx-manager-http-port=" + receiverLocatorHttpPort,
         "--J=-Dgemfire.jmx-manager-port=" + receiverLocatorJmxPort);
 
     String startSenderServerCommand = String.join(GFSH_COMMAND_SEPARATOR,

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/MicrometerBinderTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/MicrometerBinderTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.metrics;
 
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.test.compiler.ClassBuilder.writeJarFromClasses;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,7 +41,6 @@ import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.rules.ServiceJarRule;
 import org.apache.geode.test.junit.rules.gfsh.GfshRule;
 
@@ -64,7 +64,7 @@ public class MicrometerBinderTest {
   public void startServer() throws IOException {
     serverFolder = temporaryFolder.getRoot().toPath().toAbsolutePath();
 
-    int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(2);
+    int[] ports = getRandomAvailableTCPPorts(2);
 
     int serverPort = ports[0];
     int jmxRmiPort = ports[1];
@@ -78,6 +78,7 @@ public class MicrometerBinderTest {
         "--dir=" + serverFolder,
         "--server-port=" + serverPort,
         "--classpath=" + serviceJarPath,
+        "--http-service-port=0",
         "--J=-Dgemfire.enable-cluster-config=true",
         "--J=-Dgemfire.jmx-manager=true",
         "--J=-Dgemfire.jmx-manager-start=true",

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerLonerTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerLonerTest.java
@@ -213,6 +213,7 @@ public class FunctionExecutionsTimerLonerTest {
         "--server-port=" + serverPort,
         "--classpath=" + serviceJarPath + pathSeparatorChar + functionHelpersJarPath,
         "--enable-time-statistics=" + enableTimeStatistics,
+        "--http-service-port=0",
         "--J=-Dgemfire.enable-cluster-config=true",
         "--J=-Dgemfire.jmx-manager=true",
         "--J=-Dgemfire.jmx-manager-start=true",
@@ -231,8 +232,13 @@ public class FunctionExecutionsTimerLonerTest {
   }
 
   private void closeClientAndPool() {
-    serverPool.destroy();
-    clientCache.close();
+    if (serverPool != null) {
+      serverPool.destroy();
+    }
+
+    if (clientCache != null) {
+      clientCache.close();
+    }
   }
 
   private void stopServer() {

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerNoResultTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/metrics/function/executions/FunctionExecutionsTimerNoResultTest.java
@@ -69,10 +69,11 @@ public class FunctionExecutionsTimerNoResultTest {
 
   @Before
   public void setUp() throws IOException {
-    int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
+    int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(3);
 
     locatorPort = availablePorts[0];
-    int serverPort = availablePorts[1];
+    int locatorJmxPort = availablePorts[1];
+    int serverPort = availablePorts[2];
 
     Path serviceJarPath = serviceJarRule.createJarFor("metrics-publishing-service.jar",
         MetricsPublishingService.class, SimpleMetricsPublishingService.class);
@@ -87,7 +88,9 @@ public class FunctionExecutionsTimerNoResultTest {
         "start locator",
         "--name=" + "locator",
         "--dir=" + temporaryFolder.newFolder("locator").getAbsolutePath(),
-        "--port=" + locatorPort);
+        "--port=" + locatorPort,
+        "--http-service-port=0",
+        "--J=-Dgemfire.jmx-manager-port=" + locatorJmxPort);
 
     String serverName = "server1";
     String startServerCommand =

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/GfshExecution.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/gfsh/GfshExecution.java
@@ -38,6 +38,10 @@ import org.apache.geode.test.junit.rules.gfsh.internal.ProcessLogger;
 
 public class GfshExecution {
   private static final String DOUBLE_QUOTE = "\"";
+  private static final String SCRIPT_TIMEOUT_FAILURE_MESSAGE =
+      "Process started by [%s] did not exit after %s %s";
+  private static final String SCRIPT_EXIT_VALUE_DESCRIPTION =
+      "Exit value from process started by [%s]";
 
   private final Process process;
   private final File workingDir;
@@ -124,9 +128,13 @@ public class GfshExecution {
     boolean exited = process.waitFor(script.getTimeout(), script.getTimeoutTimeUnit());
 
     try {
-      assertThat(exited).describedAs("Process of [" + script.toString() + "] did not exit after "
-          + script.getTimeout() + " " + script.getTimeoutTimeUnit().toString()).isTrue();
-      assertThat(process.exitValue()).isEqualTo(script.getExpectedExitValue());
+      assertThat(exited)
+          .withFailMessage(SCRIPT_TIMEOUT_FAILURE_MESSAGE, script, script.getTimeout(),
+              script.getTimeoutTimeUnit())
+          .isTrue();
+      assertThat(process.exitValue())
+          .as(SCRIPT_EXIT_VALUE_DESCRIPTION, script)
+          .isEqualTo(script.getExpectedExitValue());
     } catch (AssertionError error) {
       printLogFiles();
       throw error;


### PR DESCRIPTION
Some metrics acceptance tests uses hard-coded ports, and others used
default ports for various processes. This caused failures in CI on
Windows.

These tests have been updated to allocate random ports.

Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [N/A] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

Please review @aaronlindsey 