### PR TITLE
GEODE-7487: Update Running CQ Context

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/ExecutionContext.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/ExecutionContext.java
@@ -102,13 +102,19 @@ public class ExecutionContext {
   static final ThreadLocal<AtomicBoolean> isCanceled =
       ThreadLocal.withInitial(AtomicBoolean::new);
 
-  // Authorizer to use during the query execution.
-  private final MethodInvocationAuthorizer methodInvocationAuthorizer;
+  /**
+   * Authorizer to use during query execution.
+   * It can not be changed for queries in flight, but it should be modifiable for running CQs,
+   * that's the only reason why this field is not marked as {@code final}.
+   *
+   * @see ExecutionContext#reset()
+   */
+  private MethodInvocationAuthorizer methodInvocationAuthorizer;
+  private final QueryConfigurationService queryConfigurationService;
 
   /**
    * Returns the {@link MethodInvocationAuthorizer} that will be used, if needed, during the
-   * execution
-   * of the query associated with this context.
+   * execution of the query associated with this context.
    *
    * @return the {@link MethodInvocationAuthorizer} that will be used, if needed, during the
    *         execution of the query associated with this context.
@@ -127,13 +133,8 @@ public class ExecutionContext {
     this.bindArguments = bindArguments;
     this.cache = cache;
     this.cancelationTask = Optional.empty();
-
-    // Authorization & authentication logic happens on server side only.
-    if (cache.isClient()) {
-      this.methodInvocationAuthorizer = QueryConfigurationServiceImpl.getNoOpAuthorizer();
-    } else {
-      this.methodInvocationAuthorizer = cache.getQueryService().getMethodInvocationAuthorizer();
-    }
+    this.queryConfigurationService = cache.getService(QueryConfigurationService.class);
+    this.methodInvocationAuthorizer = queryConfigurationService.getMethodAuthorizer();
   }
 
   Optional<ScheduledFuture> getCancelationTask() {
@@ -585,6 +586,8 @@ public class ExecutionContext {
    */
   public void reset() {
     scopes.clear();
+    // Make sure we use the most up to date authorizer in CQs.
+    methodInvocationAuthorizer = queryConfigurationService.getMethodAuthorizer();
   }
 
   public BucketRegion getBucketRegion() {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/cq/ServerCQ.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/cq/ServerCQ.java
@@ -54,6 +54,13 @@ public interface ServerCQ extends InternalCqQuery {
   void removeFromCqResultKeys(Object key, boolean isTokenMode);
 
   /**
+   * Invalidates the internal cache containing the keys that are part of the CQ query results.
+   * Once this method finishes, the CQ engine will not apply the internal optimization for already
+   * seen keys anymore, not until the cache is manually rebuilt.
+   */
+  void invalidateCqResultKeys();
+
+  /**
    * Sets the CQ Results key cache state as initialized.
    */
   void setCqResultsCacheInitialized();

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/ServerCQImpl.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/ServerCQImpl.java
@@ -280,7 +280,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    *
    * @return String modified query.
    */
-  private Query constructServerSideQuery() throws QueryException {
+  Query constructServerSideQuery() throws QueryException {
     InternalCache cache = cqService.getInternalCache();
     DefaultQuery locQuery = (DefaultQuery) cache.getLocalQueryService().newQuery(this.queryString);
     CompiledSelect select = locQuery.getSimpleSelect();
@@ -359,6 +359,20 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
             this.destroysWhileCqResultsInProgress.add(key);
           }
         }
+      }
+    }
+  }
+
+  @Override
+  public void invalidateCqResultKeys() {
+    if (!CqServiceProvider.MAINTAIN_KEYS) {
+      return;
+    }
+
+    if (this.cqResultKeys != null) {
+      synchronized (this.cqResultKeys) {
+        this.cqResultKeys.clear();
+        this.cqResultKeysInitialized = false;
       }
     }
   }

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/cq/internal/ServerCQImplTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/cq/internal/ServerCQImplTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.cq.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.query.Query;
+import org.apache.geode.cache.query.QueryException;
+import org.apache.geode.cache.query.internal.CqStateImpl;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.logging.InternalLogWriter;
+
+public class ServerCQImplTest {
+  private ServerCQImpl serverCq;
+  private CqServiceImpl mockCqService;
+
+  @Before
+  @SuppressWarnings("deprecation")
+  public void setUp() {
+    mockCqService = mock(CqServiceImpl.class);
+    when(mockCqService.getCache()).thenReturn(mock(Cache.class));
+    when(mockCqService.getCache().getSecurityLoggerI18n())
+        .thenReturn(mock(InternalLogWriter.class));
+    serverCq = spy(
+        new ServerCQImpl(mockCqService, "cqName", "SELECT * FROM /region", false, "test"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void invalidateCqResultKeysShouldClearCacheAndDisableInitializedFlag()
+      throws QueryException {
+    ClientProxyMembershipID mockClientProxyMembershipID = mock(ClientProxyMembershipID.class);
+    doNothing().when(serverCq).validateCq();
+    doReturn(mock(Query.class)).when(serverCq).constructServerSideQuery();
+    LocalRegion mockLocalRegion = mock(LocalRegion.class);
+    when(mockLocalRegion.getDataPolicy()).thenReturn(DataPolicy.PARTITION);
+    when(mockCqService.getCache().getRegion(any())).thenReturn(mockLocalRegion);
+    doNothing().when(serverCq).updateCqCreateStats();
+    serverCq.registerCq(mockClientProxyMembershipID, null, CqStateImpl.INIT);
+
+    // Initialize cache
+    serverCq.addToCqResultKeys("key1");
+    serverCq.setCqResultsCacheInitialized();
+    assertThat(serverCq.cqResultKeysInitialized).isTrue();
+    assertThat(serverCq.isPartOfCqResult("key1")).isTrue();
+
+    // Invalidate and assert results
+    serverCq.invalidateCqResultKeys();
+    assertThat(serverCq.cqResultKeysInitialized).isFalse();
+    assertThat(serverCq.isPartOfCqResult("key1")).isFalse();
+  }
+}


### PR DESCRIPTION
- Added unit and integration tests.
- Implemented method to invalidate the cache used by CQs.
- Updated the context implementation to change the internal
  MethodInvocationAuthorizer used whenever the CQ resets the
  ExecutionContext.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
