### PR TITLE
GEODE-7369: Deprecate SystemFailure Class

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/SystemFailure.java
+++ b/geode-core/src/main/java/org/apache/geode/SystemFailure.java
@@ -24,6 +24,12 @@ import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.logging.internal.executors.LoggingThread;
 
 /**
+ *
+ * @deprecated since Geode 1.11 since it is potentially counterproductive to try
+ * to mitigate a VirtualMachineError since the JVM (spec) makes no guarantees about the
+ * soundness of the JVM after such an error. In the presence of a VirtualMachineError,
+ * the simplest solution is really the only solution: exit the JVM as soon as possible.
+ *
  * Catches and responds to JVM failure
  * <p>
  * This class represents a catastrophic failure of the system, especially the Java virtual machine.
@@ -143,6 +149,7 @@ import org.apache.geode.logging.internal.executors.LoggingThread;
  *
  * @since GemFire 5.1
  */
+@Deprecated
 @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "DM_GC",
     justification = "This class performs System.gc as last ditch effort during out-of-memory condition.")
 public final class SystemFailure {

--- a/geode-core/src/main/java/org/apache/geode/SystemFailure.java
+++ b/geode-core/src/main/java/org/apache/geode/SystemFailure.java
@@ -25,11 +25,6 @@ import org.apache.geode.logging.internal.executors.LoggingThread;
 
 /**
  *
- * @deprecated since Geode 1.11 since it is potentially counterproductive to try
- * to mitigate a VirtualMachineError since the JVM (spec) makes no guarantees about the
- * soundness of the JVM after such an error. In the presence of a VirtualMachineError,
- * the simplest solution is really the only solution: exit the JVM as soon as possible.
- *
  * Catches and responds to JVM failure
  * <p>
  * This class represents a catastrophic failure of the system, especially the Java virtual machine.
@@ -148,6 +143,12 @@ import org.apache.geode.logging.internal.executors.LoggingThread;
  * </pre>
  *
  * @since GemFire 5.1
+ *
+ * @deprecated since Geode 1.11 because it is potentially counterproductive to try
+ *             to mitigate a VirtualMachineError since the JVM (spec) makes no guarantees about the
+ *             soundness of the JVM after such an error. In the presence of a VirtualMachineError,
+ *             the simplest solution is really the only solution: exit the JVM as soon as possible.
+ *
  */
 @Deprecated
 @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "DM_GC",


### PR DESCRIPTION
[GEODE-7369](https://issues.apache.org/jira/browse/GEODE-7369)

Deprecate SystemFailure class.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
