### PR TITLE
Revert "GEODE-7445: do not use internal class (#4331)"

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/TransactionId.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/TransactionId.java
@@ -17,7 +17,7 @@ package org.apache.geode.cache;
 
 import java.io.Externalizable;
 
-import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
 /**
  * The TransactionId interface is a "marker" interface that represents a unique GemFire transaction.
@@ -29,5 +29,5 @@ import org.apache.geode.distributed.DistributedMember;
  * @see CacheTransactionManager#getTransactionId
  */
 public interface TransactionId extends Externalizable {
-  DistributedMember getMemberId();
+  InternalDistributedMember getMemberId();
 }


### PR DESCRIPTION
This reverts commit 4a92c8e4fd071e540843411a8ea0baf94fd9a1fe which caused some problems.
Reverting until the problems are diagnosed and addressed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
