### PR TITLE
GEODE-7344: break dependencies on DataSerializer

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
@@ -184,10 +184,10 @@ public class LocatorLoadBalancingDUnitTest extends LocatorTestBase {
                 .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
         InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
         InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
-                    .requestToServer(InetAddress.getByName(hostName),
-                        locatorPort,
-                        request,
-                        10000, replyExpected);
+            .requestToServer(InetAddress.getByName(hostName),
+                locatorPort,
+                request,
+                10000, replyExpected);
   }
 
   /**

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
@@ -47,6 +47,7 @@ import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.ServerLocator;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -180,7 +181,9 @@ public class LocatorLoadBalancingDUnitTest extends LocatorTestBase {
     return new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)))
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
                     .requestToServer(InetAddress.getByName(hostName),
                         locatorPort,
                         request,

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerBackwardCompatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerBackwardCompatDUnitTest.java
@@ -152,7 +152,7 @@ public class TcpServerBackwardCompatDUnitTest extends JUnit4DistributedTestCase 
                   .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
           InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
           InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
-                      .requestToServer(SocketCreator.getLocalHost(), port0, req, 5000);
+              .requestToServer(SocketCreator.getLocalHost(), port0, req, 5000);
       assertThat(response).isNotNull();
 
     } catch (IllegalStateException e) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerBackwardCompatDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerBackwardCompatDUnitTest.java
@@ -34,6 +34,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordinatorRequest;
 import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordinatorResponse;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -148,7 +149,9 @@ public class TcpServerBackwardCompatDUnitTest extends JUnit4DistributedTestCase 
       response = (FindCoordinatorResponse) new TcpClient(
           asTcpSocketCreator(
               SocketCreatorFactory
-                  .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)))
+                  .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+          InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+          InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
                       .requestToServer(SocketCreator.getLocalHost(), port0, req, 5000);
       assertThat(response).isNotNull();
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -76,6 +76,7 @@ import org.apache.geode.distributed.internal.membership.gms.membership.HostAddre
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.PoolStats;
 import org.apache.geode.internal.cache.tier.InternalClientMembership;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
@@ -163,7 +164,9 @@ public class AutoConnectionSourceImplJUnitTest {
     new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)))
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
                     .stop(InetAddress.getLocalHost(), port);
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -167,7 +167,7 @@ public class AutoConnectionSourceImplJUnitTest {
                 .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
         InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
         InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
-                    .stop(InetAddress.getLocalHost(), port);
+            .stop(InetAddress.getLocalHost(), port);
   }
 
   /**

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorIntegrationTest.java
@@ -56,6 +56,7 @@ import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.membership.gms.messenger.JGroupsMessenger;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -176,7 +177,9 @@ public class LocatorIntegrationTest {
     TcpClient client = new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     String[] info = client.getInfo(InetAddress.getLocalHost(), boundPort);
 
     assertThat(info).isNotNull();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -277,7 +277,9 @@ public class MembershipJUnitTest {
             .setLocatorClient(new TcpClient(
                 asTcpSocketCreator(
                     SocketCreatorFactory
-                        .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR))))
+                        .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+                InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+                InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()))
             .create();
     m1.startEventProcessing();
     return Pair.of(m1, messageListener);
@@ -468,7 +470,9 @@ public class MembershipJUnitTest {
     GMSJoinLeave joinLeave = new GMSJoinLeave(new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory.setDistributionConfig(config)
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR))));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
     try {
       joinLeave.init(services);
       throw new Error(

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -38,6 +38,7 @@ import org.apache.geode.distributed.internal.membership.gms.interfaces.JoinLeave
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Messenger;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
@@ -81,7 +82,9 @@ public class GMSLocatorIntegrationTest {
             temporaryFolder.getRoot().toPath(), new TcpClient(
                 asTcpSocketCreator(
                     SocketCreatorFactory
-                        .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR))));
+                        .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
     gmsLocator.setServices(services);
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -83,8 +83,8 @@ public class GMSLocatorIntegrationTest {
                 asTcpSocketCreator(
                     SocketCreatorFactory
                         .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
-            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
-            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
+                InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+                InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
     gmsLocator.setServices(services);
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -100,8 +100,8 @@ public class GMSLocatorRecoveryIntegrationTest {
             asTcpSocketCreator(
                 SocketCreatorFactory
                     .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
-        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
-        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
+            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
     gmsLocator.setViewFile(stateFile);
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -99,7 +99,9 @@ public class GMSLocatorRecoveryIntegrationTest {
         temporaryFolder.getRoot().toPath(), new TcpClient(
             asTcpSocketCreator(
                 SocketCreatorFactory
-                    .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR))));
+                    .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
     gmsLocator.setViewFile(stateFile);
   }
 
@@ -186,7 +188,9 @@ public class GMSLocatorRecoveryIntegrationTest {
     final TcpClient locatorClient = new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
 
     // start the membership manager
     membershipManager =

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
@@ -44,6 +44,8 @@ import org.apache.geode.distributed.internal.DistributionStats;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.internal.AvailablePort;
+import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
@@ -103,7 +105,9 @@ public class TCPClientSSLIntegrationTest {
         asTcpSocketCreator(
             new SocketCreator(
                 SSLConfigurationFactory.getSSLConfigForComponent(clientProperties,
-                    SecurableCommunicationChannel.LOCATOR))));
+                    SecurableCommunicationChannel.LOCATOR))),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
   }
 
   private void startTcpServer(Properties sslProperties) throws IOException {
@@ -125,7 +129,9 @@ public class TCPClientSSLIntegrationTest {
             new SocketCreator(
                 SSLConfigurationFactory.getSSLConfigForComponent(
                     new DistributionConfigImpl(sslProperties),
-                    SecurableCommunicationChannel.LOCATOR))));
+                    SecurableCommunicationChannel.LOCATOR))),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
 
     server.start();
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
@@ -45,7 +45,6 @@ import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.InternalDataSerializer;
-import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
@@ -47,6 +47,7 @@ import org.apache.geode.distributed.internal.DistributionStats;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.internal.AvailablePort;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -95,7 +96,9 @@ public class TCPServerSSLJUnitTest {
         (socket, input, firstByte) -> false, DistributionStats::getStatTime,
         TcpServerFactory.createExecutorServiceSupplier(Mockito.mock(PoolStatHelper.class)),
         asTcpSocketCreator(
-            socketCreator));
+            socketCreator),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
 
     server.start();
   }
@@ -159,7 +162,9 @@ public class TCPServerSSLJUnitTest {
             SocketCreatorFactory
                 .getSocketCreatorForComponent(
                     new DistributionConfigImpl(getSSLConfigurationProperties()),
-                    SecurableCommunicationChannel.LOCATOR)));
+                    SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
   }
 
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -50,6 +50,7 @@ import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.InfoRequestHandler;
 import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.internal.AvailablePort;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.tier.sockets.TcpServerFactory;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -116,7 +117,9 @@ public class TcpServerJUnitTest {
     return new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorConfigImpl.java
@@ -26,6 +26,7 @@ import org.apache.geode.GemFireConfigException;
 import org.apache.geode.admin.DistributionLocator;
 import org.apache.geode.admin.DistributionLocatorConfig;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 
@@ -76,7 +77,9 @@ public class DistributionLocatorConfigImpl extends ManagedEntityConfigImpl
       TcpClient client = new TcpClient(
           asTcpSocketCreator(
               SocketCreatorFactory
-                  .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                  .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+          InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+          InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
       if (bindAddress != null) {
         info = client.getInfo(bindAddress, port);
       } else {

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
@@ -53,6 +53,7 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -117,7 +118,9 @@ public class AutoConnectionSourceImpl implements ConnectionSource {
     this.tcpClient = new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -66,8 +66,6 @@ import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.DistributionLocator;
 import org.apache.geode.internal.GemFireVersion;
-import org.apache.geode.internal.admin.SSLConfig;
-import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.lang.ObjectUtils;

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -67,6 +67,9 @@ import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.DistributionLocator;
 import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.admin.SSLConfig;
+import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.lang.ObjectUtils;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
@@ -319,7 +322,9 @@ public class LocatorLauncher extends AbstractLauncher<String> {
           properties,
           SecurableCommunicationChannel.LOCATOR);
       final TcpSocketCreator socketCreator = asTcpSocketCreator(new SocketCreator(sslConfig));
-      final TcpClient client = new TcpClient(socketCreator);
+      final TcpClient client = new TcpClient(socketCreator,
+          InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+          InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
 
       return (LocatorStatusResponse) client.requestToServer(bindAddress, port,
           new LocatorStatusRequest(), timeout, true);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -470,7 +470,9 @@ public class ClusterDistributionManager implements DistributionManager {
           .setLocatorClient(new TcpClient(
               asTcpSocketCreator(
                   SocketCreatorFactory
-                      .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR))))
+                      .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+              InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+              InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()))
           .create();
 
       sb.append(System.currentTimeMillis() - start);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -922,7 +922,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
                     .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
             InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
             InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
-                        .stop(bindAddress, getPort());
+                .stop(bindAddress, getPort());
       } catch (ConnectException ignore) {
         // must not be running
       }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -70,6 +70,7 @@ import org.apache.geode.distributed.internal.tcpserver.InfoRequest;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
 import org.apache.geode.internal.GemFireVersion;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
@@ -918,7 +919,9 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
         new TcpClient(
             asTcpSocketCreator(
                 SocketCreatorFactory
-                    .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)))
+                    .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
                         .stop(bindAddress, getPort());
       } catch (ConnectException ignore) {
         // must not be running

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
@@ -32,6 +32,7 @@ import org.apache.geode.distributed.internal.membership.gms.interfaces.Locator;
 import org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 
@@ -55,7 +56,9 @@ public class GMSLocatorAdapter implements RestartableTcpHandler, NetLocator {
     final TcpClient locatorClient = new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     gmsLocator =
         new GMSLocator(bindAddress, locatorString, usePreferredCoordinators,
             networkPartitionDetectionEnabled,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/InfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/InfoResponse.java
@@ -20,7 +20,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 import org.apache.geode.DataSerializable;
-import org.apache.geode.DataSerializer;
+import org.apache.geode.internal.serialization.StaticSerialization;
 
 /**
  * A response from the TCP server with information about the server
@@ -44,11 +44,11 @@ public class InfoResponse implements DataSerializable {
 
   @Override
   public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    info = DataSerializer.readStringArray(in);
+    info = StaticSerialization.readStringArray(in);
   }
 
   @Override
   public void toData(DataOutput out) throws IOException {
-    DataSerializer.writeStringArray(info, out);
+    StaticSerialization.writeStringArray(info, out);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
@@ -65,11 +65,9 @@ public class TcpClient {
    * Constructs a new TcpClient
    *
    * @param socketCreator the SocketCreator to use in communicating with the Locator
-   * @param objectSerializer
-   * @param objectDeserializer
    */
   public TcpClient(TcpSocketCreator socketCreator, final ObjectSerializer objectSerializer,
-                   final ObjectDeserializer objectDeserializer) {
+      final ObjectDeserializer objectDeserializer) {
     this.socketCreator = socketCreator;
     this.objectSerializer = objectSerializer;
     this.objectDeserializer = objectDeserializer;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
@@ -31,8 +31,9 @@ import javax.net.ssl.SSLException;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.DataSerializer;
 import org.apache.geode.annotations.internal.MakeNotStatic;
+import org.apache.geode.internal.serialization.ObjectDeserializer;
+import org.apache.geode.internal.serialization.ObjectSerializer;
 import org.apache.geode.internal.serialization.UnsupportedSerializationVersionException;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.internal.serialization.VersionedDataInputStream;
@@ -57,14 +58,21 @@ public class TcpClient {
       new HashMap<>();
 
   private final TcpSocketCreator socketCreator;
+  private final ObjectSerializer objectSerializer;
+  private final ObjectDeserializer objectDeserializer;
 
   /**
    * Constructs a new TcpClient
    *
    * @param socketCreator the SocketCreator to use in communicating with the Locator
+   * @param objectSerializer
+   * @param objectDeserializer
    */
-  public TcpClient(TcpSocketCreator socketCreator) {
+  public TcpClient(TcpSocketCreator socketCreator, final ObjectSerializer objectSerializer,
+                   final ObjectDeserializer objectDeserializer) {
     this.socketCreator = socketCreator;
+    this.objectSerializer = objectSerializer;
+    this.objectDeserializer = objectDeserializer;
   }
 
   /**
@@ -191,14 +199,15 @@ public class TcpClient {
       if (gossipVersion > TcpServer.getOldGossipVersion()) {
         out.writeShort(serverVersion);
       }
-      DataSerializer.writeObject(request, out);
+
+      objectSerializer.writeObject(request, out);
       out.flush();
 
       if (replyExpected) {
         DataInputStream in = new DataInputStream(sock.getInputStream());
         in = new VersionedDataInputStream(in, Version.fromOrdinal(serverVersion));
         try {
-          Object response = DataSerializer.readObject(in);
+          Object response = objectDeserializer.readObject(in);
           logger.debug("received response: {}", response);
           return response;
         } catch (EOFException ex) {
@@ -272,14 +281,14 @@ public class TcpClient {
       out.writeInt(gossipVersion);
 
       VersionRequest verRequest = new VersionRequest();
-      DataSerializer.writeObject(verRequest, out);
+      objectSerializer.writeObject(verRequest, out);
       out.flush();
 
       InputStream inputStream = sock.getInputStream();
       DataInputStream in = new DataInputStream(inputStream);
       in = new VersionedDataInputStream(in, Version.GFE_57);
       try {
-        Object readObject = DataSerializer.readObject(in);
+        Object readObject = objectDeserializer.readObject(in);
         if (!(readObject instanceof VersionResponse)) {
           throw new IllegalThreadStateException(
               "Server version response invalid: "

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -40,7 +40,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.CancelException;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.internal.serialization.ObjectDeserializer;
 import org.apache.geode.internal.serialization.ObjectSerializer;
 import org.apache.geode.internal.serialization.UnsupportedSerializationVersionException;
@@ -139,12 +138,12 @@ public class TcpServer {
   }
 
   public TcpServer(int port, InetAddress bind_address, TcpHandler handler,
-                   String threadName, ProtocolChecker protocolChecker,
-                   final LongSupplier nanoTimeSupplier,
-                   final Supplier<ExecutorService> executorServiceSupplier,
-                   final TcpSocketCreator socketCreator,
-                   final ObjectSerializer objectSerializer,
-                   final ObjectDeserializer objectDeserializer) {
+      String threadName, ProtocolChecker protocolChecker,
+      final LongSupplier nanoTimeSupplier,
+      final Supplier<ExecutorService> executorServiceSupplier,
+      final TcpSocketCreator socketCreator,
+      final ObjectSerializer objectSerializer,
+      final ObjectDeserializer objectDeserializer) {
     this.port = port;
     this.bind_address = bind_address;
     this.handler = handler;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -38,9 +38,11 @@ import javax.net.ssl.SSLException;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
-import org.apache.geode.DataSerializer;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.internal.serialization.ObjectDeserializer;
+import org.apache.geode.internal.serialization.ObjectSerializer;
 import org.apache.geode.internal.serialization.UnsupportedSerializationVersionException;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.internal.serialization.VersionedDataInputStream;
@@ -104,6 +106,8 @@ public class TcpServer {
   private static final int BACKLOG =
       Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "TcpServer.BACKLOG", P2P_BACKLOG);
   private final ProtocolChecker protocolChecker;
+  private final ObjectDeserializer objectDeserializer;
+  private final ObjectSerializer objectSerializer;
 
   private int port;
   private ServerSocket srv_sock = null;
@@ -134,12 +138,13 @@ public class TcpServer {
     return map;
   }
 
-  public TcpServer(int port, InetAddress bind_address,
-      TcpHandler handler,
-      String threadName, ProtocolChecker protocolChecker,
-      final LongSupplier nanoTimeSupplier,
-      final Supplier<ExecutorService> executorServiceSupplier,
-      final TcpSocketCreator socketCreator) {
+  public TcpServer(int port, InetAddress bind_address, TcpHandler handler,
+                   String threadName, ProtocolChecker protocolChecker,
+                   final LongSupplier nanoTimeSupplier,
+                   final Supplier<ExecutorService> executorServiceSupplier,
+                   final TcpSocketCreator socketCreator,
+                   final ObjectSerializer objectSerializer,
+                   final ObjectDeserializer objectDeserializer) {
     this.port = port;
     this.bind_address = bind_address;
     this.handler = handler;
@@ -149,6 +154,8 @@ public class TcpServer {
     this.threadName = threadName;
     this.nanoTimeSupplier = nanoTimeSupplier;
     this.socketCreator = socketCreator;
+    this.objectSerializer = objectSerializer;
+    this.objectDeserializer = objectDeserializer;
   }
 
   public void restarting() throws IOException {
@@ -395,7 +402,7 @@ public class TcpServer {
             + Version.fromOrdinal(versionOrdinal));
       }
       input = new VersionedDataInputStream(input, Version.fromOrdinal(versionOrdinal));
-      request = DataSerializer.readObject(input);
+      request = objectDeserializer.readObject(input);
       if (logger.isDebugEnabled()) {
         logger.debug("Locator received request " + request + " from " + socket.getInetAddress());
       }
@@ -420,7 +427,7 @@ public class TcpServer {
           output =
               new VersionedDataOutputStream(output, Version.fromOrdinal(versionOrdinal));
         }
-        DataSerializer.writeObject(response, output);
+        objectSerializer.writeObject(response, output);
         output.flush();
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/DistributionLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DistributionLocator.java
@@ -74,7 +74,9 @@ public class DistributionLocator {
       new TcpClient(
           asTcpSocketCreator(
               SocketCreatorFactory
-                  .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR))).stop(addr,
+                  .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+          InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+          InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()).stop(addr,
                       port);
     } catch (ConnectException ignore) {
       // must not be running

--- a/geode-core/src/main/java/org/apache/geode/internal/DistributionLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DistributionLocator.java
@@ -77,7 +77,7 @@ public class DistributionLocator {
                   .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
           InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
           InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()).stop(addr,
-                      port);
+              port);
     } catch (ConnectException ignore) {
       // must not be running
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
@@ -298,7 +298,9 @@ public class SystemAdmin {
         new TcpClient(
             asTcpSocketCreator(
                 SocketCreatorFactory
-                    .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)))
+                    .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
                         .stop(addr, port);
       } catch (java.net.ConnectException ce) {
         System.out.println(

--- a/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
@@ -301,7 +301,7 @@ public class SystemAdmin {
                     .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
             InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
             InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
-                        .stop(addr, port);
+                .stop(addr, port);
       } catch (java.net.ConnectException ce) {
         System.out.println(
             "Unable to connect to Locator process. Possible causes are that an incorrect bind address/port combination was specified to the stop-locator command or the process is unresponsive.");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -31,6 +31,7 @@ import org.apache.geode.distributed.internal.PoolStatHelper;
 import org.apache.geode.distributed.internal.ProtocolCheckerImpl;
 import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpServer;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.client.protocol.ClientProtocolServiceLoader;
 import org.apache.geode.internal.logging.CoreLoggingExecutors;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -58,7 +59,9 @@ public class TcpServerFactory {
         DistributionStats::getStatTime, createExecutorServiceSupplier(poolHelper),
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
   }
 
   public static Supplier<ExecutorService> createExecutorServiceSupplier(PoolStatHelper poolHelper) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocatorRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocatorRequest.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
@@ -85,7 +86,9 @@ public class JmxManagerLocatorRequest implements DataSerializableFixedID {
     SSLConfig sslConfig = SSLConfigurationFactory.getSSLConfigForComponent(sslConfigProps,
         SecurableCommunicationChannel.LOCATOR);
     SocketCreator socketCreator = new SocketCreator(sslConfig);
-    TcpClient client = new TcpClient(asTcpSocketCreator(socketCreator));
+    TcpClient client = new TcpClient(asTcpSocketCreator(socketCreator),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     Object responseFromServer = client.requestToServer(inetSockAddr, SINGLETON, msTimeout, true);
 
     if (responseFromServer instanceof JmxManagerLocatorResponse)

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/GeodeClusterManagementServiceBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/GeodeClusterManagementServiceBuilder.java
@@ -37,6 +37,7 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
@@ -122,7 +123,9 @@ public class GeodeClusterManagementServiceBuilder implements
     DistributionConfig config = ((GemFireCacheImpl) clientCache).getSystem().getConfig();
     TcpClient client =
         new TcpClient(asTcpSocketCreator(SocketCreatorFactory.setDistributionConfig(config)
-            .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+            .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     ClusterManagementServiceInfo cmsInfo = null;
     for (InetSocketAddress locator : locators) {
       try {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/utils/ClusterConfigurationStatusRetriever.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/utils/ClusterConfigurationStatusRetriever.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.persistence.PersistentMemberPattern;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreator;
@@ -43,7 +44,9 @@ public class ClusterConfigurationStatusRetriever {
 
       TcpClient client = new TcpClient(asTcpSocketCreator(
           new SocketCreator(SSLConfigurationFactory.getSSLConfigForComponent(configProps,
-              SecurableCommunicationChannel.LOCATOR))));
+              SecurableCommunicationChannel.LOCATOR))),
+          InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+          InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
       SharedConfigurationStatusResponse statusResponse =
           (SharedConfigurationStatusResponse) client.requestToServer(networkAddress, locatorPort,
               new SharedConfigurationStatusRequest(), 10000, true);

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
@@ -49,6 +49,5 @@ public class TcpServerDependenciesTest {
               .or(resideInAPackage("org.apache.geode.test.."))
 
               // TODO - serialization related classes
-              .or(type(DataSerializer.class))
               .or(type(DataSerializable.class)));
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
@@ -26,7 +26,6 @@ import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.DataSerializable;
-import org.apache.geode.DataSerializer;
 
 
 @RunWith(ArchUnitRunner.class)

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorDiscovery.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorDiscovery.java
@@ -24,6 +24,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.WanLocatorDiscoverer;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -68,7 +69,9 @@ public class LocatorDiscovery {
     this.locatorClient = new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
   }
 
   /**

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.CopyOnWriteHashSet;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
@@ -64,7 +65,9 @@ public class LocatorMembershipListenerImpl implements LocatorMembershipListener 
     this.tcpClient = new TcpClient(
         asTcpSocketCreator(
             SocketCreatorFactory
-                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)));
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
   }
 
   LocatorMembershipListenerImpl(TcpClient tcpClient) {

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
@@ -87,8 +87,8 @@ public abstract class AbstractRemoteGatewaySender extends AbstractGatewaySender 
                         .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
                 InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
                 InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
-                            .requestToServer(locatorID.getHost(), request,
-                                WanLocatorDiscoverer.WAN_LOCATOR_CONNECTION_TIMEOUT, true);
+                    .requestToServer(locatorID.getHost(), request,
+                        WanLocatorDiscoverer.WAN_LOCATOR_CONNECTION_TIMEOUT, true);
 
         if (response != null) {
           if (response.getLocators() == null) {

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
@@ -30,6 +30,7 @@ import org.apache.geode.cache.client.internal.locator.wan.RemoteLocatorResponse;
 import org.apache.geode.cache.wan.GatewayReceiver;
 import org.apache.geode.distributed.internal.WanLocatorDiscoverer;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.admin.remote.DistributionLocatorId;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
@@ -83,7 +84,9 @@ public abstract class AbstractRemoteGatewaySender extends AbstractGatewaySender 
             (RemoteLocatorResponse) new TcpClient(
                 asTcpSocketCreator(
                     SocketCreatorFactory
-                        .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)))
+                        .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+                InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+                InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer())
                             .requestToServer(locatorID.getHost(), request,
                                 WanLocatorDiscoverer.WAN_LOCATOR_CONNECTION_TIMEOUT, true);
 


### PR DESCRIPTION
This PR implements the first half of [GEODE-7344](https://issues.apache.org/jira/browse/GEODE-7344), to wit, eliminating dependencies on `DataSerializer` from classes in the `org.apache.geode.distributed.internal.tcpserver` package.

The main change is that now we are injecting an `ObjectSerializer` and an `ObjectDeserializer` into the `TcpClient` constructor in order to break the dependency from the latter to the `DataSerializer` class. Also `TcpServer` got the same treatment!

I'd like to get this approved and merged before tackling the harder second half (eliminating dependencies on `DataSerializable`).

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
