### PR TITLE
GEODE-7450 SSL peerAppDataBuffer expansion needs work

### DIFF
--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -107,8 +107,6 @@ public class DurableClientTestCase extends DurableClientTestBase {
 
         // Verify that it is durable and its properties are correct
         assertThat(proxy.isDurable()).isTrue();
-        System.out.println("BRUCE: durableClientId is " + durableClientId);
-        System.out.println("BRUCE: proxy durable id is " + proxy.getDurableId());
         assertThat(durableClientId).isNotEqualTo(proxy.getDurableId());
 
         /*


### PR DESCRIPTION
The expansion logic for the decrypted buffer in NioSslEngine was
expanding the buffer to twice its old capacity and wouldn't go
beyond that.  Some ciphers will compress data a lot more than that, so
we need to continually increase available space in the decryption buffer
if the SslEngine reports a BUFFER_OVERFLOW status.  The changes in
this commit do that by always doubling the available space in the
decryption buffer in response to a BUFFER_OVERFLOW.

Along with that I found it unnecessary to take preemptive action to
increase the size of the buffer and deleted that code.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
