### PR TITLE
GEODE-7212: Docs update of CLUSTER:MANAGE:QUERY for CqQuery.stop()

### DIFF
--- a/geode-docs/managing/security/implementing_authorization.html.md.erb
+++ b/geode-docs/managing/security/implementing_authorization.html.md.erb
@@ -104,7 +104,7 @@ a Client-Server interaction.
 | Region.put(key)                    | DATA:WRITE:RegionName:Key           |
 | Region.replace                     | DATA:WRITE:RegionName:Key           |
 | queryService.newCq                 | DATA:READ:RegionName                |
-| CqQuery.stop                       | DATA:MANAGE:QUERY                   |
+| CqQuery.stop                       | CLUSTER:MANAGE:QUERY                   |
 
 
 This table classifies the permissions assigned for `gfsh` operations.


### PR DESCRIPTION
The previous PR for this change contained an error.  New PR to correct the error. DATA:MANAGE:QUERY was incorrect.  CLUSTER:MANAGE:QUERY is the correct permission listed in our wiki.