### PR TITLE
GEODE-7475: Include remote stack trace in AsyncInvocation timeout

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
@@ -329,7 +329,7 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
     final String invalidationKey = "invalidationKey";
     final String destroyKey = "destroyKey";
     SerializableRunnable test =
-        new SerializableRunnable("case 1: second invalidation not applied or distributed") {
+        new SerializableRunnable() {
           @Override
           public void run() {
             CCRegion.put(invalidationKey, "initialValue");
@@ -351,11 +351,10 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
             assertEquals(destroyCount + 1, CCRegion.getCachePerfStats().getDestroys());
           }
         };
-    vm0.invoke(test);
+    vm0.invoke("case 1: second invalidation not applied or distributed", test);
 
     // now do the same with the datapolicy=normal region
-    test.setName("case 2: second invalidation not applied or distributed");
-    vm1.invoke(test);
+    vm1.invoke("case 2: second invalidation not applied or distributed", test);
   }
 
   /**

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryWithIndexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryWithIndexDistributedTest.java
@@ -141,29 +141,29 @@ public class PRQueryWithIndexDistributedTest implements Serializable {
     }
   }
 
-  @SuppressWarnings("unused")
   private static class NotDeserializableAsset implements DataSerializable {
 
-    private int disallowedPid;
+    private int disallowedVmId;
 
+    @SuppressWarnings("unused")
     public NotDeserializableAsset() {
       // nothing
     }
 
-    public NotDeserializableAsset(final int disallowedPid) {
-      this.disallowedPid = disallowedPid;
+    public NotDeserializableAsset(final int disallowedVmId) {
+      this.disallowedVmId = disallowedVmId;
     }
 
     @Override
     public void toData(final DataOutput out) throws IOException {
-      out.writeInt(disallowedPid);
+      out.writeInt(disallowedVmId);
 
     }
 
     @Override
     public void fromData(final DataInput in) throws IOException, ClassNotFoundException {
-      disallowedPid = in.readInt();
-      if (disallowedPid == get().getPid()) {
+      disallowedVmId = in.readInt();
+      if (disallowedVmId == get().getId()) {
         throw new IOException("Cannot deserialize");
       }
     }

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/AsyncInvocationTimeoutDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/AsyncInvocationTimeoutDistributedTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.tests;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.io.Serializable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.dunit.internal.StackTrace;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+
+@SuppressWarnings("serial")
+public class AsyncInvocationTimeoutDistributedTest implements Serializable {
+
+  private static final long TIMEOUT_MILLIS = getTimeout().getValueInMS();
+
+  private static final AtomicReference<Long> threadId = new AtomicReference<>();
+  private static final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @After
+  public void tearDown() {
+    getVM(0).invoke(() -> {
+      CountDownLatch latchInVM0 = latch.get();
+      while (latchInVM0 != null && latchInVM0.getCount() > 0) {
+        latchInVM0.countDown();
+      }
+    });
+  }
+
+  @Test
+  public void await_runnable_timeout_includesStackTraceAsCause() {
+    AsyncInvocation<Void> hangInVM0 = getVM(0).invokeAsync(() -> {
+      latch.set(new CountDownLatch(1));
+      threadId.set(Thread.currentThread().getId());
+      latch.get().await(TIMEOUT_MILLIS, MILLISECONDS);
+    });
+
+    long remoteThreadId = getVM(0).invoke(() -> {
+      await().until(() -> threadId.get() > 0);
+      return threadId.get();
+    });
+
+    Throwable thrown = catchThrowable(() -> hangInVM0.await(1, SECONDS));
+    assertThat(thrown)
+        .isInstanceOf(TimeoutException.class);
+    Throwable cause = thrown.getCause();
+    assertThat(cause)
+        .isInstanceOf(StackTrace.class)
+        .hasMessage("Stack trace for vm-0 thread-" + remoteThreadId);
+  }
+
+  @Test
+  public void await_callable_timeout_includesStackTraceAsCause() {
+    AsyncInvocation<Integer> hangInVM0 = getVM(0).invokeAsync(() -> {
+      latch.set(new CountDownLatch(1));
+      threadId.set(Thread.currentThread().getId());
+      latch.get().await(TIMEOUT_MILLIS, MILLISECONDS);
+      return 42;
+    });
+
+    long remoteThreadId = getVM(0).invoke(() -> {
+      await().until(() -> threadId.get() > 0);
+      return threadId.get();
+    });
+
+    Throwable thrown = catchThrowable(() -> hangInVM0.await(1, SECONDS));
+    assertThat(thrown)
+        .isInstanceOf(TimeoutException.class);
+    Throwable cause = thrown.getCause();
+    assertThat(cause)
+        .isInstanceOf(StackTrace.class)
+        .hasMessage("Stack trace for vm-0 thread-" + remoteThreadId);
+  }
+
+  @Test
+  public void get_callable_timeout_includesStackTraceAsCause() {
+    AsyncInvocation<Integer> hangInVM0 = getVM(0).invokeAsync(() -> {
+      latch.set(new CountDownLatch(1));
+      threadId.set(Thread.currentThread().getId());
+      latch.get().await(TIMEOUT_MILLIS, MILLISECONDS);
+      return 42;
+    });
+
+    long remoteThreadId = getVM(0).invoke(() -> {
+      await().until(() -> threadId.get() > 0);
+      return threadId.get();
+    });
+
+    Throwable thrown = catchThrowable(() -> hangInVM0.get(1, SECONDS));
+    assertThat(thrown)
+        .isInstanceOf(TimeoutException.class);
+    Throwable cause = thrown.getCause();
+    assertThat(cause)
+        .isInstanceOf(StackTrace.class)
+        .hasMessage("Stack trace for vm-0 thread-" + remoteThreadId);
+  }
+}

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
@@ -129,24 +129,24 @@ public class BasicDistributedTest extends DistributedTestCase {
 
   @Test
   public void testInvokeWithLambda() {
-    assertThat(vm0.invoke(() -> DUnitEnv.get().getVMID()), is(0));
-    assertThat(vm1.invoke(() -> DUnitEnv.get().getVMID()), is(1));
+    assertThat(vm0.invoke(() -> DUnitEnv.get().getId()), is(0));
+    assertThat(vm1.invoke(() -> DUnitEnv.get().getId()), is(1));
   }
 
   @Test
   public void testInvokeLambdaAsync() throws Exception {
-    assertThat(vm0.invokeAsync(() -> DUnitEnv.get().getVMID()).getResult(), is(0));
+    assertThat(vm0.invokeAsync(() -> DUnitEnv.get().getId()).getResult(), is(0));
   }
 
   @Test
   public void testInvokeWithNamedLambda() {
-    assertThat(vm0.invoke("getVMID", () -> DUnitEnv.get().getVMID()), is(0));
-    assertThat(vm1.invoke("getVMID", () -> DUnitEnv.get().getVMID()), is(1));
+    assertThat(vm0.invoke("getId", () -> DUnitEnv.get().getId()), is(0));
+    assertThat(vm1.invoke("getId", () -> DUnitEnv.get().getId()), is(1));
   }
 
   @Test
   public void testInvokeNamedLambdaAsync() throws Exception {
-    assertThat(vm0.invokeAsync("getVMID", () -> DUnitEnv.get().getVMID()).getResult(), is(0));
+    assertThat(vm0.invokeAsync("getId", () -> DUnitEnv.get().getId()).getResult(), is(0));
   }
 
   @Test

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/StackTraceDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/StackTraceDistributedTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.tests;
+
+import static java.lang.System.lineSeparator;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.internal.StackTrace;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+
+public class StackTraceDistributedTest {
+
+  private static final long TIMEOUT_MILLIS = getTimeout().getValueInMS();
+  private static final Pattern COUNTDOWNLATCH_AWAIT = Pattern.compile(
+      ".*java\\.util\\.concurrent\\.CountDownLatch\\.await\\(CountDownLatch\\.java:\\d+\\).*");
+
+  private static final AtomicReference<Long> threadId = new AtomicReference<>();
+  private static final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @After
+  public void tearDown() {
+    getVM(0).invoke(() -> {
+      CountDownLatch latchInVM0 = latch.get();
+      while (latchInVM0 != null && latchInVM0.getCount() > 0) {
+        latchInVM0.countDown();
+      }
+    });
+  }
+
+  @Test
+  public void stackTraceShouldIncludeWaitingElementOfRemoteThread() {
+    getVM(0).invokeAsync(() -> {
+      latch.set(new CountDownLatch(1));
+      threadId.set(Thread.currentThread().getId());
+      latch.get().await(TIMEOUT_MILLIS, MILLISECONDS);
+    });
+
+    long remoteThreadId = getVM(0).invoke(() -> {
+      await().until(() -> threadId.get() > 0);
+      return threadId.get();
+    });
+
+    StackTrace stackTrace = getVM(0).invoke(() -> new StackTrace(remoteThreadId));
+    assertThat(stackTrace).hasMessage("Stack trace for vm-0 thread-" + remoteThreadId);
+
+    List<String> stackTraceLines = Arrays.stream(stackTrace.getStackTrace())
+        .map(StackTraceElement::toString)
+        .collect(Collectors.toList());
+    assertThat(StringUtils.join(stackTraceLines, "\", " + lineSeparator() + "  \""))
+        .containsPattern(COUNTDOWNLATCH_AWAIT);
+  }
+}

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/VMDumpThreadsDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/VMDumpThreadsDistributedTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.test.dunit.tests;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+
+@SuppressWarnings("serial")
+public class VMDumpThreadsDistributedTest implements Serializable {
+
+  private static final long TIMEOUT_MILLIS = getTimeout().getValueInMS();
+
+  private static final AtomicReference<ExecutorService> executor = new AtomicReference<>();
+  private static final AtomicReference<CountDownLatch> latch = new AtomicReference<>();
+  private static final AtomicReference<ThreadInfo> threadInfo1 = new AtomicReference<>();
+  private static final AtomicReference<ThreadInfo> threadInfo2 = new AtomicReference<>();
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @Before
+  public void setUp() {
+    getVM(0).invoke(() -> {
+      executor.set(Executors.newFixedThreadPool(2));
+      latch.set(new CountDownLatch(1));
+    });
+  }
+
+  @After
+  public void tearDown() {
+    getVM(0).invoke(() -> {
+      latch.get().countDown();
+      executor.get().shutdown();
+    });
+  }
+
+  @Test
+  public void threadDumpOfVmContainsRemoteThreads() {
+    ThreadInfo remoteThreadInfo1 = getVM(0).invoke(() -> {
+      executor.get().submit(() -> {
+        threadInfo1.set(new ThreadInfo(Thread.currentThread()));
+        latch.get();
+      });
+
+      await().untilAsserted(() -> assertThat(threadInfo1.get()).isNotNull());
+      return threadInfo1.get();
+    });
+
+    ThreadInfo remoteThreadInfo2 = getVM(0).invoke(() -> {
+      executor.get().submit(() -> {
+        threadInfo2.set(new ThreadInfo(Thread.currentThread()));
+        syncMethod();
+      });
+
+      await().untilAsserted(() -> assertThat(threadInfo2.get()).isNotNull());
+      return threadInfo2.get();
+    });
+
+    assertThat(remoteThreadInfo1.getThreadId()).isNotEqualTo(remoteThreadInfo2.getThreadId());
+    assertThat(remoteThreadInfo1.getThreadName()).isNotEqualTo(remoteThreadInfo2.getThreadName());
+
+    String threadDump = getVM(0).invoke(VM::dumpThreads);
+
+    assertThat(threadDump)
+        .contains("\"" + remoteThreadInfo1.getThreadName() + "\" Id=" + remoteThreadInfo1.threadId +
+            " WAITING on java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject@")
+        .contains("\"" + remoteThreadInfo2.getThreadName() + "\" Id=" + remoteThreadInfo2.threadId +
+            " TIMED_WAITING on java.util.concurrent.CountDownLatch$Sync@")
+        .contains("\"main\" Id=1 TIMED_WAITING");
+  }
+
+  private synchronized void syncMethod() {
+    try {
+      latch.get().await(TIMEOUT_MILLIS, MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static class ThreadInfo implements Serializable {
+
+    private final String threadName;
+    private final long threadId;
+
+    ThreadInfo(Thread thread) {
+      this(thread.getName(), thread.getId());
+    }
+
+    private ThreadInfo(String threadName, long threadId) {
+      this.threadName = threadName;
+      this.threadId = threadId;
+    }
+
+    String getThreadName() {
+      return threadName;
+    }
+
+    long getThreadId() {
+      return threadId;
+    }
+
+    @Override
+    public String toString() {
+      return "ThreadInfo(name=" + threadName + ", id=" + threadId + ")";
+    }
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/CacheSerializableRunnable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/CacheSerializableRunnable.java
@@ -29,14 +29,14 @@ import org.apache.geode.test.dunit.VM;
 public abstract class CacheSerializableRunnable extends SerializableRunnable {
 
   /**
-   * Creates a new {@code CacheSerializableRunnable} with the given name
+   * Creates a new {@code CacheSerializableRunnable}.
    */
   public CacheSerializableRunnable() {
     // super
   }
 
   /**
-   * Creates a new {@code CacheSerializableRunnable} with the given name
+   * Creates a new {@code CacheSerializableRunnable} with the given name.
    *
    * @deprecated Please pass name as the first argument to {@link VM} invoke or asyncInvoke.
    */

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/CacheSerializableRunnable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/CacheSerializableRunnable.java
@@ -17,6 +17,7 @@ package org.apache.geode.cache30;
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.CacheRuntimeException;
 import org.apache.geode.test.dunit.SerializableRunnable;
+import org.apache.geode.test.dunit.VM;
 
 /**
  * A helper class that provides the {@link SerializableRunnable} class, but uses a {@link #run2}
@@ -28,36 +29,33 @@ import org.apache.geode.test.dunit.SerializableRunnable;
 public abstract class CacheSerializableRunnable extends SerializableRunnable {
 
   /**
-   * Creates a new <code>CacheSerializableRunnable</code> with the given name
+   * Creates a new {@code CacheSerializableRunnable} with the given name
    */
+  public CacheSerializableRunnable() {
+    // super
+  }
+
+  /**
+   * Creates a new {@code CacheSerializableRunnable} with the given name
+   *
+   * @deprecated Please pass name as the first argument to {@link VM} invoke or asyncInvoke.
+   */
+  @Deprecated
   public CacheSerializableRunnable(String name) {
     super(name);
   }
 
   /**
-   * Creates a new <code>CacheSerializableRunnable</code> with the given name
-   */
-  public CacheSerializableRunnable(String name, Object[] args) {
-    super(name);
-    this.args = args;
-  }
-
-  /**
    * Invokes the {@link #run2} method and will wrap any {@link CacheException} thrown by
-   * <code>run2</code> in a {@link CacheSerializableRunnableException}.
+   * {@code run2} in a {@link CacheSerializableRunnableException}.
    */
   @Override
   public void run() {
     try {
-      if (args == null) {
-        run2();
-      } else {
-        run3();
-      }
-
-    } catch (CacheException ex) {
-      String s = "While invoking \"" + this + "\"";
-      throw new CacheSerializableRunnableException(s, ex);
+      run2();
+    } catch (CacheException exception) {
+      String message = "While invoking \"" + this + "\"";
+      throw new CacheSerializableRunnableException(message, exception);
     }
   }
 
@@ -65,8 +63,6 @@ public abstract class CacheSerializableRunnable extends SerializableRunnable {
    * A {@link SerializableRunnable#run run} method that may throw a {@link CacheException}.
    */
   public abstract void run2() throws CacheException;
-
-  public void run3() throws CacheException {}
 
   /**
    * An exception that wraps a {@link CacheException}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/AsyncInvocation.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/AsyncInvocation.java
@@ -15,16 +15,22 @@
 package org.apache.geode.test.dunit;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+import static org.apache.geode.test.dunit.VM.dumpThreads;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 
 import org.apache.geode.SystemFailure;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.internal.AsyncThreadId;
+import org.apache.geode.test.dunit.internal.IdentifiableCallable;
+import org.apache.geode.test.dunit.internal.IdentifiableRunnable;
+import org.apache.geode.test.dunit.internal.StackTrace;
 
 /**
  * An {@code AsyncInvocation} represents the invocation of a remote invocation that executes
@@ -35,20 +41,20 @@ import org.apache.geode.SystemFailure;
  * {@code AsyncInvocation} can be used as follows:
  *
  * <pre>
- *   AsyncInvocation ai1 = vm.invokeAsync(() -> Test.method1());
- *   AsyncInvocation ai2 = vm.invokeAsync(() -> Test.method2());
+ *   AsyncInvocation doPutsInVM0 = vm0.invokeAsync(() -> doPuts());
+ *   AsyncInvocation doDestroysInVM1 = vm1.invokeAsync(() -> doDestroys());
  *
- *   ai1.await();
- *   ai2.await();
+ *   doPutsInVM0.await();
+ *   doDestroysInVM1.await();
  * </pre>
  *
  * @param <V> The result type returned by this AsyncInvocation's {@code get} methods
  *
- * @see VM#invokeAsync(Class, String)
+ * @see VM#invokeAsync(SerializableCallableIF)
  */
 public class AsyncInvocation<V> implements Future<V> {
 
-  private static final long DEFAULT_JOIN_MILLIS = getTimeout().getValueInMS();
+  private static final long DEFAULT_TIMEOUT_MILLIS = getTimeout().getValueInMS();
 
   private final Thread thread;
 
@@ -58,13 +64,32 @@ public class AsyncInvocation<V> implements Future<V> {
   private final AtomicReference<Throwable> resultThrowable = new AtomicReference<>();
 
   /** The object (or class) that is the target of this {@code AsyncInvocation} */
-  private Object target;
+  private final Object target;
 
   /** The name of the method being invoked */
-  private String methodName;
+  private final String methodName;
+
+  private final Function<TimeoutException, TimeoutException> asyncTimeoutHandler;
 
   /** True if this {@code AsyncInvocation} has been cancelled */
   private boolean cancelled;
+
+  public static <V> AsyncInvocation<V> create(IdentifiableRunnable target, Callable<V> work,
+      VM vm) {
+    return new AsyncInvocation<>(target, target.getMethodName(), work,
+        asyncTimeoutHandler(vm, target.getId()));
+  }
+
+  public static <V> AsyncInvocation<V> create(IdentifiableCallable<V> target, Callable<V> work,
+      VM vm) {
+    return new AsyncInvocation<>(target, target.getMethodName(), work,
+        asyncTimeoutHandler(vm, target.getId()));
+  }
+
+  public static <V> AsyncInvocation<V> create(Object target, String methodName, Callable<V> work,
+      VM vm) {
+    return new AsyncInvocation<>(target, methodName, work, timeoutException -> timeoutException);
+  }
 
   /**
    * Creates a new {@code AsyncInvocation}.
@@ -73,187 +98,12 @@ public class AsyncInvocation<V> implements Future<V> {
    * @param methodName The name of the method being invoked
    * @param work The actual invocation of the method
    */
-  public AsyncInvocation(final Object target, final String methodName, final Callable<V> work) {
+  private AsyncInvocation(Object target, String methodName, Callable<V> work,
+      Function<TimeoutException, TimeoutException> asyncTimeoutHandler) {
     this.target = target;
     this.methodName = methodName;
-    thread =
-        new Thread(new AsyncInvocationGroup(), runnable(work), getName(target, methodName));
-  }
-
-  /**
-   * Returns the target of this async method invocation.
-   *
-   * @deprecated This method is not required for anything.
-   */
-  public Object getTarget() {
-    return target;
-  }
-
-  /**
-   * Returns the name of the method being invoked remotely.
-   *
-   * @deprecated This method is not required for anything.
-   */
-  public String getMethodName() {
-    return methodName;
-  }
-
-  /**
-   * Returns whether or not an exception occurred during this async method invocation.
-   *
-   * @throws AssertionError if this {@code AsyncInvocation} is not done.
-   */
-  public boolean exceptionOccurred() {
-    return getException() != null;
-  }
-
-  /**
-   * Returns the exception that was thrown during this async method invocation.
-   *
-   * @throws AssertionError if this {@code AsyncInvocation} is not done.
-   */
-  public Throwable getException() {
-    try {
-      checkIsDone("Exception status not available while thread is alive.");
-    } catch (IllegalStateException illegalStateException) {
-      throw new AssertionError(illegalStateException);
-    }
-
-    if (resultThrowable.get() instanceof RMIException) { // TODO: delete our RMIException
-      return resultThrowable.get().getCause();
-
-    } else {
-      return resultThrowable.get();
-    }
-  }
-
-  /**
-   * Throws {@code AssertionError} wrapping any {@code Exception} thrown by this
-   * {@code AsyncInvocation}.
-   *
-   * @return this {@code AsyncInvocation}
-   *
-   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
-   */
-  public AsyncInvocation<V> checkException() {
-    if (resultThrowable.get() != null) {
-      throw new AssertionError("An exception occurred during asynchronous invocation.",
-          getException());
-    }
-    return this;
-  }
-
-  /**
-   * Returns the result of this {@code AsyncInvocation}.
-   *
-   * @return the result of this {@code AsyncInvocation}
-   *
-   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
-   *
-   * @throws AssertionError wrapping a {@code TimeoutException} if this {@code AsyncInvocation}
-   *         fails to complete within the default timeout of 60 seconds as defined by
-   *         {@link #DEFAULT_JOIN_MILLIS}.
-   *
-   * @throws InterruptedException if the current thread is interrupted.
-   *
-   * @deprecated Please use {@link #get()} instead.
-   */
-  public V getResult() throws InterruptedException {
-    join();
-    checkException();
-    checkIsDone("Return value not available while thread is alive.");
-    return resultValue.get();
-  }
-
-  /**
-   * Returns the result of this {@code AsyncInvocation}.
-   *
-   * @param millis the time to wait in milliseconds
-   *
-   * @return the result of this {@code AsyncInvocation}
-   *
-   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
-   *
-   * @throws AssertionError wrapping a {@code TimeoutException} if this {@code AsyncInvocation}
-   *         fails to complete within the specified timeout of {@code millis}.
-   *
-   * @throws InterruptedException if the current thread is interrupted.
-   *
-   * @deprecated Please use {@link #get(long, TimeUnit)} instead.
-   */
-  public V getResult(final long millis) throws InterruptedException {
-    try {
-      return get(millis, TimeUnit.MILLISECONDS);
-    } catch (ExecutionException executionException) {
-      throw new AssertionError(executionException);
-    } catch (TimeoutException timeoutException) {
-      throw new AssertionError(timeoutException);
-    }
-  }
-
-  /**
-   * Returns the result of this {@code AsyncInvocation}.
-   *
-   * @return the result of this {@code AsyncInvocation}
-   *
-   * @throws AssertionError if this {@code AsyncInvocation} is not done.
-   *
-   * @deprecated Please use {@link #get()} instead.
-   */
-  public V getReturnValue() {
-    checkIsDone("Return value not available while thread is alive.");
-    return resultValue.get();
-  }
-
-  /**
-   * Waits at most {@code millis} milliseconds for this {@code AsyncInvocation} to complete. A
-   * timeout of {@code 0} means to wait forever.
-   *
-   * @param millis the time to wait in milliseconds
-   *
-   * @return this {@code AsyncInvocation}
-   *
-   * @throws IllegalArgumentException if the value of {@code millis} is negative.
-   *
-   * @throws InterruptedException if the current thread is interrupted.
-   */
-  public synchronized AsyncInvocation<V> join(final long millis) throws InterruptedException {
-    thread.join(millis);
-    return this;
-  }
-
-  /**
-   * Waits at most {@code millis} milliseconds plus {@code nanos} nanoseconds for this
-   * {@code AsyncInvocation} to complete.
-   *
-   * @param millis the time to wait in milliseconds
-   * @param nanos {@code 0-999999} additional nanoseconds to wait
-   *
-   * @return this {@code AsyncInvocation}
-   *
-   * @throws IllegalArgumentException if the value of {@code millis} is negative, or the value of
-   *         {@code nanos} is not in the range {@code 0-999999}.
-   *
-   * @throws InterruptedException if the current thread is interrupted.
-   */
-  public synchronized AsyncInvocation<V> join(final long millis, final int nanos)
-      throws InterruptedException {
-    thread.join(millis, nanos);
-    return this;
-  }
-
-  /**
-   * Waits for this thread to die up to a default of 60 seconds as defined by
-   * {@link #DEFAULT_JOIN_MILLIS}.
-   *
-   * @return this {@code AsyncInvocation}
-   *
-   * @throws InterruptedException if the current thread is interrupted.
-   */
-  public AsyncInvocation<V> join() throws InterruptedException {
-    // do NOT invoke Thread#join() without a timeout
-    join(DEFAULT_JOIN_MILLIS);
-    return this;
+    thread = new Thread(new AsyncInvocationGroup(), answer(work), getName(target, methodName));
+    this.asyncTimeoutHandler = asyncTimeoutHandler;
   }
 
   /**
@@ -293,7 +143,7 @@ public class AsyncInvocation<V> implements Future<V> {
 
   @Override
   public synchronized boolean isDone() {
-    return !thread.isAlive(); // state != NEW;
+    return !thread.isAlive();
   }
 
   @Override
@@ -309,34 +159,7 @@ public class AsyncInvocation<V> implements Future<V> {
   }
 
   /**
-   * Waits if necessary for at most the given time for the computation to complete.
-   *
-   * @param timeout the maximum time to wait
-   * @param unit the time unit of the timeout argument
-   *
-   * @return this {@code AsyncInvocation}
-   *
-   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
-   *
-   * @throws CancellationException if the computation was cancelled
-   *
-   * @throws ExecutionException if the computation threw an exception
-   *
-   * @throws InterruptedException if the current thread is interrupted.
-   *
-   * @throws TimeoutException if the wait timed out
-   */
-  public AsyncInvocation<V> await(final long timeout, final TimeUnit unit)
-      throws ExecutionException, InterruptedException, TimeoutException {
-    long millis = unit.toMillis(timeout);
-    join(millis);
-    timeoutIfAlive(millis);
-    checkException();
-    return this;
-  }
-
-  /**
-   * Waits if necessary for at most the given time for the computation to complete.
+   * Waits at most {@link GeodeAwaitility#getTimeout()} for the computation to complete.
    *
    * @return this {@code AsyncInvocation}
    *
@@ -344,25 +167,23 @@ public class AsyncInvocation<V> implements Future<V> {
    *
    * @throws AssertionError wrapping a {@code TimeoutException} if this {@code AsyncInvocation}
    *         fails to complete within the default timeout of 60 seconds as defined by
-   *         {@link #DEFAULT_JOIN_MILLIS}.
+   *         {@link #DEFAULT_TIMEOUT_MILLIS}.
    *
    * @throws CancellationException if the computation was cancelled
    *
-   * @throws ExecutionException if the computation threw an exception
-   *
    * @throws InterruptedException if the current thread is interrupted.
    */
-  public AsyncInvocation<V> await() throws ExecutionException, InterruptedException {
+  public AsyncInvocation<V> await() throws InterruptedException {
     try {
-      return await(DEFAULT_JOIN_MILLIS, TimeUnit.MILLISECONDS);
+      return await(DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     } catch (TimeoutException timeoutException) {
       throw new AssertionError(timeoutException);
     }
   }
 
   /**
-   * Waits if necessary for the work to complete, and then returns the result of this
-   * {@code AsyncInvocation}.
+   * Waits at most {@link GeodeAwaitility#getTimeout()} for the work to complete, and then returns
+   * the result of this {@code AsyncInvocation}.
    *
    * @return the result of this {@code AsyncInvocation}
    *
@@ -370,50 +191,19 @@ public class AsyncInvocation<V> implements Future<V> {
    *
    * @throws AssertionError wrapping a {@code TimeoutException} if this {@code AsyncInvocation}
    *         fails to complete within the default timeout of 60 seconds as defined by
-   *         {@link #DEFAULT_JOIN_MILLIS}.
+   *         {@link #DEFAULT_TIMEOUT_MILLIS}.
    *
    * @throws CancellationException if the computation was cancelled
-   *
-   * @throws ExecutionException if the computation threw an exception
    *
    * @throws InterruptedException if the current thread is interrupted.
    */
   @Override
-  public V get() throws ExecutionException, InterruptedException {
+  public V get() throws InterruptedException {
     try {
-      return get(DEFAULT_JOIN_MILLIS, TimeUnit.MILLISECONDS);
+      return get(DEFAULT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
     } catch (TimeoutException timeoutException) {
       throw new AssertionError(timeoutException);
     }
-  }
-
-  /**
-   * Waits if necessary for at most the given time for the computation to complete, and then
-   * retrieves its result, if available.
-   *
-   * @param timeout the maximum time to wait
-   * @param unit the time unit of the timeout argument
-   *
-   * @return the result of this {@code AsyncInvocation}
-   *
-   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
-   *
-   * @throws CancellationException if the computation was cancelled
-   *
-   * @throws ExecutionException if the computation threw an exception
-   *
-   * @throws InterruptedException if the current thread is interrupted.
-   *
-   * @throws TimeoutException if the wait timed out
-   */
-  @Override
-  public V get(final long timeout, final TimeUnit unit)
-      throws ExecutionException, InterruptedException, TimeoutException {
-    long millis = unit.toMillis(timeout);
-    join(millis);
-    timeoutIfAlive(millis);
-    checkException();
-    return resultValue.get();
   }
 
   /**
@@ -434,6 +224,262 @@ public class AsyncInvocation<V> implements Future<V> {
   }
 
   /**
+   * Returns the target of this async method invocation.
+   *
+   * @deprecated This method is not required for anything.
+   */
+  @Deprecated
+  public Object getTarget() {
+    return target;
+  }
+
+  /**
+   * Returns the name of the method being invoked remotely.
+   *
+   * @deprecated This method is not required for anything.
+   */
+  @Deprecated
+  public String getMethodName() {
+    return methodName;
+  }
+
+  /**
+   * Returns whether or not an exception occurred during this async method invocation.
+   *
+   * @throws AssertionError if this {@code AsyncInvocation} is not done.
+   *
+   * @deprecated Please use {@link #await()} or {@link #get()} which will throw any underlying
+   *             exception.
+   */
+  @Deprecated
+  public boolean exceptionOccurred() {
+    return getException() != null;
+  }
+
+  /**
+   * Returns the exception that was thrown during this async method invocation.
+   *
+   * @throws AssertionError if this {@code AsyncInvocation} is not done.
+   *
+   * @deprecated Please use {@link #await()} or {@link #get()} which will throw any underlying
+   *             exception.
+   */
+  @Deprecated
+  public Throwable getException() {
+    try {
+      checkIsDone("Exception status not available while thread is alive.");
+    } catch (IllegalStateException illegalStateException) {
+      throw new AssertionError(illegalStateException);
+    }
+
+    if (resultThrowable.get() instanceof RMIException) {
+      return resultThrowable.get().getCause();
+    }
+
+    return resultThrowable.get();
+  }
+
+  /**
+   * Throws {@code AssertionError} wrapping any {@code Exception} thrown by this
+   * {@code AsyncInvocation}.
+   *
+   * @return this {@code AsyncInvocation}
+   *
+   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
+   *
+   * @deprecated Please use {@link #await()} or {@link #get()} which will throw any underlying
+   *             exception.
+   */
+  @Deprecated
+  public AsyncInvocation<V> checkException() {
+    if (resultThrowable.get() != null) {
+      throw new AssertionError("An exception occurred during asynchronous invocation.",
+          getException());
+    }
+    return this;
+  }
+
+  /**
+   * Returns the result of this {@code AsyncInvocation}.
+   *
+   * @return the result of this {@code AsyncInvocation}
+   *
+   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
+   *
+   * @throws AssertionError wrapping a {@code TimeoutException} if this {@code AsyncInvocation}
+   *         fails to complete within the default timeout of 60 seconds as defined by
+   *         {@link #DEFAULT_TIMEOUT_MILLIS}.
+   *
+   * @throws InterruptedException if the current thread is interrupted.
+   *
+   * @deprecated Please use {@link #get()} instead.
+   */
+  @Deprecated
+  public V getResult() throws InterruptedException {
+    join();
+    checkException();
+    checkIsDone("Return value not available while thread is alive.");
+    return resultValue.get();
+  }
+
+  /**
+   * Returns the result of this {@code AsyncInvocation}.
+   *
+   * @param millis the time to wait in milliseconds
+   *
+   * @return the result of this {@code AsyncInvocation}
+   *
+   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
+   *
+   * @throws AssertionError wrapping a {@code TimeoutException} if this {@code AsyncInvocation}
+   *         fails to complete within the specified timeout of {@code millis}.
+   *
+   * @throws InterruptedException if the current thread is interrupted.
+   *
+   * @deprecated Please use {@link #get()} instead.
+   */
+  @Deprecated
+  public V getResult(final long millis) throws InterruptedException {
+    try {
+      return get(millis, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException timeoutException) {
+      throw new AssertionError(timeoutException);
+    }
+  }
+
+  /**
+   * Returns the result of this {@code AsyncInvocation}.
+   *
+   * @return the result of this {@code AsyncInvocation}
+   *
+   * @throws AssertionError if this {@code AsyncInvocation} is not done.
+   *
+   * @deprecated Please use {@link #get()} instead.
+   */
+  @Deprecated
+  public V getReturnValue() {
+    checkIsDone("Return value not available while thread is alive.");
+    return resultValue.get();
+  }
+
+  /**
+   * Waits at most {@code millis} milliseconds for this {@code AsyncInvocation} to complete. A
+   * timeout of {@code 0} means to wait forever.
+   *
+   * @param millis the time to wait in milliseconds
+   *
+   * @return this {@code AsyncInvocation}
+   *
+   * @throws IllegalArgumentException if the value of {@code millis} is negative.
+   *
+   * @throws InterruptedException if the current thread is interrupted.
+   *
+   * @deprecated Please use {@link #await()} or {@link #get()} instead.
+   */
+  @Deprecated
+  public synchronized AsyncInvocation<V> join(final long millis) throws InterruptedException {
+    thread.join(millis);
+    return this;
+  }
+
+  /**
+   * Waits at most {@code millis} milliseconds plus {@code nanos} nanoseconds for this
+   * {@code AsyncInvocation} to complete.
+   *
+   * @param millis the time to wait in milliseconds
+   * @param nanos {@code 0-999999} additional nanoseconds to wait
+   *
+   * @return this {@code AsyncInvocation}
+   *
+   * @throws IllegalArgumentException if the value of {@code millis} is negative, or the value of
+   *         {@code nanos} is not in the range {@code 0-999999}.
+   *
+   * @throws InterruptedException if the current thread is interrupted.
+   *
+   * @deprecated Please use {@link #await()} or {@link #get()} instead.
+   */
+  @Deprecated
+  public synchronized AsyncInvocation<V> join(final long millis, final int nanos)
+      throws InterruptedException {
+    thread.join(millis, nanos);
+    return this;
+  }
+
+  /**
+   * Waits at most {@link GeodeAwaitility#getTimeout()} for this thread to die.
+   *
+   * @return this {@code AsyncInvocation}
+   *
+   * @throws InterruptedException if the current thread is interrupted.
+   *
+   * @deprecated Please use {@link #await()} or {@link #get()} instead.
+   */
+  @Deprecated
+  public AsyncInvocation<V> join() throws InterruptedException {
+    // do NOT invoke Thread#join() without a timeout
+    join(DEFAULT_TIMEOUT_MILLIS);
+    return this;
+  }
+
+  /**
+   * Waits if necessary for at most the given time for the computation to complete.
+   *
+   * @param timeout the maximum time to wait
+   * @param unit the time unit of the timeout argument
+   *
+   * @return this {@code AsyncInvocation}
+   *
+   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
+   *
+   * @throws CancellationException if the computation was cancelled
+   *
+   * @throws InterruptedException if the current thread is interrupted.
+   *
+   * @throws TimeoutException if the wait timed out
+   *
+   * @deprecated Please use {@link #await()} which uses {@link GeodeAwaitility#getTimeout()}.
+   */
+  @Deprecated
+  public AsyncInvocation<V> await(final long timeout, final TimeUnit unit)
+      throws InterruptedException, TimeoutException {
+    long millis = unit.toMillis(timeout);
+    join(millis);
+    timeoutIfAlive(millis);
+    checkException();
+    return this;
+  }
+
+  /**
+   * Waits at most the given time for the computation to complete, and then retrieves its result,
+   * if available.
+   *
+   * @param timeout the maximum time to wait
+   * @param unit the time unit of the timeout argument
+   *
+   * @return the result of this {@code AsyncInvocation}
+   *
+   * @throws AssertionError wrapping any {@code Exception} thrown by this {@code AsyncInvocation}.
+   *
+   * @throws CancellationException if the computation was cancelled
+   *
+   * @throws InterruptedException if the current thread is interrupted.
+   *
+   * @throws TimeoutException if the wait timed out
+   *
+   * @deprecated Please use {@link #get()} which uses {@link GeodeAwaitility#getTimeout()}.
+   */
+  @Deprecated
+  @Override
+  public V get(final long timeout, final TimeUnit unit)
+      throws InterruptedException, TimeoutException {
+    long millis = unit.toMillis(timeout);
+    join(millis);
+    timeoutIfAlive(millis);
+    checkException();
+    return resultValue.get();
+  }
+
+  /**
    * Throws {@code IllegalStateException} if this {@code AsyncInvocation} is not done.
    *
    * @param message The value to be used in constructing detail message
@@ -451,23 +497,23 @@ public class AsyncInvocation<V> implements Future<V> {
 
   /**
    * Throws {@code AssertionError} wrapping a {@code TimeoutException} if this
-   * {@code AsyncInvocation} fails to complete within the default timeout of 60 seconds as defined
-   * by {@link #DEFAULT_JOIN_MILLIS}.
+   * {@code AsyncInvocation} fails to complete within {@link GeodeAwaitility#getTimeout()}.
    *
    * @return this {@code AsyncInvocation}
    *
-   * @throws TimeoutException if this {@code AsyncInvocation} fails to complete within the default
-   *         timeout of 60 seconds as defined by {@link #DEFAULT_JOIN_MILLIS}.
+   * @throws TimeoutException if this {@code AsyncInvocation} fails to complete within
+   *         {@link GeodeAwaitility#getTimeout()}.
    */
   private AsyncInvocation<V> timeoutIfAlive(final long timeout) throws TimeoutException {
     if (thread.isAlive()) {
-      throw new TimeoutException(
+      TimeoutException timeoutException = new TimeoutException(
           "Timed out waiting " + timeout + " milliseconds for AsyncInvocation to complete.");
+      throw asyncTimeoutHandler.apply(timeoutException);
     }
     return this;
   }
 
-  private Runnable runnable(final Callable<V> work) {
+  private Runnable answer(final Callable<V> work) {
     return () -> {
       try {
         resultValue.set(work.call());
@@ -482,18 +528,25 @@ public class AsyncInvocation<V> implements Future<V> {
    * {@code methodName}.
    */
   private static String getName(final Object target, final String methodName) {
-    StringBuilder sb = new StringBuilder(methodName);
-    sb.append(" invoked on ");
+    StringBuilder sb = new StringBuilder(methodName).append(" invoked on ");
     if (target instanceof Class) {
-      sb.append("class ");
-      sb.append(((Class) target).getName());
-
+      sb.append("class ").append(((Class) target).getName());
     } else {
-      sb.append("an instance of ");
-      sb.append(target.getClass().getName());
+      sb.append("an instance of ").append(target.getClass().getName());
     }
-
     return sb.toString();
+  }
+
+  private static Function<TimeoutException, TimeoutException> asyncTimeoutHandler(VM vm, long id) {
+    return timeoutException -> {
+      StackTrace stackTrace =
+          vm.invoke(() -> {
+            System.out.println(dumpThreads());
+            return new StackTrace(vm.getId(), AsyncThreadId.get(id));
+          });
+      timeoutException.initCause(stackTrace);
+      return timeoutException;
+    };
   }
 
   /**
@@ -508,7 +561,7 @@ public class AsyncInvocation<V> implements Future<V> {
     @Override
     public void uncaughtException(Thread thread, Throwable throwable) {
       if (throwable instanceof VirtualMachineError) {
-        SystemFailure.setFailure((VirtualMachineError) throwable); // don't throw
+        SystemFailure.setFailure((Error) throwable);
       }
       resultThrowable.set(throwable);
     }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/DUnitEnv.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/DUnitEnv.java
@@ -59,9 +59,7 @@ public abstract class DUnitEnv {
 
   public abstract Properties getDistributedSystemProperties();
 
-  public abstract int getPid();
-
-  public abstract int getVMID();
+  public abstract int getId();
 
   public abstract BounceResult bounce(String version, int pid, boolean force)
       throws RemoteException;

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/RMIException.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/RMIException.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.test.dunit;
 
+import java.io.PrintWriter;
+
 import org.apache.geode.GemFireException;
 
 /**
@@ -21,7 +23,7 @@ import org.apache.geode.GemFireException;
  * {@link RuntimeException} wraps the actual exception. It allows distributed unit tests to verify
  * that an exception was thrown in a different VM.
  *
- * <PRE>
+ * <pre>
  *     VM vm0 = host0.getVM(0);
  *     try {
  *       vm.invoke(() -> this.getUnknownObject());
@@ -29,14 +31,12 @@ import org.apache.geode.GemFireException;
  *     } catch (RMIException ex) {
  *       assertIndexDetailsEquals(ex.getCause() instanceof ObjectException);
  *     }
- * </PRE>
+ * </pre>
  *
+ * <p>
  * Note that special steps are taken so that the stack trace of the cause exception reflects the
  * call stack on the remote machine. The stack trace of the exception returned by
  * {@link #getCause()} may not be available.
- *
- * see hydra.RemoteTestModuleIF
- *
  */
 @SuppressWarnings("serial")
 public class RMIException extends GemFireException {
@@ -44,29 +44,21 @@ public class RMIException extends GemFireException {
   /**
    * SHADOWED FIELD that holds the cause exception (as opposed to the HokeyException
    */
-  private Throwable cause;
+  private final Throwable cause;
 
   /** The name of the method being invoked */
-  private String methodName;
+  private final String methodName;
 
   /**
    * The name of the class (or class of the object type) whose method was being invoked
    */
-  private String className;
-
-  /** The type of exception that was thrown in the remote VM */
-  private String exceptionClassName;
-
-  /** Stack trace for the exception that was thrown in the remote VM */
-  private String stackTrace;
+  private final String className;
 
   /** The VM in which the method was executing */
-  private VM vm;
-
-  //////////////////////// Constructors ////////////////////////
+  private final VM vm;
 
   /**
-   * Creates a new <code>RMIException</code> that was caused by a given <code>Throwable</code> while
+   * Creates a new {@code RMIException} that was caused by a given {@code Throwable} while
    * invoking a given method.
    */
   public RMIException(VM vm, String className, String methodName, Throwable cause) {
@@ -78,7 +70,7 @@ public class RMIException extends GemFireException {
   }
 
   /**
-   * Creates a new <code>RMIException</code> to indicate that an exception of a given type was
+   * Creates a new {@code RMIException} to indicate that an exception of a given type was
    * thrown while invoking a given method.
    *
    * @param vm The VM in which the method was executing
@@ -95,24 +87,7 @@ public class RMIException extends GemFireException {
     this.cause = cause;
     this.className = className;
     this.methodName = methodName;
-    // this.exceptionClassName = exceptionClassName; assignment has no effect
-    this.stackTrace = stackTrace;
   }
-
-  /**
-   * Returns the class name of the exception that was thrown in a remote method invocation.
-   */
-  public String getExceptionClassName() {
-    return this.exceptionClassName;
-  }
-
-  // /**
-  // * Returns the stack trace for the exception that was thrown in a
-  // * remote method invocation.
-  // */
-  // public String getStackTrace() {
-  // return this.stackTrace;
-  // }
 
   /**
    * Returns the cause of this exception. Note that this is not necessarily the exception that gets
@@ -120,38 +95,37 @@ public class RMIException extends GemFireException {
    */
   @Override
   public Throwable getCause() {
-    return this.cause;
+    return cause;
   }
 
   /**
    * Returns the VM in which the remote method was invoked
    */
   public VM getVM() {
-    return this.vm;
+    return vm;
   }
-
-  ////////////////////// Inner Classes //////////////////////
 
   /**
    * A hokey exception class that makes it looks like we have a real cause exception.
    */
   private static class HokeyException extends Throwable {
-    private String stackTrace;
-    private String toString;
+
+    private final String stackTrace;
+    private final String toString;
 
     HokeyException(Throwable cause, String stackTrace) {
-      this.toString = cause.toString();
+      toString = cause.toString();
       this.stackTrace = stackTrace;
     }
 
     @Override
-    public void printStackTrace(java.io.PrintWriter pw) {
-      pw.print(this.stackTrace);
+    public void printStackTrace(PrintWriter pw) {
+      pw.print(stackTrace);
       pw.flush();
     }
 
     public String toString() {
-      return this.toString;
+      return toString;
     }
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/SerializableCallable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/SerializableCallable.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.test.dunit;
 
+import static java.lang.Integer.toHexString;
+
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 
@@ -21,13 +23,13 @@ import java.util.concurrent.Callable;
  * This interface provides both {@link Serializable} and {@link Callable}. It is often used in
  * conjunction with {@link VM#invoke(SerializableCallableIF)}.
  *
- * <PRE>
+ * <pre>
  * public void testReplicatedRegionPut() {
- *   final Host host = Host.getHost(0);
- *   VM vm0 = host.getVM(0);
- *   VM vm1 = host.getVM(1);
- *   final String name = this.getUniqueName();
- *   final Object value = new Integer(42);
+ *   VM vm0 = VM.getVM(0);
+ *   VM vm1 = VM.getVM(1);
+ *
+ *   String name = getUniqueName();
+ *   Object value = new Integer(42);
  *
  *   SerializableCallable putMethod = new SerializableCallable("Replicated put") {
  *       public Object call() throws Exception {
@@ -38,29 +40,54 @@ import java.util.concurrent.Callable;
  *   assertNull(vm0.invoke(putMethod));
  *   assertIndexDetailsEquals(value, vm1.invoke(putMethod));
  *  }
- * </PRE>
- *
+ * </pre>
  */
 public abstract class SerializableCallable<T> implements SerializableCallableIF<T> {
 
-  private static final long serialVersionUID = -5914706166172952484L;
+  private static final String DEFAULT_NAME = "";
+  private static final long DEFAULT_ID = 0L;
 
-  private String name;
+  private final String name;
+  private final long id;
 
   public SerializableCallable() {
-    this.name = null;
+    this(DEFAULT_NAME, DEFAULT_ID);
   }
 
+  /**
+   * @deprecated Please pass name as the first argument to {@link VM} invoke or asyncInvoke.
+   */
+  @Deprecated
   public SerializableCallable(String name) {
-    this.name = name;
+    this(name, DEFAULT_ID);
   }
 
-  public String toString() {
-    if (this.name != null) {
-      return "\"" + this.name + "\"";
+  public SerializableCallable(long id) {
+    this(DEFAULT_NAME, id);
+  }
 
-    } else {
-      return super.toString();
-    }
+  private SerializableCallable(String name, long id) {
+    this.name = name;
+    this.id = id;
+  }
+
+  /**
+   * @deprecated Please pass name as the first argument to {@link VM} invoke or asyncInvoke.
+   */
+  @Deprecated
+  public String getName() {
+    return name;
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder()
+        .append(getClass().getSimpleName()).append("@").append(toHexString(hashCode()))
+        .append('(').append(id).append(", \"").append(name).append("\")")
+        .toString();
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/SerializableRunnable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/SerializableRunnable.java
@@ -14,81 +14,93 @@
  */
 package org.apache.geode.test.dunit;
 
+import static java.lang.Integer.toHexString;
+
 import java.io.Serializable;
 
 /**
  * This interface provides both {@link Serializable} and {@link Runnable}. It is often used in
  * conjunction with {@link VM#invoke(SerializableRunnableIF)}.
  *
- * <PRE>
+ * <pre>
  * public void testRegionPutGet() {
- *   final Host host = Host.getHost(0);
- *   VM vm0 = host.getVM(0);
- *   VM vm1 = host.getVM(1);
- *   final String name = this.getUniqueName();
- *   final Object value = new Integer(42);
+ *   VM vm0 = VM.getVM(0);
+ *   VM vm1 = VM.getVM(1);
  *
- *   vm0.invoke(new SerializableRunnable("Put value") {
+ *   String regionName = getUniqueName();
+ *   Object value = new Integer(42);
+ *
+ *   vm0.invoke("Put value", new SerializableRunnable() {
  *       public void run() {
  *         ...// get the region //...
  *         region.put(name, value);
  *       }
  *      });
- *   vm1.invoke(new SerializableRunnable("Get value") {
+ *   vm1.invoke("Get value", new SerializableRunnable() {
  *       public void run() {
  *         ...// get the region //...
  *         assertIndexDetailsEquals(value, region.get(name));
  *       }
  *     });
  *  }
- * </PRE>
+ * </pre>
  */
 public abstract class SerializableRunnable implements SerializableRunnableIF {
 
-  private static final long serialVersionUID = 7584289978241650456L;
+  private static final String DEFAULT_NAME = "";
+  private static final long DEFAULT_ID = 0L;
 
-  private String name;
-  protected Object[] args;
+  private final String name;
+  private final long id;
 
   public SerializableRunnable() {
-    this.name = null;
+    this(DEFAULT_NAME, DEFAULT_ID);
   }
 
   /**
    * This constructor lets you do the following:
    *
-   * <PRE>
+   * <pre>
    * vm.invoke(new SerializableRunnable("Do some work") {
    *   public void run() {
    *     // ...
    *   }
    * });
-   * </PRE>
+   * </pre>
+   *
+   * @deprecated Please pass name as the first argument to {@link VM} invoke or asyncInvoke.
    */
+  @Deprecated
   public SerializableRunnable(String name) {
+    this(name, DEFAULT_ID);
+  }
+
+  public SerializableRunnable(long id) {
+    this(DEFAULT_NAME, id);
+  }
+
+  private SerializableRunnable(String name, long id) {
     this.name = name;
+    this.id = id;
   }
 
-  public SerializableRunnable(String name, Object[] args) {
-    this.name = name;
-    this.args = args;
-  }
-
-  public void setName(String newName) {
-    this.name = newName;
-  }
-
+  /**
+   * @deprecated Please pass name as the first argument to {@link VM} invoke or asyncInvoke.
+   */
+  @Deprecated
   public String getName() {
-    return this.name;
+    return name;
   }
 
+  public long getId() {
+    return id;
+  }
+
+  @Override
   public String toString() {
-    if (this.name != null) {
-      return "\"" + this.name + "\"";
-
-    } else {
-      return super.toString();
-    }
+    return new StringBuilder()
+        .append(getClass().getSimpleName()).append("@").append(toHexString(hashCode()))
+        .append('(').append(id).append(", \"").append(name).append("\")")
+        .toString();
   }
-
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/SerializableRunnableIF.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/SerializableRunnableIF.java
@@ -14,11 +14,19 @@
  */
 package org.apache.geode.test.dunit;
 
-import java.io.Serializable;
+import org.apache.geode.test.dunit.internal.Identifiable;
+import org.apache.geode.test.dunit.internal.Invocable;
 
 /**
  * Interface for {@link SerializableRunnable} to enable use with lambdas.
  */
-public interface SerializableRunnableIF extends Serializable {
-  public void run() throws Exception;
+@FunctionalInterface
+public interface SerializableRunnableIF extends Identifiable, Invocable {
+
+  void run() throws Exception;
+
+  @Override
+  default String getMethodName() {
+    return "run";
+  }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
@@ -14,14 +14,20 @@
  */
 package org.apache.geode.test.dunit;
 
+import static org.apache.geode.test.dunit.internal.AsyncThreadId.nextId;
 import static org.apache.geode.test.dunit.internal.DUnitLauncher.NUM_VMS;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 
 import org.apache.commons.lang3.ArrayUtils;
@@ -30,6 +36,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.internal.process.ProcessUtils;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.dunit.internal.ChildVMLauncher;
+import org.apache.geode.test.dunit.internal.IdentifiableCallable;
+import org.apache.geode.test.dunit.internal.IdentifiableRunnable;
 import org.apache.geode.test.dunit.internal.MethodInvokerResult;
 import org.apache.geode.test.dunit.internal.ProcessHolder;
 import org.apache.geode.test.dunit.internal.RemoteDUnitVMIF;
@@ -42,18 +50,19 @@ import org.apache.geode.test.version.VersionManager;
  */
 @SuppressWarnings("serial,unused")
 public class VM implements Serializable {
-
   private static final Logger logger = LogService.getLogger();
 
   public static final int CONTROLLER_VM = -1;
 
   public static final int DEFAULT_VM_COUNT = NUM_VMS;
 
+  private static final Object[] EMPTY = new Object[0];
+
   /** The host on which this VM runs */
   private final Host host;
 
   /** The sequential id of this VM */
-  private int id;
+  private final int id;
 
   /** The version of Geode used in this VM */
   private String version;
@@ -72,8 +81,16 @@ public class VM implements Serializable {
    * Returns the {@code VM} identity. For {@link StandAloneDUnitEnv} the number returned is a
    * zero-based sequence representing the order in with the DUnit {@code VM}s were launched.
    */
+  public static int getVMId() {
+    return DUnitEnv.get().getId();
+  }
+
+  /**
+   * @deprecated Please use {@link #getVMId()} instead.
+   */
+  @Deprecated
   public static int getCurrentVMNum() {
-    return DUnitEnv.get().getVMID();
+    return DUnitEnv.get().getId();
   }
 
   /**
@@ -190,6 +207,18 @@ public class VM implements Serializable {
     getVMEventNotifier().removeVMEventListener(listener);
   }
 
+  public static String dumpThreads() {
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    long[] allThreadIds = threadMXBean.getAllThreadIds();
+    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(allThreadIds, true, true);
+
+    StringBuilder dumpWriter = new StringBuilder();
+    Arrays.stream(threadInfos)
+        .filter(Objects::nonNull)
+        .forEach(dumpWriter::append);
+    return dumpWriter.toString();
+  }
+
   private static VMEventNotifier getVMEventNotifier() {
     return Host.getHost(0).getVMEventNotifier();
   }
@@ -260,7 +289,7 @@ public class VM implements Serializable {
    * @param targetClass The class on which to invoke the method
    * @param methodName The name of the method to invoke
    *
-   * @deprecated Please use {@link #invoke(SerializableCallableIF)} instead
+   * @deprecated Please use {@link #invokeAsync(SerializableCallableIF)} instead
    */
   @Deprecated
   public <V> AsyncInvocation<V> invokeAsync(final Class<?> targetClass, final String methodName) {
@@ -273,7 +302,7 @@ public class VM implements Serializable {
    *
    * @param targetClass The class on which to invoke the method
    * @param methodName The name of the method to invoke
-   * @param args Arguments passed to the method call (must be {@link java.io.Serializable}).
+   * @param args Arguments passed to the method call (must be {@link Serializable}).
    *
    * @throws RMIException Wraps any underlying exception thrown while invoking the method in this
    *         {@code VM}
@@ -292,15 +321,16 @@ public class VM implements Serializable {
    *
    * @param targetObject The object on which to invoke the method
    * @param methodName The name of the method to invoke
-   * @param args Arguments passed to the method call (must be {@link java.io.Serializable}).
+   * @param args Arguments passed to the method call (must be {@link Serializable}).
    *
    * @deprecated Please use {@link #invoke(SerializableCallableIF)} instead
    */
   @Deprecated
   public <V> AsyncInvocation<V> invokeAsync(final Object targetObject, final String methodName,
       final Object[] args) {
-    return new AsyncInvocation<V>(targetObject, methodName,
-        () -> invoke(targetObject, methodName, args)).start();
+    return AsyncInvocation
+        .<V>create(targetObject, methodName, () -> invoke(targetObject, methodName, args), this)
+        .start();
   }
 
   /**
@@ -309,15 +339,16 @@ public class VM implements Serializable {
    *
    * @param targetClass The class on which to invoke the method
    * @param methodName The name of the method to invoke
-   * @param args Arguments passed to the method call (must be {@link java.io.Serializable}).
+   * @param args Arguments passed to the method call (must be {@link Serializable}).
    *
    * @deprecated Please use {@link #invoke(SerializableCallableIF)} instead
    */
   @Deprecated
   public <V> AsyncInvocation<V> invokeAsync(final Class<?> targetClass, final String methodName,
       final Object[] args) {
-    return new AsyncInvocation<V>(targetClass, methodName,
-        () -> invoke(targetClass, methodName, args)).start();
+    return AsyncInvocation
+        .<V>create(targetClass, methodName, () -> invoke(targetClass, methodName, args), this)
+        .start();
   }
 
   /**
@@ -329,13 +360,15 @@ public class VM implements Serializable {
    * @see SerializableRunnable
    */
   public <V> AsyncInvocation<V> invokeAsync(final SerializableRunnableIF runnable) {
-    return invokeAsync(runnable, "run", new Object[0]);
+    IdentifiableRunnable target = new IdentifiableRunnable(nextId(), runnable);
+    return AsyncInvocation
+        .<V>create(target, () -> invoke(target, target.getMethodName(), EMPTY), this).start();
   }
 
   /**
    * Invokes the {@code run} method of a {@link Runnable} in this VM. Recall that {@code run} takes
    * no arguments and has no return value. The {@code Runnable} is wrapped in a
-   * {@link NamedRunnable} having the given name so it shows up in DUnit logs.
+   * {@link IdentifiableRunnable} having the given name so it shows up in DUnit logs.
    *
    * @param runnable The {@code Runnable} to be run
    * @param name The name of the {@code Runnable}, which will be logged in DUnit output
@@ -344,7 +377,9 @@ public class VM implements Serializable {
    */
   public <V> AsyncInvocation<V> invokeAsync(final String name,
       final SerializableRunnableIF runnable) {
-    return invokeAsync(new NamedRunnable(name, runnable), "run", new Object[0]);
+    IdentifiableRunnable target = new IdentifiableRunnable(nextId(), name, runnable);
+    return AsyncInvocation
+        .<V>create(target, () -> invoke(target, target.getMethodName(), EMPTY), this).start();
   }
 
   /**
@@ -357,7 +392,9 @@ public class VM implements Serializable {
    */
   public <V> AsyncInvocation<V> invokeAsync(final String name,
       final SerializableCallableIF<V> callable) {
-    return invokeAsync(new NamedCallable<>(name, callable), "call", new Object[0]);
+    IdentifiableCallable<V> target = new IdentifiableCallable<>(nextId(), name, callable);
+    return AsyncInvocation.create(target, () -> invoke(target, target.getMethodName(), EMPTY), this)
+        .start();
   }
 
   /**
@@ -368,7 +405,9 @@ public class VM implements Serializable {
    * @see SerializableCallable
    */
   public <V> AsyncInvocation<V> invokeAsync(final SerializableCallableIF<V> callable) {
-    return invokeAsync(callable, "call", new Object[0]);
+    IdentifiableCallable<V> target = new IdentifiableCallable<>(nextId(), callable);
+    return AsyncInvocation.create(target, () -> invoke(target, target.getMethodName(), EMPTY), this)
+        .start();
   }
 
   /**
@@ -381,8 +420,8 @@ public class VM implements Serializable {
    * @see SerializableRunnable
    */
   public void invoke(final String name, final SerializableRunnableIF runnable) {
-    checkAvailability(NamedRunnable.class.getName(), "run");
-    executeMethodOnObject(new NamedRunnable(name, runnable), "run", new Object[0]);
+    checkAvailability(IdentifiableRunnable.class.getName(), "run");
+    executeMethodOnObject(new IdentifiableRunnable(name, runnable), "run", new Object[0]);
   }
 
   /**
@@ -407,8 +446,8 @@ public class VM implements Serializable {
    * @see SerializableCallable
    */
   public <V> V invoke(final String name, final SerializableCallableIF<V> callable) {
-    checkAvailability(NamedCallable.class.getName(), "call");
-    return executeMethodOnObject(new NamedCallable<>(name, callable), "call", new Object[0]);
+    checkAvailability(IdentifiableCallable.class.getName(), "call");
+    return executeMethodOnObject(new IdentifiableCallable<>(name, callable), "call", new Object[0]);
   }
 
   /**
@@ -449,7 +488,7 @@ public class VM implements Serializable {
    *
    * @param targetObject The receiver of the method invocation
    * @param methodName The name of the method to invoke
-   * @param args Arguments passed to the method call (must be {@link java.io.Serializable}).
+   * @param args Arguments passed to the method call (must be {@link Serializable}).
    *
    * @throws RMIException Wraps any underlying exception thrown while invoking the method in this
    *         {@code VM}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/AsyncThreadId.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/AsyncThreadId.java
@@ -12,21 +12,34 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.test.dunit;
+package org.apache.geode.test.dunit.internal;
 
-import java.util.concurrent.Callable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.geode.test.dunit.internal.Identifiable;
-import org.apache.geode.test.dunit.internal.Invocable;
+import org.apache.geode.annotations.internal.MakeNotStatic;
 
-/**
- * Interface for {@link SerializableCallable} to enable use with lambdas.
- */
-@FunctionalInterface
-public interface SerializableCallableIF<T> extends Callable<T>, Identifiable, Invocable {
+public class AsyncThreadId {
 
-  @Override
-  default String getMethodName() {
-    return "call";
+  private static final AtomicLong ASYNC_ID_COUNTER = new AtomicLong();
+
+  @MakeNotStatic
+  private static final Map<Long, Long> ASYNC_THREAD_ID_MAP = new ConcurrentHashMap<>();
+
+  public static long nextId() {
+    return ASYNC_ID_COUNTER.incrementAndGet();
+  }
+
+  public static void put(long asyncId, long threadId) {
+    ASYNC_THREAD_ID_MAP.put(asyncId, threadId);
+  }
+
+  public static void remove(long asyncId) {
+    ASYNC_THREAD_ID_MAP.remove(asyncId);
+  }
+
+  public static long get(long asyncId) {
+    return ASYNC_THREAD_ID_MAP.get(asyncId);
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/Identifiable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/Identifiable.java
@@ -12,28 +12,13 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.test.dunit;
+package org.apache.geode.test.dunit.internal;
 
-public class NamedCallable<T> implements SerializableCallableIF<T> {
+import java.io.Serializable;
 
-  private static final long serialVersionUID = -4417299628656632541L;
+public interface Identifiable extends Serializable {
 
-  String name;
-  SerializableCallableIF<T> delegate;
-
-  public NamedCallable(String name, SerializableCallableIF<T> delegate) {
-    this.name = name;
-    this.delegate = delegate;
+  default long getId() {
+    return 0;
   }
-
-  @Override
-  public T call() throws Exception {
-    return delegate.call();
-  }
-
-  @Override
-  public String toString() {
-    return ("callable(" + name + ")");
-  }
-
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/IdentifiableCallable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/IdentifiableCallable.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.internal;
+
+import org.apache.geode.test.dunit.SerializableCallableIF;
+
+public class IdentifiableCallable<T> implements SerializableCallableIF<T> {
+
+  private final long id;
+  private final String name;
+  private final SerializableCallableIF<T> delegate;
+
+  public IdentifiableCallable(String name, SerializableCallableIF<T> delegate) {
+    this(0, name, delegate);
+  }
+
+  public IdentifiableCallable(long id, SerializableCallableIF<T> delegate) {
+    this(id, String.valueOf(id), delegate);
+  }
+
+  public IdentifiableCallable(long id, String name, SerializableCallableIF<T> delegate) {
+    this.id = id;
+    this.name = name;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public T call() throws Exception {
+    return delegate.call();
+  }
+
+  @Override
+  public long getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder()
+        .append(getClass().getSimpleName())
+        .append("(").append(id).append(":").append(name).append(")")
+        .toString();
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/IdentifiableRunnable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/IdentifiableRunnable.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.internal;
+
+import org.apache.geode.test.dunit.SerializableRunnableIF;
+
+public class IdentifiableRunnable implements SerializableRunnableIF {
+
+  private final long id;
+  private final String name;
+  private final SerializableRunnableIF delegate;
+
+  public IdentifiableRunnable(String name, SerializableRunnableIF delegate) {
+    this(0, name, delegate);
+  }
+
+  public IdentifiableRunnable(long id, SerializableRunnableIF delegate) {
+    this(id, String.valueOf(id), delegate);
+  }
+
+  public IdentifiableRunnable(long id, String name, SerializableRunnableIF delegate) {
+    this.id = id;
+    this.name = name;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void run() throws Exception {
+    delegate.run();
+  }
+
+  @Override
+  public long getId() {
+    return id;
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder()
+        .append(getClass().getSimpleName())
+        .append("(").append(id).append(":").append(name).append(")")
+        .toString();
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/Invocable.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/Invocable.java
@@ -12,21 +12,10 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.test.dunit;
+package org.apache.geode.test.dunit.internal;
 
-import java.util.concurrent.Callable;
-
-import org.apache.geode.test.dunit.internal.Identifiable;
-import org.apache.geode.test.dunit.internal.Invocable;
-
-/**
- * Interface for {@link SerializableCallable} to enable use with lambdas.
- */
 @FunctionalInterface
-public interface SerializableCallableIF<T> extends Callable<T>, Identifiable, Invocable {
+public interface Invocable {
 
-  @Override
-  default String getMethodName() {
-    return "call";
-  }
+  String getMethodName();
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StackTrace.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StackTrace.java
@@ -12,28 +12,22 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.test.dunit;
+package org.apache.geode.test.dunit.internal;
 
-public class NamedRunnable implements SerializableRunnableIF {
+import static org.apache.geode.test.dunit.VM.getVMId;
 
-  private static final long serialVersionUID = -2786841298145567914L;
+public class StackTrace extends Throwable {
 
-  String name;
-  SerializableRunnableIF delegate;
-
-  public NamedRunnable(String name, SerializableRunnableIF delegate) {
-    this.name = name;
-    this.delegate = delegate;
+  public StackTrace(long threadId) {
+    this(getVMId(), threadId);
   }
 
-  @Override
-  public void run() throws Exception {
-    delegate.run();
+  public StackTrace(int vmId, long threadId) {
+    this(StackTraceInfo.create(vmId, threadId));
   }
 
-  @Override
-  public String toString() {
-    return ("runnable(" + name + ")");
+  StackTrace(StackTraceInfo info) {
+    super(info.getMessage());
+    setStackTrace(info.getStackTraceElements());
   }
-
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StackTraceInfo.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StackTraceInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+class StackTraceInfo implements Serializable {
+
+  private final String message;
+  private final StackTraceElement[] stackTraceElements;
+
+  static StackTraceInfo create(int vmId, long threadId) {
+    long[] threadIds = new long[] {threadId};
+
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    ThreadInfo[] threadInfos = threadMXBean.getThreadInfo(threadIds, true, true);
+
+    assertThat(threadInfos).hasSize(1);
+
+    String message = "Stack trace for vm-" + vmId + " thread-" + threadId;
+    return new StackTraceInfo(message, threadInfos[0].getStackTrace());
+  }
+
+  StackTraceInfo(String message, StackTraceElement[] stackTraceElements) {
+    this.message = message;
+    this.stackTraceElements = stackTraceElements;
+  }
+
+  String getMessage() {
+    return message;
+  }
+
+  StackTraceElement[] getStackTraceElements() {
+    return stackTraceElements;
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StandAloneDUnitEnv.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StandAloneDUnitEnv.java
@@ -50,13 +50,8 @@ public class StandAloneDUnitEnv extends DUnitEnv {
   }
 
   @Override
-  public int getPid() {
+  public int getId() {
     return Integer.getInteger(DUnitLauncher.VM_NUM_PARAM, -1).intValue();
-  }
-
-  @Override
-  public int getVMID() {
-    return getPid();
   }
 
   @Override

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1047,7 +1047,7 @@ public class WANTestBase extends DistributedTestCase {
     for (AsyncInvocation invocation : tasks) {
       try {
         invocation.await();
-      } catch (InterruptedException | ExecutionException e) {
+      } catch (InterruptedException e) {
         fail("Starting senders was interrupted");
       }
     }


### PR DESCRIPTION
Update AsyncInvocation and dunit with these changes:
1) Add stack trace of remote thread as the cause of an AsyncInvocation TimeoutException.
2) Clean up AsyncInvocation and SerializableRunnable/SerializableCallable hierarchy of classes.
3) New tests for StackTrace, VM.dumpThreads, and AsyncInvocation asyncTimeoutHandler.
4) Deprecate and reorganize some additional dunit methods that are either not used or have a newer preferred alternative.
5) Trigger remote VM to dump all threads to stdout when an AsyncInvocation times out.

Presently, when an AsyncInvocation times out, it throws a TimeoutException that doesn't really provide enough information to debug the underlying cause.

The current stack trace of a TimeoutException thrown from AsyncInvocation looks like:
```
java.util.concurrent.TimeoutException: Timed out waiting 1000 milliseconds for AsyncInvocation to complete.
	at org.apache.geode.test.dunit.AsyncInvocation.timeoutIfAlive(AsyncInvocation.java:525)
	at org.apache.geode.test.dunit.AsyncInvocation.await(AsyncInvocation.java:463)
	at org.apache.geode.test.dunit.tests.AsyncInvokeTimeoutDistributedTest.stackTrace(AsyncInvokeTimeoutDistributedTest.java:66)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.apache.geode.test.dunit.rules.AbstractDistributedRule$1.evaluate(AbstractDistributedRule.java:59)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
```

The changes in this PR adds in a stack trace of the remote thread as a cause for the TimeoutException:
```
java.util.concurrent.TimeoutException: Timed out waiting 1000 milliseconds for AsyncInvocation to complete.
	at org.apache.geode.test.dunit.AsyncInvocation.timeoutIfAlive(AsyncInvocation.java:525)
	at org.apache.geode.test.dunit.AsyncInvocation.await(AsyncInvocation.java:463)
	at org.apache.geode.test.dunit.tests.AsyncInvokeTimeoutDistributedTest.stackTrace(AsyncInvokeTimeoutDistributedTest.java:66)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.apache.geode.test.dunit.rules.AbstractDistributedRule$1.evaluate(AbstractDistributedRule.java:59)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: org.apache.geode.test.dunit.internal.StackTrace: Stack trace for vm-0 thread-19
	at sun.misc.Unsafe.park(Native Method)
	at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:215)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1037)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1328)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:277)
	at org.apache.geode.test.dunit.tests.AsyncInvokeTimeoutDistributedTest.lambda$stackTrace$8f88eb8d$1(AsyncInvokeTimeoutDistributedTest.java:63)
	at org.apache.geode.test.dunit.tests.AsyncInvokeTimeoutDistributedTest$$Lambda$10/2122073979.run(Unknown Source)
	at org.apache.geode.test.dunit.internal.IdentifiableRunnable.run(IdentifiableRunnable.java:41)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.geode.test.dunit.internal.MethodInvoker.executeObject(MethodInvoker.java:123)
	at org.apache.geode.test.dunit.internal.RemoteDUnitVM.executeMethodOnObject(RemoteDUnitVM.java:79)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:357)
	at sun.rmi.transport.Transport$1.run(Transport.java:200)
	at sun.rmi.transport.Transport$1.run(Transport.java:197)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.Transport.serviceCall(Transport.java:196)
	at sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:573)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:834)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:688)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler$$Lambda$8/1344771925.run(Unknown Source)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:687)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```