### PR TITLE
GEODE-7552: Break dependency on Services

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
@@ -418,10 +418,6 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
               failure = false;
               cache = ((InternalLocator) locator).getCache();
               system = cache.getInternalDistributedSystem();
-              assertTrue(
-                  (getDistribution(system))
-                      .getServices().getMessenger()
-                      .isOldMembershipIdentifier(dm));
               return ds.getReconnectedSystem().getDistributedMember();
             } catch (InterruptedException e) {
               System.err.println("interrupted while waiting for reconnect");

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -288,7 +288,7 @@ public class MembershipJUnitTest {
                 InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()))
             .create();
     doAnswer(invocation -> {
-      DistributionImpl.connectLocatorToServices(m1.getServices());
+      DistributionImpl.connectLocatorToServices(m1);
       return null;
     }).when(lifeCycleListener).started();
     m1.start();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -32,6 +32,7 @@ import org.junit.rules.TemporaryFolder;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.JoinLeave;
@@ -85,7 +86,9 @@ public class GMSLocatorIntegrationTest {
                         .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
                 InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
                 InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
-    gmsLocator.setServices(services);
+    GMSMembership membership = mock(GMSMembership.class);
+    when(membership.getServices()).thenReturn(services);
+    gmsLocator.setMembership(membership);
   }
 
   @After

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumCheckerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumCheckerJUnitTest.java
@@ -77,7 +77,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -97,7 +97,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -112,7 +112,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -126,7 +126,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -153,7 +153,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -183,7 +183,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -216,7 +216,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -247,7 +247,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -271,7 +271,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -296,7 +296,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
@@ -876,7 +876,6 @@ public class JGroupsMessengerJUnitTest {
     initMocks(false);
     JChannel channel = messenger.myChannel;
     tconfig.setOldDSMembershipInfo(new MembershipInformationImpl(channel,
-        Collections.singleton(new InternalDistributedMember("localhost", 10000)),
         new ConcurrentLinkedQueue<>()));
     JGroupsMessenger newMessenger = new JGroupsMessenger();
     newMessenger.init(services);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
@@ -25,7 +25,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.MembershipView;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
-import org.apache.geode.distributed.internal.membership.gms.Services;
+import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.gms.api.QuorumChecker;
 
@@ -123,8 +123,6 @@ public interface Distribution {
 
   Set<InternalDistributedMember> getMembersNotShuttingDown();
 
-  Services getServices();
-
   // TODO - this method is only used by tests
   @VisibleForTesting
   void forceDisconnect(String reason);
@@ -166,4 +164,7 @@ public interface Distribution {
    * method so that services will know how to react.
    */
   void setCloseInProgress();
+
+  Membership getMembership();
+
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -45,7 +45,6 @@ import org.apache.geode.distributed.internal.direct.DirectChannel;
 import org.apache.geode.distributed.internal.direct.ShunnedMemberException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.MembershipView;
-import org.apache.geode.distributed.internal.membership.adapter.GMSLocatorAdapter;
 import org.apache.geode.distributed.internal.membership.adapter.ServiceConfig;
 import org.apache.geode.distributed.internal.membership.adapter.auth.GMSAuthenticator;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
@@ -157,15 +156,17 @@ public class DistributionImpl implements Distribution {
     GMSHealthMonitor.loadEmergencyClasses();
   }
 
-  public static void connectLocatorToServices(Services services) {
+  public static void connectLocatorToServices(Membership membership) {
     // see if a locator was started and put it in GMS Services
     InternalLocator l = (InternalLocator) Locator.getLocator();
     if (l != null && l.getLocatorHandler() != null) {
-      if (l.getLocatorHandler().setServices(services)) {
-        services
-            .setLocator(((GMSLocatorAdapter) l.getLocatorHandler()).getGMSLocator());
-      }
+      l.getLocatorHandler().setMembership(membership);
     }
+  }
+
+  @Override
+  public Membership getMembership() {
+    return membership;
   }
 
   @Override
@@ -572,11 +573,6 @@ public class DistributionImpl implements Distribution {
     return membership.getMembersNotShuttingDown();
   }
 
-  @Override
-  public Services getServices() {
-    return membership.getServices();
-  }
-
   // TODO - this method is only used by tests
   @Override
   @VisibleForTesting
@@ -920,7 +916,7 @@ public class DistributionImpl implements Distribution {
 
     @Override
     public void started() {
-      connectLocatorToServices(distribution.getServices());
+      connectLocatorToServices(distribution.getMembership());
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -707,9 +707,10 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
           (InternalDistributedSystem) DistributedSystem.connect(distributedSystemProperties);
 
       if (peerLocator) {
-        netLocator.setServices(
-            internalDistributedSystem.getDM().getDistribution()
-                .getServices());
+        // We've created a peer location message handler - it needs to be connected to
+        // the membership service in order to get membership view notifications
+        netLocator
+            .setMembership(internalDistributedSystem.getDM().getDistribution().getMembership());
       }
 
       internalDistributedSystem.addDisconnectListener(sys -> stop(false, false, false));

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/NetLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/NetLocator.java
@@ -15,7 +15,7 @@
 package org.apache.geode.distributed.internal.membership;
 
 import org.apache.geode.distributed.internal.RestartableTcpHandler;
-import org.apache.geode.distributed.internal.membership.gms.Services;
+import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 
 public interface NetLocator extends RestartableTcpHandler {
 
@@ -25,6 +25,6 @@ public interface NetLocator extends RestartableTcpHandler {
    *
    * @return true if the membership manager was accepted
    */
-  boolean setServices(Services pservices);
+  boolean setMembership(Membership membership);
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
@@ -22,12 +22,13 @@ import java.nio.file.Path;
 
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.Distribution;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.distributed.internal.membership.NetLocator;
-import org.apache.geode.distributed.internal.membership.gms.Services;
+import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Locator;
 import org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
@@ -88,8 +89,9 @@ public class GMSLocatorAdapter implements RestartableTcpHandler, NetLocator {
   @Override
   public void restarting(DistributedSystem ds, GemFireCache cache,
       InternalConfigurationPersistenceService sharedConfig) {
-    gmsLocator.setServices(
-        ((InternalDistributedSystem) ds).getDM().getDistribution().getServices());
+    InternalDistributedSystem ids = (InternalDistributedSystem) ds;
+    Distribution distribution = ids.getDM().getDistribution();
+    gmsLocator.setMembership(distribution.getMembership());
   }
 
   @Override
@@ -98,8 +100,8 @@ public class GMSLocatorAdapter implements RestartableTcpHandler, NetLocator {
   }
 
   @Override
-  public boolean setServices(Services pservices) {
-    return gmsLocator.setServices(pservices);
+  public boolean setMembership(Membership membership) {
+    return gmsLocator.setMembership(membership);
   }
 
   public Locator getGMSLocator() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -1239,7 +1239,6 @@ public class GMSMembership implements Membership {
     return address;
   }
 
-  @Override
   public Services getServices() {
     return services;
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/Membership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/Membership.java
@@ -23,7 +23,6 @@ import org.apache.geode.SystemFailure;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.MembershipView;
-import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave;
 
 public interface Membership {
@@ -299,8 +298,6 @@ public interface Membership {
    * return a list of all members excluding those in the process of shutting down
    */
   Set<InternalDistributedMember> getMembersNotShuttingDown();
-
-  Services getServices();
 
   /**
    * Process a message and pass it on to the {@link MessageListener} that was configured

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Messenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Messenger.java
@@ -52,11 +52,6 @@ public interface Messenger extends Service {
   MemberIdentifier getMemberID();
 
   /**
-   * check to see if a member ID has already been used
-   */
-  boolean isOldMembershipIdentifier(MemberIdentifier id);
-
-  /**
    * retrieves the quorum checker that is used during auto-reconnect attempts
    */
   GMSQuorumChecker getQuorumChecker();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -40,10 +40,12 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.InternalGemFireException;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.internal.LocatorStats;
+import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.GMSUtil;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Locator;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
 import org.apache.geode.distributed.internal.membership.gms.messenger.GMSMemberWrapper;
@@ -111,9 +113,9 @@ public class GMSLocator implements Locator {
     this.locatorClient = locatorClient;
   }
 
-  public synchronized boolean setServices(Services pservices) {
+  public synchronized boolean setMembership(Membership membership) {
     if (services == null || services.isStopped()) {
-      services = pservices;
+      services = ((GMSMembership) membership).getServices();
       localAddress = services.getMessenger().getMemberID();
       Objects.requireNonNull(localAddress, "member address should have been established");
       logger.info("Peer locator is connecting to local membership services with ID {}",

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
@@ -55,15 +55,12 @@ public class GMSQuorumChecker implements QuorumChecker {
   private final JChannel channel;
   private JGAddress myAddress;
   private final long partitionThreshold;
-  private Set<MemberIdentifier> oldMemberIdentifiers;
   private ConcurrentLinkedQueue<Message> messageQueue = new ConcurrentLinkedQueue<>();
 
-  public GMSQuorumChecker(GMSMembershipView jgView, int partitionThreshold, JChannel channel,
-      Set<MemberIdentifier> oldMemberIdentifiers) {
+  public GMSQuorumChecker(GMSMembershipView jgView, int partitionThreshold, JChannel channel) {
     this.lastView = jgView;
     this.partitionThreshold = partitionThreshold;
     this.channel = channel;
-    this.oldMemberIdentifiers = oldMemberIdentifiers;
   }
 
   public void initialize() {
@@ -115,7 +112,7 @@ public class GMSQuorumChecker implements QuorumChecker {
 
 
   public MembershipInformation getMembershipInfo() {
-    return new MembershipInformationImpl(channel, oldMemberIdentifiers, messageQueue);
+    return new MembershipInformationImpl(channel, messageQueue);
   }
 
   private boolean calculateQuorum() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/MembershipInformationImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/MembershipInformationImpl.java
@@ -15,12 +15,10 @@
 package org.apache.geode.distributed.internal.membership.gms.messenger;
 
 import java.util.Queue;
-import java.util.Set;
 
 import org.jgroups.JChannel;
 import org.jgroups.Message;
 
-import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipInformation;
 
 /**
@@ -29,15 +27,12 @@ import org.apache.geode.distributed.internal.membership.gms.api.MembershipInform
  */
 public class MembershipInformationImpl implements MembershipInformation {
   private final JChannel channel;
-  private final Set<MemberIdentifier> membershipIdentifiers;
   private final Queue<Message> queuedMessages;
 
   protected MembershipInformationImpl(JChannel channel,
-      Set<MemberIdentifier> oldMembershipIdentifiers,
       Queue<Message> queuedMessages) {
 
     this.channel = channel;
-    this.membershipIdentifiers = oldMembershipIdentifiers;
     this.queuedMessages = queuedMessages;
   }
 
@@ -45,11 +40,7 @@ public class MembershipInformationImpl implements MembershipInformation {
     return channel;
   }
 
-  public Set<MemberIdentifier> getMembershipIdentifiers() {
-    return membershipIdentifiers;
-  }
-
-  public Queue<Message> getQueuedMessages() {
+  Queue<Message> getQueuedMessages() {
     return this.queuedMessages;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
@@ -32,7 +32,6 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.MembershipView;
 import org.apache.geode.distributed.internal.membership.gms.MemberDataBuilderImpl;
 import org.apache.geode.distributed.internal.membership.gms.MembershipBuilderImpl;
-import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 
 @RunWith(ArchUnitRunner.class)
@@ -63,9 +62,5 @@ public class MembershipAPIArchUnitTest {
               .or(type(InternalDistributedMember.class))
               .or(type(MembershipView.class))
               .or(type(DistributedMember.class))
-              .or(type(InternalDistributedMember[].class))
-
-              // TODO: This is used by the GMSLocatorAdapter to reach into the locator
-              // part of the services
-              .or(type(Services.class)));
+              .or(type(InternalDistributedMember[].class)));
 }


### PR DESCRIPTION
Rewrote locator installation to use Membership rather than the "hidden"
Services interface.

I rewrote some tests to stop using the internal interfaces of membership
as well, and along the way saw that JGroupsMessenger was maintaining a
collection of old identifiers that was only being consumed by a test & I
removed it.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
