### PR TITLE
GEODE-7407: Remove AttributesFactory (4/4)

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsOnGroupsFunctionExecutionDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsOnGroupsFunctionExecutionDUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.rest.internal.web.controllers;
 
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -31,11 +31,10 @@ import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.rest.internal.web.RestFunctionTemplate;
-import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.junit.categories.RestAPITest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({RestAPITest.class})
+@Category(RestAPITest.class)
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class RestAPIsOnGroupsFunctionExecutionDUnitTest extends RestAPITestBase {
@@ -47,7 +46,6 @@ public class RestAPIsOnGroupsFunctionExecutionDUnitTest extends RestAPITestBase 
   public static Collection<String> data() {
     return Arrays.asList("/geode", "/gemfire-api");
   }
-
 
   private void setupCacheWithGroupsAndFunction() {
     restURLs.add(vm0.invoke("createCacheWithGroups",
@@ -125,18 +123,19 @@ public class RestAPIsOnGroupsFunctionExecutionDUnitTest extends RestAPITestBase 
     restURLs.clear();
   }
 
-  private class OnGroupsFunction extends RestFunctionTemplate {
+  @SuppressWarnings("unchecked")
+  private static class OnGroupsFunction extends RestFunctionTemplate {
     static final String Id = "OnGroupsFunction";
 
     @Override
     public void execute(FunctionContext context) {
-      LogWriterUtils.getLogWriter().fine("SWAP:1:executing OnGroupsFunction:" + invocationCount);
       InternalDistributedSystem ds = InternalDistributedSystem.getConnectedInstance();
       invocationCount++;
       ArrayList<String> l = (ArrayList<String>) context.getArguments();
       if (l != null) {
-        assertFalse(Collections.disjoint(l, ds.getDistributedMember().getGroups()));
+        assertThat(Collections.disjoint(l, ds.getDistributedMember().getGroups())).isFalse();
       }
+
       context.getResultSender().lastResult(Boolean.TRUE);
     }
 


### PR DESCRIPTION
This is one the commits to remove the deprecated 'AttributesFactory'
class from the geode-assembly module. The work is splitted to avoid
hitting issues in CI.

- Fixed some minor warnings.
- Replaced usages of 'junit.Assert' by 'assertj'.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
