### PR TITLE
Clean up deploy_meta.sh and don't get sha if geode's not there.

### DIFF
--- a/ci/pipelines/examples/jinja.template.yml
+++ b/ci/pipelines/examples/jinja.template.yml
@@ -52,7 +52,7 @@ resources:
 - name: geode-examples
   type: git
   source:
-    uri: https://github.com/apache/geode-examples.git
+    uri: https://github.com/{{repository.fork}}/geode-examples.git
     branch: {{ repository.branch }}
     depth: 10
 - name: geode-ci
@@ -83,9 +83,10 @@ jobs:
   public: true
   serial: true
   plan:
-  - get: geode-ci
   - aggregate:
+    - get: geode-ci
     - get: alpine-tools-image
+  - aggregate:
     - get: geode-examples
       trigger: true
     - get: 24h

--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -103,6 +103,7 @@ YML
 
   python3 ../render.py jinja.template.yml --variable-file ../shared/jinja.variables.yml repository.yml --environment ../shared/ --output ${SCRIPTDIR}/generated-pipeline.yml --debug || exit 1
 
+  set -e
   fly -t ${FLY_TARGET} sync
   fly -t ${FLY_TARGET} set-pipeline \
     -p ${META_PIPELINE} \
@@ -121,11 +122,8 @@ YML
     --var sanitized-geode-fork=${SANITIZED_GEODE_FORK} \
     --var semver-prerelease-token="${SEMVER_PRERELEASE_TOKEN}" \
     --var upstream-fork=${UPSTREAM_FORK} \
-    --yaml-var public-pipelines=${PUBLIC} 2>&1 |tee flyOutput.log
-
-  if [[ "$(tail -n1 flyOutput.log)" == "bailing out" ]]; then
-    exit 1
-  fi
+    --yaml-var public-pipelines=${PUBLIC}
+    set +e
 popd 2>&1 > /dev/null
 
 

--- a/ci/scripts/create_instance.sh
+++ b/ci/scripts/create_instance.sh
@@ -43,9 +43,13 @@ if [[ -z "${GEODE_BRANCH}" ]]; then
   exit 1
 fi
 
-pushd geode
-GEODE_SHA=$(git rev-parse --verify HEAD)
-popd
+if [[ -d geode ]]; then
+  pushd geode
+  GEODE_SHA=$(git rev-parse --verify HEAD)
+  popd
+else
+  GEODE_SHA="unknown"
+fi
 
 . ${SCRIPTDIR}/../pipelines/shared/utilities.sh
 SANITIZED_GEODE_BRANCH=$(getSanitizedBranch ${GEODE_BRANCH})


### PR DESCRIPTION
* fix geode-examples resource to pull from upstream fork.
* fetch alpine-tools-image before creating the instance.

Authored-by: Sean Goller <sgoller@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
