### PR TITLE
GEODE-7485: REST URLs accept dots in trailing parameters

### DIFF
--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GatewayManagementControllerSpringTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/GatewayManagementControllerSpringTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.apache.geode.management.configuration.GatewayReceiver.GATEWAY_RECEIVERS_ENDPOINTS;
+import static org.apache.geode.management.configuration.Links.URI_VERSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.management.api.ClusterManagementGetResult;
+import org.apache.geode.management.api.ClusterManagementService;
+import org.apache.geode.management.configuration.GatewayReceiver;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/management-servlet.xml"},
+    loader = MockLocatorContextLoader.class)
+@WebAppConfiguration
+public class GatewayManagementControllerSpringTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  private LocatorWebContext context;
+  private MockLocatorContextLoader mockLocator;
+  private ClusterManagementService cms;
+
+  @Before
+  public void before() {
+    context = new LocatorWebContext(webApplicationContext);
+    mockLocator = (MockLocatorContextLoader) context.getLocator();
+    cms = mockLocator.getClusterManagementService();
+  }
+
+  @After
+  public void clearMocks() {
+    Mockito.clearInvocations(cms);
+  }
+
+  @Test
+  public void getGatewayReceiverMappingRecognizesReceiverIdWithDot() throws Exception {
+    String receiverIdWithDot = "receiver.id";
+    String requestPath = URI_VERSION + GATEWAY_RECEIVERS_ENDPOINTS + "/" + receiverIdWithDot;
+
+    when(cms.get(any())).thenReturn(new ClusterManagementGetResult<>());
+
+    context.perform(get(requestPath))
+        .andExpect(status().is2xxSuccessful());
+
+    ArgumentCaptor<GatewayReceiver> gatewayReceiverCaptor =
+        ArgumentCaptor.forClass(GatewayReceiver.class);
+    verify(cms).get(gatewayReceiverCaptor.capture());
+
+    assertThat(gatewayReceiverCaptor.getValue().getId())
+        .isEqualTo(receiverIdWithDot);
+  }
+}

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/MemberManagementControllerSpringTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/MemberManagementControllerSpringTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.apache.geode.management.configuration.Links.URI_VERSION;
+import static org.apache.geode.management.configuration.Member.MEMBER_ENDPOINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.management.api.ClusterManagementGetResult;
+import org.apache.geode.management.api.ClusterManagementService;
+import org.apache.geode.management.configuration.Member;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/management-servlet.xml"},
+    loader = MockLocatorContextLoader.class)
+@WebAppConfiguration
+public class MemberManagementControllerSpringTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  private LocatorWebContext context;
+  private MockLocatorContextLoader mockLocator;
+  private ClusterManagementService cms;
+
+  @Before
+  public void before() {
+    context = new LocatorWebContext(webApplicationContext);
+    mockLocator = (MockLocatorContextLoader) context.getLocator();
+    cms = mockLocator.getClusterManagementService();
+  }
+
+  @After
+  public void clearMocks() {
+    Mockito.clearInvocations(cms);
+  }
+
+  @Test
+  public void getMemberMappingRecognizesMemberIdWithDot() throws Exception {
+    String memberIdWithDot = "member.id";
+    String requestPath = URI_VERSION + MEMBER_ENDPOINT + "/" + memberIdWithDot;
+
+    when(cms.get(any())).thenReturn(new ClusterManagementGetResult<>());
+
+    context.perform(get(requestPath))
+        .andExpect(status().is2xxSuccessful());
+
+    ArgumentCaptor<Member> memberCaptor =
+        ArgumentCaptor.forClass(Member.class);
+    verify(cms).get(memberCaptor.capture());
+
+    assertThat(memberCaptor.getValue().getId())
+        .isEqualTo(memberIdWithDot);
+  }
+}

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RebalanceOperationControllerSpringTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RebalanceOperationControllerSpringTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.apache.geode.management.configuration.Links.URI_VERSION;
+import static org.apache.geode.management.operation.RebalanceOperation.REBALANCE_ENDPOINT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.management.api.ClusterManagementResult;
+import org.apache.geode.management.internal.ClusterManagementOperationStatusResult;
+import org.apache.geode.management.internal.api.LocatorClusterManagementService;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/management-servlet.xml"},
+    loader = MockLocatorContextLoader.class)
+@WebAppConfiguration
+public class RebalanceOperationControllerSpringTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  private LocatorWebContext context;
+  private MockLocatorContextLoader mockLocator;
+  private LocatorClusterManagementService cms;
+
+  @Before
+  public void before() {
+    context = new LocatorWebContext(webApplicationContext);
+    mockLocator = (MockLocatorContextLoader) context.getLocator();
+    cms = (LocatorClusterManagementService) mockLocator.getClusterManagementService();
+  }
+
+  @After
+  public void clearMocks() {
+    Mockito.clearInvocations(cms);
+  }
+
+  @Test
+  public void checkStatusMappingRecognizesRebalanceIdWithDot() throws Exception {
+    String rebalanceIdWithDot = "rebalance.id";
+    String requestPath = URI_VERSION + REBALANCE_ENDPOINT + "/" + rebalanceIdWithDot;
+
+    when(cms.checkStatus(any()))
+        .thenReturn(new ClusterManagementOperationStatusResult<>(
+            new ClusterManagementResult()));
+
+    context.perform(get(requestPath))
+        .andExpect(status().is2xxSuccessful());
+
+    verify(cms).checkStatus(rebalanceIdWithDot);
+  }
+}

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementControllerSpringTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/RegionManagementControllerSpringTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.management.internal.rest;
+
+import static org.apache.geode.management.configuration.Links.URI_VERSION;
+import static org.apache.geode.management.configuration.Region.REGION_CONFIG_ENDPOINT;
+import static org.apache.geode.management.internal.rest.controllers.RegionManagementController.INDEXES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+
+import org.apache.geode.management.api.ClusterManagementGetResult;
+import org.apache.geode.management.api.ClusterManagementRealizationResult;
+import org.apache.geode.management.api.ClusterManagementService;
+import org.apache.geode.management.configuration.Index;
+import org.apache.geode.management.configuration.Region;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(locations = {"classpath*:WEB-INF/management-servlet.xml"},
+    loader = MockLocatorContextLoader.class)
+@WebAppConfiguration
+public class RegionManagementControllerSpringTest {
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  private LocatorWebContext context;
+  private MockLocatorContextLoader mockLocator;
+  private ClusterManagementService cms;
+
+  @Before
+  public void before() {
+    context = new LocatorWebContext(webApplicationContext);
+    mockLocator = (MockLocatorContextLoader) context.getLocator();
+    cms = mockLocator.getClusterManagementService();
+  }
+
+  @After
+  public void clearMocks() {
+    Mockito.clearInvocations(cms);
+  }
+
+  @Test
+  public void getIndexMappingRecognizesIndexIdWithDot() throws Exception {
+    String regionName = "myregion";
+    String indexNameWithDot = "index.name";
+    String requestPath = URI_VERSION + REGION_CONFIG_ENDPOINT
+        + "/" + regionName + INDEXES + "/" + indexNameWithDot;
+
+    when(cms.get(any())).thenReturn(new ClusterManagementGetResult<>());
+
+    context.perform(get(requestPath))
+        .andExpect(status().is2xxSuccessful());
+
+    ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
+    verify(cms).get(indexCaptor.capture());
+    Index indexPassedToGet = indexCaptor.getValue();
+
+    assertThat(indexPassedToGet.getId())
+        .isEqualTo(indexNameWithDot);
+  }
+
+  @Test
+  public void getRegionMappingRecognizesRegionNameWithDot() throws Exception {
+    String regionNameWithDot = "region.name";
+    String requestPath = URI_VERSION + REGION_CONFIG_ENDPOINT + "/" + regionNameWithDot;
+
+    when(cms.get(any())).thenReturn(new ClusterManagementGetResult<>());
+
+    context.perform(get(requestPath))
+        .andExpect(status().is2xxSuccessful());
+
+    ArgumentCaptor<Region> regionCaptor = ArgumentCaptor.forClass(Region.class);
+    verify(cms).get(regionCaptor.capture());
+    Region regionPassedToGet = regionCaptor.getValue();
+
+    assertThat(regionPassedToGet.getName())
+        .isEqualTo(regionNameWithDot);
+  }
+
+  @Test
+  public void deleteRegionMappingRecognizesRegionNameWithDot() throws Exception {
+    String regionNameWithDot = "region.name";
+    String requestPath = URI_VERSION + REGION_CONFIG_ENDPOINT + "/" + regionNameWithDot;
+
+    when(cms.delete(any())).thenReturn(new ClusterManagementRealizationResult());
+
+    context.perform(delete(requestPath))
+        .andExpect(status().is2xxSuccessful());
+
+    ArgumentCaptor<Region> regionCaptor = ArgumentCaptor.forClass(Region.class);
+    verify(cms).delete(regionCaptor.capture());
+    Region regionPassedToGet = regionCaptor.getValue();
+
+    assertThat(regionPassedToGet.getName())
+        .isEqualTo(regionNameWithDot);
+  }
+}

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/GatewayManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/GatewayManagementController.java
@@ -57,7 +57,7 @@ public class GatewayManagementController extends AbstractManagementController {
 
   @ApiOperation(value = "get gateway-receiver")
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ')")
-  @GetMapping(GATEWAY_RECEIVERS_ENDPOINTS + "/{id}")
+  @GetMapping(GATEWAY_RECEIVERS_ENDPOINTS + "/{id:.+}")
   public ClusterManagementGetResult<GatewayReceiver, GatewayReceiverInfo> getGatewayReceiver(
       @PathVariable(name = "id") String id) {
     GatewayReceiver config = new GatewayReceiver();

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/MemberManagementController.java
@@ -42,7 +42,7 @@ public class MemberManagementController extends AbstractManagementController {
           @ExtensionProperty(name = "jqFilter",
               value = ".result | .runtimeInfo[] | {name:.memberName,status:.status}")})})
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ')")
-  @GetMapping(MEMBER_ENDPOINT + "/{id}")
+  @GetMapping(MEMBER_ENDPOINT + "/{id:.+}")
   public ClusterManagementGetResult<Member, MemberInformation> getMember(
       @PathVariable(name = "id") String id) {
     Member config = new Member();

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RebalanceOperationController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RebalanceOperationController.java
@@ -62,7 +62,7 @@ public class RebalanceOperationController extends AbstractManagementController {
 
   @ApiOperation(value = "check rebalance")
   @PreAuthorize("@securityService.authorize('DATA', 'MANAGE')")
-  @GetMapping(REBALANCE_ENDPOINT + "/{id}")
+  @GetMapping(REBALANCE_ENDPOINT + "/{id:.+}")
   public ResponseEntity<ClusterManagementOperationStatusResult<RebalanceResult>> checkRebalanceStatus(
       @PathVariable String id) {
     ClusterManagementOperationStatusResult<RebalanceResult> result =

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/RegionManagementController.java
@@ -49,7 +49,7 @@ import org.apache.geode.security.ResourcePermission.Resource;
 @RestController("regionManagement")
 @RequestMapping(URI_VERSION)
 public class RegionManagementController extends AbstractManagementController {
-  private static final String INDEXES = "/indexes";
+  public static final String INDEXES = "/indexes";
 
   @ApiOperation(value = "create region")
   @ApiResponses({
@@ -89,7 +89,7 @@ public class RegionManagementController extends AbstractManagementController {
       extensions = {@Extension(properties = {
           @ExtensionProperty(name = "jqFilter",
               value = ".result | .runtimeInfo[] + .configuration | {name:.name,type:.type,entryCount:.entryCount}")})})
-  @GetMapping(REGION_CONFIG_ENDPOINT + "/{id}")
+  @GetMapping(REGION_CONFIG_ENDPOINT + "/{id:.+}")
   public ClusterManagementGetResult<Region, RuntimeRegionInfo> getRegion(
       @PathVariable(name = "id") String id) {
     securityService.authorize(Resource.CLUSTER, Operation.READ, id);
@@ -100,7 +100,7 @@ public class RegionManagementController extends AbstractManagementController {
 
   @ApiOperation(value = "delete region")
   @PreAuthorize("@securityService.authorize('DATA', 'MANAGE')")
-  @DeleteMapping(REGION_CONFIG_ENDPOINT + "/{id}")
+  @DeleteMapping(REGION_CONFIG_ENDPOINT + "/{id:.+}")
   public ClusterManagementResult deleteRegion(
       @PathVariable(name = "id") String id,
       @RequestParam(required = false) String group) {
@@ -149,7 +149,7 @@ public class RegionManagementController extends AbstractManagementController {
       extensions = {@Extension(properties = {
           @ExtensionProperty(name = "jqFilter",
               value = ".result | .configuration | {name:.name,expression:.expression}")})})
-  @GetMapping(REGION_CONFIG_ENDPOINT + "/{regionName}" + INDEXES + "/{id}")
+  @GetMapping(REGION_CONFIG_ENDPOINT + "/{regionName}" + INDEXES + "/{id:.+}")
   @PreAuthorize("@securityService.authorize('CLUSTER', 'READ', 'QUERY')")
   public ClusterManagementGetResult<Index, RuntimeInfo> getIndex(
       @PathVariable String regionName,


### PR DESCRIPTION
By default, when Spring parses a request mapping parameter at the end of a URL, it treats the last dot in the paramater value to be the start of a file extension, and discards the 'extension" before passing the parameter to the handler method.

Several of our configurable items allow dots in their IDs. And several of our REST request mappings place those IDs at the end of the URL. In those cases, Spring's default behavior truncates the ID at the last dot, and passes the truncated ID to the request handler. As a result, the request fails.                                                

This commit configure all current management REST API request mappings to allow dots in their final parameters.

Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Jinmei Liao <jiliao@pivotal.io>
Co-authored-by: Darrel Schneider <dschneider@pivotal.io>

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
