### PR TITLE
GEODE-7383: geode-ci concourse resource doesn't care about all of ci

### DIFF
--- a/ci/pipelines/examples/jinja.template.yml
+++ b/ci/pipelines/examples/jinja.template.yml
@@ -62,8 +62,7 @@ resources:
     uri: https://github.com/{{repository.fork}}/geode.git
     branch: {{ repository.branch }}
     paths:
-    - ci/pipelines/geode-build/*
-    - ci/scripts/*
+    - ci/*
 - name: concourse-metadata-resource
   type: concourse-metadata-resource
   source: {}

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -164,8 +164,7 @@ resources:
     branch: ((geode-build-branch))
     depth: 1
     paths:
-    - ci/pipelines/geode-build/*
-    - ci/scripts/*
+    - ci/*
     {{ github_access() | indent(4) }}
 - name: geode-benchmarks
   type: git

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -44,8 +44,7 @@ resources:
     branch: develop
     depth: 1
     paths:
-    - ci/pipelines/geode-build/*
-    - ci/scripts/*
+    - ci/*
     uri: https://github.com/apache/geode.git
 - name: concourse-metadata-resource
   type: concourse-metadata-resource


### PR DESCRIPTION
directory

Update geode-ci resource declarations to look for changes in all of the
ci directory.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
