### PR TITLE
Disable windows update on heavy-lifter instances.

### DIFF
--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -43,7 +43,9 @@
         "Install-WindowsFeature Containers",
         "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force",
         "Install-Module DockerMsftProvider -Force",
-        "Install-Package Docker -ProviderName DockerMsftProvider -Force"
+        "Install-Package Docker -ProviderName DockerMsftProvider -Force",
+        "Set-Service wuauserv -StartupType Disabled",
+        "Stop-Service wuauserv"
         ]
     },
     {


### PR DESCRIPTION
May mitigate our loss of connection to instances in the middle of jobs.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Scott Jewell <sjewell@pivotal.io>

