### PR TITLE
Add JUnit 5 to geode-junit and geode-core

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -404,6 +404,12 @@
         <scope>compile</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>5.5.2</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>2.23.0</version>
@@ -653,6 +659,24 @@
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
         <version>1.3</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.5.2</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.5.2</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>5.5.2</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -67,6 +67,7 @@ class DependencyConstraints implements Plugin<Project> {
 
     // These versions are referenced in test.gradle, which is aggressively injected into all projects.
     deps.put("junit.version", "4.12")
+    deps.put("junit-jupiter.version", "5.5.2")
     deps.put("cglib.version", "3.2.9")
     return deps
   }
@@ -145,6 +146,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.httpunit', name: 'httpunit', version: '1.7.3')
         api(group: 'org.iq80.snappy', name: 'snappy', version: '0.4')
         api(group: 'org.jgroups', name: 'jgroups', version: get('jgroups.version'))
+        api(group: 'org.junit.vintage', name: 'junit-vintage-engine', version: get('junit-jupiter.version'))
         api(group: 'org.mockito', name: 'mockito-core', version: '2.23.0')
         api(group: 'org.mortbay.jetty', name: 'servlet-api', version: '3.0.20100224')
         api(group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.21')
@@ -215,6 +217,12 @@ class DependencyConstraints implements Plugin<Project> {
       entry('hamcrest-all')
       entry('hamcrest-core')
       entry('hamcrest-library')
+    }
+
+    dependencySet(group: 'org.junit.jupiter', version: get('junit-jupiter.version')) {
+      entry('junit-jupiter-api')
+      entry('junit-jupiter-engine')
+      entry('junit-vintage-engine')
     }
 
     dependencySet(group: 'org.powermock', version: '2.0.0-beta.5') {

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -343,7 +343,8 @@ dependencies {
   testRuntime('commons-validator:commons-validator')
   testRuntime('com.pholser:junit-quickcheck-generators')
   testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
-
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 
   integrationTestCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
@@ -364,7 +365,8 @@ dependencies {
 
   integrationTestRuntime('org.apache.derby:derby')
   integrationTestRuntime('xerces:xercesImpl')
-
+  integrationTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  integrationTestRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 
   distributedTestCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
@@ -381,6 +383,8 @@ dependencies {
 
   distributedTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
   distributedTestRuntime('org.apache.derby:derby')
+  distributedTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  distributedTestRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 
 
   upgradeTestCompile(project(':geode-dunit')) {
@@ -389,12 +393,16 @@ dependencies {
 
   upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
   upgradeTestRuntime(project(':geode-log4j'))
+  upgradeTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  upgradeTestRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 
 
   performanceTestCompile(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
   performanceTestImplementation(project(':geode-log4j'))
+  performanceTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  performanceTestRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 jmh {
@@ -422,9 +430,36 @@ jmhJar {
 
 tasks.eclipse.dependsOn(generateGrammarSource)
 
+test {
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter',  'junit-vintage'
+  }
+}
+
+integrationTest {
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter',  'junit-vintage'
+  }
+}
+
 distributedTest {
   // Some tests have inner tests that should be ignored
   exclude "**/*\$*.class"
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter',  'junit-vintage'
+  }
+}
+
+upgradeTest {
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter',  'junit-vintage'
+  }
+}
+
+performanceTest {
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter',  'junit-vintage'
+  }
 }
 
 rootProject.generate.dependsOn(generateGrammarSource)

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   compile('junit:junit') {
     exclude module: 'hamcrest-core'
   }
+  api("org.junit.jupiter:junit-jupiter-api")
   compile('org.apache.commons:commons-lang3')
   compile('org.apache.logging.log4j:log4j-api')
   compile('org.assertj:assertj-core')
@@ -50,16 +51,26 @@ dependencies {
   compile('org.skyscreamer:jsonassert')
 
   testCompile('pl.pragmatists:JUnitParams')
-
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
   testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+
+  integrationTestRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+  integrationTestRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 test {
   // Some tests have inner tests that should be ignored
   exclude "**/*\$*.class"
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter', 'junit-vintage'
+  }
 }
 
 integrationTest {
   // Some tests have inner tests that should be ignored
   exclude "**/*\$*.class"
+  useJUnitPlatform {
+    includeEngines 'junit-jupiter', 'junit-vintage'
+  }
 }

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
@@ -33,11 +33,11 @@ import java.util.function.Consumer;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
-import org.junit.ComparisonFailure;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.MultipleFailureException;
+import org.opentest4j.AssertionFailedError;
 
 @RunWith(JUnitParamsRunner.class)
 public class ConcurrencyRuleTest {
@@ -398,7 +398,7 @@ public class ConcurrencyRuleTest {
         .repeatForDuration(Duration.ofSeconds(2));
 
     assertThatThrownBy(() -> execution.execute(concurrencyRule))
-        .isInstanceOf(ComparisonFailure.class);
+        .isInstanceOf(AssertionFailedError.class);
     assertThat(invoked.get()).isTrue();
   }
 
@@ -518,8 +518,8 @@ public class ConcurrencyRuleTest {
     assertThat(errors.get(0)).isInstanceOf(AssertionError.class)
         .hasMessageContaining(IOException.class.getName());
     assertThat(errors.get(1)).isInstanceOf(AssertionError.class)
-        .hasMessageContaining("[successful] value")
-        .hasMessageContaining("[wrong] value");
+        .hasMessageContaining("successful value")
+        .hasMessageContaining("wrong value");
     assertThat(errors.get(2)).hasMessageContaining("foo")
         .isInstanceOf(IOException.class);
   }

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -83,6 +83,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
- Make the JUnit 5 API available to all modules by adding it to the
  geode-junit API.
- Use Jupiter and Vintage engines to run all test types in geode-junit
  and geode-core.
- Update ConcurrencyRuleTest assertions to match those now thrown by
  AssertJ
  - ConcurrencyRule uses AssertJ to make assertions.
  - ConcurrencyRuleTest validates the type and messages of assertion
    failures thrown by ConcurrencyRule.
  - JUnit 5 puts opentest4j on the classpath.
  - When AssertJ finds opentest4j on the classpath, it configures itself
    to throw opentest4j assertion failures, which differ in type and
    message from the ones it throws when opentest4j is not present.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
