### PR TITLE
GEODE-7396: Fixed incorrect regex in JavaBeanAccessorMethodAuthorizer

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/security/JavaBeanAccessorMethodAuthorizer.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/security/JavaBeanAccessorMethodAuthorizer.java
@@ -73,7 +73,7 @@ public final class JavaBeanAccessorMethodAuthorizer implements MethodInvocationA
   static final String NULL_CACHE_MESSAGE = "Cache should be provided to configure the authorizer.";
   static final String GEODE_BASE_PACKAGE = "org.apache.geode";
 
-  private static final Pattern pattern = Pattern.compile("^(get|is)($|[^A-Z])+");
+  private static final Pattern pattern = Pattern.compile("^(get|is)($|[A-Z])+.*");
 
   private final RestrictedMethodAuthorizer restrictedMethodAuthorizer;
   private final Set<String> allowedPackages;
@@ -167,7 +167,7 @@ public final class JavaBeanAccessorMethodAuthorizer implements MethodInvocationA
    *
    * @return an unmodifiable view of the allowed packages for this authorizer.
    */
-  Set<String> getAllowedPackages() {
+  public Set<String> getAllowedPackages() {
     return allowedPackages;
   }
 }


### PR DESCRIPTION
Authored-by: Donal Evans <doevans@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
