### PR TITLE
GEODE-7503: GemFireCacheImpl close will block until close completes

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/snapshot/GFSnapshotDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/snapshot/GFSnapshotDUnitTest.java
@@ -66,7 +66,7 @@ public class GFSnapshotDUnitTest extends JUnit4DistributedTestCase {
   @Before
   public void before() {
     host = Host.getHost(0);
-    locator = host.getVM(0);
+    locator = host.getVM(-1);
     server = host.getVM(1);
     client = host.getVM(2);
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -1274,6 +1274,7 @@ public class InternalDistributedSystem extends DistributedSystem
       }
     });
     try {
+      logger.warn("KIRK: runDisconnect", new Exception("KIRK"));
       t.start();
       t.join(MAX_DISCONNECT_WAIT);
     } catch (InterruptedException e) {
@@ -1542,7 +1543,7 @@ public class InternalDistributedSystem extends DistributedSystem
             isDisconnectThread.set(Boolean.TRUE); // bug #42663 - this must be set while
             // closing the cache
             try {
-              currentCache.close(reason, dm.getRootCause(), keepAlive, true); // fix for 42150
+              currentCache.close(reason, dm.getRootCause(), keepAlive, true, false);
             } catch (VirtualMachineError e) {
               SystemFailure.initiateFailure(e);
               throw e;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -945,7 +945,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       }
 
       if (server.isAlive()) {
-        logger.fatal("Could not stop {} in 60 seconds", this);
+        logger.fatal("Could not stop {} in 60 seconds", this, new Exception("KIRK"));
       }
     }
 
@@ -983,7 +983,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
     if (internalCache != null && !stoppedForReconnect && !forcedDisconnect) {
       logger.info("Closing locator's cache");
       try {
-        internalCache.close();
+        internalCache.close("Normal disconnect", null, false, false, true);
       } catch (RuntimeException ex) {
         logger.info("Could not close locator's cache because: {}", ex.getMessage(), ex);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -415,7 +415,7 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, Inte
    */
   QueryMonitor getQueryMonitor();
 
-  void close(String reason, Throwable systemFailureCause, boolean keepAlive, boolean keepDS);
+  void close(String reason, Throwable systemFailureCause, boolean keepAlive, boolean keepDS, boolean skipAwait);
 
   JmxManagerAdvisor getJmxManagerAdvisor();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -1020,9 +1020,8 @@ public class InternalCacheForClientAccess implements InternalCache {
   }
 
   @Override
-  public void close(String reason, Throwable systemFailureCause, boolean keepAlive,
-      boolean keepDS) {
-    delegate.close(reason, systemFailureCause, keepAlive, keepDS);
+  public void close(String reason, Throwable systemFailureCause, boolean keepAlive, boolean keepDS, boolean skipAwait) {
+    delegate.close(reason, systemFailureCause, keepAlive, keepDS, skipAwait);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -1254,7 +1254,7 @@ public class CacheCreation implements InternalCache {
 
   @Override
   public void close(final String reason, final Throwable systemFailureCause,
-      final boolean keepAlive, final boolean keepDS) {
+                    final boolean keepAlive, final boolean keepDS, boolean skipAwait) {
     throw new UnsupportedOperationException("Should not be invoked");
   }
 

--- a/geode-junit/src/main/java/org/apache/geode/internal/util/concurrent/MeteredCountDownLatch.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/util/concurrent/MeteredCountDownLatch.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.util.concurrent;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MeteredCountDownLatch extends CountDownLatch {
+
+  private final AtomicInteger waitCount = new AtomicInteger();
+
+  public MeteredCountDownLatch(int count) {
+    super(count);
+  }
+
+  @Override
+  public void await() throws InterruptedException {
+    waitCount.incrementAndGet();
+    try {
+      super.await();
+    } finally {
+      waitCount.decrementAndGet();
+    }
+  }
+
+  @Override
+  public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+    waitCount.incrementAndGet();
+    try {
+      return super.await(timeout, unit);
+    } finally {
+      waitCount.decrementAndGet();
+    }
+  }
+
+  public long getWaitCount() {
+    return waitCount.get();
+  }
+}


### PR DESCRIPTION
Subsequent calls to GemFireCacheImpl close will now block until the
first call to close completes.

Additional changes:
* Expand unit testing of GemFireCacheImpl
* Inject dependencies into GemFireCacheImpl constructor
* Cleanup existing tests of GemFireCacheImpl
