### PR TITLE
GEODE-7212: update docs permission for CqQuery.stop()

### DIFF
--- a/geode-docs/managing/security/implementing_authorization.html.md.erb
+++ b/geode-docs/managing/security/implementing_authorization.html.md.erb
@@ -104,7 +104,7 @@ a Client-Server interaction.
 | Region.put(key)                    | DATA:WRITE:RegionName:Key           |
 | Region.replace                     | DATA:WRITE:RegionName:Key           |
 | queryService.newCq                 | DATA:READ:RegionName                |
-| CqQuery.stop                       | DATA:READ                           |
+| CqQuery.stop                       | DATA:MANAGE:QUERY                   |
 
 
 This table classifies the permissions assigned for `gfsh` operations.


### PR DESCRIPTION
I only found one item on the wiki that did not have the proper permission listed in the docs.
