### PR TITLE
GEODE-7522: always put version in REST wiki page title

### DIFF
--- a/geode-management/src/test/script/update-management-wiki.sh
+++ b/geode-management/src/test/script/update-management-wiki.sh
@@ -71,13 +71,13 @@ else
 fi
 
 
-GEODE_VERSION=$($GEODE/bin/gfsh version)
+GEODE_VERSION=$($GEODE/bin/gfsh version | sed 's/-SNAPSHOT//')
 [[ "${GEODE_VERSION%.*}" == "1.10" ]] && PAGE_ID=115511910
 [[ "${GEODE_VERSION%.*}" == "1.11" ]] && PAGE_ID=135861023
-[[ "${BRANCH}" == "develop" ]] && GEODE_VERSION=develop && PAGE_ID=132322415
+[[ "${GEODE_VERSION%.*}" == "1.12" ]] && PAGE_ID=132322415
 
 if [[ -z "${PAGE_ID}" ]] ; then
-    echo "Please create a new wiki page for $GEODE_VERSION and add its page ID to $0 near line 77"
+    echo "Please create a new wiki page for $GEODE_VERSION and add its page ID to $0 near line 78"
     exit 1
 fi
 
@@ -181,6 +181,7 @@ sed -e "s#/management${URI_VERSION}#${URI_VERSION}#g" -e "s#${URI_VERSION}#/mana
 # remove internal swagger endpoint id */*
 sed -e 's/ .<span class="nickname" style="font-weight:bold">[^<]*<.span>.//' |
 # remove Controller from endpoint categories
+sed -e 's/DocLinksController/Supported Versions/g' |
 sed -e 's/PingManagementController/Ping/g' |
 sed -e 's/ManagementController/ Management/g' |
 sed -e 's/OperationController/ Operation/g' |

--- a/geode-management/src/test/script/update-management-wiki.sh
+++ b/geode-management/src/test/script/update-management-wiki.sh
@@ -176,12 +176,12 @@ awk '
 ' |
 # combine duplicate model name+desc
 sed -e 's#pre;*">\([^<]*\)</code> - \1#pre">\1</code>#g' |
-# prepend /management to /v1 links
-sed -e "s#/management${URI_VERSION}#${URI_VERSION}#g" -e "s#${URI_VERSION}#/management${URI_VERSION}#g" |
+# prepend /management to /v1 and / links
+sed -e "s#/management${URI_VERSION}#${URI_VERSION}#g" -e "s#${URI_VERSION}#/management${URI_VERSION}#g" -e "s#GET /<#GET /management<#g" |
 # remove internal swagger endpoint id */*
 sed -e 's/ .<span class="nickname" style="font-weight:bold">[^<]*<.span>.//' |
 # remove Controller from endpoint categories
-sed -e 's/DocLinksController/Supported Versions/g' |
+sed -e 's/DocLinksController/Versions/g' |
 sed -e 's/PingManagementController/Ping/g' |
 sed -e 's/ManagementController/ Management/g' |
 sed -e 's/OperationController/ Operation/g' |


### PR DESCRIPTION
updated wiki generator script to name the page with the actual version rather than `develop` so that corresponding documentation can be created with a link that will remain valid through development phase, release phase, and after release.  This helps #4390 avoid awkwardness.

@jmelchio this script change renames https://cwiki.apache.org/confluence/display/GEODE/develop+Management+REST+API+-+v1 to https://cwiki.apache.org/confluence/display/GEODE/1.12.0+Management+REST+API+-+v1