### PR TITLE
GEODE-7643: Gateway unprocessedTokensMap appears to grow without bounds with replicated regions and peer accessors

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractBucketRegionQueue.java
@@ -294,10 +294,11 @@ public abstract class AbstractBucketRegionQueue extends BucketRegion {
   @Override
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModificaiton)
+      throws TimeoutException, CacheWriterException {
     try {
       boolean success = super.virtualPut(event, ifNew, ifOld, expectedOldValue, requireOldValue,
-          lastModified, overwriteDestroyed);
+          lastModified, overwriteDestroyed, invokeCallbacks, throwConcurrentModificaiton);
       if (success) {
         if (logger.isDebugEnabled()) {
           logger.debug("Key : ----> {}", event.getKey());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractUpdateOperation.java
@@ -135,6 +135,8 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
     try {
       boolean updated = false;
       boolean doUpdate = true; // start with assumption we have key and need value
+      boolean invokeCallbacks = true;
+
       if (shouldDoRemoteCreate(rgn, ev)) {
         if (logger.isDebugEnabled()) {
           logger.debug("doPutOrCreate: attempting to update or create entry");
@@ -149,14 +151,19 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
           // if the oldValue is the DESTROYED token and overwrite is disallowed,
           // then basicPut will set the blockedDestroyed flag in the event
           boolean overwriteDestroyed = ev.getOperation().isCreate();
-          if (rgn.basicUpdate(ev, true /* ifNew */, false/* ifOld */, lastMod,
-              overwriteDestroyed)) {
-            rgn.getCachePerfStats().endPut(startPut, ev.isOriginRemote());
-            // we did a create, or replayed a create event
-            doUpdate = false;
-            updated = true;
-          } else { // already exists. If it was blocked by the DESTROYED token, then
-            // do no update.
+          try {
+            if (rgn.basicUpdate(ev, true, false, lastMod, overwriteDestroyed, true, true)) {
+              rgn.getCachePerfStats().endPut(startPut, ev.isOriginRemote());
+              // we did a create, or replayed a create event
+              doUpdate = false;
+              updated = true;
+            } else {
+              // already exists. If it was blocked by the DESTROYED token, then
+              // do no update.
+              doUpdate = checkIfToUpdateAfterCreateFailed(rgn, ev);
+            }
+          } catch (ConcurrentCacheModificationException ex) {
+            invokeCallbacks = false;
             doUpdate = checkIfToUpdateAfterCreateFailed(rgn, ev);
           }
         } finally {
@@ -179,22 +186,32 @@ public abstract class AbstractUpdateOperation extends DistributedCacheOperation 
             br.getPartitionedRegion().getPrStats().startApplyReplication();
           }
           try {
-            if (rgn.basicUpdate(ev, false/* ifNew */, true/* ifOld */, lastMod,
-                overwriteDestroyed)) {
+            boolean secondUpdateSuccess;
+            try {
+              secondUpdateSuccess = rgn.basicUpdate(ev, false, true, lastMod, overwriteDestroyed,
+                  invokeCallbacks, true);
+            } catch (ConcurrentCacheModificationException ex) {
+              secondUpdateSuccess = false;
+              invokeCallbacks = false;
+            }
+            if (secondUpdateSuccess) {
               rgn.getCachePerfStats().endPut(startPut, ev.isOriginRemote());
               if (logger.isTraceEnabled()) {
                 logger.trace("Processing put key {} in region {}", ev.getKey(), rgn.getFullPath());
               }
               updated = true;
-            } else { // key not here or blocked by DESTROYED token
+            } else {
+              // key not here, blocked by DESTROYED token or ConcurrentCacheModificationException
+              // thrown during second update attempt
               if (rgn.isUsedForPartitionedRegionBucket()
                   || (rgn.getDataPolicy().withReplication() && rgn.getConcurrencyChecksEnabled())) {
-                overwriteDestroyed = true;
                 ev.makeCreate();
-                rgn.basicUpdate(ev, false /* ifNew */, false/* ifOld */, lastMod,
-                    overwriteDestroyed);
-                rgn.getCachePerfStats().endPut(startPut, ev.isOriginRemote());
-                updated = true;
+                boolean thirdUpdateSuccess =
+                    rgn.basicUpdate(ev, false, false, lastMod, true, invokeCallbacks, false);
+                if (thirdUpdateSuccess) {
+                  rgn.getCachePerfStats().endPut(startPut, ev.isOriginRemote());
+                  updated = true;
+                }
               } else {
                 if (rgn.getVersionVector() != null && ev.getVersionTag() != null) {
                   rgn.getVersionVector().recordVersion(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -517,7 +517,8 @@ public class BucketRegion extends DistributedRegion implements Bucket {
   @Override
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModificaiton)
+      throws TimeoutException, CacheWriterException {
     boolean locked = lockKeysAndPrimary(event);
 
     try {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegionQueue.java
@@ -250,10 +250,11 @@ public class BucketRegionQueue extends AbstractBucketRegionQueue {
   @Override
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModificaiton)
+      throws TimeoutException, CacheWriterException {
     try {
       boolean success = super.virtualPut(event, ifNew, ifOld, expectedOldValue, requireOldValue,
-          lastModified, overwriteDestroyed);
+          lastModified, overwriteDestroyed, invokeCallbacks, throwConcurrentModificaiton);
 
       if (success) {
         if (getPartitionedRegion().getColocatedWith() == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistPeerTXStateStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistPeerTXStateStub.java
@@ -136,6 +136,15 @@ public class DistPeerTXStateStub extends PeerTXStateStub implements DistTXCoordi
     super.cleanup();
   }
 
+  @Override
+  public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, long lastModified,
+      boolean overwriteDestroyed) {
+    return this.putEntry(event, ifNew, ifOld, expectedOldValue, requireOldValue, lastModified,
+        overwriteDestroyed, true,
+        false);
+  }
+
   /*
    * (non-Javadoc)
    *
@@ -145,13 +154,13 @@ public class DistPeerTXStateStub extends PeerTXStateStub implements DistTXCoordi
   @Override
   public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModification) {
     if (logger.isDebugEnabled()) {
       // [DISTTX] TODO Remove throwable
       logger.debug("DistPeerTXStateStub.putEntry " + event.getKeyInfo().getKey(), new Throwable());
     }
     boolean returnValue = super.putEntry(event, ifNew, ifOld, expectedOldValue, requireOldValue,
-        lastModified, overwriteDestroyed);
+        lastModified, overwriteDestroyed, invokeCallbacks, throwConcurrentModification);
     addPrimaryTransactionalOperations(new DistTxEntryEvent(event));
 
     return returnValue;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistTXStateOnCoordinator.java
@@ -100,6 +100,15 @@ public class DistTXStateOnCoordinator extends DistTXState implements DistTXCoord
     // Cleanup is called next
   }
 
+  @Override
+  public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, long lastModified,
+      boolean overwriteDestroyed) {
+    return this.putEntry(event, ifNew, ifOld, expectedOldValue, requireOldValue, lastModified,
+        overwriteDestroyed, true,
+        false);
+  }
+
   /*
    * (non-Javadoc)
    *
@@ -109,7 +118,7 @@ public class DistTXStateOnCoordinator extends DistTXState implements DistTXCoord
   @Override
   public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwsConcurrentModification) {
     if (logger.isDebugEnabled()) {
       // [DISTTX] TODO Remove throwable
       logger.debug(
@@ -119,7 +128,7 @@ public class DistTXStateOnCoordinator extends DistTXState implements DistTXCoord
     }
 
     boolean returnValue = super.putEntry(event, ifNew, ifOld, expectedOldValue, requireOldValue,
-        lastModified, overwriteDestroyed);
+        lastModified, overwriteDestroyed, invokeCallbacks, throwsConcurrentModification);
 
     // putAll event is already added in postPutAll, don't add individual events
     // from the putAll operation again

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRegion.java
@@ -334,7 +334,8 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
   @Override
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModificaiton)
+      throws TimeoutException, CacheWriterException {
     final boolean isTraceEnabled = logger.isTraceEnabled();
 
     Lock dlock = null;
@@ -383,7 +384,7 @@ public class DistributedRegion extends LocalRegion implements InternalDistribute
           }
         }
         return super.virtualPut(event, ifNew, ifOld, expectedOldValue, requireOldValue,
-            lastModified, overwriteDestroyed);
+            lastModified, overwriteDestroyed, invokeCallbacks, throwConcurrentModificaiton);
       } else {
         if (event.getDeltaBytes() != null && event.getRawNewValue() == null) {
           // This means that this event has delta bytes but no full value.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalDataView.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalDataView.java
@@ -86,6 +86,9 @@ public interface InternalDataView {
   Entry getEntryOnRemote(KeyInfo key, LocalRegion localRegion, boolean allowTombstones)
       throws DataLocationException;
 
+  boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld, Object expectedOldValue,
+      boolean requireOldValue, long lastModified, boolean overwriteDestroyed);
+
   /**
    * Put or create an entry in the data view.
    *
@@ -93,7 +96,8 @@ public interface InternalDataView {
    * @return true if operation updated existing data, otherwise false
    */
   boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld, Object expectedOldValue,
-      boolean requireOldValue, long lastModified, boolean overwriteDestroyed);
+      boolean requireOldValue, long lastModified, boolean overwriteDestroyed,
+      boolean invokeCallbacks, boolean throwConcurrentModification);
 
   /**
    * Put or create an entry in the data view. Called only on the farside.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -384,6 +384,11 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
   boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld, Object expectedOldValue,
       boolean requireOldValue, long lastModified, boolean overwriteDestroyed);
 
+  boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld, Object expectedOldValue,
+      boolean requireOldValue, long lastModified, boolean overwriteDestroyed,
+      boolean invokeCallbacks,
+      boolean throwsConcurrentModification);
+
   long postPutAllSend(DistributedPutAllOperation putallOp, VersionedObjectList successfulPuts);
 
   void postPutAllFireEvents(DistributedPutAllOperation putallOp,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5547,6 +5547,11 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    *        the following effect: even when ifNew is true will write over DESTROYED token when
    *        overwriteDestroyed is false and ifNew or ifOld is true then if the put doesn't occur
    *        because there is a DESTROYED token present then the entry flag blockedDestroyed is set.
+   * @param invokeCallbacks true if this operation should notify bridge clients and gateway senders
+   *        in the event of a ConcurrentCacheModificationException being thrown during the update
+   * @param throwConcurrentModificationException true if this operation should be allowed to throw
+   *        any ConcurrentCacheModificationException that occurs during the update. If false, any
+   *        ConcurrentCacheModificationExceptions that are thrown will be suppressed
    * @return false if ifNew is true and there is an existing key, or ifOld is true and there is no
    *         existing entry; otherwise return true.
    */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5528,6 +5528,12 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     getDataView().updateEntryVersion(event);
   }
 
+  boolean basicUpdate(final EntryEventImpl event, final boolean ifNew, final boolean ifOld,
+      final long lastModified, final boolean overwriteDestroyed)
+      throws TimeoutException, CacheWriterException {
+    return this.basicUpdate(event, ifNew, ifOld, lastModified, overwriteDestroyed, true, false);
+  }
+
   /**
    * Allows null as new value to accommodate create with a null value.
    *
@@ -5545,7 +5551,8 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    *         existing entry; otherwise return true.
    */
   boolean basicUpdate(final EntryEventImpl event, final boolean ifNew, final boolean ifOld,
-      final long lastModified, final boolean overwriteDestroyed)
+      final long lastModified, final boolean overwriteDestroyed, final boolean invokeCallbacks,
+      final boolean throwConcurrentModificationException)
       throws TimeoutException, CacheWriterException {
 
     // check validity of key against keyConstraint
@@ -5560,7 +5567,14 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     validateValue(event.basicGetNewValue());
 
     return getDataView().putEntry(event, ifNew, ifOld, null, false, lastModified,
-        overwriteDestroyed);
+        overwriteDestroyed, invokeCallbacks, throwConcurrentModificationException);
+  }
+
+  public boolean virtualPut(final EntryEventImpl event, final boolean ifNew, final boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, final long lastModified,
+      final boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+    return this.virtualPut(event, ifNew, ifOld, expectedOldValue, requireOldValue, lastModified,
+        overwriteDestroyed, true, false);
   }
 
   /**
@@ -5569,7 +5583,9 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   @Override
   public boolean virtualPut(final EntryEventImpl event, final boolean ifNew, final boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, final long lastModified,
-      final boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+      final boolean overwriteDestroyed, boolean invokeCallbacks,
+      boolean throwsConcurrentModification)
+      throws TimeoutException, CacheWriterException {
 
     if (!MemoryThresholds.isLowMemoryExceptionDisabled()) {
       checkIfAboveThreshold(event);
@@ -5581,17 +5597,23 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     try {
       oldEntry = entries.basicPut(event, lastModified, ifNew, ifOld, expectedOldValue,
           requireOldValue, overwriteDestroyed);
-    } catch (ConcurrentCacheModificationException ignore) {
-      // this can happen in a client cache when another thread
-      // managed to slip in its version info to the region entry before this
-      // thread got around to doing so
+    } catch (ConcurrentCacheModificationException concCacheModException) {
+      // this can happen in a client cache when another thread managed to slip in its version info
+      // to the region entry before this thread got around to doing so
       if (logger.isDebugEnabled()) {
         logger.debug("caught concurrent modification attempt when applying {}", event);
       }
-      notifyBridgeClients(event);
-      notifyGatewaySender(event.getOperation().isUpdate() ? EnumListenerEvent.AFTER_UPDATE
-          : EnumListenerEvent.AFTER_CREATE, event);
-      return false;
+      if (invokeCallbacks) {
+        notifyBridgeClients(event);
+        notifyGatewaySender(event.getOperation().isUpdate() ? EnumListenerEvent.AFTER_UPDATE
+            : EnumListenerEvent.AFTER_CREATE, event);
+      }
+      if (throwsConcurrentModification) {
+        throw concCacheModException;
+      } else {
+        return false;
+      }
+
     }
 
     // for EMPTY clients, see if a concurrent map operation had an entry on the server

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegionDataView.java
@@ -149,6 +149,14 @@ public class LocalRegionDataView implements InternalDataView {
   }
 
 
+  @Override
+  public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, long lastModified,
+      boolean overwriteDestroyed) {
+    return event.getRegion().virtualPut(event, ifNew, ifOld, expectedOldValue, requireOldValue,
+        lastModified, overwriteDestroyed);
+  }
+
   /*
    * (non-Javadoc)
    *
@@ -158,9 +166,9 @@ public class LocalRegionDataView implements InternalDataView {
   @Override
   public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwsConcurrentModification) {
     return event.getRegion().virtualPut(event, ifNew, ifOld, expectedOldValue, requireOldValue,
-        lastModified, overwriteDestroyed);
+        lastModified, overwriteDestroyed, invokeCallbacks, throwsConcurrentModification);
   }
 
   /*

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -2163,7 +2163,8 @@ public class PartitionedRegion extends LocalRegion
   @Override
   public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModificaiton)
+      throws TimeoutException, CacheWriterException {
     final long startTime = prStats.getTime();
     boolean result = false;
     final DistributedPutAllOperation putAllOp_save = event.setPutAllOperation(null);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PausedTXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PausedTXStateProxyImpl.java
@@ -253,6 +253,13 @@ public class PausedTXStateProxyImpl implements TXStateProxy {
   }
 
   @Override
+  public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, long lastModified,
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModification) {
+    return false;
+  }
+
+  @Override
   public boolean putEntryOnRemote(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
       boolean overwriteDestroyed) throws DataLocationException {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -1700,6 +1700,15 @@ public class TXState implements TXStateInterface {
     return localRegion.nonTXbasicGetValueInVM(keyInfo);
   }
 
+  @Override
+  public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, long lastModified,
+      boolean overwriteDestroyed) {
+    return this.putEntry(event, ifNew, ifOld, expectedOldValue, requireOldValue, lastModified,
+        overwriteDestroyed, true,
+        false);
+  }
+
   /*
    * (non-Javadoc)
    *
@@ -1709,7 +1718,7 @@ public class TXState implements TXStateInterface {
   @Override
   public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModification) {
     validateDelta(event);
     return txPutEntry(event, ifNew, requireOldValue, true, expectedOldValue);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateProxyImpl.java
@@ -670,6 +670,14 @@ public class TXStateProxyImpl implements TXStateProxy {
   public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
       boolean overwriteDestroyed) {
+    return putEntry(event, ifNew, ifOld, expectedOldValue, requireOldValue, lastModified,
+        overwriteDestroyed, true, false);
+  }
+
+  @Override
+  public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, long lastModified,
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModification) {
     try {
       this.operationCount++;
       boolean retVal = getRealDeal(event.getKeyInfo(), event.getRegion()).putEntry(event, ifNew,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateStub.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXStateStub.java
@@ -534,6 +534,15 @@ public abstract class TXStateStub implements TXStateInterface {
     return true;
   }
 
+  @Override
+  public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
+      Object expectedOldValue, boolean requireOldValue, long lastModified,
+      boolean overwriteDestroyed) {
+    return putEntry(event, ifNew, ifOld, expectedOldValue, requireOldValue, lastModified,
+        overwriteDestroyed, true,
+        false);
+  }
+
   /*
    * (non-Javadoc)
    *
@@ -543,7 +552,7 @@ public abstract class TXStateStub implements TXStateInterface {
   @Override
   public boolean putEntry(EntryEventImpl event, boolean ifNew, boolean ifOld,
       Object expectedOldValue, boolean requireOldValue, long lastModified,
-      boolean overwriteDestroyed) {
+      boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModification) {
     return getTXRegionStub(event.getRegion()).putEntry(event, ifNew, ifOld, expectedOldValue,
         requireOldValue, lastModified, overwriteDestroyed);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderEventProcessor.java
@@ -901,4 +901,8 @@ public class SerialGatewaySenderEventProcessor extends AbstractGatewaySenderEven
       return printEventIdList(this.unprocessedTokens.keySet());
     }
   }
+
+  public int numUnprocessedEventTokens() {
+    return unprocessedTokens.entrySet().size();
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -1207,10 +1207,11 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     @Override
     public boolean virtualPut(EntryEventImpl event, boolean ifNew, boolean ifOld,
         Object expectedOldValue, boolean requireOldValue, long lastModified,
-        boolean overwriteDestroyed) throws TimeoutException, CacheWriterException {
+        boolean overwriteDestroyed, boolean invokeCallbacks, boolean throwConcurrentModificaiton)
+        throws TimeoutException, CacheWriterException {
       try {
         boolean success = super.virtualPut(event, ifNew, ifOld, expectedOldValue, requireOldValue,
-            lastModified, overwriteDestroyed);
+            lastModified, overwriteDestroyed, invokeCallbacks, throwConcurrentModificaiton);
         if (!success) {
           // release offheap reference if GatewaySenderEventImpl is not put into
           // the region queue

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/UpdateOperationJUnitTest.java
@@ -65,12 +65,16 @@ public class UpdateOperationJUnitTest {
    */
   @Test
   public void createSucceedShouldNotRetryAnymore() {
-    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
-        .thenReturn(true);
+    when(
+        region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true), eq(true), eq(true)))
+            .thenReturn(true);
     message.basicOperateOnRegion(event, region);
-    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
-    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
-    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true),
+        eq(true), eq(true));
   }
 
   /**
@@ -80,13 +84,17 @@ public class UpdateOperationJUnitTest {
    */
   @Test
   public void createFailWithConcurrencyConflictShouldNotRetry() {
-    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
-        .thenReturn(false);
+    when(
+        region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true), eq(true), eq(true)))
+            .thenReturn(false);
     when(event.isConcurrencyConflict()).thenReturn(true);
     message.basicOperateOnRegion(event, region);
-    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
-    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
-    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true),
+        eq(true), eq(true));
   }
 
   /**
@@ -95,14 +103,19 @@ public class UpdateOperationJUnitTest {
    */
   @Test
   public void updateSucceedShouldNotRetryAnymore() {
-    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
-        .thenReturn(false);
-    when(region.basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true)))
-        .thenReturn(true);
+    when(
+        region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true), eq(true), eq(true)))
+            .thenReturn(false);
+    when(
+        region.basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true), eq(true), eq(true)))
+            .thenReturn(true);
     message.basicOperateOnRegion(event, region);
-    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
-    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
-    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(0)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true),
+        eq(true), eq(true));
   }
 
   /**
@@ -112,14 +125,19 @@ public class UpdateOperationJUnitTest {
    */
   @Test
   public void doPutOrCreate3rdRetryShouldBeUpdate() {
-    when(region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true)))
-        .thenReturn(false);
-    when(region.basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true)))
-        .thenReturn(false);
+    when(
+        region.basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true), eq(true), eq(true)))
+            .thenReturn(false);
+    when(
+        region.basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true), eq(true), eq(true)))
+            .thenReturn(false);
     message.basicOperateOnRegion(event, region);
-    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true));
-    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true));
-    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(true), eq(false), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(true), anyLong(), eq(true),
+        eq(true), eq(true));
+    verify(region, times(1)).basicUpdate(eq(event), eq(false), eq(false), anyLong(), eq(true),
+        eq(true), eq(false));
   }
 
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
@@ -61,7 +61,6 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.partitioned.PRLocallyDestroyedException;
-import org.apache.geode.internal.cache.versions.ConcurrentCacheModificationException;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
@@ -271,11 +270,7 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
 
     EntryEventImpl event =
         createNewEvent((DistributedRegion) region, versionTag, entry.getKey(), "value-3");
-    try {
-      ((LocalRegion) region).basicUpdate(event, false, true, 0L, false);
-    } catch (ConcurrentCacheModificationException ex) {
-      // do nothing
-    }
+    ((LocalRegion) region).basicUpdate(event, false, true, 0L, false);
 
     // Verify the new stamp
     entry = region.getEntry(key);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
@@ -61,6 +61,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.partitioned.PRLocallyDestroyedException;
+import org.apache.geode.internal.cache.versions.ConcurrentCacheModificationException;
 import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
@@ -270,8 +271,11 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
 
     EntryEventImpl event =
         createNewEvent((DistributedRegion) region, versionTag, entry.getKey(), "value-3");
-
-    ((LocalRegion) region).basicUpdate(event, false, true, 0L, false);
+    try {
+      ((LocalRegion) region).basicUpdate(event, false, true, 0L, false);
+    } catch (ConcurrentCacheModificationException ex) {
+      // do nothing
+    }
 
     // Verify the new stamp
     entry = region.getEntry(key);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -437,6 +437,35 @@ public class WANTestBase extends DistributedTestCase {
     }
   }
 
+
+  public static void createReplicatedProxyRegion(String regionName, String senderIds,
+      Boolean offHeap) {
+    IgnoredException exp =
+        IgnoredException.addIgnoredException(ForceReattemptException.class.getName());
+    IgnoredException exp1 =
+        IgnoredException.addIgnoredException(InterruptedException.class.getName());
+    IgnoredException exp2 =
+        IgnoredException.addIgnoredException(GatewaySenderException.class.getName());
+    try {
+      RegionFactory fact = cache.createRegionFactory(RegionShortcut.REPLICATE_PROXY);
+      if (senderIds != null) {
+        StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
+        while (tokenizer.hasMoreTokens()) {
+          String senderId = tokenizer.nextToken();
+          fact.addGatewaySenderId(senderId);
+        }
+      }
+
+      fact.setOffHeap(offHeap);
+      Region r = fact.create(regionName);
+      assertNotNull(r);
+    } finally {
+      exp.remove();
+      exp1.remove();
+      exp2.remove();
+    }
+  }
+
   public static void createNormalRegion(String regionName, String senderIds) {
     RegionFactory fact = cache.createRegionFactory(RegionShortcut.LOCAL);
     if (senderIds != null) {
@@ -2254,6 +2283,24 @@ public class WANTestBase extends DistributedTestCase {
       exp2.remove();
     }
   }
+
+  public static void doPutsSameKey(String regionName, int numPuts, String key) {
+    IgnoredException exp1 =
+        IgnoredException.addIgnoredException(InterruptedException.class.getName());
+    IgnoredException exp2 =
+        IgnoredException.addIgnoredException(GatewaySenderException.class.getName());
+    try {
+      Region r = cache.getRegion(Region.SEPARATOR + regionName);
+      assertNotNull(r);
+      for (long i = 0; i < numPuts; i++) {
+        r.put(key, "Value_" + i);
+      }
+    } finally {
+      exp1.remove();
+      exp2.remove();
+    }
+  }
+
 
   public static void doPutsAfter300(String regionName, int numPuts) {
     Region r = cache.getRegion(Region.SEPARATOR + regionName);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueueDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueueDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.wan.serial;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -48,6 +49,7 @@ import org.apache.geode.internal.cache.RegionQueue;
 import org.apache.geode.internal.cache.ha.ThreadIdentifier;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.WANTestBase;
+import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
@@ -55,6 +57,85 @@ import org.apache.geode.test.junit.categories.WanTest;
 
 @Category({WanTest.class})
 public class SerialGatewaySenderQueueDUnitTest extends WANTestBase {
+
+  @Test
+  public void unprocessEventsLinger() throws Exception {
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+
+    vm2.invoke(() -> WANTestBase.createCache(nyPort));
+    vm3.invoke(() -> WANTestBase.createCache(nyPort));
+
+    vm2.invoke(
+        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap()));
+    vm3.invoke(
+        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap()));
+
+    vm2.invoke(WANTestBase::createReceiver);
+    vm3.invoke(WANTestBase::createReceiver);
+
+    vm4.invoke(() -> WANTestBase.createCache(lnPort));
+    vm5.invoke(() -> WANTestBase.createCache(lnPort));
+    vm6.invoke(() -> WANTestBase.createCache(lnPort));
+    vm7.invoke(() -> WANTestBase.createCache(lnPort));
+
+    vm4.invoke(() -> WANTestBase.createSenderWithMultipleDispatchers("ln", 2, false, 100, 10, false,
+        false, null, true, 1, OrderPolicy.KEY));
+    vm5.invoke(() -> WANTestBase.createSenderWithMultipleDispatchers("ln", 2, false, 100, 10, false,
+        false, null, true, 1, OrderPolicy.KEY));
+
+    startSenderInVMs("ln", vm4, vm5);
+
+    vm4.invoke(
+        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
+    vm5.invoke(
+        () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
+    vm6.invoke(
+        () -> WANTestBase.createReplicatedProxyRegion(getTestMethodName() + "_RR", "ln",
+            isOffHeap()));
+    vm7.invoke(
+        () -> WANTestBase.createReplicatedProxyRegion(getTestMethodName() + "_RR", "ln",
+            isOffHeap()));
+
+    AsyncInvocation a1 =
+        vm6.invokeAsync(() -> WANTestBase.doPutsSameKey(getTestMethodName() + "_RR", 1000, "DA"));
+    AsyncInvocation a2 =
+        vm7.invokeAsync(() -> WANTestBase.doPutsSameKey(getTestMethodName() + "_RR", 1000, "DA"));
+
+    a1.await();
+    a2.await();
+
+    // Give the unprocessedTokens map time to empty
+    Thread.sleep(2000);
+
+    int numUnprocessedTokensVM4 = vm4.invoke(() -> unprocessedTokensSize("ln"));
+    assertThat(numUnprocessedTokensVM4).isEqualTo(0);
+
+    int numUnprocessedTokensVM5 = vm5.invoke(() -> unprocessedTokensSize("ln"));
+    assertThat(numUnprocessedTokensVM5).isEqualTo(0);
+  }
+
+  private int unprocessedTokensSize(String senderId) {
+    AbstractGatewaySender sender = (AbstractGatewaySender) findGatewaySender(senderId);
+    SerialGatewaySenderEventProcessor processor =
+        (SerialGatewaySenderEventProcessor) sender.getEventProcessor();
+    return processor.numUnprocessedEventTokens();
+  }
+
+  private GatewaySender findGatewaySender(String senderId) {
+    Set<GatewaySender> senders = cache.getGatewaySenders();
+    GatewaySender sender = null;
+    for (GatewaySender s : senders) {
+      if (s.getId().equals(senderId)) {
+        sender = s;
+        break;
+      }
+    }
+
+    return sender;
+  }
+
 
   @Test
   public void testPrimarySecondaryQueueDrainInOrder_RR() throws Exception {
@@ -148,6 +229,7 @@ public class SerialGatewaySenderQueueDUnitTest extends WANTestBase {
     vm4.invoke(() -> WANTestBase.getSenderStats("ln", 0));
     vm5.invoke(() -> WANTestBase.getSenderStats("ln", 0));
   }
+
 
   protected void checkPrimarySenderUpdatesOnVM5(HashMap primarySenderUpdates) {
     vm5.invoke(() -> WANTestBase.checkQueueOnSecondary(primarySenderUpdates));

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueueDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueueDUnitTest.java
@@ -59,7 +59,7 @@ import org.apache.geode.test.junit.categories.WanTest;
 public class SerialGatewaySenderQueueDUnitTest extends WANTestBase {
 
   @Test
-  public void unprocessEventsLinger() throws Exception {
+  public void unprocessedTokensMapShouldDrainCompletely() throws Exception {
     Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
 
     Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));


### PR DESCRIPTION
Allow LocalRegion.virtualPut() to throw ConcurrentCacheModificationException
Added throwsConcurrentModifiaction boolean argument to LocalRegion.virtualPut() to determine if the exception should be thrown
Added invokeCallbacks boolean argument to LocalRegion.virtualPut() to determine if bridge clients and gateway senders should be notified of the event
Fixed issue with inheriting new virtualPut implementations
Added DUnit test to confirm fix

Co-authored-by: Benjamin Ross <bross@pivotal.io>
Co-authored-by: Donal Evans <doevans@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
