### PR TITLE
GEODE-7442: Fix RegionAttributesCreation

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGeneratorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGeneratorIntegrationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.xmlcache;
+
+import static org.apache.geode.distributed.ConfigurationProperties.OFF_HEAP_MEMORY_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+@RunWith(Parameterized.class)
+public class CacheXmlGeneratorIntegrationTest {
+
+  @Rule
+  public TestName testName = new TestName();
+
+  @Rule
+  public ServerStarterRule serverStarterRule = new ServerStarterRule();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Parameterized.Parameter
+  public PartitionAttributes partitionAttributes;
+
+  @Parameterized.Parameters
+  public static Collection<PartitionAttributes> partitionAttributes() {
+    return Arrays.asList(
+        new PartitionAttributesFactory().create(),
+        new PartitionAttributesFactory().setLocalMaxMemory(16).create());
+  }
+
+  @Test
+  public void generateXmlForPartitionRegionWithOffHeapWhenDistributedSystemDoesNotExistShouldWorkProperly()
+      throws Exception {
+    CacheCreation cacheCreation = new CacheCreation();
+    RegionAttributesCreation attributes = new RegionAttributesCreation(cacheCreation);
+    attributes.setOffHeap(true);
+    attributes.setPartitionAttributes(partitionAttributes);
+    cacheCreation.createVMRegion(testName.getMethodName(), attributes);
+    File cacheXmlFile = temporaryFolder.newFile(testName.getMethodName() + ".xml");
+    PrintWriter printWriter = new PrintWriter(new FileWriter(cacheXmlFile), true);
+    CacheXmlGenerator.generate(cacheCreation, printWriter);
+
+    serverStarterRule.withProperty(OFF_HEAP_MEMORY_SIZE, "32m")
+        .withProperty("cache-xml-file", cacheXmlFile.getAbsolutePath()).startServer();
+
+    Cache cache = serverStarterRule.getCache();
+    assertThat(cache).isNotNull();
+    Region<Object, Object> region = cache.getRegion(testName.getMethodName());
+    assertThat(region).isNotNull();
+    assertThat(region.getAttributes().getOffHeap()).isTrue();
+    PartitionAttributes parsedAttributes = region.getAttributes().getPartitionAttributes();
+    assertThat(parsedAttributes.getLocalMaxMemory())
+        .isEqualTo(parsedAttributes.getLocalMaxMemory());
+    assertThat(parsedAttributes.getTotalNumBuckets())
+        .isEqualTo(parsedAttributes.getTotalNumBuckets());
+    assertThat(parsedAttributes.getRedundantCopies())
+        .isEqualTo(parsedAttributes.getRedundantCopies());
+    assertThat(parsedAttributes.getPartitionResolver())
+        .isEqualTo(parsedAttributes.getPartitionResolver());
+    assertThat(parsedAttributes.getPartitionListeners())
+        .isEqualTo(parsedAttributes.getPartitionListeners());
+    assertThat(parsedAttributes.getFixedPartitionAttributes())
+        .isEqualTo(parsedAttributes.getFixedPartitionAttributes());
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGeneratorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/xmlcache/CacheXmlGeneratorIntegrationTest.java
@@ -80,16 +80,16 @@ public class CacheXmlGeneratorIntegrationTest {
     assertThat(region.getAttributes().getOffHeap()).isTrue();
     PartitionAttributes parsedAttributes = region.getAttributes().getPartitionAttributes();
     assertThat(parsedAttributes.getLocalMaxMemory())
-        .isEqualTo(parsedAttributes.getLocalMaxMemory());
+        .isEqualTo(partitionAttributes.getLocalMaxMemory());
     assertThat(parsedAttributes.getTotalNumBuckets())
-        .isEqualTo(parsedAttributes.getTotalNumBuckets());
+        .isEqualTo(partitionAttributes.getTotalNumBuckets());
     assertThat(parsedAttributes.getRedundantCopies())
-        .isEqualTo(parsedAttributes.getRedundantCopies());
+        .isEqualTo(partitionAttributes.getRedundantCopies());
     assertThat(parsedAttributes.getPartitionResolver())
-        .isEqualTo(parsedAttributes.getPartitionResolver());
+        .isEqualTo(partitionAttributes.getPartitionResolver());
     assertThat(parsedAttributes.getPartitionListeners())
-        .isEqualTo(parsedAttributes.getPartitionListeners());
+        .isEqualTo(partitionAttributes.getPartitionListeners());
     assertThat(parsedAttributes.getFixedPartitionAttributes())
-        .isEqualTo(parsedAttributes.getFixedPartitionAttributes());
+        .isEqualTo(partitionAttributes.getFixedPartitionAttributes());
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/RegionAttributesCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/RegionAttributesCreation.java
@@ -1576,7 +1576,6 @@ public class RegionAttributesCreation extends UserSpecifiedRegionAttributes
       }
 
       setHasPartitionAttributes(true);
-      ((PartitionAttributesImpl) partitionAttributes).setOffHeap(offHeap);
     } else {
       partitionAttributes = null;
       setHasPartitionAttributes(false);


### PR DESCRIPTION
- Do not automatically override the 'off-heap' property when
  configuring the 'PartitionAttributes' declaratively.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
