### PR TITLE
GEODE-7351: OQL Method Authorizer Constraints

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
@@ -1,0 +1,595 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal;
+
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
+import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.ServerOperationException;
+import org.apache.geode.cache.query.Index;
+import org.apache.geode.cache.query.Query;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.cache.query.security.MethodInvocationAuthorizer;
+import org.apache.geode.cache.query.security.RestrictedMethodAuthorizer;
+import org.apache.geode.examples.SimpleSecurityManager;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.security.NotAuthorizedException;
+import org.apache.geode.test.assertj.LogFileAssert;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.OQLQueryTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@RunWith(JUnitParamsRunner.class)
+@Category({OQLQueryTest.class, SecurityTest.class})
+public class QueryConfigurationServiceConstraintsDistributedTest implements Serializable {
+  private static final int ENTRIES = 500;
+  private static final int PUT_KEY = ENTRIES + 1;
+  private static final int CREATE_KEY = ENTRIES + 2;
+  private static final int REMOVE_KEY = ENTRIES - 1;
+  private static final int DESTROY_KEY = ENTRIES - 2;
+  private static final int UPDATE_KEY = ENTRIES - 3;
+  private static final int REPLACE_KEY = ENTRIES - 4;
+  private static final int INVALIDATE_KEY = ENTRIES - 5;
+  private File logFile;
+  protected MemberVM server;
+  protected ClientVM client;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Rule
+  public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
+
+  @SuppressWarnings("unused")
+  private Object[] getRegionTypeAndOperation() {
+    return new Object[] {
+        new Object[] {"LOCAL", "PUT"},
+        new Object[] {"LOCAL", "CREATE"},
+        new Object[] {"LOCAL", "REMOVE"},
+        new Object[] {"LOCAL", "DESTROY"},
+        new Object[] {"LOCAL", "UPDATE"},
+        new Object[] {"LOCAL", "REPLACE"},
+        new Object[] {"LOCAL", "INVALIDATE"},
+
+        new Object[] {"REPLICATE", "PUT"},
+        new Object[] {"REPLICATE", "CREATE"},
+        new Object[] {"REPLICATE", "REMOVE"},
+        new Object[] {"REPLICATE", "DESTROY"},
+        new Object[] {"REPLICATE", "UPDATE"},
+        new Object[] {"REPLICATE", "REPLACE"},
+        new Object[] {"REPLICATE", "INVALIDATE"},
+
+        new Object[] {"PARTITION", "PUT"},
+        new Object[] {"PARTITION", "CREATE"},
+        new Object[] {"PARTITION", "REMOVE"},
+        new Object[] {"PARTITION", "DESTROY"},
+        new Object[] {"PARTITION", "UPDATE"},
+        new Object[] {"PARTITION", "REPLACE"},
+        new Object[] {"PARTITION", "INVALIDATE"},
+    };
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    logFile = temporaryFolder.newFile(testName.getMethodName());
+
+    server = cluster.startServerVM(1, cf -> cf
+        .withProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName())
+        .withProperty(SERIALIZABLE_OBJECT_FILTER, "org.apache.geode.cache.query.internal.*")
+        .withProperty("security-username", "cluster").withProperty("security-password", "cluster")
+        .withProperty("log-file", logFile.getAbsolutePath()));
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, false, TestMethodAuthorizer.class.getName(),
+          Stream.of("getId", "getName").collect(Collectors.toSet()));
+    });
+
+    client = cluster.startClientVM(2, ccf -> ccf
+        .withCredential("data", "data")
+        .withServerConnection(server.getPort())
+        .withProperty(SERIALIZABLE_OBJECT_FILTER, "org.apache.geode.cache.query.internal.*"));
+  }
+
+  @After
+  public void tearDown() {
+    server.invoke(QueryObserverHolder::reset);
+  }
+
+  private void createAndPopulateRegion(String regionName, RegionShortcut shortcut) {
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      Region<Integer, QueryObject> region =
+          internalCache.<Integer, QueryObject>createRegionFactory(shortcut).create(regionName);
+      IntStream.range(0, ENTRIES).forEach(id -> region.put(id, new QueryObject(id, "name_" + id)));
+      await().untilAsserted(() -> assertThat(region.size()).isEqualTo(ENTRIES));
+    });
+  }
+
+  private ThrowableAssert.ThrowingCallable getRegionOperation(Operation operation,
+      Region<Integer, QueryObject> region, QueryObject testValue) {
+    switch (operation) {
+      case PUT:
+        return () -> region.put(PUT_KEY, testValue);
+      case CREATE:
+        return () -> region.create(CREATE_KEY, testValue);
+      case REMOVE:
+        return () -> region.remove(REMOVE_KEY);
+      case DESTROY:
+        return () -> region.destroy(DESTROY_KEY);
+      case UPDATE:
+        return () -> region.put(UPDATE_KEY, testValue);
+      case REPLACE:
+        return () -> region.replace(REPLACE_KEY, testValue);
+      case INVALIDATE:
+        return () -> region.invalidate(INVALIDATE_KEY);
+      default:
+        return () -> {
+        };
+    }
+  }
+
+  private void assertRegionOperationResult(Operation operation, Region<Integer, QueryObject> region,
+      QueryObject testValue) {
+    // Assert operation result.
+    switch (operation) {
+      case PUT:
+        assertThat(region.get(PUT_KEY)).isEqualTo(testValue);
+        break;
+      case CREATE:
+        assertThat(region.get(CREATE_KEY)).isEqualTo(testValue);
+        break;
+      case REMOVE:
+        assertThat(region.get(REMOVE_KEY)).isNull();
+        break;
+      case DESTROY:
+        assertThat(region.get(DESTROY_KEY)).isNull();
+        break;
+      case UPDATE:
+        assertThat(region.get(UPDATE_KEY)).isEqualTo(testValue);
+        break;
+      case REPLACE:
+        assertThat(region.get(REPLACE_KEY)).isEqualTo(testValue);
+        break;
+      case INVALIDATE:
+        assertThat(region.get(INVALIDATE_KEY)).isNull();
+        break;
+    }
+  }
+
+  private void executeOperationFromClient(String regionName, Operation operation,
+      QueryObject testValue) {
+    client.invoke(() -> {
+      assertThat(ClusterStartupRule.getClientCache()).isNotNull();
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Integer, QueryObject> region =
+          clientCache.<Integer, QueryObject>createClientRegionFactory(ClientRegionShortcut.PROXY)
+              .create(regionName);
+
+      ThrowableAssert.ThrowingCallable operationCallable =
+          getRegionOperation(operation, region, testValue);
+      assertThatCode(operationCallable).doesNotThrowAnyException();
+    });
+  }
+
+  /**
+   * The test registers a {@link QueryObserver} that changes the installed
+   * {@link MethodInvocationAuthorizer} to the default one (denies everything) as soon as the query
+   * starts, and makes sure the query succeeds (it is no affected by the authorizer change).
+   * The query is executed from the client.
+   */
+  @Test
+  @Parameters({"LOCAL", "REPLICATE", "PARTITION"})
+  @TestCaseName("[{index}] {method}(RegionType:{0})")
+  public void queriesInFlightExecutedByClientsShouldNotBeAffectedWhenMethodAuthorizerIsChanged(
+      RegionShortcut regionShortcut) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+    String queryString = "<TRACE> SELECT object.getName() FROM /" + regionName + " object";
+
+    // Set test query observer.
+    server.invoke(() -> {
+      TestQueryObserver queryObserver =
+          new TestQueryObserver(RestrictedMethodAuthorizer.class.getName(), Collections.emptySet());
+      QueryObserverHolder.setInstance(queryObserver);
+    });
+
+    // Execute query from the client.
+    client.invoke(() -> {
+      assertThat(ClusterStartupRule.getClientCache()).isNotNull();
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Query query = clientCache.getQueryService().newQuery(queryString);
+      @SuppressWarnings("unchecked")
+      SelectResults<QueryObject> result = (SelectResults<QueryObject>) query.execute();
+      assertThat(result.size()).isEqualTo(ENTRIES);
+    });
+
+    // Execute query again, it should fail as the restricted authorizer has been installed.
+    server.invoke(QueryObserverHolder::reset);
+    client.invoke(() -> {
+      assertThat(ClusterStartupRule.getClientCache()).isNotNull();
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Query newQuery = clientCache.getQueryService().newQuery(queryString);
+      assertThatThrownBy(newQuery::execute)
+          .isInstanceOf(ServerOperationException.class)
+          .hasCauseInstanceOf(NotAuthorizedException.class)
+          .hasStackTraceContaining(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING + "getName");
+    });
+  }
+
+  /**
+   * The test registers a {@link QueryObserver} that changes the installed
+   * {@link MethodInvocationAuthorizer} to the default one (denies everything) as soon as the query
+   * starts, and makes sure the query succeeds (it is no affected by the authorizer change).
+   * The query is executed from the server.
+   */
+  @Test
+  @Parameters({"LOCAL", "REPLICATE", "PARTITION"})
+  @TestCaseName("[{index}] {method}(RegionType:{0})")
+  public void queriesInFlightExecutedByServersShouldNotBeAffectedWhenMethodAuthorizerIsChanged(
+      RegionShortcut regionShortcut) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+    String queryString = "<TRACE> SELECT object.getName() FROM /" + regionName + " object";
+
+    server.invoke(() -> {
+      // Set test query observer.
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      TestQueryObserver queryObserver =
+          new TestQueryObserver(RestrictedMethodAuthorizer.class.getName(), Collections.emptySet());
+      QueryObserverHolder.setInstance(queryObserver);
+
+      // Execute query.
+      Query query = internalCache.getQueryService().newQuery(queryString);
+      @SuppressWarnings("unchecked")
+      SelectResults<QueryObject> result = (SelectResults<QueryObject>) query.execute();
+      assertThat(queryObserver.invocations.get()).isEqualTo(1);
+      assertThat(result.size()).isEqualTo(ENTRIES);
+
+      // Execute query again, it should fail as the restricted authorizer has been installed.
+      QueryObserverHolder.reset();
+      Query newQuery = internalCache.getQueryService().newQuery(queryString);
+      assertThatThrownBy(newQuery::execute)
+          .isInstanceOf(NotAuthorizedException.class)
+          .hasMessage(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING + "getName");
+    });
+  }
+
+  /**
+   * The test creates an index with a method invocation as part of the expression, changes
+   * the {@link MethodInvocationAuthorizer} to a custom one that still allows the methods part of
+   * the index expression and executes a region operation from the client that would cause an
+   * index mapping removal/addition.
+   * The operation should succeed, the index should still be valid and no errors should be logged.
+   */
+  @Test
+  @Parameters(method = "getRegionTypeAndOperation")
+  @TestCaseName("[{index}] {method}(RegionType:{0};Operation:{1})")
+  public void indexesShouldNotBeAffectedByMethodAuthorizerChangeAfterRegionOperationOnClientWhenIndexedExpressionContainsMethodsAllowedByTheNewAuthorizer(
+      RegionShortcut regionShortcut, Operation operation) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+    QueryObject testValue = new QueryObject(999, "name_999");
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+
+      // Index is valid.
+      QueryService queryService = internalCache.getQueryService();
+      queryService.createIndex("NameIndex", "e.getName()", "/" + regionName + " e");
+      Index index = queryService.getIndex(internalCache.getRegion(regionName), "NameIndex");
+      assertThat(index.isValid()).isTrue();
+
+      // Change the authorizer (still allow 'getName' to be executed)
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, false, TestMethodAuthorizer.class.getName(),
+          Stream.of("getName").collect(Collectors.toSet()));
+    });
+
+    // Execute operation on client side.
+    executeOperationFromClient(regionName, operation, testValue);
+
+    // Assert that operation succeeded and that index is still valid.
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      QueryService queryService = internalCache.getQueryService();
+      Region<Integer, QueryObject> region = internalCache.getRegion(regionName);
+      Index indexInvalid = queryService.getIndex(internalCache.getRegion(regionName), "NameIndex");
+      assertThat(indexInvalid.isValid()).isTrue();
+      assertRegionOperationResult(operation, region, testValue);
+    });
+
+    // No errors logged on server side.
+    LogFileAssert.assertThat(logFile)
+        .doesNotContain(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING);
+  }
+
+  /**
+   * The test creates an index with a method invocation as part of the expression, changes
+   * the {@link MethodInvocationAuthorizer} to a custom one that still allows the methods part of
+   * the index expression and executes a region operation from the server that would cause an
+   * index mapping removal/addition.
+   * The operation should succeed, the index should still be valid and no errors should be logged.
+   */
+  @Test
+  @Parameters(method = "getRegionTypeAndOperation")
+  @TestCaseName("[{index}] {method}(RegionType:{0};Operation:{1})")
+  public void indexesShouldNotBeAffectedByMethodAuthorizerChangeAfterRegionOperationOnServerWhenIndexedExpressionContainsMethodsAllowedByTheNewAuthorizer(
+      RegionShortcut regionShortcut, Operation operation) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      Region<Integer, QueryObject> region = internalCache.getRegion(regionName);
+
+      // Index is valid.
+      QueryService queryService = internalCache.getQueryService();
+      queryService.createIndex("NameIndex", "e.getName()", "/" + regionName + " e");
+      Index index = queryService.getIndex(internalCache.getRegion(regionName), "NameIndex");
+      assertThat(index.isValid()).isTrue();
+
+      // Operation to invoke.
+      QueryObject testValue = new QueryObject(999, "name_999");
+      ThrowableAssert.ThrowingCallable operationCallable =
+          getRegionOperation(operation, region, testValue);
+
+      // Change the authorizer (still allow 'getName' to be executed)
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, false, TestMethodAuthorizer.class.getName(),
+          Stream.of("getName").collect(Collectors.toSet()));
+
+      // Execute operation, assert operation result, index is valid and no exceptions logged.
+      assertThatCode(operationCallable).doesNotThrowAnyException();
+      Index indexInvalid = queryService.getIndex(internalCache.getRegion(regionName), "NameIndex");
+      assertThat(indexInvalid.isValid()).isTrue();
+      assertRegionOperationResult(operation, region, testValue);
+    });
+
+    // No errors logged on server side.
+    LogFileAssert.assertThat(logFile)
+        .doesNotContain(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING);
+  }
+
+  /**
+   * The test creates an index with a method invocation as part of the expression, changes
+   * the {@link MethodInvocationAuthorizer} to the default one (denies everything) and executes a
+   * region operation from the client that would cause an index mapping removal/addition.
+   * The operation should succeed, the index should be marked as invalid and the error should be
+   * logged.
+   */
+  @Test
+  @Parameters(method = "getRegionTypeAndOperation")
+  @TestCaseName("[{index}] {method}(RegionType:{0};Operation:{1})")
+  public void indexesShouldBeMarkedAsInvalidDuringMappingRemovalOrAdditionAfterRegionOperationOnClientWhenMethodAuthorizerIsChangedAndIndexExpressionContainsMethodsNotAllowedByTheNewAuthorizer(
+      RegionShortcut regionShortcut, Operation operation) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+    QueryObject testValue = new QueryObject(888, "name_888");
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+
+      // Index is valid.
+      QueryService queryService = internalCache.getQueryService();
+      queryService.createIndex("IdIndex", "e.getId()", "/" + regionName + " e");
+      Index index = queryService.getIndex(internalCache.getRegion(regionName), "IdIndex");
+      assertThat(index.isValid()).isTrue();
+
+      // Change the authorizer (deny everything not allowed by default).
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, false, RestrictedMethodAuthorizer.class.getName(), Collections.emptySet());
+    });
+
+    // Execute operation on client side.
+    executeOperationFromClient(regionName, operation, testValue);
+
+    // Assert that operation succeeded but index is marked as invalid.
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      QueryService queryService = internalCache.getQueryService();
+      Region<Integer, QueryObject> region = internalCache.getRegion(regionName);
+      Index indexInvalid = queryService.getIndex(internalCache.getRegion(regionName), "IdIndex");
+      assertThat(indexInvalid.isValid()).isFalse();
+      assertRegionOperationResult(operation, region, testValue);
+    });
+
+    // Assert index modification failure was logged.
+    LogFileAssert.assertThat(logFile)
+        .contains(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING + "getId");
+  }
+
+
+  /**
+   * The test creates an index with a method invocation as part of the expression, changes
+   * the {@link MethodInvocationAuthorizer} to the default one (denies everything) and executes a
+   * region operation on the server that would cause an index mapping removal/addition.
+   * The operation should succeed, the index should be marked as invalid and the error should be
+   * logged.
+   */
+  @Test
+  @Parameters(method = "getRegionTypeAndOperation")
+  @TestCaseName("[{index}] {method}(RegionType:{0};Operation:{1})")
+  public void indexesShouldBeMarkedAsInvalidDuringMappingRemovalOrAdditionAfterRegionOperationOnServerWhenMethodAuthorizerIsChangedAndIndexExpressionContainsMethodsNotAllowedByTheNewAuthorizer(
+      RegionShortcut regionShortcut, Operation operation) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      Region<Integer, QueryObject> region = internalCache.getRegion(regionName);
+
+      // Index is valid.
+      QueryService queryService = internalCache.getQueryService();
+      queryService.createIndex("IdIndex", "e.getId()", "/" + regionName + " e");
+      Index index = queryService.getIndex(internalCache.getRegion(regionName), "IdIndex");
+      assertThat(index.isValid()).isTrue();
+
+      // Operation to invoke.
+      QueryObject testValue = new QueryObject(999, "name_999");
+      ThrowableAssert.ThrowingCallable operationCallable =
+          getRegionOperation(operation, region, testValue);
+
+      // Change the authorizer (deny everything not allowed by default).
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, false, RestrictedMethodAuthorizer.class.getName(), Collections.emptySet());
+
+      // Execute operation, should succeed but index modification should fail, marking it as
+      // invalid.
+      assertThatCode(operationCallable).doesNotThrowAnyException();
+      Index indexInvalid = queryService.getIndex(internalCache.getRegion(regionName), "IdIndex");
+      assertThat(indexInvalid.isValid()).isFalse();
+
+      // Assert operation result.
+      assertRegionOperationResult(operation, region, testValue);
+    });
+
+    // Assert index modification failure was logged.
+    LogFileAssert.assertThat(logFile)
+        .contains(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING + "getId");
+  }
+
+  public enum Operation {
+    PUT, CREATE, REMOVE, DESTROY, UPDATE, REPLACE, INVALIDATE
+  }
+
+  private static class QueryObject implements Serializable {
+    private final int id;
+    private final String name;
+
+    public int getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    QueryObject(int id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o)
+        return true;
+      if (o == null || getClass() != o.getClass())
+        return false;
+      QueryObject that = (QueryObject) o;
+      if (getId() != that.getId())
+        return false;
+
+      return getName() != null ? getName().equals(that.getName()) : that.getName() == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = getId();
+      result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+      return result;
+    }
+  }
+
+  public static class TestMethodAuthorizer implements MethodInvocationAuthorizer {
+    private Set<String> authorizedMethods;
+    private RestrictedMethodAuthorizer restrictedMethodAuthorizer;
+
+    @Override
+    public void initialize(Cache cache, Set<String> parameters) {
+      this.authorizedMethods = parameters;
+      this.restrictedMethodAuthorizer = new RestrictedMethodAuthorizer(cache);
+    }
+
+    @Override
+    public boolean authorize(Method method, Object target) {
+      if (restrictedMethodAuthorizer.authorize(method, target)) {
+        return true;
+      }
+
+      return authorizedMethods.contains(method.getName());
+    }
+  }
+
+  // Query Observer to change the authorizer right after the query execution starts.
+  private static class TestQueryObserver extends QueryObserverAdapter implements Serializable {
+    final AtomicInteger invocations = new AtomicInteger(0);
+    private final String authorizerClassName;
+    private final Set<String> authorizerParameters;
+
+    TestQueryObserver(String authorizerClassName, Set<String> authorizerParameters) {
+      this.authorizerClassName = authorizerClassName;
+      this.authorizerParameters = authorizerParameters;
+    }
+
+    @Override
+    public void startQuery(Query query) {
+      invocations.incrementAndGet();
+
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      assertThat(internalCache).isNotNull();
+      internalCache.getService(QueryConfigurationService.class)
+          .updateMethodAuthorizer(internalCache, false, authorizerClassName, authorizerParameters);
+    }
+  }
+}

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal;
+
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
+import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.io.File;
+import java.io.Serializable;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqQuery;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.security.MethodInvocationAuthorizer;
+import org.apache.geode.cache.query.security.RestrictedMethodAuthorizer;
+import org.apache.geode.examples.SimpleSecurityManager;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.security.query.TestCqListener;
+import org.apache.geode.test.assertj.LogFileAssert;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.OQLQueryTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@RunWith(JUnitParamsRunner.class)
+@Category({OQLQueryTest.class, SecurityTest.class})
+public class QueryConfigurationServiceConstraintsDistributedTest implements Serializable {
+  private static final int ENTRIES = 300;
+  private static final int PUT_KEY = ENTRIES + 1;
+  private static final int CREATE_KEY = ENTRIES + 2;
+  private static final int REMOVE_KEY = ENTRIES - 1;
+  private static final int DESTROY_KEY = ENTRIES - 2;
+  private static final int UPDATE_KEY = ENTRIES - 3;
+  private static final int REPLACE_KEY = ENTRIES - 4;
+  private static final int INVALIDATE_KEY = ENTRIES - 5;
+  private File logFile;
+  protected MemberVM server;
+  protected ClientVM client;
+  private static TestCqListener cqListener = null;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Rule
+  public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
+
+  @SuppressWarnings("unused")
+  private Object[] getRegionTypeOperationsAndCqExecutionType() {
+    return new Object[] {
+        new Object[] {"REPLICATE", "PUT", true},
+        new Object[] {"REPLICATE", "PUT", false},
+        new Object[] {"REPLICATE", "CREATE", true},
+        new Object[] {"REPLICATE", "CREATE", false},
+        new Object[] {"REPLICATE", "REMOVE", true},
+        new Object[] {"REPLICATE", "REMOVE", false},
+        new Object[] {"REPLICATE", "DESTROY", true},
+        new Object[] {"REPLICATE", "DESTROY", false},
+        new Object[] {"REPLICATE", "UPDATE", true},
+        new Object[] {"REPLICATE", "UPDATE", false},
+        new Object[] {"REPLICATE", "REPLACE", true},
+        new Object[] {"REPLICATE", "REPLACE", false},
+        new Object[] {"REPLICATE", "INVALIDATE", true},
+        new Object[] {"REPLICATE", "INVALIDATE", false},
+
+        new Object[] {"PARTITION", "PUT", true},
+        new Object[] {"PARTITION", "PUT", false},
+        new Object[] {"PARTITION", "CREATE", true},
+        new Object[] {"PARTITION", "CREATE", false},
+        new Object[] {"PARTITION", "REMOVE", true},
+        new Object[] {"PARTITION", "REMOVE", false},
+        new Object[] {"PARTITION", "DESTROY", true},
+        new Object[] {"PARTITION", "DESTROY", false},
+        new Object[] {"PARTITION", "UPDATE", true},
+        new Object[] {"PARTITION", "UPDATE", false},
+        new Object[] {"PARTITION", "REPLACE", true},
+        new Object[] {"PARTITION", "REPLACE", false},
+        new Object[] {"PARTITION", "INVALIDATE", true},
+        new Object[] {"PARTITION", "INVALIDATE", false},
+    };
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    logFile = temporaryFolder.newFile(testName.getMethodName());
+
+    server = cluster.startServerVM(1, cf -> cf
+        .withProperty(SECURITY_MANAGER, SimpleSecurityManager.class.getName())
+        .withProperty(SERIALIZABLE_OBJECT_FILTER, "org.apache.geode.cache.query.internal.*")
+        .withProperty("security-username", "cluster").withProperty("security-password", "cluster")
+        .withProperty("log-file", logFile.getAbsolutePath()));
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, true, TestMethodAuthorizer.class.getName(),
+          Stream.of("getId", "getName").collect(Collectors.toSet()));
+    });
+
+    client = cluster.startClientVM(2, ccf -> ccf
+        .withCredential("data", "data")
+        .withPoolSubscription(true)
+        .withServerConnection(server.getPort())
+        .withProperty(SERIALIZABLE_OBJECT_FILTER, "org.apache.geode.cache.query.internal.*"));
+  }
+
+  private void createAndPopulateRegion(String regionName, RegionShortcut shortcut) {
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      Region<Integer, QueryObject> region =
+          internalCache.<Integer, QueryObject>createRegionFactory(shortcut).create(regionName);
+      IntStream.range(0, ENTRIES).forEach(id -> region.put(id, new QueryObject(id, "name_" + id)));
+      await().untilAsserted(() -> assertThat(region.size()).isEqualTo(ENTRIES));
+    });
+  }
+
+  private ThrowableAssert.ThrowingCallable getRegionOperation(Operation operation,
+      Region<Integer, QueryObject> region, QueryObject testValue) {
+    switch (operation) {
+      case PUT:
+        return () -> region.put(PUT_KEY, testValue);
+      case CREATE:
+        return () -> region.create(CREATE_KEY, testValue);
+      case REMOVE:
+        return () -> region.remove(REMOVE_KEY);
+      case DESTROY:
+        return () -> region.destroy(DESTROY_KEY);
+      case UPDATE:
+        return () -> region.put(UPDATE_KEY, testValue);
+      case REPLACE:
+        return () -> region.replace(REPLACE_KEY, testValue);
+      case INVALIDATE:
+        return () -> region.invalidate(INVALIDATE_KEY);
+      default:
+        return () -> {
+        };
+    }
+  }
+
+  private void executeOperationsAndAssertResults(String regionName, Operation operation) {
+    // Execute operation that would cause the CQ to process the event.
+    QueryObject testValue = new QueryObject(999, "name_999");
+    assertThat(ClusterStartupRule.getCache()).isNotNull();
+    Region<Integer, QueryObject> region = ClusterStartupRule.getCache().getRegion(regionName);
+
+    // The initial operation should fail, every later one should fail as well.
+    ThrowableAssert.ThrowingCallable operationCallable =
+        getRegionOperation(operation, region, testValue);
+    assertThatCode(operationCallable).doesNotThrowAnyException();
+
+    // Execute all operations after the initial one.
+    Arrays.stream(Operation.values())
+        .filter(op -> !operation.equals(op))
+        .forEach(op -> assertThatCode(getRegionOperation(op, region, testValue))
+            .doesNotThrowAnyException());
+
+    // Assert results from operations.
+    assertThat(region.get(PUT_KEY)).isEqualTo(testValue);
+    assertThat(region.get(CREATE_KEY)).isEqualTo(testValue);
+    assertThat(region.get(REMOVE_KEY)).isNull();
+    assertThat(region.get(DESTROY_KEY)).isNull();
+    assertThat(region.get(UPDATE_KEY)).isEqualTo(testValue);
+    assertThat(region.get(REPLACE_KEY)).isEqualTo(testValue);
+    assertThat(region.get(INVALIDATE_KEY)).isNull();
+  }
+
+  private void createClientCq(String queryString, boolean executeWithInitialResults) {
+    client.invoke(() -> {
+      QueryConfigurationServiceConstraintsDistributedTest.cqListener = new TestCqListener();
+      assertThat(ClusterStartupRule.getClientCache()).isNotNull();
+      QueryService queryService = ClusterStartupRule.getClientCache().getQueryService();
+      CqAttributesFactory cqAttributesFactory = new CqAttributesFactory();
+      cqAttributesFactory
+          .addCqListener(QueryConfigurationServiceConstraintsDistributedTest.cqListener);
+
+      CqQuery cq = queryService.newCq(queryString, cqAttributesFactory.create());
+      if (!executeWithInitialResults) {
+        cq.execute();
+      } else {
+        assertThat(cq.executeWithInitialResults().size()).isEqualTo(ENTRIES);
+      }
+    });
+  }
+
+  /**
+   * The test creates a CQ with a method invocation as part of the expression, changes
+   * the {@link MethodInvocationAuthorizer} to a custom one that still allows the methods part of
+   * the expression and executes all region operations that would fire the CQ.
+   * The operations should succeed, the CQ should fire 'onEvent' and no errors should be logged.
+   */
+  @Test
+  @Parameters(method = "getRegionTypeOperationsAndCqExecutionType")
+  @TestCaseName("[{index}] {method}(RegionType:{0};Operation:{1},ExecuteWithInitialResults:{2})")
+  public void cqsShouldSucceedDuringEventProcessingAfterRegionOperationWhenMethodAuthorizerIsChangedAndQueryContainsMethodsAllowedByTheNewAuthorizer(
+      RegionShortcut regionShortcut, Operation operation, boolean executeWithInitialResults) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+    String queryString = "SELECT * FROM /" + regionName + " object WHERE object.getId > -1";
+    createClientCq(queryString, executeWithInitialResults);
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      assertThat(internalCache.getCqService().getAllCqs().size()).isEqualTo(1);
+
+      // Change the authorizer (still allow 'getId' to be executed)
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, true, TestMethodAuthorizer.class.getName(),
+          Stream.of("getId").collect(Collectors.toSet()));
+
+      // Execute operations that would cause the CQ to process the event.
+      executeOperationsAndAssertResults(regionName, operation);
+    });
+
+    client.invoke(() -> {
+      await().untilAsserted(() -> assertThat(
+          QueryConfigurationServiceConstraintsDistributedTest.cqListener.getNumErrors())
+              .isEqualTo(0));
+      await().untilAsserted(() -> assertThat(
+          QueryConfigurationServiceConstraintsDistributedTest.cqListener.getNumEvents())
+              .isEqualTo(Operation.values().length));
+    });
+
+    // No errors logged on server side.
+    LogFileAssert.assertThat(logFile)
+        .doesNotContain(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING);
+  }
+
+  /**
+   * The test creates a CQ with a method invocation as part of the expression, changes
+   * the {@link MethodInvocationAuthorizer} to the default one (denies everything) and executes
+   * all region operations that would fire the CQ.
+   * The operations should succeed, the CQ should fire 'onError' and the issues should be logged.
+   */
+  @Test
+  @Parameters(method = "getRegionTypeOperationsAndCqExecutionType")
+  @TestCaseName("[{index}] {method}(RegionType:{0};Operation:{1},ExecuteWithInitialResults:{2})")
+  public void cqsShouldFailDuringEventProcessingAfterRegionOperationWhenMethodAuthorizerIsChangedAndQueryContainsMethodsNotAllowedByTheNewAuthorizer(
+      RegionShortcut regionShortcut, Operation operation, boolean executeWithInitialResults) {
+    String regionName = testName.getMethodName();
+    createAndPopulateRegion(regionName, regionShortcut);
+    String queryString = "SELECT * FROM /" + regionName + " object WHERE object.getId > -1";
+    createClientCq(queryString, executeWithInitialResults);
+
+    server.invoke(() -> {
+      assertThat(ClusterStartupRule.getCache()).isNotNull();
+      InternalCache internalCache = ClusterStartupRule.getCache();
+      assertThat(internalCache.getCqService().getAllCqs().size()).isEqualTo(1);
+
+      // Change the authorizer (deny everything not allowed by default).
+      internalCache.getService(QueryConfigurationService.class).updateMethodAuthorizer(
+          internalCache, true, RestrictedMethodAuthorizer.class.getName(), Collections.emptySet());
+
+      // Execute operations that would cause the CQ to process the event.
+      executeOperationsAndAssertResults(regionName, operation);
+    });
+
+    client.invoke(() -> {
+      await().untilAsserted(() -> assertThat(
+          QueryConfigurationServiceConstraintsDistributedTest.cqListener.getNumEvents())
+              .isEqualTo(0));
+      await().untilAsserted(() -> assertThat(
+          QueryConfigurationServiceConstraintsDistributedTest.cqListener.getNumErrors())
+              .isEqualTo(Operation.values().length));
+    });
+
+    // No errors logged on server side.
+    LogFileAssert.assertThat(logFile).contains(RestrictedMethodAuthorizer.UNAUTHORIZED_STRING);
+  }
+
+  public enum Operation {
+    PUT, CREATE, REMOVE, DESTROY, UPDATE, REPLACE, INVALIDATE
+  }
+
+  private static class QueryObject implements Serializable {
+    private final int id;
+    private final String name;
+
+    public int getId() {
+      return id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    QueryObject(int id, String name) {
+      this.id = id;
+      this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o)
+        return true;
+      if (o == null || getClass() != o.getClass())
+        return false;
+      QueryObject that = (QueryObject) o;
+      if (getId() != that.getId())
+        return false;
+
+      return getName() != null ? getName().equals(that.getName()) : that.getName() == null;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = getId();
+      result = 31 * result + (getName() != null ? getName().hashCode() : 0);
+      return result;
+    }
+  }
+
+  public static class TestMethodAuthorizer implements MethodInvocationAuthorizer {
+    private Set<String> authorizedMethods;
+    private RestrictedMethodAuthorizer restrictedMethodAuthorizer;
+
+    @Override
+    public void initialize(Cache cache, Set<String> parameters) {
+      this.authorizedMethods = parameters;
+      this.restrictedMethodAuthorizer = new RestrictedMethodAuthorizer(cache);
+    }
+
+    @Override
+    public boolean authorize(Method method, Object target) {
+      if (restrictedMethodAuthorizer.authorize(method, target)) {
+        return true;
+      }
+
+      return authorizedMethods.contains(method.getName());
+    }
+  }
+}


### PR DESCRIPTION
Added distributed tests to verify the required constraints are met
whenever the MethodInvocationAuthorizer is changed in runtime.

- Once the authorizer is changed, all queries executed afterwards
  should use the newly configured authorizer.
- Once a query execution starts, the authorizer used can not be
  changed for that particular query.
- Continuous queries already running should pick up the new authorizer
  the next time the query is internally executed to detect whether an
  event matches or not. If the CQ has methods not allowed by the newly
  configured authorizer, any matching events from that moment on should
  invoke 'onError' instead of 'onEvent' on the associated 'CqListener'.
- Indexes should pick up the newly configured authorizer the next time
  an entry is added or removed from the index, and the index itself
  should be marked as invalid if it uses method invocations not allowed
  by the newly configured authorizer.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
