### PR TITLE
GEODE-4187: Fix PersistentColocatedPartitionedRegionDistributedTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/MockAppender.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/MockAppender.java
@@ -43,8 +43,8 @@ public class MockAppender implements AutoCloseable {
     logger.setLevel(Level.WARN);
   }
 
-  public Appender getMock() {
-    return this.mockAppender;
+  public Appender getAppender() {
+    return mockAppender;
   }
 
   public List<LogEvent> getLogs() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
@@ -80,7 +80,7 @@ import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.RegionsTest;
 
 @Category({RegionsTest.class})
-public class PersistentColocatedPartitionedRegionDUnitTest
+public class PersistentColocatedPartitionedRegionDistributedTest
     extends PersistentPartitionedRegionTestBase {
 
   private static final String PATTERN_FOR_MISSING_CHILD_LOG =
@@ -94,7 +94,7 @@ public class PersistentColocatedPartitionedRegionDUnitTest
   // Default region creation delay long enough for the initial cycle of logger warnings
   private static int delayForChildCreation = MAX_WAIT * 2 / 3;
 
-  public PersistentColocatedPartitionedRegionDUnitTest() {
+  public PersistentColocatedPartitionedRegionDistributedTest() {
     super();
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
@@ -14,569 +14,231 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
+import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.cache.RegionShortcut.PARTITION;
+import static org.apache.geode.cache.RegionShortcut.PARTITION_PERSISTENT;
+import static org.apache.geode.cache.partition.PartitionRegionHelper.getPartitionRegionInfo;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
+import static org.apache.geode.test.dunit.DistributedTestUtils.getLocators;
+import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
+import static org.apache.geode.test.dunit.VM.getController;
+import static org.apache.geode.test.dunit.VM.getCurrentVMNum;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.VM.toArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
-import org.apache.geode.admin.internal.AdminDistributedSystemImpl;
-import org.apache.geode.cache.AttributesFactory;
-import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.DiskStore;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.control.RebalanceOperation;
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.control.RebalanceResults;
+import org.apache.geode.cache.partition.PartitionRegionInfo;
 import org.apache.geode.cache.persistence.PartitionOfflineException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
-import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.ColocationLogger;
 import org.apache.geode.internal.cache.InitialImageOperation.RequestImageMessage;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
-import org.apache.geode.internal.cache.PartitionedRegionHelper;
+import org.apache.geode.internal.cache.PartitionedRegionDataStore;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
 import org.apache.geode.internal.cache.control.InternalResourceManager.ResourceObserver;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.AsyncInvocation;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.LogWriterUtils;
-import org.apache.geode.test.dunit.RMIException;
 import org.apache.geode.test.dunit.SerializableCallable;
-import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
+import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.RegionsTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 
-@Category({RegionsTest.class})
-public class PersistentColocatedPartitionedRegionDistributedTest
-    extends PersistentPartitionedRegionTestBase {
+@Category(RegionsTest.class)
+@RunWith(JUnitParamsRunner.class)
+@SuppressWarnings("serial")
+public class PersistentColocatedPartitionedRegionDistributedTest implements Serializable {
+
+  private static final long TIMEOUT_MILLIS = GeodeAwaitility.getTimeout().getValueInMS();
+
+  private static final long DEFAULT_RECOVERY_DELAY = -1;
+  private static final int DEFAULT_REDUNDANT_COPIES = 0;
+  private static final long DEFAULT_STARTUP_RECOVERY_DELAY = 0;
 
   private static final String PATTERN_FOR_MISSING_CHILD_LOG =
       "(?s)Persistent data recovery for region .*is prevented by offline colocated region.*";
+
   private static final int NUM_BUCKETS = 15;
-  private static final int MAX_WAIT = 60 * 1000;
-  private static final int DEFAULT_NUM_EXPECTED_LOG_MESSAGES = 1;
-  private static int numExpectedLogMessages = DEFAULT_NUM_EXPECTED_LOG_MESSAGES;
-  private static int numChildPRs = 1;
-  private static int numChildPRGenerations = 2;
-  // Default region creation delay long enough for the initial cycle of logger warnings
-  private static int delayForChildCreation = MAX_WAIT * 2 / 3;
 
-  public PersistentColocatedPartitionedRegionDistributedTest() {
-    super();
+  private static volatile InternalCache cache;
+  private static volatile CountDownLatch latch;
+
+  private final transient List<AsyncInvocation<Void>> asyncInvocations = new ArrayList<>();
+
+  private String locators;
+  private String regionName;
+  private String childRegionName1;
+  private String childRegionName2;
+  private String diskStoreName1;
+  private String diskStoreName2;
+
+  private VM vm0;
+  private VM vm1;
+  private VM vm2;
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @Rule
+  public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
+
+  @Before
+  public void setUp() {
+    locators = getLocators();
+    regionName = getClass().getSimpleName() + "_region";
+    childRegionName1 = "region2";
+    childRegionName2 = "region3";
+    diskStoreName1 = "disk1";
+    diskStoreName2 = "disk2";
+
+    vm0 = getVM(0);
+    vm1 = getVM(1);
+    vm2 = getVM(2);
   }
 
-  @Override
-  public final void preTearDownCacheTestCase() throws Exception {
-    FileUtils.deleteDirectory(getBackupDir());
-  }
+  @After
+  public void tearDown() {
+    for (VM vm : toArray(vm0, vm1, vm2, getController())) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookResetLogInterval();
+        DistributionMessageObserver.setInstance(null);
+        tearDownPartitionedRegionObserver();
 
-  @Test
-  public void testColocatedPRAttributes() {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(1);
-
-    vm0.invoke(new SerializableRunnable("create") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
+        while (latch != null && latch.getCount() > 0) {
+          latch.countDown();
         }
 
-        // Create Persistent region
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion("persistentLeader", af.create());
-
-        af.setDataPolicy(DataPolicy.PARTITION);
-        af.setDiskStoreName(null);
-        cache.createRegion("nonPersistentLeader", af.create());
-
-
-        // Create a non persistent PR
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        paf.setColocatedWith("nonPersistentLeader");
-        af.setPartitionAttributes(paf.create());
-
-        // Try to colocate a persistent PR with the non persistent PR. This should fail.
-        IgnoredException exp = IgnoredException.addIgnoredException("IllegalStateException");
-        try {
-          cache.createRegion("colocated", af.create());
-          fail(
-              "should not have been able to create a persistent region colocated with a non persistent region");
-        } catch (IllegalStateException expected) {
-          // do nothing
-        } finally {
-          exp.remove();
-        }
-
-        // Try to colocate a persistent PR with another persistent PR. This should work.
-        paf.setColocatedWith("persistentLeader");
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("colocated", af.create());
-
-        // We should also be able to colocate a non persistent region with a persistent region.
-        af.setDataPolicy(DataPolicy.PARTITION);
-        af.setDiskStoreName(null);
-        paf.setColocatedWith("persistentLeader");
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("colocated2", af.create());
-      }
-    });
+        closeCache();
+      });
+    }
+    disconnectAllFromDS();
   }
 
   /**
    * Testing that we can colocate persistent PRs
    */
   @Test
-  public void testColocatedPRs() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+  public void testColocatedPRs() throws Exception {
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR(regionName, childRegionName2, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
-    SerializableRunnable createPRs = new SerializableRunnable("region1") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+      createData(childRegionName2, "c");
+    });
 
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+        assertThat(getBucketIds(childRegionName2)).isEqualTo(bucketIds);
+        return bucketIds;
+      }));
+    }
 
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-        paf.setColocatedWith("region2");
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PARTITION);
-        af.setDiskStoreName(null);
-        cache.createRegion("region3", af.create());
-      }
-    };
-    vm0.invoke(createPRs);
-    vm1.invoke(createPRs);
-    vm2.invoke(createPRs);
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> closeCache());
+    }
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-    createData(vm0, 0, NUM_BUCKETS, "c", "region3");
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      addAsync(vm.invokeAsync(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR(regionName, childRegionName2, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      }));
+    }
+    awaitAllAsync();
 
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    assertEquals(vm0Buckets, getBucketList(vm0, "region3"));
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
-    assertEquals(vm1Buckets, getBucketList(vm1, "region3"));
-    Set<Integer> vm2Buckets = getBucketList(vm2, getPartitionedRegionName());
-    assertEquals(vm2Buckets, getBucketList(vm2, "region2"));
-    assertEquals(vm2Buckets, getBucketList(vm2, "region3"));
+    // The secondary buckets can be recovered asynchronously, so wait for them to come back.
+    for (VM vm : toArray(vm0, vm1)) {
+      Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+      vm.invoke(() -> {
+        waitForBuckets(regionName, bucketIds);
+        waitForBuckets(childRegionName1, bucketIds);
+      });
+    }
 
-    closeCache(vm0);
-    closeCache(vm1);
-    closeCache(vm2);
+    vm0.invoke(() -> {
+      validateData(regionName, "a");
+      validateData(childRegionName1, "b");
 
-    AsyncInvocation async0 = vm0.invokeAsync(createPRs);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRs);
-    AsyncInvocation async2 = vm2.invokeAsync(createPRs);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
-    async2.getResult(MAX_WAIT);
+      // region 3 didn't have persistent data, so it nothing should be recovered
+      validateData(childRegionName2, null);
+      // Make sure can do a put in all of the buckets in region 3
+      createData(childRegionName2, "c");
+      // Now all of those buckets should exist.
+      validateData(childRegionName2, "c");
+    });
 
-
-    // The secondary buckets can be recovered asynchronously,
-    // so wait for them to come back.
-    waitForBuckets(vm0, vm0Buckets, getPartitionedRegionName());
-    waitForBuckets(vm0, vm0Buckets, "region2");
-    waitForBuckets(vm1, vm1Buckets, getPartitionedRegionName());
-    waitForBuckets(vm1, vm1Buckets, "region2");
-
-    checkData(vm0, 0, NUM_BUCKETS, "a");
-    checkData(vm0, 0, NUM_BUCKETS, "b", "region2");
-
-    // region 3 didn't have persistent data, so it nothing should be recovered
-    checkData(vm0, 0, NUM_BUCKETS, null, "region3");
-
-    // Make sure can do a put in all of the buckets in region 3
-    createData(vm0, 0, NUM_BUCKETS, "c", "region3");
-    // Now all of those buckets should exist.
-    checkData(vm0, 0, NUM_BUCKETS, "c", "region3");
     // The region 3 buckets should be restored in the appropriate places.
-    assertEquals(vm0Buckets, getBucketList(vm0, "region3"));
-    assertEquals(vm1Buckets, getBucketList(vm1, "region3"));
-    assertEquals(vm2Buckets, getBucketList(vm2, "region3"));
-
-  }
-
-  private void createPR(String regionName, boolean persistent) {
-    createPR(regionName, null, persistent, "disk");
-  }
-
-  private void createPR(String regionName, String colocatedWith, boolean persistent) {
-    createPR(regionName, colocatedWith, persistent, "disk");
-  }
-
-  private void createPR(String regionName, String colocatedRegionName, boolean persistent,
-      String diskName) {
-    Cache cache = getCache();
-
-    DiskStore ds = cache.findDiskStore(diskName);
-    if (ds == null) {
-      ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create(diskName);
-    }
-    AttributesFactory af = new AttributesFactory();
-    PartitionAttributesFactory paf = new PartitionAttributesFactory();
-    paf.setRedundantCopies(0);
-    if (colocatedRegionName != null) {
-      paf.setColocatedWith(colocatedRegionName);
-    }
-    af.setPartitionAttributes(paf.create());
-    if (persistent) {
-      af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-      af.setDiskStoreName(diskName);
-    } else {
-      af.setDataPolicy(DataPolicy.PARTITION);
-      af.setDiskStoreName(null);
-    }
-    cache.createRegion(regionName, af.create());
-  }
-
-  private SerializableRunnable createPRsColocatedPairThread =
-      new SerializableRunnable("create2PRs") {
-        @Override
-        public void run() {
-          createPR(getPartitionedRegionName(), true);
-          createPR("region2", getPartitionedRegionName(), true);
-        }
-      };
-
-  private SerializableRunnable createMultipleColocatedChildPRs =
-      new SerializableRunnable("create multiple child PRs") {
-        @Override
-        public void run() throws Exception {
-          createPR(getPartitionedRegionName(), true);
-          for (int i = 2; i < numChildPRs + 2; ++i) {
-            createPR("region" + i, getPartitionedRegionName(), true);
-          }
-        }
-      };
-
-  private SerializableRunnable createPRColocationHierarchy =
-      new SerializableRunnable("create PR colocation hierarchy") {
-        @Override
-        public void run() throws Exception {
-          createPR(getPartitionedRegionName(), true);
-          createPR("region2", getPartitionedRegionName(), true);
-          for (int i = 3; i < numChildPRGenerations + 2; ++i) {
-            createPR("region" + i, "region" + (i - 1), true);
-          }
-        }
-      };
-
-  private SerializableCallable createPRsMissingParentRegionThread =
-      new SerializableCallable("createPRsMissingParentRegion") {
-        @Override
-        public Object call() throws Exception {
-          String exClass = "";
-          Exception ex = null;
-          try {
-            // Skip creation of first region - expect region2 creation to fail
-            // createPR(PR_REGION_NAME, true);
-            createPR("region2", getPartitionedRegionName(), true);
-          } catch (Exception e) {
-            ex = e;
-            exClass = e.getClass().toString();
-          } finally {
-            return ex;
-          }
-        }
-      };
-
-  private SerializableCallable delayedCreatePRsMissingParentRegionThread =
-      new SerializableCallable("delayedCreatePRsMissingParentRegion") {
-        @Override
-        public Object call() throws Exception {
-          String exClass = "";
-          Exception ex = null;
-          // To ensure that the targeted code paths in ColocationHelper.getColocatedRegion is taken,
-          // this
-          // thread delays the attempted creation on the local member of colocated child region when
-          // parent doesn't exist.
-          // The delay is so that both parent and child regions will be created on another member
-          // and the PR root config
-          // will have an entry for the parent region.
-          Thread.sleep(100);
-          try {
-            // Skip creation of first region - expect region2 creation to fail
-            // createPR(PR_REGION_NAME, true);
-            createPR("region2", getPartitionedRegionName(), true);
-          } catch (Exception e) {
-            ex = e;
-            exClass = e.getClass().toString();
-          } finally {
-            return ex;
-          }
-        }
-      };
-
-  private SerializableCallable createPRsMissingChildRegionThread =
-      new SerializableCallable("createPRsMissingChildRegion") {
-
-        @Override
-        public Object call() throws Exception {
-
-          try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
-            createPR(getPartitionedRegionName(), true);
-            // Let this thread continue running long enough for the missing region to be logged a
-            // couple times.
-            // Child regions do not get created by this thread.
-            await().untilAsserted(
-                () -> assertEquals(numExpectedLogMessages, mockAppender.getLogs().size()));
-
-            return mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
-          } finally {
-            numExpectedLogMessages = 1;
-          }
-        }
-      };
-
-  private SerializableCallable createPRsMissingChildRegionDelayedStartThread =
-      new SerializableCallable("createPRsMissingChildRegionDelayedStart") {
-
-        @Override
-        public Object call() throws Exception {
-
-          try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
-            createPR(getPartitionedRegionName(), true);
-            // Delay creation of second (i.e child) region to see missing colocated region log
-            // message (logInterval/2 < delay < logInterval)
-            await().untilAsserted(
-                () -> assertEquals(numExpectedLogMessages, mockAppender.getLogs().size()));
-            createPR("region2", getPartitionedRegionName(), true);
-            // Another delay before exiting the thread to make sure that missing region logging
-            // doesn't continue after missing region is created (delay > logInterval)
-            Thread.sleep(ColocationLogger.getLogInterval() + 10000);
-            return mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
-          } finally {
-            numExpectedLogMessages = 1;
-          }
-        }
-      };
-
-  private SerializableCallable createPRsSequencedChildrenCreationThread =
-      new SerializableCallable("createPRsSequencedChildrenCreation") {
-
-        @Override
-        public Object call() throws Exception {
-
-          try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
-            createPR(getPartitionedRegionName(), true);
-            // Delay creation of child generation regions to see missing colocated region log
-            // message
-            // parent region is generation 1, child region is generation 2, grandchild is 3, etc.
-            for (int generation = 2; generation < (numChildPRGenerations + 2); ++generation) {
-              String childPRName = "region" + generation;
-              String colocatedWithRegionName =
-                  generation == 2 ? getPartitionedRegionName() : "region" + (generation - 1);
-
-              // delay between starting generations of child regions until the expected missing
-              // colocation messages are logged
-              int n = (generation - 1) * generation / 2;
-              await().untilAsserted(() -> assertEquals(n, mockAppender.getLogs().size()));
-
-              // Start the child region
-              createPR(childPRName, colocatedWithRegionName, true);
-            }
-            assertEquals(numExpectedLogMessages, mockAppender.getLogs().size());
-
-            // Another delay before exiting the thread to make sure that missing region logging
-            // doesn't continue after all regions are created (delay > logInterval)
-            verify(mockAppender.getMock(), atLeastOnce()).getName();
-            verify(mockAppender.getMock(), atLeastOnce()).isStarted();
-            Thread.sleep(ColocationLogger.getLogInterval() + 10000);
-            verifyNoMoreInteractions(mockAppender.getMock());
-            return mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
-          } finally {
-            numExpectedLogMessages = 1;
-          }
-        }
-      };
-
-  private SerializableCallable createMultipleColocatedChildPRsWithSequencedStart =
-      new SerializableCallable("createPRsMultipleSequencedChildrenCreation") {
-
-        @Override
-        public Object call() throws Exception {
-
-
-          try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
-            createPR(getPartitionedRegionName(), true);
-            // Delay creation of child generation regions to see missing colocated region log
-            // message
-            for (int regionNum = 2; regionNum < (numChildPRs + 2); ++regionNum) {
-              String childPRName = "region" + regionNum;
-
-              // delay between starting generations of child regions until the expected missing
-              // colocation messages are logged
-              int n = regionNum - 1;
-              await().untilAsserted(() -> assertEquals(n, mockAppender.getLogs().size()));
-              int numLogEvents = mockAppender.getLogs().size();
-              assertEquals("Expected warning messages to be logged.", regionNum - 1, numLogEvents);
-
-              // Start the child region
-              createPR(childPRName, getPartitionedRegionName(), true);
-            }
-            String logMsg = "";
-            assertEquals(String.format("Expected warning messages to be logged."),
-                numExpectedLogMessages, mockAppender.getLogs().size());
-            logMsg = mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
-
-            // Another delay before exiting the thread to make sure that missing region logging
-            // doesn't continue after all regions are created (delay > logInterval)
-            verify(mockAppender.getMock(), atLeastOnce()).getName();
-            verify(mockAppender.getMock(), atLeastOnce()).isStarted();
-            Thread.sleep(ColocationLogger.getLogInterval() * 2);
-            verifyNoMoreInteractions(mockAppender.getMock());
-            return logMsg;
-          } finally {
-
-            numExpectedLogMessages = 1;
-          }
-        }
-      };
-
-  private class ColocationLoggerIntervalSetter extends SerializableRunnable {
-    private int logInterval;
-
-    ColocationLoggerIntervalSetter(int newInterval) {
-      this.logInterval = newInterval;
-    }
-
-    @Override
-    public void run() throws Exception {
-      ColocationLogger.testhookSetLogInterval(logInterval);
-    }
-  }
-
-  private class ColocationLoggerIntervalResetter extends SerializableRunnable {
-    private int logInterval;
-
-    @Override
-    public void run() throws Exception {
-      ColocationLogger.testhookResetLogInterval();
-    }
-  }
-
-  private class ExpectedNumLogMessageSetter extends SerializableRunnable {
-    private int numMsgs;
-
-    ExpectedNumLogMessageSetter(int num) {
-      this.numMsgs = num;
-    }
-
-    @Override
-    public void run() throws Exception {
-      numExpectedLogMessages = numMsgs;
-    }
-  }
-
-  private class ExpectedNumLogMessageResetter extends SerializableRunnable {
-    private int numMsgs;
-
-    ExpectedNumLogMessageResetter() {
-      this.numMsgs = DEFAULT_NUM_EXPECTED_LOG_MESSAGES;
-    }
-
-    @Override
-    public void run() throws Exception {
-      numExpectedLogMessages = numMsgs;
-    }
-  }
-
-  private class NumChildPRsSetter extends SerializableRunnable {
-    private int numChildren;
-
-    NumChildPRsSetter(int num) {
-      this.numChildren = num;
-    }
-
-    @Override
-    public void run() throws Exception {
-      numChildPRs = numChildren;
-    }
-  }
-
-  private class NumChildPRGenerationsSetter extends SerializableRunnable {
-    private int numGenerations;
-
-    NumChildPRGenerationsSetter(int num) {
-      this.numGenerations = num;
-    }
-
-    @Override
-    public void run() throws Exception {
-      numChildPRGenerations = numGenerations;
-    }
-  }
-
-  private class DelayForChildCreationSetter extends SerializableRunnable {
-    private int delay;
-
-    DelayForChildCreationSetter(int millis) {
-      this.delay = millis;
-    }
-
-    @Override
-    public void run() throws Exception {
-      delayForChildCreation = delay;
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+      assertThat(vm.invoke(() -> getBucketIds(childRegionName2))).isEqualTo(bucketIds);
     }
   }
 
@@ -584,183 +246,229 @@ public class PersistentColocatedPartitionedRegionDistributedTest
    * Testing that missing colocated persistent PRs are logged as warning
    */
   @Test
-  public void testMissingColocatedParentPR() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testMissingColocatedParentPR() {
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
-    vm0.invoke(createPRsColocatedPairThread);
-    vm1.invoke(createPRsColocatedPairThread);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+    });
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+      });
+    }
 
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    // The following should fail immediately with ISE on vm0,
+    // it's not necessary to also try the operation on vm1.
+    vm0.invoke("createPRsMissingParentRegion", () -> {
+      createCache();
 
-    // The following should fail immediately with ISE on vm0, it's not necessary to also try the
-    // operation on vm1.
-    Object remoteException = null;
-    remoteException = vm0.invoke(createPRsMissingParentRegionThread);
+      Throwable thrown =
+          catchThrowable(
+              () -> createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+                  DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES,
+                  DEFAULT_STARTUP_RECOVERY_DELAY));
 
-    assertEquals("Expected IllegalState Exception for missing colocated parent region",
-        IllegalStateException.class, remoteException.getClass());
-    assertTrue("Expected IllegalState Exception for missing colocated parent region",
-        remoteException.toString()
-            .matches("java.lang.IllegalStateException: Region specified in 'colocated-with'.*"));
+      assertThat(thrown)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Region specified in 'colocated-with'");
+    });
   }
 
   /**
    * Testing that parent colocated persistent PRs only missing on local member throws exception
    */
   @Test
-  public void testMissingColocatedParentPRWherePRConfigExists() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    vm0.invoke(createPRsColocatedPairThread);
-    vm1.invoke(createPRsColocatedPairThread);
-
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
-
-    closeCache(vm0);
-    closeCache(vm1);
-
-    AsyncInvocation async0 = null;
-    AsyncInvocation async1a = null;
-    AsyncInvocation async1b = null;
-    try {
-      async0 = vm0.invokeAsync(createPRsColocatedPairThread);
-
-      Object logMsg = "";
-      Object remoteException = null;
-      async1a = vm1.invokeAsync(delayedCreatePRsMissingParentRegionThread);
-      remoteException = async1a.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-
-      assertEquals("Expected IllegalState Exception for missing colocated parent region",
-          IllegalStateException.class, remoteException.getClass());
-      assertTrue("Expected IllegalState Exception for missing colocated parent region",
-          remoteException.toString()
-              .matches("java.lang.IllegalStateException: Region specified in 'colocated-with'.*"));
-    } finally {
-      // The real test is done now (either passing or failing) but there's some cleanup in this test
-      // that needs to be done.
-      //
-      // The vm0 invokeAsync thread is still alive after the expected exception on vm1. Cleanup by
-      // first re-creating both regions
-      // on vm1, vm0 thread should now complete. Then wait (i.e. join() on the thread) for the new
-      // vm1 thread and the vm0 thread to
-      // verify they terminated without timing out, and close the caches.
-      async1b = vm1.invokeAsync(createPRsColocatedPairThread);
-      async1b.join(MAX_WAIT);
-      async0.join(MAX_WAIT);
-      closeCache(vm1);
-      closeCache(vm0);
+  public void testMissingColocatedParentPRWherePRConfigExists() throws Exception {
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
     }
+
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+    });
+
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+      });
+    }
+
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    vm1.invoke(() -> {
+      latch = new CountDownLatch(1);
+    });
+
+    AsyncInvocation createPRsInVM0 = vm0.invokeAsync(() -> {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+          DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      vm1.invoke(() -> latch.countDown());
+
+      createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+          DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+    });
+
+    vm1.invoke(() -> {
+      // this thread delays the attempted creation on the local member of colocated child region
+      // when parent doesn't exist. The delay is so that both parent and child regions will be
+      // created on another member and the PR root config will have an entry for the parent region.
+      createCache();
+      createDiskStore(diskStoreName1);
+
+      latch.await(TIMEOUT_MILLIS, MILLISECONDS);
+
+      Throwable thrown =
+          catchThrowable(
+              () -> createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+                  DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES,
+                  DEFAULT_STARTUP_RECOVERY_DELAY));
+
+      assertThat(thrown)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageMatching("Region specified in 'colocated-with'.*");
+
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+          DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+          DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+    });
+
+    createPRsInVM0.await();
   }
 
   /**
    * Testing that missing colocated child persistent PRs are logged as warning
    */
   @Test
-  public void testMissingColocatedChildPRDueToDelayedStart() throws Throwable {
-    int loggerTestInterval = 4000; // millis
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testMissingColocatedChildPRDueToDelayedStart() throws Exception {
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
-    vm0.invoke(createPRsColocatedPairThread);
-    vm1.invoke(createPRsColocatedPairThread);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+    });
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+      });
+    }
 
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    int colocationLoggerIntervalMillis = 1000;
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookSetLogInterval(colocationLoggerIntervalMillis);
+      });
+    }
 
-    vm0.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm1.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm0.invoke(new ExpectedNumLogMessageSetter(1));
-    vm1.invoke(new ExpectedNumLogMessageSetter(1));
+    AsyncInvocation<String> createMissingChildPRInVM0 =
+        vm0.invokeAsync(() -> createMissingChildPR(1));
+    AsyncInvocation<String> createMissingChildPRInVM1 =
+        vm1.invokeAsync(() -> createMissingChildPR(1));
 
-    Object logMsg = "";
-    AsyncInvocation async0 = vm0.invokeAsync(createPRsMissingChildRegionDelayedStartThread);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRsMissingChildRegionDelayedStartThread);
-    logMsg = async1.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    async0.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    vm0.invoke(new ExpectedNumLogMessageResetter());
-    vm1.invoke(new ExpectedNumLogMessageResetter());
-    vm0.invoke(new ColocationLoggerIntervalResetter());
-    vm1.invoke(new ColocationLoggerIntervalResetter());
+    createMissingChildPRInVM0.await();
 
-    assertTrue(
-        "Expected missing colocated region warning on remote. Got message \"" + logMsg + "\"",
-        logMsg.toString().matches(PATTERN_FOR_MISSING_CHILD_LOG));
+    String colocationLogMessage = createMissingChildPRInVM1.get();
+    assertThat(colocationLogMessage).matches(PATTERN_FOR_MISSING_CHILD_LOG);
   }
 
   /**
    * Testing that missing colocated child persistent PRs are logged as warning
    */
   @Test
-  public void testMissingColocatedChildPR() throws Throwable {
-    int loggerTestInterval = 4000; // millis
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testMissingColocatedChildPR() throws Exception {
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
-    vm0.invoke(createPRsColocatedPairThread);
-    vm1.invoke(createPRsColocatedPairThread);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+    });
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+      });
+    }
 
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    int colocationLoggerIntervalMillis = 1000;
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookSetLogInterval(colocationLoggerIntervalMillis);
+      });
+    }
 
-    vm0.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm1.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm0.invoke(new ExpectedNumLogMessageSetter(2));
-    vm1.invoke(new ExpectedNumLogMessageSetter(2));
+    AsyncInvocation<String> createPRWithMissingChildInVM0 =
+        vm0.invokeAsync(() -> createPRWithMissingChild(2));
+    AsyncInvocation<String> createPRWithMissingChildInVM1 =
+        vm1.invokeAsync(() -> createPRWithMissingChild(2));
 
-    Object logMsg = "";
-    AsyncInvocation async0 = vm0.invokeAsync(createPRsMissingChildRegionThread);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRsMissingChildRegionThread);
-    logMsg = async1.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    async0.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    vm0.invoke(new ExpectedNumLogMessageResetter());
-    vm1.invoke(new ExpectedNumLogMessageResetter());
-    vm0.invoke(new ColocationLoggerIntervalResetter());
-    vm1.invoke(new ColocationLoggerIntervalResetter());
+    createPRWithMissingChildInVM0.await();
 
-    assertTrue(
-        "Expected missing colocated region warning on remote. Got message \"" + logMsg + "\"",
-        logMsg.toString().matches(PATTERN_FOR_MISSING_CHILD_LOG));
+    String colocationLogMessage = createPRWithMissingChildInVM1.get();
+    assertThat(colocationLogMessage).matches(PATTERN_FOR_MISSING_CHILD_LOG);
   }
 
   /**
@@ -768,53 +476,67 @@ public class PersistentColocatedPartitionedRegionDistributedTest
    * missing regions are logged in the warning.
    */
   @Test
-  public void testMultipleColocatedChildPRsMissing() throws Throwable {
-    int loggerTestInterval = 4000; // millis
-    int numChildPRs = 2;
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testMultipleColocatedChildPRsMissing() throws Exception {
+    int childPRCount = 2;
 
-    vm0.invoke(new NumChildPRsSetter(numChildPRs));
-    vm1.invoke(new NumChildPRsSetter(numChildPRs));
-    vm0.invoke(createMultipleColocatedChildPRs);
-    vm1.invoke(createMultipleColocatedChildPRs);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-    createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertFalse(vm1Buckets.isEmpty());
-    for (int i = 2; i < numChildPRs + 2; ++i) {
-      String childName = "region" + i;
-      assertEquals(vm0Buckets, getBucketList(vm0, childName));
-      assertEquals(vm1Buckets, getBucketList(vm1, childName));
+        for (int i = 2; i < childPRCount + 2; ++i) {
+          createChildPR_withPersistence(regionName, "region" + i, diskStoreName1,
+              DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES,
+              DEFAULT_STARTUP_RECOVERY_DELAY);
+        }
+      });
     }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+      createData(childRegionName1, "c");
+    });
 
-    vm0.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm1.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm0.invoke(new ExpectedNumLogMessageSetter(2));
-    vm1.invoke(new ExpectedNumLogMessageSetter(2));
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        return bucketIds;
+      }));
+    }
 
-    Object logMsg = "";
-    AsyncInvocation async0 = vm0.invokeAsync(createPRsMissingChildRegionThread);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRsMissingChildRegionThread);
-    logMsg = async1.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    async0.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    vm0.invoke(new ExpectedNumLogMessageResetter());
-    vm1.invoke(new ExpectedNumLogMessageResetter());
-    vm0.invoke(new ColocationLoggerIntervalResetter());
-    vm1.invoke(new ColocationLoggerIntervalResetter());
+    for (int i = 2; i < childPRCount + 2; ++i) {
+      String childRegionName = "region" + i;
+      for (VM vm : toArray(vm0, vm1)) {
+        Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+        assertThat(vm.invoke(() -> getBucketIds(childRegionName))).isEqualTo(bucketIds);
+      }
+    }
 
-    assertTrue(
-        "Expected missing colocated region warning on remote. Got message \"" + logMsg + "\"",
-        logMsg.toString().matches(PATTERN_FOR_MISSING_CHILD_LOG));
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    int colocationLoggerIntervalMillis = 1000;
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookSetLogInterval(colocationLoggerIntervalMillis);
+      });
+    }
+
+    AsyncInvocation<String> createPRWithMissingChildInVM0 =
+        vm0.invokeAsync(() -> createPRWithMissingChild(2));
+    AsyncInvocation<String> createPRWithMissingChildInVM1 =
+        vm1.invokeAsync(() -> createPRWithMissingChild(2));
+
+    createPRWithMissingChildInVM0.await();
+
+    String colocationLogMessage = createPRWithMissingChildInVM1.get();
+    assertThat(colocationLogMessage).matches(PATTERN_FOR_MISSING_CHILD_LOG);
   }
 
   /**
@@ -823,276 +545,215 @@ public class PersistentColocatedPartitionedRegionDistributedTest
    * appear in the warning.
    */
   @Test
-  public void testMultipleColocatedChildPRsMissingWithSequencedStart() throws Throwable {
-    int loggerTestInterval = 4000; // millis
-    int numChildPRs = 2;
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testMultipleColocatedChildPRsMissingWithSequencedStart() throws Exception {
+    int childPRCount = 2;
 
-    vm0.invoke(new NumChildPRsSetter(numChildPRs));
-    vm1.invoke(new NumChildPRsSetter(numChildPRs));
-    vm0.invoke(createMultipleColocatedChildPRs);
-    vm1.invoke(createMultipleColocatedChildPRs);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-    createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertFalse(vm1Buckets.isEmpty());
-    for (int i = 2; i < numChildPRs + 2; ++i) {
-      String childName = "region" + i;
-      assertEquals(vm0Buckets, getBucketList(vm0, childName));
-      assertEquals(vm1Buckets, getBucketList(vm1, childName));
+        for (int i = 2; i < childPRCount + 2; ++i) {
+          createChildPR_withPersistence(regionName, "region" + i, diskStoreName1,
+              DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES,
+              DEFAULT_STARTUP_RECOVERY_DELAY);
+        }
+      });
     }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+      createData(childRegionName1, "c");
+    });
 
-    vm0.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm1.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm0.invoke(new ExpectedNumLogMessageSetter(2));
-    vm1.invoke(new ExpectedNumLogMessageSetter(2));
-    vm0.invoke(new DelayForChildCreationSetter((int) (loggerTestInterval)));
-    vm1.invoke(new DelayForChildCreationSetter((int) (loggerTestInterval)));
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        return bucketIds;
+      }));
+    }
 
-    Object logMsg = "";
-    AsyncInvocation async0 = vm0.invokeAsync(createMultipleColocatedChildPRsWithSequencedStart);
-    AsyncInvocation async1 = vm1.invokeAsync(createMultipleColocatedChildPRsWithSequencedStart);
-    logMsg = async1.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    async0.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    vm0.invoke(new ExpectedNumLogMessageResetter());
-    vm1.invoke(new ExpectedNumLogMessageResetter());
-    vm0.invoke(new ColocationLoggerIntervalResetter());
-    vm1.invoke(new ColocationLoggerIntervalResetter());
+    for (int i = 2; i < childPRCount + 2; ++i) {
+      String childRegionName = "region" + i;
+      for (VM vm : toArray(vm0, vm1)) {
+        Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+        assertThat(vm.invoke(() -> getBucketIds(childRegionName))).isEqualTo(bucketIds);
+      }
+    }
 
-    assertTrue(
-        "Expected missing colocated region warning on remote. Got message \"" + logMsg + "\"",
-        logMsg.toString().matches(PATTERN_FOR_MISSING_CHILD_LOG));
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    int colocationLoggerIntervalMillis = 1000;
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookSetLogInterval(colocationLoggerIntervalMillis);
+      });
+    }
+
+    int expectedLogMessagesCount = 2;
+
+    AsyncInvocation<String> createMultipleChildPRGenerationsInVM0 =
+        vm0.invokeAsync(
+            () -> createMultipleChildPRGenerations(childPRCount, expectedLogMessagesCount));
+    AsyncInvocation<String> createMultipleChildPRGenerationsInVM1 =
+        vm1.invokeAsync(
+            () -> createMultipleChildPRGenerations(childPRCount, expectedLogMessagesCount));
+
+    createMultipleChildPRGenerationsInVM0.await();
+
+    String colocationLogMessage = createMultipleChildPRGenerationsInVM1.get();
+    assertThat(colocationLogMessage).matches(PATTERN_FOR_MISSING_CHILD_LOG);
   }
 
   /**
    * Testing that all missing persistent PRs in a colocation hierarchy are logged as warnings
    */
   @Test
-  public void testHierarchyOfColocatedChildPRsMissing() throws Throwable {
-    int loggerTestInterval = 4000; // millis
-    int numChildGenerations = 2;
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testHierarchyOfColocatedChildPRsMissing() throws Exception {
+    int childPRGenerations = 2;
 
-    vm0.invoke(new NumChildPRGenerationsSetter(numChildGenerations));
-    vm1.invoke(new NumChildPRGenerationsSetter(numChildGenerations));
-    vm0.invoke(createPRColocationHierarchy);
-    vm1.invoke(createPRColocationHierarchy);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-    createData(vm0, 0, NUM_BUCKETS, "c", "region3");
-
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertFalse(vm1Buckets.isEmpty());
-    for (int i = 2; i < numChildGenerations + 2; ++i) {
-      String childName = "region" + i;
-      assertEquals(vm0Buckets, getBucketList(vm0, childName));
-      assertEquals(vm1Buckets, getBucketList(vm1, childName));
+        for (int i = 3; i < childPRGenerations + 2; ++i) {
+          createChildPR_withPersistence("region" + (i - 1), "region" + i, diskStoreName1,
+              DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        }
+      });
     }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+      createData(childRegionName2, "c");
+    });
 
-    vm0.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm1.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        return bucketIds;
+      }));
+    }
+
+    for (int i = 2; i < childPRGenerations + 2; ++i) {
+      String childRegionName = "region" + i;
+      for (VM vm : toArray(vm0, vm1)) {
+        Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+        assertThat(vm.invoke(() -> getBucketIds(childRegionName))).isEqualTo(bucketIds);
+      }
+    }
+
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    int colocationLoggerIntervalMillis = 1000;
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookSetLogInterval(colocationLoggerIntervalMillis);
+      });
+    }
+
     // Expected warning logs only on the child region, because without the child there's nothing
     // known about the remaining hierarchy
-    vm0.invoke(new ExpectedNumLogMessageSetter(numChildGenerations));
-    vm1.invoke(new ExpectedNumLogMessageSetter(numChildGenerations));
 
-    Object logMsg = "";
-    AsyncInvocation async0 = vm0.invokeAsync(createPRsMissingChildRegionThread);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRsMissingChildRegionThread);
-    logMsg = async1.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    async0.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    vm0.invoke(new ExpectedNumLogMessageResetter());
-    vm1.invoke(new ExpectedNumLogMessageResetter());
-    vm0.invoke(new ColocationLoggerIntervalResetter());
-    vm1.invoke(new ColocationLoggerIntervalResetter());
+    AsyncInvocation<String> createPRWithMissingChildInVM0 =
+        vm0.invokeAsync(() -> createPRWithMissingChild(childPRGenerations));
+    AsyncInvocation<String> createPRWithMissingChildInVM1 =
+        vm1.invokeAsync(() -> createPRWithMissingChild(childPRGenerations));
 
-    assertTrue(
-        "Expected missing colocated region warning on remote. Got message \"" + logMsg + "\"",
-        logMsg.toString().matches(PATTERN_FOR_MISSING_CHILD_LOG));
+    createPRWithMissingChildInVM0.await();
+
+    String colocationLogMessage = createPRWithMissingChildInVM1.get();
+    assertThat(colocationLogMessage).matches(PATTERN_FOR_MISSING_CHILD_LOG);
   }
 
   /**
    * Testing that all missing persistent PRs in a colocation hierarchy are logged as warnings
    */
   @Test
-  public void testHierarchyOfColocatedChildPRsMissingGrandchild() throws Throwable {
-    int loggerTestInterval = 4000; // millis
-    int numChildGenerations = 3;
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testHierarchyOfColocatedChildPRsMissingGrandchild() throws Exception {
+    int childPRGenerationsCount = 3;
 
-    vm0.invoke(new NumChildPRGenerationsSetter(numChildGenerations));
-    vm1.invoke(new NumChildPRGenerationsSetter(numChildGenerations));
-    vm0.invoke(createPRColocationHierarchy);
-    vm1.invoke(createPRColocationHierarchy);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-    createData(vm0, 0, NUM_BUCKETS, "c", "region3");
-
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertFalse(vm0Buckets.isEmpty());
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertFalse(vm1Buckets.isEmpty());
-    for (int i = 2; i < numChildGenerations + 2; ++i) {
-      String childName = "region" + i;
-      assertEquals(vm0Buckets, getBucketList(vm0, childName));
-      assertEquals(vm1Buckets, getBucketList(vm1, childName));
+        for (int i = 3; i < childPRGenerationsCount + 2; ++i) {
+          createChildPR_withPersistence("region" + (i - 1), "region" + i, diskStoreName1,
+              DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        }
+      });
     }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+      createData(childRegionName2, "c");
+    });
 
-    vm0.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm1.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    // Expected warning logs only on the child region, because without the child there's nothing
-    // known about the remaining hierarchy
-    vm0.invoke(
-        new ExpectedNumLogMessageSetter(numChildGenerations * (numChildGenerations + 1) / 2));
-    vm1.invoke(
-        new ExpectedNumLogMessageSetter(numChildGenerations * (numChildGenerations + 1) / 2));
-    vm0.invoke(new DelayForChildCreationSetter((int) (loggerTestInterval)));
-    vm1.invoke(new DelayForChildCreationSetter((int) (loggerTestInterval)));
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        return bucketIds;
+      }));
+    }
 
-    Object logMsg = "";
-    AsyncInvocation async0 = vm0.invokeAsync(createPRsSequencedChildrenCreationThread);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRsSequencedChildrenCreationThread);
-    logMsg = async1.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    async0.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    vm0.invoke(new ExpectedNumLogMessageResetter());
-    vm1.invoke(new ExpectedNumLogMessageResetter());
-    vm0.invoke(new ColocationLoggerIntervalResetter());
-    vm1.invoke(new ColocationLoggerIntervalResetter());
+    for (int i = 2; i < childPRGenerationsCount + 2; ++i) {
+      String childRegionName = "region" + i;
+      for (VM vm : toArray(vm0, vm1)) {
+        Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+        assertThat(vm.invoke(() -> getBucketIds(childRegionName))).isEqualTo(bucketIds);
+      }
+    }
 
-    assertTrue(
-        "Expected missing colocated region warning on remote. Got message \"" + logMsg + "\"",
-        logMsg.toString().matches(PATTERN_FOR_MISSING_CHILD_LOG));
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    int colocationLoggerIntervalMillis = 1000;
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookSetLogInterval(colocationLoggerIntervalMillis);
+      });
+    }
+
+    // Expected warning logs only on the child region, because without the child
+    // there's nothing known about the remaining hierarchy
+    int expectedLogMessagesCount = childPRGenerationsCount * (childPRGenerationsCount + 1) / 2;
+
+    AsyncInvocation<String> createChildPRGenerationsInVM0 = vm0.invokeAsync(
+        () -> createChildPRGenerations(childPRGenerationsCount, expectedLogMessagesCount));
+    AsyncInvocation<String> createChildPRGenerationsInVM1 = vm1.invokeAsync(
+        () -> createChildPRGenerations(childPRGenerationsCount, expectedLogMessagesCount));
+
+    createChildPRGenerationsInVM0.await();
+
+    String colocationLogMessage = createChildPRGenerationsInVM1.get();
+    assertThat(colocationLogMessage).matches(PATTERN_FOR_MISSING_CHILD_LOG);
   }
-
-  private SerializableRunnable createPRColocationTree =
-      new SerializableRunnable("create PR colocation hierarchy") {
-        @Override
-        public void run() throws Exception {
-          createPR("Parent", true);
-          createPR("Gen1_C1", "Parent", true);
-          createPR("Gen1_C2", "Parent", true);
-          createPR("Gen2_C1_1", "Gen1_C1", true);
-          createPR("Gen2_C1_2", "Gen1_C1", true);
-          createPR("Gen2_C2_1", "Gen1_C2", true);
-          createPR("Gen2_C2_2", "Gen1_C2", true);
-        }
-      };
-
-  /**
-   * The colocation tree has the regions started in a specific order so that the logging is
-   * predictable. For each entry in the list, the array values are:
-   *
-   * <pre>
-   *
-   *   [0] - the region name
-   *   [1] - the name of that region's parent
-   *   [2] - the number of warnings that will be logged after the region is created (1 warning for
-   *         each region in the tree that exists that still has 1 or more missing children.)
-   * </pre>
-   */
-  private static final List<Object[]> CHILD_REGION_RESTART_ORDER = new ArrayList<Object[]>();
-  static {
-    CHILD_REGION_RESTART_ORDER.add(new Object[] {"Gen1_C1", "Parent", 2});
-    CHILD_REGION_RESTART_ORDER.add(new Object[] {"Gen2_C1_1", "Gen1_C1", 2});
-    CHILD_REGION_RESTART_ORDER.add(new Object[] {"Gen1_C2", "Parent", 3});
-    CHILD_REGION_RESTART_ORDER.add(new Object[] {"Gen2_C1_2", "Gen1_C1", 2});
-    CHILD_REGION_RESTART_ORDER.add(new Object[] {"Gen2_C2_1", "Gen1_C2", 2});
-    CHILD_REGION_RESTART_ORDER.add(new Object[] {"Gen2_C2_2", "Gen1_C2", 0});
-  }
-
-  /**
-   * This thread starts up multiple colocated child regions in the sequence defined by
-   * {@link #CHILD_REGION_RESTART_ORDER}. The complete startup sequence, which includes timed
-   * periods waiting for log messages, takes at least 28 secs. Tests waiting for this
-   * {@link SerializableCallable} to complete must have sufficient overhead in the wait for runtime
-   * variations that exceed the minimum time to complete.
-   */
-  private SerializableCallable createPRsSequencedColocationTreeCreationThread =
-      new SerializableCallable("createPRsSequencedColocationTreeCreation") {
-        Appender mockAppender;
-        ArgumentCaptor<LogEvent> loggingEventCaptor;
-
-        @Override
-        public Object call() throws Exception {
-          // Setup for capturing logger messages
-          mockAppender = mock(Appender.class);
-          when(mockAppender.getName()).thenReturn("MockAppender");
-          when(mockAppender.isStarted()).thenReturn(true);
-          when(mockAppender.isStopped()).thenReturn(false);
-          Logger logger = (Logger) LogManager.getLogger(ColocationLogger.class);
-          logger.addAppender(mockAppender);
-          logger.setLevel(Level.WARN);
-          loggingEventCaptor = ArgumentCaptor.forClass(LogEvent.class);
-
-          // Logger interval may have been hooked by the test, so adjust test delays here
-          int logInterval = ColocationLogger.getLogInterval();
-          List<LogEvent> logEvents = Collections.emptyList();
-          int nExpectedLogs = 1;
-
-          createPR("Parent", true);
-          // Delay creation of descendant regions in the hierarchy to see missing colocated region
-          // log messages (logInterval/2 < delay < logInterval)
-          for (Object[] regionInfo : CHILD_REGION_RESTART_ORDER) {
-            loggingEventCaptor = ArgumentCaptor.forClass(LogEvent.class);
-            String childPRName = (String) regionInfo[0];
-            String colocatedWithRegionName = (String) regionInfo[1];
-
-            // delay between starting generations of child regions and verify expected logging
-            await().untilAsserted(() -> {
-              verify(mockAppender, times(nExpectedLogs)).append(loggingEventCaptor.capture());
-            });
-
-            // Finally start the next child region
-            createPR(childPRName, colocatedWithRegionName, true);
-          }
-          String logMsg;
-          logEvents = loggingEventCaptor.getAllValues();
-          assertEquals(String.format("Expected warning messages to be logged."), nExpectedLogs,
-              logEvents.size());
-          logMsg = logEvents.get(0).getMessage().getFormattedMessage();
-
-          // acknowledge interactions with the mock that have occurred
-          verify(mockAppender, atLeastOnce()).getName();
-          verify(mockAppender, atLeastOnce()).isStarted();
-          try {
-            // Another delay before exiting the thread to make sure that missing region logging
-            // doesn't continue after all regions are created (delay > logInterval)
-            verify(mockAppender, atLeastOnce()).append(any(LogEvent.class));
-            Thread.sleep(logInterval * 2);
-            verifyNoMoreInteractions(mockAppender);
-          } finally {
-            logger.removeAppender(mockAppender);
-          }
-
-          numExpectedLogMessages = 1;
-          mockAppender = null;
-          return logMsg;
-        }
-      };
 
   /**
    * Testing that all missing persistent PRs in a colocation tree hierarchy are logged as warnings.
@@ -1109,56 +770,73 @@ public class PersistentColocatedPartitionedRegionDistributedTest
    * </pre>
    */
   @Test
-  public void testFullTreeOfColocatedChildPRsWithMissingRegions() throws Throwable {
-    int loggerTestInterval = 4000; // millis
-    int numChildPRs = 2;
-    int numChildGenerations = 2;
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-
-    vm0.invoke(createPRColocationTree);
-    vm1.invoke(createPRColocationTree);
-
-    createData(vm0, 0, NUM_BUCKETS, "a", "Parent");
-    createData(vm0, 0, NUM_BUCKETS, "b", "Gen1_C1");
-    createData(vm0, 0, NUM_BUCKETS, "c", "Gen1_C2");
-    createData(vm0, 0, NUM_BUCKETS, "c", "Gen2_C1_1");
-    createData(vm0, 0, NUM_BUCKETS, "c", "Gen2_C1_2");
-    createData(vm0, 0, NUM_BUCKETS, "c", "Gen2_C2_1");
-    createData(vm0, 0, NUM_BUCKETS, "c", "Gen2_C2_2");
-
-    Set<Integer> vm0Buckets = getBucketList(vm0, "Parent");
-    assertFalse(vm0Buckets.isEmpty());
-    Set<Integer> vm1Buckets = getBucketList(vm1, "Parent");
-    assertFalse(vm1Buckets.isEmpty());
-    for (String region : new String[] {"Gen1_C1", "Gen1_C2", "Gen2_C1_1", "Gen2_C1_2", "Gen2_C2_1",
-        "Gen2_C2_2"}) {
-      assertEquals(vm0Buckets, getBucketList(vm0, region));
-      assertEquals(vm1Buckets, getBucketList(vm1, region));
+  public void testFullTreeOfColocatedChildPRsWithMissingRegions() throws Exception {
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence("Parent", diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence("Parent", "Gen1_C1", diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence("Parent", "Gen1_C2", diskStoreName1, DEFAULT_RECOVERY_DELAY,
+            DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence("Gen1_C1", "Gen2_C1_1", diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence("Gen1_C1", "Gen2_C1_2", diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence("Gen1_C2", "Gen2_C2_1", diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence("Gen1_C2", "Gen2_C2_2", diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
     }
 
-    closeCache(vm0);
-    closeCache(vm1);
+    vm0.invoke(() -> {
+      createData("Parent", "a");
+      createData("Gen1_C1", "b");
+      createData("Gen1_C2", "c");
+      createData("Gen2_C1_1", "c");
+      createData("Gen2_C1_2", "c");
+      createData("Gen2_C2_1", "c");
+      createData("Gen2_C2_2", "c");
+    });
 
-    vm0.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm1.invoke(new ColocationLoggerIntervalSetter(loggerTestInterval));
-    vm0.invoke(new DelayForChildCreationSetter((int) (loggerTestInterval)));
-    vm1.invoke(new DelayForChildCreationSetter((int) (loggerTestInterval)));
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds("Parent");
+        assertThat(bucketIds).isNotEmpty();
+        return bucketIds;
+      }));
+    }
 
-    Object logMsg = "";
-    AsyncInvocation async0 = vm0.invokeAsync(createPRsSequencedColocationTreeCreationThread);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRsSequencedColocationTreeCreationThread);
-    logMsg = async1.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    async0.get(MAX_WAIT, TimeUnit.MILLISECONDS);
-    vm0.invoke(new ColocationLoggerIntervalResetter());
-    vm1.invoke(new ColocationLoggerIntervalResetter());
+    for (String region : asList("Gen1_C1", "Gen1_C2", "Gen2_C1_1", "Gen2_C1_2", "Gen2_C2_1",
+        "Gen2_C2_2")) {
+      for (VM vm : toArray(vm0, vm1)) {
+        Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+        assertThat(vm.invoke(() -> getBucketIds(region))).isEqualTo(bucketIds);
+      }
+    }
 
-    // Expected warning logs only on the child region, because without the child there's nothing
-    // known about the remaining hierarchy
-    assertTrue(
-        "Expected missing colocated region warning on remote. Got message \"" + logMsg + "\"",
-        logMsg.toString().matches(PATTERN_FOR_MISSING_CHILD_LOG));
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    int colocationLoggerIntervalMillis = 1000;
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        ColocationLogger.testhookSetLogInterval(colocationLoggerIntervalMillis);
+      });
+    }
+
+    AsyncInvocation<String> createChildPRTreeInVM0 = vm0.invokeAsync(() -> createChildPRTree());
+    AsyncInvocation<String> createChildPRTreeInVM1 = vm1.invokeAsync(() -> createChildPRTree());
+
+    createChildPRTreeInVM0.await();
+
+    String colocationLogMessage = createChildPRTreeInVM1.get();
+    assertThat(colocationLogMessage).matches(PATTERN_FOR_MISSING_CHILD_LOG);
   }
 
   /**
@@ -1166,1630 +844,1390 @@ public class PersistentColocatedPartitionedRegionDistributedTest
    * then the other PR everywhere.
    */
   @Test
-  public void testColocatedPRsRecoveryOnePRAtATime() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+  public void testColocatedPRsRecoveryOnePRAtATime() throws Exception {
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
-    SerializableRunnable createParentPR = new SerializableRunnable("createParentPR") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> createChildPR_withRecovery(regionName, childRegionName1,
+          DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
 
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-      }
-    };
-    SerializableRunnable createChildPR = getCreateChildPRRunnable();
-    vm0.invoke(createParentPR);
-    vm1.invoke(createParentPR);
-    vm2.invoke(createParentPR);
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
-    vm2.invoke(createChildPR);
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+    });
 
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(bucketIds).isNotEmpty();
+        return bucketIds;
+      }));
+    }
 
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
-    Set<Integer> vm2Buckets = getBucketList(vm2, getPartitionedRegionName());
-    assertEquals(vm2Buckets, getBucketList(vm2, "region2"));
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        Set<Integer> primaryBucketIds = getPrimaryBucketIds(regionName);
+        assertThat(getPrimaryBucketIds(childRegionName1)).isEqualTo(primaryBucketIds);
+      });
+    }
 
-    Set<Integer> vm0PrimaryBuckets = getPrimaryBucketList(vm0, getPartitionedRegionName());
-    assertEquals(vm0PrimaryBuckets, getPrimaryBucketList(vm0, "region2"));
-    Set<Integer> vm1PrimaryBuckets = getPrimaryBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1PrimaryBuckets, getPrimaryBucketList(vm1, "region2"));
-    Set<Integer> vm2PrimaryBuckets = getPrimaryBucketList(vm2, getPartitionedRegionName());
-    assertEquals(vm2PrimaryBuckets, getPrimaryBucketList(vm2, "region2"));
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> closeCache());
+    }
 
-    closeCache(vm0);
-    closeCache(vm1);
-    closeCache(vm2);
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      addAsync(
+          vm.invokeAsync(() -> {
+            createCache();
+            createDiskStore(diskStoreName1);
+            createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+                DEFAULT_STARTUP_RECOVERY_DELAY);
+          }));
+    }
+    awaitAllAsync();
 
-    AsyncInvocation async0 = vm0.invokeAsync(createParentPR);
-    AsyncInvocation async1 = vm1.invokeAsync(createParentPR);
-    AsyncInvocation async2 = vm2.invokeAsync(createParentPR);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
-    async2.getResult(MAX_WAIT);
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> createChildPR_withRecovery(regionName, childRegionName1,
+          DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
 
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
-    vm2.invoke(createChildPR);
-
-    Wait.pause(4000);
-
-    assertEquals(vm0Buckets, getBucketList(vm0, getPartitionedRegionName()));
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    assertEquals(vm1Buckets, getBucketList(vm1, getPartitionedRegionName()));
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
-    assertEquals(vm2Buckets, getBucketList(vm2, getPartitionedRegionName()));
-    assertEquals(vm2Buckets, getBucketList(vm2, "region2"));
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+      vm.invoke(() -> {
+        assertThat(getBucketIds(regionName)).isEqualTo(bucketIds);
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+      });
+    }
 
     // primary can differ
-    vm0PrimaryBuckets = getPrimaryBucketList(vm0, getPartitionedRegionName());
-    assertEquals(vm0PrimaryBuckets, getPrimaryBucketList(vm0, "region2"));
-    vm1PrimaryBuckets = getPrimaryBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1PrimaryBuckets, getPrimaryBucketList(vm1, "region2"));
-    vm2PrimaryBuckets = getPrimaryBucketList(vm2, getPartitionedRegionName());
-    assertEquals(vm2PrimaryBuckets, getPrimaryBucketList(vm2, "region2"));
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        Set<Integer> primaryBucketIds = getPrimaryBucketIds(regionName);
+        assertThat(getPrimaryBucketIds(childRegionName1)).isEqualTo(primaryBucketIds);
+      });
+    }
 
-
-    checkData(vm0, 0, NUM_BUCKETS, "a");
-
-    // region 2 didn't have persistent data, so it nothing should be recovered
-    checkData(vm0, 0, NUM_BUCKETS, null, "region2");
-
-    // Make sure can do a put in all of the buckets in vm2
-    createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-
-    // Now all of those buckets should exist
-    checkData(vm0, 0, NUM_BUCKETS, "c", "region2");
+    vm0.invoke(() -> {
+      validateData(regionName, "a");
+      // region 2 didn't have persistent data, so it nothing should be recovered
+      validateData(childRegionName1, null);
+      // Make sure can do a put in all of the buckets in vm2
+      createData(childRegionName1, "c");
+      // Now all of those buckets should exist
+      validateData(childRegionName1, "c");
+    });
 
     // Now all the buckets should be restored in the appropriate places.
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
-    assertEquals(vm2Buckets, getBucketList(vm2, "region2"));
-  }
-
-  private SerializableRunnable getCreateChildPRRunnable() {
-    return new SerializableRunnable("createChildPR") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        final CountDownLatch recoveryDone = new CountDownLatch(1);
-        ResourceObserver observer = new InternalResourceManager.ResourceObserverAdapter() {
-          @Override
-          public void recoveryFinished(Region region) {
-            if (region.getName().equals("region2")) {
-              recoveryDone.countDown();
-            }
-          }
-        };
-        InternalResourceManager.setResourceObserver(observer);
-
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-
-        try {
-          recoveryDone.await(MAX_WAIT, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-          Assert.fail("interrupted", e);
-        }
-      }
-    };
-  }
-
-  @Test
-  public void testColocatedPRsRecoveryOneMemberLater() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-    SerializableRunnable createParentPR = new SerializableRunnable("createParentPR") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-      }
-    };
-    SerializableRunnable createChildPR = getCreateChildPRRunnable();
-
-    vm0.invoke(createParentPR);
-    vm1.invoke(createParentPR);
-    vm2.invoke(createParentPR);
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
-    vm2.invoke(createChildPR);
-
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-
-    Set<Integer> vm0Buckets = getBucketList(vm0, getPartitionedRegionName());
-    assertEquals(vm0Buckets, getBucketList(vm0, "region2"));
-    Set<Integer> vm1Buckets = getBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1Buckets, getBucketList(vm1, "region2"));
-    Set<Integer> vm2Buckets = getBucketList(vm2, getPartitionedRegionName());
-    assertEquals(vm2Buckets, getBucketList(vm2, "region2"));
-
-    Set<Integer> vm0PrimaryBuckets = getPrimaryBucketList(vm0, getPartitionedRegionName());
-    assertEquals(vm0PrimaryBuckets, getPrimaryBucketList(vm0, "region2"));
-    Set<Integer> vm1PrimaryBuckets = getPrimaryBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1PrimaryBuckets, getPrimaryBucketList(vm1, "region2"));
-    Set<Integer> vm2PrimaryBuckets = getPrimaryBucketList(vm2, getPartitionedRegionName());
-    assertEquals(vm2PrimaryBuckets, getPrimaryBucketList(vm2, "region2"));
-
-    closeCache(vm2);
-    // Make sure the other members notice that vm2 has gone
-    // TODO use a callback for this.
-    Thread.sleep(4000);
-
-    closeCache(vm0);
-    closeCache(vm1);
-
-    // Create the members, but don't initialize
-    // VM2 yet
-    AsyncInvocation async0 = vm0.invokeAsync(createParentPR);
-    AsyncInvocation async1 = vm1.invokeAsync(createParentPR);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
-
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
-    waitForBucketRecovery(vm0, vm0Buckets);
-    waitForBucketRecovery(vm1, vm1Buckets);
-
-    checkData(vm0, 0, NUM_BUCKETS, "a");
-
-    // region 2 didn't have persistent data, so it nothing should be recovered
-    checkData(vm0, 0, NUM_BUCKETS, null, "region2");
-
-    // Make sure can do a put in all of the buckets in vm2
-    createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-
-    // Now all of those buckets should exist
-    checkData(vm0, 0, NUM_BUCKETS, "c", "region2");
-
-    // Now we initialize vm2.
-    vm2.invoke(createParentPR);
-    // Make sure vm2 hasn't created any buckets in the parent PR yet
-    // We don't want any buckets until the child PR is created
-    assertEquals(Collections.emptySet(), getBucketList(vm2, getPartitionedRegionName()));
-    vm2.invoke(createChildPR);
-
-    // Now vm2 should have created all of the appropriate buckets.
-    assertEquals(vm2Buckets, getBucketList(vm2, getPartitionedRegionName()));
-    assertEquals(vm2Buckets, getBucketList(vm2, "region2"));
-
-    vm0PrimaryBuckets = getPrimaryBucketList(vm0, getPartitionedRegionName());
-    assertEquals(vm0PrimaryBuckets, getPrimaryBucketList(vm0, "region2"));
-    vm1PrimaryBuckets = getPrimaryBucketList(vm1, getPartitionedRegionName());
-    assertEquals(vm1PrimaryBuckets, getPrimaryBucketList(vm1, "region2"));
-    vm2PrimaryBuckets = getPrimaryBucketList(vm2, getPartitionedRegionName());
-    assertEquals(vm2PrimaryBuckets, getPrimaryBucketList(vm2, "region2"));
-  }
-
-  @Test
-  public void testReplaceOfflineMemberAndRestart() throws Throwable {
-    SerializableRunnable createPRs = new SerializableRunnable("region1") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-
-        final CountDownLatch recoveryDone = new CountDownLatch(2);
-        ResourceObserver observer = new InternalResourceManager.ResourceObserverAdapter() {
-          @Override
-          public void recoveryFinished(Region region) {
-            recoveryDone.countDown();
-          }
-        };
-        InternalResourceManager.setResourceObserver(observer);
-
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-
-        try {
-          if (!recoveryDone.await(MAX_WAIT, TimeUnit.MILLISECONDS)) {
-            fail("timed out");
-          }
-        } catch (InterruptedException e) {
-          Assert.fail("interrupted", e);
-        }
-      }
-    };
-
-    replaceOfflineMemberAndRestart(createPRs);
-  }
-
-  /**
-   * Test that if we replace an offline member, even if colocated regions are in different disk
-   * stores, we still keep our metadata consistent.
-   *
-   */
-  @Test
-  public void testReplaceOfflineMemberAndRestartTwoDiskStores() throws Throwable {
-    SerializableRunnable createPRs = new SerializableRunnable("region1") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-
-        final CountDownLatch recoveryDone = new CountDownLatch(2);
-        ResourceObserver observer = new InternalResourceManager.ResourceObserverAdapter() {
-          @Override
-          public void recoveryFinished(Region region) {
-            recoveryDone.countDown();
-          }
-        };
-        InternalResourceManager.setResourceObserver(observer);
-
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-
-        DiskStore ds2 = cache.findDiskStore("disk2");
-        if (ds2 == null) {
-          ds2 = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk2");
-        }
-
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setPartitionAttributes(paf.create());
-        af.setDiskStoreName("disk2");
-        cache.createRegion("region2", af.create());
-
-        try {
-          if (!recoveryDone.await(MAX_WAIT, TimeUnit.MILLISECONDS)) {
-            fail("timed out");
-          }
-        } catch (InterruptedException e) {
-          Assert.fail("interrupted", e);
-        }
-      }
-    };
-
-    replaceOfflineMemberAndRestart(createPRs);
-  }
-
-  /**
-   * Test for support issue 7870. 1. Run three members with redundancy 1 and recovery delay 0 2.
-   * Kill one of the members, to trigger replacement of buckets 3. Shutdown all members and restart.
-   *
-   * What was happening is that in the parent PR, we discarded our offline data in one member, but
-   * in the child PR the other members ended up waiting for the child bucket to be created in the
-   * member that discarded it's offline data.
-   *
-   */
-  public void replaceOfflineMemberAndRestart(SerializableRunnable createPRs) throws Throwable {
-    disconnectAllFromDS();
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-    // Create the PR on three members
-    vm0.invoke(createPRs);
-    vm1.invoke(createPRs);
-    vm2.invoke(createPRs);
-
-    // Create some buckets.
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "a", "region2");
-
-    // Close one of the members to trigger redundancy recovery.
-    closeCache(vm2);
-
-    // Wait until redundancy is recovered.
-    waitForRedundancyRecovery(vm0, 1, getPartitionedRegionName());
-    waitForRedundancyRecovery(vm0, 1, "region2");
-
-    createData(vm0, 0, NUM_BUCKETS, "b");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
-    IgnoredException expected = IgnoredException.addIgnoredException("PartitionOfflineException");
-    try {
-
-      // Close the remaining members.
-      vm0.invoke(new SerializableCallable() {
-
-        @Override
-        public Object call() throws Exception {
-          InternalDistributedSystem ds =
-              (InternalDistributedSystem) getCache().getDistributedSystem();
-          AdminDistributedSystemImpl.shutDownAllMembers(ds.getDistributionManager(), 600000);
-          return null;
-        }
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+      vm.invoke(() -> {
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
       });
-
-      // Make sure that vm-1 is completely disconnected
-      // The shutdown all asynchronously finishes the disconnect after
-      // replying to the admin member.
-      vm1.invoke(new SerializableRunnable() {
-        @Override
-        public void run() {
-          basicGetSystem().disconnect();
-        }
-      });
-
-      // Recreate the members. Try to make sure that
-      // the member with the latest copy of the buckets
-      // is the one that decides to throw away it's copy
-      // by starting it last.
-      AsyncInvocation async0 = vm0.invokeAsync(createPRs);
-      AsyncInvocation async1 = vm1.invokeAsync(createPRs);
-      Wait.pause(2000);
-      AsyncInvocation async2 = vm2.invokeAsync(createPRs);
-      async0.getResult(MAX_WAIT);
-      async1.getResult(MAX_WAIT);
-      async2.getResult(MAX_WAIT);
-
-      checkData(vm0, 0, NUM_BUCKETS, "b");
-      checkData(vm0, 0, NUM_BUCKETS, "b", "region2");
-
-      waitForRedundancyRecovery(vm0, 1, getPartitionedRegionName());
-      waitForRedundancyRecovery(vm0, 1, "region2");
-      waitForRedundancyRecovery(vm1, 1, getPartitionedRegionName());
-      waitForRedundancyRecovery(vm1, 1, "region2");
-      waitForRedundancyRecovery(vm2, 1, getPartitionedRegionName());
-      waitForRedundancyRecovery(vm2, 1, "region2");
-
-      // Make sure we don't have any extra buckets after the restart
-      int totalBucketCount = getBucketList(vm0).size();
-      totalBucketCount += getBucketList(vm1).size();
-      totalBucketCount += getBucketList(vm2).size();
-
-      assertEquals(2 * NUM_BUCKETS, totalBucketCount);
-
-      totalBucketCount = getBucketList(vm0, "region2").size();
-      totalBucketCount += getBucketList(vm1, "region2").size();
-      totalBucketCount += getBucketList(vm2, "region2").size();
-
-      assertEquals(2 * NUM_BUCKETS, totalBucketCount);
-    } finally {
-      expected.remove();
     }
   }
 
   @Test
-  public void testReplaceOfflineMemberAndRestartCreateColocatedPRLate() throws Throwable {
-    SerializableRunnable createParentPR = new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+  public void testColocatedPRsRecoveryOneMemberLater() throws Exception {
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-      }
-    };
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> createChildPR_withRecovery(regionName, childRegionName1,
+          DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
 
-    SerializableRunnable createChildPR = new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "b");
+    });
 
-        final CountDownLatch recoveryDone = new CountDownLatch(1);
-        ResourceObserver observer = new InternalResourceManager.ResourceObserverAdapter() {
-          @Override
-          public void recoveryFinished(Region region) {
-            if (region.getName().contains("region2")) {
-              recoveryDone.countDown();
-            }
-          }
-        };
-        InternalResourceManager.setResourceObserver(observer);
+    Map<Integer, Set<Integer>> bucketIdsInVM = new HashMap<>();
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      bucketIdsInVM.put(vm.getId(), vm.invoke(() -> {
+        Set<Integer> bucketIds = getBucketIds(regionName);
+        assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+        return bucketIds;
+      }));
+    }
 
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(0);
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        Set<Integer> primaryBucketIds = getPrimaryBucketIds(regionName);
+        assertThat(getPrimaryBucketIds(childRegionName1)).isEqualTo(primaryBucketIds);
+      });
+    }
 
-        try {
-          if (!recoveryDone.await(MAX_WAIT, TimeUnit.MILLISECONDS)) {
-            fail("timed out");
-          }
-        } catch (InterruptedException e) {
-          Assert.fail("interrupted", e);
-        }
-      }
-    };
+    vm0.invoke(() -> {
+      assertThat(getCache().getDistributionManager().getDistributionManagerIds()).hasSize(4);
+    });
 
-    replaceOfflineMemberAndRestartCreateColocatedPRLate(createParentPR, createChildPR);
+    vm2.invoke(() -> closeCache());
+
+    // Make sure the other members notice that vm2 has gone
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        await().untilAsserted(() -> {
+          assertThat(getCache().getDistributionManager().getDistributionManagerIds()).hasSize(3);
+        });
+      });
+    }
+
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    // Create the members, but don't initialize VM2 yet
+    for (VM vm : toArray(vm0, vm1)) {
+      addAsync(vm.invokeAsync(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      }));
+    }
+    awaitAllAsync();
+
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> createChildPR_withRecovery(regionName, childRegionName1,
+          DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
+
+    for (VM vm : toArray(vm0, vm1)) {
+      Set<Integer> bucketIds = bucketIdsInVM.get(vm.getId());
+      vm.invoke(() -> waitForBucketRecovery(regionName, bucketIds));
+    }
+
+    vm0.invoke(() -> {
+      validateData(regionName, "a");
+      // region 2 didn't have persistent data, so it nothing should be recovered
+      validateData(childRegionName1, null);
+      // Make sure can do a put in all of the buckets in vm2
+      createData(childRegionName1, "c");
+      // Now all of those buckets should exist
+      validateData(childRegionName1, "c");
+    });
+
+    // Now we initialize vm2.
+    Set<Integer> bucketIds = bucketIdsInVM.get(vm2.getId());
+    vm2.invoke(() -> {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      // Make sure vm2 hasn't created any buckets in the parent PR yet
+      // We don't want any buckets until the child PR is created
+      assertThat(getBucketIds(regionName)).isEmpty();
+
+      createChildPR_withRecovery(regionName, childRegionName1, DEFAULT_RECOVERY_DELAY, 1,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      // Now vm2 should have created all of the appropriate buckets.
+      assertThat(getBucketIds(regionName)).isEqualTo(bucketIds);
+      assertThat(getBucketIds(childRegionName1)).isEqualTo(bucketIds);
+    });
+
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        Set<Integer> buckets = getPrimaryBucketIds(regionName);
+        assertThat(getPrimaryBucketIds(childRegionName1)).isEqualTo(buckets);
+      });
+    }
   }
 
   @Test
-  public void testReplaceOfflineMemberAndRestartCreateColocatedPRLateTwoDiskStores()
-      throws Throwable {
-    SerializableRunnable createParentPR = new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+  public void testReplaceOfflineMemberAndRestart() throws Exception {
+    // Create the PR on three members
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        CountDownLatch recoveryDone = prepareRecovery(2);
 
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-      }
-    };
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
 
-    SerializableRunnable createChildPR = new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        final CountDownLatch recoveryDone = new CountDownLatch(1);
-        ResourceObserver observer = new InternalResourceManager.ResourceObserverAdapter() {
-          @Override
-          public void recoveryFinished(Region region) {
-            if (region.getName().contains("region2")) {
-              recoveryDone.countDown();
-            }
-          }
-        };
-        InternalResourceManager.setResourceObserver(observer);
-
-        DiskStore ds2 = cache.findDiskStore("disk2");
-        if (ds2 == null) {
-          ds2 = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk2");
-        }
-
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(0);
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk2");
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-
-        try {
-          if (!recoveryDone.await(MAX_WAIT, TimeUnit.MILLISECONDS)) {
-            fail("timed out");
-          }
-        } catch (InterruptedException e) {
-          Assert.fail("interrupted", e);
-        }
-      }
-    };
-
-    replaceOfflineMemberAndRestartCreateColocatedPRLate(createParentPR, createChildPR);
-  }
-
-  /**
-   * Test for support issue 7870. 1. Run three members with redundancy 1 and recovery delay 0 2.
-   * Kill one of the members, to trigger replacement of buckets 3. Shutdown all members and restart.
-   *
-   * What was happening is that in the parent PR, we discarded our offline data in one member, but
-   * in the child PR the other members ended up waiting for the child bucket to be created in the
-   * member that discarded it's offline data.
-   *
-   * In this test case, we're creating the child PR later, after the parent buckets have already
-   * been completely created.
-   *
-   */
-  public void replaceOfflineMemberAndRestartCreateColocatedPRLate(
-      SerializableRunnable createParentPR, SerializableRunnable createChildPR) throws Throwable {
-    IgnoredException.addIgnoredException("PartitionOfflineException");
-    IgnoredException.addIgnoredException("RegionDestroyedException");
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-
-
-    // Create the PRs on three members
-    vm0.invoke(createParentPR);
-    vm1.invoke(createParentPR);
-    vm2.invoke(createParentPR);
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
-    vm2.invoke(createChildPR);
+        assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+      });
+    }
 
     // Create some buckets.
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "a", "region2");
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
 
     // Close one of the members to trigger redundancy recovery.
-    closeCache(vm2);
+    vm2.invoke(() -> closeCache());
 
-    // Wait until redundancy is recovered.
-    waitForRedundancyRecovery(vm0, 1, getPartitionedRegionName());
-    waitForRedundancyRecovery(vm0, 1, "region2");
+    vm0.invoke(() -> {
+      // Wait until redundancy is recovered.
+      waitForRedundancyRecovery(regionName, 1);
+      waitForRedundancyRecovery(childRegionName1, 1);
 
-    createData(vm0, 0, NUM_BUCKETS, "b");
-    createData(vm0, 0, NUM_BUCKETS, "b", "region2");
+      createData(regionName, "b");
+      createData(childRegionName1, "b");
+    });
+
+    addIgnoredException(PartitionOfflineException.class);
 
     // Close the remaining members.
-    vm0.invoke(new SerializableCallable() {
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
 
-      @Override
-      public Object call() throws Exception {
-        InternalDistributedSystem ds =
-            (InternalDistributedSystem) getCache().getDistributedSystem();
-        AdminDistributedSystemImpl.shutDownAllMembers(ds.getDistributionManager(), 0);
-        return null;
-      }
+    vm2.invoke(() -> {
+      latch = new CountDownLatch(2);
     });
 
-    // Make sure that vm-1 is completely disconnected
-    // The shutdown all asynchronously finishes the disconnect after
-    // replying to the admin member.
-    vm1.invoke(new SerializableRunnable() {
-      @Override
-      public void run() {
-        basicGetSystem().disconnect();
-      }
+    // Recreate the members. Try to make sure that the member with the latest copy of the buckets
+    // is the one that decides to throw away it's copy by starting it last.
+    for (VM vm : toArray(vm0, vm1)) {
+      addAsync(vm.invokeAsync(() -> {
+        CountDownLatch recoveryDone = prepareRecovery(2);
+
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+
+        vm2.invoke(() -> latch.countDown());
+
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+
+        assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+      }));
+    }
+    addAsync(vm2.invokeAsync(() -> {
+      latch.await();
+
+      CountDownLatch recoveryDone = prepareRecovery(2);
+
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+      createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1, 0, 1,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+    }));
+    awaitAllAsync();
+
+    vm0.invoke(() -> {
+      validateData(regionName, "b");
+      validateData(childRegionName1, "b");
     });
 
-    // Recreate the parent region. Try to make sure that
-    // the member with the latest copy of the buckets
-    // is the one that decides to throw away it's copy
-    // by starting it last.
-    AsyncInvocation async2 = vm2.invokeAsync(createParentPR);
-    AsyncInvocation async1 = vm1.invokeAsync(createParentPR);
-    Wait.pause(2000);
-    AsyncInvocation async0 = vm0.invokeAsync(createParentPR);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
-    async2.getResult(MAX_WAIT);
-
-    // Wait for async tasks
-    Wait.pause(2000);
-
-    // Recreate the child region.
-    async2 = vm2.invokeAsync(createChildPR);
-    async1 = vm1.invokeAsync(createChildPR);
-    async0 = vm0.invokeAsync(createChildPR);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
-    async2.getResult(MAX_WAIT);
-
-    // Validate the data
-    checkData(vm0, 0, NUM_BUCKETS, "b");
-    checkData(vm0, 0, NUM_BUCKETS, "b", "region2");
-
-    // Make sure we can actually use the buckets in the child region.
-    createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-
-    waitForRedundancyRecovery(vm0, 1, getPartitionedRegionName());
-    waitForRedundancyRecovery(vm0, 1, "region2");
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        waitForRedundancyRecovery(regionName, 1);
+        waitForRedundancyRecovery(childRegionName1, 1);
+      });
+    }
 
     // Make sure we don't have any extra buckets after the restart
-    int totalBucketCount = getBucketList(vm0).size();
-    totalBucketCount += getBucketList(vm1).size();
-    totalBucketCount += getBucketList(vm2).size();
+    int parentRegionBucketCount = vm0.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm1.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm2.invoke(() -> getBucketIds(regionName).size());
 
-    assertEquals(2 * NUM_BUCKETS, totalBucketCount);
+    assertThat(parentRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
 
-    totalBucketCount = getBucketList(vm0, "region2").size();
-    totalBucketCount += getBucketList(vm1, "region2").size();
-    totalBucketCount += getBucketList(vm2, "region2").size();
+    int childRegionBucketCount = vm0.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm1.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm2.invoke(() -> getBucketIds(childRegionName1).size());
 
-    assertEquals(2 * NUM_BUCKETS, totalBucketCount);
+    assertThat(childRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
+  }
+
+  @Test
+  public void testReplaceOfflineMemberAndRestart_WithMultipleDiskStores() throws Exception {
+    // Create the PR on three members
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        CountDownLatch recoveryDone = prepareRecovery(2);
+
+        createCache();
+        createDiskStore(diskStoreName1);
+        createDiskStore(diskStoreName2);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName2, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+
+        assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+      });
+    }
+
+    // Create some buckets.
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
+
+    // Close one of the members to trigger redundancy recovery.
+    vm2.invoke(() -> closeCache());
+
+    vm0.invoke(() -> {
+      // Wait until redundancy is recovered.
+      waitForRedundancyRecovery(regionName, 1);
+      waitForRedundancyRecovery(childRegionName1, 1);
+
+      createData(regionName, "b");
+      createData(childRegionName1, "b");
+    });
+
+    addIgnoredException(PartitionOfflineException.class);
+
+    // Close the remaining members.
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    vm2.invoke(() -> {
+      latch = new CountDownLatch(2);
+    });
+
+    // Recreate the members. Try to make sure that the member with the latest copy of the buckets
+    // is the one that decides to throw away it's copy by starting it last.
+    for (VM vm : toArray(vm0, vm1)) {
+      addAsync(vm.invokeAsync(() -> {
+        CountDownLatch recoveryDone = prepareRecovery(2);
+
+        createCache();
+        createDiskStore(diskStoreName1);
+        createDiskStore(diskStoreName2);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+
+        vm2.invoke(() -> latch.countDown());
+
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName2, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+
+        assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+      }));
+    }
+    addAsync(vm2.invokeAsync(() -> {
+      latch.await();
+
+      CountDownLatch recoveryDone = prepareRecovery(2);
+
+      createCache();
+      createDiskStore(diskStoreName1);
+      createDiskStore(diskStoreName2);
+      createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+      createChildPR_withPersistence(regionName, childRegionName1, diskStoreName2, 0, 1,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+    }));
+    awaitAllAsync();
+
+    vm0.invoke(() -> {
+      validateData(regionName, "b");
+      validateData(childRegionName1, "b");
+    });
+
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        waitForRedundancyRecovery(regionName, 1);
+        waitForRedundancyRecovery(childRegionName1, 1);
+      });
+    }
+
+    // Make sure we don't have any extra buckets after the restart
+    int parentRegionBucketCount = vm0.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm1.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm2.invoke(() -> getBucketIds(regionName).size());
+
+    assertThat(parentRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
+
+    int childRegionBucketCount = vm0.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm1.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm2.invoke(() -> getBucketIds(childRegionName1).size());
+
+    assertThat(childRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
+  }
+
+  @Test
+  public void testReplaceOfflineMemberAndRestartCreateColocatedPRLate() throws Exception {
+    addIgnoredException(PartitionOfflineException.class);
+    addIgnoredException(RegionDestroyedException.class);
+
+    // Create the PRs on three members
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
+
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> createChildPR_withPersistence_andRecovery(regionName, childRegionName1,
+          diskStoreName1, 0, 1, DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
+
+    // Create some buckets.
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
+
+    // Close one of the members to trigger redundancy recovery.
+    vm2.invoke(() -> closeCache());
+
+    // Wait until redundancy is recovered.
+    vm0.invoke(() -> {
+      waitForRedundancyRecovery(regionName, 1);
+      waitForRedundancyRecovery(childRegionName1, 1);
+
+      createData(regionName, "b");
+      createData(childRegionName1, "b");
+    });
+
+    // Close the remaining members.
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    // Recreate the parent region. Try to make sure that the member with the latest copy of the
+    // buckets is the one that decides to throw away it's copy by starting it last.
+    for (VM vm : toArray(vm2, vm1, vm0)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
+
+    // Recreate the child region.
+    for (VM vm : toArray(vm2, vm1, vm0)) {
+      addAsync(vm.invokeAsync(() -> createChildPR_withPersistence_andRecovery(regionName,
+          childRegionName1, diskStoreName1, 0, 1, DEFAULT_STARTUP_RECOVERY_DELAY)));
+    }
+    awaitAllAsync();
+
+    vm0.invoke(() -> {
+      // Validate the data
+      validateData(regionName, "b");
+      validateData(childRegionName1, "b");
+
+      // Make sure we can actually use the buckets in the child region.
+      createData(childRegionName1, "c");
+
+      waitForRedundancyRecovery(regionName, 1);
+      waitForRedundancyRecovery(childRegionName1, 1);
+    });
+
+    // Make sure we don't have any extra buckets after the restart
+    int parentRegionBucketCount = vm0.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm1.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm2.invoke(() -> getBucketIds(regionName).size());
+
+    assertThat(parentRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
+
+    int childRegionBucketCount = vm0.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm1.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm2.invoke(() -> getBucketIds(childRegionName1).size());
+
+    assertThat(childRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
+  }
+
+  @Test
+  public void testReplaceOfflineMemberAndRestartCreateColocatedPRLate_withMultipleDiskStore()
+      throws Exception {
+    addIgnoredException(PartitionOfflineException.class);
+    addIgnoredException(RegionDestroyedException.class);
+
+    // Create the PRs on three members
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
+
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> createChildPR_withPersistence_andRecovery(regionName, childRegionName1,
+          diskStoreName2, 0, 1, DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
+
+    // Create some buckets.
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
+
+    // Close one of the members to trigger redundancy recovery.
+    vm2.invoke(() -> closeCache());
+
+    // Wait until redundancy is recovered.
+    vm0.invoke(() -> {
+      waitForRedundancyRecovery(regionName, 1);
+      waitForRedundancyRecovery(childRegionName1, 1);
+
+      createData(regionName, "b");
+      createData(childRegionName1, "b");
+    });
+
+    // Close the remaining members.
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    // Recreate the parent region. Try to make sure that the member with the latest copy of the
+    // buckets is the one that decides to throw away it's copy by starting it last.
+    for (VM vm : toArray(vm2, vm1, vm0)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
+
+    // Recreate the child region.
+    for (VM vm : toArray(vm2, vm1, vm0)) {
+      addAsync(vm.invokeAsync(() -> createChildPR_withPersistence_andRecovery(regionName,
+          childRegionName1, diskStoreName2, 0, 1, DEFAULT_STARTUP_RECOVERY_DELAY)));
+    }
+    awaitAllAsync();
+
+    // Validate the data
+    vm0.invoke(() -> {
+      validateData(regionName, "b");
+      validateData(childRegionName1, "b");
+
+      // Make sure we can actually use the buckets in the child region.
+      createData(childRegionName1, "c");
+
+      waitForRedundancyRecovery(regionName, 1);
+      waitForRedundancyRecovery(childRegionName1, 1);
+    });
+
+    // Make sure we don't have any extra buckets after the restart
+    int parentRegionBucketCount = vm0.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm1.invoke(() -> getBucketIds(regionName).size());
+    parentRegionBucketCount += vm2.invoke(() -> getBucketIds(regionName).size());
+
+    assertThat(parentRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
+
+    int childRegionBucketCount = vm0.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm1.invoke(() -> getBucketIds(childRegionName1).size());
+    childRegionBucketCount += vm2.invoke(() -> getBucketIds(childRegionName1).size());
+
+    assertThat(childRegionBucketCount).isEqualTo(2 * NUM_BUCKETS);
   }
 
   /**
    * Test what happens when we crash in the middle of satisfying redundancy for a colocated bucket.
-   *
    */
-  // This test method is disabled because it is failing
-  // periodically and causing cruise control failures
-  // See bug #46748
   @Test
-  public void testCrashDuringRedundancySatisfaction() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
+  public void testCrashDuringRedundancySatisfaction() throws Exception {
+    vm0.invoke(() -> {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1, -1);
+      createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+          DEFAULT_RECOVERY_DELAY, 1, -1);
 
-    SerializableRunnable createPRs = new SerializableRunnable("region1") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
 
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        // Workaround for 44414 - disable recovery delay so we shutdown
-        // vm1 at a predictable point.
-        paf.setRecoveryDelay(-1);
-        paf.setStartupRecoveryDelay(-1);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-      }
-    };
-
-    // Create the PR on vm0
-    vm0.invoke(createPRs);
-
-
-    // Create some buckets.
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "a", "region2");
-
-    vm1.invoke(createPRs);
+    vm1.invoke(() -> {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1, -1);
+      createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+          DEFAULT_RECOVERY_DELAY, 1, -1);
+    });
 
     // We shouldn't have created any buckets in vm1 yet.
-    assertEquals(Collections.emptySet(), getBucketList(vm1));
+    vm1.invoke(() -> {
+      assertThat(getBucketIds(regionName)).isEmpty();
+    });
 
-    // Add an observer that will disconnect before allowing the peer to
-    // GII a colocated bucket. This should leave the peer with only the parent
-    // bucket
-    vm0.invoke(new SerializableRunnable() {
+    // Add an observer that will disconnect before allowing the peer to GII a colocated bucket.
+    // This should leave the peer with only the parent bucket
+    vm0.invoke(() -> {
+      latch = new CountDownLatch(1);
 
-      @Override
-      public void run() {
-        DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
-          @Override
-          public void beforeProcessMessage(ClusterDistributionManager dm,
-              DistributionMessage message) {
-            if (message instanceof RequestImageMessage) {
-              if (((RequestImageMessage) message).regionPath.contains("region2")) {
-                DistributionMessageObserver.setInstance(null);
-                disconnectFromDS();
-              }
+      DistributionMessageObserver.setInstance(new DistributionMessageObserver() {
+        @Override
+        public void beforeProcessMessage(ClusterDistributionManager dm,
+            DistributionMessage message) {
+          if (message instanceof RequestImageMessage) {
+            RequestImageMessage requestImageMessage = (RequestImageMessage) message;
+            if (requestImageMessage.getRegionPath().contains(regionName) ||
+                requestImageMessage.getRegionPath().contains(childRegionName1)) {
+              DistributionMessageObserver.setInstance(null);
+
+              latch.countDown();
             }
           }
+        }
+      });
+    });
+
+    AsyncInvocation<Void> disconnectDuringGiiInVm0 = vm0.invokeAsync(() -> {
+      latch.await(TIMEOUT_MILLIS, MILLISECONDS);
+
+      closeCache();
+    });
+
+    vm1.invoke(() -> {
+      try (IgnoredException ie = addIgnoredException(PartitionOfflineException.class)) {
+        // Do a rebalance to create buckets in vm1. THis will cause vm0 to disconnect
+        // as we satisfy redundancy with vm1.
+        Throwable thrown = catchThrowable(() -> {
+          getCache().getResourceManager().createRebalanceFactory().start().getResults();
         });
+        if (thrown != null) {
+          assertThat(thrown).isInstanceOf(PartitionOfflineException.class);
+        }
       }
     });
 
-    IgnoredException ex = IgnoredException.addIgnoredException("PartitionOfflineException", vm1);
-    try {
+    disconnectDuringGiiInVm0.await();
 
-      // Do a rebalance to create buckets in vm1. THis will cause vm0 to disconnect
-      // as we satisfy redundancy with vm1.
-      try {
-        RebalanceResults rr = rebalance(vm1);
-      } catch (Exception expected) {
-        // We expect to see a partition offline exception because of the
-        // disconnect
-        if (!(expected.getCause() instanceof PartitionOfflineException)) {
-          throw expected;
-        }
-      }
-
-
-      // Wait for vm0 to be closed by the callback
-      vm0.invoke(new SerializableCallable() {
-
-        @Override
-        public Object call() throws Exception {
-          GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-            @Override
-            public boolean done() {
-              InternalDistributedSystem ds = basicGetSystem();
-              return ds == null || !ds.isConnected();
-            }
-
-            @Override
-            public String description() {
-              return "DS did not disconnect";
-            }
-          });
-
-          return null;
-        }
-      });
-
-      // close the cache in vm1
-      SerializableCallable disconnectFromDS = new SerializableCallable() {
-
-        @Override
-        public Object call() throws Exception {
-          disconnectFromDS();
-          return null;
-        }
-      };
-      vm1.invoke(disconnectFromDS);
-
-      // Make sure vm0 is disconnected. This avoids a race where we
-      // may still in the process of disconnecting even though the our async listener
-      // found the system was disconnected
-      vm0.invoke(disconnectFromDS);
-    } finally {
-      ex.remove();
-    }
+    // close the cache in vm1
+    vm1.invoke(() -> closeCache());
 
     // Create the cache and PRs on both members
-    AsyncInvocation async0 = vm0.invokeAsync(createPRs);
-    AsyncInvocation async1 = vm1.invokeAsync(createPRs);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
+    for (VM vm : toArray(vm0, vm1)) {
+      addAsync(vm.invokeAsync(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1, -1);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, 1, -1);
+      }));
+    }
+    awaitAllAsync();
 
     // Make sure the data was recovered correctly
-    checkData(vm0, 0, NUM_BUCKETS, "a");
-    // Workaround for bug 46748.
-    checkData(vm0, 0, NUM_BUCKETS, "a", "region2");
+    vm0.invoke(() -> {
+      validateData(regionName, "a");
+      validateData(childRegionName1, "a");
+    });
   }
 
   @Test
-  public void testRebalanceWithOfflineChildRegion() throws Throwable {
-    SerializableRunnable createParentPR = new SerializableRunnable("createParentPR") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+  @Parameters({"disk1", "disk2"})
+  @TestCaseName("{method}(childRegionDiskStore={0})")
+  public void testRebalanceWithOfflineChildRegion(String childRegionDiskStore) throws Exception {
+    // Create the PRs on two members
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, DEFAULT_REDUNDANT_COPIES,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        paf.setRecoveryDelay(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-      }
-    };
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> createChildPR_withPersistence(regionName, childRegionName1,
+          childRegionDiskStore, 0, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
 
-    SerializableRunnable createChildPR = new SerializableRunnable("createChildPR") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
+    // Create some buckets.
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
 
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        paf.setRecoveryDelay(0);
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-      }
-    };
+    // Close the members
+    for (VM vm : toArray(vm1, vm0)) {
+      vm.invoke(() -> closeCache());
+    }
 
-    rebalanceWithOfflineChildRegion(createParentPR, createChildPR);
+    // Recreate the parent region. Try to make sure that the member with the latest copy of the
+    // buckets is the one that decides to throw away it's copy by starting it last.
 
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, DEFAULT_REDUNDANT_COPIES,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
+
+    // Now create the parent region on vm-2. vm-2 did not previous host the child region.
+    vm2.invoke(() -> {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, 0, DEFAULT_REDUNDANT_COPIES,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+    });
+
+    // Rebalance the parent region.
+    // This should not move any buckets, because we haven't recovered the child region
+    vm2.invoke(() -> {
+      RebalanceResults rebalanceResults =
+          getCache().getResourceManager().createRebalanceFactory().start().getResults();
+      assertThat(rebalanceResults.getTotalBucketTransfersCompleted()).isZero();
+    });
+
+    // Recreate the child region.
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      addAsync(vm.invokeAsync(() -> createChildPR_withPersistence(regionName, childRegionName1,
+          childRegionDiskStore, 0, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY)));
+    }
+    awaitAllAsync();
+
+    vm0.invoke(() -> {
+      // Validate the data
+      validateData(regionName, "a");
+      validateData(childRegionName1, "a");
+
+      // Make sure we can actually use the buckets in the child region.
+      createData(childRegionName1, "c");
+    });
   }
 
   /**
    * Test that a rebalance will regions are in the middle of recovery doesn't cause issues.
    *
-   * This is slightly different than {{@link #testRebalanceWithOfflineChildRegion()} because in this
-   * case all of the regions have been created, but they are in the middle of actually recovering
-   * buckets from disk.
+   * This is slightly different than {@link #testRebalanceWithOfflineChildRegion(boolean)} because
+   * in this case all of the regions have been created, but they are in the middle of actually
+   * recovering buckets from disk.
    */
   @Test
-  public void testRebalanceDuringRecovery() throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-    SerializableRunnable createPRs = new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-
-        paf.setRedundantCopies(1);
-        paf.setRecoveryDelay(-1);
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-      }
-    };
-
-
+  public void testRebalanceDuringRecovery() throws Exception {
     // Create the PRs on two members
-    vm0.invoke(createPRs);
-    vm1.invoke(createPRs);
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
 
     // Create some buckets.
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "a", "region2");
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
 
     // Close the members
-    closeCache(vm1);
-    closeCache(vm0);
+    for (VM vm : toArray(vm1, vm0)) {
+      vm.invoke(() -> closeCache());
+    }
 
-    SerializableRunnable addHook = new SerializableRunnable() {
-      @Override
-      public void run() {
-        PartitionedRegionObserverHolder.setInstance(new PRObserver());
-      }
-    };
-
-    SerializableRunnable waitForHook = new SerializableRunnable() {
-      @Override
-      public void run() {
-        PRObserver observer = (PRObserver) PartitionedRegionObserverHolder.getInstance();
-        try {
-          observer.waitForCreate();
-        } catch (InterruptedException e) {
-          Assert.fail("interrupted", e);
-        }
-      }
-    };
-
-    SerializableRunnable removeHook = new SerializableRunnable() {
-      @Override
-      public void run() {
-        PRObserver observer = (PRObserver) PartitionedRegionObserverHolder.getInstance();
-        observer.release();
-        PartitionedRegionObserverHolder.setInstance(new PartitionedRegionObserverAdapter());
-      }
-    };
-
-    vm1.invoke(addHook);
-    AsyncInvocation async0;
-    AsyncInvocation async1;
-    AsyncInvocation async2;
-    RebalanceResults rebalanceResults;
+    vm1.invoke(() -> {
+      PartitionedRegionObserverHolder.setInstance(new PRObserver(childRegionName1));
+    });
     try {
-      async0 = vm0.invokeAsync(createPRs);
-      async1 = vm1.invokeAsync(createPRs);
+      for (VM vm : toArray(vm0, vm1)) {
+        addAsync(vm.invokeAsync(() -> {
+          createCache();
+          createDiskStore(diskStoreName1);
+          createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+              DEFAULT_STARTUP_RECOVERY_DELAY);
+          createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+              DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY);
+        }));
+      }
 
-      vm1.invoke(waitForHook);
+      vm1.invoke(() -> {
+        PRObserver observer = (PRObserver) PartitionedRegionObserverHolder.getInstance();
+        observer.waitForCreate();
+      });
 
       // Now create the parent region on vm-2. vm-2 did not
       // previous host the child region.
-      vm2.invoke(createPRs);
+      vm2.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
 
       // Try to forcibly move some buckets to vm2 (this should not succeed).
       moveBucket(0, vm1, vm2);
       moveBucket(1, vm1, vm2);
 
     } finally {
-      vm1.invoke(removeHook);
+      vm1.invoke(() -> {
+        PRObserver observer = (PRObserver) PartitionedRegionObserverHolder.getInstance();
+        observer.tearDown();
+        PartitionedRegionObserverHolder.setInstance(new PartitionedRegionObserverAdapter());
+      });
     }
 
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
+    awaitAllAsync();
 
-    // Validate the data
-    checkData(vm0, 0, NUM_BUCKETS, "a");
-    checkData(vm0, 0, NUM_BUCKETS, "a", "region2");
+    vm0.invoke(() -> {
+      // Validate the data
+      validateData(regionName, "a");
+      validateData(childRegionName1, "a");
 
-    // Make sure we can actually use the buckets in the child region.
-    createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-
-    // Make sure the system is recoverable
-    // by restarting it
-    closeCache(vm2);
-    closeCache(vm1);
-    closeCache(vm0);
-
-    async0 = vm0.invokeAsync(createPRs);
-    async1 = vm1.invokeAsync(createPRs);
-    async2 = vm2.invokeAsync(createPRs);
-    async0.getResult();
-    async1.getResult();
-    async2.getResult();
-  }
-
-  @Test
-  public void testRebalanceWithOfflineChildRegionTwoDiskStores() throws Throwable {
-    SerializableRunnable createParentPR = new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        DiskStore ds = cache.findDiskStore("disk");
-        if (ds == null) {
-          ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-        }
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        paf.setRecoveryDelay(0);
-        af.setPartitionAttributes(paf.create());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk");
-        cache.createRegion(getPartitionedRegionName(), af.create());
-      }
-    };
-
-    SerializableRunnable createChildPR = new SerializableRunnable() {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-
-        DiskStore ds2 = cache.findDiskStore("disk2");
-        if (ds2 == null) {
-          ds2 = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk2");
-        }
-
-        AttributesFactory af = new AttributesFactory();
-        PartitionAttributesFactory paf = new PartitionAttributesFactory();
-        paf.setRedundantCopies(0);
-        paf.setRecoveryDelay(0);
-        paf.setColocatedWith(getPartitionedRegionName());
-        af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-        af.setDiskStoreName("disk2");
-        af.setPartitionAttributes(paf.create());
-        cache.createRegion("region2", af.create());
-      }
-    };
-
-    rebalanceWithOfflineChildRegion(createParentPR, createChildPR);
-  }
-
-  /**
-   * Test that a user is not allowed to change the colocation of a PR with persistent data.
-   *
-   */
-  @Test
-  public void testModifyColocation() throws Throwable {
-    // Create PRs where region3 is colocated with region1.
-    createColocatedPRs("region1");
-
-    // Close everything
-    closeCache();
-
-    // Restart colocated with "region2"
-    IgnoredException ex =
-        IgnoredException.addIgnoredException("DiskAccessException|IllegalStateException");
-    try {
-      createColocatedPRs("region2");
-      fail("Should have received an illegal state exception");
-    } catch (IllegalStateException expected) {
-      // do nothing
-    } finally {
-      ex.remove();
-    }
-
-    // Close everything
-    closeCache();
-
-    // Restart colocated with region1.
-    // Make sure we didn't screw anything up.
-    createColocatedPRs("/region1");
-
-    // Close everything
-    closeCache();
-
-    // Restart uncolocated. We don't allow changing
-    // from uncolocated to colocated.
-    ex = IgnoredException.addIgnoredException("DiskAccessException|IllegalStateException");
-    try {
-      createColocatedPRs(null);
-      fail("Should have received an illegal state exception");
-    } catch (IllegalStateException expected) {
-      // do nothing
-    } finally {
-      ex.remove();
-    }
-
-    // Close everything
-    closeCache();
-  }
-
-  @Test
-  public void testParentRegionGetWithOfflineChildRegion() throws Throwable {
-
-    SerializableRunnable createParentPR = new SerializableRunnable("createParentPR") {
-      @Override
-      public void run() {
-        String oldRetryTimeout = System.setProperty(
-            DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout", "10000");
-        try {
-          Cache cache = getCache();
-          DiskStore ds = cache.findDiskStore("disk");
-          if (ds == null) {
-            ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-          }
-          AttributesFactory af = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(0);
-          af.setPartitionAttributes(paf.create());
-          af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-          af.setDiskStoreName("disk");
-          cache.createRegion(getPartitionedRegionName(), af.create());
-        } finally {
-          System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout",
-              String.valueOf(PartitionedRegionHelper.DEFAULT_TOTAL_WAIT_RETRY_ITERATION));
-        }
-      }
-    };
-
-    SerializableRunnable createChildPR = new SerializableRunnable("createChildPR") {
-      @Override
-      public void run() throws InterruptedException {
-        String oldRetryTimeout = System.setProperty(
-            DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout", "10000");
-        try {
-          Cache cache = getCache();
-          AttributesFactory af = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(0);
-          paf.setColocatedWith(getPartitionedRegionName());
-          af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-          af.setDiskStoreName("disk");
-          af.setPartitionAttributes(paf.create());
-          // delay child region creations to cause a delay in persistent recovery
-          Thread.sleep(100);
-          cache.createRegion("region2", af.create());
-        } finally {
-          System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout",
-              String.valueOf(PartitionedRegionHelper.DEFAULT_TOTAL_WAIT_RETRY_ITERATION));
-        }
-      }
-    };
-
-    boolean caughtException = false;
-    try {
-      // Expect a get() on the un-recovered (due to offline child) parent region to fail
-      regionGetWithOfflineChild(createParentPR, createChildPR, false);
-    } catch (Exception e) {
-      caughtException = true;
-      assertTrue(e instanceof RMIException);
-      assertTrue(e.getCause() instanceof PartitionOfflineException);
-    }
-    if (!caughtException) {
-      fail("Expected TimeoutException from remote");
-    }
-  }
-
-  @Test
-  public void testParentRegionGetWithRecoveryInProgress() throws Throwable {
-    SerializableRunnable createParentPR = new SerializableRunnable("createParentPR") {
-      @Override
-      public void run() {
-        String oldRetryTimeout = System.setProperty(
-            DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout", "10000");
-        try {
-          Cache cache = getCache();
-          DiskStore ds = cache.findDiskStore("disk");
-          if (ds == null) {
-            ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-          }
-          AttributesFactory af = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(0);
-          af.setPartitionAttributes(paf.create());
-          af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-          af.setDiskStoreName("disk");
-          cache.createRegion(getPartitionedRegionName(), af.create());
-        } finally {
-          System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout",
-              String.valueOf(PartitionedRegionHelper.DEFAULT_TOTAL_WAIT_RETRY_ITERATION));
-          System.out.println("oldRetryTimeout = " + oldRetryTimeout);
-        }
-      }
-    };
-
-    SerializableRunnable createChildPR = new SerializableRunnable("createChildPR") {
-      @Override
-      public void run() throws InterruptedException {
-        String oldRetryTimeout = System.setProperty(
-            DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout", "10000");
-        try {
-          Cache cache = getCache();
-          AttributesFactory af = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(0);
-          paf.setColocatedWith(getPartitionedRegionName());
-          af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-          af.setDiskStoreName("disk");
-          af.setPartitionAttributes(paf.create());
-          cache.createRegion("region2", af.create());
-        } finally {
-          System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout",
-              String.valueOf(PartitionedRegionHelper.DEFAULT_TOTAL_WAIT_RETRY_ITERATION));
-        }
-      }
-    };
-
-    boolean caughtException = false;
-    try {
-      // Expect a get() on the un-recovered (due to offline child) parent region to fail
-      regionGetWithOfflineChild(createParentPR, createChildPR, false);
-    } catch (Exception e) {
-      caughtException = true;
-      assertTrue(e instanceof RMIException);
-      assertTrue(e.getCause() instanceof PartitionOfflineException);
-    }
-    if (!caughtException) {
-      fail("Expected TimeoutException from remote");
-    }
-  }
-
-  @Test
-  public void testParentRegionPutWithRecoveryInProgress() throws Throwable {
-    SerializableRunnable createParentPR = new SerializableRunnable("createParentPR") {
-      @Override
-      public void run() {
-        String oldRetryTimeout = System.setProperty(
-            DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout", "10000");
-        System.out.println("oldRetryTimeout = " + oldRetryTimeout);
-        try {
-          Cache cache = getCache();
-          DiskStore ds = cache.findDiskStore("disk");
-          if (ds == null) {
-            ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-          }
-          AttributesFactory af = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(0);
-          af.setPartitionAttributes(paf.create());
-          af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-          af.setDiskStoreName("disk");
-          cache.createRegion(getPartitionedRegionName(), af.create());
-        } finally {
-          System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout",
-              String.valueOf(PartitionedRegionHelper.DEFAULT_TOTAL_WAIT_RETRY_ITERATION));
-        }
-      }
-    };
-
-    SerializableRunnable createChildPR = new SerializableRunnable("createChildPR") {
-      @Override
-      public void run() throws InterruptedException {
-        String oldRetryTimeout = System.setProperty(
-            DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout", "10000");
-        try {
-          Cache cache = getCache();
-          AttributesFactory af = new AttributesFactory();
-          PartitionAttributesFactory paf = new PartitionAttributesFactory();
-          paf.setRedundantCopies(0);
-          paf.setRecoveryDelay(0);
-          paf.setColocatedWith(getPartitionedRegionName());
-          af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-          af.setDiskStoreName("disk");
-          af.setPartitionAttributes(paf.create());
-          Thread.sleep(1000);
-          cache.createRegion("region2", af.create());
-        } finally {
-          System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "partitionedRegionRetryTimeout",
-              String.valueOf(PartitionedRegionHelper.DEFAULT_TOTAL_WAIT_RETRY_ITERATION));
-        }
-      }
-    };
-
-    boolean caughtException = false;
-    try {
-      // Expect a get() on the un-recovered (due to offline child) parent region to fail
-      regionGetWithOfflineChild(createParentPR, createChildPR, false);
-    } catch (Exception e) {
-      caughtException = true;
-      assertTrue(e instanceof RMIException);
-      assertTrue(e.getCause() instanceof PartitionOfflineException);
-    }
-    if (!caughtException) {
-      fail("Expected TimeoutException from remote");
-    }
-  }
-
-  /**
-   * Create three PRs on a VM, named region1, region2, and region3. The colocated with attribute
-   * describes which region region3 should be colocated with.
-   *
-   */
-  private void createColocatedPRs(final String colocatedWith) {
-    Cache cache = getCache();
-
-    DiskStore ds = cache.findDiskStore("disk");
-    if (ds == null) {
-      ds = cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
-    }
-    AttributesFactory af = new AttributesFactory();
-    PartitionAttributesFactory paf = new PartitionAttributesFactory();
-    paf.setRedundantCopies(0);
-    af.setPartitionAttributes(paf.create());
-    af.setDataPolicy(DataPolicy.PERSISTENT_PARTITION);
-    af.setDiskStoreName("disk");
-    cache.createRegion("region1", af.create());
-
-    cache.createRegion("region2", af.create());
-
-    if (colocatedWith != null) {
-      paf.setColocatedWith(colocatedWith);
-    }
-    af.setPartitionAttributes(paf.create());
-    cache.createRegion("region3", af.create());
-  }
-
-  /**
-   * Test for bug 43570. Rebalance a persistent parent PR before we recover the persistent child PR
-   * from disk.
-   *
-   */
-  public void rebalanceWithOfflineChildRegion(SerializableRunnable createParentPR,
-      SerializableRunnable createChildPR) throws Throwable {
-    Host host = Host.getHost(0);
-    VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-
-
-    // Create the PRs on two members
-    vm0.invoke(createParentPR);
-    vm1.invoke(createParentPR);
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
-
-    // Create some buckets.
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "a", "region2");
-
-    // Close the members
-    closeCache(vm1);
-    closeCache(vm0);
-
-    // Recreate the parent region. Try to make sure that
-    // the member with the latest copy of the buckets
-    // is the one that decides to throw away it's copy
-    // by starting it last.
-    AsyncInvocation async0 = vm0.invokeAsync(createParentPR);
-    AsyncInvocation async1 = vm1.invokeAsync(createParentPR);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
-
-    // Now create the parent region on vm-2. vm-2 did not
-    // previous host the child region.
-    vm2.invoke(createParentPR);
-
-    // Rebalance the parent region.
-    // This should not move any buckets, because
-    // we haven't recovered the child region
-    RebalanceResults rebalanceResults = rebalance(vm2);
-    assertEquals(0, rebalanceResults.getTotalBucketTransfersCompleted());
-
-    // Recreate the child region.
-    async1 = vm1.invokeAsync(createChildPR);
-    async0 = vm0.invokeAsync(createChildPR);
-    AsyncInvocation async2 = vm2.invokeAsync(createChildPR);
-    async0.getResult(MAX_WAIT);
-    async1.getResult(MAX_WAIT);
-    async2.getResult(MAX_WAIT);
-
-    // Validate the data
-    checkData(vm0, 0, NUM_BUCKETS, "a");
-    checkData(vm0, 0, NUM_BUCKETS, "a", "region2");
-
-    // Make sure we can actually use the buckets in the child region.
-    createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-  }
-
-  /**
-   * Create a colocated pair of persistent regions and populate them with data. Shut down the
-   * servers and then restart them and check the data.
-   * <p>
-   * On the restart, try region operations ({@code get()}) on the parent region before or during
-   * persistent recovery. The {@code concurrentCheckData} argument determines whether the operation
-   * from the parent region occurs before or concurrent with the child region creation and recovery.
-   *
-   * @param createParentPR {@link SerializableRunnable} for creating the parent region on one member
-   * @param createChildPR {@link SerializableRunnable} for creating the child region on one member
-   */
-  public void regionGetWithOfflineChild(SerializableRunnable createParentPR,
-      SerializableRunnable createChildPR, boolean concurrentCheckData) throws Throwable {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
-
-    // Create the PRs on two members
-    vm0.invoke(createParentPR);
-    vm1.invoke(createParentPR);
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
-
-    // Create some buckets.
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "a", "region2");
-
-    // Close the members
-    closeCache(vm1);
-    closeCache(vm0);
-
-    SerializableRunnable checkDataOnParent = (new SerializableRunnable("checkDataOnParent") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(getPartitionedRegionName());
-
-        for (int i = 0; i < NUM_BUCKETS; i++) {
-          assertEquals("For key " + i, "a", region.get(i));
-        }
-      }
+      // Make sure we can actually use the buckets in the child region.
+      createData(childRegionName1, "c");
     });
 
-    try {
-      // Recreate the parent region. Try to make sure that
-      // the member with the latest copy of the buckets
-      // is the one that decides to throw away it's copy
-      // by starting it last.
-      AsyncInvocation async0 = vm0.invokeAsync(createParentPR);
-      AsyncInvocation async1 = vm1.invokeAsync(createParentPR);
-      async0.getResult(MAX_WAIT);
-      async1.getResult(MAX_WAIT);
-      // Now create the parent region on vm-2. vm-2 did not
-      // previously host the child region.
-      vm2.invoke(createParentPR);
+    // Make sure the system is recoverable by restarting it
 
-      AsyncInvocation async2 = null;
-      AsyncInvocation asyncCheck = null;
-      if (concurrentCheckData) {
-        // Recreate the child region.
-        async1 = vm1.invokeAsync(createChildPR);
-        async0 = vm0.invokeAsync(createChildPR);
-        async2 = vm2.invokeAsync(new SerializableRunnable("delay") {
-          @Override
-          public void run() throws InterruptedException {
-            Thread.sleep(100);
-            vm2.invoke(createChildPR);
-          }
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    for (VM vm : toArray(vm0, vm1, vm2)) {
+      addAsync(vm.invokeAsync(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY, 1,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+        createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, 1, DEFAULT_STARTUP_RECOVERY_DELAY);
+      }));
+    }
+    awaitAllAsync();
+  }
+
+  @Test
+  public void testParentRegionGetWithOfflineChildRegion() {
+    // Expect a get() on the un-recovered (due to offline child) parent region to fail
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, DEFAULT_REDUNDANT_COPIES,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
+
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(
+          () -> createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1, 0,
+              DEFAULT_REDUNDANT_COPIES,
+              DEFAULT_STARTUP_RECOVERY_DELAY));
+    }
+
+    // Create some buckets.
+    vm0.invoke(() -> {
+      createData(regionName, "a");
+      createData(childRegionName1, "a");
+    });
+
+    // Close the members
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> closeCache());
+    }
+
+    // Recreate the parent region. Try to make sure that the member with the latest copy of the
+    // buckets is the one that decides to throw away it's copy by starting it last.
+    for (VM vm : toArray(vm0, vm1)) {
+      vm.invoke(() -> {
+        createCache();
+        createDiskStore(diskStoreName1);
+        createPR_withPersistence(regionName, diskStoreName1, 0, DEFAULT_REDUNDANT_COPIES,
+            DEFAULT_STARTUP_RECOVERY_DELAY);
+      });
+    }
+
+    // Now create the parent region on vm-2. vm-2 did not previously host the child region.
+    vm2.invoke(() -> {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, 0, DEFAULT_REDUNDANT_COPIES,
+          DEFAULT_STARTUP_RECOVERY_DELAY);
+    });
+
+    vm0.invoke(() -> {
+      Region<Integer, String> region = getCache().getRegion(regionName);
+      Throwable thrown = catchThrowable(() -> region.get(0));
+      assertThat(thrown).isInstanceOf(PartitionOfflineException.class);
+    });
+  }
+
+  private void createPR_withPersistence(String regionName, String diskStoreName, long recoveryDelay,
+      int redundantCopies, long startupRecoveryDelay) {
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRecoveryDelay(recoveryDelay);
+    partitionAttributesFactory.setRedundantCopies(redundantCopies);
+    partitionAttributesFactory.setStartupRecoveryDelay(startupRecoveryDelay);
+
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION_PERSISTENT);
+    regionFactory.setDiskStoreName(diskStoreName);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(regionName);
+  }
+
+  private void createChildPR(String parentRegionName, String childRegionName, long recoveryDelay,
+      int redundantCopies, long startupRecoveryDelay) {
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setColocatedWith(parentRegionName);
+    partitionAttributesFactory.setRecoveryDelay(recoveryDelay);
+    partitionAttributesFactory.setRedundantCopies(redundantCopies);
+    partitionAttributesFactory.setStartupRecoveryDelay(startupRecoveryDelay);
+
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(childRegionName);
+  }
+
+  private void createChildPR_withPersistence(String parentRegionName, String childRegionName,
+      String diskStoreName, long recoveryDelay, int redundantCopies, long startupRecoveryDelay) {
+    createDiskStore(diskStoreName);
+
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setColocatedWith(parentRegionName);
+    partitionAttributesFactory.setRecoveryDelay(recoveryDelay);
+    partitionAttributesFactory.setRedundantCopies(redundantCopies);
+    partitionAttributesFactory.setStartupRecoveryDelay(startupRecoveryDelay);
+
+    RegionFactory regionFactory = getCache().createRegionFactory(PARTITION_PERSISTENT);
+    regionFactory.setDiskStoreName(diskStoreName);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create(childRegionName);
+  }
+
+  private void createChildPR_withPersistence_andRecovery(String parentRegionName,
+      String childRegionName, String diskStoreName, long recoveryDelay, int redundantCopies,
+      long startupRecoveryDelay) throws InterruptedException {
+    CountDownLatch recoveryDone = prepareRecovery(1, childRegionName1);
+
+    createChildPR_withPersistence(parentRegionName, childRegionName, diskStoreName, recoveryDelay,
+        redundantCopies, startupRecoveryDelay);
+
+    assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+  }
+
+  private void createChildPR_withRecovery(String parentRegionName, String childRegionName,
+      long recoveryDelay, int redundantCopies, long startupRecoveryDelay)
+      throws InterruptedException {
+    CountDownLatch recoveryDone = prepareRecovery(1, childRegionName1);
+
+    createChildPR(parentRegionName, childRegionName, recoveryDelay, redundantCopies,
+        startupRecoveryDelay);
+
+    assertThat(recoveryDone.await(TIMEOUT_MILLIS, MILLISECONDS)).isTrue();
+  }
+
+  private CountDownLatch prepareRecovery(int count) {
+    return prepareRecovery(count, null);
+  }
+
+  private CountDownLatch prepareRecovery(int count, String regionName) {
+    CountDownLatch recoveryDone = new CountDownLatch(count);
+    ResourceObserver observer = new InternalResourceManager.ResourceObserverAdapter() {
+      @Override
+      public void recoveryFinished(Region region) {
+        if (regionName == null || region.getName().contains(regionName)) {
+          recoveryDone.countDown();
+        }
+      }
+    };
+    InternalResourceManager.setResourceObserver(observer);
+    return recoveryDone;
+  }
+
+  private String createPRWithMissingChild(int expectedLogMessagesCount) {
+    try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+          DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      // Let this thread continue running long enough for the missing region to be logged a
+      // couple times. Child regions do not get created by this thread.
+      await().untilAsserted(() -> {
+        assertThat(mockAppender.getLogs()).hasSize(expectedLogMessagesCount);
+      });
+
+      return mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
+    }
+  }
+
+  private String createMissingChildPR(int expectedLogMessagesCount) throws InterruptedException {
+    try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+          DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      // Delay creation of second (i.e child) region to see missing colocated region log
+      // message (logInterval/2 < delay < logInterval)
+      await().untilAsserted(() -> {
+        assertThat(mockAppender.getLogs()).hasSize(expectedLogMessagesCount);
+      });
+
+      createChildPR_withPersistence(regionName, childRegionName1, diskStoreName1,
+          DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      return mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
+    }
+  }
+
+  private String createChildPRGenerations(int childPRGenerationsCount, int expectedLogMessagesCount)
+      throws InterruptedException {
+    try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+          DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      // Delay creation of child generation regions to see missing colocated region log message
+      // parent region is generation 1, child region is generation 2, grandchild is 3, etc.
+      for (int generation = 2; generation < childPRGenerationsCount + 2; ++generation) {
+        String childPRName = "region" + generation;
+        String colocatedWithRegionName =
+            generation == 2 ? regionName : "region" + (generation - 1);
+
+        // delay between starting generations of child regions until the expected missing
+        // colocation messages are logged
+        int expectedCount = (generation - 1) * generation / 2;
+        await().untilAsserted(() -> {
+          assertThat(mockAppender.getLogs()).hasSize(expectedCount);
         });
 
-        asyncCheck = vm0.invokeAsync(checkDataOnParent);
-      } else {
-        vm0.invoke(checkDataOnParent);
+        // Start the child region
+        createChildPR_withPersistence(colocatedWithRegionName, childPRName, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
       }
-      async0.getResult(MAX_WAIT);
-      async1.getResult(MAX_WAIT);
-      async2.getResult(MAX_WAIT);
-      asyncCheck.getResult(MAX_WAIT);
-      // Validate the data
-      checkData(vm0, 0, NUM_BUCKETS, "a");
-      checkData(vm0, 0, NUM_BUCKETS, "a", "region2");
-      // Make sure we can actually use the buckets in the child region.
-      createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-    } finally {
-      // Close the members
-      closeCache(vm1);
-      closeCache(vm0);
-      closeCache(vm2);
+
+      assertThat(mockAppender.getLogs()).hasSize(expectedLogMessagesCount);
+
+      verify(mockAppender.getAppender(), atLeastOnce()).getName();
+      verify(mockAppender.getAppender(), atLeastOnce()).isStarted();
+
+      // Another delay before exiting the thread to make sure that missing region logging
+      // doesn't continue after all regions are created (delay > logInterval)
+      Thread.sleep(ColocationLogger.getLogInterval() * 2);
+
+      verifyNoMoreInteractions(mockAppender.getAppender());
+
+      return mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
+    }
+  }
+
+  private String createMultipleChildPRGenerations(int childCount, int expectedLogMessagesCount)
+      throws InterruptedException {
+    try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,
+          DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      // Delay creation of child generation regions to see missing colocated region log message
+      for (int regionCount = 2; regionCount < childCount + 2; ++regionCount) {
+        String childPRName = "region" + regionCount;
+
+        // delay between starting generations of child regions until the expected missing
+        // colocation messages are logged
+        int expectedCount = regionCount - 1;
+        await().untilAsserted(() -> {
+          assertThat(mockAppender.getLogs()).hasSize(expectedCount);
+        });
+
+        assertThat(mockAppender.getLogs().size()).isEqualTo(regionCount - 1);
+
+        // Start the child region
+        createChildPR_withPersistence(regionName, childPRName, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+      }
+
+      assertThat(mockAppender.getLogs()).hasSize(expectedLogMessagesCount);
+
+      String logMessage = mockAppender.getLogs().get(0).getMessage().getFormattedMessage();
+
+      verify(mockAppender.getAppender(), atLeastOnce()).getName();
+      verify(mockAppender.getAppender(), atLeastOnce()).isStarted();
+
+      // Another delay before exiting the thread to make sure that missing region logging
+      // doesn't continue after all regions are created (delay > logInterval)
+      Thread.sleep(ColocationLogger.getLogInterval() * 2);
+
+      verifyNoMoreInteractions(mockAppender.getAppender());
+
+      return logMessage;
     }
   }
 
   /**
-   * Create a colocated pair of persistent regions and populate them with data. Shut down the
-   * servers and then restart them.
-   * <p>
-   * On the restart, try region operations ({@code put()}) on the parent region before or during
-   * persistent recovery. The {@code concurrentCreatekData} argument determines whether the
-   * operation from the parent region occurs before or concurrent with the child region creation and
-   * recovery.
-   *
-   * @param createParentPR {@link SerializableRunnable} for creating the parent region on one member
-   * @param createChildPR {@link SerializableRunnable} for creating the child region on one member
+   * This thread starts up multiple colocated child regions in the sequence defined by
+   * {@link #childRegionTreeRestartOrder}. The complete startup sequence, which includes timed
+   * periods waiting for log messages, takes at least 28 secs. Tests waiting for this
+   * {@link SerializableCallable} to complete must have sufficient overhead in the wait for runtime
+   * variations that exceed the minimum time to complete.
    */
-  public void regionPutWithOfflineChild(SerializableRunnable createParentPR,
-      SerializableRunnable createChildPR, boolean concurrentCreateData) throws Throwable {
-    Host host = Host.getHost(0);
-    final VM vm0 = host.getVM(0);
-    VM vm1 = host.getVM(1);
-    VM vm2 = host.getVM(2);
+  private String createChildPRTree() throws InterruptedException {
+    try (MockAppender mockAppender = new MockAppender(ColocationLogger.class)) {
 
-    SerializableRunnable checkDataOnParent = (new SerializableRunnable("checkDataOnParent") {
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        Region region = cache.getRegion(getPartitionedRegionName());
+      // Logger interval may have been hooked by the test, so adjust test delays here
+      int logInterval = ColocationLogger.getLogInterval();
 
-        for (int i = 0; i < NUM_BUCKETS; i++) {
-          assertEquals("For key " + i, "a", region.get(i));
-        }
+      createCache();
+      createDiskStore(diskStoreName1);
+      createPR_withPersistence("Parent", diskStoreName1, DEFAULT_RECOVERY_DELAY,
+          DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
+
+      // Delay creation of descendant regions in the hierarchy to see missing colocated region
+      // log messages (logInterval/2 < delay < logInterval)
+
+      int expectedLogMessagesCount = 1;
+      ArgumentCaptor<LogEvent> logEventCaptor = ArgumentCaptor.forClass(LogEvent.class);
+      Appender appender = mockAppender.getAppender();
+
+      for (Object[] regionInfo : childRegionTreeRestartOrder()) {
+        logEventCaptor = ArgumentCaptor.forClass(LogEvent.class);
+        String childRegionName = (String) regionInfo[0];
+        String parentRegionName = (String) regionInfo[1];
+
+        // delay between starting generations of child regions and verify expected logging
+        ArgumentCaptor<LogEvent> loggingEventCaptorRef = logEventCaptor;
+        await().untilAsserted(() -> {
+          verify(appender, times(expectedLogMessagesCount))
+              .append(loggingEventCaptorRef.capture());
+        });
+
+        // Finally start the next child region
+        createChildPR_withPersistence(parentRegionName, childRegionName, diskStoreName1,
+            DEFAULT_RECOVERY_DELAY, DEFAULT_REDUNDANT_COPIES, DEFAULT_STARTUP_RECOVERY_DELAY);
       }
-    });
 
-    SerializableRunnable createDataOnParent = new SerializableRunnable("createDataOnParent") {
+      List<LogEvent> logEvents = logEventCaptor.getAllValues();
+      assertThat(logEvents).hasSize(expectedLogMessagesCount);
 
-      @Override
-      public void run() {
-        Cache cache = getCache();
-        LogWriterUtils.getLogWriter().info("creating data in " + getPartitionedRegionName());
-        Region region = cache.getRegion(getPartitionedRegionName());
+      String logMessage = logEvents.get(0).getMessage().getFormattedMessage();
 
-        for (int i = 0; i < NUM_BUCKETS; i++) {
-          region.put(i, "c");
-          assertEquals("For key " + i, "c", region.get(i));
-        }
-      }
-    };
+      // acknowledge interactions with the mock that have occurred
+      verify(appender, atLeastOnce()).getName();
+      verify(appender, atLeastOnce()).isStarted();
+      verify(appender, atLeastOnce()).append(any(LogEvent.class));
 
-    // Create the PRs on two members
-    vm0.invoke(createParentPR);
-    vm1.invoke(createParentPR);
-    vm0.invoke(createChildPR);
-    vm1.invoke(createChildPR);
+      // Another delay before exiting the thread to make sure that missing region logging
+      // doesn't continue after all regions are created (delay > logInterval)
+      Thread.sleep(logInterval * 2);
 
-    // Create some buckets.
-    createData(vm0, 0, NUM_BUCKETS, "a");
-    createData(vm0, 0, NUM_BUCKETS, "a", "region2");
+      verifyNoMoreInteractions(appender);
 
-    // Close the members
-    closeCache(vm1);
-    closeCache(vm0);
-
-    try {
-      // Recreate the parent region. Try to make sure that
-      // the member with the latest copy of the buckets
-      // is the one that decides to throw away it's copy
-      // by starting it last.
-      AsyncInvocation async0 = vm0.invokeAsync(createParentPR);
-      AsyncInvocation async1 = vm1.invokeAsync(createParentPR);
-      async0.getResult(MAX_WAIT);
-      async1.getResult(MAX_WAIT);
-      // Now create the parent region on vm-2. vm-2 did not
-      // previous host the child region.
-      vm2.invoke(createParentPR);
-
-      AsyncInvocation async2 = null;
-      AsyncInvocation asyncPut = null;
-      if (concurrentCreateData) {
-        // Recreate the child region.
-        async1 = vm1.invokeAsync(createChildPR);
-        async0 = vm0.invokeAsync(createChildPR);
-        async2 = vm2.invokeAsync(createChildPR);
-
-        Thread.sleep(100);
-        asyncPut = vm0.invokeAsync(createDataOnParent);
-      } else {
-        vm0.invoke(createDataOnParent);
-      }
-      async0.getResult(MAX_WAIT);
-      async1.getResult(MAX_WAIT);
-      async2.getResult(MAX_WAIT);
-      asyncPut.getResult(MAX_WAIT);
-      // Validate the data
-      checkData(vm0, 0, NUM_BUCKETS, "c");
-      checkData(vm0, 0, NUM_BUCKETS, "a", "region2");
-      // Make sure we can actually use the buckets in the child region.
-      createData(vm0, 0, NUM_BUCKETS, "c", "region2");
-    } finally {
-      // Close the members
-      closeCache(vm1);
-      closeCache(vm0);
-      closeCache(vm2);
+      return logMessage;
     }
   }
 
-  private RebalanceResults rebalance(VM vm) {
-    return (RebalanceResults) vm.invoke(new SerializableCallable() {
+  /**
+   * The colocation tree has the regions started in a specific order so that the logging is
+   * predictable. For each entry in the list, the array values are:
+   *
+   * <pre>
+   *   [0] - the region name
+   *   [1] - the name of that region's parent
+   *   [2] - the number of warnings that will be logged after the region is created (1 warning for
+   *         each region in the tree that exists that still has 1 or more missing children.)
+   * </pre>
+   */
+  private List<Object[]> childRegionTreeRestartOrder() {
+    List<Object[]> list = new ArrayList<>();
+    list.add(new Object[] {"Gen1_C1", "Parent", 2});
+    list.add(new Object[] {"Gen2_C1_1", "Gen1_C1", 2});
+    list.add(new Object[] {"Gen1_C2", "Parent", 3});
+    list.add(new Object[] {"Gen2_C1_2", "Gen1_C1", 2});
+    list.add(new Object[] {"Gen2_C2_1", "Gen1_C2", 2});
+    list.add(new Object[] {"Gen2_C2_2", "Gen1_C2", 0});
+    return list;
+  }
 
-      @Override
-      public Object call() throws Exception {
-        RebalanceOperation op = getCache().getResourceManager().createRebalanceFactory().start();
-        return op.getResults();
-      }
+  private void createData(String regionName, String value) {
+    Region<Integer, String> region = getCache().getRegion(regionName);
+    int startKey = 0;
+    int endKey = NUM_BUCKETS;
+    for (int i = startKey; i < endKey; i++) {
+      region.put(i, value);
+    }
+  }
+
+  private Set<Integer> getBucketIds(String regionName) {
+    PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+    return new TreeSet<>(region.getDataStore().getAllLocalBucketIds());
+  }
+
+  private Set<Integer> getPrimaryBucketIds(String regionName) {
+    PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+    return new TreeSet<>(region.getDataStore().getAllLocalPrimaryBucketIds());
+  }
+
+  private void moveBucket(int bucketId, VM sourceVM, VM targetVM) {
+    InternalDistributedMember sourceId =
+        sourceVM.invoke(() -> getCache().getInternalDistributedSystem().getDistributedMember());
+
+    targetVM.invoke(() -> {
+      PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+      region.getDataStore().moveBucket(bucketId, sourceId, false);
     });
+  }
+
+  private void validateData(String regionName, String value) {
+    Region region = getCache().getRegion(regionName);
+    int startKey = 0;
+    int endKey = NUM_BUCKETS;
+    for (int i = startKey; i < endKey; i++) {
+      assertThat(region.get(i)).isEqualTo(value);
+    }
+  }
+
+  private void waitForBuckets(String regionName, Set<Integer> expectedBucketIds) {
+    PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+
+    await().untilAsserted(() -> {
+      Set<Integer> allLocalBucketIds = new TreeSet<>(region.getDataStore().getAllLocalBucketIds());
+      assertThat(allLocalBucketIds).isEqualTo(expectedBucketIds);
+    });
+  }
+
+  private void waitForBucketRecovery(String regionName, Set<Integer> lostBucketIds) {
+    PartitionedRegion region = (PartitionedRegion) getCache().getRegion(regionName);
+    PartitionedRegionDataStore dataStore = region.getDataStore();
+
+    await().untilAsserted(() -> {
+      Set<Integer> allLocalBucketIds = dataStore.getAllLocalBucketIds();
+      assertThat(lostBucketIds).isEqualTo(allLocalBucketIds);
+    });
+  }
+
+  private void waitForRedundancyRecovery(String regionName, int expectedRedundancy) {
+    Region region = getCache().getRegion(regionName);
+
+    await().untilAsserted(() -> {
+      PartitionRegionInfo info = getPartitionRegionInfo(region);
+      assertThat(info.getActualRedundantCopies()).isEqualTo(expectedRedundancy);
+    });
+  }
+
+  private void addAsync(AsyncInvocation<Void> asyncInvocation) {
+    asyncInvocations.add(asyncInvocation);
+  }
+
+  private void awaitAllAsync() throws ExecutionException, InterruptedException {
+    for (AsyncInvocation<Void> asyncInvocation : asyncInvocations) {
+      asyncInvocation.await();
+    }
+    asyncInvocations.clear();
+  }
+
+  private void createDiskStore(String diskStoreName) {
+    DiskStore diskStore = getCache().findDiskStore(diskStoreName);
+    if (diskStore == null) {
+      getCache().createDiskStoreFactory().setDiskDirs(getDiskDirs()).create(diskStoreName);
+    }
+  }
+
+  private void createCache() {
+    assertThat(cache).isNull();
+    // cache = (InternalCache) new CacheFactory(getDistributedSystemProperties()).create();
+    cache = (InternalCache) new CacheFactory().set(LOCATORS, locators).create();
+  }
+
+  private InternalCache getCache() {
+    return cache;
+  }
+
+  private void closeCache() {
+    if (cache != null) {
+      cache.close();
+      cache = null;
+    }
+  }
+
+  private File getDiskDir() {
+    try {
+      File file = new File(temporaryFolder.getRoot(), diskStoreName1 + getCurrentVMNum());
+      if (!file.exists()) {
+        temporaryFolder.newFolder(diskStoreName1 + getCurrentVMNum());
+      }
+      return file.getAbsoluteFile();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private File[] getDiskDirs() {
+    return new File[] {getDiskDir()};
+  }
+
+  private void tearDownPartitionedRegionObserver() {
+    PartitionedRegionObserver prObserver = PartitionedRegionObserverHolder.getInstance();
+    if (prObserver != null) {
+      if (prObserver instanceof PRObserver) {
+        ((PRObserver) prObserver).tearDown();
+      }
+      PartitionedRegionObserverHolder.setInstance(new PartitionedRegionObserverAdapter());
+    }
   }
 
   private static class PRObserver extends PartitionedRegionObserverAdapter {
-    private CountDownLatch rebalanceDone = new CountDownLatch(1);
-    private CountDownLatch bucketCreateStarted = new CountDownLatch(3);
+
+    private final CountDownLatch rebalanceDone = new CountDownLatch(1);
+    private final CountDownLatch bucketCreateStarted = new CountDownLatch(3);
+
+    private final String childRegionName;
+
+    PRObserver(String childRegionName) {
+      this.childRegionName = childRegionName;
+    }
+
+    public void tearDown() {
+      bucketCreateStarted.countDown();
+      rebalanceDone.countDown();
+    }
 
     @Override
     public void beforeBucketCreation(PartitionedRegion region, int bucketId) {
-      if (region.getName().contains("region2")) {
+      if (region.getName().contains(childRegionName)) {
         bucketCreateStarted.countDown();
         waitForRebalance();
       }
     }
 
-
+    void waitForCreate() throws InterruptedException {
+      assertThat(bucketCreateStarted.await(TIMEOUT_MILLIS, TimeUnit.SECONDS))
+          .withFailMessage("Failed waiting for bucket creation to start")
+          .isTrue();
+    }
 
     private void waitForRebalance() {
       try {
-        if (!rebalanceDone.await(MAX_WAIT, TimeUnit.SECONDS)) {
-          fail("Failed waiting for the rebalance to start");
-        }
+        assertThat(rebalanceDone.await(TIMEOUT_MILLIS, TimeUnit.SECONDS))
+            .withFailMessage("Failed waiting for the rebalance to start")
+            .isTrue();
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
     }
-
-    public void waitForCreate() throws InterruptedException {
-      if (!bucketCreateStarted.await(MAX_WAIT, TimeUnit.SECONDS)) {
-        fail("Failed waiting for bucket creation to start");
-      }
-    }
-
-    public void release() {
-      rebalanceDone.countDown();
-    }
   }
-
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/partitioned/ModifyColocationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/partitioned/ModifyColocationIntegrationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.partitioned;
+
+import static org.apache.geode.cache.RegionShortcut.PARTITION_PERSISTENT;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.junit.categories.RegionsTest;
+
+@Category(RegionsTest.class)
+public class ModifyColocationIntegrationTest {
+
+  private InternalCache cache;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @After
+  public void tearDown() {
+    closeCache();
+  }
+
+  /**
+   * Test that a user is not allowed to change the colocation of a PR with persistent data.
+   */
+  @Test
+  public void testModifyColocation() throws Exception {
+    // Create PRs where region3 is colocated with region1.
+    createColocatedPRs("region1");
+
+    pause();
+
+    // Close everything
+    closeCache();
+
+    // Restart colocated with "region2"
+    Throwable thrown = catchThrowable(() -> createColocatedPRs("region2"));
+    assertThat(thrown)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Cannot change colocated-with to")
+        .hasMessageContaining(
+            "because there is persistent data with different colocation. Previous configured value is");
+
+    pause();
+
+    // Close everything
+    closeCache();
+
+    // Restart colocated with region1.
+    // Make sure we didn't screw anything up.
+    createColocatedPRs("/region1");
+
+    pause();
+
+    // Close everything
+    closeCache();
+
+    // Restart uncolocated. We don't allow changing
+    // from uncolocated to colocated.
+    try {
+      createColocatedPRs(null);
+      fail("Should have received an illegal state exception");
+    } catch (IllegalStateException expected) {
+      // do nothing
+    }
+
+    pause();
+
+    // Close everything
+    closeCache();
+  }
+
+  /**
+   * Create three PRs on a VM, named region1, region2, and region3. The colocated with attribute
+   * describes which region region3 should be colocated with.
+   */
+  private void createColocatedPRs(String colocatedWith) {
+    Cache cache = getCache();
+
+    cache.createDiskStoreFactory().setDiskDirs(getDiskDirs()).create("disk");
+
+    {
+      PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+      partitionAttributesFactory.setRedundantCopies(0);
+      partitionAttributesFactory.setRecoveryDelay(-1);
+      partitionAttributesFactory.setStartupRecoveryDelay(-1);
+
+      RegionFactory regionFactory = cache.createRegionFactory(PARTITION_PERSISTENT);
+      regionFactory.setDiskStoreName("disk");
+      regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+      regionFactory.create("region1");
+      regionFactory.create("region2");
+    }
+
+    {
+      PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+      partitionAttributesFactory.setRedundantCopies(0);
+      partitionAttributesFactory.setRecoveryDelay(-1);
+      partitionAttributesFactory.setStartupRecoveryDelay(-1);
+      if (colocatedWith != null) {
+        partitionAttributesFactory.setColocatedWith(colocatedWith);
+      }
+
+      RegionFactory regionFactory = cache.createRegionFactory(PARTITION_PERSISTENT);
+      regionFactory.setDiskStoreName("disk");
+      regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+      regionFactory.create("region3");
+    }
+  }
+
+  private InternalCache getCache() {
+    if (cache == null) {
+      cache = (InternalCache) new CacheFactory().set(LOCATORS, "").create();
+    }
+    return cache;
+  }
+
+  private void closeCache() {
+    if (cache != null) {
+      cache.close();
+      cache = null;
+    }
+  }
+
+  private File[] getDiskDirs() {
+    return new File[] {temporaryFolder.getRoot()};
+  }
+
+  private void pause() throws InterruptedException {
+    Thread.sleep(2_000);
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionIntegrationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.partitioned;
+
+import static org.apache.geode.cache.RegionShortcut.PARTITION;
+import static org.apache.geode.cache.RegionShortcut.PARTITION_PERSISTENT;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.test.junit.categories.RegionsTest;
+
+@Category(RegionsTest.class)
+public class PersistentColocatedPartitionedRegionIntegrationTest {
+
+  private Cache cache;
+  private String diskStoreName;
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void setUp() {
+    cache = new CacheFactory().set(LOCATORS, "").create();
+
+    Path diskDirPath = temporaryFolder.getRoot().toPath();
+    File[] diskDirs = new File[] {diskDirPath.toFile()};
+
+    diskStoreName = "disk";
+    cache.createDiskStoreFactory().setDiskDirs(diskDirs).create(diskStoreName);
+
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(0);
+    RegionFactory regionFactory = cache.createRegionFactory(PARTITION_PERSISTENT);
+    regionFactory.setDiskStoreName(diskStoreName);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+    regionFactory.create("persistentLeader");
+
+    partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setRedundantCopies(0);
+    regionFactory = cache.createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    regionFactory.create("nonPersistentLeader");
+  }
+
+  @After
+  public void tearDown() {
+    cache.close();
+  }
+
+  @Test
+  public void persistentPR_cannotColocateWith_nonPersistentPR() {
+    // Try to colocate a persistent PR with the non persistent PR. This should fail.
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setColocatedWith("nonPersistentLeader");
+    partitionAttributesFactory.setRedundantCopies(0);
+
+    RegionFactory regionFactory = cache.createRegionFactory(PARTITION_PERSISTENT);
+    regionFactory.setDiskStoreName(diskStoreName);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    Throwable thrown = catchThrowable(() -> regionFactory.create("colocated"));
+    assertThat(thrown).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void persistentPR_canColocateWith_persistentPR() {
+    // Try to colocate a persistent PR with another persistent PR. This should work.
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setColocatedWith("persistentLeader");
+    partitionAttributesFactory.setRedundantCopies(0);
+
+    RegionFactory regionFactory = cache.createRegionFactory(PARTITION_PERSISTENT);
+    regionFactory.setDiskStoreName(diskStoreName);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    assertThatCode(() -> regionFactory.create("colocated")).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void nonPersistentPR_canColocateWith_persistentPR() {
+    // We should also be able to colocate a non persistent region with a persistent region.
+    PartitionAttributesFactory partitionAttributesFactory = new PartitionAttributesFactory();
+    partitionAttributesFactory.setColocatedWith("persistentLeader");
+    partitionAttributesFactory.setRedundantCopies(0);
+
+    RegionFactory regionFactory = cache.createRegionFactory(PARTITION);
+    regionFactory.setPartitionAttributes(partitionAttributesFactory.create());
+
+    assertThatCode(() -> regionFactory.create("colocated")).doesNotThrowAnyException();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationLogger.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationLogger.java
@@ -44,6 +44,7 @@ public class ColocationLogger implements Runnable {
    * Sleep period (milliseconds) between posting log entries.
    */
   private static final int DEFAULT_LOG_INTERVAL = 30000;
+
   @MutableForTesting
   private static int LOG_INTERVAL = DEFAULT_LOG_INTERVAL;
 
@@ -118,7 +119,7 @@ public class ColocationLogger implements Runnable {
   public void stopLogger() {
     synchronized (loggerLock) {
       missingChildren.clear();
-      loggerLock.notify();
+      loggerLock.notifyAll();
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -47,6 +47,7 @@ import org.apache.geode.InternalGemFireError;
 import org.apache.geode.InternalGemFireException;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.cache.DiskAccessException;
 import org.apache.geode.cache.RegionDestroyedException;
@@ -1616,6 +1617,11 @@ public class InitialImageOperation {
         return true;
       }
       return false;
+    }
+
+    @VisibleForTesting
+    public String getRegionPath() {
+      return regionPath;
     }
 
     @Override


### PR DESCRIPTION
GEODE-4187: Fix PersistentColocatedPartitionedRegionDistributedTest
    
Fix flakiness in PersistentColocatedPartitionedRegionDistributedTest:
* GEODE-4187 testRebalanceDuringRecovery hang
* GEODE-5175 inline PersistentPartitionedRegionTestBase
* GEODE-6499 AsyncInvocation timeout
* GEODE-7082 testReplaceOfflineMemberAndRestartCreateColocatedPRLate hang
    
Split out integration tests:
* PersistentColocatedPartitionedRegionIntegrationTest
* ModifyColocationIntegrationTest