### PR TITLE
GEODE-7427: Avoid failure when configuring DUnit suspect logging

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
@@ -260,10 +260,17 @@ public class DUnitLauncher {
   private static void addSuspectFileAppender(final String workspaceDir) {
     final String suspectFilename = new File(workspaceDir, SUSPECT_FILENAME).getAbsolutePath();
 
+
+    Object mainLogger = LogManager.getLogger(LoggingProvider.MAIN_LOGGER_NAME);
+    if (!(mainLogger instanceof org.apache.logging.log4j.core.Logger)) {
+      System.err.format(
+          "Unable to configure suspect file appender - cannot retrieve LoggerContext from type: %s\n",
+          mainLogger.getClass().getName());
+      return;
+    }
+
     final LoggerContext appenderContext =
-        ((org.apache.logging.log4j.core.Logger) LogManager
-            .getLogger(LoggingProvider.MAIN_LOGGER_NAME))
-                .getContext();
+        ((org.apache.logging.log4j.core.Logger) mainLogger).getContext();
 
     final PatternLayout layout = PatternLayout.createLayout(
         "[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} <%thread> tid=%tid] %message%n%throwable%n",


### PR DESCRIPTION
- Make sure that log4j is being used as the logging provider.

Authored-by: Jens Deppe <jdeppe@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
