### PR TITLE
GEODE-7435 - Improve performance of GMSMembershipManager.handleOrDefe…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -895,14 +895,14 @@ public class GMSMembership implements Membership {
    * @param msg the message to process
    */
   protected void handleOrDeferMessage(DistributionMessage msg) {
-    // if (!processingEvents) {
-    // synchronized(startupLock) {
-    // if (!startupMessagesDrained) {
-    // startupMessages.add(new StartupEvent(msg));
-    // return;
-    // }
-    // }
-    // }
+    if (!processingEvents) {
+      synchronized (startupLock) {
+        if (!startupMessagesDrained) {
+          startupMessages.add(new StartupEvent(msg));
+          return;
+        }
+      }
+    }
     dispatchMessage(msg);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -739,8 +739,8 @@ public class GMSMembership implements Membership {
       synchronized (startupLock) {
         if (!startupMessagesDrained) {
           startupMessages.add(new StartupEvent(member));
+          return;
         }
-        return;
       }
     }
     processSurpriseConnect(member);


### PR DESCRIPTION
Modified the method to avoid synchronization unless we're in an initialization phase.
While initializaing we synchronize and queue messages unless we're told the
queue has been drained.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a - there are already tests] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
