### PR TITLE
GEODE-7365: Increase AcceptanceTest timeout by 30m to 1h30m

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -78,10 +78,10 @@ tests:
   RAM: '16'
   name: Unit
 - ARTIFACT_SLUG: acceptancetestfiles
-  CALL_STACK_TIMEOUT: '1800'
+  CALL_STACK_TIMEOUT: '4500'
   CPUS: '8'
   DUNIT_PARALLEL_FORKS: '0'
-  EXECUTE_TEST_TIMEOUT: 1h
+  EXECUTE_TEST_TIMEOUT: 1h30m
   GRADLE_TASK: acceptanceTest
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'


### PR DESCRIPTION
AcceptanceTest has started timing out a lot, with no apparent hang, just tests are still running.  Successful runs were coming in just barely under the timeout.  This increases the timeout to give acceptance tests more time to finish.