### PR TITLE
GEODE-7431: limit Benchmarks to three-at-a-time to stay within quota

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -406,6 +406,7 @@ jobs:
 
 - name: Benchmark
   public: true
+  max_in_flight: 3
   plan:
   - get: geode-ci
     passed:


### PR DESCRIPTION
For example, https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/Benchmark/builds/677 failed because there were already 3 benchmarks jobs running at the time.

Since the quota is 40 and each benchmark job uses 12, this PR restricts `max_in_flight` to `3`
