### PR TITLE
GEODE-7338: Trigger test container builds on bionic-scm, not openjdk-8

### DIFF
--- a/ci/pipelines/images/jinja.template.yml
+++ b/ci/pipelines/images/jinja.template.yml
@@ -79,6 +79,13 @@ resources:
     password: ((docker-password))
     repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
 
+- name: bionic-scm-docker-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: buildpack-deps
+    tag: bionic-scm
+
 - name: test-container-dockerfile
   type: git
   source:
@@ -231,7 +238,7 @@ jobs:
   serial: true
   plan:
   - aggregate:
-    - get: openjdk8-docker-image
+    - get: bionic-scm-docker-image
       trigger: true
     - get: test-container-dockerfile
       trigger: true


### PR DESCRIPTION
Consistency is key.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Scott Jewell <sjewell@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
