### PR TITLE
GEODE-7310: Aborting backup when member departs

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/IncrementalBackupDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/IncrementalBackupDistributedTest.java
@@ -40,6 +40,9 @@ import java.util.regex.Pattern;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.MembershipListener;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
@@ -80,6 +83,7 @@ public class IncrementalBackupDistributedTest implements Serializable {
 
   private static final int DATA_INCREMENT = 10_000;
   private static final RegexFileFilter OPLOG_FILTER = new RegexFileFilter(".*\\.[kdc]rf$");
+  private static BackupMembershipListener backupMembershipListener = new BackupMembershipListener();
 
   private int dataStart;
   private int dataEnd = dataStart + DATA_INCREMENT;
@@ -216,7 +220,7 @@ public class IncrementalBackupDistributedTest implements Serializable {
 
     // Shut down our member so we can perform a restore
     PersistentID id = vm1.invoke(() -> getPersistentID(diskStoreName1));
-    vm1.invoke(() -> cacheRule.closeAndWaitForLifecycleEvent());
+    vm1.invoke(() -> cacheRule.getCache().close());
 
     // Execute the restore
     performRestore(new File(id.getDirectory()),
@@ -261,12 +265,14 @@ public class IncrementalBackupDistributedTest implements Serializable {
   public void testMissingMemberInBaseline() {
     // Simulate the missing member by forcing a persistent member to go offline.
     PersistentID missingMember = vm0.invoke(() -> getPersistentID(diskStoreName1));
+    vm1.invoke(() ->installNewBackupMembershipListener());
+
     vm0.invoke(() -> {
-      cacheRule.closeAndWaitForLifecycleEvent();
+      cacheRule.getCache().close();
     });
 
     await()
-        .until(() -> vm1.invoke(() -> getMissingPersistentMembers().contains(missingMember)));
+        .until(() -> vm1.invoke(() -> getMissingPersistentMembers().contains(missingMember) && backupMembershipListener.hasMemberDeparted()));
 
     // Perform performBackupBaseline and make sure that list of offline disk stores contains our
     // missing member.
@@ -443,7 +449,7 @@ public class IncrementalBackupDistributedTest implements Serializable {
 
     // Shut down our member so we can perform a restore
     PersistentID id = vm0.invoke(() -> getPersistentID(diskStoreName1));
-    vm0.invoke(() -> cacheRule.closeAndWaitForLifecycleEvent());
+    vm0.invoke(() -> cacheRule.getCache().close());
 
     // Get the VM's user directory.
     String vmDir = vm0.invoke(() -> System.getProperty("user.dir"));
@@ -698,4 +704,24 @@ public class IncrementalBackupDistributedTest implements Serializable {
     }
   }
 
+  public static class BackupMembershipListener implements MembershipListener {
+    private boolean memberDeparted = false;
+
+    @Override
+    public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id, boolean crashed) {
+      memberDeparted = true;
+    }
+
+    public boolean hasMemberDeparted() {
+      return memberDeparted;
+    }
+  }
+
+  public void installNewBackupMembershipListener() {
+    if (backupMembershipListener != null) {
+      cacheRule.getCache().getDistributionManager().removeMembershipListener(backupMembershipListener);
+    }
+    backupMembershipListener = new BackupMembershipListener();
+    cacheRule.getCache().getDistributionManager().addMembershipListener(backupMembershipListener);
+  }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/IncrementalBackupDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/IncrementalBackupDistributedTest.java
@@ -216,7 +216,7 @@ public class IncrementalBackupDistributedTest implements Serializable {
 
     // Shut down our member so we can perform a restore
     PersistentID id = vm1.invoke(() -> getPersistentID(diskStoreName1));
-    vm1.invoke(() -> cacheRule.getCache().close());
+    vm1.invoke(() -> cacheRule.closeAndWaitForLifecycleEvent());
 
     // Execute the restore
     performRestore(new File(id.getDirectory()),
@@ -261,7 +261,9 @@ public class IncrementalBackupDistributedTest implements Serializable {
   public void testMissingMemberInBaseline() {
     // Simulate the missing member by forcing a persistent member to go offline.
     PersistentID missingMember = vm0.invoke(() -> getPersistentID(diskStoreName1));
-    vm0.invoke(() -> cacheRule.getCache().close());
+    vm0.invoke(() -> {
+      cacheRule.closeAndWaitForLifecycleEvent();
+    });
 
     await()
         .until(() -> vm1.invoke(() -> getMissingPersistentMembers().contains(missingMember)));
@@ -441,7 +443,7 @@ public class IncrementalBackupDistributedTest implements Serializable {
 
     // Shut down our member so we can perform a restore
     PersistentID id = vm0.invoke(() -> getPersistentID(diskStoreName1));
-    vm0.invoke(() -> cacheRule.getCache().close());
+    vm0.invoke(() -> cacheRule.closeAndWaitForLifecycleEvent());
 
     // Get the VM's user directory.
     String vmDir = vm0.invoke(() -> System.getProperty("user.dir"));
@@ -695,4 +697,5 @@ public class IncrementalBackupDistributedTest implements Serializable {
       Files.delete(file.toPath());
     }
   }
+
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
@@ -136,6 +136,7 @@ public class BackupService {
     return LoggingExecutors.newSingleThreadExecutor("BackupServiceThread", true);
   }
 
+
   private void cleanup() {
     cache.getDistributionManager().removeAllMembershipListener(membershipListener);
     currentTask.set(null);
@@ -146,7 +147,7 @@ public class BackupService {
     @Override
     public void memberDeparted(DistributionManager distributionManager,
         InternalDistributedMember id, boolean crashed) {
-      cleanup();
+      abortBackup();
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/backup/BackupService.java
@@ -123,7 +123,7 @@ public class BackupService {
     Set allIds =
         cache.getDistributionManager().addAllMembershipListenerAndGetAllIds(membershipListener);
     if (!allIds.contains(sender)) {
-      cleanup();
+      abortBackup();
       throw new IllegalStateException("The member requesting a backup has already departed");
     }
   }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/CacheRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/CacheRule.java
@@ -22,17 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.MembershipListener;
-import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.cache.CacheLifecycleListener;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.HARegion;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
@@ -219,32 +213,6 @@ public class CacheRule extends AbstractDistributedRule {
   public void closeAndNullCache() {
     closeCache();
     nullCache();
-  }
-
-  public void closeAndWaitForLifecycleEvent() {
-    final AtomicBoolean closed = new AtomicBoolean(false);
-    CacheLifecycleListener adhocListener = new CacheLifecycleListener() {
-      @Override
-      public void cacheCreated(InternalCache cache) {
-
-      }
-
-      @Override
-      public void cacheClosed(InternalCache cache) {
-        //closed.set(true);
-      }
-    };
-    GemFireCacheImpl.addCacheLifecycleListener(adhocListener);
-    closeCache();
-    cache.getDistributionManager().addMembershipListener(new MembershipListener() {
-      @Override
-      public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id, boolean crashed) {
-        closed.set(true);
-      }
-    });
-    while (closed.get() == false) {
-
-    }
   }
 
   private Properties config() {

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/CacheRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/CacheRule.java
@@ -27,7 +27,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.MembershipListener;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.CacheLifecycleListener;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.HARegion;
@@ -228,11 +231,17 @@ public class CacheRule extends AbstractDistributedRule {
 
       @Override
       public void cacheClosed(InternalCache cache) {
-        closed.set(true);
+        //closed.set(true);
       }
     };
     GemFireCacheImpl.addCacheLifecycleListener(adhocListener);
     closeCache();
+    cache.getDistributionManager().addMembershipListener(new MembershipListener() {
+      @Override
+      public void memberDeparted(DistributionManager distributionManager, InternalDistributedMember id, boolean crashed) {
+        closed.set(true);
+      }
+    });
     while (closed.get() == false) {
 
     }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/CacheRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/CacheRule.java
@@ -242,7 +242,6 @@ public class CacheRule extends AbstractDistributedRule {
     }
   }
 
-
   private static void nullCache() {
     cache = null;
   }


### PR DESCRIPTION
  *  The test can hang if the backup task is nulled out but hasn't countdown(ed) the latch.  This state was possible due to the test not waiting for a cache to be completely closed before executing a backup.  So the fix is to abort the task (countdown the latch) and also modify the test not to get into this state.

  * Added membership listener to test to have member departed callback before starting backup
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
