### PR TITLE
GEODE-7399: Use LogManager instead of LogService in test functions

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/CommitFunction.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/CommitFunction.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializable;
@@ -35,7 +36,6 @@ import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * This function can be used by GemFire clients and peers to commit an existing transaction. A
@@ -67,7 +67,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * @since GemFire 6.6.1
  */
 public class CommitFunction implements Function, DataSerializable {
-  private static final Logger logger = LogService.getLogger();
+  private static final Logger logger = LogManager.getLogger();
 
   private static final long serialVersionUID = 7851518767859544501L;
 

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/NestedTransactionFunction.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/NestedTransactionFunction.java
@@ -19,6 +19,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializable;
@@ -29,7 +30,6 @@ import org.apache.geode.cache.TransactionId;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * This function is used by {@link CommitFunction} to commit existing transaction. A
@@ -49,7 +49,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  */
 public class NestedTransactionFunction implements Function, DataSerializable {
-  private static final Logger logger = LogService.getLogger();
+  private static final Logger logger = LogManager.getLogger();
 
   public static final int COMMIT = 1;
   public static final int ROLLBACK = 2;

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/PartitionedRegionGetSomeKeys.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/PartitionedRegionGetSomeKeys.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Random;
 import java.util.Set;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -27,14 +28,13 @@ import org.apache.geode.internal.cache.partitioned.FetchKeysMessage;
 import org.apache.geode.internal.cache.partitioned.FetchKeysMessage.FetchKeysResponse;
 import org.apache.geode.internal.cache.partitioned.PRLocallyDestroyedException;
 import org.apache.geode.internal.cache.tier.InterestType;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
- * Extracted from {@link PartitionedRegion}. This is a utility used by Hydra test code only.
+ * Extracted from {@link PartitionedRegion}. This is a utility used by test code only.
  */
 public class PartitionedRegionGetSomeKeys {
 
-  private static final Logger logger = LogService.getLogger();
+  private static final Logger logger = LogManager.getLogger();
 
   /**
    * Test Method: Get a random set of keys from a randomly selected bucket using the provided

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/RollbackFunction.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/RollbackFunction.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializable;
@@ -34,7 +35,6 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * This function can be used by GemFire clients and peers to rollback an existing transaction. A
@@ -66,7 +66,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * @since GemFire 6.6.1
  */
 public class RollbackFunction implements Function, DataSerializable {
-  private static final Logger logger = LogService.getLogger();
+  private static final Logger logger = LogManager.getLogger();
 
   private static final long serialVersionUID = 1377183180063184795L;
 


### PR DESCRIPTION
These test functions should not use an internal logging API.
