### PR TITLE
GEODE-7503: Add new unit tests for GemFireCacheImpl

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemFireCacheImplEmergencyCloseDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemFireCacheImplEmergencyCloseDistributedTest.java
@@ -14,36 +14,46 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 
 public class GemFireCacheImplEmergencyCloseDistributedTest {
 
+  private VM vm;
+
   @Rule
-  public DistributedRule distributedRule = new DistributedRule();
+  public DistributedRule distributedRule = new DistributedRule(1);
 
-  @Test
-  public void inAbsenceOfGatewayReceiverServerEmergencyCloseWillCloseCache() {
-
-    VM node = VM.getVM(0);
-
-    node.invoke(() -> {
-      GemFireCacheImpl gemFireCacheImpl = (GemFireCacheImpl) new CacheFactory().create();
-
-      gemFireCacheImpl.emergencyClose();
-
-      assertThat(gemFireCacheImpl.isClosed()).isTrue();
-    });
-
-    // This is to close the resources that are left over after
-    // GemfireCacheImpl.emergencyClose().
-    node.bounceForcibly();
+  @Before
+  public void setUp() {
+    vm = getVM(0);
   }
 
+  @After
+  public void tearDown() {
+    // This is to close the resources that are left over after emergencyClose().
+    vm.bounceForcibly();
+  }
+
+  @Test
+  public void emergencyClose_closesCache() {
+    vm.invoke(() -> {
+      Cache cache = new CacheFactory().create();
+
+      GemFireCacheImpl.emergencyClose();
+
+      assertThat(cache.isClosed())
+          .isTrue();
+    });
+  }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemFireCacheImplEmergencyCloseDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GemFireCacheImplEmergencyCloseDistributedTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 
-public class GemfireCacheImplDUnitTest {
+public class GemFireCacheImplEmergencyCloseDistributedTest {
 
   @Rule
   public DistributedRule distributedRule = new DistributedRule();

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/CacheFactoryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/CacheFactoryIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache;
 
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,6 +35,15 @@ public class CacheFactoryIntegrationTest {
     if (cache != null) {
       cache.close();
     }
+  }
+
+  @Test
+  public void recreateDoesNotThrowDistributedSystemDisconnectedException() {
+    cache = (InternalCache) new CacheFactory().set(LOCATORS, "").create();
+
+    cache.close();
+
+    cache = (InternalCache) new CacheFactory().set(LOCATORS, "").create();
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplCloseTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplCloseTest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.client.PoolFactory;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.ReplyProcessor21;
+import org.apache.geode.internal.SystemTimer;
+import org.apache.geode.internal.cache.GemFireCacheImpl.ReplyProcessor21Factory;
+import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.control.ResourceAdvisor;
+import org.apache.geode.internal.cache.eviction.HeapEvictor;
+import org.apache.geode.internal.cache.eviction.OffHeapEvictor;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.management.internal.JmxManagerAdvisor;
+import org.apache.geode.pdx.internal.TypeRegistry;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+/**
+ * Unit tests for closing GemFireCacheImpl.
+ */
+public class GemFireCacheImplCloseTest {
+
+  private static final long TIMEOUT_MILLIS = GeodeAwaitility.getTimeout().getValueInMS();
+
+  private CacheConfig cacheConfig;
+  private CompositeMeterRegistry meterRegistry;
+  private InternalDistributedSystem internalDistributedSystem;
+  private PoolFactory poolFactory;
+  private ReplyProcessor21Factory replyProcessor21Factory;
+  private TypeRegistry typeRegistry;
+
+  private GemFireCacheImpl gemFireCacheImpl;
+
+  @Rule
+  public ExecutorServiceRule executorServiceRule = new ExecutorServiceRule();
+
+  @Before
+  public void setUp() {
+    cacheConfig = mock(CacheConfig.class);
+    internalDistributedSystem = mock(InternalDistributedSystem.class);
+    poolFactory = mock(PoolFactory.class);
+    replyProcessor21Factory = mock(ReplyProcessor21Factory.class);
+    typeRegistry = mock(TypeRegistry.class);
+
+    DistributionConfig distributionConfig = mock(DistributionConfig.class);
+    DistributionManager distributionManager = mock(DistributionManager.class);
+    ReplyProcessor21 replyProcessor21 = mock(ReplyProcessor21.class);
+
+    when(distributionConfig.getSecurityProps())
+        .thenReturn(new Properties());
+    when(internalDistributedSystem.getConfig())
+        .thenReturn(distributionConfig);
+    when(internalDistributedSystem.getDistributionManager())
+        .thenReturn(distributionManager);
+    when(internalDistributedSystem.getCancelCriterion())
+        .thenReturn(mock(CancelCriterion.class));
+    when(replyProcessor21.getProcessorId())
+        .thenReturn(21);
+    when(replyProcessor21Factory.create(any(), any()))
+        .thenReturn(replyProcessor21);
+
+    gemFireCacheImpl = gemFireCacheImpl(false);
+  }
+
+  @After
+  public void tearDown() {
+    if (gemFireCacheImpl != null) {
+      gemFireCacheImpl.close();
+    }
+    if (meterRegistry != null) {
+      meterRegistry.close();
+    }
+  }
+
+  @Test
+  public void isClosed_returnsFalse_ifCacheExists() {
+    assertThat(gemFireCacheImpl.isClosed())
+        .isFalse();
+  }
+
+  @Test
+  public void isClosed_returnsTrue_ifCacheIsClosed() {
+    gemFireCacheImpl.close();
+
+    assertThat(gemFireCacheImpl.isClosed())
+        .isTrue();
+  }
+
+  @Test
+  public void close_closesHeapEvictor() {
+    HeapEvictor heapEvictor = mock(HeapEvictor.class);
+    gemFireCacheImpl.setHeapEvictor(heapEvictor);
+
+    gemFireCacheImpl.close();
+
+    verify(heapEvictor)
+        .close();
+  }
+
+  @Test
+  public void close_closesOffHeapEvictor() {
+    OffHeapEvictor offHeapEvictor = mock(OffHeapEvictor.class);
+    gemFireCacheImpl.setOffHeapEvictor(offHeapEvictor);
+
+    gemFireCacheImpl.close();
+
+    verify(offHeapEvictor)
+        .close();
+  }
+
+  @Test
+  public void close_doesNotCloseUserMeterRegistries() {
+    meterRegistry = new CompositeMeterRegistry();
+    MeterRegistry userRegistry = spy(new SimpleMeterRegistry());
+    meterRegistry.add(userRegistry);
+    when(internalDistributedSystem.getMeterRegistry())
+        .thenReturn(meterRegistry);
+
+    gemFireCacheImpl.close();
+
+    assertThat(userRegistry.isClosed())
+        .isFalse();
+  }
+
+  /**
+   * InternalDistributed.disconnect is invoked only once despite invoking GemFireCacheImpl.close
+   * more than once.
+   */
+  @Test
+  public void close_doesNothingIfAlreadyClosed() {
+    gemFireCacheImpl.close();
+
+    verify(internalDistributedSystem).disconnect();
+
+    assertThatCode(() -> gemFireCacheImpl.close())
+        .doesNotThrowAnyException();
+
+    verify(internalDistributedSystem).disconnect();
+  }
+
+  @SuppressWarnings({"SameParameterValue", "LambdaParameterHidesMemberVariable",
+      "OverlyCoupledMethod", "unchecked"})
+  private GemFireCacheImpl gemFireCacheImpl(boolean useAsyncEventListeners) {
+    return new GemFireCacheImpl(
+        false,
+        poolFactory,
+        internalDistributedSystem,
+        cacheConfig,
+        useAsyncEventListeners,
+        typeRegistry,
+        mock(Consumer.class),
+        (properties, cacheConfigArg) -> mock(SecurityService.class),
+        () -> true,
+        mock(Function.class),
+        mock(Function.class),
+        (factory, clock) -> mock(CachePerfStats.class),
+        mock(GemFireCacheImpl.TXManagerImplFactory.class),
+        mock(Supplier.class),
+        distributionAdvisee -> mock(ResourceAdvisor.class),
+        mock(Function.class),
+        jmxManagerAdvisee -> mock(JmxManagerAdvisor.class),
+        internalCache -> mock(InternalResourceManager.class),
+        () -> 1,
+        (cache, statisticsClock) -> mock(HeapEvictor.class),
+        mock(Consumer.class),
+        mock(Consumer.class),
+        mock(Consumer.class),
+        mock(Function.class),
+        mock(Consumer.class),
+        mock(GemFireCacheImpl.TypeRegistryFactory.class),
+        mock(Consumer.class),
+        mock(Consumer.class),
+        o -> mock(SystemTimer.class),
+        internalCache -> mock(TombstoneService.class),
+        internalDistributedSystem -> mock(ExpirationScheduler.class),
+        file -> mock(DiskStoreMonitor.class),
+        () -> mock(RegionEntrySynchronizationListener.class),
+        mock(Function.class),
+        mock(Function.class),
+        mock(TXEntryStateFactory.class),
+        replyProcessor21Factory);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -17,13 +17,9 @@ package org.apache.geode.internal.cache;
 import static org.apache.geode.distributed.internal.InternalDistributedSystem.ALLOW_MULTIPLE_SYSTEMS_PROPERTY;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,36 +29,79 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.SerializationException;
 import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.client.PoolFactory;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.wan.GatewayReceiver;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.ReplyProcessor21;
 import org.apache.geode.internal.SystemTimer;
+import org.apache.geode.internal.cache.GemFireCacheImpl.ReplyProcessor21Factory;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.control.ResourceAdvisor;
 import org.apache.geode.internal.cache.eviction.HeapEvictor;
-import org.apache.geode.internal.cache.eviction.OffHeapEvictor;
-import org.apache.geode.metrics.internal.InternalDistributedSystemMetricsService;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.pdx.internal.TypeRegistry;
-import org.apache.geode.test.fake.Fakes;
 
 /**
  * Unit tests for {@link GemFireCacheImpl}.
  */
 public class GemFireCacheImplTest {
 
+  private CacheConfig cacheConfig;
+  private InternalDistributedSystem internalDistributedSystem;
+  private PoolFactory poolFactory;
+  private ReplyProcessor21Factory replyProcessor21Factory;
+  private TypeRegistry typeRegistry;
+
+  private GemFireCacheImpl gemFireCacheImpl;
+
   @Rule
   public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-  private GemFireCacheImpl gemFireCacheImpl;
+  @Before
+  public void setUp() {
+    cacheConfig = mock(CacheConfig.class);
+    internalDistributedSystem = mock(InternalDistributedSystem.class);
+    poolFactory = mock(PoolFactory.class);
+    replyProcessor21Factory = mock(ReplyProcessor21Factory.class);
+    typeRegistry = mock(TypeRegistry.class);
+
+    DistributionConfig distributionConfig = mock(DistributionConfig.class);
+    DistributionManager distributionManager = mock(DistributionManager.class);
+    ReplyProcessor21 replyProcessor21 = mock(ReplyProcessor21.class);
+
+    when(distributionConfig.getSecurityProps())
+        .thenReturn(new Properties());
+    when(internalDistributedSystem.getConfig())
+        .thenReturn(distributionConfig);
+    when(internalDistributedSystem.getDistributionManager())
+        .thenReturn(distributionManager);
+    when(internalDistributedSystem.getCancelCriterion())
+        .thenReturn(mock(CancelCriterion.class));
+    when(replyProcessor21.getProcessorId())
+        .thenReturn(21);
+    when(replyProcessor21Factory.create(any(), any()))
+        .thenReturn(replyProcessor21);
+
+    gemFireCacheImpl = gemFireCacheImpl(false);
+  }
 
   @After
   public void tearDown() {
@@ -73,231 +112,246 @@ public class GemFireCacheImplTest {
 
   @Test
   public void canBeMocked() {
-    GemFireCacheImpl mockGemFireCacheImpl = mock(GemFireCacheImpl.class);
-    InternalResourceManager mockInternalResourceManager = mock(InternalResourceManager.class);
+    GemFireCacheImpl gemFireCacheImpl = mock(GemFireCacheImpl.class);
+    InternalResourceManager internalResourceManager = mock(InternalResourceManager.class);
 
-    when(mockGemFireCacheImpl.getInternalResourceManager()).thenReturn(mockInternalResourceManager);
+    when(gemFireCacheImpl.getInternalResourceManager())
+        .thenReturn(internalResourceManager);
 
-    assertThat(mockGemFireCacheImpl.getInternalResourceManager())
-        .isSameAs(mockInternalResourceManager);
+    assertThat(gemFireCacheImpl.getInternalResourceManager())
+        .isSameAs(internalResourceManager);
   }
 
   @Test
   public void checkPurgeCCPTimer() {
     SystemTimer cacheClientProxyTimer = mock(SystemTimer.class);
-
-    gemFireCacheImpl = createGemFireCacheImpl();
-
     gemFireCacheImpl.setCCPTimer(cacheClientProxyTimer);
+
     for (int i = 1; i < GemFireCacheImpl.PURGE_INTERVAL; i++) {
       gemFireCacheImpl.purgeCCPTimer();
-      verify(cacheClientProxyTimer, times(0)).timerPurge();
+      verify(cacheClientProxyTimer,
+          times(0))
+              .timerPurge();
     }
+
     gemFireCacheImpl.purgeCCPTimer();
-    verify(cacheClientProxyTimer, times(1)).timerPurge();
+    verify(cacheClientProxyTimer,
+        times(1))
+            .timerPurge();
+
     for (int i = 1; i < GemFireCacheImpl.PURGE_INTERVAL; i++) {
       gemFireCacheImpl.purgeCCPTimer();
-      verify(cacheClientProxyTimer, times(1)).timerPurge();
+      verify(cacheClientProxyTimer,
+          times(1))
+              .timerPurge();
     }
+
     gemFireCacheImpl.purgeCCPTimer();
-    verify(cacheClientProxyTimer, times(2)).timerPurge();
-  }
-
-  @Test
-  public void checkEvictorsClosed() {
-    HeapEvictor heapEvictor = mock(HeapEvictor.class);
-    OffHeapEvictor offHeapEvictor = mock(OffHeapEvictor.class);
-
-    gemFireCacheImpl = createGemFireCacheImpl();
-
-    gemFireCacheImpl.setHeapEvictor(heapEvictor);
-    gemFireCacheImpl.setOffHeapEvictor(offHeapEvictor);
-    gemFireCacheImpl.close();
-
-    verify(heapEvictor).close();
-    verify(offHeapEvictor).close();
+    verify(cacheClientProxyTimer,
+        times(2))
+            .timerPurge();
   }
 
   @Test
   public void registerPdxMetaDataThrowsIfInstanceNotSerializable() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+    Throwable thrown = catchThrowable(() -> gemFireCacheImpl.registerPdxMetaData(new Object()));
 
-    assertThatThrownBy(() -> gemFireCacheImpl.registerPdxMetaData(new Object()))
-        .isInstanceOf(SerializationException.class).hasMessage("Serialization failed")
+    assertThat(thrown)
+        .isInstanceOf(SerializationException.class)
+        .hasMessage("Serialization failed")
         .hasCauseInstanceOf(NotSerializableException.class);
   }
 
   @Test
   public void registerPdxMetaDataThrowsIfInstanceIsNotPDX() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+    Throwable thrown = catchThrowable(() -> {
+      gemFireCacheImpl.registerPdxMetaData("string");
+    });
 
-    assertThatThrownBy(() -> gemFireCacheImpl.registerPdxMetaData("string"))
+    assertThat(thrown)
         .isInstanceOf(SerializationException.class)
         .hasMessage("The instance is not PDX serializable");
   }
 
   @Test
   public void checkThatAsyncEventListenersUseAllThreadsInPool() {
-    gemFireCacheImpl = createGemFireCacheWithTypeRegistry();
-
+    gemFireCacheImpl = gemFireCacheImpl(true);
     ThreadPoolExecutor eventThreadPoolExecutor =
         (ThreadPoolExecutor) gemFireCacheImpl.getEventThreadPool();
-    assertEquals(0, eventThreadPoolExecutor.getCompletedTaskCount());
-    assertEquals(0, eventThreadPoolExecutor.getActiveCount());
 
-    int MAX_THREADS = GemFireCacheImpl.EVENT_THREAD_LIMIT;
-    final CountDownLatch threadLatch = new CountDownLatch(MAX_THREADS);
-    for (int i = 1; i <= MAX_THREADS; i++) {
+    assertThat(eventThreadPoolExecutor.getCompletedTaskCount())
+        .isZero();
+    assertThat(eventThreadPoolExecutor.getActiveCount())
+        .isZero();
+
+    int eventThreadLimit = GemFireCacheImpl.EVENT_THREAD_LIMIT;
+    CountDownLatch threadLatch = new CountDownLatch(eventThreadLimit);
+
+    for (int i = 1; i <= eventThreadLimit; i++) {
       eventThreadPoolExecutor.execute(() -> {
         threadLatch.countDown();
         try {
           threadLatch.await();
         } catch (InterruptedException ignore) {
+          // ignored
         }
       });
     }
 
-    await().untilAsserted(
-        () -> assertThat(eventThreadPoolExecutor.getCompletedTaskCount()).isEqualTo(MAX_THREADS));
+    await().untilAsserted(() -> {
+      assertThat(eventThreadPoolExecutor.getCompletedTaskCount())
+          .isEqualTo(eventThreadLimit);
+    });
   }
 
   @Test
-  public void getCacheClosedExceptionWithNoReasonOrCauseGivesExceptionWithoutEither() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void getCacheClosedException_withoutReasonOrCauseGivesExceptionWithoutEither() {
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException(null, null);
 
-    CacheClosedException cacheClosedException =
-        gemFireCacheImpl.getCacheClosedException(null, null);
-
-    assertThat(cacheClosedException.getCause()).isNull();
-    assertThat(cacheClosedException.getMessage()).isNull();
+    assertThat(value.getCause())
+        .isNull();
+    assertThat(value.getMessage())
+        .isNull();
   }
 
   @Test
-  public void getCacheClosedExceptionWithNoCauseGivesExceptionWithReason() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void getCacheClosedException_withoutCauseGivesExceptionWithReason() {
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException("message");
 
-    CacheClosedException cacheClosedException = gemFireCacheImpl
-        .getCacheClosedException("message", null);
-
-    assertThat(cacheClosedException.getCause()).isNull();
-    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
+    assertThat(value.getCause())
+        .isNull();
+    assertThat(value.getMessage())
+        .isEqualTo("message");
   }
 
   @Test
-  public void getCacheClosedExceptionReturnsExceptionWithProvidedCauseAndReason() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void getCacheClosedException_returnsExceptionWithProvidedCauseAndReason() {
     Throwable cause = new Throwable();
 
-    CacheClosedException cacheClosedException = gemFireCacheImpl
-        .getCacheClosedException("message", cause);
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException("message", cause);
 
-    assertThat(cacheClosedException.getCause()).isEqualTo(cause);
-    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
+    assertThat(value.getCause())
+        .isEqualTo(cause);
+    assertThat(value.getMessage())
+        .isEqualTo("message");
   }
 
   @Test
-  public void getCacheClosedExceptionWhenCauseGivenButDisconnectExceptionExistsPrefersCause() {
-    gemFireCacheImpl = createGemFireCacheImpl();
-    gemFireCacheImpl.disconnectCause = new Throwable("disconnectCause");
+  public void getCacheClosedException_prefersGivenCauseWhenDisconnectExceptionExists() {
+    gemFireCacheImpl.setDisconnectCause(new Throwable("disconnectCause"));
     Throwable cause = new Throwable();
 
-    CacheClosedException cacheClosedException = gemFireCacheImpl
-        .getCacheClosedException("message", cause);
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException("message", cause);
 
-    assertThat(cacheClosedException.getCause()).isEqualTo(cause);
-    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
+    assertThat(value.getCause())
+        .isEqualTo(cause);
+    assertThat(value.getMessage())
+        .isEqualTo("message");
   }
 
   @Test
-  public void getCacheClosedExceptionWhenNoCauseGivenProvidesDisconnectExceptionIfExists() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void getCacheClosedException_withoutCauseGiven_providesDisconnectExceptionIfExists() {
     Throwable disconnectCause = new Throwable("disconnectCause");
-    gemFireCacheImpl.disconnectCause = disconnectCause;
+    gemFireCacheImpl.setDisconnectCause(disconnectCause);
 
-    CacheClosedException cacheClosedException = gemFireCacheImpl
-        .getCacheClosedException("message", null);
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException("message");
 
-    assertThat(cacheClosedException.getCause()).isEqualTo(disconnectCause);
-    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
+    assertThat(value.getCause())
+        .isEqualTo(disconnectCause);
+    assertThat(value.getMessage())
+        .isEqualTo("message");
   }
 
   @Test
-  public void getCacheClosedExceptionReturnsExceptionWithProvidedReason() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void getCacheClosedException_returnsExceptionWithProvidedReason() {
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException("message");
 
-    CacheClosedException cacheClosedException = gemFireCacheImpl.getCacheClosedException("message");
-
-    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
-    assertThat(cacheClosedException.getCause()).isNull();
+    assertThat(value.getMessage())
+        .isEqualTo("message");
+    assertThat(value.getCause())
+        .isNull();
   }
 
   @Test
-  public void getCacheClosedExceptionReturnsExceptionWithNoMessageWhenReasonNotGiven() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void getCacheClosedException_returnsExceptionWithoutMessageWhenReasonNotGiven() {
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException(null);
 
-    CacheClosedException cacheClosedException = gemFireCacheImpl.getCacheClosedException(null);
-
-    assertThat(cacheClosedException.getMessage()).isEqualTo(null);
-    assertThat(cacheClosedException.getCause()).isNull();
+    assertThat(value.getMessage())
+        .isEqualTo(null);
+    assertThat(value.getCause())
+        .isNull();
   }
 
   @Test
-  public void getCacheClosedExceptionReturnsExceptionWithDisconnectCause() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void getCacheClosedException_returnsExceptionWithDisconnectCause() {
     Throwable disconnectCause = new Throwable("disconnectCause");
-    gemFireCacheImpl.disconnectCause = disconnectCause;
+    gemFireCacheImpl.setDisconnectCause(disconnectCause);
 
-    CacheClosedException cacheClosedException = gemFireCacheImpl.getCacheClosedException("message");
+    CacheClosedException value = gemFireCacheImpl.getCacheClosedException("message");
 
-    assertThat(cacheClosedException.getMessage()).isEqualTo("message");
-    assertThat(cacheClosedException.getCause()).isEqualTo(disconnectCause);
+    assertThat(value.getMessage())
+        .isEqualTo("message");
+    assertThat(value.getCause())
+        .isEqualTo(disconnectCause);
   }
 
   @Test
-  public void addGatewayReceiverDoesNotAllowMoreThanOneReceiver() {
+  public void addGatewayReceiverDoesNotAllowMoreThanOneGatewayReceiver() {
     GatewayReceiver receiver = mock(GatewayReceiver.class);
     GatewayReceiver receiver2 = mock(GatewayReceiver.class);
-    gemFireCacheImpl = createGemFireCacheImpl();
     gemFireCacheImpl.addGatewayReceiver(receiver);
-    assertThat(gemFireCacheImpl.getGatewayReceivers()).hasSize(1);
 
     gemFireCacheImpl.addGatewayReceiver(receiver2);
 
     assertThat(gemFireCacheImpl.getGatewayReceivers())
-        .hasSize(1)
         .containsOnly(receiver2);
   }
 
   @Test
   public void addGatewayReceiverRequiresSuppliedGatewayReceiver() {
-    gemFireCacheImpl = createGemFireCacheImpl();
-
     Throwable thrown = catchThrowable(() -> gemFireCacheImpl.addGatewayReceiver(null));
 
-    assertThat(thrown).isInstanceOf(NullPointerException.class);
+    assertThat(thrown)
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
-  public void removeGatewayReceiverRemovesTheReceiver() {
+  public void addGatewayReceiverAddsGatewayReceiver() {
     GatewayReceiver receiver = mock(GatewayReceiver.class);
-    gemFireCacheImpl = createGemFireCacheImpl();
+
     gemFireCacheImpl.addGatewayReceiver(receiver);
-    assertThat(gemFireCacheImpl.getGatewayReceivers()).hasSize(1);
+
+    assertThat(gemFireCacheImpl.getGatewayReceivers())
+        .hasSize(1);
+  }
+
+  @Test
+  public void removeGatewayReceiverRemovesGatewayReceiver() {
+    GatewayReceiver receiver = mock(GatewayReceiver.class);
+    gemFireCacheImpl.addGatewayReceiver(receiver);
 
     gemFireCacheImpl.removeGatewayReceiver(receiver);
 
-    assertThat(gemFireCacheImpl.getGatewayReceivers()).isEmpty();
+    assertThat(gemFireCacheImpl.getGatewayReceivers())
+        .isEmpty();
   }
 
   @Test
-  public void removeFromCacheServerShouldRemoveFromCacheServersList() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+  public void addCacheServerAddsOneCacheServer() {
+    gemFireCacheImpl.addCacheServer();
+
+    assertThat(gemFireCacheImpl.getCacheServers())
+        .hasSize(1);
+  }
+
+  @Test
+  public void removeCacheServerRemovesSpecifiedCacheServer() {
     CacheServer cacheServer = gemFireCacheImpl.addCacheServer();
-    assertEquals(1, gemFireCacheImpl.getCacheServers().size());
 
     gemFireCacheImpl.removeCacheServer(cacheServer);
 
-    assertEquals(0, gemFireCacheImpl.getCacheServers().size());
+    assertThat(gemFireCacheImpl.getCacheServers())
+        .isEmpty();
   }
 
   @Test
@@ -306,57 +360,60 @@ public class GemFireCacheImplTest {
     Properties serverProps = new Properties();
 
     // both does not have the key
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
 
     // cluster has the key, not the server
     clusterProps.setProperty("key", "value");
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
+
     clusterProps.setProperty("key", "");
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
 
     // server has the key, not the cluster
     clusterProps.clear();
     serverProps.clear();
     serverProps.setProperty("key", "value");
-    assertTrue(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isTrue();
+
     serverProps.setProperty("key", "");
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
 
     // server has the key, not the cluster
     clusterProps.clear();
     serverProps.clear();
     clusterProps.setProperty("key", "");
     serverProps.setProperty("key", "value");
-    assertTrue(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isTrue();
+
     serverProps.setProperty("key", "");
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
 
     // server and cluster has the same value
     clusterProps.clear();
     serverProps.clear();
     clusterProps.setProperty("key", "value");
     serverProps.setProperty("key", "value");
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
+
     clusterProps.setProperty("key", "");
     serverProps.setProperty("key", "");
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
 
     // server and cluster has the different value
     clusterProps.clear();
     serverProps.clear();
     clusterProps.setProperty("key", "value1");
     serverProps.setProperty("key", "value2");
-    assertTrue(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isTrue();
+
     clusterProps.setProperty("key", "value1");
     serverProps.setProperty("key", "");
-    assertFalse(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key"));
+    assertThat(GemFireCacheImpl.isMisConfigured(clusterProps, serverProps, "key")).isFalse();
   }
 
   @Test
-  public void clientCacheWouldNotRequestClusterConfig() {
+  public void clientCacheDoesNotRequestClusterConfig() {
     System.setProperty(ALLOW_MULTIPLE_SYSTEMS_PROPERTY, "true");
-
-    InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
     gemFireCacheImpl = mock(GemFireCacheImpl.class);
     when(internalDistributedSystem.getCache()).thenReturn(gemFireCacheImpl);
 
@@ -364,28 +421,18 @@ public class GemFireCacheImplTest {
         .setIsClient(true)
         .create(internalDistributedSystem);
 
-    verify(gemFireCacheImpl, times(0)).requestSharedConfiguration();
-    verify(gemFireCacheImpl, times(0)).applyJarAndXmlFromClusterConfig();
+    verify(gemFireCacheImpl,
+        times(0))
+            .requestSharedConfiguration();
+    verify(gemFireCacheImpl,
+        times(0))
+            .applyJarAndXmlFromClusterConfig();
   }
 
   @Test
   public void getMeterRegistry_returnsTheSystemMeterRegistry() {
     MeterRegistry systemMeterRegistry = mock(MeterRegistry.class);
-
-    InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
     when(internalDistributedSystem.getMeterRegistry()).thenReturn(systemMeterRegistry);
-
-    InternalCacheBuilder cacheBuilder =
-        new InternalCacheBuilder(new Properties(), new CacheConfig(),
-            new InternalDistributedSystemMetricsService.Builder(),
-            InternalDistributedSystem::getConnectedInstance,
-            InternalDistributedSystem::connectInternal, GemFireCacheImpl::getInstance,
-            GemFireCacheImpl::new);
-
-    gemFireCacheImpl = (GemFireCacheImpl) cacheBuilder
-        .setUseAsyncEventListeners(true)
-        .setTypeRegistry(mock(TypeRegistry.class))
-        .create(internalDistributedSystem);
 
     assertThat(gemFireCacheImpl.getMeterRegistry())
         .isSameAs(systemMeterRegistry);
@@ -393,30 +440,28 @@ public class GemFireCacheImplTest {
 
   @Test
   public void addGatewayReceiverServer_requiresPreviouslyAddedGatewayReceiver() {
-    gemFireCacheImpl = createGemFireCacheImpl();
+    Throwable thrown = catchThrowable(() -> {
+      gemFireCacheImpl.addGatewayReceiverServer(mock(GatewayReceiver.class));
+    });
 
-    Throwable thrown = catchThrowable(
-        () -> gemFireCacheImpl.addGatewayReceiverServer(mock(GatewayReceiver.class)));
-
-    assertThat(thrown).isInstanceOf(NullPointerException.class);
+    assertThat(thrown)
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   public void addGatewayReceiverServer_requiresSuppliedGatewayReceiver() {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
-    gemFireCacheImpl = createGemFireCacheImpl();
     gemFireCacheImpl.addGatewayReceiver(gatewayReceiver);
 
-    Throwable thrown = catchThrowable(
-        () -> gemFireCacheImpl.addGatewayReceiverServer(null));
+    Throwable thrown = catchThrowable(() -> gemFireCacheImpl.addGatewayReceiverServer(null));
 
-    assertThat(thrown).isInstanceOf(NullPointerException.class);
+    assertThat(thrown)
+        .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   public void addGatewayReceiverServer_addsCacheServer() {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
-    gemFireCacheImpl = createGemFireCacheImpl();
     gemFireCacheImpl.addGatewayReceiver(gatewayReceiver);
 
     InternalCacheServer receiverServer = gemFireCacheImpl.addGatewayReceiverServer(gatewayReceiver);
@@ -427,50 +472,48 @@ public class GemFireCacheImplTest {
 
   @Test
   public void getCacheServers_isEmptyByDefault() {
-    gemFireCacheImpl = createGemFireCacheImpl();
-
     List<CacheServer> value = gemFireCacheImpl.getCacheServers();
 
-    assertThat(value).isEmpty();
+    assertThat(value)
+        .isEmpty();
   }
 
   @Test
   public void getCacheServers_returnsAddedCacheServer() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     CacheServer cacheServer = gemFireCacheImpl.addCacheServer();
 
     List<CacheServer> value = gemFireCacheImpl.getCacheServers();
 
-    assertThat(value).containsExactly(cacheServer);
+    assertThat(value)
+        .containsExactly(cacheServer);
   }
 
   @Test
   public void getCacheServers_returnsMultipleAddedCacheServers() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     CacheServer cacheServer1 = gemFireCacheImpl.addCacheServer();
     CacheServer cacheServer2 = gemFireCacheImpl.addCacheServer();
     CacheServer cacheServer3 = gemFireCacheImpl.addCacheServer();
 
     List<CacheServer> value = gemFireCacheImpl.getCacheServers();
 
-    assertThat(value).containsExactlyInAnyOrder(cacheServer1, cacheServer2, cacheServer3);
+    assertThat(value)
+        .containsExactlyInAnyOrder(cacheServer1, cacheServer2, cacheServer3);
   }
 
   @Test
   public void getCacheServers_isStillEmptyAfterAddingGatewayReceiverServer() {
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
-    gemFireCacheImpl = createGemFireCacheImpl();
     gemFireCacheImpl.addGatewayReceiver(gatewayReceiver);
     gemFireCacheImpl.addGatewayReceiverServer(gatewayReceiver);
 
     List<CacheServer> value = gemFireCacheImpl.getCacheServers();
 
-    assertThat(value).isEmpty();
+    assertThat(value)
+        .isEmpty();
   }
 
   @Test
   public void getCacheServers_doesNotIncludeGatewayReceiverServer() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     CacheServer cacheServer1 = gemFireCacheImpl.addCacheServer();
     CacheServer cacheServer2 = gemFireCacheImpl.addCacheServer();
     CacheServer cacheServer3 = gemFireCacheImpl.addCacheServer();
@@ -480,45 +523,44 @@ public class GemFireCacheImplTest {
 
     List<CacheServer> value = gemFireCacheImpl.getCacheServers();
 
-    assertThat(value).containsExactlyInAnyOrder(cacheServer1, cacheServer2, cacheServer3);
+    assertThat(value)
+        .containsExactlyInAnyOrder(cacheServer1, cacheServer2, cacheServer3);
   }
 
   @Test
   public void getCacheServersAndGatewayReceiver_isEmptyByDefault() {
-    gemFireCacheImpl = createGemFireCacheImpl();
-
     List<InternalCacheServer> value = gemFireCacheImpl.getCacheServersAndGatewayReceiver();
 
-    assertThat(value).isEmpty();
+    assertThat(value)
+        .isEmpty();
   }
 
   @Test
   public void getCacheServersAndGatewayReceiver_includesCacheServers() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     InternalCacheServer cacheServer1 = (InternalCacheServer) gemFireCacheImpl.addCacheServer();
     InternalCacheServer cacheServer2 = (InternalCacheServer) gemFireCacheImpl.addCacheServer();
     InternalCacheServer cacheServer3 = (InternalCacheServer) gemFireCacheImpl.addCacheServer();
 
     List<InternalCacheServer> value = gemFireCacheImpl.getCacheServersAndGatewayReceiver();
 
-    assertThat(value).containsExactlyInAnyOrder(cacheServer1, cacheServer2, cacheServer3);
+    assertThat(value)
+        .containsExactlyInAnyOrder(cacheServer1, cacheServer2, cacheServer3);
   }
 
   @Test
   public void getCacheServersAndGatewayReceiver_includesGatewayReceiver() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     gemFireCacheImpl.addGatewayReceiver(gatewayReceiver);
     InternalCacheServer receiverServer = gemFireCacheImpl.addGatewayReceiverServer(gatewayReceiver);
 
     List<InternalCacheServer> value = gemFireCacheImpl.getCacheServersAndGatewayReceiver();
 
-    assertThat(value).containsExactly(receiverServer);
+    assertThat(value)
+        .containsExactly(receiverServer);
   }
 
   @Test
   public void getCacheServersAndGatewayReceiver_includesCacheServersAndGatewayReceiver() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     InternalCacheServer cacheServer1 = (InternalCacheServer) gemFireCacheImpl.addCacheServer();
     InternalCacheServer cacheServer2 = (InternalCacheServer) gemFireCacheImpl.addCacheServer();
     InternalCacheServer cacheServer3 = (InternalCacheServer) gemFireCacheImpl.addCacheServer();
@@ -534,84 +576,89 @@ public class GemFireCacheImplTest {
 
   @Test
   public void isServer_isFalseByDefault() {
-    gemFireCacheImpl = createGemFireCacheImpl();
-
     boolean value = gemFireCacheImpl.isServer();
 
-    assertThat(value).isFalse();
+    assertThat(value)
+        .isFalse();
   }
 
   @Test
   public void isServer_isTrueIfIsServerIsSet() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     gemFireCacheImpl.setIsServer(true);
 
     boolean value = gemFireCacheImpl.isServer();
 
-    assertThat(value).isTrue();
+    assertThat(value)
+        .isTrue();
   }
 
   @Test
   public void isServer_isTrueIfCacheServerExists() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     gemFireCacheImpl.addCacheServer();
 
     boolean value = gemFireCacheImpl.isServer();
 
-    assertThat(value).isTrue();
+    assertThat(value)
+        .isTrue();
   }
 
   @Test
   public void isServer_isFalseEvenIfGatewayReceiverServerExists() {
-    gemFireCacheImpl = createGemFireCacheImpl();
     GatewayReceiver gatewayReceiver = mock(GatewayReceiver.class);
     gemFireCacheImpl.addGatewayReceiver(gatewayReceiver);
     gemFireCacheImpl.addGatewayReceiverServer(gatewayReceiver);
 
     boolean value = gemFireCacheImpl.isServer();
 
-    assertThat(value).isFalse();
+    assertThat(value)
+        .isFalse();
   }
 
   @Test
-  public void getCacheServersIsCanonical() {
-    gemFireCacheImpl = createGemFireCacheImpl();
-    List<CacheServer> list1 = gemFireCacheImpl.getCacheServers();
-    List<CacheServer> list2 = gemFireCacheImpl.getCacheServers();
-    assertThat(list1).isSameAs(list2);
+  public void getCacheServers_isCanonical() {
+    assertThat(gemFireCacheImpl.getCacheServers())
+        .isSameAs(gemFireCacheImpl.getCacheServers());
   }
 
-  @Test
-  public void closeDoesNotCloseUserMeterRegistries() {
-    MeterRegistry userRegistry = spy(new SimpleMeterRegistry());
-    gemFireCacheImpl = (GemFireCacheImpl) new InternalCacheBuilder()
-        .addMeterSubregistry(userRegistry)
-        .setTypeRegistry(mock(TypeRegistry.class))
-        .create(distributedSystem());
-
-    gemFireCacheImpl.close();
-
-    assertThat(userRegistry.isClosed()).isFalse();
-  }
-
-  private static GemFireCacheImpl createGemFireCacheImpl() {
-    return (GemFireCacheImpl) new InternalCacheBuilder()
-        .setTypeRegistry(mock(TypeRegistry.class))
-        .create(distributedSystem());
-  }
-
-  private static GemFireCacheImpl createGemFireCacheWithTypeRegistry() {
-    InternalDistributedSystem internalDistributedSystem = distributedSystem();
-    TypeRegistry typeRegistry = mock(TypeRegistry.class);
-    return (GemFireCacheImpl) new InternalCacheBuilder()
-        .setUseAsyncEventListeners(true)
-        .setTypeRegistry(typeRegistry)
-        .create(internalDistributedSystem);
-  }
-
-  private static InternalDistributedSystem distributedSystem() {
-    InternalDistributedSystem internalDistributedSystem = Fakes.distributedSystem();
-    when(internalDistributedSystem.getName()).thenReturn("my-name");
-    return internalDistributedSystem;
+  @SuppressWarnings({"LambdaParameterHidesMemberVariable", "OverlyCoupledMethod", "unchecked"})
+  private GemFireCacheImpl gemFireCacheImpl(boolean useAsyncEventListeners) {
+    return new GemFireCacheImpl(
+        false,
+        poolFactory,
+        internalDistributedSystem,
+        cacheConfig,
+        useAsyncEventListeners,
+        typeRegistry,
+        mock(Consumer.class),
+        (properties, cacheConfigArg) -> mock(SecurityService.class),
+        () -> true,
+        mock(Function.class),
+        mock(Function.class),
+        (factory, clock) -> mock(CachePerfStats.class),
+        mock(GemFireCacheImpl.TXManagerImplFactory.class),
+        mock(Supplier.class),
+        distributionAdvisee -> mock(ResourceAdvisor.class),
+        mock(Function.class),
+        jmxManagerAdvisee -> mock(JmxManagerAdvisor.class),
+        internalCache -> mock(InternalResourceManager.class),
+        () -> 1,
+        (cache, statisticsClock) -> mock(HeapEvictor.class),
+        mock(Consumer.class),
+        mock(Consumer.class),
+        mock(Consumer.class),
+        mock(Function.class),
+        mock(Consumer.class),
+        mock(GemFireCacheImpl.TypeRegistryFactory.class),
+        mock(Consumer.class),
+        mock(Consumer.class),
+        o -> mock(SystemTimer.class),
+        internalCache -> mock(TombstoneService.class),
+        internalDistributedSystem -> mock(ExpirationScheduler.class),
+        file -> mock(DiskStoreMonitor.class),
+        () -> mock(RegionEntrySynchronizationListener.class),
+        mock(Function.class),
+        mock(Function.class),
+        mock(TXEntryStateFactory.class),
+        replyProcessor21Factory);
   }
 }


### PR DESCRIPTION
GEODE-7503: Add new unit tests for GemFireCacheImpl
Inject dependencies into GemFireCacheImpl constructor.

GEODE-7503: Rename GemFireCacheImplEmergencyCloseDistributedTest
Rename from GemfireCacheImplDUnitTest.

The fix for GEODE-7503 will be in a follow-up PR (if at all). Also, I think the fix is going to require some additional community discussion.