### PR TITLE
GEODE-7540: use max_in_flight to spread out peak load on CI

### DIFF
--- a/ci/pipelines/examples/jinja.template.yml
+++ b/ci/pipelines/examples/jinja.template.yml
@@ -113,7 +113,7 @@ jobs:
           - name: attempts-log
             path: new
         timeout: 15m
-        attempts: 10
+        attempts: 2
       - task: rsync_code_up
         image: alpine-tools-image
         config:

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -226,7 +226,7 @@ jobs:
 {% endfor %}
 - name: {{build_test.name}}
   public: true
-  serial: true
+  max_in_flight: {{build_test.MAX_IN_FLIGHT}}
   plan:
   - aggregate:
     - get: geode-ci
@@ -630,6 +630,7 @@ jobs:
           attempts: 10
         - task: execute_tests-{{java_test_version.name}}
           image: alpine-tools-image
+          max_in_flight: {{parameters.MAX_IN_FLIGHT}}
           config:
             platform: linux
             params:

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -581,6 +581,7 @@ jobs:
       {%- do deep_merge(parameters, java_test_version.override[test.name]) %}
     {%- endif %}
 - name: {{test.name}}Test{{java_test_version.name}}
+  max_in_flight: {{parameters.MAX_IN_FLIGHT}}
   public: true
   plan:
   - do:
@@ -630,7 +631,6 @@ jobs:
           attempts: 10
         - task: execute_tests-{{java_test_version.name}}
           image: alpine-tools-image
-          max_in_flight: {{parameters.MAX_IN_FLIGHT}}
           config:
             platform: linux
             params:

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -261,7 +261,7 @@ jobs:
           path: new
         - name: instance-data
       timeout: 15m
-      attempts: 10
+      attempts: 2
   - aggregate:
     - put: geode-build-version
       params:
@@ -528,7 +528,7 @@ jobs:
       - name: attempts-log
         path: new
     timeout: 15m
-    attempts: 10
+    attempts: 2
   - task: rsync_code_up
     image: alpine-tools-image
     config:
@@ -615,7 +615,7 @@ jobs:
             - name: attempts-log
               path: new
           timeout: 15m
-          attempts: 10
+          attempts: 2
         - task: rsync_code_up-{{java_test_version.name}}
           image: alpine-tools-image
           config:
@@ -628,7 +628,7 @@ jobs:
             - name: instance-data-{{java_test_version.name}}
               path: instance-data
           timeout: 15m
-          attempts: 10
+          attempts: 2
         - task: execute_tests-{{java_test_version.name}}
           image: alpine-tools-image
           config:
@@ -666,7 +666,7 @@ jobs:
               - name: geode-results-{{java_test_version.name}}
                 path: geode-results
             timeout: 15m
-            attempts: 10
+            attempts: 2
           ensure:
             do:
             - aggregate:

--- a/ci/pipelines/images/jinja.template.yml
+++ b/ci/pipelines/images/jinja.template.yml
@@ -202,7 +202,7 @@ jobs:
       - build-alpine-tools-docker-image
   - task: build-image
     timeout: 3h
-    attempts: 5
+    attempts: 3
     image: alpine-tools-docker-image
     config:
       inputs:

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -118,7 +118,7 @@ jobs:
             - name: attempts-log
               path: new
           timeout: 15m
-          attempts: 10
+          attempts: 2
     - task: rsync_code_up
       image: alpine-tools-image
       config:
@@ -272,7 +272,7 @@ jobs:
             - name: attempts-log
               path: new
           timeout: 15m
-          attempts: 10
+          attempts: 2
     - task: rsync_code_up-{{java_test_version.name}}
       image: alpine-tools-image
       config:

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -37,6 +37,7 @@ build_test:
   DUNIT_PARALLEL_FORKS: '4'
   EXECUTE_TEST_TIMEOUT: 20m
   GRADLE_TASK: build
+  MAX_IN_FLIGHT: 2
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   RAM: '16'
@@ -82,6 +83,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '0'
   EXECUTE_TEST_TIMEOUT: 30m
   GRADLE_TASK: test
+  MAX_IN_FLIGHT: 1
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'true'
   PLATFORM: linux
@@ -93,6 +95,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '0'
   EXECUTE_TEST_TIMEOUT: 1h30m
   GRADLE_TASK: acceptanceTest
+  MAX_IN_FLIGHT: 2
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: linux
@@ -104,6 +107,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '24'
   EXECUTE_TEST_TIMEOUT: 3h00m
   GRADLE_TASK: distributedTest
+  MAX_IN_FLIGHT: 3
   PARALLEL_DUNIT: 'true'
   PLATFORM: linux
   RAM: '250'
@@ -114,6 +118,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '48'
   EXECUTE_TEST_TIMEOUT: 40m
   GRADLE_TASK: integrationTest
+  MAX_IN_FLIGHT: 1
   PARALLEL_DUNIT: 'true'
   PLATFORM: linux
   RAM: '90'
@@ -124,6 +129,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '48'
   EXECUTE_TEST_TIMEOUT: 1h
   GRADLE_TASK: upgradeTest
+  MAX_IN_FLIGHT: 2
   PARALLEL_DUNIT: 'true'
   PLATFORM: linux
   RAM: '210'
@@ -144,6 +150,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '0'
   EXECUTE_TEST_TIMEOUT: 6h
   GRADLE_TASK: :geode-assembly:acceptanceTest
+  MAX_IN_FLIGHT: 3
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: windows
@@ -155,6 +162,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   GRADLE_TASK: distributedTest
   GRADLE_TASK_OPTIONS: -PtestCategory=org.apache.geode.test.junit.categories.GfshTest
+  MAX_IN_FLIGHT: 5
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: windows
@@ -166,6 +174,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   GRADLE_TASK: integrationTest
   GRADLE_TASK_OPTIONS: -x geode-core:integrationTest
+  MAX_IN_FLIGHT: 2
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: windows
@@ -176,6 +185,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '0'
   EXECUTE_TEST_TIMEOUT: 6h
   GRADLE_TASK: geode-core:integrationTest
+  MAX_IN_FLIGHT: 6
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: windows
@@ -186,6 +196,7 @@ tests:
   DUNIT_PARALLEL_FORKS: '0'
   EXECUTE_TEST_TIMEOUT: 6h
   GRADLE_TASK: test
+  MAX_IN_FLIGHT: 1
   PARALLEL_DUNIT: 'false'
   PLATFORM: windows
   RAM: '64'


### PR DESCRIPTION
Instead of immediately launching all jobs at once, this PR evens out the load by setting lower max_in_flight settings for shorter jobs. I estimate this will cut peak load in half without builds taking any longer (for a scenario where 6 commits are in the pipeline at the same time).
Reducing load on concourse is desirable because we tend to have more unexplained rsync failures, etc, when concourse is under heavy load.

Also dial down unnecessarily-high retry counts from `10` to `2`, which rarely helped but greatly increased number of containers when things were already overloaded.

Note: This PR does NOT throttle PR pipeline.