### PR TITLE
GEODE-7400: Prevent RejectedExecutionException in FederatingManager

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/MBeanFederationErrorHandlingDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/MBeanFederationErrorHandlingDistributedTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import javax.management.ObjectName;
 
@@ -204,9 +205,9 @@ public class MBeanFederationErrorHandlingDistributedTest implements Serializable
     public FederatingManager create(ManagementResourceRepo repo, InternalDistributedSystem system,
         SystemManagementService service, InternalCache cache, StatisticsFactory statisticsFactory,
         StatisticsClock statisticsClock, MBeanProxyFactory proxyFactory, MemberMessenger messenger,
-        ExecutorService executorService) {
+        Supplier<ExecutorService> executorServiceSupplier) {
       return new FederatingManager(repo, system, service, cache, statisticsFactory,
-          statisticsClock, spy(proxyFactory), messenger, executorService);
+          statisticsClock, spy(proxyFactory), messenger, executorServiceSupplier);
     }
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/FederatingManagerConcurrencyIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/FederatingManagerConcurrencyIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.UnknownHostException;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import org.junit.After;
 import org.junit.Before;
@@ -42,7 +43,7 @@ import org.apache.geode.management.ManagementService;
 import org.apache.geode.test.junit.categories.JMXTest;
 
 @Category(JMXTest.class)
-public class FederatingManagerIntegrationTest {
+public class FederatingManagerConcurrencyIntegrationTest {
 
   private InternalCache cache;
   private FederatingManager federatingManager;
@@ -102,9 +103,9 @@ public class FederatingManagerIntegrationTest {
     public FederatingManager create(ManagementResourceRepo repo, InternalDistributedSystem system,
         SystemManagementService service, InternalCache cache, StatisticsFactory statisticsFactory,
         StatisticsClock statisticsClock, MBeanProxyFactory proxyFactory, MemberMessenger messenger,
-        ExecutorService executorService) {
+        Supplier<ExecutorService> executorServiceSupplier) {
       return new FederatingManager(repo, system, service, cache, statisticsFactory,
-          statisticsClock, proxyFactory, mock(MemberMessenger.class), executorService);
+          statisticsClock, proxyFactory, mock(MemberMessenger.class), executorServiceSupplier);
     }
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/FederatingManagerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/FederatingManagerIntegrationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalCacheForClientAccess;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.test.junit.categories.JMXTest;
+
+@Category(JMXTest.class)
+public class FederatingManagerIntegrationTest {
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(STRICT_STUBS);
+
+  @Mock
+  public InternalCache cache;
+  @Mock
+  public InternalCacheForClientAccess cacheForClientAccess;
+  @Mock
+  public MBeanProxyFactory proxyFactory;
+  @Mock
+  public MemberMessenger messenger;
+  @Mock
+  public ManagementResourceRepo repo;
+  @Mock
+  public SystemManagementService service;
+  @Mock
+  public StatisticsFactory statisticsFactory;
+  @Mock
+  public StatisticsClock statisticsClock;
+  @Mock
+  public InternalDistributedSystem system;
+  @Mock
+  public DistributionManager distributionManager;
+
+  @Before
+  public void setUp() throws IOException, ClassNotFoundException {
+    when(cache.getCacheForProcessingClientRequests())
+        .thenReturn(cacheForClientAccess);
+    when(system.getDistributionManager())
+        .thenReturn(distributionManager);
+  }
+
+  @Test
+  public void restartDoesNotThrowIfOtherMembersExist() {
+    when(distributionManager.getOtherDistributionManagerIds())
+        .thenReturn(Collections.singleton(mock(InternalDistributedMember.class)));
+
+    FederatingManager federatingManager =
+        new FederatingManager(repo, system, service, cache, statisticsFactory,
+            statisticsClock, proxyFactory, messenger, Executors::newSingleThreadExecutor);
+
+    federatingManager.startManager();
+    federatingManager.stopManager();
+
+    assertThatCode(federatingManager::startManager)
+        .doesNotThrowAnyException();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManagerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManagerFactory.java
@@ -17,6 +17,7 @@
 package org.apache.geode.management.internal;
 
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
@@ -29,5 +30,5 @@ interface FederatingManagerFactory {
   FederatingManager create(ManagementResourceRepo repo, InternalDistributedSystem system,
       SystemManagementService service, InternalCache cache, StatisticsFactory statisticsFactory,
       StatisticsClock statisticsClock, MBeanProxyFactory proxyFactory, MemberMessenger messenger,
-      ExecutorService executorService);
+      Supplier<ExecutorService> executorServiceSupplier);
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/SystemManagementService.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import javax.management.Notification;
 import javax.management.ObjectName;
@@ -570,7 +571,7 @@ public class SystemManagementService extends BaseManagementService {
       federatingManager = federatingManagerFactory.create(repo, system, this, cache,
           statisticsFactory, statisticsClock, new MBeanProxyFactory(jmxAdapter, this),
           new MemberMessenger(jmxAdapter, system),
-          LoggingExecutors.newFixedThreadPool("FederatingManager", true,
+          () -> LoggingExecutors.newFixedThreadPool("FederatingManager", true,
               Runtime.getRuntime().availableProcessors()));
       cache.getJmxManagerAdvisor().broadcastChange();
       return true;
@@ -721,9 +722,9 @@ public class SystemManagementService extends BaseManagementService {
     public FederatingManager create(ManagementResourceRepo repo, InternalDistributedSystem system,
         SystemManagementService service, InternalCache cache, StatisticsFactory statisticsFactory,
         StatisticsClock statisticsClock, MBeanProxyFactory proxyFactory, MemberMessenger messenger,
-        ExecutorService executorService) {
+        Supplier<ExecutorService> executorServiceSupplier) {
       return new FederatingManager(repo, system, service, cache, statisticsFactory,
-          statisticsClock, proxyFactory, messenger, executorService);
+          statisticsClock, proxyFactory, messenger, executorServiceSupplier);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
@@ -25,6 +25,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 
 import java.net.InetAddress;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -413,6 +414,19 @@ public class FederatingManagerTest {
 
     assertThat(thrown)
         .isNull();
+  }
+
+  @Test
+  public void startManagerGetsNewExecutorServiceFromSupplier() {
+    @SuppressWarnings("unchecked")
+    Supplier<ExecutorService> executorServiceSupplier = mock(Supplier.class);
+    when(executorServiceSupplier.get()).thenReturn(mock(ExecutorService.class));
+    FederatingManager federatingManager = new FederatingManager(repo, system, service, cache,
+        statisticsFactory, statisticsClock, proxyFactory, messenger, executorServiceSupplier);
+
+    federatingManager.startManager();
+
+    verify(executorServiceSupplier).get();
   }
 
   private InternalDistributedMember member() {


### PR DESCRIPTION
Commit f0c96db changed the `FederatingManager` class so that it reuses the same `ExecutorService` between restarts. After that change, if we start the manager after previously starting and stopping it, we get `RejectedExecutionException` because it tries to invoke a task on the same `ExecutorService` which has been shut down.

This PR changes the `FederatingManager` so that it invokes a supplier to get a new `ExecutorService` each time it is started to prevent the `RejectedExecutionException`.

Co-authored-by: Aaron Lindsey <alindsey@pivotal.io>
Co-authored-by: Kirk Lund <klund@apache.org>