### PR TITLE
GEODE-7478: Register interest in appropriate cases.

### DIFF
--- a/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/common/ClientServerSessionCache.java
+++ b/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/common/ClientServerSessionCache.java
@@ -23,7 +23,9 @@ import javax.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.cache.InterestResultPolicy;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
@@ -124,6 +126,10 @@ public class ClientServerSessionCache extends AbstractSessionCache {
       LOG.debug("Created session region: " + this.sessionRegion);
     } else {
       LOG.debug("Retrieved session region: " + this.sessionRegion);
+    }
+
+    if (sessionRegion.getAttributes().getDataPolicy() != DataPolicy.EMPTY) {
+      sessionRegion.registerInterestForAllKeys(InterestResultPolicy.KEYS);
     }
   }
 

--- a/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/common/ClientServerSessionCache.java
+++ b/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/common/ClientServerSessionCache.java
@@ -23,7 +23,6 @@ import javax.servlet.http.HttpSession;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.cache.InterestResultPolicy;
 import org.apache.geode.cache.Region;
@@ -126,9 +125,8 @@ public class ClientServerSessionCache extends AbstractSessionCache {
       LOG.debug("Created session region: " + this.sessionRegion);
     } else {
       LOG.debug("Retrieved session region: " + this.sessionRegion);
-    }
 
-    if (sessionRegion.getAttributes().getDataPolicy() != DataPolicy.EMPTY) {
+      // Register interest in case users provide their own client cache region
       sessionRegion.registerInterestForAllKeys(InterestResultPolicy.KEYS);
     }
   }
@@ -175,6 +173,9 @@ public class ClientServerSessionCache extends AbstractSessionCache {
     }
 
     // Create the region
-    return factory.create(regionName);
+    Region region = factory.create(regionName);
+
+    region.registerInterestForAllKeys(InterestResultPolicy.KEYS);
+    return region;
   }
 }

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCache.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCache.java
@@ -190,9 +190,8 @@ public class ClientServerSessionCache extends AbstractSessionCache {
         sessionRegion.getAttributesMutator().addCacheListener(new SessionExpirationCacheListener());
       }
 
-      // This is true for PROXY regions
-      if (sessionRegion.getAttributes().getDataPolicy() == DataPolicy.EMPTY) {
-        sessionRegion.registerInterest("ALL_KEYS", InterestResultPolicy.KEYS);
+      if (sessionRegion.getAttributes().getDataPolicy() != DataPolicy.EMPTY) {
+        sessionRegion.registerInterestForAllKeys(InterestResultPolicy.KEYS);
       }
     }
   }
@@ -247,12 +246,9 @@ public class ClientServerSessionCache extends AbstractSessionCache {
     // Create the region
     Region region = factory.create(getSessionManager().getRegionName());
 
-    /*
-     * If we're using an empty client region, we register interest so that expired sessions are
-     * destroyed correctly.
-     */
-    if (!getSessionManager().getEnableLocalCache()) {
-      region.registerInterest("ALL_KEYS", InterestResultPolicy.KEYS);
+    // register interest to get updates from server if local cache is enabled
+    if (getSessionManager().getEnableLocalCache()) {
+      region.registerInterestForAllKeys(InterestResultPolicy.KEYS);
     }
 
     return region;

--- a/extensions/geode-modules/src/test/java/org/apache/geode/modules/session/catalina/ClientServerSessionCacheTest.java
+++ b/extensions/geode-modules/src/test/java/org/apache/geode/modules/session/catalina/ClientServerSessionCacheTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.modules.session.catalina;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.InterestResultPolicy;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+
+public class ClientServerSessionCacheTest {
+
+
+  @Test
+  public void registerInterestForSessionRegion() {
+    SessionManager manager = mock(SessionManager.class);
+    ClientCache clientCache = mock(ClientCache.class);
+    Region region = mock(Region.class);
+    ClientServerSessionCache cache = spy(new ClientServerSessionCache(manager, clientCache));
+    doReturn(region).when(cache).createLocalSessionRegion();
+
+    cache.createLocalSessionRegionWithRegisterInterest();
+
+    verify(region).registerInterestForAllKeys(InterestResultPolicy.KEYS);
+  }
+
+}

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
@@ -170,6 +170,7 @@ public class TomcatInstall extends ContainerInstall {
         className += "PeerToPeer";
         break;
       case CLIENT_SERVER:
+      case CACHING_CLIENT_SERVER:
         className += "ClientServer";
         break;
       default:

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/CargoTestBase.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/CargoTestBase.java
@@ -281,8 +281,13 @@ public abstract class CargoTestBase {
   protected void verifyMaxInactiveInterval(int expected) throws IOException, URISyntaxException {
     for (int i = 0; i < manager.numContainers(); i++) {
       client.setPort(Integer.parseInt(manager.getContainerPort(i)));
-      assertEquals(Integer.toString(expected),
-          client.executionFunction(GetMaxInactiveInterval.class).getResponse());
+      if (install.getConnectionType() == ContainerInstall.ConnectionType.CACHING_CLIENT_SERVER) {
+        GeodeAwaitility.await().until(() -> Integer.toString(expected)
+            .equals(client.executionFunction(GetMaxInactiveInterval.class).getResponse()));
+      } else {
+        assertEquals(Integer.toString(expected),
+            client.executionFunction(GetMaxInactiveInterval.class).getResponse());
+      }
     }
   }
 

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/CargoTestBase.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/CargoTestBase.java
@@ -31,7 +31,9 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
 import org.apache.geode.internal.UniquePortSupplier;
+import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.modules.session.functions.GetMaxInactiveInterval;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.SessionTest;
@@ -131,8 +133,29 @@ public abstract class CargoTestBase {
             resp.getSessionCookie());
 
       // Check that the response from this server is correct
-      assertEquals("Session data is not replicating properly", expectedValue, resp.getResponse());
+      if (install.getConnectionType() == ContainerInstall.ConnectionType.CACHING_CLIENT_SERVER) {
+        // There might be delay for other client cache to gets the update through
+        // HARegionQueue
+        String value = resp.getResponse();
+        if (!expectedValue.equals(value)) {
+          LogService.getLogger().info("verifying container {} for expected value of {}"
+              + " for key {}, but gets response value of {}. Waiting for update from server.", i,
+              expectedValue, key, value);
+        }
+        GeodeAwaitility.await().until(() -> expectedValue.equals(getResponseValue(client, key)));
+      } else {
+        // either p2p cache or client cache which has proxy/empty region - retrieving session from
+        // servers
+        assertEquals("Session data is not replicating properly", expectedValue, resp.getResponse());
+      }
     }
+  }
+
+  private String getResponseValue(Client client, String key)
+      throws IOException, URISyntaxException {
+    String value = client.get(key).getResponse();
+    LogService.getLogger().info("client gets response value of {}", value);
+    return value;
   }
 
   /**
@@ -224,18 +247,12 @@ public abstract class CargoTestBase {
     client.setPort(Integer.parseInt(manager.getContainerPort(0)));
     Client.Response resp = client.set(key, value);
 
-    if (!localCacheEnabled()) {
-      getKeyValueDataOnAllClients(key, value, resp.getSessionCookie());
-    }
+    getKeyValueDataOnAllClients(key, value, resp.getSessionCookie());
 
     client.setMaxInactive(1);
     Thread.sleep(5000);
 
     verifySessionIsRemoved(key);
-  }
-
-  private boolean localCacheEnabled() {
-    return install.getConnectionType().enableLocalCache();
   }
 
   /**
@@ -256,11 +273,8 @@ public abstract class CargoTestBase {
     // 59 minutes is the value configured in web.xml
     verifyMaxInactiveInterval(59 * 60);
 
-    if (!localCacheEnabled()) {
-      client.setMaxInactive(63);
-
-      verifyMaxInactiveInterval(63);
-    }
+    client.setMaxInactive(63);
+    verifyMaxInactiveInterval(63);
 
   }
 
@@ -322,10 +336,7 @@ public abstract class CargoTestBase {
     client.setPort(Integer.parseInt(manager.getContainerPort(0)));
     Client.Response resp = client.set(key, value);
 
-
-    if (!localCacheEnabled()) {
-      getKeyValueDataOnAllClients(key, value, resp.getSessionCookie());
-    }
+    getKeyValueDataOnAllClients(key, value, resp.getSessionCookie());
 
     client.setPort(Integer.parseInt(manager.getContainerPort(0)));
     client.remove(key);

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat6CachingClientServerTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat6CachingClientServerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.session.tests;
+
+import static org.apache.geode.session.tests.ContainerInstall.ConnectionType.CACHING_CLIENT_SERVER;
+import static org.apache.geode.session.tests.TomcatInstall.TomcatVersion.TOMCAT6;
+
+import java.util.function.IntSupplier;
+
+public class Tomcat6CachingClientServerTest extends TomcatClientServerTest {
+  @Override
+  public ContainerInstall getInstall(IntSupplier portSupplier) throws Exception {
+    return new TomcatInstall(getClass().getSimpleName(), TOMCAT6, CACHING_CLIENT_SERVER,
+        portSupplier);
+  }
+}

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat7CachingClientServerTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat7CachingClientServerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.session.tests;
+
+import static org.apache.geode.session.tests.ContainerInstall.ConnectionType.CACHING_CLIENT_SERVER;
+import static org.apache.geode.session.tests.TomcatInstall.TomcatVersion.TOMCAT7;
+
+import java.util.function.IntSupplier;
+
+public class Tomcat7CachingClientServerTest extends TomcatClientServerTest {
+  @Override
+  public ContainerInstall getInstall(IntSupplier portSupplier) throws Exception {
+    return new TomcatInstall(getClass().getSimpleName(), TOMCAT7, CACHING_CLIENT_SERVER,
+        portSupplier);
+  }
+}

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat8CachingClientServerTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat8CachingClientServerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.session.tests;
+
+import static org.apache.geode.session.tests.ContainerInstall.ConnectionType.CACHING_CLIENT_SERVER;
+import static org.apache.geode.session.tests.TomcatInstall.TomcatVersion.TOMCAT8;
+
+import java.util.function.IntSupplier;
+
+public class Tomcat8CachingClientServerTest extends TomcatClientServerTest {
+  @Override
+  public ContainerInstall getInstall(IntSupplier portSupplier) throws Exception {
+    return new TomcatInstall(getClass().getSimpleName(), TOMCAT8, CACHING_CLIENT_SERVER,
+        portSupplier);
+  }
+}

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat9CachingClientServerTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Tomcat9CachingClientServerTest.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.session.tests;
+
+import static org.apache.geode.session.tests.ContainerInstall.ConnectionType.CACHING_CLIENT_SERVER;
+import static org.apache.geode.session.tests.TomcatInstall.TomcatVersion.TOMCAT9;
+
+import java.util.function.IntSupplier;
+
+public class Tomcat9CachingClientServerTest extends TomcatClientServerTest {
+  @Override
+  public ContainerInstall getInstall(IntSupplier portSupplier) throws Exception {
+    return new TomcatInstall(getClass().getSimpleName(), TOMCAT9, CACHING_CLIENT_SERVER,
+        portSupplier);
+  }
+}


### PR DESCRIPTION
 * register intesest only when local cache is enabled for Tomcat
 * add register interest in other app server when local cache is enabled.
 * add cache client test cases for tomcat cases.
 * modify test to allow gets mutliple times on containers when local cache is enabled
   on client cache to verify the fix.

