### PR TITLE
Revert "rsync all inputs and outputs between the heavy-lifter and concourse"

### DIFF
--- a/ci/scripts/rsync_code_down.sh
+++ b/ci/scripts/rsync_code_down.sh
@@ -49,6 +49,6 @@ esac
 
 ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "${EXEC_COMMAND}"
 
-time rsync -e "ssh ${SSH_OPTIONS}" -ah geode@${INSTANCE_IP_ADDRESS}:* ${OUTPUT_DIR}/
+time rsync -e "ssh ${SSH_OPTIONS}" -ah geode@${INSTANCE_IP_ADDRESS}:geode ${OUTPUT_DIR}/
 
 set +x

--- a/ci/scripts/rsync_code_up.sh
+++ b/ci/scripts/rsync_code_up.sh
@@ -36,4 +36,4 @@ SSH_OPTIONS="-i ${SSHKEY_FILE} -o ConnectionAttempts=60 -o StrictHostKeyChecking
 
 INSTANCE_IP_ADDRESS="$(cat instance-data/instance-ip-address)"
 
-time rsync -e "ssh ${SSH_OPTIONS}" -ah * geode@${INSTANCE_IP_ADDRESS}:.
+time rsync -e "ssh ${SSH_OPTIONS}" -ah ${REPODIR} geode@${INSTANCE_IP_ADDRESS}:.


### PR DESCRIPTION
Reverts apache/geode#4391 as it broke rsync on Windows