### PR TITLE
GEODE-7448: Increase heavy-lifter instance time-to-live value

### DIFF
--- a/ci/scripts/create_instance.sh
+++ b/ci/scripts/create_instance.sh
@@ -103,7 +103,7 @@ echo "${ZONE}" > "instance-data/zone"
 echo 'StrictHostKeyChecking no' >> /etc/ssh/ssh_config
 RAM_MEGABYTES=$( expr ${RAM} \* 1024 )
 
-TTL=$(($(date +%s) + 60 * 60 * 6))
+TTL=$(($(date +%s) + 60 * 60 * 12))
 LABELS="instance_type=heavy-lifter,time-to-live=${TTL},job-name=${SANITIZED_BUILD_JOB_NAME},pipeline-name=${SANITIZED_BUILD_PIPELINE_NAME},build-name=${SANITIZED_BUILD_NAME},sha=${GEODE_SHA}"
 echo "Applying the following labels to the instance: ${LABELS}"
 


### PR DESCRIPTION
Increasing the time-to-live value to 12 hrs as the new tests take longer
than 6 hrs. And as this value is used to delete heavy-lifter instance it
might to be too close to kill them.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
