### PR TITLE
GEODE-7519 GMSHealthMonitorJUnitTest fails in testCheckIfAvailableNoH…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -725,7 +725,48 @@ public class GMSHealthMonitorJUnitTest {
     verify(joinLeave).remove(isA(MemberIdentifier.class), isA(String.class));
   }
 
+  /*
+   * The next two tests are like the previous two except the next two do not set up failure
+   * detection ports.
+   */
 
+  @Test
+  public void testFailedCheckIfAvailableWithoutFailureDetectionPortDoesNotRemoveMember() {
+    useGMSHealthMonitorTestClass = true;
+    simulateHeartbeatInGMSHealthMonitorTestClass = false;
+
+    final long checkRequestsSentBefore = services.getStatistics().getUdpFinalCheckRequestsSent();
+
+    GMSMembershipView v = installAView();
+
+    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    boolean available = gmsHealthMonitor.checkIfAvailable(memberToCheck, "Not responding", false);
+    assertFalse(available);
+    verify(joinLeave, never()).remove(isA(MemberIdentifier.class), isA(String.class));
+    assertTrue(gmsHealthMonitor.isSuspectMember(memberToCheck));
+
+    final long checkRequestsSentAfter = services.getStatistics().getUdpFinalCheckRequestsSent();
+    assertThat(checkRequestsSentAfter).isGreaterThan(checkRequestsSentBefore);
+  }
+
+  @Test
+  public void testFailedCheckIfAvailableWithoutFailureDetectionPortRemovesMember() {
+    useGMSHealthMonitorTestClass = true;
+    simulateHeartbeatInGMSHealthMonitorTestClass = false;
+
+    final long checkRequestsSentBefore = services.getStatistics().getUdpFinalCheckRequestsSent();
+
+    GMSMembershipView v = installAView();
+
+    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    boolean available = gmsHealthMonitor.checkIfAvailable(memberToCheck, "Not responding", true);
+
+    assertFalse(available);
+    verify(joinLeave).remove(isA(MemberIdentifier.class), isA(String.class));
+
+    final long checkRequestsSentAfter = services.getStatistics().getUdpFinalCheckRequestsSent();
+    assertThat(checkRequestsSentAfter).isGreaterThan(checkRequestsSentBefore);
+  }
 
   @Test
   public void testShutdown() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -450,25 +450,6 @@ public class GMSHealthMonitorJUnitTest {
     Assert.assertTrue(gmsHealthMonitor.getStats().getSuspectsReceived() > 0);
   }
 
-  /***
-   * validates HealthMonitor.CheckIfAvailable api
-   */
-  @Test
-  public void testCheckIfAvailableNoHeartBeatDontRemoveMember() {
-    useGMSHealthMonitorTestClass = true;
-    simulateHeartbeatInGMSHealthMonitorTestClass = false;
-
-    installAView();
-
-    long startTime = System.currentTimeMillis();
-    boolean retVal = gmsHealthMonitor.checkIfAvailable(mockMembers.get(1), "Not responding", true);
-    long timeTaken = System.currentTimeMillis() - startTime;
-
-    assertFalse("CheckIfAvailable should have return false", retVal);
-    assertTrue("This should have taken member ping timeout 100ms but it took " + timeTaken,
-        timeTaken >= gmsHealthMonitor.memberTimeout);
-  }
-
   @Test
   public void testCheckIfAvailableWithSimulatedHeartBeat() {
     GMSMembershipView v = installAView();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DMStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DMStats.java
@@ -558,9 +558,6 @@ public interface DMStats extends MembershipStatistics {
 
   long getHeartbeatsReceived();
 
-
-  long getUdpFinalCheckRequestsSent();
-
   long getUdpFinalCheckResponsesReceived();
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipStatistics.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipStatistics.java
@@ -115,6 +115,8 @@ public interface MembershipStatistics {
 
   void incUdpFinalCheckRequestsSent();
 
+  long getUdpFinalCheckRequestsSent();
+
   void incUdpFinalCheckResponsesReceived();
 
   long getHeartbeatRequestsReceived();


### PR DESCRIPTION
…eartBeatDontRemoveMember

Removing time-sensitive test.  There are other tests that already
exercise the checkIfAvailable health-monitor method.  Two of those tests make
sure that the initiateRemoval parameter (the last parameter) to
checkIfAvailable functions properly and that the value returned by the
method is correct.  Other tests already ensure that a member that
checks out okay is not removed from the cluster and that the value
returned by checkIfAvailable is correct.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
