### PR TITLE
GEODE-7497: Check CQs prior to change authorizer

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandWithSecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandWithSecurityDUnitTest.java
@@ -100,7 +100,8 @@ public class AlterQueryServiceCommandWithSecurityDUnitTest {
     return commandBuilder.toString();
   }
 
-  private void executeAndAssertGfshCommandIsSuccessful(Class authorizerClass,
+  private void executeAndAssertGfshCommandIsSuccessful(
+      Class<? extends MethodInvocationAuthorizer> authorizerClass,
       String authorizerParameters) {
     gfsh.executeAndAssertThat(buildCommand(authorizerClass.getName(), authorizerParameters))
         .statusIsSuccess().hasTableSection().hasRowSize(servers.size());
@@ -123,7 +124,8 @@ public class AlterQueryServiceCommandWithSecurityDUnitTest {
     });
   }
 
-  private void verifyCurrentAuthorizerClass(Class authorizerClass) {
+  private void verifyCurrentAuthorizerClass(
+      Class<? extends MethodInvocationAuthorizer> authorizerClass) {
     servers.forEach(server -> server.invoke(() -> {
       MethodInvocationAuthorizer methodAuthorizer =
           Objects.requireNonNull(ClusterStartupRule.getCache())
@@ -132,7 +134,7 @@ public class AlterQueryServiceCommandWithSecurityDUnitTest {
     }));
   }
 
-  private String getFilePath() throws IOException {
+  private String getTestMethodAuthorizerFilePath() throws IOException {
     URL url = getClass().getResource(TEST_AUTHORIZER_TXT);
     File textFile = this.tempFolder.newFile(TEST_AUTHORIZER_TXT);
     FileUtils.copyURLToFile(url, textFile);
@@ -186,7 +188,8 @@ public class AlterQueryServiceCommandWithSecurityDUnitTest {
     verifyCurrentAuthorizerClass(DEFAULT_AUTHORIZER_CLASS);
     Class<TestMethodAuthorizer> authorizerClass = TestMethodAuthorizer.class;
     String authorizerName = authorizerClass.getName();
-    String classContent = new String(Files.readAllBytes(Paths.get(getFilePath())));
+    String classContent =
+        new String(Files.readAllBytes(Paths.get(getTestMethodAuthorizerFilePath())));
     String jarFileName = "testJar.jar";
     File jarFile = tempFolder.newFile(jarFileName);
     new ClassBuilder().writeJarFromContent(authorizerName, classContent, jarFile);

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeQueryServiceCommandDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeQueryServiceCommandDUnitTest.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.AUTHORIZER_NAME;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.AUTHORIZER_PARAMETERS;
-import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.METHOD_AUTHORIZER_NAME;
 import static org.apache.geode.management.internal.cli.commands.DescribeQueryServiceCommand.ALL_METHODS_ALLOWED;
 import static org.apache.geode.management.internal.cli.commands.DescribeQueryServiceCommand.AUTHORIZER_CLASS_NAME;
 import static org.apache.geode.management.internal.cli.commands.DescribeQueryServiceCommand.COMMAND_NAME;
@@ -92,7 +92,7 @@ public class DescribeQueryServiceCommandDUnitTest {
     String authorizerName = JavaBeanAccessorMethodAuthorizer.class.getName();
     String parameters = "param1;param2;param3";
     String alterQueryService = AlterQueryServiceCommand.COMMAND_NAME + " --"
-        + METHOD_AUTHORIZER_NAME + "=" + authorizerName
+        + AUTHORIZER_NAME + "=" + authorizerName
         + " --" + AUTHORIZER_PARAMETERS + "=" + parameters;
 
     gfsh.executeAndAssertThat(alterQueryService).statusIsSuccess();

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/DefaultQuerySecurityIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/DefaultQuerySecurityIntegrationTest.java
@@ -117,7 +117,7 @@ public class DefaultQuerySecurityIntegrationTest {
 
     spiedCache = spy(server.getCache());
     QueryConfigurationService queryConfig = spiedCache.getService(QueryConfigurationService.class);
-    queryConfig.updateMethodAuthorizer(spiedCache, SpyAuthorizer.class.getName(),
+    queryConfig.updateMethodAuthorizer(spiedCache, false, SpyAuthorizer.class.getName(),
         Collections.emptySet());
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/DefaultQueryServiceDeprecationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/DefaultQueryServiceDeprecationTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.query.internal;
 
-import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY;
 import static org.apache.geode.distributed.internal.DistributionConfig.LOG_FILE_NAME;
 
 import java.io.File;
@@ -38,10 +38,10 @@ public class DefaultQueryServiceDeprecationTest implements Serializable {
   public ServerStarterRule server = new ServerStarterRule();
 
   @Test
+  @SuppressWarnings("deprecation")
   public void warningMessageIsOnlyLoggedOnceWhenDeprecatedPropertyUsed() throws IOException {
     File logFile = folderRule.newFile("customLog1.log");
-    System.setProperty(GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation",
-        "true");
+    System.setProperty(ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY, "true");
     server.withProperty(LOG_FILE_NAME, logFile.getAbsolutePath()).startServer();
     server.getCache().getQueryService();
     server.getCache().getQueryService();

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/ExecutionContextIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/ExecutionContextIntegrationTest.java
@@ -159,7 +159,7 @@ public class ExecutionContextIntegrationTest {
   }
 
   @Test
-  public void resetShouldUpdateTheMethodInvocationAuthorizer() throws ClassNotFoundException {
+  public void resetShouldUpdateTheMethodInvocationAuthorizer() {
     server.stopMember();
 
     // Security Enabled -> RestrictedMethodAuthorizer
@@ -172,7 +172,7 @@ public class ExecutionContextIntegrationTest {
     // Change the authorizer
     InternalCache internalCache = server.getCache();
     internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(internalCache,
-        RegExMethodAuthorizer.class.getName(), Collections.emptySet());
+        false, RegExMethodAuthorizer.class.getName(), Collections.emptySet());
 
     // Reset the context - used by CQs when processing events
     securedContext.reset();

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationService.java
@@ -32,7 +32,8 @@ public interface QueryConfigurationService extends CacheService {
   MethodInvocationAuthorizer getMethodAuthorizer();
 
   /**
-   * Updates the configured {@link MethodInvocationAuthorizer}.
+   * Sets the configured {@link MethodInvocationAuthorizer} when creating the cache using a
+   * declarative approach.
    *
    * @param cache the cache on which the {@link MethodInvocationAuthorizer} instance will be
    *        configured.
@@ -54,7 +55,7 @@ public interface QueryConfigurationService extends CacheService {
    *        continuous queries running, {@code false} otherwise.
    * @param className the fully qualified name of the class that will be created and configured as
    *        the new {@link MethodInvocationAuthorizer}.
-   * @param parameters the list of parameters that will be used to initialize the new
+   * @param parameters the set of parameters that will be used to initialize the new
    *        {@link MethodInvocationAuthorizer}.
    * @throws QueryConfigurationServiceException when there is an error while updating the new
    *         {@link MethodInvocationAuthorizer}.

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationService.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationService.java
@@ -24,12 +24,41 @@ import org.apache.geode.internal.cache.CacheService;
 
 public interface QueryConfigurationService extends CacheService {
 
+  /**
+   * Returns the currently configured {@link MethodInvocationAuthorizer} instance.
+   *
+   * @return the currently configured {@link MethodInvocationAuthorizer}
+   */
   MethodInvocationAuthorizer getMethodAuthorizer();
 
-  void updateMethodAuthorizer(Cache cache, QueryMethodAuthorizerCreation creation)
-      throws ClassNotFoundException;
+  /**
+   * Updates the configured {@link MethodInvocationAuthorizer}.
+   *
+   * @param cache the cache on which the {@link MethodInvocationAuthorizer} instance will be
+   *        configured.
+   * @param forceUpdate {@code true} to apply the configuration change even when there are
+   *        continuous queries running, {@code false} otherwise.
+   * @param creation the authorizer creation parameters.
+   * @throws QueryConfigurationServiceException when there is an error while updating the new
+   *         {@link MethodInvocationAuthorizer}.
+   */
+  void updateMethodAuthorizer(Cache cache, boolean forceUpdate,
+      QueryMethodAuthorizerCreation creation) throws QueryConfigurationServiceException;
 
-  void updateMethodAuthorizer(Cache cache, String className, Set<String> parameters)
-      throws ClassNotFoundException, QueryConfigurationServiceException;
-
+  /**
+   * Updates the configured {@link MethodInvocationAuthorizer}.
+   *
+   * @param cache the cache on which the {@link MethodInvocationAuthorizer} instance will be
+   *        configured.
+   * @param forceUpdate {@code true} to apply the configuration change even when there are
+   *        continuous queries running, {@code false} otherwise.
+   * @param className the fully qualified name of the class that will be created and configured as
+   *        the new {@link MethodInvocationAuthorizer}.
+   * @param parameters the list of parameters that will be used to initialize the new
+   *        {@link MethodInvocationAuthorizer}.
+   * @throws QueryConfigurationServiceException when there is an error while updating the new
+   *         {@link MethodInvocationAuthorizer}.
+   */
+  void updateMethodAuthorizer(Cache cache, boolean forceUpdate, String className,
+      Set<String> parameters) throws QueryConfigurationServiceException;
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImpl.java
@@ -41,6 +41,7 @@ import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
 
 public class QueryConfigurationServiceImpl implements QueryConfigurationService {
   private static final Logger logger = LogService.getLogger();
+  static final String NULL_CACHE_ERROR_MESSAGE = "Cache must not be null";
   private static final String UPDATE_ERROR_MESSAGE =
       "Exception while updating MethodInvocationAuthorizer.";
   public static final String INTERFACE_NOT_IMPLEMENTED_MESSAGE =
@@ -85,7 +86,7 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
   @Override
   public boolean init(Cache cache) {
     if (cache == null) {
-      throw new IllegalArgumentException("Cache must not be null");
+      throw new IllegalArgumentException(NULL_CACHE_ERROR_MESSAGE);
     }
 
     if (System.getProperty(ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY) != null) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImpl.java
@@ -25,6 +25,8 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.query.internal.cq.CqService;
+import org.apache.geode.cache.query.internal.cq.ServerCQ;
 import org.apache.geode.cache.query.internal.xml.QueryMethodAuthorizerCreation;
 import org.apache.geode.cache.query.security.JavaBeanAccessorMethodAuthorizer;
 import org.apache.geode.cache.query.security.MethodInvocationAuthorizer;
@@ -38,11 +40,13 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
 
 public class QueryConfigurationServiceImpl implements QueryConfigurationService {
-
-  static final String UPDATE_ERROR_MESSAGE =
-      "Exception while updating MethodInvocationAuthorizer. ";
+  private static final Logger logger = LogService.getLogger();
+  private static final String UPDATE_ERROR_MESSAGE =
+      "Exception while updating MethodInvocationAuthorizer.";
   public static final String INTERFACE_NOT_IMPLEMENTED_MESSAGE =
       "Provided method authorizer %S does not implement interface %S";
+  public static final String CONTINUOUS_QUERIES_RUNNING_MESSAGE =
+      "There are CQs running which might have method invocations not allowed by the new MethodInvocationAuthorizer, the update operation can not be completed on this member.";
 
   /**
    * Instead of the below property, please use the UnrestrictedMethodAuthorizer
@@ -51,12 +55,17 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
   @Deprecated
   public final boolean ALLOW_UNTRUSTED_METHOD_INVOCATION;
 
-  public static final String DEPRECATION_WARNING = "The property " + GEMFIRE_PREFIX +
-      "QueryService.allowUntrustedMethodInvocation is deprecated. " +
-      "Please use the UnrestrictedMethodAuthorizer implementation of MethodInvocationAuthorizer " +
-      "instead";
+  /**
+   * Delete this once {@code ALLOW_UNTRUSTED_METHOD_INVOCATION} is removed.
+   * Keeping it here and public to avoid using using the same constant String across classes.
+   */
+  @Deprecated
+  public static final String ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY =
+      GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation";
 
-  private static final Logger logger = LogService.getLogger();
+  public static final String DEPRECATION_WARNING = "The property "
+      + ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY
+      + " is deprecated. Please use the UnrestrictedMethodAuthorizer implementation of MethodInvocationAuthorizer instead.";
 
   private MethodInvocationAuthorizer authorizer;
 
@@ -64,8 +73,8 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
   private static final MethodInvocationAuthorizer NO_OP_AUTHORIZER = new NoOpAuthorizer();
 
   public QueryConfigurationServiceImpl() {
-    ALLOW_UNTRUSTED_METHOD_INVOCATION = Boolean.parseBoolean(
-        System.getProperty(GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation"));
+    ALLOW_UNTRUSTED_METHOD_INVOCATION =
+        Boolean.parseBoolean(System.getProperty(ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY));
   }
 
   public static MethodInvocationAuthorizer getNoOpAuthorizer() {
@@ -76,11 +85,10 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
   @Override
   public boolean init(Cache cache) {
     if (cache == null) {
-      throw new IllegalArgumentException("cache must not be null");
+      throw new IllegalArgumentException("Cache must not be null");
     }
 
-    if (System
-        .getProperty(GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation") != null) {
+    if (System.getProperty(ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY) != null) {
       logger.warn(DEPRECATION_WARNING);
     }
 
@@ -89,6 +97,7 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
     } else {
       this.authorizer = new RestrictedMethodAuthorizer(cache);
     }
+
     return true;
   }
 
@@ -103,9 +112,7 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
   }
 
   @Override
-  public void close() {
-
-  }
+  public void close() {}
 
   @Override
   public MethodInvocationAuthorizer getMethodAuthorizer() {
@@ -113,16 +120,23 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
   }
 
   @Override
-  public void updateMethodAuthorizer(Cache cache, QueryMethodAuthorizerCreation creation)
-      throws QueryConfigurationServiceException {
-    updateMethodAuthorizer(cache, creation.getClassName(), creation.getParameters());
+  public void updateMethodAuthorizer(Cache cache, boolean forceUpdate,
+      QueryMethodAuthorizerCreation creation) throws QueryConfigurationServiceException {
+    updateMethodAuthorizer(cache, forceUpdate, creation.getClassName(), creation.getParameters());
   }
 
   @Override
-  public void updateMethodAuthorizer(Cache cache, String className, Set<String> parameters)
-      throws QueryConfigurationServiceException {
+  public void updateMethodAuthorizer(Cache cache, boolean forceUpdate, String className,
+      Set<String> parameters) throws QueryConfigurationServiceException {
+    // Return quickly if security is disabled or deprecated flag is set
     if (isSecurityDisabled((InternalCache) cache) || ALLOW_UNTRUSTED_METHOD_INVOCATION) {
       return;
+    }
+
+    // Throw exception if there are CQs running and forceUpdate flag is false.
+    CqService cqService = ((InternalCache) cache).getCqService();
+    if ((!cqService.getAllCqs().isEmpty()) && (!forceUpdate)) {
+      throw new QueryConfigurationServiceException(CONTINUOUS_QUERIES_RUNNING_MESSAGE);
     }
 
     try {
@@ -141,12 +155,18 @@ public class QueryConfigurationServiceImpl implements QueryConfigurationService 
               String.format(INTERFACE_NOT_IMPLEMENTED_MESSAGE, userClass.getName(),
                   MethodInvocationAuthorizer.class.getName()));
         }
+
         MethodInvocationAuthorizer tmpAuthorizer =
             (MethodInvocationAuthorizer) userClass.newInstance();
         tmpAuthorizer.initialize(cache, parameters);
         this.authorizer = tmpAuthorizer;
-
       }
+
+      // Invalidate cached CQ results, if any.
+      cqService.getAllCqs().forEach(cqQuery -> {
+        ServerCQ serverCQ = (ServerCQ) cqQuery;
+        serverCQ.invalidateCqResultKeys();
+      });
     } catch (Exception e) {
       throw new QueryConfigurationServiceException(UPDATE_ERROR_MESSAGE, e);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -617,7 +617,7 @@ public class CacheCreation implements InternalCache {
         QueryMethodAuthorizerCreation authorizerCreation =
             queryConfigurationServiceCreation.getMethodAuthorizerCreation();
         if (authorizerCreation != null) {
-          queryConfigService.updateMethodAuthorizer(cache, authorizerCreation);
+          queryConfigService.updateMethodAuthorizer(cache, true, authorizerCreation);
         }
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommand.java
@@ -15,12 +15,10 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 
 import org.springframework.shell.core.annotation.CliCommand;
@@ -31,10 +29,7 @@ import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.cache.query.management.configuration.QueryConfigService;
 import org.apache.geode.distributed.ConfigurationPersistenceService;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.SingleGfshCommand;
-import org.apache.geode.management.internal.cli.AbstractCliAroundInterceptor;
-import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.AlterQueryServiceFunction;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
@@ -42,67 +37,62 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 public class AlterQueryServiceCommand extends SingleGfshCommand {
-
   static final String COMMAND_NAME = "alter query-service";
-  private static final String COMMAND_HELP =
-      "Alter configuration parameters for the query service";
-  static final String METHOD_AUTHORIZER_NAME = "method-authorizer";
+  private static final String COMMAND_HELP = "Alter configuration parameters for the query service";
+  static final String AUTHORIZER_NAME = "method-authorizer";
   private static final String METHOD_AUTHORIZER_NAME_HELP =
       "The name of the class to be used for OQL method authorization";
   static final String AUTHORIZER_PARAMETERS = "authorizer-parameters";
   private static final String AUTHORIZER_PARAMETERS_HELP =
-      "A semicolon separated list of all parameter values for the specified method authorizer. Requires '--"
-          + METHOD_AUTHORIZER_NAME + "' option to be used";
-  static final String PARAMETERS_WITHOUT_AUTHORIZER_MESSAGE = "The '--" + AUTHORIZER_PARAMETERS
-      + "' option requires '--" + METHOD_AUTHORIZER_NAME + "' to be specified";
-  static final String NO_ARGUMENTS_MESSAGE =
-      "No arguments were provided. No changes have been applied.";
+      "A semicolon separated list of all parameter values for the specified method authorizer.";
+  static final String FORCE_UPDATE = "force-update";
+  private static final String FORCE_PARAMETER_HELP =
+      "Flag to indicate whether to forcibly update the currently configured authorizer, even when there are continuous queries registered (use with caution)";
   static final String NO_MEMBERS_FOUND_MESSAGE = "No members found.";
   public static final String PARTIAL_FAILURE_MESSAGE =
       "In the event of a partial failure of this command, re-running the command or restarting failing members should restore consistency.";
   static final String SPLITTING_REGEX = ";";
 
+  private final AlterQueryServiceFunction alterQueryServiceFunction =
+      new AlterQueryServiceFunction();
+
   @CliCommand(value = COMMAND_NAME, help = COMMAND_HELP)
-  @CliMetaData(
-      interceptor = "org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand$Interceptor")
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
       operation = ResourcePermission.Operation.MANAGE)
   public ResultModel execute(
-      @CliOption(key = METHOD_AUTHORIZER_NAME,
-          help = METHOD_AUTHORIZER_NAME_HELP) String methodAuthorizerName,
-      @CliOption(key = AUTHORIZER_PARAMETERS,
-          help = AUTHORIZER_PARAMETERS_HELP,
-          optionContext = "splittingRegex=" + SPLITTING_REGEX) String[] authorizerParameters) {
-    ResultModel result;
+      @CliOption(key = AUTHORIZER_NAME, help = METHOD_AUTHORIZER_NAME_HELP,
+          mandatory = true) String methodAuthorizerName,
+      @CliOption(key = AUTHORIZER_PARAMETERS, help = AUTHORIZER_PARAMETERS_HELP,
+          optionContext = "splittingRegex=" + SPLITTING_REGEX) String[] authorizerParameters,
+      @CliOption(key = FORCE_UPDATE, help = FORCE_PARAMETER_HELP, specifiedDefaultValue = "true",
+          unspecifiedDefaultValue = "false") boolean forceUpdate) {
 
+    ResultModel result;
+    Set<String> parametersSet = new HashSet<>();
     QueryConfigService queryConfigService = getQueryConfigService();
-    Set<String> parametersSet = null;
-    if (methodAuthorizerName != null) {
-      if (authorizerParameters != null) {
-        parametersSet = new HashSet<>(Arrays.asList(authorizerParameters));
-      }
-      populateMethodAuthorizer(methodAuthorizerName, parametersSet, queryConfigService);
-    }
+    if (authorizerParameters != null)
+      parametersSet.addAll(Arrays.asList(authorizerParameters));
+    populateMethodAuthorizer(methodAuthorizerName, parametersSet, queryConfigService);
 
     Set<DistributedMember> targetMembers = findMembers(null, null);
-    if (targetMembers.size() == 0) {
+    if (targetMembers.isEmpty()) {
       result = ResultModel.createInfo(NO_MEMBERS_FOUND_MESSAGE);
     } else {
-      Object[] args = new Object[] {methodAuthorizerName, parametersSet};
-      List<CliFunctionResult> functionResults =
-          executeAndGetFunctionResult(new AlterQueryServiceFunction(), args,
-              targetMembers);
       String footer = null;
+      Object[] args = new Object[] {forceUpdate, methodAuthorizerName, parametersSet};
+      List<CliFunctionResult> functionResults =
+          executeAndGetFunctionResult(alterQueryServiceFunction, args, targetMembers);
 
-      if (functionResults.stream().anyMatch(functionResult -> functionResult.isSuccessful())
+      if (functionResults.stream().anyMatch(CliFunctionResult::isSuccessful)
           && functionResults.stream().anyMatch(functionResult -> !functionResult.isSuccessful())) {
         footer = PARTIAL_FAILURE_MESSAGE;
       }
 
-      result =
-          ResultModel.createMemberStatusResult(functionResults, null, footer, false, true);
+      result = ResultModel.createMemberStatusResult(functionResults, null, footer, false, true);
     }
+
     result.setConfigObject(queryConfigService);
+
     return result;
   }
 
@@ -112,31 +102,38 @@ public class AlterQueryServiceCommand extends SingleGfshCommand {
         new QueryConfigService.MethodAuthorizer();
     methodAuthorizer.setClassName(methodAuthorizerName);
 
-    if (parameterSet != null && parameterSet.size() != 0) {
+    if (!parameterSet.isEmpty()) {
       List<QueryConfigService.MethodAuthorizer.Parameter> parameterList = new ArrayList<>();
+
       for (String value : parameterSet) {
         QueryConfigService.MethodAuthorizer.Parameter parameter =
             new QueryConfigService.MethodAuthorizer.Parameter();
         parameter.setParameterValue(value);
         parameterList.add(parameter);
       }
+
       methodAuthorizer.setParameters(parameterList);
     }
+
     queryConfigService.setMethodAuthorizer(methodAuthorizer);
   }
 
   QueryConfigService getQueryConfigService() {
     ConfigurationPersistenceService configService = getConfigurationPersistenceService();
+
     if (configService != null) {
       CacheConfig cacheConfig = configService.getCacheConfig(null);
+
       if (cacheConfig != null) {
-        QueryConfigService queryConfigService = cacheConfig.findCustomCacheElement(
-            QueryConfigService.ELEMENT_ID, QueryConfigService.class);
+        QueryConfigService queryConfigService = cacheConfig
+            .findCustomCacheElement(QueryConfigService.ELEMENT_ID, QueryConfigService.class);
+
         if (queryConfigService != null) {
           return queryConfigService;
         }
       }
     }
+
     return new QueryConfigService();
   }
 
@@ -146,28 +143,10 @@ public class AlterQueryServiceCommand extends SingleGfshCommand {
       List<CacheElement> elements = config.getCustomCacheElements();
       elements.removeIf(e -> e instanceof QueryConfigService);
       elements.add((QueryConfigService) configObject);
+
       return true;
     }
+
     return false;
-  }
-
-
-
-  public static class Interceptor extends AbstractCliAroundInterceptor {
-    @Override
-    public ResultModel preExecution(GfshParseResult parseResult) {
-      if (Arrays.stream(parseResult.getArguments()).allMatch(Objects::isNull)) {
-        return ResultModel.createError(NO_ARGUMENTS_MESSAGE);
-      }
-
-      Object authorizerName = parseResult.getParamValue(METHOD_AUTHORIZER_NAME);
-      Object authorizerParams = parseResult.getParamValue(AUTHORIZER_PARAMETERS);
-
-      if (authorizerParams != null && authorizerName == null) {
-        return ResultModel.createError(PARAMETERS_WITHOUT_AUTHORIZER_MESSAGE);
-      }
-
-      return new ResultModel();
-    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommand.java
@@ -46,7 +46,7 @@ public class AlterQueryServiceCommand extends SingleGfshCommand {
   private static final String AUTHORIZER_PARAMETERS_HELP =
       "A semicolon separated list of all parameter values for the specified method authorizer.";
   static final String FORCE_UPDATE = "force-update";
-  private static final String FORCE_PARAMETER_HELP =
+  private static final String FORCE_UPDATE_HELP =
       "Flag to indicate whether to forcibly update the currently configured authorizer, even when there are continuous queries registered (use with caution)";
   static final String NO_MEMBERS_FOUND_MESSAGE = "No members found.";
   public static final String PARTIAL_FAILURE_MESSAGE =
@@ -64,7 +64,7 @@ public class AlterQueryServiceCommand extends SingleGfshCommand {
           mandatory = true) String methodAuthorizerName,
       @CliOption(key = AUTHORIZER_PARAMETERS, help = AUTHORIZER_PARAMETERS_HELP,
           optionContext = "splittingRegex=" + SPLITTING_REGEX) String[] authorizerParameters,
-      @CliOption(key = FORCE_UPDATE, help = FORCE_PARAMETER_HELP, specifiedDefaultValue = "true",
+      @CliOption(key = FORCE_UPDATE, help = FORCE_UPDATE_HELP, specifiedDefaultValue = "true",
           unspecifiedDefaultValue = "false") boolean forceUpdate) {
 
     ResultModel result;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/AlterQueryServiceFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/AlterQueryServiceFunction.java
@@ -15,69 +15,79 @@
 
 package org.apache.geode.management.internal.cli.functions;
 
-import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.query.internal.QueryConfigurationService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CliFunction;
 
 public class AlterQueryServiceFunction extends CliFunction<Object[]> {
-  static final String AUTHORIZER_UPDATED_MESSAGE =
+  private static final long serialVersionUID = 7155576168386556341L;
+  public static final String AUTHORIZER_UPDATED_MESSAGE =
       "Updated MethodInvocationAuthorizer. New authorizer is: ";
   static final String AUTHORIZER_PARAMETERS_MESSAGE = " with parameters: ";
+  public static final String EMPTY_AUTHORIZER_ERROR =
+      "MethodInvocationAuthorizer class name must not be empty.";
   public static final String SECURITY_NOT_ENABLED_MESSAGE =
       "Integrated security is not enabled for this distributed system. Updating the method authorizer requires integrated security to be enabled.";
-  public static final String DEPRECATED_PROPERTY_ERROR =
-      "Deprecated System Property: \"" + GEMFIRE_PREFIX
-          + "QueryService.allowUntrustedMethodInvocation\" is set to TRUE. In order to use a MethodInvocationAuthorizer, this property must be FALSE or undefined.";
-  private static final long serialVersionUID = 7155576168386556341L;
-
-  @Override
-  @SuppressWarnings("unchecked")
-  public CliFunctionResult executeFunction(FunctionContext<Object[]> context) {
-
-    String authorizerName = (String) context.getArguments()[0];
-    Set<String> parameterSet;
-
-    if (context.getArguments()[1] != null) {
-      parameterSet = (Set<String>) context.getArguments()[1];
-    } else {
-      parameterSet = new HashSet<>();
-    }
-
-    if (authorizerName != null) {
-      if (!isSecurityEnabled()) {
-        return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
-            SECURITY_NOT_ENABLED_MESSAGE);
-      }
-      if (Boolean.parseBoolean(
-          System.getProperty(GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation"))) {
-        return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
-            DEPRECATED_PROPERTY_ERROR);
-      }
-      try {
-        Cache cache = context.getCache();
-        ((InternalCache) cache)
-            .getService(org.apache.geode.cache.query.internal.QueryConfigurationService.class)
-            .updateMethodAuthorizer(cache, authorizerName, parameterSet);
-      } catch (Exception ex) {
-        return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
-            ex.getMessage());
-      }
-    }
-    String message = AUTHORIZER_UPDATED_MESSAGE + authorizerName + (parameterSet.size() > 0
-        ? AUTHORIZER_PARAMETERS_MESSAGE + String.join(", ", parameterSet) : "");
-    return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.OK,
-        message);
-  }
+  public static final String DEPRECATED_PROPERTY_ERROR = "Deprecated System Property: \""
+      + ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY
+      + "\" is set to TRUE. In order to use a MethodInvocationAuthorizer, this property must be FALSE or undefined.";
 
   boolean isSecurityEnabled() {
     return ((InternalCache) CacheFactory.getAnyInstance()).getSecurityService()
         .isIntegratedSecurity();
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "deprecation"})
+  public CliFunctionResult executeFunction(FunctionContext<Object[]> context) {
+    Set<String> parameterSet;
+    boolean forceUpdate = (boolean) context.getArguments()[0];
+    String authorizerName = (String) context.getArguments()[1];
+
+    if (context.getArguments()[2] != null) {
+      parameterSet = (Set<String>) context.getArguments()[2];
+    } else {
+      parameterSet = Collections.emptySet();
+    }
+
+    if (StringUtils.isEmpty(authorizerName)) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          EMPTY_AUTHORIZER_ERROR);
+    }
+
+    if (!isSecurityEnabled()) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          SECURITY_NOT_ENABLED_MESSAGE);
+    }
+
+    if (Boolean
+        .parseBoolean(System.getProperty(ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY))) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          DEPRECATED_PROPERTY_ERROR);
+    }
+
+    try {
+      Cache cache = context.getCache();
+      ((InternalCache) cache).getService(QueryConfigurationService.class)
+          .updateMethodAuthorizer(cache, forceUpdate, authorizerName, parameterSet);
+    } catch (Exception ex) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          ex.getMessage());
+    }
+
+    String message = AUTHORIZER_UPDATED_MESSAGE + authorizerName + (parameterSet.size() > 0
+        ? AUTHORIZER_PARAMETERS_MESSAGE + String.join(", ", parameterSet) : "");
+    return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.OK,
+        message);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImplTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.cache.query.internal;
 import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY;
 import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.CONTINUOUS_QUERIES_RUNNING_MESSAGE;
 import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.INTERFACE_NOT_IMPLEMENTED_MESSAGE;
+import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.NULL_CACHE_ERROR_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -95,7 +96,7 @@ public class QueryConfigurationServiceImplTest {
   public void initThrowsExceptionWhenCacheIsNull() {
     assertThatThrownBy(() -> configService.init(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cache must not be null");
+        .hasMessage(NULL_CACHE_ERROR_MESSAGE);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImplTest.java
@@ -14,14 +14,21 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY;
+import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.CONTINUOUS_QUERIES_RUNNING_MESSAGE;
 import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.INTERFACE_NOT_IMPLEMENTED_MESSAGE;
-import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,9 +36,13 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runner.RunWith;
 
+import org.apache.geode.cache.query.internal.cq.CqService;
+import org.apache.geode.cache.query.internal.cq.ServerCQ;
 import org.apache.geode.cache.query.security.JavaBeanAccessorMethodAuthorizer;
 import org.apache.geode.cache.query.security.MethodInvocationAuthorizer;
 import org.apache.geode.cache.query.security.RegExMethodAuthorizer;
@@ -43,26 +54,52 @@ import org.apache.geode.internal.security.SecurityService;
 
 @RunWith(JUnitParamsRunner.class)
 public class QueryConfigurationServiceImplTest {
+  private static final Set<String> EMPTY_SET = Collections.emptySet();
+  private CqService mockCqService;
   private InternalCache mockCache;
   private SecurityService mockSecurity;
   private QueryConfigurationServiceImpl configService;
 
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
   @Before
   public void setUp() {
-    mockCache = mock(InternalCache.class);
+    mockCqService = mock(CqService.class);
+    when(mockCqService.getAllCqs()).thenReturn(Collections.emptyList());
+
     mockSecurity = mock(SecurityService.class);
-    when(mockCache.getSecurityService()).thenReturn(mockSecurity);
     configService = spy(new QueryConfigurationServiceImpl());
+
+    mockCache = mock(InternalCache.class);
+    when(mockCache.getCqService()).thenReturn(mockCqService);
+    when(mockCache.getSecurityService()).thenReturn(mockSecurity);
+  }
+
+  @SuppressWarnings("unused")
+  private Object[] getMethodAuthorizerClasses() {
+    return new Object[] {
+        RegExMethodAuthorizer.class,
+        RestrictedMethodAuthorizer.class,
+        UnrestrictedMethodAuthorizer.class,
+        JavaBeanAccessorMethodAuthorizer.class,
+    };
+  }
+
+  @SuppressWarnings("deprecation")
+  private void setAllowUntrustedMethodInvocationSystemProperty() {
+    System.setProperty(ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY, "true");
   }
 
   @Test
   public void initThrowsExceptionWhenCacheIsNull() {
     assertThatThrownBy(() -> configService.init(null))
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cache must not be null");
   }
 
   @Test
-  public void queryConfigurationServiceUsesNoOpAuthorizerWithSecurityDisabled() {
+  public void initSetsNoOpAuthorizerWhenSecurityDisabled() {
     when(mockSecurity.isIntegratedSecurity()).thenReturn(false);
     configService.init(mockCache);
     assertThat(configService.getMethodAuthorizer())
@@ -70,22 +107,17 @@ public class QueryConfigurationServiceImplTest {
   }
 
   @Test
-  public void queryConfigurationServiceUsesNoOpAuthorizerWhenSystemPropertyIsSet() {
-    String propertyKey = GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation";
-    try {
-      System.setProperty(propertyKey, "true");
-      configService = new QueryConfigurationServiceImpl();
-      when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
-      configService.init(mockCache);
-      assertThat(configService.getMethodAuthorizer())
-          .isSameAs(QueryConfigurationServiceImpl.getNoOpAuthorizer());
-    } finally {
-      System.clearProperty(propertyKey);
-    }
+  public void initSetsNoOpAuthorizerWhenSystemPropertyIsSet() {
+    setAllowUntrustedMethodInvocationSystemProperty();
+    configService = new QueryConfigurationServiceImpl();
+    when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
+    configService.init(mockCache);
+    assertThat(configService.getMethodAuthorizer())
+        .isSameAs(QueryConfigurationServiceImpl.getNoOpAuthorizer());
   }
 
   @Test
-  public void queryConfigurationServiceUsesRestrictedMethodAuthorizerWhenSecurityIsEnabled() {
+  public void initSetsRestrictedMethodAuthorizerWhenSecurityIsEnabledAndSystemPropertyIsNotSet() {
     when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
     configService.init(mockCache);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
@@ -95,48 +127,37 @@ public class QueryConfigurationServiceImplTest {
   public void updateMethodAuthorizerDoesNothingWhenSecurityIsDisabled() {
     when(mockSecurity.isIntegratedSecurity()).thenReturn(false);
     configService.init(mockCache);
-
     MethodInvocationAuthorizer authorizer = configService.getMethodAuthorizer();
-
     assertThat(authorizer).isSameAs(QueryConfigurationServiceImpl.getNoOpAuthorizer());
 
-    configService.updateMethodAuthorizer(mockCache,
-        RestrictedMethodAuthorizer.class.getName(), new HashSet<>());
-
+    configService.updateMethodAuthorizer(mockCache, false,
+        RestrictedMethodAuthorizer.class.getName(), EMPTY_SET);
     assertThat(configService.getMethodAuthorizer()).isSameAs(authorizer);
   }
 
   @Test
   public void updateMethodAuthorizerDoesNothingWhenSystemPropertyIsSet() {
-    String propertyKey = GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation";
-    try {
-      System.setProperty(propertyKey, "true");
-      configService = new QueryConfigurationServiceImpl();
-      when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
-      configService.init(mockCache);
+    setAllowUntrustedMethodInvocationSystemProperty();
+    configService = new QueryConfigurationServiceImpl();
+    when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
+    configService.init(mockCache);
 
-      MethodInvocationAuthorizer authorizer = configService.getMethodAuthorizer();
+    MethodInvocationAuthorizer authorizer = configService.getMethodAuthorizer();
+    assertThat(authorizer).isSameAs(QueryConfigurationServiceImpl.getNoOpAuthorizer());
 
-      assertThat(authorizer).isSameAs(QueryConfigurationServiceImpl.getNoOpAuthorizer());
-
-      configService.updateMethodAuthorizer(mockCache,
-          RestrictedMethodAuthorizer.class.getName(), new HashSet<>());
-
-      assertThat(configService.getMethodAuthorizer()).isSameAs(authorizer);
-    } finally {
-      System.clearProperty(propertyKey);
-    }
+    configService.updateMethodAuthorizer(mockCache, false,
+        RestrictedMethodAuthorizer.class.getName(), EMPTY_SET);
+    assertThat(configService.getMethodAuthorizer()).isSameAs(authorizer);
   }
 
   @Test
   @TestCaseName("{method} Authorizer={0}")
   @Parameters(method = "getMethodAuthorizerClasses")
   public void updateMethodAuthorizerSetsCorrectAuthorizer(Class methodAuthorizerClass) {
-
     when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
 
-    configService.updateMethodAuthorizer(mockCache, methodAuthorizerClass.getName(),
-        new HashSet<>());
+    configService.updateMethodAuthorizer(mockCache, false, methodAuthorizerClass.getName(),
+        EMPTY_SET);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(methodAuthorizerClass);
   }
 
@@ -150,10 +171,8 @@ public class QueryConfigurationServiceImplTest {
     parameters.add(testParam1);
     parameters.add(testParam2);
 
-    configService.updateMethodAuthorizer(mockCache, testAuthorizerName, parameters);
-
+    configService.updateMethodAuthorizer(mockCache, false, testAuthorizerName, parameters);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(TestMethodAuthorizer.class);
-
     TestMethodAuthorizer methodAuthorizer =
         (TestMethodAuthorizer) configService.getMethodAuthorizer();
     assertThat(methodAuthorizer.getParameters()).isEqualTo(parameters);
@@ -166,7 +185,7 @@ public class QueryConfigurationServiceImplTest {
     configService.init(mockCache);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
     assertThatThrownBy(
-        () -> configService.updateMethodAuthorizer(mockCache, null, new HashSet<>()))
+        () -> configService.updateMethodAuthorizer(mockCache, false, null, EMPTY_SET))
             .isInstanceOf(QueryConfigurationServiceException.class);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
   }
@@ -179,7 +198,7 @@ public class QueryConfigurationServiceImplTest {
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
     String className = "FakeClassName";
     assertThatThrownBy(
-        () -> configService.updateMethodAuthorizer(mockCache, className, new HashSet<>()))
+        () -> configService.updateMethodAuthorizer(mockCache, false, className, EMPTY_SET))
             .isInstanceOf(QueryConfigurationServiceException.class);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
   }
@@ -191,39 +210,60 @@ public class QueryConfigurationServiceImplTest {
     configService.init(mockCache);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
     String className = this.getClass().getName();
-    try {
-      configService.updateMethodAuthorizer(mockCache,
-          className, new HashSet<>());
-    } catch (Exception expectedException) {
-      assertThat(expectedException.getCause())
-          .isInstanceOf(QueryConfigurationServiceException.class)
-          .hasMessage(String.format(INTERFACE_NOT_IMPLEMENTED_MESSAGE, className,
-              MethodInvocationAuthorizer.class.getName()));
-    }
+    assertThatThrownBy(
+        () -> configService.updateMethodAuthorizer(mockCache, false, className, EMPTY_SET))
+            .hasCauseInstanceOf(QueryConfigurationServiceException.class)
+            .hasStackTraceContaining(String.format(INTERFACE_NOT_IMPLEMENTED_MESSAGE, className,
+                MethodInvocationAuthorizer.class.getName()));
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
   }
 
   @Test
   public void updateMethodAuthorizerDoesNotChangeMethodAuthorizerWhenSecurityIsEnabledAndSpecifiedClassCannotBeInstantiated() {
     when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
-
     when(mockCache.isClosed()).thenThrow(new RuntimeException("Test exception"));
 
     configService.init(mockCache);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
-    assertThatThrownBy(
-        () -> configService.updateMethodAuthorizer(mockCache, TestMethodAuthorizer.class.getName(),
-            new HashSet<>())).isInstanceOf(QueryConfigurationServiceException.class);
+    assertThatThrownBy(() -> configService.updateMethodAuthorizer(mockCache, false,
+        TestMethodAuthorizer.class.getName(), EMPTY_SET))
+            .isInstanceOf(QueryConfigurationServiceException.class);
     assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
   }
 
-  @SuppressWarnings("unused")
-  private Object[] getMethodAuthorizerClasses() {
-    return new Object[] {
-        RestrictedMethodAuthorizer.class,
-        UnrestrictedMethodAuthorizer.class,
-        JavaBeanAccessorMethodAuthorizer.class,
-        RegExMethodAuthorizer.class
-    };
+  @Test
+  @TestCaseName("{method} Authorizer={0}")
+  @Parameters(method = "getMethodAuthorizerClasses")
+  public void updateMethodAuthorizerDoesNotChangeMethodAuthorizerAndThrowsExceptionWhenCqsAreRunningAndForceUpdateFlagIsSetAsFalse(
+      Class methodAuthorizerClass) {
+    when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
+    doReturn(Collections.singletonList(mock(ServerCQ.class))).when(mockCqService).getAllCqs();
+    configService.init(mockCache);
+    assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
+
+    assertThatThrownBy(() -> configService.updateMethodAuthorizer(mockCache, false,
+        methodAuthorizerClass.getName(), EMPTY_SET))
+            .isInstanceOf(QueryConfigurationServiceException.class)
+            .hasMessage(CONTINUOUS_QUERIES_RUNNING_MESSAGE);
+    assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
+  }
+
+  @Test
+  @TestCaseName("{method} Authorizer={0}")
+  @Parameters(method = "getMethodAuthorizerClasses")
+  public void updateMethodAuthorizerChangesMethodAuthorizerAndInvalidatesCqsCacheWhenCqsAreRunningAndForceUpdateFlagIsSetAsTrue(
+      Class methodAuthorizerClass) {
+    ServerCQ serverCQ1 = mock(ServerCQ.class);
+    ServerCQ serverCQ2 = mock(ServerCQ.class);
+    when(mockSecurity.isIntegratedSecurity()).thenReturn(true);
+    doReturn(Arrays.asList(serverCQ1, serverCQ2)).when(mockCqService).getAllCqs();
+    configService.init(mockCache);
+    assertThat(configService.getMethodAuthorizer()).isInstanceOf(RestrictedMethodAuthorizer.class);
+
+    assertThatCode(() -> configService.updateMethodAuthorizer(mockCache, true,
+        methodAuthorizerClass.getName(), EMPTY_SET)).doesNotThrowAnyException();
+    assertThat(configService.getMethodAuthorizer()).isInstanceOf(methodAuthorizerClass);
+    verify(serverCQ1, times(1)).invalidateCqResultKeys();
+    verify(serverCQ2, times(1)).invalidateCqResultKeys();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandTest.java
@@ -14,12 +14,11 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.AUTHORIZER_NAME;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.AUTHORIZER_PARAMETERS;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.COMMAND_NAME;
-import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.METHOD_AUTHORIZER_NAME;
-import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.NO_ARGUMENTS_MESSAGE;
+import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.FORCE_UPDATE;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.NO_MEMBERS_FOUND_MESSAGE;
-import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.PARAMETERS_WITHOUT_AUTHORIZER_MESSAGE;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.PARTIAL_FAILURE_MESSAGE;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.SPLITTING_REGEX;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +37,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -50,163 +50,191 @@ import org.apache.geode.cache.query.security.RegExMethodAuthorizer;
 import org.apache.geode.cache.query.security.UnrestrictedMethodAuthorizer;
 import org.apache.geode.distributed.ConfigurationPersistenceService;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.AlterQueryServiceFunction;
 import org.apache.geode.management.internal.cli.functions.CliFunctionResult;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 
 public class AlterQueryServiceCommandTest {
+  private Set<DistributedMember> members;
+  private AlterQueryServiceCommand command;
+  private QueryConfigService mockQueryConfigService;
 
   @ClassRule
   public static GfshParserRule gfsh = new GfshParserRule();
 
-  private AlterQueryServiceCommand command;
-  private Set<DistributedMember> mockMemberSet;
-  private QueryConfigService mockQueryConfigService;
-
   @Before
-  @SuppressWarnings("unchecked")
   public void setup() {
+    members = new HashSet<>();
     command = spy(new AlterQueryServiceCommand());
-    mockMemberSet = mock(HashSet.class);
     mockQueryConfigService = mock(QueryConfigService.class);
+
+    doReturn(members).when(command).findMembers(null, null);
+  }
+
+  private void mockMembers(int amount, String memberNamePreffix) {
+    IntStream.range(0, amount).forEach(i -> {
+      DistributedMember mockMember = mock(DistributedMember.class);
+      when(mockMember.getName()).thenReturn(memberNamePreffix + i);
+      members.add(mockMember);
+    });
+  }
+
+  private String buildCommandString(String authorizerName, String authorizerParameters,
+      Boolean forceUpdate) {
+    StringBuilder commandBuilder = new StringBuilder(COMMAND_NAME);
+    commandBuilder.append(" --").append(AUTHORIZER_NAME).append("=").append(authorizerName);
+
+    if (authorizerParameters != null) {
+      commandBuilder.append(" --").append(AUTHORIZER_PARAMETERS).append("=")
+          .append(authorizerParameters);
+    }
+
+    if (forceUpdate != null) {
+      commandBuilder.append(" --").append(FORCE_UPDATE).append("=").append(forceUpdate);
+    }
+
+    return commandBuilder.toString();
   }
 
   @Test
-  public void commandReturnsCorrectMessageWithNoOptions() {
+  public void commandParsesForceUpdateCorrectly() {
+    GfshParseResult noForceUpdate =
+        gfsh.parse(COMMAND_NAME + " --" + AUTHORIZER_NAME + "=MyAuthorizer");
+    assertThat(noForceUpdate.getCommandName()).isEqualTo(COMMAND_NAME);
+    assertThat(noForceUpdate.getParamValue(AUTHORIZER_NAME)).isEqualTo("MyAuthorizer");
+    assertThat(noForceUpdate.getParamValue(FORCE_UPDATE)).isEqualTo(false);
+
+    GfshParseResult forceUpdateWithoutValue =
+        gfsh.parse(COMMAND_NAME + " --" + AUTHORIZER_NAME + "=MyAuthorizer --" + FORCE_UPDATE);
+    assertThat(forceUpdateWithoutValue.getCommandName()).isEqualTo(COMMAND_NAME);
+    assertThat(forceUpdateWithoutValue.getParamValue(AUTHORIZER_NAME)).isEqualTo("MyAuthorizer");
+    assertThat(forceUpdateWithoutValue.getParamValue(FORCE_UPDATE)).isEqualTo(true);
+
+    GfshParseResult forceUpdateAsFalse = gfsh.parse(
+        COMMAND_NAME + " --" + AUTHORIZER_NAME + "=MyAuthorizer --" + FORCE_UPDATE + "=false");
+    assertThat(forceUpdateAsFalse.getCommandName()).isEqualTo(COMMAND_NAME);
+    assertThat(forceUpdateAsFalse.getParamValue(AUTHORIZER_NAME)).isEqualTo("MyAuthorizer");
+    assertThat(forceUpdateAsFalse.getParamValue(FORCE_UPDATE)).isEqualTo(false);
+
+    GfshParseResult forceUpdateAsTrue = gfsh.parse(
+        COMMAND_NAME + " --" + AUTHORIZER_NAME + "=MyAuthorizer --" + FORCE_UPDATE + "=true");
+    assertThat(forceUpdateAsTrue.getCommandName()).isEqualTo(COMMAND_NAME);
+    assertThat(forceUpdateAsTrue.getParamValue(AUTHORIZER_NAME)).isEqualTo("MyAuthorizer");
+    assertThat(forceUpdateAsTrue.getParamValue(FORCE_UPDATE)).isEqualTo(true);
+
+  }
+
+  @Test
+  public void commandShouldReturnErrorWhenMandatoryParameterIsNotSet() {
     gfsh.executeAndAssertThat(command, COMMAND_NAME).statusIsError()
-        .containsOutput(NO_ARGUMENTS_MESSAGE);
-  }
-
-  @Test
-  public void commandReturnsErrorWhenAuthorizerParametersAreSpecifiedAndAuthorizerNameIsUnspecified() {
-    gfsh.executeAndAssertThat(command,
-        COMMAND_NAME + " --" + AUTHORIZER_PARAMETERS + "=param1;param2")
-        .statusIsError().containsOutput(PARAMETERS_WITHOUT_AUTHORIZER_MESSAGE);
+        .containsOutput("Invalid command");
   }
 
   @Test
   public void commandReturnsCorrectMessageWhenMethodAuthorizerIsSpecifiedAndNoMembersAreFound() {
-    doReturn(mockMemberSet).when(command).findMembers(null, null);
-    when(mockMemberSet.size()).thenReturn(0);
-    gfsh.executeAndAssertThat(command,
-        COMMAND_NAME + " --" + METHOD_AUTHORIZER_NAME + "="
-            + UnrestrictedMethodAuthorizer.class.getName())
-        .statusIsSuccess().containsOutput(NO_MEMBERS_FOUND_MESSAGE);
+    String commandString =
+        buildCommandString(UnrestrictedMethodAuthorizer.class.getName(), null, null);
+
+    gfsh.executeAndAssertThat(command, commandString).statusIsSuccess()
+        .containsOutput(NO_MEMBERS_FOUND_MESSAGE);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void commandReturnsCorrectResultModelWhenMethodAuthorizerIsSpecified() {
-    doReturn(mockMemberSet).when(command).findMembers(null, null);
-    when(mockMemberSet.size()).thenReturn(1);
-
-    doReturn(mockQueryConfigService).when(command).getQueryConfigService();
-    doNothing().when(command).populateMethodAuthorizer(any(String.class), any(Set.class), any(
-        QueryConfigService.class));
-
-    List<CliFunctionResult> resultList = new ArrayList<>();
     String memberName = "memberName";
+    mockMembers(1, memberName);
+    doReturn(mockQueryConfigService).when(command).getQueryConfigService();
+    doNothing().when(command).populateMethodAuthorizer(any(), any(), any());
+    List<CliFunctionResult> resultList = new ArrayList<>();
     resultList.add(new CliFunctionResult(memberName, CliFunctionResult.StatusState.OK, ""));
-    doReturn(resultList).when(command).executeAndGetFunctionResult(any(
-        AlterQueryServiceFunction.class), any(Object[].class), eq(mockMemberSet));
-
+    doReturn(resultList).when(command).executeAndGetFunctionResult(any(), any(), any());
+    String authorizerName = RegExMethodAuthorizer.class.getName();
     String parameterString = "^java.util.List..{4,8}$;^java.util.Set..{4,8}$";
     Set<String> expectedParameterSet =
         new HashSet<>(Arrays.asList(parameterString.split(SPLITTING_REGEX)));
-    String authorizerName = RegExMethodAuthorizer.class.getName();
-    gfsh.executeAndAssertThat(command, COMMAND_NAME + " --" + METHOD_AUTHORIZER_NAME + "="
-        + authorizerName + " --" + AUTHORIZER_PARAMETERS + "=" + parameterString)
-        .statusIsSuccess().containsOutput(memberName);
-    verify(command).populateMethodAuthorizer(eq(authorizerName), eq(expectedParameterSet),
-        eq(mockQueryConfigService));
+    String commandString = buildCommandString(authorizerName, parameterString, null);
+
+    gfsh.executeAndAssertThat(command, commandString).statusIsSuccess().containsOutput(memberName);
+    verify(command).populateMethodAuthorizer(authorizerName, expectedParameterSet,
+        mockQueryConfigService);
+    verify(command).executeAndGetFunctionResult(any(AlterQueryServiceFunction.class),
+        eq(new Object[] {false, authorizerName, expectedParameterSet}), eq(members));
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void commandReturnsCorrectResultModelWhenCliResultListIsPartialFailure() {
-    doReturn(mockMemberSet).when(command).findMembers(null, null);
-    when(mockMemberSet.size()).thenReturn(2);
-
+    String memberName = "name";
+    mockMembers(2, memberName);
     doReturn(mockQueryConfigService).when(command).getQueryConfigService();
-    doNothing().when(command).populateMethodAuthorizer(any(String.class), any(Set.class), any(
-        QueryConfigService.class));
-
+    doNothing().when(command).populateMethodAuthorizer(any(), any(), any());
     List<CliFunctionResult> resultList = new ArrayList<>();
-    String memberName = "memberName";
     resultList.add(new CliFunctionResult(memberName + 1, CliFunctionResult.StatusState.OK, ""));
     resultList.add(new CliFunctionResult(memberName + 2, CliFunctionResult.StatusState.ERROR, ""));
-    doReturn(resultList).when(command).executeAndGetFunctionResult(any(
-        AlterQueryServiceFunction.class), any(Object[].class), eq(mockMemberSet));
+    doReturn(resultList).when(command).executeAndGetFunctionResult(any(), any(), any());
+    String commandString =
+        buildCommandString(UnrestrictedMethodAuthorizer.class.getName(), null, true);
 
-    gfsh.executeAndAssertThat(command,
-        COMMAND_NAME + " --" + METHOD_AUTHORIZER_NAME + "="
-            + UnrestrictedMethodAuthorizer.class.getName())
-        .statusIsSuccess().containsOutput(PARTIAL_FAILURE_MESSAGE);
+    gfsh.executeAndAssertThat(command, commandString).statusIsSuccess()
+        .containsOutput(PARTIAL_FAILURE_MESSAGE);
+    verify(command).executeAndGetFunctionResult(any(AlterQueryServiceFunction.class),
+        eq(new Object[] {true, UnrestrictedMethodAuthorizer.class.getName(), new HashSet<>()}),
+        eq(members));
   }
 
   @Test
   public void populateMethodAuthorizerSetsAuthorizerNameAndParameters() {
     String authorizerName = "authorizerName";
-    Set<String> parameters = new HashSet<>();
-    parameters.add("param1");
-    parameters.add("param2");
     QueryConfigService queryConfigService = new QueryConfigService();
-
+    Set<String> parameters = new HashSet<>(Arrays.asList("param1", "param2"));
     command.populateMethodAuthorizer(authorizerName, parameters, queryConfigService);
 
-    QueryConfigService.MethodAuthorizer methodAuthorizer =
-        queryConfigService.getMethodAuthorizer();
+    QueryConfigService.MethodAuthorizer methodAuthorizer = queryConfigService.getMethodAuthorizer();
     assertThat(methodAuthorizer.getClassName()).isEqualTo(authorizerName);
     assertThat(methodAuthorizer.getParameters().size()).isEqualTo(parameters.size());
-    assertThat(methodAuthorizer.getParameters().stream().map(p -> p.getParameterValue())
+    assertThat(methodAuthorizer.getParameters().stream()
+        .map(QueryConfigService.MethodAuthorizer.Parameter::getParameterValue)
         .collect(Collectors.toSet())).isEqualTo(parameters);
   }
 
   @Test
   public void getQueryConfigurationServiceReturnsExistingQueryConfigService() {
-    ConfigurationPersistenceService mockConfigPersistenceService =
-        mock(ConfigurationPersistenceService.class);
     CacheConfig mockCacheConfig = mock(CacheConfig.class);
     QueryConfigService mockQueryConfigService = mock(QueryConfigService.class);
-
+    ConfigurationPersistenceService mockConfigPersistenceService =
+        mock(ConfigurationPersistenceService.class);
     doReturn(mockConfigPersistenceService).when(command).getConfigurationPersistenceService();
     when(mockConfigPersistenceService.getCacheConfig(null)).thenReturn(mockCacheConfig);
-    when(mockCacheConfig.findCustomCacheElement(
-        QueryConfigService.ELEMENT_ID, QueryConfigService.class))
-            .thenReturn(mockQueryConfigService);
+    when(mockCacheConfig.findCustomCacheElement(QueryConfigService.ELEMENT_ID,
+        QueryConfigService.class)).thenReturn(mockQueryConfigService);
 
     assertThat(command.getQueryConfigService()).isSameAs(mockQueryConfigService);
   }
 
   @Test
   public void getQueryConfigurationServiceReturnsNewQueryConfigServiceWhenNoExistingServiceIsFound() {
+    CacheConfig mockCacheConfig = mock(CacheConfig.class);
     ConfigurationPersistenceService mockConfigPersistenceService =
         mock(ConfigurationPersistenceService.class);
-    CacheConfig mockCacheConfig = mock(CacheConfig.class);
-
     doReturn(mockConfigPersistenceService).when(command).getConfigurationPersistenceService();
     when(mockConfigPersistenceService.getCacheConfig(null)).thenReturn(mockCacheConfig);
-    when(mockCacheConfig.findCustomCacheElement(
-        QueryConfigService.ELEMENT_ID, QueryConfigService.class)).thenReturn(null);
+    when(mockCacheConfig.findCustomCacheElement(QueryConfigService.ELEMENT_ID,
+        QueryConfigService.class)).thenReturn(null);
 
-    assertThat(command.getQueryConfigService())
-        .isInstanceOf(QueryConfigService.class);
+    assertThat(command.getQueryConfigService()).isInstanceOf(QueryConfigService.class);
   }
 
   @Test
   public void updateConfigForGroupReplacesExistingElementWithNewElement() {
     CacheConfig mockCacheConfig = mock(CacheConfig.class);
-    QueryConfigService existingConfigService = mock(QueryConfigService.class);
     QueryConfigService newConfigService = mock(QueryConfigService.class);
-
+    QueryConfigService existingConfigService = mock(QueryConfigService.class);
     List<CacheElement> elements = new ArrayList<>();
     elements.add(existingConfigService);
-
     when(mockCacheConfig.getCustomCacheElements()).thenReturn(elements);
 
     assertThat(elements.size()).isEqualTo(1);
     assertThat(command.updateConfigForGroup(null, mockCacheConfig, newConfigService)).isTrue();
-
     assertThat(elements.size()).isEqualTo(1);
     assertThat(elements.get(0)).isSameAs(newConfigService);
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/AlterQueryServiceFunctionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/cli/functions/AlterQueryServiceFunctionTest.java
@@ -15,92 +15,101 @@
 
 package org.apache.geode.management.internal.cli.functions;
 
-import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY;
 import static org.apache.geode.management.internal.cli.functions.AlterQueryServiceFunction.AUTHORIZER_PARAMETERS_MESSAGE;
 import static org.apache.geode.management.internal.cli.functions.AlterQueryServiceFunction.AUTHORIZER_UPDATED_MESSAGE;
 import static org.apache.geode.management.internal.cli.functions.AlterQueryServiceFunction.DEPRECATED_PROPERTY_ERROR;
+import static org.apache.geode.management.internal.cli.functions.AlterQueryServiceFunction.EMPTY_AUTHORIZER_ERROR;
 import static org.apache.geode.management.internal.cli.functions.AlterQueryServiceFunction.SECURITY_NOT_ENABLED_MESSAGE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.query.internal.QueryConfigurationService;
 import org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl;
 import org.apache.geode.internal.cache.InternalCache;
 
 public class AlterQueryServiceFunctionTest {
-
-  private AlterQueryServiceFunction function = spy(new AlterQueryServiceFunction());
-  @SuppressWarnings("unchecked")
-  private FunctionContext<Object[]> mockContext = mock(FunctionContext.class);
+  private final String PARAMETER1 = "paramValue1";
+  private final String PARAMETER2 = "paramValue2";
   private final String AUTHORIZER_NAME = "authorizerName";
-  private final String PARAMETER_VALUE1 = "paramValue1";
-  private final String PARAMETER_VALUE2 = "paramValue2";
-  private QueryConfigurationServiceImpl mockQueryConfigService =
-      mock(QueryConfigurationServiceImpl.class);
-  private InternalCache mockCache = mock(InternalCache.class);
+  private final Set<String> parameterSet = new HashSet<>(Arrays.asList(PARAMETER1, PARAMETER2));
+  private InternalCache mockCache;
+  private AlterQueryServiceFunction function;
+  private FunctionContext<Object[]> mockContext;
+  private QueryConfigurationServiceImpl mockQueryConfigService;
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @SuppressWarnings("deprecation")
+  private void setAllowUntrustedMethodInvocationSystemProperty() {
+    System.setProperty(ALLOW_UNTRUSTED_METHOD_INVOCATION_SYSTEM_PROPERTY, "true");
+  }
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setUp() {
-    Set<String> parameterSet = new HashSet<>();
-    parameterSet.add(PARAMETER_VALUE1);
-    parameterSet.add(PARAMETER_VALUE2);
-    Object[] arguments = new Object[] {AUTHORIZER_NAME, parameterSet};
-    when(mockContext.getArguments()).thenReturn(arguments);
+    mockCache = mock(InternalCache.class);
+    mockQueryConfigService = mock(QueryConfigurationServiceImpl.class);
+    when(mockCache.getService(QueryConfigurationService.class)).thenReturn(mockQueryConfigService);
+
+    mockContext = mock(FunctionContext.class);
     when(mockContext.getCache()).thenReturn(mockCache);
-    when(mockCache.getService(any())).thenReturn(mockQueryConfigService);
+    when(mockContext.getArguments()).thenReturn(new Object[] {true, AUTHORIZER_NAME, parameterSet});
+
+    function = spy(new AlterQueryServiceFunction());
     doReturn(true).when(function).isSecurityEnabled();
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void executeFunctionUpdatesMethodAuthorizerAndReturnsMessageWhenAuthorizerNameIsNotNull() {
     CliFunctionResult result = function.executeFunction(mockContext);
-
     assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
-    assertThat(result.getStatusMessage()).contains(AUTHORIZER_UPDATED_MESSAGE + AUTHORIZER_NAME
-        + AUTHORIZER_PARAMETERS_MESSAGE).contains(PARAMETER_VALUE1).contains(PARAMETER_VALUE2);
-
-    verify(mockQueryConfigService).updateMethodAuthorizer(eq(mockCache), eq(AUTHORIZER_NAME),
-        any(Set.class));
+    assertThat(result.getStatusMessage())
+        .contains(AUTHORIZER_UPDATED_MESSAGE + AUTHORIZER_NAME + AUTHORIZER_PARAMETERS_MESSAGE)
+        .contains(PARAMETER1).contains(PARAMETER2);
+    verify(mockQueryConfigService).updateMethodAuthorizer(mockCache, true, AUTHORIZER_NAME,
+        parameterSet);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void executeFunctionUpdatesMethodAuthorizerAndReturnsMessageWhenAuthorizerNameIsNotNullAndThereAreNoParameters() {
-    when(mockContext.getArguments()).thenReturn(new Object[] {AUTHORIZER_NAME, null});
-    CliFunctionResult result = function.executeFunction(mockContext);
+    when(mockContext.getArguments()).thenReturn(new Object[] {false, AUTHORIZER_NAME, null});
 
+    CliFunctionResult result = function.executeFunction(mockContext);
     assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
     assertThat(result.getStatusMessage()).isEqualTo(AUTHORIZER_UPDATED_MESSAGE + AUTHORIZER_NAME);
-
-    verify(mockQueryConfigService).updateMethodAuthorizer(eq(mockCache), eq(AUTHORIZER_NAME),
-        any(Set.class));
+    verify(mockQueryConfigService).updateMethodAuthorizer(mockCache, false, AUTHORIZER_NAME,
+        Collections.emptySet());
   }
 
   @Test
-  public void executeFunctionDoesNotUpdateMethodAuthorizerWhenAuthorizerNameIsNull() {
-    Set<String> parameterSet = new HashSet<>();
-    parameterSet.add(PARAMETER_VALUE1);
-    parameterSet.add(PARAMETER_VALUE2);
-    when(mockContext.getArguments()).thenReturn(new Object[] {null, parameterSet});
-    CliFunctionResult result = function.executeFunction(mockContext);
+  public void executeFunctionReturnsErrorWhenAuthorizerNameIsNull() {
+    when(mockContext.getArguments()).thenReturn(new Object[] {false, null, Collections.emptySet()});
 
-    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
-    verify(mockQueryConfigService, times(0)).updateMethodAuthorizer(any(), any(), any());
+    CliFunctionResult result = function.executeFunction(mockContext);
+    verifyZeroInteractions(mockQueryConfigService);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage()).isEqualTo(EMPTY_AUTHORIZER_ERROR);
   }
 
   @Test
@@ -108,24 +117,19 @@ public class AlterQueryServiceFunctionTest {
     doReturn(false).when(function).isSecurityEnabled();
 
     CliFunctionResult result = function.executeFunction(mockContext);
-
+    verifyZeroInteractions(mockQueryConfigService);
     assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
     assertThat(result.getStatusMessage()).isEqualTo(SECURITY_NOT_ENABLED_MESSAGE);
-    verify(mockQueryConfigService, times(0)).updateMethodAuthorizer(any(), any(), any());
   }
 
   @Test
   public void executeFunctionReturnsErrorWhenDeprecatedSystemPropertyIsSet() {
-    try {
-      System.setProperty(GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation", "true");
-      CliFunctionResult result = function.executeFunction(mockContext);
+    setAllowUntrustedMethodInvocationSystemProperty();
 
-      assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
-      assertThat(result.getStatusMessage()).isEqualTo(DEPRECATED_PROPERTY_ERROR);
-      verify(mockQueryConfigService, times(0)).updateMethodAuthorizer(any(), any(), any());
-    } finally {
-      System.clearProperty(GEMFIRE_PREFIX + "QueryService.allowUntrustedMethodInvocation");
-    }
+    CliFunctionResult result = function.executeFunction(mockContext);
+    verifyZeroInteractions(mockQueryConfigService);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage()).isEqualTo(DEPRECATED_PROPERTY_ERROR);
   }
 
   @Test
@@ -133,17 +137,15 @@ public class AlterQueryServiceFunctionTest {
     when(mockContext.getCache()).thenReturn(null);
 
     CliFunctionResult result = function.executeFunction(mockContext);
-
     assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
   }
 
   @Test
   public void executeFunctionReturnsErrorWhenUpdateMethodAuthorizerThrowsException() {
     doThrow(new RuntimeException()).when(mockQueryConfigService).updateMethodAuthorizer(any(),
-        any(), any());
+        anyBoolean(), any(), any());
 
     CliFunctionResult result = function.executeFunction(mockContext);
-
     assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
   }
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandDistributedTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.CONTINUOUS_QUERIES_RUNNING_MESSAGE;
+import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.AUTHORIZER_NAME;
+import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.COMMAND_NAME;
+import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.FORCE_UPDATE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqQuery;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.internal.QueryConfigurationService;
+import org.apache.geode.cache.query.security.MethodInvocationAuthorizer;
+import org.apache.geode.cache.query.security.RestrictedMethodAuthorizer;
+import org.apache.geode.examples.SimpleSecurityManager;
+import org.apache.geode.security.query.TestCqListener;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@RunWith(JUnitParamsRunner.class)
+public class AlterQueryServiceCommandDistributedTest {
+  private static final String REPLICATE_REGION_NAME = "ReplicateRegion";
+  private static final String PARTITION_REGION_NAME = "PartitionRegion";
+  private static final Class DEFAULT_AUTHORIZER_CLASS = RestrictedMethodAuthorizer.class;
+  private MemberVM server;
+  private ClientVM client;
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Before
+  public void setUp() throws Exception {
+    MemberVM locator =
+        cluster.startLocatorVM(0, l -> l.withSecurityManager(SimpleSecurityManager.class));
+    int locatorPort = locator.getPort();
+    server = cluster.startServerVM(1,
+        s -> s.withConnectionToLocator(locatorPort).withCredential("cluster", "cluster"));
+
+    gfsh.connectAndVerify(locator);
+    gfsh.executeAndAssertThat("create region --name=" + REPLICATE_REGION_NAME + " --type=REPLICATE")
+        .statusIsSuccess();
+    gfsh.executeAndAssertThat("create region --name=" + PARTITION_REGION_NAME + " --type=PARTITION")
+        .statusIsSuccess();
+    locator.invoke(() -> {
+      ClusterStartupRule.memberStarter
+          .waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REPLICATE_REGION_NAME, 1);
+      ClusterStartupRule.memberStarter
+          .waitUntilRegionIsReadyOnExactlyThisManyServers("/" + PARTITION_REGION_NAME, 1);
+    });
+
+    client = cluster.startClientVM(2, ccf -> ccf.withCredential("data", "data")
+        .withPoolSubscription(true).withLocatorConnection(locatorPort));
+  }
+
+  @SuppressWarnings("unused")
+  private Object[] getRegionNameAndCqExecutionType() {
+    return new Object[] {
+        new Object[] {REPLICATE_REGION_NAME, true},
+        new Object[] {REPLICATE_REGION_NAME, false},
+        new Object[] {PARTITION_REGION_NAME, true},
+        new Object[] {PARTITION_REGION_NAME, false},
+    };
+  }
+
+  private String buildCommand(String authorizerName, Boolean forceUpdate) {
+    StringBuilder commandBuilder = new StringBuilder(COMMAND_NAME);
+    commandBuilder.append(" --").append(AUTHORIZER_NAME).append("=").append(authorizerName);
+
+    if (forceUpdate != null) {
+      commandBuilder.append(" --").append(FORCE_UPDATE).append("=").append(forceUpdate);
+    }
+
+    return commandBuilder.toString();
+  }
+
+  private void verifyCurrentAuthorizerClass(Class authorizerClass) {
+    server.invoke(() -> {
+      MethodInvocationAuthorizer methodAuthorizer =
+          Objects.requireNonNull(ClusterStartupRule.getCache())
+              .getService(QueryConfigurationService.class).getMethodAuthorizer();
+      assertThat(methodAuthorizer.getClass()).isEqualTo(authorizerClass);
+    });
+  }
+
+  private void createClientCq(String queryString, boolean executeWithInitialResults) {
+    client.invoke(() -> {
+      TestCqListener cqListener = new TestCqListener();
+      assertThat(ClusterStartupRule.getClientCache()).isNotNull();
+      QueryService queryService = ClusterStartupRule.getClientCache().getQueryService();
+      CqAttributesFactory cqAttributesFactory = new CqAttributesFactory();
+      cqAttributesFactory.addCqListener(cqListener);
+
+      CqQuery cq = queryService.newCq(queryString, cqAttributesFactory.create());
+      if (!executeWithInitialResults) {
+        cq.execute();
+      } else {
+        assertThat(cq.executeWithInitialResults().size()).isEqualTo(0);
+      }
+    });
+  }
+
+  @Test
+  @Parameters(method = "getRegionNameAndCqExecutionType")
+  @TestCaseName("[{index}] {method}(RegionName:{0};ExecuteWithInitialResults:{1})")
+  public void commandShouldFailWhenThereAreCqsRunningAndForceUpdateFlagIsFalse(String regionName,
+      boolean initialResults) {
+    verifyCurrentAuthorizerClass(DEFAULT_AUTHORIZER_CLASS);
+    createClientCq("SELECT * FROM /" + regionName, initialResults);
+    String command = buildCommand(DummyMethodAuthorizer.class.getName(), false);
+
+    gfsh.executeAndAssertThat(command).statusIsError()
+        .containsOutput(CONTINUOUS_QUERIES_RUNNING_MESSAGE);
+    verifyCurrentAuthorizerClass(DEFAULT_AUTHORIZER_CLASS);
+  }
+
+  @Test
+  @Parameters(method = "getRegionNameAndCqExecutionType")
+  @TestCaseName("[{index}] {method}(RegionName:{0};ExecuteWithInitialResults:{1})")
+  public void commandShouldSucceedWhenThereAreCqsRunningAndForceUpdateFlagIsTrue(String regionName,
+      boolean initialResults) {
+    verifyCurrentAuthorizerClass(DEFAULT_AUTHORIZER_CLASS);
+    createClientCq("SELECT * FROM /" + regionName, initialResults);
+    String command = buildCommand(DummyMethodAuthorizer.class.getName(), true);
+
+    gfsh.executeAndAssertThat(command).statusIsSuccess();
+    verifyCurrentAuthorizerClass(DummyMethodAuthorizer.class);
+  }
+
+  public static class DummyMethodAuthorizer implements MethodInvocationAuthorizer {
+    @Override
+    public boolean authorize(Method method, Object target) {
+      return true;
+    }
+  }
+}

--- a/geode-docs/tools_modules/gfsh/command-pages/alter.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/alter.html.md.erb
@@ -192,22 +192,23 @@ Alter configuration details of the query configuration service.
 **Syntax:**
 
 ``` pre
-alter query-service [--method-authorizer=value]
-    [--authorizer-parameters=value(;value)*]
+alter query-service --method-authorizer=value
+    [--authorizer-parameters=value(;value)*] [--force-update(=value)]
 ```
 
 **Parameters, alter query-service**
 
 | Name | Description |
 |------|-------------|
-| &#8209;&#8209;method-authorizer   | Fully qualified class name of the `MethodInvocationAuthorizer` to be used for query authorization. |
-| &#8209;&#8209;authorizer-parameters | A **semicolon-separated** list of parameters to be used by the specified `MethodInvocationAuthorizer`. This requires that a method-authorizer option has been specified. |
-
+| &#8209;&#8209;method-authorizer       | _Required._ Fully qualified class name of the `MethodInvocationAuthorizer` to be used for query authorization. |
+| &#8209;&#8209;authorizer-parameters   | A **semicolon-separated** list of parameters to be used by the specified `MethodInvocationAuthorizer`. This requires that a method-authorizer option has been specified. |
+| &#8209;&#8209;force-update            | Specifies whether to forcibly update the `MethodInvocationAuthorizer`, even when there are continuous queries registered in the member. Default (if the parameter is not specified): `false`. Default (if the parameter is specified without value): `true`. **Note:** when set as `true`, any registered CQ will pick up the new `MethodInvocationAuthorizer` and invalidate its internal cache; consider checking that the new `MethodInvocationAuthorizer` allows the methods invoked by the CQs before using this option. |
 
 **Example Commands:**
 
 ``` pre
 alter query-service --method-authorizer=org.apache.geode.cache.query.security.UnrestrictedMethodAuthorizer
+alter query-service --method-authorizer=org.apache.geode.cache.query.security.UnrestrictedMethodAuthorizer --force-update=true
 alter query-service --method-authorizer=org.apache.geode.cache.query.security.JavaBeanAccessorMethodAuthorizer --authorizer-parameters=java.lang;java.util
 ```
 


### PR DESCRIPTION
The QueryConfigurationService now requires an extra flag to determine,
in the presence of continuous queries, whether to update the configured
MethodInvocationAuthorizer and invalidate the CQ's internal cache or
throw an exception and abort the update.

- Fixed minor warnings.
- Added unit and distributed tests.
- Updated docs for alter query-service command.
- Added 'forceUpdate' flag to 'AlterQueryServiceFunction' and
  'AlterQueryServiceCommand'.
- Fixed 'AlterQueryServiceCommand' to always require the
  'method-authorizer' parameter.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
