### PR TITLE
GEODE-7450 SSL peerAppDataBuffer expansion needs work

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -275,6 +275,7 @@ public class NioSslEngine implements NioFilter {
           // buffer overflow expand and try again - double the available decryption space
           int newCapacity =
               (peerAppData.capacity() - peerAppData.position()) * 2 + peerAppData.position();
+          newCapacity = Math.max(newCapacity, peerAppData.capacity() / 2 * 3);
           peerAppData =
               bufferPool.expandWriteBufferIfNeeded(TRACKED_RECEIVER, peerAppData, newCapacity);
           peerAppData.limit(peerAppData.capacity());


### PR DESCRIPTION
ensure that the buffer capacity always increases after an overflow
status is returned.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
