### PR TITLE
GEODE-7358: Remove TcpServer's dependencies on GemFireVersion

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -45,8 +45,8 @@ import org.mockito.stubbing.Answer;
 
 import org.apache.geode.DataSerializable;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.distributed.internal.InfoRequestHandler;
 import org.apache.geode.distributed.internal.PoolStatHelper;
-import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -81,21 +81,20 @@ public class TcpServerJUnitTest {
   }
 
   @Test
-  public void test() throws Exception {
-    EchoHandler handler = new EchoHandler();
+  public void testClientGetInfo() throws Exception {
+    TcpHandler handler = new InfoRequestHandler();
     start(handler);
 
     TcpClient tcpClient = new TcpClient();
 
-    TestObject test = new TestObject();
-    test.id = 5;
-    TestObject result =
-        (TestObject) tcpClient.requestToServer(localhost, port, test, 60 * 1000);
-    assertEquals(test.id, result.id);
+    InfoRequest testInfoRequest = new InfoRequest();
+    InfoResponse testInfoResponse =
+        (InfoResponse) tcpClient.requestToServer(localhost, port, testInfoRequest, 60 * 1000);
+    assertTrue(testInfoResponse.getInfo()[0].contains("geode-core"));
 
-    String[] info = tcpClient.getInfo(localhost, port);
-    assertNotNull(info);
-    assertTrue(info.length > 1);
+    String[] requrestedInfo = tcpClient.getInfo(localhost, port);
+    assertNotNull(requrestedInfo);
+    assertTrue(requrestedInfo.length > 1);
 
     try {
       tcpClient.stop(localhost, port);
@@ -104,7 +103,6 @@ public class TcpServerJUnitTest {
     }
     server.join(60 * 1000);
     assertFalse(server.isAlive());
-    assertTrue(handler.shutdown);
 
     assertEquals(4, stats.started.get());
     assertEquals(4, stats.ended.get());
@@ -162,7 +160,7 @@ public class TcpServerJUnitTest {
       ClassNotFoundException, InterruptedException {
     // Initially mock the handler to throw a SocketException. We want to verify that the server
     // can recover and serve new client requests after a SocketException is thrown.
-    RestartableTcpHandler mockTcpHandler = mock(RestartableTcpHandler.class);
+    TcpHandler mockTcpHandler = mock(TcpHandler.class);
     doThrow(SocketException.class).when(mockTcpHandler).processRequest(any(Object.class));
     start(mockTcpHandler);
 
@@ -190,9 +188,6 @@ public class TcpServerJUnitTest {
         (TestObject) tcpClient.requestToServer(localhost, port, test, 60 * 1000);
 
     assertEquals(test.id, result.id);
-    String[] info = tcpClient.getInfo(localhost, port);
-    assertNotNull(info);
-    assertTrue(info.length > 1);
 
     try {
       tcpClient.stop(localhost, port);
@@ -202,8 +197,8 @@ public class TcpServerJUnitTest {
     server.join(60 * 1000);
     assertFalse(server.isAlive());
 
-    assertEquals(5, stats.started.get());
-    assertEquals(5, stats.ended.get());
+    assertEquals(4, stats.started.get());
+    assertEquals(4, stats.ended.get());
   }
 
   private static class TestObject implements DataSerializable {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InfoRequestHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InfoRequestHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.tcpserver.InfoResponse;
+import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+import org.apache.geode.internal.GemFireVersion;
+
+public class InfoRequestHandler implements RestartableTcpHandler {
+  public InfoRequestHandler() {}
+
+  @Override
+  public void restarting(final DistributedSystem ds, final GemFireCache cache,
+      final InternalConfigurationPersistenceService sharedConfig) {
+
+  }
+
+  @Override
+  public Object processRequest(final Object request) throws IOException {
+    String[] info = new String[2];
+    info[0] = System.getProperty("user.dir");
+
+    URL url = GemFireVersion.getJarURL();
+    if (url == null) {
+      String s = "Could not find gemfire jar";
+      throw new IllegalStateException(s);
+    }
+
+    File gemfireJar = new File(url.getPath());
+    File lib = gemfireJar.getParentFile();
+    File product = lib.getParentFile();
+    info[1] = product.getAbsolutePath();
+
+    return new InfoResponse(info);
+  }
+
+  @Override
+  public void endRequest(final Object request, final long startTime) {
+
+  }
+
+  @Override
+  public void endResponse(final Object request, final long startTime) {
+
+  }
+
+  @Override
+  public void shutDown() {
+
+  }
+
+  @Override
+  public void init(final TcpServer tcpServer) {
+
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -65,6 +65,7 @@ import org.apache.geode.distributed.internal.membership.NetLocatorFactory;
 import org.apache.geode.distributed.internal.membership.QuorumChecker;
 import org.apache.geode.distributed.internal.membership.adapter.GMSMembershipManager;
 import org.apache.geode.distributed.internal.membership.gms.locator.PeerLocatorRequest;
+import org.apache.geode.distributed.internal.tcpserver.InfoRequest;
 import org.apache.geode.distributed.internal.tcpserver.LocatorCancelException;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
@@ -523,6 +524,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       locatorListener.setConfig(getConfig());
     }
     handler = new PrimaryHandler(this, locatorListener);
+    handler.addHandler(InfoRequest.class, new InfoRequestHandler());
 
     locatorStats = new LocatorStats();
 
@@ -842,6 +844,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     handler.addHandler(ClientReplacementRequest.class, serverLocator);
     handler.addHandler(GetAllServersRequest.class, serverLocator);
     handler.addHandler(LocatorStatusRequest.class, serverLocator);
+
     this.serverLocator = serverLocator;
     if (!server.isAlive()) {
       startTcpServer();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -17,7 +17,6 @@ package org.apache.geode.distributed.internal.tcpserver;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
-import java.io.File;
 import java.io.IOException;
 import java.io.StreamCorruptedException;
 import java.net.InetAddress;
@@ -26,7 +25,6 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.net.URL;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -46,7 +44,6 @@ import org.apache.geode.SystemFailure;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
-import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -445,8 +442,6 @@ public class TcpServer {
         // Closing the socket will cause our acceptor thread to shutdown the executor
         srv_sock.close();
         response = new ShutdownResponse();
-      } else if (request instanceof InfoRequest) {
-        response = handleInfoRequest(request);
       } else if (request instanceof VersionRequest) {
         response = handleVersionRequest(request);
       } else {
@@ -485,23 +480,7 @@ public class TcpServer {
     }
   }
 
-  protected Object handleInfoRequest(Object request) {
-    String[] info = new String[2];
-    info[0] = System.getProperty("user.dir");
 
-    URL url = GemFireVersion.getJarURL();
-    if (url == null) {
-      String s = "Could not find gemfire jar";
-      throw new IllegalStateException(s);
-    }
-
-    File gemfireJar = new File(url.getPath());
-    File lib = gemfireJar.getParentFile();
-    File product = lib.getParentFile();
-    info[1] = product.getAbsolutePath();
-
-    return new InfoResponse(info);
-  }
 
   protected Object handleVersionRequest(Object request) {
     VersionResponse response = new VersionResponse();

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
@@ -31,7 +31,6 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
-import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -84,9 +83,6 @@ public class TcpServerDependenciesTest {
               // TODO - god classes
               .or(type(SystemFailure.class))
 
-              // TODO - version class? Version.java is in serialization, what is
-              // GemFireVersion?
-              .or(type(GemFireVersion.class))
 
   );
 


### PR DESCRIPTION
- Creating a handler for TcpClient InfoRequests.
- Handler is added to the PrimaryHandler's list of handlers

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.