### PR TITLE
GEODE-7551: Remove membership API dependency on ClusterDistributionManager

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -271,7 +271,7 @@ public class MembershipJUnitTest {
     });
     LifecycleListener lifeCycleListener = mock(LifecycleListener.class);
     final Membership m1 =
-        MembershipBuilder.newMembershipBuilder(null)
+        MembershipBuilder.newMembershipBuilder()
             .setAuthenticator(new GMSAuthenticator(config.getSecurityProps(), securityService,
                 mockSystem.getSecurityLogWriter(), mockSystem.getInternalLogWriter()))
             .setStatistics(stats1)

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
@@ -55,7 +55,6 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.HighPriorityAckedMessage;
-import org.apache.geode.distributed.internal.direct.DirectChannel;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.MembershipView;
 import org.apache.geode.distributed.internal.membership.adapter.LocalViewMessage;
@@ -83,7 +82,6 @@ public class GMSMembershipJUnitTest {
   private Services services;
   private MembershipConfig mockConfig;
   private DistributionConfig distConfig;
-  private Properties distProperties;
   private Authenticator authenticator;
   private HealthMonitor healthMonitor;
   private InternalDistributedMember myMemberId;
@@ -94,7 +92,6 @@ public class GMSMembershipJUnitTest {
   private MembershipListener listener;
   private GMSMembership manager;
   private List<InternalDistributedMember> members;
-  private DirectChannel dc;
   private MessageListener messageListener;
   private LifecycleListener directChannelCallback;
 
@@ -111,7 +108,6 @@ public class GMSMembershipJUnitTest {
     nonDefault.put(MEMBER_TIMEOUT, "2000");
     nonDefault.put(LOCATORS, "localhost[10344]");
     distConfig = new DistributionConfigImpl(nonDefault);
-    distProperties = nonDefault;
     RemoteTransportConfig tconfig =
         new RemoteTransportConfig(distConfig, ClusterDistributionManager.NORMAL_DM_TYPE);
 
@@ -158,7 +154,7 @@ public class GMSMembershipJUnitTest {
     listener = mock(MembershipListener.class);
     messageListener = mock(MessageListener.class);
     directChannelCallback = mock(LifecycleListener.class);
-    manager = new GMSMembership(listener, messageListener, null, directChannelCallback);
+    manager = new GMSMembership(listener, messageListener, directChannelCallback);
     manager.getGMSManager().init(services);
     when(services.getManager()).thenReturn(manager.getGMSManager());
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -1089,6 +1089,7 @@ public class ClusterDistributionManager implements DistributionManager {
         return;
       }
       closeInProgress = true;
+      this.distribution.setShutdown();
     } // synchronized
 
     // [bruce] log shutdown at info level and with ID to balance the

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -1089,7 +1089,7 @@ public class ClusterDistributionManager implements DistributionManager {
         return;
       }
       closeInProgress = true;
-      this.distribution.setShutdown();
+      this.distribution.setCloseInProgress();
     } // synchronized
 
     // [bruce] log shutdown at info level and with ID to balance the

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
@@ -160,4 +160,10 @@ public interface Distribution {
   void forceUDPMessagingForCurrentThread();
 
   void releaseUDPMessagingForCurrentThread();
+
+  /**
+   * When the ClusterDistributionManager initiates normal shutdown it should invoke this
+   * method so that services will know how to react.
+   */
+  void setCloseInProgress();
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -699,6 +699,11 @@ public class DistributionImpl implements Distribution {
     forceUseUDPMessaging.set(Boolean.FALSE);
   }
 
+  @Override
+  public void setCloseInProgress() {
+    membership.setCloseInProgress();
+  }
+
   private boolean isForceUDPCommunications() {
     return forceUseUDPMessaging.get();
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -123,8 +123,7 @@ public class DistributionImpl implements Distribution {
     }
 
     memberTimeout = system.getConfig().getMemberTimeout();
-    membership = MembershipBuilder.newMembershipBuilder(
-        clusterDistributionManager)
+    membership = MembershipBuilder.newMembershipBuilder()
         .setAuthenticator(
             new GMSAuthenticator(system.getSecurityProperties(), system.getSecurityService(),
                 system.getSecurityLogWriter(), system.getInternalLogWriter()))

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -101,6 +101,8 @@ public class GMSMembership implements Membership {
 
   private LifecycleListener lifecycleListener;
 
+  private volatile boolean isCloseInProgress;
+
   /**
    * Trick class to make the startup synch more visible in stack traces
    *
@@ -1749,7 +1751,6 @@ public class GMSMembership implements Membership {
     return shutdownInProgress;
   }
 
-
   // TODO GEODE-1752 rewrite this to get rid of the latches, which are currently a memory leak
   @Override
   public boolean waitForNewMember(DistributedMember remoteId) {
@@ -1949,6 +1950,11 @@ public class GMSMembership implements Membership {
       Services.getLogger().error("Unexpected problem starting up membership services", e);
       throw new SystemConnectException("Problem starting up membership services", e);
     }
+  }
+
+  @Override
+  public void setCloseInProgress() {
+    isCloseInProgress = true;
   }
 
 
@@ -2192,6 +2198,12 @@ public class GMSMembership implements Membership {
     public boolean shutdownInProgress() {
       return shutdownInProgress;
     }
+
+    @Override
+    public boolean isCloseInProgress() {
+      return shutdownInProgress || isCloseInProgress;
+    }
+
 
     @Override
     public boolean isReconnectingDS() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
@@ -17,7 +17,6 @@ package org.apache.geode.distributed.internal.membership.gms;
 
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.SystemConnectException;
-import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionException;
 import org.apache.geode.distributed.internal.membership.gms.api.Authenticator;
 import org.apache.geode.distributed.internal.membership.gms.api.LifecycleListener;
@@ -39,15 +38,12 @@ public class MembershipBuilderImpl implements MembershipBuilder {
   private MessageListener messageListener;
   private MembershipStatistics statistics;
   private Authenticator authenticator;
-  private ClusterDistributionManager dm;
   private MembershipConfig membershipConfig;
   private DSFIDSerializer serializer;
   private MemberIdentifierFactory memberFactory = new MemberIdentifierFactoryImpl();
   private LifecycleListener lifecycleListener;
 
-  public MembershipBuilderImpl(ClusterDistributionManager dm) {
-    this.dm = dm;
-  }
+  public MembershipBuilderImpl() {}
 
   @Override
   public MembershipBuilder setAuthenticator(Authenticator authenticator) {
@@ -107,7 +103,7 @@ public class MembershipBuilderImpl implements MembershipBuilder {
   @Override
   public Membership create() {
     GMSMembership gmsMembership =
-        new GMSMembership(membershipListener, messageListener, dm, lifecycleListener);
+        new GMSMembership(membershipListener, messageListener, lifecycleListener);
     Services services =
         new Services(gmsMembership.getGMSManager(), statistics, authenticator,
             membershipConfig, serializer, memberFactory, locatorClient);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberIdentifier.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberIdentifier.java
@@ -117,8 +117,4 @@ public interface MemberIdentifier extends DataSerializableFixedID {
    */
   void setVmKind(int dmType);
 
-  /**
-   * Set the membership data packed for this identifier
-   */
-  void setMemberData(MemberData data);
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberIdentifier.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberIdentifier.java
@@ -116,4 +116,9 @@ public interface MemberIdentifier extends DataSerializableFixedID {
    * Set the type of node
    */
   void setVmKind(int dmType);
+
+  /**
+   * Set the membership data packed for this identifier
+   */
+  void setMemberData(MemberData data);
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/Membership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/Membership.java
@@ -326,4 +326,6 @@ public interface Membership {
   boolean hasMember(InternalDistributedMember member);
 
   void start();
+
+  void setCloseInProgress();
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipBuilder.java
@@ -15,7 +15,6 @@
 package org.apache.geode.distributed.internal.membership.gms.api;
 
 
-import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.membership.gms.MembershipBuilderImpl;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
@@ -46,7 +45,7 @@ public interface MembershipBuilder {
 
   Membership create();
 
-  static MembershipBuilder newMembershipBuilder(ClusterDistributionManager dm) {
-    return new MembershipBuilderImpl(dm);
+  static MembershipBuilder newMembershipBuilder() {
+    return new MembershipBuilderImpl();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
@@ -66,4 +66,9 @@ public interface Manager extends Service, MessageHandler<Message> {
    */
   Services getServices();
 
+  /**
+   * Returns true if we've been informed that this node has started to close or has
+   * progressed past close (sending ShutdownMessages, etc) to shutting down membership services
+   */
+  boolean isCloseInProgress();
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
@@ -57,12 +57,6 @@ public interface Manager extends Service, MessageHandler<Message> {
   boolean shutdownInProgress();
 
   /**
-   * Returns true if a distributed system close is started. And shutdown msg has not sent yet,its in
-   * progress.
-   */
-  boolean isShutdownStarted();
-
-  /**
    * Indicate whether we are attempting a reconnect
    */
   boolean isReconnectingDS();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -878,7 +878,7 @@ public class GMSJoinLeave implements JoinLeave {
 
   boolean isShuttingDown() {
     return services.getCancelCriterion().isCancelInProgress()
-        || services.getManager().shutdownInProgress() || services.getManager().isShutdownStarted();
+        || services.getManager().shutdownInProgress();
   }
 
   boolean prepareView(GMSMembershipView view, List<MemberIdentifier> newMembers)

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -878,7 +878,8 @@ public class GMSJoinLeave implements JoinLeave {
 
   boolean isShuttingDown() {
     return services.getCancelCriterion().isCancelInProgress()
-        || services.getManager().shutdownInProgress();
+        || services.getManager().shutdownInProgress()
+        || services.getManager().isCloseInProgress();
   }
 
   boolean prepareView(GMSMembershipView view, List<MemberIdentifier> newMembers)

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -35,7 +35,6 @@ import org.apache.geode.InternalGemFireError;
 import org.apache.geode.alerting.internal.spi.AlertingAction;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.adapter.LocalViewMessage;
 import org.apache.geode.distributed.internal.tcpserver.ConnectionWatcher;
@@ -157,8 +156,6 @@ public class MembershipDependenciesJUnitTest {
               .or(type(DistributedMember.class))
               .or(type(MembershipView.class))
               .or(type(LocalViewMessage.class))
-
-              .or(type(ClusterDistributionManager.class))
 
   );
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
@@ -28,7 +28,6 @@ import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.MembershipView;
 import org.apache.geode.distributed.internal.membership.gms.MemberDataBuilderImpl;
@@ -63,10 +62,8 @@ public class MembershipAPIArchUnitTest {
               // TODO to be extracted as Interfaces
               .or(type(InternalDistributedMember.class))
               .or(type(MembershipView.class))
-              .or(type(MemberIdentifier.class))
               .or(type(DistributedMember.class))
               .or(type(InternalDistributedMember[].class))
-              .or(type(ClusterDistributionManager.class))
 
               // TODO: This is used by the GMSLocatorAdapter to reach into the locator
               // part of the services

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -222,7 +222,7 @@ public class ClusterStartupRule implements SerializableTestRule {
       SerializableFunction<LocatorStarterRule> ruleOperator) {
     final String defaultName = "locator-" + index;
     VM locatorVM = getVM(index, version);
-    Locator server = locatorVM.invoke(() -> {
+    Locator server = locatorVM.invoke("start locator in vm" + index, () -> {
       memberStarter = new LocatorStarterRule();
       LocatorStarterRule locatorStarter = (LocatorStarterRule) memberStarter;
       if (logFile) {


### PR DESCRIPTION
ClusterDistributionManager was only being used to get canonical IDs and
to check for shutdown conditions.  I've modified the CDM to set shutdown
status in membership in its shutdown() method and have modified
membership to just use the current MembershipView (which contains any
surprise members) instead of asking CDM for a canonical ID, which just
grabs said MembershipView and does the same thing.

I haven't added any tests because there are already tests for shutdown/closing conditions in manager/joinleave/CDM tests.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
