### PR TITLE
GEODE-7344-c: DataSerializable implements BasicSerializable

### DIFF
--- a/extensions/geode-modules-session-internal/build.gradle
+++ b/extensions/geode-modules-session-internal/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   compile('mx4j:mx4j')
   compile('org.apache.tomcat:servlet-api:' + DependencyConstraints.get('tomcat6.version'))
   compile('org.slf4j:slf4j-api')
+  implementation(project(':geode-serialization'))
 }
 
 jar {

--- a/extensions/geode-modules-session/build.gradle
+++ b/extensions/geode-modules-session/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   compile('javax.servlet:javax.servlet-api')
   compile('org.apache.tomcat:servlet-api:' + DependencyConstraints.get('tomcat6.version'))
   compile('org.slf4j:slf4j-api')
+  implementation(project(':geode-serialization'))
 
   integrationTestCompile('com.mockrunner:mockrunner-servlet') {
     exclude group: 'jboss'

--- a/extensions/geode-modules-test/build.gradle
+++ b/extensions/geode-modules-test/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     // this version of httpunit contains very outdated xercesImpl
     exclude group: 'xerces'
   }
+  implementation(project(':geode-serialization'))
 
   compileOnly('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version')) {
     exclude module: 'annotations-api'

--- a/extensions/geode-modules-tomcat7/build.gradle
+++ b/extensions/geode-modules-tomcat7/build.gradle
@@ -47,7 +47,7 @@ dependencies {
     exclude module: 'tomcat-servlet-api'
   }
   compile('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat7.version'))
-
+  implementation(project(':geode-serialization'))
 
   testCompile('org.httpunit:httpunit')
   testCompile('junit:junit')

--- a/extensions/geode-modules-tomcat8/build.gradle
+++ b/extensions/geode-modules-tomcat8/build.gradle
@@ -55,7 +55,8 @@ dependencies {
   }
   compile('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat8.version'))
   compile('javax.servlet:javax.servlet-api')
-  
+  implementation(project(':geode-serialization'))
+
   integrationTestCompile(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }

--- a/extensions/geode-modules-tomcat9/build.gradle
+++ b/extensions/geode-modules-tomcat9/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   }
   compile('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat9.version'))
   compile('javax.servlet:javax.servlet-api:' + '3.1.0')
+  implementation(project(':geode-serialization'))
 
   testCompile('org.httpunit:httpunit')
   testCompile('junit:junit')

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerGossipVersionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerGossipVersionDUnitTest.java
@@ -49,7 +49,7 @@ import org.apache.geode.test.version.VersionManager;
  * This tests the rolling upgrade for locators with different GOSSIPVERSION.
  */
 @Category({MembershipTest.class})
-public class TcpServerBackwardCompatDUnitTest extends JUnit4DistributedTestCase {
+public class TcpServerGossipVersionDUnitTest extends JUnit4DistributedTestCase {
 
   @Override
   public final void postSetUp() throws Exception {

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionDUnitTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.tcpserver;
+
+import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
+import static org.apache.geode.distributed.ConfigurationProperties.NAME;
+import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
+import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.geode.distributed.Locator;
+import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
+import org.apache.geode.test.dunit.DistributedTestUtils;
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
+import org.apache.geode.test.version.TestVersion;
+import org.apache.geode.test.version.VersionManager;
+
+/**
+ * In version 1.12 TcpServer changed: the three pairs of message types used to derive from
+ * DataSerializable, but as of 1.12 they derive from BasicSerializable.
+ *
+ * This test verifies that the current version (1.12 or later) is compatible with the latest
+ * version before 1.12
+ */
+@RunWith(Parameterized.class)
+@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
+public class TcpServerProductVersionDUnitTest implements Serializable {
+
+  private static final TestVersion FIRST_NEW_VERSION = TestVersion.valueOf("1.12.0");
+
+  @Rule
+  public DistributedRule distributedRule =
+      DistributedRule.builder().withVMCount(0).build();
+
+  @BeforeClass
+  public static void beforeClass() {
+    SocketCreatorFactory.close();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    SocketCreatorFactory.close();
+  }
+
+  private static final TestVersion oldProductVersion = getOldProductVersion();
+  private static final TestVersion currentProductVersion =
+      TestVersion.valueOf(VersionManager.CURRENT_VERSION);
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<VersionConfiguration> data() {
+    return Arrays.asList(VersionConfiguration.values());
+  }
+
+  /*
+   * We want the newest _available_ version older than FIRST_NEW_VERSION
+   */
+  private static TestVersion getOldProductVersion() {
+
+    final Map<Boolean, List<TestVersion>> groups =
+        VersionManager.getInstance().getVersionsWithoutCurrent().stream()
+            .map(TestVersion::valueOf)
+            .collect(Collectors.partitioningBy(v -> v.lessThan(FIRST_NEW_VERSION)));
+
+    final List<TestVersion> olderVersions = groups.get(true);
+
+    if (olderVersions.size() < 1) {
+      throw new AssertionError("Time to decommission TcpServerProductVersionDUnitTest "
+          + "because there are no supported versions older than " + FIRST_NEW_VERSION);
+    }
+
+    return olderVersions.get(olderVersions.size() - 1);
+  }
+
+  private enum VersionConfiguration {
+
+    // OLD_OLD(oldProductVersion, oldProductVersion),
+    OLD_CURRENT(oldProductVersion, currentProductVersion),
+    CURRENT_OLD(currentProductVersion, oldProductVersion);
+    // CURRENT_CURRENT(currentProductVersion, currentProductVersion);
+
+    final TestVersion clientProductVersion;
+    final TestVersion locatorProductVersion;
+
+    VersionConfiguration(final TestVersion clientProductVersion,
+        final TestVersion locatorProductVersion) {
+      this.clientProductVersion = clientProductVersion;
+      this.locatorProductVersion = locatorProductVersion;
+    }
+
+  }
+
+  private final VersionConfiguration versions;
+
+  public TcpServerProductVersionDUnitTest(final VersionConfiguration versions) {
+    this.versions = versions;
+  }
+
+  @Test
+  public void testAllMessageTypes() {
+    System.out.println("BB: controller clientProductVersion is " + versions.clientProductVersion
+        + " and FIRST_NEW_VERSION is " + FIRST_NEW_VERSION);
+    VM clientVM = Host.getHost(0).getVM(versions.clientProductVersion.toString(), 0);
+    VM locatorVM = Host.getHost(0).getVM(versions.locatorProductVersion.toString(), 1);
+    int locatorPort = createLocator(locatorVM, true);
+
+    clientVM.invoke(() -> System.out.println("BB: client vm started"));
+
+    clientVM.invoke("issue version request",
+        createRequestResponseFunction(locatorPort, new VersionRequest(), VersionResponse.class));
+    clientVM.invoke("issue info request",
+        createRequestResponseFunction(locatorPort, new InfoRequest(), InfoResponse.class));
+    clientVM.invoke("issue shutdown request",
+        createRequestResponseFunction(locatorPort, new ShutdownRequest(), ShutdownResponse.class));
+  }
+
+  @NotNull
+  private SerializableRunnableIF createRequestResponseFunction(
+      final int locatorPort,
+      final Object request,
+      final Class responseType) {
+
+    return () -> {
+
+      final TcpClient tcpClient;
+      System.out.println("BB: clientVM clientProductVersion is " + versions.clientProductVersion
+          + " and FIRST_NEW_VERSION is " + FIRST_NEW_VERSION);
+      if (versions.clientProductVersion.greaterThanOrEqualTo(FIRST_NEW_VERSION)) {
+        tcpClient = getTcpClient();
+      } else {
+        tcpClient = getLegacyTcpClient();
+      }
+
+      final Object response = tcpClient
+          .requestToServer(SocketCreator.getLocalHost(), locatorPort, request, 1000);
+
+      assertThat(response).isInstanceOf(responseType);
+    };
+
+  }
+
+  /*
+   * The TcpClient class changed in version FIRST_NEW_VERSION. That version (and later)
+   * no longer has the old constructor TcpClient(final Properties), so we have to access
+   * that constructor via reflection.
+   */
+  private TcpClient getLegacyTcpClient()
+      throws NoSuchMethodException, IllegalAccessException, InvocationTargetException,
+      InstantiationException {
+
+    final Constructor<TcpClient> constructor = TcpClient.class.getConstructor(Properties.class);
+    return constructor.newInstance(getDistributedSystemProperties());
+  }
+
+  @NotNull
+  private TcpClient getTcpClient() {
+
+    SocketCreatorFactory
+        .setDistributionConfig(new DistributionConfigImpl(getDistributedSystemProperties()));
+
+    return new TcpClient(
+        asTcpSocketCreator(
+            SocketCreatorFactory
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
+  }
+
+  private int createLocator(VM memberVM, boolean usingOldVersion) {
+    return memberVM.invoke("create locator", () -> {
+      System.setProperty(GMSJoinLeave.BYPASS_DISCOVERY_PROPERTY, "true");
+      try {
+        int port = 0;
+        // for stress-tests make sure that an older-version locator doesn't try
+        // to read state persisted by another run's newer-version locator
+        if (usingOldVersion) {
+          port = AvailablePortHelper.getRandomAvailableTCPPort();
+          DistributedTestUtils.deleteLocatorStateFile(port);
+        }
+        return Locator.startLocatorAndDS(port, new File(""), getDistributedSystemProperties())
+            .getPort();
+      } finally {
+        System.clearProperty(GMSJoinLeave.BYPASS_DISCOVERY_PROPERTY);
+      }
+    });
+  }
+
+  public Properties getDistributedSystemProperties() {
+    Properties properties = new Properties();
+    properties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
+    properties.setProperty(USE_CLUSTER_CONFIGURATION, "false");
+    properties.setProperty(NAME, "vm" + VM.getCurrentVMNum());
+    return properties;
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/DataSerializable.java
+++ b/geode-core/src/main/java/org/apache/geode/DataSerializable.java
@@ -19,6 +19,8 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.apache.geode.internal.serialization.BasicSerializable;
+
 /**
  * An interface for objects whose state can be written/read as primitive types and strings ("data").
  * That is, instead of serializing itself to an {@link java.io.ObjectOutputStream}, a
@@ -71,7 +73,7 @@ import java.io.Serializable;
  *
  * @since GemFire 3.5
  */
-public interface DataSerializable extends Serializable {
+public interface DataSerializable extends Serializable, BasicSerializable {
 
   /**
    * Writes the state of this object as primitive data to the given <code>DataOutput</code>.

--- a/geode-core/src/main/java/org/apache/geode/DataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/DataSerializer.java
@@ -213,7 +213,7 @@ public abstract class DataSerializer {
     }
 
     if (c == null || c.isPrimitive()) {
-      InternalDataSerializer.writePrimitiveClass(c, out);
+      StaticSerialization.writePrimitiveClass(c, out);
     } else {
       // non-primitive classes have a second CLASS byte
       // if readObject/writeObject is called:
@@ -263,7 +263,7 @@ public abstract class DataSerializer {
       String className = readString(in);
       return InternalDataSerializer.getCachedClass(className);
     } else {
-      return InternalDataSerializer.decodePrimitiveClass(typeCode);
+      return StaticSerialization.decodePrimitiveClass(typeCode);
     }
   }
 
@@ -1741,7 +1741,7 @@ public abstract class DataSerializer {
         if (typeCode == DSCODE.CLASS.toByte()) {
           c = InternalDataSerializer.getCachedClass(typeString);
         } else {
-          c = InternalDataSerializer.decodePrimitiveClass(typeCode);
+          c = StaticSerialization.decodePrimitiveClass(typeCode);
         }
       }
       Object o = null;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/InfoRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/InfoRequest.java
@@ -18,8 +18,9 @@ package org.apache.geode.distributed.internal.tcpserver;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 
-import org.apache.geode.DataSerializable;
+import org.apache.geode.internal.serialization.BasicSerializable;
 
 /**
  * A request to the TCP server to provide information about the server
@@ -27,7 +28,7 @@ import org.apache.geode.DataSerializable;
  * @since GemFire 5.7
  *
  */
-public class InfoRequest implements DataSerializable {
+public class InfoRequest implements BasicSerializable, Serializable {
   private static final long serialVersionUID = -9129777520477738699L;
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/InfoResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/InfoResponse.java
@@ -18,8 +18,9 @@ package org.apache.geode.distributed.internal.tcpserver;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 
-import org.apache.geode.DataSerializable;
+import org.apache.geode.internal.serialization.BasicSerializable;
 import org.apache.geode.internal.serialization.StaticSerialization;
 
 /**
@@ -27,7 +28,7 @@ import org.apache.geode.internal.serialization.StaticSerialization;
  *
  * @since GemFire 5.7
  */
-public class InfoResponse implements DataSerializable {
+public class InfoResponse implements BasicSerializable, Serializable {
   private static final long serialVersionUID = 6249492407448855032L;
   private String[] info;
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/ShutdownRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/ShutdownRequest.java
@@ -18,15 +18,16 @@ package org.apache.geode.distributed.internal.tcpserver;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 
-import org.apache.geode.DataSerializable;
+import org.apache.geode.internal.serialization.BasicSerializable;
 
 /**
  * A request to the TCP server to shutdown
  *
  * @since GemFire 5.7
  */
-public class ShutdownRequest implements DataSerializable {
+public class ShutdownRequest implements BasicSerializable, Serializable {
   private static final long serialVersionUID = 7920535743546544136L;
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/ShutdownResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/ShutdownResponse.java
@@ -18,15 +18,16 @@ package org.apache.geode.distributed.internal.tcpserver;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 
-import org.apache.geode.DataSerializable;
+import org.apache.geode.internal.serialization.BasicSerializable;
 
 /**
  * A response from the TCP server that it received the shutdown request
  *
  * @since GemFire 5.7
  */
-public class ShutdownResponse implements DataSerializable {
+public class ShutdownResponse implements BasicSerializable, Serializable {
   private static final long serialVersionUID = -7223807212380360314L;
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/VersionRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/VersionRequest.java
@@ -17,13 +17,14 @@ package org.apache.geode.distributed.internal.tcpserver;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 
-import org.apache.geode.DataSerializable;
+import org.apache.geode.internal.serialization.BasicSerializable;
 
 /**
  * @since GemFire 7.1
  */
-public class VersionRequest implements DataSerializable {
+public class VersionRequest implements BasicSerializable, Serializable {
 
 
   private static final long serialVersionUID = -8272913634136267812L;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/VersionResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/tcpserver/VersionResponse.java
@@ -17,8 +17,9 @@ package org.apache.geode.distributed.internal.tcpserver;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.io.Serializable;
 
-import org.apache.geode.DataSerializable;
+import org.apache.geode.internal.serialization.BasicSerializable;
 import org.apache.geode.internal.serialization.Version;
 
 /**
@@ -26,7 +27,7 @@ import org.apache.geode.internal.serialization.Version;
  *
  * @since GemFire 7.1
  */
-public class VersionResponse implements DataSerializable {
+public class VersionResponse implements BasicSerializable, Serializable {
 
 
   private static final long serialVersionUID = 8320323031808601748L;

--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -78,7 +78,6 @@ import org.apache.geode.GemFireConfigException;
 import org.apache.geode.GemFireIOException;
 import org.apache.geode.GemFireRethrowable;
 import org.apache.geode.Instantiator;
-import org.apache.geode.InternalGemFireError;
 import org.apache.geode.SerializationException;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.ToDataException;
@@ -107,6 +106,7 @@ import org.apache.geode.internal.cache.tier.sockets.OldClientSupportService;
 import org.apache.geode.internal.cache.tier.sockets.Part;
 import org.apache.geode.internal.lang.ClassUtils;
 import org.apache.geode.internal.logging.log4j.LogMarker;
+import org.apache.geode.internal.serialization.BasicSerializable;
 import org.apache.geode.internal.serialization.DSCODE;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 import org.apache.geode.internal.serialization.DSFIDSerializerFactory;
@@ -254,10 +254,6 @@ public abstract class InternalDataSerializer extends DataSerializer {
       LOAD_CLASS_EACH_TIME ? null : new CopyOnWriteHashMap<>();
   private static final Object cacheAccessLock = new Object();
 
-  private static final String PRE_GEODE_100_TCPSERVER_PACKAGE =
-      "com.gemstone.org.jgroups.stack.tcpserver";
-  private static final String POST_GEODE_100_TCPSERVER_PACKAGE =
-      "org.apache.geode.distributed.internal.tcpserver";
   private static final String POST_GEODE_190_SERVER_CQIMPL =
       "org.apache.geode.cache.query.cq.internal.ServerCQImpl";
   private static final String PRE_GEODE_190_SERVER_CQIMPL =
@@ -321,15 +317,14 @@ public abstract class InternalDataSerializer extends DataSerializer {
    * For backward compatibility we must swizzle the package of some classes that had to be moved
    * when GemFire was open- sourced. This preserves backward-compatibility.
    *
-   * @param name the fully qualified class name
+   * @param nameArg the fully qualified class name
    * @return the name of the class in this implementation
    */
-  public static String processIncomingClassName(String name) {
-    // TCPServer classes are used before a cache exists and support for old clients has been
-    // initialized
-    if (name.startsWith(PRE_GEODE_100_TCPSERVER_PACKAGE)) {
-      return POST_GEODE_100_TCPSERVER_PACKAGE
-          + name.substring(PRE_GEODE_100_TCPSERVER_PACKAGE.length());
+  public static String processIncomingClassName(String nameArg) {
+    final String name = StaticSerialization.processIncomingClassName(nameArg);
+    // using identity comparison on purpose because we are on the hot path
+    if (name != nameArg) {
+      return name;
     }
     if (name.equals(PRE_GEODE_190_SERVER_CQIMPL)) {
       return POST_GEODE_190_SERVER_CQIMPL;
@@ -345,17 +340,18 @@ public abstract class InternalDataSerializer extends DataSerializer {
    * For backward compatibility we must swizzle the package of some classes that had to be moved
    * when GemFire was open- sourced. This preserves backward-compatibility.
    *
-   * @param name the fully qualified class name
+   * @param nameArg the fully qualified class name
    * @param out the consumer of the serialized object
    * @return the name of the class in this implementation
    */
-  public static String processOutgoingClassName(String name, DataOutput out) {
-    // TCPServer classes are used before a cache exists and support for old clients has been
-    // initialized
-    if (name.startsWith(POST_GEODE_100_TCPSERVER_PACKAGE)) {
-      return PRE_GEODE_100_TCPSERVER_PACKAGE
-          + name.substring(POST_GEODE_100_TCPSERVER_PACKAGE.length());
+  public static String processOutgoingClassName(final String nameArg, DataOutput out) {
+
+    final String name = StaticSerialization.processOutgoingClassName(nameArg);
+    // using identity comparison on purpose because we are on the hot path
+    if (name != nameArg) {
+      return name;
     }
+
     if (out instanceof VersionedDataStream) {
       VersionedDataStream vout = (VersionedDataStream) out;
       Version version = vout.getVersion();
@@ -506,7 +502,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
       public boolean toData(Object o, DataOutput out) throws IOException {
         Class c = (Class) o;
         if (c.isPrimitive()) {
-          writePrimitiveClass(c, out);
+          StaticSerialization.writePrimitiveClass(c, out);
         } else {
           out.writeByte(DSCODE.CLASS.toByte());
           writeClass(c, out);
@@ -1487,7 +1483,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
     int dsfid = o.getDSFID();
     try {
       if (dsfid != DataSerializableFixedID.NO_FIXED_ID) {
-        dsfidSerializer.writeDSFID(o, out);
+        dsfidSerializer.write(o, out);
         return;
       }
       out.writeByte(DSCODE.DS_NO_FIXED_ID.toByte());
@@ -1835,66 +1831,6 @@ public abstract class InternalDataSerializer extends DataSerializer {
   }
 
   /**
-   * Writes the type code for a primitive type Class to {@code DataOutput}.
-   */
-  public static void writePrimitiveClass(Class c, DataOutput out) throws IOException {
-    if (c == Boolean.TYPE) {
-      out.writeByte(DSCODE.BOOLEAN_TYPE.toByte());
-    } else if (c == Character.TYPE) {
-      out.writeByte(DSCODE.CHARACTER_TYPE.toByte());
-    } else if (c == Byte.TYPE) {
-      out.writeByte(DSCODE.BYTE_TYPE.toByte());
-    } else if (c == Short.TYPE) {
-      out.writeByte(DSCODE.SHORT_TYPE.toByte());
-    } else if (c == Integer.TYPE) {
-      out.writeByte(DSCODE.INTEGER_TYPE.toByte());
-    } else if (c == Long.TYPE) {
-      out.writeByte(DSCODE.LONG_TYPE.toByte());
-    } else if (c == Float.TYPE) {
-      out.writeByte(DSCODE.FLOAT_TYPE.toByte());
-    } else if (c == Double.TYPE) {
-      out.writeByte(DSCODE.DOUBLE_TYPE.toByte());
-    } else if (c == Void.TYPE) {
-      out.writeByte(DSCODE.VOID_TYPE.toByte());
-    } else if (c == null) {
-      out.writeByte(DSCODE.NULL.toByte());
-    } else {
-      throw new InternalGemFireError(
-          String.format("unknown primitive type: %s",
-              c.getName()));
-    }
-  }
-
-  public static Class<?> decodePrimitiveClass(byte typeCode) throws IOException {
-    DSCODE dscode = DscodeHelper.toDSCODE(typeCode);
-    switch (dscode) {
-      case BOOLEAN_TYPE:
-        return Boolean.TYPE;
-      case CHARACTER_TYPE:
-        return Character.TYPE;
-      case BYTE_TYPE:
-        return Byte.TYPE;
-      case SHORT_TYPE:
-        return Short.TYPE;
-      case INTEGER_TYPE:
-        return Integer.TYPE;
-      case LONG_TYPE:
-        return Long.TYPE;
-      case FLOAT_TYPE:
-        return Float.TYPE;
-      case DOUBLE_TYPE:
-        return Double.TYPE;
-      case VOID_TYPE:
-        return Void.TYPE;
-      case NULL:
-        return null;
-      default:
-        throw new InternalGemFireError(
-            String.format("unexpected typeCode: %s", typeCode));
-    }
-  }
-
-  /**
    * Reads a {@code TimeUnit} from a {@code DataInput}.
    *
    * @throws IOException A problem occurs while writing to {@code out}
@@ -2067,7 +2003,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
     } else if (o instanceof DataSerializableFixedID) {
       checkPdxCompatible(o, ensurePdxCompatibility);
       DataSerializableFixedID dsfid = (DataSerializableFixedID) o;
-      dsfidSerializer.writeDSFID(dsfid, out);
+      dsfidSerializer.write(dsfid, out);
     } else if (autoSerialized(o, out)) {
       // all done
     } else if (o instanceof DataSerializable.Replaceable) {
@@ -2079,7 +2015,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
     } else if (o instanceof PdxSerializable) {
       writePdx(out, GemFireCacheImpl
           .getForPdx("PDX registry is unavailable because the Cache has been closed."), o, null);
-    } else if (o instanceof DataSerializable) {
+    } else if (o instanceof BasicSerializable) {
       if (isDebugEnabled_SERIALIZER) {
         logger.trace(LogMarker.SERIALIZER_VERBOSE, "Writing DataSerializable: {}", o);
       }
@@ -2094,8 +2030,8 @@ public abstract class InternalDataSerializer extends DataSerializer {
         out.writeByte(DSCODE.DATA_SERIALIZABLE.toByte());
         DataSerializer.writeClass(c, out);
       }
-      DataSerializable ds = (DataSerializable) o;
-      invokeToData(ds, out);
+      final BasicSerializable bs = (BasicSerializable) o;
+      invokeToData(bs, out);
 
     } else if (o instanceof Sendable) {
       if (!(o instanceof PdxInstance) || o instanceof PdxInstanceEnum) {
@@ -2302,7 +2238,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
       }
 
       if (!invoked) {
-        ((DataSerializable) ds).toData(out);
+        ((BasicSerializable) ds).toData(out);
       }
     } catch (IOException io) {
       throw new ToDataException("toData failed on DataSerializable " + ds.getClass(), io);
@@ -2366,7 +2302,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
         }
       }
       if (!invoked) {
-        ((DataSerializable) ds).fromData(in);
+        ((BasicSerializable) ds).fromData(in);
 
         if (logger.isTraceEnabled(LogMarker.SERIALIZER_VERBOSE)) {
           logger.trace(LogMarker.SERIALIZER_VERBOSE, "Read DataSerializable {}",
@@ -2387,9 +2323,9 @@ public abstract class InternalDataSerializer extends DataSerializer {
   @SuppressWarnings("unchecked")
   private static Object readDataSerializable(final DataInput in)
       throws IOException, ClassNotFoundException {
-    Class<? extends DataSerializer> c = (Class<? extends DataSerializer>) readClass(in);
+    final Class<?> c = readClass(in);
     try {
-      Constructor<? extends DataSerializer> init = c.getConstructor();
+      Constructor<?> init = c.getConstructor();
       init.setAccessible(true);
       Object o = init.newInstance();
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.distributed.internal.tcpserver;
 
 import static com.tngtech.archunit.base.DescribedPredicate.not;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
 import com.tngtech.archunit.junit.AnalyzeClasses;
@@ -25,7 +24,6 @@ import com.tngtech.archunit.junit.ArchUnitRunner;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
-import org.apache.geode.DataSerializable;
 
 
 @RunWith(ArchUnitRunner.class)
@@ -45,8 +43,5 @@ public class TcpServerDependenciesTest {
               .or(resideInAPackage("org.apache.geode.logging.internal.executors.."))
 
               .or(not(resideInAPackage("org.apache.geode..")))
-              .or(resideInAPackage("org.apache.geode.test.."))
-
-              // TODO - serialization related classes
-              .or(type(DataSerializable.class)));
+              .or(resideInAPackage("org.apache.geode.test..")));
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
@@ -512,7 +512,7 @@ public class VM implements Serializable {
   private synchronized void bounce(final String targetVersion, boolean force) {
     checkAvailability(getClass().getName(), "bounceVM");
 
-    logger.info("Bouncing {} old pid is {}", id, getPid());
+    logger.info("Bouncing {} old pid is {} and version is {}", id, getPid(), version);
     getVMEventNotifier().notifyBeforeBounceVM(this);
 
     available = false;
@@ -537,7 +537,7 @@ public class VM implements Serializable {
       client = childVMLauncher.getStub(id);
       available = true;
 
-      logger.info("Bounced {} new pid is {}", id, getPid());
+      logger.info("Bounced {}.  New pid is {} and version is {}", id, getPid(), version);
       getVMEventNotifier().notifyAfterBounceVM(this);
 
     } catch (InterruptedException | IOException | NotBoundException e) {

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitHost.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitHost.java
@@ -83,8 +83,6 @@ class DUnitHost extends Host {
     if (n < getVMCount()) {
       VM current = super.getVM(n);
       if (!current.getVersion().equals(version)) {
-        System.out.println(
-            "Bouncing VM" + n + " from version " + current.getVersion() + " to " + version);
         current.bounce(version);
       }
       return current;

--- a/geode-memcached/build.gradle
+++ b/geode-memcached/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation(project(':geode-logging'))
   implementation('org.apache.logging.log4j:log4j-api')
   implementation('com.github.stephenc.findbugs:findbugs-annotations')
+  implementation(project(':geode-serialization'))
 
   testImplementation('org.mockito:mockito-core')
   testImplementation(project(':geode-junit'))

--- a/geode-memcached/src/test/resources/expected-pom.xml
+++ b/geode-memcached/src/test/resources/expected-pom.xml
@@ -66,5 +66,10 @@
       <artifactId>findbugs-annotations</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/BasicSerializable.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/BasicSerializable.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.serialization;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+/**
+ * This interface supports toData/fromData serialization. DataSerializableFixedID is almost always
+ * preferable to this interface for new work.
+ */
+public interface BasicSerializable {
+
+  /**
+   * Writes the state of this object as primitive data to the given <code>DataOutput</code>.
+   * <p>
+   * Since 5.7 it is possible for any method call to the specified <code>DataOutput</code> to throw
+   * {@link GemFireRethrowable}. It should <em>not</em> be caught by user code. If it is it
+   * <em>must</em> be rethrown.
+   *
+   * @throws IOException A problem occurs while writing to <code>out</code>
+   */
+  void toData(DataOutput out) throws IOException;
+
+  /**
+   * Reads the state of this object as primitive data from the given <code>DataInput</code>.
+   *
+   * @throws IOException A problem occurs while reading from <code>in</code>
+   * @throws ClassNotFoundException A class could not be loaded while reading from <code>in</code>
+   */
+  void fromData(DataInput in) throws IOException, ClassNotFoundException;
+}

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DSFIDSerializer.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DSFIDSerializer.java
@@ -61,7 +61,9 @@ public interface DSFIDSerializer {
 
 
 
-  void writeDSFID(DataSerializableFixedID dsfid, DataOutput out) throws IOException;
+  void write(DataSerializableFixedID dsfid, DataOutput out) throws IOException;
+
+  void write(BasicSerializable bs, DataOutput out) throws IOException;
 
   void writeDSFIDHeader(int dsfid, DataOutput out) throws IOException;
 


### PR DESCRIPTION
Experiment: break `TcpServer` dependency on `geode-core` by making `DataSerializable` implement `BasicSerializable`.

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
