### PR TITLE
GEODE-7567: Improve cleanup logic in create_instance.sh

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -261,7 +261,7 @@ jobs:
           path: new
         - name: instance-data
       timeout: 15m
-      attempts: 2
+      attempts: 5
   - aggregate:
     - put: geode-build-version
       params:
@@ -528,7 +528,7 @@ jobs:
       - name: attempts-log
         path: new
     timeout: 15m
-    attempts: 2
+    attempts: 5
   - task: rsync_code_up
     image: alpine-tools-image
     config:
@@ -615,7 +615,7 @@ jobs:
             - name: attempts-log
               path: new
           timeout: 15m
-          attempts: 2
+          attempts: 5
         - task: rsync_code_up-{{java_test_version.name}}
           image: alpine-tools-image
           config:
@@ -628,7 +628,7 @@ jobs:
             - name: instance-data-{{java_test_version.name}}
               path: instance-data
           timeout: 15m
-          attempts: 2
+          attempts: 5
         - task: execute_tests-{{java_test_version.name}}
           image: alpine-tools-image
           config:
@@ -666,7 +666,7 @@ jobs:
               - name: geode-results-{{java_test_version.name}}
                 path: geode-results
             timeout: 15m
-            attempts: 2
+            attempts: 5
           ensure:
             do:
             - aggregate:

--- a/ci/scripts/create_instance.sh
+++ b/ci/scripts/create_instance.sh
@@ -85,22 +85,18 @@ cp old/attempts new/
 echo attempt >> new/attempts
 attempts=$(cat new/attempts | wc -l)
 
+PERMITTED_ZONES=(us-central1-a us-central1-b us-central1-c us-central1-f)
 if [ $attempts -eq 1 ]; then
   ZONE=${MY_ZONE}
 else
-  #during retry we need to clean up the prior zone
-  PRIOR_ZONE=$(cat new/prior-zone)
-  gcloud compute instances delete ${INSTANCE_NAME} --zone=${PRIOR_ZONE} --quiet &>/dev/null || true
-  PERMITTED_ZONES=(us-central1-a us-central1-b us-central1-c us-central1-f)
   ZONE=${PERMITTED_ZONES[$((${RANDOM} % 4))]}
 fi
 echo "Deploying to zone ${ZONE}"
 
-#remember zone in case we retry
-echo ${ZONE} > new/prior-zone
-
-#in a retry loop we intentionally generate the same instance name, so make sure prior attempt is cleaned up
-gcloud compute instances delete ${INSTANCE_NAME} --zone=${ZONE} --quiet &>/dev/null || true
+# Ensure no existing instance with this name in any zone
+for KILL_ZONE in "${PERMITTED_ZONES}"; do
+  gcloud compute instances delete ${INSTANCE_NAME} --zone=${KILL_ZONE} --quiet &>/dev/null || true
+done
 
 echo "${INSTANCE_NAME}" > "instance-data/instance-name"
 echo "${GCP_PROJECT}" > "instance-data/project"


### PR DESCRIPTION
Improve cleanup logic in create_instance.sh

Delete any existing instance with our name in all available zones.