### PR TITLE
GEODE-7535: Prevent exception throw during getAll

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientCachingProxyRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientCachingProxyRegionDistributedTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import junitparams.JUnitParamsRunner;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.EntryDestroyedException;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@RunWith(JUnitParamsRunner.class)
+public class ClientCachingProxyRegionDistributedTest implements Serializable {
+  protected static final List<String> KEYS = Arrays.asList("Key1", "Key2");
+  protected static final List<String> VALUES = Arrays.asList("Value1", "Value2");
+  protected MemberVM server;
+  protected ClientVM client;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Before
+  public void setUp() throws Exception {
+    server = cluster
+        .startServerVM(1, cf -> cf.withRegion(RegionShortcut.REPLICATE, testName.getMethodName()));
+
+    client = cluster.startClientVM(2, ccf -> ccf
+        .withPoolSubscription(true)
+        .withServerConnection(server.getPort()));
+
+    client.invoke(() -> {
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      assertThat(clientCache).isNotNull();
+      Region<String, String> clientRegion = clientCache
+          .<String, String>createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY)
+          .create(testName.getMethodName());
+
+      IntStream.range(0, KEYS.size()).forEach(i -> clientRegion.put(KEYS.get(i), VALUES.get(i)));
+    });
+  }
+
+  /**
+   * See GEODE-7535.
+   * This test executes a getAll operation from the client and, between the internal retrievals of
+   * the actual entry within the {@link LocalRegion#basicGetAll(Collection, Object)} method, locally
+   * destroy the entry to simulate an eviction/expiration action.
+   * The region should try to get the entry from the server instead of failing with
+   * {@link EntryDestroyedException}.
+   */
+  @Test
+  public void getAllShouldNotThrowExceptionWhenEntryIsLocallyDeletedBetweenFetches() {
+    client.invoke(() -> {
+      final String testKey = KEYS.get(0);
+      assertThat(ClusterStartupRule.getClientCache()).isNotNull();
+      LocalRegion clientRegion = spy((LocalRegion) ClusterStartupRule.getClientCache()
+          .getRegion(testName.getMethodName()));
+
+      doAnswer(invocation -> {
+        // Retrieve the original entry.
+        Object entry = invocation.callRealMethod();
+        // Destroy the entry locally to simulate an expiration/eviction.
+        clientRegion.localDestroy(testKey);
+        // Return the original entry.
+        return entry;
+      }).when(clientRegion).accessEntry(KEYS.get(0), true);
+
+      @SuppressWarnings("unchecked")
+      Map<String, String> getAllResult = (Map<String, String>) clientRegion.getAll(KEYS);
+      // Locally destroyed entries should be retrieved from the server.
+      IntStream.range(0, KEYS.size())
+          .forEach(i -> assertThat(getAllResult.get(KEYS.get(i))).isEqualTo(VALUES.get(i)));
+    });
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -8604,14 +8604,21 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
           keysList = new ArrayList(keys);
         }
         for (Iterator iterator = keysList.iterator(); iterator.hasNext();) {
-          Object key = iterator.next();
           Object value;
+          Object key = iterator.next();
           Region.Entry entry = accessEntry(key, true);
-          if (entry != null && (value = entry.getValue()) != null) {
-            allResults.put(key, value);
-            iterator.remove();
+
+          try {
+            if (entry != null && (value = entry.getValue()) != null) {
+              allResults.put(key, value);
+              iterator.remove();
+            }
+          } catch (EntryDestroyedException ignored) {
+            // The entry might have been removed locally between first and second fetch.
+            // If that's the case, don't remove the key and try to retrieve the value from server.
           }
         }
+
         if (isDebugEnabled) {
           logger.debug("Added local results for getAll request: {}", allResults);
         }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
@@ -15,14 +15,19 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.junit.Before;
@@ -35,12 +40,14 @@ import org.mockito.quality.Strictness;
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskWriteAttributes;
+import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.cache.EvictionAction;
 import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.ExpirationAttributes;
 import org.apache.geode.cache.MembershipAttributes;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.client.internal.ServerRegionProxy;
 import org.apache.geode.distributed.internal.DSClock;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
@@ -49,16 +56,16 @@ import org.apache.geode.internal.cache.AbstractRegion.PoolFinder;
 import org.apache.geode.internal.cache.LocalRegion.RegionMapConstructor;
 import org.apache.geode.internal.cache.LocalRegion.ServerRegionProxyConstructor;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
 
 public class LocalRegionTest {
-
   private EntryEventFactory entryEventFactory;
   private InternalCache cache;
   private InternalDataView internalDataView;
   private InternalDistributedSystem internalDistributedSystem;
   private InternalRegionArguments internalRegionArguments;
   private PoolFinder poolFinder;
-  private RegionAttributes regionAttributes;
+  private RegionAttributes<?, ?> regionAttributes;
   private RegionMapConstructor regionMapConstructor;
   private Function<LocalRegion, RegionPerfStats> regionPerfStatsFactory;
   private ServerRegionProxyConstructor serverRegionProxyConstructor;
@@ -141,7 +148,7 @@ public class LocalRegionTest {
     when(hasCachePerfStats.hasOwnStats())
         .thenReturn(true);
 
-    Region region =
+    Region<?, ?> region =
         new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
             internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
             poolFinder, regionPerfStatsFactory, disabledClock());
@@ -179,7 +186,7 @@ public class LocalRegionTest {
     when(hasCachePerfStats.hasOwnStats())
         .thenReturn(false);
 
-    Region region =
+    Region<?, ?> region =
         new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
             internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
             poolFinder, regionPerfStatsFactory, disabledClock());
@@ -187,5 +194,32 @@ public class LocalRegionTest {
     region.destroyRegion();
 
     verify(cachePerfStats, never()).close();
+  }
+
+  @Test
+  public void getAllShouldNotThrowExceptionWhenEntryIsLocallyDeletedBetweenFetches() {
+    when(cache.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
+    LocalRegion region =
+        spy(new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock()));
+    when(region.hasServerProxy()).thenReturn(true);
+
+    @SuppressWarnings("unchecked")
+    Region.Entry<String, String> mockEntryKey1 = mock(Region.Entry.class);
+    when(mockEntryKey1.getValue()).thenThrow(new EntryDestroyedException("Mock Exception"));
+    doReturn(mockEntryKey1).when(region).accessEntry("key1", true);
+    when(region.getServerProxy()).thenReturn(mock(ServerRegionProxy.class));
+    when(region.getServerProxy().getAll(any(), any())).thenReturn(new VersionedObjectList());
+
+    @SuppressWarnings("unchecked")
+    Region.Entry<String, String> mockEntryKey2 = mock(Region.Entry.class);
+    when(mockEntryKey2.getValue()).thenReturn("value2");
+    doReturn(mockEntryKey2).when(region).accessEntry("key2", true);
+
+    @SuppressWarnings("unchecked")
+    Map<String, String> result = region.getAll(Arrays.asList("key1", "key2"));
+    assertThat(result.get("key1")).isNull();
+    assertThat(result.get("key2")).isEqualTo("value2");
   }
 }


### PR DESCRIPTION
Added a try-catch block during basicGetAll to avoid throwing
EntryDestroyedException whenever the value is locally destroyed as a result
of another concurrent region operation (like eviction/expiration).
The  operation will try to retrieve the value from the server as it
regularly does for any entry that doesn't exist locally.

- Fixed minor warnings.
- Added unit and distributed tests.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
