### PR TITLE
GEODE-7489 DistributionArchUnitTest is running out of memory for some users

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -361,6 +361,8 @@ dependencies {
   integrationTestCompile('org.powermock:powermock-api-mockito2')
   integrationTestCompile('org.springframework:spring-test')
   integrationTestCompile('pl.pragmatists:JUnitParams')
+  integrationTestCompile('com.tngtech.archunit:archunit-junit4')
+
 
   integrationTestRuntime('org.apache.derby:derby')
   integrationTestRuntime('xerces:xercesImpl')

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/DistributionArchUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/DistributionArchUnitTest.java
@@ -18,18 +18,20 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPac
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.junit.CacheMode;
 import com.tngtech.archunit.lang.ArchRule;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
+import org.apache.geode.distributed.internal.membership.MembershipJUnitTest;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 
 @RunWith(ArchUnitRunner.class)
-@AnalyzeClasses(packages = "org.apache.geode")
-@Ignore("Disabling until we can fix the memory usage of this test")
+@AnalyzeClasses(packages = "org.apache.geode", cacheMode = CacheMode.PER_CLASS,
+    importOptions = ImportOption.DoNotIncludeArchives.class)
 public class DistributionArchUnitTest {
 
   @ArchTest
@@ -38,7 +40,7 @@ public class DistributionArchUnitTest {
       .should()
       .onlyBeAccessed()
       .byClassesThat(type(Distribution.class)
-          .or(type(DistributionTest.class))
+          .or(type(MembershipJUnitTest.class)) // another integrationTest
           .or(type(DistributionImpl.MyDCReceiver.class))
           .or(resideInAPackage("org.apache.geode.distributed.internal.membership.gms.."))
           .or(resideInAPackage("org.apache.geode.internal.tcp.."))

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -20,10 +20,12 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPac
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchIgnore;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.junit.CacheMode;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
@@ -51,7 +53,9 @@ import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.util.JavaWorkarounds;
 
 @RunWith(ArchUnitRunner.class)
-@AnalyzeClasses(packages = "org.apache.geode.distributed.internal.membership.gms..")
+@AnalyzeClasses(packages = "org.apache.geode.distributed.internal.membership.gms..",
+    cacheMode = CacheMode.PER_CLASS,
+    importOptions = ImportOption.DoNotIncludeArchives.class)
 public class MembershipDependenciesJUnitTest {
 
   /*

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
@@ -19,9 +19,11 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPac
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.junit.CacheMode;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
@@ -36,7 +38,9 @@ import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 
 @RunWith(ArchUnitRunner.class)
-@AnalyzeClasses(packages = "org.apache.geode.distributed.internal.membership.gms.api")
+@AnalyzeClasses(packages = "org.apache.geode.distributed.internal.membership.gms.api",
+    cacheMode = CacheMode.PER_CLASS,
+    importOptions = ImportOption.DoNotIncludeArchives.class)
 public class MembershipAPIArchUnitTest {
 
   @ArchTest

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
@@ -19,9 +19,11 @@ import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPac
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 
+import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.junit.CacheMode;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
@@ -29,7 +31,9 @@ import org.apache.geode.DataSerializable;
 
 
 @RunWith(ArchUnitRunner.class)
-@AnalyzeClasses(packages = "org.apache.geode.distributed.internal.tcpserver")
+@AnalyzeClasses(packages = "org.apache.geode.distributed.internal.tcpserver",
+    cacheMode = CacheMode.PER_CLASS,
+    importOptions = ImportOption.DoNotIncludeArchives.class)
 public class TcpServerDependenciesTest {
 
   @ArchTest

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/SerializationDependenciesJUnitTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/SerializationDependenciesJUnitTest.java
@@ -22,13 +22,15 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
 import com.tngtech.archunit.junit.ArchUnitRunner;
+import com.tngtech.archunit.junit.CacheMode;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
 
 @RunWith(ArchUnitRunner.class)
 @AnalyzeClasses(packages = "org.apache.geode.internal.serialization..",
-    importOptions = ImportOption.DoNotIncludeTests.class)
+    cacheMode = CacheMode.PER_CLASS,
+    importOptions = {ImportOption.DoNotIncludeArchives.class, ImportOption.DoNotIncludeTests.class})
 public class SerializationDependenciesJUnitTest {
 
   @ArchTest


### PR DESCRIPTION
Added archive excludes to all membership arch unit tests.  Moved
DistributionArchUnitTest to integrationTests and added an exclude
for another integration test to it.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
