### PR TITLE
GEODE-7554: Add retry mechanism for failed tests

### DIFF
--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -75,8 +75,8 @@ do
     METADATA_BASELINE="'benchmark_version':'${BASELINE_VERSION}'"
   fi
 
-  ./run_on_cluster.sh -t testGets -- pkill -9 java
-  ./run_on_cluster.sh -t testGets -- rm /home/geode/locator10334view.dat;
+  ./run_on_cluster.sh -t ${CLUSTER_TAG} -- pkill -9 java
+  ./run_on_cluster.sh -t ${CLUSTER_TAG} -- rm /home/geode/locator10334view.dat;
   ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} ${BASELINE_OPTION} -e ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR} -m "'source':'geode-ci',${METADATA_BASELINE},'baseline_branch':'${BASELINE_BRANCH}','geode_branch':'${GEODE_SHA}'" --ci -- ${FLAGS} ${TEST_OPTIONS}
 
   if [[ $? -eq 0 ]]; then

--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -41,6 +41,8 @@ pushd geode
 GEODE_SHA=$(git rev-parse --verify HEAD)
 popd
 
+input= "$(pwd)/results/failedTests"
+
 pushd geode-benchmarks/infrastructure/scripts/aws/
 ./launch_cluster.sh -t ${CLUSTER_TAG} -c ${CLUSTER_COUNT} --ci
 
@@ -48,7 +50,6 @@ pushd geode-benchmarks/infrastructure/scripts/aws/
 # failed tests. Test failures only result in an exit code of 1 when on the last iteration of loop.
 for i in {1..5}
 do
-  input="/tmp/build/eeb5231a/results/failedTests"
   if [[ -f ${input} ]]; then
     unset TEST_OPTIONS
     TEST_OPTIONS=""

--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -50,6 +50,8 @@ pushd geode-benchmarks/infrastructure/scripts/aws/
 # failed tests. Test failures only result in an exit code of 1 when on the last iteration of loop.
 for i in {1..5}
 do
+  echo "This is ITERATION ${i} of benchmarking against baseline."
+
   if [[ -f ${input} ]]; then
     unset TEST_OPTIONS
     TEST_OPTIONS=""

--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -68,14 +68,16 @@ do
   fi
 
   if [ -z "${BASELINE_VERSION}" ]; then
-    ./run_on_cluster.sh -t testGets -- pkill -9 java
-    ./run_on_cluster.sh -t testGets -- rm /home/geode/locator10334view.dat;
-    ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} -B ${BASELINE_BRANCH} -e ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR} -m "'source':'geode-ci','benchmark_branch':'${BENCHMARK_BRANCH}','baseline_branch':'${BASELINE_BRANCH}','geode_branch':'${GEODE_SHA}'" --ci -- ${FLAGS} ${TEST_OPTIONS}
+    BASELINE_OPTION="-B ${BASELINE_BRANCH}"
+    METADATA_BASELINE="'benchmark_branch':'${BASELINE_BRANCH}'"
   else
-    ./run_on_cluster.sh -t testGets -- pkill -9 java
-    ./run_on_cluster.sh -t testGets -- rm /home/geode/locator10334view.dat;
-    ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} -V ${BASELINE_VERSION} -e ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR} -m "'source':'geode-ci','benchmark_branch':'${BENCHMARK_BRANCH}','baseline_version':'${BASELINE_VERSION}','geode_branch':'${GEODE_SHA}'" --ci -- ${FLAGS} ${TEST_OPTIONS}
+    BASELINE_OPTION="-V ${BASELINE_VERSION}"
+    METADATA_BASELINE="'benchmark_version':'${BASELINE_VERSION}'"
   fi
+
+  ./run_on_cluster.sh -t testGets -- pkill -9 java
+  ./run_on_cluster.sh -t testGets -- rm /home/geode/locator10334view.dat;
+  ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} ${BASELINE_OPTION} -e ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR} -m "'source':'geode-ci',${METADATA_BASELINE},'baseline_branch':'${BASELINE_BRANCH}','geode_branch':'${GEODE_SHA}'" --ci -- ${FLAGS} ${TEST_OPTIONS}
 
   if [[ $? -eq 0 ]]; then
     break;


### PR DESCRIPTION
There are still some flaky benchmarks. Retry tests that have failed, up
to 5 times, to determine if the failure is legitimate or just a flaky
test. If the test fails 5 times in a row, we know that it is a
legitimate failure.

With each run of run_against_baseline (in the apache/geode-benchmarks
repo), the class names of all failed tests will be written to a file.
The run_benchmarks script called by CI will read the failed tests from
the file and run only those tests. Once the return code is 0, or once
we've tried 5 times, exit.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
