### PR TITLE
GEODE-7384: Members's old Persistent Member Id should be removed

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImpl.java
@@ -646,7 +646,7 @@ public class PersistenceAdvisorImpl implements InternalPersistenceAdvisor {
     }
   }
 
-  private void memberRemoved(PersistentMemberID id, boolean revoked) {
+  void memberRemoved(PersistentMemberID id, boolean revoked) {
     if (logger.isDebugEnabled(LogMarker.PERSIST_ADVISOR_VERBOSE)) {
       logger.debug(LogMarker.PERSIST_ADVISOR_VERBOSE, "{}-{}: Member removed. persistentID={}",
           shortDiskStoreId(), regionPath, id);
@@ -758,9 +758,7 @@ public class PersistenceAdvisorImpl implements InternalPersistenceAdvisor {
 
       // The oldId and newId could be the same if the member is retrying a GII. See bug #42051
       if (oldId != null && !oldId.equals(newId)) {
-        if (initialized) {
-          memberRemoved(oldId, false);
-        }
+        memberRemoved(oldId, false);
       }
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceAdvisorImplTest.java
@@ -17,7 +17,10 @@ package org.apache.geode.internal.cache.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -235,5 +238,20 @@ public class PersistenceAdvisorImplTest {
   private DiskStoreID getNewDiskStoreID() {
     UUID uuid = new UUID(diskStoreIDIndex++, diskStoreIDIndex++);
     return new DiskStoreID(uuid);
+  }
+
+  @Test
+  public void prepareNewMemberRemovesOldPersistentMemberId() {
+    InternalDistributedMember sender = mock(InternalDistributedMember.class);
+    PersistentMemberID oldId = mock(PersistentMemberID.class);
+    PersistentMemberID newId = mock(PersistentMemberID.class);
+    when(cacheDistributionAdvisor.containsId(sender)).thenReturn(true);
+    PersistenceAdvisorImpl spy = spy(persistenceAdvisorImpl);
+    doNothing().when(spy).memberRemoved(oldId, false);
+
+    spy.prepareNewMember(sender, oldId, newId);
+
+    verify(persistentMemberView).memberOnline(newId);
+    verify(spy).memberRemoved(oldId, false);
   }
 }


### PR DESCRIPTION
  * Always remove old Persistent Member Id if persisting its new Id.

