### PR TITLE
GEODE-7577: Log when waiting for missing persistent members

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/persistence/MissingDiskStoreAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/persistence/MissingDiskStoreAcceptanceTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.persistence;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.cache.client.ClientRegionShortcut.PROXY;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+
+import java.nio.file.Path;
+import java.util.concurrent.Future;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.internal.InternalClientCache;
+import org.apache.geode.test.assertj.LogFileAssert;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+
+public class MissingDiskStoreAcceptanceTest {
+
+  private static final String SERVER_1_NAME = "server1";
+  private static final String SERVER_2_NAME = "server2";
+  private static final String LOCATOR_NAME = "locator";
+  private static final String REGION_NAME = "myRegion";
+
+  private InternalClientCache clientCache;
+
+  private Path locatorFolder;
+  private Path server1Folder;
+  private Path server2Folder;
+
+  private int locatorPort;
+
+  private String startServer1Command;
+  private String startServer2Command;
+
+  @Rule
+  public ExecutorServiceRule executorServiceRule = new ExecutorServiceRule();
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Before
+  public void setUp() throws Exception {
+    locatorFolder = temporaryFolder.newFolder(LOCATOR_NAME).toPath().toAbsolutePath();
+    server1Folder = temporaryFolder.newFolder(SERVER_1_NAME).toPath().toAbsolutePath();
+    server2Folder = temporaryFolder.newFolder(SERVER_2_NAME).toPath().toAbsolutePath();
+
+    int[] ports = getRandomAvailableTCPPorts(3);
+    locatorPort = ports[0];
+    int server1Port = ports[1];
+    int server2Port = ports[2];
+
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + LOCATOR_NAME,
+        "--dir=" + locatorFolder,
+        "--port=" + locatorPort,
+        "--locators=localhost[" + locatorPort + "]");
+
+    startServer1Command = String.join(" ",
+        "start server",
+        "--name=" + SERVER_1_NAME,
+        "--dir=" + server1Folder,
+        "--locators=localhost[" + locatorPort + "]",
+        "--server-port=" + server1Port);
+
+    startServer2Command = String.join(" ",
+        "start server",
+        "--name=" + SERVER_2_NAME,
+        "--dir=" + server2Folder,
+        "--locators=localhost[" + locatorPort + "]",
+        "--server-port=" + server2Port);
+
+    String createRegionCommand = String.join(" ",
+        "create region",
+        "--name=" + REGION_NAME,
+        "--type=REPLICATE_PERSISTENT");
+
+    gfshRule.execute(startLocatorCommand, startServer1Command, startServer2Command,
+        createRegionCommand);
+
+    clientCache = (InternalClientCache) new ClientCacheFactory()
+        .addPoolLocator("localhost", locatorPort)
+        .create();
+  }
+
+  @After
+  public void tearDown() {
+    if (clientCache != null) {
+      clientCache.close();
+    }
+
+    gfshRule.execute("stop server --dir=" + server1Folder);
+    gfshRule.execute("stop server --dir=" + server2Folder);
+    gfshRule.execute("stop locator --dir=" + locatorFolder);
+  }
+
+  @Test
+  public void waitingForMembersMessageIsLogged() throws Exception {
+    Region<Integer, Integer> region = clientCache.<Integer, Integer>createClientRegionFactory(PROXY)
+        .create(REGION_NAME);
+
+    region.put(1, 1);
+    gfshRule.execute("stop server --dir=" + server1Folder);
+
+    region.put(1, 2);
+    gfshRule.execute("stop server --dir=" + server2Folder);
+
+    String connectToLocatorCommand = "connect --locator=localhost[" + locatorPort + "]";
+
+    Future<Void> startServer1 = executorServiceRule.submit(() -> {
+      gfshRule.execute(connectToLocatorCommand, startServer1Command);
+    });
+
+    await().untilAsserted(() -> {
+      String waitingForMembersMessage = String.format(
+          "Region %s has potentially stale data. It is waiting for another member to recover the latest data.",
+          Region.SEPARATOR + REGION_NAME);
+
+      LogFileAssert.assertThat(server1Folder.resolve(SERVER_1_NAME + ".log").toFile())
+          .exists()
+          .contains(waitingForMembersMessage);
+    });
+
+    gfshRule.execute(connectToLocatorCommand, startServer2Command);
+
+    startServer1.get(getTimeout().getValueInMS(), MILLISECONDS);
+  }
+}

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/persistence/MissingDiskStoreAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/persistence/MissingDiskStoreAcceptanceTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
-import org.apache.geode.cache.client.internal.InternalClientCache;
 import org.apache.geode.test.assertj.LogFileAssert;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 import org.apache.geode.test.junit.rules.gfsh.GfshRule;
@@ -43,7 +43,7 @@ public class MissingDiskStoreAcceptanceTest {
   private static final String LOCATOR_NAME = "locator";
   private static final String REGION_NAME = "myRegion";
 
-  private InternalClientCache clientCache;
+  private ClientCache clientCache;
 
   private Path locatorFolder;
   private Path server1Folder;
@@ -103,7 +103,7 @@ public class MissingDiskStoreAcceptanceTest {
     gfshRule.execute(startLocatorCommand, startServer1Command, startServer2Command,
         createRegionCommand);
 
-    clientCache = (InternalClientCache) new ClientCacheFactory()
+    clientCache = new ClientCacheFactory()
         .addPoolLocator("localhost", locatorPort)
         .create();
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderOldConfigDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderOldConfigDUnitTest.java
@@ -22,33 +22,33 @@ import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskWriteAttributesFactory;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.Scope;
-import org.apache.geode.test.dunit.AsyncInvocation;
-import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 
 @Category(PersistenceTest.class)
 @SuppressWarnings("serial")
 public class PersistentRecoveryOrderOldConfigDUnitTest extends PersistentRecoveryOrderDUnitTest {
 
+  /**
+   * Override to use deprecated APIs for the creation of disk and region. This test class can
+   * probably be deleted.
+   */
   @Override
-  AsyncInvocation createPersistentRegionAsync(VM vm) {
-    return vm.invokeAsync(() -> {
-      getCache();
+  @SuppressWarnings("deprecation")
+  protected void createReplicateRegion(String regionName, File[] diskDirs,
+      boolean diskSynchronous) {
+    getCache();
 
-      File dir = getDiskDirForVM(vm);
-      dir.mkdirs();
+    DiskWriteAttributesFactory diskWriteAttributesFactory = new DiskWriteAttributesFactory();
+    diskWriteAttributesFactory.setMaxOplogSize(1);
+    diskWriteAttributesFactory.setSynchronous(diskSynchronous);
 
-      DiskWriteAttributesFactory diskWriteAttributesFactory = new DiskWriteAttributesFactory();
-      diskWriteAttributesFactory.setMaxOplogSize(1);
-      diskWriteAttributesFactory.setSynchronous(true);
+    RegionFactory regionFactory = new RegionFactory();
+    regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
+    regionFactory.setScope(Scope.DISTRIBUTED_ACK);
+    regionFactory.setDiskDirs(diskDirs);
+    regionFactory.setDiskWriteAttributes(diskWriteAttributesFactory.create());
 
-      RegionFactory regionFactory = new RegionFactory();
-      regionFactory.setDataPolicy(DataPolicy.PERSISTENT_REPLICATE);
-      regionFactory.setScope(Scope.DISTRIBUTED_ACK);
-      regionFactory.setDiskDirs(new File[] {dir});
-      regionFactory.setDiskWriteAttributes(diskWriteAttributesFactory.create());
-
-      regionFactory.create(regionName);
-    });
+    regionFactory.create(regionName);
   }
+
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -1346,8 +1346,6 @@ public class DistributionAdvisor {
     }
   }
 
-  // ------------------------------------ inner classes --------------------------------------------
-
   @FunctionalInterface
   public interface InitializationListener {
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionAdvisor.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static java.lang.System.lineSeparator;
+import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -35,6 +38,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.GemFireIOException;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -42,6 +46,7 @@ import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor.CacheProfile;
 import org.apache.geode.internal.cache.DistributedRegion;
+import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.UpdateAttributesProcessor;
 import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.internal.cache.versions.VersionSource;
@@ -57,13 +62,15 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * Provides advice on sending distribution messages. For a given operation, this advisor will
  * provide a list of recipients that a message should be sent to, and other information depending on
  * the operation. Each distributed entity that can have remote counterparts maintains an instance of
- * <code>DistributionAdvisor</code> and maintains it by giving it a <code>Profile</code> for each of
+ * {@code DistributionAdvisor} and maintains it by giving it a {@code Profile} for each of
  * its remote counterparts, and telling it to delete a profile when that counterpart no longer
  * exists.
+ *
  * <p>
- * Provides <code>advise</code> methods for each type of operation that requires specialized
+ * Provides {@code advise} methods for each type of operation that requires specialized
  * decision making based on the profiles. For all other operations that do not require specialized
  * decision making, the {@link #adviseGeneric} method is provided.
+ *
  * <p>
  * A primary design goal of this class is scalability: the footprint must be kept to a minimum as
  * the number of instances grows across a growing number of members in the distributed system.
@@ -78,15 +85,13 @@ public class DistributionAdvisor {
    * Specifies the starting version number for the profileVersionSequencer.
    */
   private static final int START_VERSION_NUMBER = Integer
-      .getInteger(DistributionConfig.GEMFIRE_PREFIX + "DistributionAdvisor.startVersionNumber", 1);
+      .getInteger(GEMFIRE_PREFIX + "DistributionAdvisor.startVersionNumber", 1);
 
   /**
    * Specifies the starting serial number for the serialNumberSequencer.
    */
   private static final int START_SERIAL_NUMBER =
-      Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "Cache.startSerialNumber", 1
-      // Integer.MAX_VALUE-10
-      );
+      Integer.getInteger(GEMFIRE_PREFIX + "Cache.startSerialNumber", 1);
 
   /**
    * Incrementing serial number used to identify order of resource creation
@@ -104,8 +109,7 @@ public class DistributionAdvisor {
    * {@link Integer#MIN_VALUE} to determine if a rollover has occurred.
    */
   private static final int ROLLOVER_THRESHOLD = Integer
-      .getInteger(DistributionConfig.GEMFIRE_PREFIX + "CacheDistributionAdvisor.rolloverThreshold",
-          1000);
+      .getInteger(GEMFIRE_PREFIX + "CacheDistributionAdvisor.rolloverThreshold", 1000);
 
   /**
    * {@link Integer#MAX_VALUE} minus {@link #ROLLOVER_THRESHOLD} determines the upper threshold for
@@ -134,12 +138,11 @@ public class DistributionAdvisor {
       logger.isDebugEnabled() ? new ThreadTrackingOperationMonitor(this)
           : new OperationMonitor(this);
 
-
   /**
    * Indicates whether this advisor is has been initialized. This will be false when a shared region
    * is mapped into the cache but there has been no distributed operations done on it yet.
    */
-  private volatile boolean initialized = false;
+  private volatile boolean initialized;
 
   /**
    * Synchronization lock used for controlling access to initialization. We do not synchronize on
@@ -168,21 +171,22 @@ public class DistributionAdvisor {
   /**
    * Number of active profiles
    */
-  private int numActiveProfiles = 0;
+  private int numActiveProfiles;
 
   /**
    * A collection of MembershipListeners that want to be notified when a profile is added to or
    * removed from this DistributionAdvisor. The keys are membership listeners and the values are
    * Boolean.TRUE.
    */
-  private ConcurrentMap<MembershipListener, Boolean> membershipListeners =
+  private final ConcurrentMap<MembershipListener, Boolean> membershipListeners =
       new ConcurrentHashMap<>();
 
   /**
    * A collection of listeners for changes to profiles. These listeners are notified if a profile is
    * added, removed, or updated.
    */
-  private ConcurrentMap<ProfileListener, Boolean> profileListeners = new ConcurrentHashMap<>();
+  private final ConcurrentMap<ProfileListener, Boolean> profileListeners =
+      new ConcurrentHashMap<>();
 
   private volatile InitializationListener initializationListener;
 
@@ -200,23 +204,11 @@ public class DistributionAdvisor {
     membershipListener = new MembershipListener() {
 
       @Override
-      public void memberJoined(DistributionManager distributionManager,
-          InternalDistributedMember id) {
-        // Ignore
-      }
-
-      @Override
-      public void quorumLost(DistributionManager distributionManager,
-          Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
-
-      @Override
-      @SuppressWarnings("synthetic-access")
       public void memberDeparted(DistributionManager distributionManager,
           final InternalDistributedMember id, boolean crashed) {
         boolean shouldSync = crashed && shouldSyncForCrashedMember(id);
         final Profile profile = getProfile(id);
-        boolean removed =
-            removeId(id, crashed, false/* destroyed */, true/* fromMembershipListener */);
+        boolean removed = removeId(id, crashed, false, true);
         // if concurrency checks are enabled and this was a crash we may need to
         // sync with other members in case an update was lost. We do this in the
         // waiting thread pool so as not to block other membership listeners
@@ -224,27 +216,11 @@ public class DistributionAdvisor {
           syncForCrashedMember(id, profile);
         }
       }
-
-      @Override
-      public void memberSuspect(DistributionManager distributionManager,
-          InternalDistributedMember id, InternalDistributedMember whoSuspected, String reason) {}
-
     };
   }
 
-  public static DistributionAdvisor createDistributionAdvisor(DistributionAdvisee advisee) {
-    DistributionAdvisor advisor = new DistributionAdvisor(advisee);
-    advisor.initialize();
-    return advisor;
-  }
-
   protected void initialize() {
-    subInit();
     getDistributionManager().addMembershipListener(membershipListener);
-  }
-
-  private void subInit() {
-    // override for any additional initialization specific to subclass
   }
 
   /**
@@ -253,11 +229,13 @@ public class DistributionAdvisor {
    * @return true if a delta-gii should be performed
    */
   public boolean shouldSyncForCrashedMember(InternalDistributedMember id) {
-    return (advisee instanceof DistributedRegion)
-        && ((DistributedRegion) advisee).shouldSyncForCrashedMember(id);
+    return advisee instanceof DistributedRegion
+        && ((InternalRegion) advisee).shouldSyncForCrashedMember(id);
   }
 
-  /** perform a delta-GII for the given lost member */
+  /**
+   * perform a delta-GII for the given lost member
+   */
   public void syncForCrashedMember(final InternalDistributedMember id, final Profile profile) {
     final DistributedRegion dr = getRegionForDeltaGII();
     if (dr == null) {
@@ -300,16 +278,20 @@ public class DistributionAdvisor {
     }
   }
 
+  @VisibleForTesting
   PersistentMemberID getPersistentID(CacheProfile cp) {
     return cp.persistentID;
   }
 
+  @VisibleForTesting
   long getDelay(DistributedRegion dr) {
     return dr.getGemFireCache().getCacheServers().stream()
         .mapToLong(CacheServer::getMaximumTimeBetweenPings).max().orElse(0L);
   }
 
-  /** find the region for a delta-gii operation (synch) */
+  /**
+   * find the region for a delta-gii operation (synch)
+   */
   public DistributedRegion getRegionForDeltaGII() {
     if (advisee instanceof DistributedRegion) {
       return (DistributedRegion) advisee;
@@ -394,7 +376,6 @@ public class DistributionAdvisor {
     }
   }
 
-
   /**
    * Atomically add listener to the list to receive notification when a *new* profile is added or a
    * profile is removed, and return adviseGeneric(). This ensures that no membership listener calls
@@ -407,7 +388,6 @@ public class DistributionAdvisor {
     return adviseGeneric();
   }
 
-
   /**
    * Add listener to the list to receive notification when a profile is added or removed. Note that
    * there is no guarantee that the listener will not get redundant calls, but the listener is
@@ -417,15 +397,8 @@ public class DistributionAdvisor {
     membershipListeners.putIfAbsent(listener, Boolean.TRUE);
   }
 
-  public interface InitializationListener {
-    /**
-     * Called after this DistributionAdvisor has been initialized.
-     */
-    void initialized();
-  }
-
   public void setInitializationListener(InitializationListener listener) {
-    this.initializationListener = listener;
+    initializationListener = listener;
   }
 
   public boolean addProfileChangeListener(ProfileListener listener) {
@@ -445,14 +418,18 @@ public class DistributionAdvisor {
     return membershipListeners.remove(listener) != null;
   }
 
-  /** Called by CreateRegionProcessor after it does its own profile exchange */
+  /**
+   * Called by CreateRegionProcessor after it does its own profile exchange
+   */
   public void setInitialized() {
     synchronized (initializeLock) {
       initialized = true;
     }
   }
 
-  /** Return true if exchanged profiles */
+  /**
+   * Return true if exchanged profiles
+   */
   public boolean initializationGate() {
     if (initialized) {
       return false;
@@ -468,16 +445,18 @@ public class DistributionAdvisor {
       }
     } finally {
       if (exchangedProfiles) {
-        if (this.initializationListener != null) {
+        if (initializationListener != null) {
           // this needs to be done outside the initializeLock
-          this.initializationListener.initialized();
+          initializationListener.initialized();
         }
       }
     }
     return false;
   }
 
-  // wait for pending profile exchange to complete before returning
+  /**
+   * wait for pending profile exchange to complete before returning
+   */
   public boolean isInitialized() {
     synchronized (initializeLock) {
       return initialized;
@@ -499,7 +478,6 @@ public class DistributionAdvisor {
    *
    * @param infoMsg prefix message to log
    */
-
   public void dumpProfiles(String infoMsg) {
     Profile[] profs = profiles;
     final StringBuilder buf = new StringBuilder(2000);
@@ -508,17 +486,17 @@ public class DistributionAdvisor {
       buf.append(": ");
     }
     buf.append("FYI, DUMPING PROFILES IN ");
-    buf.append(toString());
-    buf.append(":\n");
+    buf.append(this);
+    buf.append(":").append(lineSeparator());
 
     buf.append("My Profile=");
     buf.append(getAdvisee().getProfile());
-    buf.append("\nOther Profiles:\n");
+    buf.append(lineSeparator()).append("Other Profiles:").append(lineSeparator());
 
     for (Profile prof : profs) {
       buf.append("\t");
-      buf.append(prof.toString());
-      buf.append("\n");
+      buf.append(prof);
+      buf.append(lineSeparator());
     }
     if (logger.isDebugEnabled()) {
       logger.debug(buf.toString());
@@ -753,7 +731,7 @@ public class DistributionAdvisor {
     operationMonitor.waitForCurrentOperations();
   }
 
-  public void waitForCurrentOperations(Logger alertLogger, long warnMS, long severeAlertMS) {
+  void waitForCurrentOperations(Logger alertLogger, long warnMS, long severeAlertMS) {
     // this may wait longer than it should if the membership version changes, dumping
     // more operations into the previousVersionOpCount
     operationMonitor.waitForCurrentOperations(alertLogger, warnMS, severeAlertMS);
@@ -763,6 +741,7 @@ public class DistributionAdvisor {
    * Bypass the distribution manager and ask the membership manager directly if a given member is
    * still in the view.
    *
+   * <p>
    * We need this because we're asking membership questions from within listeners, and we don't know
    * whether the DM's membership listener fires before or after our own.
    *
@@ -773,15 +752,15 @@ public class DistributionAdvisor {
     if (id instanceof InternalDistributedMember) {
       InternalDistributedMember memberId = (InternalDistributedMember) id;
       return getDistributionManager().getViewMembers().contains(memberId);
-    } else {
-      // if id is not a InternalDistributedMember then return false
-      return false;
     }
+    // if id is not a InternalDistributedMember then return false
+    return false;
   }
 
   /**
    * Given member is no longer pertinent to this advisor; remove it.
    *
+   * <p>
    * This is often overridden in subclasses, but they need to defer to their superclass at some
    * point in their re-implementation.
    *
@@ -825,12 +804,11 @@ public class DistributionAdvisor {
   }
 
   /**
-   * Removes the profile for the given member. This method is meant to be overriden by subclasses.
+   * Removes the profile for the given member. This method is meant to be overridden by subclasses.
    *
    * @param memberId the member whose profile should be removed
    * @param crashed true if the member crashed
    * @param fromMembershipListener true if this call is a result of MembershipEvent invocation
-   *        (fixes #42000)
    * @return true when the profile was removed, false otherwise
    */
   public boolean removeId(final ProfileId memberId, boolean crashed, boolean destroyed,
@@ -858,7 +836,6 @@ public class DistributionAdvisor {
       // If the member has disappeared, completely remove
       if (!fromMembershipListener) {
         boolean result = false;
-        // Assert.assertTrue(!crashed); // should not get here :-)
 
         // Is there an existing profile? If so, add it to list of those removed.
         Profile profileToRemove = getProfile(memberId);
@@ -874,15 +851,14 @@ public class DistributionAdvisor {
           profileToRemove = getProfile(memberId);
         }
         return result;
-      } else {
-        // Garbage collect; this profile is no longer pertinent
-        removedProfiles.remove(memberId);
-        boolean result = basicRemoveId(memberId, crashed, destroyed);
-        while (basicRemoveId(memberId, crashed, destroyed)) {
-          // keep removing profiles that match until we have no more
-        }
-        return result;
       }
+      // Garbage collect; this profile is no longer pertinent
+      removedProfiles.remove(memberId);
+      boolean result = basicRemoveId(memberId, crashed, destroyed);
+      while (basicRemoveId(memberId, crashed, destroyed)) {
+        // keep removing profiles that match until we have no more
+      }
+      return result;
     }
   }
 
@@ -1001,9 +977,8 @@ public class DistributionAdvisor {
    * @return true if the member was being tracked
    */
   public synchronized boolean containsId(InternalDistributedMember memberId) {
-    return (indexOfMemberId(memberId) > -1);
+    return indexOfMemberId(memberId) > -1;
   }
-
 
   public synchronized int getNumProfiles() {
     return numActiveProfiles;
@@ -1018,7 +993,7 @@ public class DistributionAdvisor {
 
   public Profile getProfile(ProfileId id) {
     Profile[] allProfiles = profiles; // volatile read
-    boolean isIDM = (id instanceof InternalDistributedMember);
+    boolean isIDM = id instanceof InternalDistributedMember;
     for (Profile allProfile : allProfiles) {
       if (isIDM) {
         if (allProfile.getDistributedMember().equals(id)) {
@@ -1033,7 +1008,9 @@ public class DistributionAdvisor {
     return null;
   }
 
-  /** exchange profiles to initialize this advisor */
+  /**
+   * exchange profiles to initialize this advisor
+   */
   public void exchangeProfiles() {
     Assert.assertHoldsLock(this, false); // causes deadlock
     Assert.assertHoldsLock(initializeLock, true);
@@ -1041,7 +1018,9 @@ public class DistributionAdvisor {
     setInitialized();
   }
 
-  /** Creates the current distribution profile for this member */
+  /**
+   * Creates the current distribution profile for this member
+   */
   public Profile createProfile() {
     Profile newProfile =
         instantiateProfile(getDistributionManager().getId(), incrementAndGetVersion());
@@ -1049,7 +1028,9 @@ public class DistributionAdvisor {
     return newProfile;
   }
 
-  /** Instantiate new distribution profile for this member */
+  /**
+   * Instantiate new distribution profile for this member
+   */
   protected Profile instantiateProfile(InternalDistributedMember memberId, int version) {
     return new Profile(memberId, version);
   }
@@ -1068,10 +1049,15 @@ public class DistributionAdvisor {
   /**
    * Provide recipients for profile exchange, called by UpdateAttributesProcessor and
    * CreateRegionProcessor. Can not be initialized at this point because it is only called in the
-   * following scenarios: 1) We're doing a lazy initialization and synchronization on initializeLock
-   * prevents other threads from causing initialization on this advisor. 2) We're creating a new
-   * region and doing profile exchange as part of region initialization, in which case no other
-   * threads have access to the region or this advisor.
+   * following scenarios:
+   *
+   * <pre>
+   * 1) We're doing a lazy initialization and synchronization on initializeLock prevents other
+   * threads from causing initialization on this advisor.
+   *
+   * 2) We're creating a new region and doing profile exchange as part of region initialization, in
+   * which case no other threads have access to the region or this advisor.
+   * </pre>
    */
   public Set adviseProfileExchange() {
     // Get the list of recipients from the nearest initialized advisor
@@ -1081,8 +1067,9 @@ public class DistributionAdvisor {
     DistributionAdvisee advisee = getAdvisee();
     do {
       advisee = advisee.getParentAdvisee();
-      if (advisee == null)
+      if (advisee == null) {
         return getDefaultDistributionMembers();
+      }
       advisor = advisee.getDistributionAdvisor();
     } while (!advisor.isInitialized());
     // do not call adviseGeneric because we don't want to trigger another
@@ -1098,9 +1085,8 @@ public class DistributionAdvisor {
   private Set<InternalDistributedMember> getDefaultDistributionMembers() {
     if (!useAdminMembersForDefault()) {
       return getDistributionManager().getOtherDistributionManagerIds();
-    } else {
-      return getDistributionManager().getAllOtherMembers();
     }
+    return getDistributionManager().getAllOtherMembers();
   }
 
   /**
@@ -1124,8 +1110,7 @@ public class DistributionAdvisor {
   private void notifyListenersMemberRemoved(InternalDistributedMember member, boolean crashed) {
     for (MembershipListener membershipListener : membershipListeners.keySet()) {
       try {
-        membershipListener.memberDeparted(getDistributionManagerWithNoCheck(), member,
-            crashed);
+        membershipListener.memberDeparted(getDistributionManagerWithNoCheck(), member, crashed);
       } catch (Exception e) {
         logger.warn("Ignoring exception during member departed listener notification", e);
       }
@@ -1134,19 +1119,19 @@ public class DistributionAdvisor {
 
   private void notifyListenersProfileRemoved(Profile profile, boolean destroyed) {
     for (ProfileListener profileListener : profileListeners.keySet()) {
-      (profileListener).profileRemoved(profile, destroyed);
+      profileListener.profileRemoved(profile, destroyed);
     }
   }
 
   private void notifyListenersProfileAdded(Profile profile) {
     for (ProfileListener profileListener : profileListeners.keySet()) {
-      (profileListener).profileCreated(profile);
+      profileListener.profileCreated(profile);
     }
   }
 
   private void notifyListenersProfileUpdated(Profile profile) {
     for (ProfileListener profileListener : profileListeners.keySet()) {
-      (profileListener).profileUpdated(profile);
+      profileListener.profileUpdated(profile);
     }
   }
 
@@ -1156,7 +1141,9 @@ public class DistributionAdvisor {
    *
    * @param profile the created profile
    */
-  protected void profileCreated(Profile profile) {}
+  protected void profileCreated(Profile profile) {
+    // empty by default
+  }
 
   /**
    * Template method for sub-classes to override. Method is invoked after a profile is updated in
@@ -1164,7 +1151,9 @@ public class DistributionAdvisor {
    *
    * @param profile the updated profile
    */
-  protected void profileUpdated(Profile profile) {}
+  protected void profileUpdated(Profile profile) {
+    // empty by default
+  }
 
   /**
    * Template method for sub-classes to override. Method is invoked after a profile is removed from
@@ -1172,9 +1161,13 @@ public class DistributionAdvisor {
    *
    * @param profile the removed profile
    */
-  protected void profileRemoved(Profile profile) {}
+  protected void profileRemoved(Profile profile) {
+    // empty by default
+  }
 
-  /** All advise methods go through this method */
+  /**
+   * All advise methods go through this method
+   */
   protected Set<InternalDistributedMember> adviseFilter(Filter f) {
     initializationGate();
     Set<InternalDistributedMember> recipients = null;
@@ -1189,9 +1182,8 @@ public class DistributionAdvisor {
     }
     if (recipients == null) {
       return Collections.emptySet();
-    } else {
-      return recipients;
     }
+    return recipients;
   }
 
   /**
@@ -1208,31 +1200,6 @@ public class DistributionAdvisor {
       }
     }
     return false;
-  }
-
-  /**
-   * A visitor interface for all the available profiles used by
-   * {@link DistributionAdvisor#accept(ProfileVisitor, Object)}. Unlike the {@link Filter} class
-   * this does not assume of two state visit of inclusion or exclusion rather allows manipulation of
-   * an arbitrary aggregator that has been passed to the {@link #visit} method. In addition this is
-   * public for use by other classes.
-   */
-  public interface ProfileVisitor<T> {
-
-    /**
-     * Visit a given {@link Profile} accumulating the results in the given aggregate. Returns false
-     * when the visit has to be terminated.
-     *
-     * @param advisor the DistributionAdvisor that invoked this visitor
-     * @param profile the profile being visited
-     * @param profileIndex the index of current profile
-     * @param numProfiles the total number of profiles being visited
-     * @param aggregate result aggregated so far, if any
-     *
-     * @return false if the visit has to be terminated immediately and false otherwise
-     */
-    boolean visit(DistributionAdvisor advisor, Profile profile, int profileIndex, int numProfiles,
-        T aggregate);
   }
 
   /**
@@ -1266,7 +1233,7 @@ public class DistributionAdvisor {
   }
 
   /**
-   * Get an unmodifiable list of the <code>Profile</code>s that match the given <code>Filter</code>.
+   * Get an unmodifiable list of the {@code Profile}s that match the given {@code Filter}.
    *
    * @since GemFire 5.7
    */
@@ -1293,7 +1260,7 @@ public class DistributionAdvisor {
   }
 
   /** Provide recipients for profile update. */
-  public Set adviseProfileUpdate() {
+  public Set<InternalDistributedMember> adviseProfileUpdate() {
     return adviseGeneric();
   }
 
@@ -1302,7 +1269,7 @@ public class DistributionAdvisor {
    *
    * @since GemFire 5.7
    */
-  public Set adviseProfileRemove() {
+  public Set<InternalDistributedMember> adviseProfileRemove() {
     return adviseGeneric();
   }
 
@@ -1310,8 +1277,9 @@ public class DistributionAdvisor {
    * @return true if new profile added, false if already had profile (but profile is still replaced
    *         with new one)
    */
-  // must synchronize when modifying profile array
   private synchronized boolean basicAddProfile(Profile p) {
+    // must synchronize when modifying profile array
+
     // don't add more than once, but replace existing profile
     // try {
 
@@ -1334,23 +1302,19 @@ public class DistributionAdvisor {
     return true;
   }
 
-
-  // must synchronize when modifying profile array
   /**
    * Perform work of removing the given member from this advisor.
    */
   private synchronized Profile basicRemoveMemberId(ProfileId id) {
-    // try {
+    // must synchronize when modifying profile array
+
     int i = indexOfMemberId(id);
     if (i >= 0) {
       Profile profileRemoved = profiles[i];
       basicRemoveIndex(i);
       return profileRemoved;
-    } else
-      return null;
-    // } finally {
-    // Assert.assertTrue(-1 == indexOfMemberId(id));
-    // }
+    }
+    return null;
   }
 
   private int indexOfMemberId(ProfileId id) {
@@ -1382,9 +1346,46 @@ public class DistributionAdvisor {
     }
   }
 
+  // ------------------------------------ inner classes --------------------------------------------
 
-  /** Filter interface */
+  @FunctionalInterface
+  public interface InitializationListener {
+
+    /**
+     * Called after this DistributionAdvisor has been initialized.
+     */
+    void initialized();
+  }
+
+  /**
+   * A visitor interface for all the available profiles used by
+   * {@link DistributionAdvisor#accept(ProfileVisitor, Object)}. Unlike the {@link Filter} class
+   * this does not assume of two state visit of inclusion or exclusion rather allows manipulation of
+   * an arbitrary aggregator that has been passed to the {@link #visit} method. In addition this is
+   * public for use by other classes.
+   */
+  @FunctionalInterface
+  public interface ProfileVisitor<T> {
+
+    /**
+     * Visit a given {@link Profile} accumulating the results in the given aggregate. Returns false
+     * when the visit has to be terminated.
+     *
+     * @param advisor the DistributionAdvisor that invoked this visitor
+     * @param profile the profile being visited
+     * @param profileIndex the index of current profile
+     * @param numProfiles the total number of profiles being visited
+     * @param aggregate result aggregated so far, if any
+     *
+     * @return false if the visit has to be terminated immediately and false otherwise
+     */
+    boolean visit(DistributionAdvisor advisor, Profile profile, int profileIndex, int numProfiles,
+        T aggregate);
+  }
+
+  @FunctionalInterface
   protected interface Filter {
+
     boolean include(Profile profile);
   }
 
@@ -1394,15 +1395,24 @@ public class DistributionAdvisor {
    */
   public interface ProfileId {
   }
+
   /**
    * Profile information for a remote counterpart.
    */
   public static class Profile implements DataSerializableFixedID {
-    /** Member for whom this profile represents */
+
+    /**
+     * Member for whom this profile represents
+     */
     public InternalDistributedMember peerMemberId;
-    /** Serial number incremented every time profile is updated by memberId */
+
+    /**
+     * Serial number incremented every time profile is updated by memberId
+     */
     public int version;
+
     public int serialNumber = ILLEGAL_SERIAL;
+
     /**
      * The DistributionAdvisor's membership version where this member was added
      *
@@ -1410,13 +1420,16 @@ public class DistributionAdvisor {
      */
     public transient long initialMembershipVersion;
 
-    /** for internal use, required for DataSerializable.Helper.readObject */
-    public Profile() {}
+    /**
+     * for internal use, required for DataSerializable.Helper.readObject
+     */
+    public Profile() {
+      // nothing
+    }
 
     public Profile(InternalDistributedMember memberId, int version) {
       if (memberId == null) {
-        throw new IllegalArgumentException(
-            "memberId cannot be null");
+        throw new IllegalArgumentException("memberId cannot be null");
       }
       peerMemberId = memberId;
       this.version = version;
@@ -1446,12 +1459,15 @@ public class DistributionAdvisor {
 
     @Override
     public boolean equals(Object obj) {
-      if (obj == this)
+      if (obj == this) {
         return true;
-      if (obj == null)
+      }
+      if (obj == null) {
         return false;
-      if (!getClass().equals(obj.getClass()))
+      }
+      if (!getClass().equals(obj.getClass())) {
         return false;
+      }
       return getId().equals(((Profile) obj).getId());
     }
 
@@ -1470,16 +1486,15 @@ public class DistributionAdvisor {
     }
 
     @Override
-    public void toData(DataOutput out,
-        SerializationContext context) throws IOException {
+    public void toData(DataOutput out, SerializationContext context) throws IOException {
       InternalDataSerializer.invokeToData(peerMemberId, out);
       out.writeInt(version);
       out.writeInt(serialNumber);
     }
 
     @Override
-    public void fromData(DataInput in,
-        DeserializationContext context) throws IOException, ClassNotFoundException {
+    public void fromData(DataInput in, DeserializationContext context)
+        throws IOException, ClassNotFoundException {
       peerMemberId = new InternalDistributedMember();
       InternalDataSerializer.invokeFromData(peerMemberId, in);
       version = in.readInt();
@@ -1533,10 +1548,10 @@ public class DistributionAdvisor {
 
     /**
      * This will be get called when profile will be removed from advisor Do local cleanup in this
-     * thread, otherwsie spawn another thread to do cleanup
+     * thread, otherwise spawn another thread to do cleanup
      */
     public void cleanUp() {
-
+      // empty by default
     }
 
     public StringBuilder getToStringHeader() {
@@ -1556,9 +1571,8 @@ public class DistributionAdvisor {
     }
   }
 
-
-
   private static class OperationMonitor {
+
     private final DistributionAdvisor distributionAdvisor;
 
     /**
@@ -1595,7 +1609,7 @@ public class DistributionAdvisor {
      *
      * @since GemFire 5.1
      */
-    synchronized void forceNewMembershipVersion() {
+    private synchronized void forceNewMembershipVersion() {
       if (!closed) {
         incrementMembershipVersion();
         previousVersionOpCount += currentVersionOpCount;
@@ -1613,7 +1627,7 @@ public class DistributionAdvisor {
      * @return the current membership version for this advisor
      * @since GemFire 5.1
      */
-    synchronized long startOperation() {
+    private synchronized long startOperation() {
       logNewOperation();
       currentVersionOpCount++;
       return membershipVersion;
@@ -1626,7 +1640,7 @@ public class DistributionAdvisor {
      * @param version The membership version returned by startOperation
      * @since GemFire 5.1
      */
-    synchronized void endOperation(long version) {
+    private synchronized void endOperation(long version) {
       if (version == membershipVersion) {
         currentVersionOpCount--;
         logEndOperation(true);
@@ -1642,14 +1656,14 @@ public class DistributionAdvisor {
      *
      * @since GemFire 5.1
      */
-    void waitForCurrentOperations() {
+    private void waitForCurrentOperations() {
       long timeout =
           1000L * distributionAdvisor.getDistributionManager().getSystem().getConfig()
               .getAckWaitThreshold();
       waitForCurrentOperations(logger, timeout, timeout * 2L);
     }
 
-    void waitForCurrentOperations(Logger alertLogger, long warnMS, long severeAlertMS) {
+    private void waitForCurrentOperations(Logger alertLogger, long warnMS, long severeAlertMS) {
       // this may wait longer than it should if the membership version changes, dumping
       // more operations into the previousVersionOpCount
       final long startTime = System.currentTimeMillis();
@@ -1666,10 +1680,10 @@ public class DistributionAdvisor {
           throw new GemFireIOException("State flush interrupted");
         }
         long now = System.currentTimeMillis();
-        if ((!warned) && System.currentTimeMillis() >= warnTime) {
+        if (!warned && System.currentTimeMillis() >= warnTime) {
           warned = true;
           logWaitOnOperationsWarning(alertLogger, warnMS);
-        } else if (warned && !severeAlertIssued && (now >= severeAlertTime)) {
+        } else if (warned && !severeAlertIssued && now >= severeAlertTime) {
           logWaitOnOperationsSevere(alertLogger, severeAlertMS);
           severeAlertIssued = true;
         }
@@ -1679,15 +1693,14 @@ public class DistributionAdvisor {
       }
     }
 
-    synchronized boolean operationsAreInProgress() {
+    private synchronized boolean operationsAreInProgress() {
       return previousVersionOpCount > 0;
     }
 
-    synchronized void initNewProfile(Profile newProfile) {
+    private synchronized void initNewProfile(Profile newProfile) {
       membershipVersion++;
       newProfile.initialMembershipVersion = membershipVersion;
-      previousVersionOpCount =
-          previousVersionOpCount + currentVersionOpCount;
+      previousVersionOpCount = previousVersionOpCount + currentVersionOpCount;
       currentVersionOpCount = 0;
       membershipVersionChanged();
     }
@@ -1698,12 +1711,15 @@ public class DistributionAdvisor {
       closed = true;
     }
 
-    void logNewOperation() {}
+    void logNewOperation() {
+      // empty by default
+    }
 
-    void logEndOperation(boolean newOperation) {}
+    void logEndOperation(boolean newOperation) {
+      // empty by default
+    }
 
     void logWaitOnOperationsSevere(Logger alertLogger, long severeAlertMS) {
-      // OSProcess.printStacks(0);
       alertLogger.fatal("This thread has been stalled for {} milliseconds "
           + "waiting for current operations to complete.  Something may be blocking operations.",
           severeAlertMS);
@@ -1714,21 +1730,21 @@ public class DistributionAdvisor {
           + "current operations to complete.", warnMS);
     }
 
-    void membershipVersionChanged() {}
-
+    void membershipVersionChanged() {
+      // empty by default
+    }
   }
 
   private static class ThreadTrackingOperationMonitor extends OperationMonitor {
 
     /**
      * for debugging stalled state-flush operations we track threads performing operations
-     * and capture the state when startOperatiopn is invoked
+     * and capture the state when startOperation is invoked
      */
     private final Map<Thread, ExceptionWrapper> currentVersionOperationThreads;
     private final Map<Thread, ExceptionWrapper> previousVersionOperationThreads;
 
-    private ThreadTrackingOperationMonitor(
-        DistributionAdvisor distributionAdvisor) {
+    private ThreadTrackingOperationMonitor(DistributionAdvisor distributionAdvisor) {
       super(distributionAdvisor);
       currentVersionOperationThreads = new HashMap<>();
       previousVersionOperationThreads = new HashMap<>();
@@ -1753,10 +1769,8 @@ public class DistributionAdvisor {
     void logWaitOnOperationsWarning(Logger alertLogger, long warnMS) {
       super.logWaitOnOperationsWarning(alertLogger, warnMS);
       synchronized (this) {
-        logger
-            .debug("Waiting for these threads: {}", previousVersionOperationThreads);
-        logger
-            .debug("New version threads are {}", currentVersionOperationThreads);
+        logger.debug("Waiting for these threads: {}", previousVersionOperationThreads);
+        logger.debug("New version threads are {}", currentVersionOperationThreads);
       }
     }
 
@@ -1764,30 +1778,27 @@ public class DistributionAdvisor {
     void logWaitOnOperationsSevere(Logger alertLogger, long severeAlertMS) {
       super.logWaitOnOperationsSevere(alertLogger, severeAlertMS);
       synchronized (this) {
-        logger
-            .debug("Waiting for these threads: {}", previousVersionOperationThreads);
-        logger
-            .debug("New version threads are {}", currentVersionOperationThreads);
+        logger.debug("Waiting for these threads: {}", previousVersionOperationThreads);
+        logger.debug("New version threads are {}", currentVersionOperationThreads);
       }
     }
 
     @Override
     void membershipVersionChanged() {
       super.membershipVersionChanged();
-      previousVersionOperationThreads
-          .putAll(currentVersionOperationThreads);
+      previousVersionOperationThreads.putAll(currentVersionOperationThreads);
       currentVersionOperationThreads.clear();
     }
 
-
     /**
-     * ExceptionWrapper is used in debugging hangs in waitForCurrentOperations(). It
-     * captures the call stack of a thread invoking startOperation().
+     * ExceptionWrapper is used in debugging hangs in waitForCurrentOperations(). It captures the
+     * call stack of a thread invoking startOperation().
      */
     private static class ExceptionWrapper {
-      private Exception exception;
 
-      ExceptionWrapper(Exception exception) {
+      private final Exception exception;
+
+      private ExceptionWrapper(Exception exception) {
         this.exception = exception;
       }
 
@@ -1805,7 +1816,5 @@ public class DistributionAdvisor {
         return builder.toString();
       }
     }
-
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketPersistenceAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketPersistenceAdvisor.java
@@ -14,24 +14,34 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.lang.System.lineSeparator;
+import static java.time.Duration.ofSeconds;
+import static java.util.Collections.synchronizedSet;
+import static org.apache.geode.internal.cache.persistence.MembershipChangeListenerFactory.cancelCondition;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.persistence.PartitionOfflineException;
 import org.apache.geode.distributed.DistributedLockService;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.PartitionedRegion.BucketLock;
 import org.apache.geode.internal.cache.partitioned.RedundancyAlreadyMetException;
+import org.apache.geode.internal.cache.persistence.InternalPersistenceAdvisor;
 import org.apache.geode.internal.cache.persistence.MembershipChangeListener;
+import org.apache.geode.internal.cache.persistence.MembershipChangeListenerFactory;
 import org.apache.geode.internal.cache.persistence.PersistenceAdvisorImpl;
 import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.internal.cache.persistence.PersistentMemberManager;
@@ -45,8 +55,8 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
 
   private static final Logger logger = LogService.getLogger();
 
-  public CountDownLatch someMemberRecoveredLatch = new CountDownLatch(1);
-  public boolean recovering = true;
+  private final CountDownLatch someMemberRecoveredLatch = new CountDownLatch(1);
+  private boolean recovering = true;
   private boolean atomicCreation;
   private final BucketLock bucketLock;
   /**
@@ -55,40 +65,63 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
    */
   private final RecoveryListener recoveryListener;
   private final ProxyBucketRegion proxyBucket;
+  private final Function<InternalPersistenceAdvisor, MembershipChangeListener> membershipChangeListenerProvider;
   private short version;
   private RuntimeException recoveryException;
 
-  public BucketPersistenceAdvisor(CacheDistributionAdvisor advisor, DistributedLockService dl,
-      PersistentMemberView storage, String regionPath, DiskRegionStats diskStats,
-      PersistentMemberManager memberManager, BucketLock bucketLock,
-      ProxyBucketRegion proxyBucketRegion) {
-    super(advisor, dl, storage, regionPath, diskStats, memberManager);
+  BucketPersistenceAdvisor(CacheDistributionAdvisor cacheDistributionAdvisor,
+      DistributedLockService distributedLockService, PersistentMemberView storage,
+      String regionPath, DiskRegionStats diskStats, PersistentMemberManager memberManager,
+      BucketLock bucketLock, ProxyBucketRegion proxyBucketRegion) {
+    this(cacheDistributionAdvisor, distributedLockService, storage, regionPath, diskStats,
+        memberManager, bucketLock, proxyBucketRegion,
+        internalPersistenceAdvisor -> {
+          CacheDistributionAdvisor advisor =
+              internalPersistenceAdvisor.getCacheDistributionAdvisor();
+          DistributionConfig config = advisor.getDistributionManager().getConfig();
+          CancelCriterion stopper = advisor.getAdvisee().getCancelCriterion();
+
+          return new MembershipChangeListenerFactory()
+              .setWarningDelay(ofSeconds(config.getAckWaitThreshold() / 2))
+              .setPollDuration(ofSeconds(config.getAckWaitThreshold()))
+              .setCancelCondition(cancelCondition(internalPersistenceAdvisor, stopper))
+              .setWarning(internalPersistenceAdvisor::logWaitingForMembers)
+              .create();
+        });
+  }
+
+  private BucketPersistenceAdvisor(CacheDistributionAdvisor cacheDistributionAdvisor,
+      DistributedLockService distributedLockService, PersistentMemberView storage,
+      String regionPath, DiskRegionStats diskStats, PersistentMemberManager memberManager,
+      BucketLock bucketLock, ProxyBucketRegion proxyBucketRegion,
+      Function<InternalPersistenceAdvisor, MembershipChangeListener> membershipChangeListenerProvider) {
+    super(cacheDistributionAdvisor, distributedLockService, storage, regionPath, diskStats,
+        memberManager);
     this.bucketLock = bucketLock;
 
     recoveryListener = new RecoveryListener();
-    this.proxyBucket = proxyBucketRegion;
+    proxyBucket = proxyBucketRegion;
+    this.membershipChangeListenerProvider = membershipChangeListenerProvider;
     addListener(recoveryListener);
   }
 
   public void recoveryDone(RuntimeException e) {
-    this.recovering = false;
+    recovering = false;
     if (!getPersistedMembers().isEmpty()) {
       ((BucketAdvisor) cacheDistributionAdvisor).setHadPrimary();
     }
-    // Make sure any removes that we saw during recovery are
-    // applied.
+    // Make sure any removes that we saw during recovery are applied.
     removeListener(recoveryListener);
     for (PersistentMemberID id : recoveryListener.getRemovedMembers()) {
       removeMember(id);
     }
     if (someMemberRecoveredLatch.getCount() > 0) {
-      this.recoveryException = e;
-      this.someMemberRecoveredLatch.countDown();
+      recoveryException = e;
+      someMemberRecoveredLatch.countDown();
     } else if (recoveryException != null) {
       logger.fatal(
           String.format("Unable to recover secondary bucket from disk for region %s bucket %s",
-              new Object[] {proxyBucket.getPartitionedRegion().getFullPath(),
-                  proxyBucket.getBucketId()}),
+              proxyBucket.getPartitionedRegion().getFullPath(), proxyBucket.getBucketId()),
           e);
     }
   }
@@ -102,8 +135,9 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     proxyBucket.getPartitionedRegion().checkReadiness();
   }
 
+  @VisibleForTesting
   public boolean isRecovering() {
-    return this.recovering;
+    return recovering;
   }
 
   @Override
@@ -125,18 +159,16 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
   public void logWaitingForMembers() {
     // We only log the bucket level information at fine level.
     if (logger.isDebugEnabled(LogMarker.PERSIST_ADVISOR_VERBOSE)) {
-      Set<String> membersToWaitForPrettyFormat = new HashSet<String>();
+      Set<String> membersToWaitForPrettyFormat = new HashSet<>();
 
       if (offlineMembersWaitingFor != null && !offlineMembersWaitingFor.isEmpty()) {
         TransformUtils.transform(offlineMembersWaitingFor, membersToWaitForPrettyFormat,
             TransformUtils.persistentMemberIdToLogEntryTransformer);
         logger.debug(LogMarker.PERSIST_ADVISOR_VERBOSE,
             "Region {}, bucket {} has potentially stale data.  It is waiting for another member to recover the latest data.My persistent id: {} Members with potentially new data:{}  Use the gfsh show missing-disk-stores command to see all disk stores that are being waited on by other members.",
-            new Object[] {proxyBucket.getPartitionedRegion().getFullPath(),
-                proxyBucket.getBucketId(),
-                TransformUtils.persistentMemberIdToLogEntryTransformer
-                    .transform(getPersistentID()),
-                membersToWaitForPrettyFormat});
+            proxyBucket.getPartitionedRegion().getFullPath(), proxyBucket.getBucketId(),
+            TransformUtils.persistentMemberIdToLogEntryTransformer.transform(getPersistentID()),
+            membersToWaitForPrettyFormat);
       } else {
         TransformUtils.transform(allMembersWaitingFor, membersToWaitForPrettyFormat,
             TransformUtils.persistentMemberIdToLogEntryTransformer);
@@ -146,11 +178,9 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
         }
         logger.debug(LogMarker.PERSIST_ADVISOR_VERBOSE,
             "Region {}, bucket {} has potentially stale data.  It is waiting for another member to recover the latest data. My persistent id: {} Members with potentially new data:{}  Use the gfsh show missing-disk-stores command to see all disk stores that are being waited on by other members.",
-            new Object[] {proxyBucket.getPartitionedRegion().getFullPath(),
-                proxyBucket.getBucketId(),
-                TransformUtils.persistentMemberIdToLogEntryTransformer
-                    .transform(getPersistentID()),
-                membersToWaitForPrettyFormat});
+            proxyBucket.getPartitionedRegion().getFullPath(), proxyBucket.getBucketId(),
+            TransformUtils.persistentMemberIdToLogEntryTransformer.transform(getPersistentID()),
+            membersToWaitForPrettyFormat);
       }
     }
   }
@@ -162,7 +192,6 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
       // We allow regions with persistent colocated children to exceed redundancy
       // so that we can create the child bucket. Otherwise, we need to check
       // that redundancy has not already been met now that we've got the dlock
-      // the delock.
       if (!proxyBucket.hasPersistentChildRegion()
           && !proxyBucket.checkBucketRedundancyBeforeGrab(null, false)) {
         if (logger.isDebugEnabled(LogMarker.PERSIST_ADVISOR_VERBOSE)) {
@@ -170,8 +199,7 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
               "{}-{}: After reacquiring dlock, we detected that redundancy is already satisfied",
               shortDiskStoreId(), regionPath);
         }
-        // Remove the persistent data for this bucket, since
-        // redundancy is already satisfied.
+        // Remove the persistent data for this bucket, since redundancy is already satisfied.
         proxyBucket.destroyOfflineData();
         throw new RedundancyAlreadyMetException();
       }
@@ -184,18 +212,16 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     if (recovering) {
       super.updateMembershipView(replicate, targetReinitializing);
       someMemberRecoveredLatch.countDown();
-    } else {
-      // don't update the membership view, we already updated it during recovery.
     }
+    // else don't update the membership view, we already updated it during recovery.
   }
 
   /**
    * Wait for there to be initialized copies of this bucket. Get the latest membership view from
    * those copies.
-   *
    */
-  public void initializeMembershipView() {
-    MembershipChangeListener listener = new MembershipChangeListener(this);
+  void initializeMembershipView() {
+    MembershipChangeListener listener = membershipChangeListenerProvider.apply(this);
     addListener(listener);
     boolean interrupted = false;
     try {
@@ -258,8 +284,8 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     return false;
   }
 
-  public void bucketRemoved() {
-    this.resetState();
+  void bucketRemoved() {
+    resetState();
   }
 
   @Override
@@ -275,7 +301,6 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     // holding the bucket lock when we create a bucket region
   }
 
-
   @Override
   protected String getRegionPathForOfflineMembers() {
     return proxyBucket.getPartitionedRegion().getFullPath();
@@ -285,11 +310,10 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
   public Set<PersistentMemberID> getMissingMembers() {
     if (recovering) {
       return super.getMissingMembers();
-    } else {
-      Set<PersistentMemberID> offlineMembers = getPersistedMembers();
-      offlineMembers.removeAll(cacheDistributionAdvisor.advisePersistentMembers().values());
-      return offlineMembers;
     }
+    Set<PersistentMemberID> offlineMembers = getPersistedMembers();
+    offlineMembers.removeAll(cacheDistributionAdvisor.advisePersistentMembers().values());
+    return offlineMembers;
   }
 
   @Override
@@ -297,34 +321,14 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     PersistentMemberID id = persistentMemberView.generatePersistentID();
     if (id == null) {
       return id;
-    } else {
-      id = new PersistentMemberID(id.getDiskStoreId(), id.getHost(), id.getDirectory(),
-          this.proxyBucket.getPartitionedRegion().getBirthTime(), version++);
-      return id;
     }
-  }
-
-
-
-  private static class RecoveryListener extends PersistentStateAdapter {
-    private Set<PersistentMemberID> removedMembers =
-        Collections.synchronizedSet(new HashSet<PersistentMemberID>());
-
-    @Override
-    public void memberRemoved(PersistentMemberID persistentID, boolean revoked) {
-      this.removedMembers.add(persistentID);
-    }
-
-    public HashSet<PersistentMemberID> getRemovedMembers() {
-      synchronized (removedMembers) {
-        return new HashSet<PersistentMemberID>(removedMembers);
-      }
-    }
+    id = new PersistentMemberID(id.getDiskStoreId(), id.getHost(), id.getDirectory(),
+        proxyBucket.getPartitionedRegion().getBirthTime(), version++);
+    return id;
   }
 
   /**
    * Callers should have already verified that debug output is enabled.
-   *
    */
   public void dump(String infoMsg) {
     persistentMemberView.getOnlineMembers();
@@ -337,30 +341,30 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
       buf.append(infoMsg);
       buf.append(": ");
     }
-    buf.append("\nMY PERSISTENT ID:\n");
+    buf.append(lineSeparator()).append("MY PERSISTENT ID:").append(lineSeparator());
     buf.append(persistentMemberView.getMyPersistentID());
-    buf.append("\nMY INITIALIZING ID:\n");
+    buf.append(lineSeparator()).append("MY INITIALIZING ID:").append(lineSeparator());
     buf.append(persistentMemberView.getMyInitializingID());
 
-    buf.append("\nONLINE MEMBERS:\n");
+    buf.append(lineSeparator()).append("ONLINE MEMBERS:").append(lineSeparator());
     for (PersistentMemberID id : persistentMemberView.getOnlineMembers()) {
       buf.append("\t");
       buf.append(id);
-      buf.append("\n");
+      buf.append(lineSeparator());
     }
 
-    buf.append("\nOFFLINE MEMBERS:\n");
+    buf.append(lineSeparator()).append("OFFLINE MEMBERS:").append(lineSeparator());
     for (PersistentMemberID id : persistentMemberView.getOfflineMembers()) {
       buf.append("\t");
       buf.append(id);
-      buf.append("\n");
+      buf.append(lineSeparator());
     }
 
-    buf.append("\nOFFLINE AND EQUAL MEMBERS:\n");
+    buf.append(lineSeparator()).append("OFFLINE AND EQUAL MEMBERS:").append(lineSeparator());
     for (PersistentMemberID id : persistentMemberView.getOfflineAndEqualMembers()) {
       buf.append("\t");
       buf.append(id);
-      buf.append("\n");
+      buf.append(lineSeparator());
     }
     logger.debug(buf.toString());
   }
@@ -369,9 +373,10 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
    * Wait for this bucket to be recovered from disk, at least to the point where it starts doing a
    * GII.
    *
+   * <p>
    * This method will throw an exception if the recovery thread encountered an exception.
    */
-  public void waitForPrimaryPersistentRecovery() {
+  void waitForPrimaryPersistentRecovery() {
     boolean interupted = false;
     while (true) {
       try {
@@ -389,7 +394,7 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     if (recoveryException != null) {
       StackTraceElement[] oldStack = recoveryException.getStackTrace();
       recoveryException.fillInStackTrace();
-      ArrayList<StackTraceElement> newStack = new ArrayList<StackTraceElement>();
+      ArrayList<StackTraceElement> newStack = new ArrayList<>();
       newStack.addAll(Arrays.asList(oldStack));
       newStack.addAll(Arrays.asList(recoveryException.getStackTrace()));
 
@@ -398,11 +403,9 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     }
   }
 
-
-
   /**
-   * Overridden to fix bug 41336. We defer initialization of this member until after the atomic
-   * bucket creation phase is over.
+   * Overridden to defer initialization of this member until after the atomic bucket creation phase
+   * is over.
    */
   @Override
   public void setInitializing(PersistentMemberID newId) {
@@ -418,8 +421,8 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
   }
 
   /**
-   * Overridden to fix bug 41336. We defer initialization of this member until after the atomic
-   * bucket creation phase is over.
+   * Overridden to defer initialization of this member until after the atomic bucket creation phase
+   * is over.
    */
   @Override
   public void setOnline(boolean didGII, boolean wasAtomicCreation, PersistentMemberID newId)
@@ -428,7 +431,7 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     // creation, we will do nothing right now. Later, when endBucketCreation
     // is called, we will pass the "wasAtomicCreation" flag down to the super
     // class to ensure that it knows its coming online as part of an atomic creation.
-    if (this.atomicCreation) {
+    if (atomicCreation) {
       if (logger.isDebugEnabled(LogMarker.PERSIST_ADVISOR_VERBOSE)) {
         logger.debug(LogMarker.PERSIST_ADVISOR_VERBOSE,
             "{}-{}: {} Deferring setOnline until the EndBucketCreation phase for {}",
@@ -443,7 +446,7 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
    * Finish the atomic creation of this bucket on multiple members This method is called with the
    * proxy bucket synchronized.
    */
-  public void endBucketCreation(PersistentMemberID newId) {
+  void endBucketCreation(PersistentMemberID newId) {
     synchronized (lock) {
       if (!atomicCreation) {
         if (logger.isDebugEnabled(LogMarker.PERSIST_ADVISOR_VERBOSE)) {
@@ -464,11 +467,12 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     super.setOnline(false, true, newId);
   }
 
-  public boolean isAtomicCreation() {
-    return this.atomicCreation;
+  @VisibleForTesting
+  boolean isAtomicCreation() {
+    return atomicCreation;
   }
 
-  public void setAtomicCreation(boolean atomicCreation) {
+  void setAtomicCreation(boolean atomicCreation) {
     if (getPersistentID() != null) {
       return;
     }
@@ -477,14 +481,19 @@ public class BucketPersistenceAdvisor extends PersistenceAdvisorImpl {
     }
   }
 
-  private BucketPersistenceAdvisor getColocatedPersistenceAdvisor() {
-    PartitionedRegion colocatedRegion =
-        ColocationHelper.getColocatedRegion(proxyBucket.getPartitionedRegion());
-    if (colocatedRegion == null) {
-      return null;
+  private static class RecoveryListener extends PersistentStateAdapter {
+
+    private final Set<PersistentMemberID> removedMembers = synchronizedSet(new HashSet<>());
+
+    @Override
+    public void memberRemoved(PersistentMemberID persistentID, boolean revoked) {
+      removedMembers.add(persistentID);
     }
-    ProxyBucketRegion colocatedProxyBucket =
-        colocatedRegion.getRegionAdvisor().getProxyBucketArray()[proxyBucket.getBucketId()];
-    return colocatedProxyBucket.getPersistenceAdvisor();
+
+    private HashSet<PersistentMemberID> getRemovedMembers() {
+      synchronized (removedMembers) {
+        return new HashSet<>(removedMembers);
+      }
+    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -445,4 +445,13 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
       DistributedRemoveAllOperation removeAllOp, List<VersionTag> retryVersions);
 
   VersionTag getVersionTag(Object key);
+
+  /**
+   * This method determines whether this region should synchronize with peer replicated regions when
+   * the given member has crashed.
+   *
+   * @param id the crashed member
+   * @return true if synchronization should be attempted
+   */
+  boolean shouldSyncForCrashedMember(InternalDistributedMember id);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -3433,7 +3433,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
    * @since GemFire 3.2
    */
   @Override
-  public Object getValueInVM(Object key) throws EntryNotFoundException { // KIRK
+  public Object getValueInVM(Object key) throws EntryNotFoundException {
     return basicGetValueInVM(key, true);
   }
 
@@ -9694,13 +9694,6 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     return isUsedForPartitionedRegionAdmin;
   }
 
-  /**
-   * This method determines whether this region should synchronize with peer replicated regions when
-   * the given member has crashed.
-   *
-   * @param id the crashed member
-   * @return true if synchronization should be attempted
-   */
   public boolean shouldSyncForCrashedMember(InternalDistributedMember id) {
     return getConcurrencyChecksEnabled() && getDataPolicy().withReplication()
         && !isUsedForPartitionedRegionAdmin && !isUsedForMetaRegion

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PersistentBucketRecoverer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PersistentBucketRecoverer.java
@@ -70,19 +70,27 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
 
   private final List<RegionStatus> regions;
 
+  private final StartupStatus startupStatus;
 
   /**
    * Creates a new PersistentBucketRecoverer.
-   *
    */
   public PersistentBucketRecoverer(PRHARedundancyProvider prhaRedundancyProvider,
       int proxyBuckets) {
+    this(prhaRedundancyProvider, proxyBuckets, new StartupStatus());
+  }
+
+  private PersistentBucketRecoverer(PRHARedundancyProvider prhaRedundancyProvider, int proxyBuckets,
+      StartupStatus startupStatus) {
     super(prhaRedundancyProvider);
+
+    this.startupStatus = startupStatus;
+
     PartitionedRegion baseRegion =
         ColocationHelper.getLeaderRegion(redundancyProvider.getPartitionedRegion());
     List<PartitionedRegion> colocatedRegions =
         getColocatedChildRegions(baseRegion);
-    List<RegionStatus> allRegions = new ArrayList<RegionStatus>(colocatedRegions.size() + 1);
+    List<RegionStatus> allRegions = new ArrayList<>(colocatedRegions.size() + 1);
     if (baseRegion.getDataPolicy().withPersistence()) {
       allRegions.add(new RegionStatus(baseRegion));
     }
@@ -96,7 +104,6 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
     allBucketsRecoveredFromDisk = new CountDownLatch(proxyBuckets);
     membershipChanged = true;
     addListeners();
-
   }
 
   List<PartitionedRegion> getColocatedChildRegions(PartitionedRegion baseRegion) {
@@ -117,7 +124,7 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
    */
   @Override
   public void memberOnline(InternalDistributedMember member, PersistentMemberID persistentID) {
-    this.membershipChanged = true;
+    membershipChanged = true;
   }
 
   /**
@@ -125,7 +132,7 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
    */
   @Override
   public void memberOffline(InternalDistributedMember member, PersistentMemberID persistentID) {
-    this.membershipChanged = true;
+    membershipChanged = true;
   }
 
   /**
@@ -133,7 +140,7 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
    */
   @Override
   public void memberRemoved(PersistentMemberID persistentID, boolean revoked) {
-    this.membershipChanged = true;
+    membershipChanged = true;
   }
 
 
@@ -177,8 +184,8 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
         }
         Thread.sleep(sleepMillis);
 
-        if (this.membershipChanged) {
-          this.membershipChanged = false;
+        if (membershipChanged) {
+          membershipChanged = false;
           for (RegionStatus region : regions) {
             region.logWaitingForMembers();
           }
@@ -233,19 +240,19 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
     private volatile boolean loggedDoneMessage = true;
 
     public RegionStatus(PartitionedRegion region) {
-      this.thisMember = createPersistentMemberID(region);
+      thisMember = createPersistentMemberID(region);
       this.region = region.getFullPath();
-      this.bucketRegions = region.getRegionAdvisor().getProxyBucketArray();
+      bucketRegions = region.getRegionAdvisor().getProxyBucketArray();
     }
 
     public void removeListeners() {
-      for (ProxyBucketRegion proxyBucket : this.bucketRegions) {
+      for (ProxyBucketRegion proxyBucket : bucketRegions) {
         proxyBucket.getPersistenceAdvisor().removeListener(PersistentBucketRecoverer.this);
       }
     }
 
     public void addListeners() {
-      for (ProxyBucketRegion proxyBucket : this.bucketRegions) {
+      for (ProxyBucketRegion proxyBucket : bucketRegions) {
         proxyBucket.getPersistenceAdvisor().addListener(PersistentBucketRecoverer.this);
       }
     }
@@ -306,7 +313,7 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
           new HashMap<PersistentMemberID, Set<Integer>>();
 
 
-      for (ProxyBucketRegion proxyBucket : this.bucketRegions) {
+      for (ProxyBucketRegion proxyBucket : bucketRegions) {
         Integer bucketId = proxyBucket.getBucketId();
 
         // Get the set of missing members from the persistence advisor
@@ -337,13 +344,12 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
      * Prints a recovery completion message to the log.
      */
     private void logDoneMessage() {
-      this.loggedDoneMessage = true;
-      StartupStatus.startup(
+      loggedDoneMessage = true;
+      startupStatus.startup(
           String.format(
               "Region %s has successfully completed waiting for other members to recover the latest data.My persistent member information:%s",
-              new Object[] {this.region,
-                  TransformUtils.persistentMemberIdToLogEntryTransformer
-                      .transform(this.thisMember)}));
+              region,
+              TransformUtils.persistentMemberIdToLogEntryTransformer.transform(thisMember)));
     }
 
     /**
@@ -359,43 +365,41 @@ public class PersistentBucketRecoverer extends RecoveryRunnable implements Persi
        * Log any offline members the region is waiting for.
        */
       if (thereAreBucketsToBeRecovered && !offlineMembers.isEmpty()) {
-        Set<String> membersToWaitForLogEntries = new HashSet<String>();
+        Set<String> membersToWaitForLogEntries = new HashSet<>();
 
         TransformUtils.transform(offlineMembers.entrySet(), membersToWaitForLogEntries,
             TransformUtils.persistentMemberEntryToLogEntryTransformer);
 
         Set<Integer> missingBuckets = getAllWaitingBuckets(offlineMembers);
 
-        StartupStatus.startup(
+        startupStatus.startup(
             String.format(
                 "Region %s (and any colocated sub-regions) has potentially stale data.  Buckets %s are waiting for another offline member to recover the latest data.My persistent id is:%sOffline members with potentially new data:%sUse the gfsh show missing-disk-stores command to see all disk stores that are being waited on by other members.",
-                new Object[] {this.region, missingBuckets,
-                    TransformUtils.persistentMemberIdToLogEntryTransformer
-                        .transform(this.thisMember),
-                    membersToWaitForLogEntries}));
+                region, missingBuckets,
+                TransformUtils.persistentMemberIdToLogEntryTransformer.transform(thisMember),
+                membersToWaitForLogEntries));
 
-        this.loggedDoneMessage = false;
+        loggedDoneMessage = false;
       }
       /*
        * No offline? Then log any online members the region is waiting for.
        */
       else if (thereAreBucketsToBeRecovered && !allMembersToWaitFor.isEmpty()) {
-        Set<String> membersToWaitForLogEntries = new HashSet<String>();
+        Set<String> membersToWaitForLogEntries = new HashSet<>();
 
         Set<Integer> missingBuckets = getAllWaitingBuckets(allMembersToWaitFor);
         TransformUtils.transform(allMembersToWaitFor.entrySet(), membersToWaitForLogEntries,
             TransformUtils.persistentMemberEntryToLogEntryTransformer);
 
-        StartupStatus.startup(
+        startupStatus.startup(
             String.format(
                 "Region %s (and any colocated sub-regions) has potentially stale data.  Buckets %s are waiting for another online member to recover the latest data.My persistent id is:%sOnline members with potentially new data:%sUse the gfsh show missing-disk-stores command to see all disk stores that are being waited on by other members.",
-                new Object[] {this.region, missingBuckets,
-                    TransformUtils.persistentMemberIdToLogEntryTransformer
-                        .transform(this.thisMember),
-                    membersToWaitForLogEntries}));
+                region, missingBuckets,
+                TransformUtils.persistentMemberIdToLogEntryTransformer.transform(thisMember),
+                membersToWaitForLogEntries));
 
 
-        this.loggedDoneMessage = false;
+        loggedDoneMessage = false;
       }
       /*
        * No online? Then log that we are done.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListener.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListener.java
@@ -14,58 +14,51 @@
  */
 package org.apache.geode.internal.cache.persistence;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductIntegerProperty;
+import static java.time.Instant.now;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
-import java.util.Set;
 import java.util.function.BooleanSupplier;
 
-import org.apache.geode.CancelCriterion;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.MembershipListener;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
 public class MembershipChangeListener implements MembershipListener, PersistentStateListener {
+
   private static final int POLL_INTERVAL_MILLIS = 100;
 
-  private final Runnable warning;
-  private final BooleanSupplier cancelCondition;
   private final Duration pollDuration;
   private final Duration warningDelay;
+  private final BooleanSupplier cancelCondition;
+  private final Runnable warning;
 
   private boolean membershipChanged;
   private boolean warned;
 
-  public MembershipChangeListener(InternalPersistenceAdvisor persistenceAdvisor) {
-    warningDelay = warningDelay(persistenceAdvisor);
-    cancelCondition = cancelCondition(persistenceAdvisor);
-    warning = persistenceAdvisor::logWaitingForMembers;
-    pollDuration = pollDuration();
-  }
-
-  private Duration warningDelay(InternalPersistenceAdvisor persistenceAdvisor) {
-    return Duration.ofSeconds(persistenceAdvisor.getCacheDistributionAdvisor()
-        .getDistributionManager().getConfig().getAckWaitThreshold());
+  MembershipChangeListener(Duration warningDelay, Duration pollDuration,
+      BooleanSupplier cancelCondition, Runnable warning) {
+    this.warningDelay = warningDelay;
+    this.pollDuration = pollDuration;
+    this.cancelCondition = cancelCondition;
+    this.warning = warning;
   }
 
   public synchronized void waitForChange() throws InterruptedException {
-    Instant now = Instant.now();
+    Instant now = now();
     Instant timeoutTime = now.plus(pollDuration);
     Instant warningTime = now.plus(warningDelay);
 
-    while (!membershipChanged && !cancelCondition.getAsBoolean()
-        && Instant.now().isBefore(timeoutTime)) {
+    while (!membershipChanged && !cancelCondition.getAsBoolean() && now().isBefore(timeoutTime)) {
       warnOnceAfter(warningTime);
       wait(POLL_INTERVAL_MILLIS);
     }
+
     membershipChanged = false;
   }
 
   private void warnOnceAfter(Instant warningTime) {
-    if (!warned && warningTime.isBefore(Instant.now())) {
+    if (!warned && warningTime.isBefore(now())) {
       warning.run();
       warned = true;
     }
@@ -88,14 +81,6 @@ public class MembershipChangeListener implements MembershipListener, PersistentS
   }
 
   @Override
-  public void memberSuspect(DistributionManager distributionManager, InternalDistributedMember id,
-      InternalDistributedMember whoSuspected, String reason) {}
-
-  @Override
-  public void quorumLost(DistributionManager distributionManager,
-      Set<InternalDistributedMember> failures, List<InternalDistributedMember> remaining) {}
-
-  @Override
   public void memberOffline(InternalDistributedMember member, PersistentMemberID persistentID) {
     afterMembershipChange();
   }
@@ -108,20 +93,5 @@ public class MembershipChangeListener implements MembershipListener, PersistentS
   @Override
   public void memberRemoved(PersistentMemberID id, boolean revoked) {
     afterMembershipChange();
-  }
-
-  private static BooleanSupplier cancelCondition(InternalPersistenceAdvisor persistenceAdvisor) {
-    CancelCriterion cancelCriterion =
-        persistenceAdvisor.getCacheDistributionAdvisor().getAdvisee().getCancelCriterion();
-    return () -> {
-      persistenceAdvisor.checkInterruptedByShutdownAll();
-      cancelCriterion.checkCancelInProgress(null);
-      return persistenceAdvisor.isClosed();
-    };
-  }
-
-  private static Duration pollDuration() {
-    return Duration
-        .ofSeconds(getProductIntegerProperty(PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS).orElse(5));
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListener.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListener.java
@@ -24,6 +24,9 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.MembershipListener;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
+/**
+ * Provides warning logging for persistence advisors while waiting for membership changes.
+ */
 public class MembershipChangeListener implements MembershipListener, PersistentStateListener {
 
   private static final int POLL_INTERVAL_MILLIS = 100;
@@ -36,6 +39,14 @@ public class MembershipChangeListener implements MembershipListener, PersistentS
   private boolean membershipChanged;
   private boolean warned;
 
+  /**
+   * Please use {@link MembershipChangeListenerFactory} to create instances.
+   *
+   * @param warningDelay delay before logging the warning once
+   * @param pollDuration timeout before returning from wait for change
+   * @param cancelCondition indicates if wait for change has been cancelled
+   * @param warning simple runnable for logging the warning
+   */
   MembershipChangeListener(Duration warningDelay, Duration pollDuration,
       BooleanSupplier cancelCondition, Runnable warning) {
     this.warningDelay = warningDelay;
@@ -44,6 +55,9 @@ public class MembershipChangeListener implements MembershipListener, PersistentS
     this.warning = warning;
   }
 
+  /**
+   * Wait for membership change and log warning after waiting at least the warning delay.
+   */
   public synchronized void waitForChange() throws InterruptedException {
     Instant now = now();
     Instant timeoutTime = now.plus(pollDuration);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListenerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListenerFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.persistence;
+
+import static java.time.Duration.ofSeconds;
+import static java.util.Objects.requireNonNull;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductIntegerProperty;
+
+import java.time.Duration;
+import java.util.function.BooleanSupplier;
+
+import org.apache.geode.CancelCriterion;
+
+public class MembershipChangeListenerFactory {
+
+  public static final int DEFAULT_PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS = 15;
+
+  public static BooleanSupplier cancelCondition(InternalPersistenceAdvisor persistenceAdvisor,
+      CancelCriterion cancelCriterion) {
+    return () -> {
+      persistenceAdvisor.checkInterruptedByShutdownAll();
+      cancelCriterion.checkCancelInProgress(null);
+      return persistenceAdvisor.isClosed();
+    };
+  }
+
+  public static Duration warningDelay(int value) {
+    return ofSeconds(value);
+  }
+
+  public static Duration pollDuration(int value) {
+    return ofSeconds(
+        getProductIntegerProperty(PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS).orElse(value));
+  }
+
+  private Duration warningDelay;
+  private Duration pollDuration;
+  private BooleanSupplier cancelCondition;
+  private Runnable warning;
+
+  public MembershipChangeListenerFactory setWarningDelay(Duration warningDelay) {
+    this.warningDelay = warningDelay;
+    return this;
+  }
+
+  public MembershipChangeListenerFactory setPollDuration(Duration pollDuration) {
+    this.pollDuration = pollDuration;
+    return this;
+  }
+
+  public MembershipChangeListenerFactory setCancelCondition(BooleanSupplier cancelCondition) {
+    this.cancelCondition = cancelCondition;
+    return this;
+  }
+
+  public MembershipChangeListenerFactory setWarning(Runnable warning) {
+    this.warning = warning;
+    return this;
+  }
+
+  public MembershipChangeListener create() {
+    return create(warningDelay, pollDuration, cancelCondition, warning);
+  }
+
+  public MembershipChangeListener create(Duration warningDelay, Duration pollDuration,
+      BooleanSupplier cancelCondition, Runnable warning) {
+    requireNonNull(warningDelay);
+    requireNonNull(pollDuration);
+
+    int diff = warningDelay.compareTo(pollDuration);
+    if (diff >= 0) {
+      throw new IllegalArgumentException("Warning delay \"" + warningDelay.getSeconds()
+          + "\" seconds must be less than poll duration \"" + pollDuration.getSeconds()
+          + "\" seconds.");
+    }
+
+    return new MembershipChangeListener(warningDelay, pollDuration, cancelCondition, warning);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListenerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/MembershipChangeListenerFactory.java
@@ -14,19 +14,21 @@
  */
 package org.apache.geode.internal.cache.persistence;
 
-import static java.time.Duration.ofSeconds;
 import static java.util.Objects.requireNonNull;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductIntegerProperty;
 
 import java.time.Duration;
 import java.util.function.BooleanSupplier;
 
 import org.apache.geode.CancelCriterion;
 
+/**
+ * Creates instances of {@link MembershipChangeListener} with validation of arguments.
+ *
+ * <p>
+ * The warning delay must be less than the poll duration. If the values are identical then the
+ * persistence advisors will fail to log warnings about missing persistent members.
+ */
 public class MembershipChangeListenerFactory {
-
-  public static final int DEFAULT_PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS = 15;
 
   public static BooleanSupplier cancelCondition(InternalPersistenceAdvisor persistenceAdvisor,
       CancelCriterion cancelCriterion) {
@@ -35,15 +37,6 @@ public class MembershipChangeListenerFactory {
       cancelCriterion.checkCancelInProgress(null);
       return persistenceAdvisor.isClosed();
     };
-  }
-
-  public static Duration warningDelay(int value) {
-    return ofSeconds(value);
-  }
-
-  public static Duration pollDuration(int value) {
-    return ofSeconds(
-        getProductIntegerProperty(PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS).orElse(value));
   }
 
   private Duration warningDelay;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisor.java
@@ -14,11 +14,18 @@
  */
 package org.apache.geode.internal.cache.persistence;
 
+import static java.time.Duration.ofSeconds;
+import static org.apache.geode.internal.cache.persistence.MembershipChangeListenerFactory.cancelCondition;
+
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor;
@@ -26,7 +33,7 @@ import org.apache.geode.internal.cache.CacheDistributionAdvisor.InitialImageAdvi
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
-public class PersistenceInitialImageAdvisor {
+class PersistenceInitialImageAdvisor {
 
   private static final Logger logger = LogService.getLogger();
 
@@ -35,22 +42,47 @@ public class PersistenceInitialImageAdvisor {
   private final String regionPath;
   private final CacheDistributionAdvisor cacheDistributionAdvisor;
   private final boolean hasDiskImageToRecoverFrom;
+  private final Function<InternalPersistenceAdvisor, MembershipChangeListener> membershipChangeListenerProvider;
 
-  public PersistenceInitialImageAdvisor(InternalPersistenceAdvisor persistenceAdvisor,
+  PersistenceInitialImageAdvisor(InternalPersistenceAdvisor persistenceAdvisor,
       String shortDiskStoreID, String regionPath, CacheDistributionAdvisor cacheDistributionAdvisor,
       boolean hasDiskImageToRecoverFrom) {
+    this(persistenceAdvisor, shortDiskStoreID, regionPath, cacheDistributionAdvisor,
+        hasDiskImageToRecoverFrom,
+        internalPersistenceAdvisor -> {
+          CacheDistributionAdvisor advisor =
+              internalPersistenceAdvisor.getCacheDistributionAdvisor();
+          DistributionConfig config = advisor.getDistributionManager().getConfig();
+          CancelCriterion stopper = advisor.getAdvisee().getCancelCriterion();
+
+          return new MembershipChangeListenerFactory()
+              .setWarningDelay(ofSeconds(config.getAckWaitThreshold() / 2))
+              .setPollDuration(ofSeconds(config.getAckWaitThreshold()))
+              .setCancelCondition(cancelCondition(internalPersistenceAdvisor, stopper))
+              .setWarning(internalPersistenceAdvisor::logWaitingForMembers)
+              .create();
+        });
+  }
+
+  @VisibleForTesting
+  PersistenceInitialImageAdvisor(InternalPersistenceAdvisor persistenceAdvisor,
+      String shortDiskStoreID, String regionPath, CacheDistributionAdvisor cacheDistributionAdvisor,
+      boolean hasDiskImageToRecoverFrom,
+      Function<InternalPersistenceAdvisor, MembershipChangeListener> membershipChangeListenerProvider) {
     this.persistenceAdvisor = persistenceAdvisor;
     this.shortDiskStoreID = shortDiskStoreID;
     this.regionPath = regionPath;
     this.cacheDistributionAdvisor = cacheDistributionAdvisor;
     this.hasDiskImageToRecoverFrom = hasDiskImageToRecoverFrom;
+    this.membershipChangeListenerProvider = membershipChangeListenerProvider;
   }
 
-  public InitialImageAdvice getAdvice(InitialImageAdvice previousAdvice) {
+  @VisibleForTesting
+  InitialImageAdvice getAdvice(InitialImageAdvice previousAdvice) {
     final boolean isPersistAdvisorDebugEnabled =
         logger.isDebugEnabled(LogMarker.PERSIST_ADVISOR_VERBOSE);
 
-    MembershipChangeListener listener = new MembershipChangeListener(persistenceAdvisor);
+    MembershipChangeListener listener = membershipChangeListenerProvider.apply(persistenceAdvisor);
     cacheDistributionAdvisor.addMembershipAndProxyListener(listener);
     persistenceAdvisor.addListener(listener);
     try {
@@ -67,12 +99,13 @@ public class PersistenceInitialImageAdvisor {
               removeReplicatesIfWeAreEqualToAnyOrElseClearEqualMembers(advice.getReplicates());
             }
             return advice;
-          } else if (hasNonPersistentMember(advice)) {
+          }
+          if (hasNonPersistentMember(advice)) {
             updateMembershipViewFromAnyPeer(advice.getNonPersistent(), hasDiskImageToRecoverFrom);
           }
 
-          // Fix for 51698 - If there are online members that we previously failed to get a GII
-          // from, retry those members rather than wait for new persistent members to recover.
+          // If there are online members that we previously failed to get a GII from, retry those
+          // members rather than wait for new persistent members to recover.
           if (hasReplicates(previousAdvice)) {
             logger.info(
                 "GII failed from all sources, but members are still online. Retrying the GII.");

--- a/geode-core/src/main/java/org/apache/geode/internal/process/ProcessLauncherContext.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/ProcessLauncherContext.java
@@ -105,12 +105,12 @@ public class ProcessLauncherContext {
 
   private static void installLogListener(final StartupStatusListener startupListener) {
     if (startupListener != null) {
-      StartupStatus.setListener(startupListener);
+      StartupStatusListenerRegistry.setListener(startupListener);
     }
   }
 
   private static void clearLogListener() {
-    StartupStatus.clearListener();
+    StartupStatusListenerRegistry.clearListener();
   }
 
   private ProcessLauncherContext(final boolean redirectOutput, final Properties overriddenDefaults,

--- a/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatus.java
@@ -16,53 +16,40 @@ package org.apache.geode.internal.process;
 
 import static org.apache.commons.lang3.Validate.notNull;
 
+import java.util.function.Consumer;
+
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
-/**
- * Extracted from LogWriterImpl and changed to static.
- */
 public class StartupStatus {
-  private static final Logger logger = LogService.getLogger();
+  private static final Logger LOGGER = LogService.getLogger();
 
-  /** protected by static synchronized */
-  @MakeNotStatic
-  private static StartupStatusListener listener;
+  private final Consumer<String> logger;
 
-  private StartupStatus() {
-    // do nothing
+  public StartupStatus() {
+    this(LOGGER::info);
+  }
+
+  private StartupStatus(Consumer<String> logger) {
+    this.logger = logger;
   }
 
   /**
    * Writes both a message and exception to this writer. If a startup listener is registered, the
    * message will be written to the listener as well to be reported to a user.
-   *
-   * @since GemFire 7.0
    */
-  public static synchronized void startup(final String msg, final Object... params) {
-    notNull(msg, "Invalid msgId '" + msg + "' specified");
+  public void startup(String message, Object... params) {
+    notNull(message, "Invalid message '" + message + "' specified");
     notNull(params, "Invalid params specified");
 
-    String message = String.format(msg, params);
+    String formattedMessage = String.format(message, params);
 
+    StartupStatusListener listener = StartupStatusListenerRegistry.getStartupListener();
     if (listener != null) {
-      listener.setStatus(message);
+      listener.setStatus(formattedMessage);
     }
 
-    logger.info(message);
-  }
-
-  public static synchronized void setListener(final StartupStatusListener listener) {
-    StartupStatus.listener = listener;
-  }
-
-  public static synchronized StartupStatusListener getStartupListener() {
-    return StartupStatus.listener;
-  }
-
-  public static synchronized void clearListener() {
-    StartupStatus.listener = null;
+    logger.accept(formattedMessage);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatusListener.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatusListener.java
@@ -18,11 +18,12 @@ package org.apache.geode.internal.process;
  * A listener for events that should be reported to the users console during the startup of a
  * gemfire member.
  */
+@FunctionalInterface
 public interface StartupStatusListener {
 
   /**
    * Report the current status of system startup. The status message reported to this method should
    * already be internationalized.
    */
-  void setStatus(final String status);
+  void setStatus(String status);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatusListenerRegistry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatusListenerRegistry.java
@@ -14,26 +14,28 @@
  */
 package org.apache.geode.internal.process;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.geode.annotations.internal.MakeNotStatic;
 
 public class StartupStatusListenerRegistry {
 
   @MakeNotStatic
-  private static volatile StartupStatusListener listener;
+  private static final AtomicReference<StartupStatusListener> listener = new AtomicReference<>();
 
   private StartupStatusListenerRegistry() {
     // do nothing
   }
 
   public static void setListener(StartupStatusListener listener) {
-    StartupStatusListenerRegistry.listener = listener;
+    StartupStatusListenerRegistry.listener.set(listener);
   }
 
   static StartupStatusListener getStartupListener() {
-    return listener;
+    return listener.get();
   }
 
   static void clearListener() {
-    listener = null;
+    listener.set(null);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatusListenerRegistry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/process/StartupStatusListenerRegistry.java
@@ -12,21 +12,28 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.test.dunit;
+package org.apache.geode.internal.process;
 
-import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
-import org.apache.geode.test.dunit.rules.ClusterStartupRule;
-import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.annotations.internal.MakeNotStatic;
 
-/**
- * This class is the superclass of all distributed unit tests.
- *
- * @deprecated this class used to be the base for distributed test cases, but due to its complexity
- *             and the complexity of inheritance in test classes, it should not be used.
- *             Please use {@link DistributedRule} and Geode User APIs or
- *             {@link ClusterStartupRule} instead.
- */
-@Deprecated
-@SuppressWarnings("serial")
-public abstract class DistributedTestCase extends JUnit4DistributedTestCase {
+public class StartupStatusListenerRegistry {
+
+  @MakeNotStatic
+  private static volatile StartupStatusListener listener;
+
+  private StartupStatusListenerRegistry() {
+    // do nothing
+  }
+
+  public static void setListener(StartupStatusListener listener) {
+    StartupStatusListenerRegistry.listener = listener;
+  }
+
+  static StartupStatusListener getStartupListener() {
+    return listener;
+  }
+
+  static void clearListener() {
+    listener = null;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/util/TransformUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/TransformUtils.java
@@ -115,6 +115,12 @@ public class TransformUtils {
     }
   }
 
+  @FunctionalInterface
+  public interface CollectionTransformer<T1, T2> {
+
+    void transform(Collection<T1> from, Collection<T2> to, Transformer<T1, T2> transformer);
+  }
+
   /**
    * Transforms a collection of one data type into another and returns a map using the transformed
    * type as the key and the original type as the value.

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/MembershipChangeListenerFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/MembershipChangeListenerFactoryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.persistence;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import org.junit.Test;
+
+public class MembershipChangeListenerFactoryTest {
+
+  @Test
+  public void warningDelayMustMustNotBeSameAsPollDuration() {
+    Throwable thrown = catchThrowable(() -> {
+      new MembershipChangeListenerFactory()
+          .setWarningDelay(ofSeconds(20))
+          .setPollDuration(ofSeconds(20))
+          .create();
+    });
+
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void warningDelayMustBeLessThanPollDuration() {
+    Throwable thrown = catchThrowable(() -> {
+      new MembershipChangeListenerFactory()
+          .setWarningDelay(ofSeconds(20))
+          .setPollDuration(ofSeconds(10))
+          .create();
+    });
+
+    assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void warningDelayCanBeLessThanPollDuration() {
+    Throwable thrown = catchThrowable(() -> {
+      new MembershipChangeListenerFactory()
+          .setWarningDelay(ofSeconds(10))
+          .setPollDuration(ofSeconds(20))
+          .create();
+    });
+
+    assertThat(thrown).isNull();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisorTest.java
@@ -14,11 +14,16 @@
  */
 package org.apache.geode.internal.cache.persistence;
 
+import static java.time.Duration.ofSeconds;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.geode.internal.cache.persistence.MembershipChangeListenerFactory.cancelCondition;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,8 +37,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
 
-import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.IntStream;
@@ -43,6 +48,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.mockito.InOrder;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.CacheClosedException;
@@ -51,25 +58,25 @@ import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor.InitialImageAdvice;
-import org.apache.geode.internal.lang.SystemPropertyHelper;
 
 public class PersistenceInitialImageAdvisorTest {
+
+  private InternalPersistenceAdvisor persistenceAdvisor;
+  private CacheDistributionAdvisor cacheDistributionAdvisor;
+  private PersistenceInitialImageAdvisor persistenceInitialImageAdvisor;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(STRICT_STUBS);
 
   @Rule
   public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-  private InternalPersistenceAdvisor persistenceAdvisor;
-  private CacheDistributionAdvisor cacheDistributionAdvisor =
-      mock(CacheDistributionAdvisor.class, RETURNS_DEEP_STUBS);
-  private PersistenceInitialImageAdvisor persistenceInitialImageAdvisor;
-
   @Before
-  public void setup() {
-    when(cacheDistributionAdvisor.getDistributionManager().getConfig().getAckWaitThreshold())
-        .thenReturn(15);
+  public void setUp() {
+    System.setProperty(GEODE_PREFIX + PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS, String.valueOf(15));
 
     persistenceAdvisor = mock(InternalPersistenceAdvisor.class);
-    when(persistenceAdvisor.getCacheDistributionAdvisor()).thenReturn(cacheDistributionAdvisor);
+    cacheDistributionAdvisor = mock(CacheDistributionAdvisor.class, RETURNS_DEEP_STUBS);
   }
 
   @Test
@@ -82,7 +89,8 @@ public class PersistenceInitialImageAdvisorTest {
 
     persistenceInitialImageAdvisor.getAdvice(null);
 
-    verify(persistenceAdvisor, times(1)).clearEqualMembers();
+    verify(persistenceAdvisor, times(1))
+        .clearEqualMembers();
   }
 
   @Test
@@ -105,11 +113,13 @@ public class PersistenceInitialImageAdvisorTest {
 
     when(cacheDistributionAdvisor.adviseInitialImage(isNull(), anyBoolean()))
         .thenReturn(adviceWithReplicates(9));
-    when(persistenceAdvisor.checkMyStateOnMembers(any())).thenReturn(true);
+    when(persistenceAdvisor.checkMyStateOnMembers(any()))
+        .thenReturn(true);
 
     InitialImageAdvice result = persistenceInitialImageAdvisor.getAdvice(null);
 
-    assertThat(result.getReplicates()).isEmpty();
+    assertThat(result.getReplicates())
+        .isEmpty();
   }
 
   @Test
@@ -136,16 +146,17 @@ public class PersistenceInitialImageAdvisorTest {
 
     when(cacheDistributionAdvisor.adviseInitialImage(isNotNull(), anyBoolean()))
         .thenReturn(adviceWithReplicates(0));
-    when(cacheDistributionAdvisor.adviseInitialImage(isNull(), anyBoolean()))
-        .thenReturn(adviceWithReplicates(1));
 
     persistenceInitialImageAdvisor.getAdvice(previousAdviceWithReplicates);
 
     InOrder inOrder = inOrder(cacheDistributionAdvisor);
+
     inOrder.verify(cacheDistributionAdvisor, times(1))
         .adviseInitialImage(same(previousAdviceWithReplicates), anyBoolean());
-    inOrder.verify(cacheDistributionAdvisor, times(1)).adviseInitialImage(isNull(), anyBoolean());
-    inOrder.verify(cacheDistributionAdvisor, times(0)).adviseInitialImage(any(), anyBoolean());
+    inOrder.verify(cacheDistributionAdvisor, times(1))
+        .adviseInitialImage(isNull(), anyBoolean());
+    inOrder.verify(cacheDistributionAdvisor, times(0))
+        .adviseInitialImage(any(), anyBoolean());
   }
 
   @Test
@@ -158,13 +169,14 @@ public class PersistenceInitialImageAdvisorTest {
         .thenReturn(adviceWithNonPersistentReplicates, adviceWithReplicates(1));
 
     // Make every attempt fail, forcing the advisor to try them all.
-    doThrow(ReplyException.class).when(persistenceAdvisor).updateMembershipView(any(),
-        anyBoolean());
+    doThrow(ReplyException.class)
+        .when(persistenceAdvisor).updateMembershipView(any(), anyBoolean());
 
     persistenceInitialImageAdvisor.getAdvice(null);
 
     for (InternalDistributedMember peer : adviceWithNonPersistentReplicates.getNonPersistent()) {
-      verify(persistenceAdvisor, times(1)).updateMembershipView(peer, true);
+      verify(persistenceAdvisor, times(1))
+          .updateMembershipView(peer, true);
     }
   }
 
@@ -184,18 +196,24 @@ public class PersistenceInitialImageAdvisorTest {
     persistenceInitialImageAdvisor.getAdvice(null);
 
     // The second call succeeds. Expect no further calls.
-    verify(persistenceAdvisor, times(2)).updateMembershipView(any(), anyBoolean());
+    verify(persistenceAdvisor, times(2))
+        .updateMembershipView(any(), anyBoolean());
   }
 
-  @Test(expected = CacheClosedException.class)
+  @Test
   public void propagatesException_ifCancelInProgress() {
     persistenceInitialImageAdvisor = persistenceInitialImageAdvisorWithDiskImage();
 
     CancelCriterion cancelCriterion = mock(CancelCriterion.class);
-    when(cacheDistributionAdvisor.getAdvisee().getCancelCriterion()).thenReturn(cancelCriterion);
-    doThrow(new CacheClosedException()).when(cancelCriterion).checkCancelInProgress(any());
+    when(cacheDistributionAdvisor.getAdvisee().getCancelCriterion())
+        .thenReturn(cancelCriterion);
+    doThrow(new CacheClosedException("test"))
+        .when(cancelCriterion).checkCancelInProgress(any());
 
-    persistenceInitialImageAdvisor.getAdvice(null);
+    Throwable thrown = catchThrowable(() -> persistenceInitialImageAdvisor.getAdvice(null));
+
+    assertThat(thrown)
+        .isInstanceOf(CacheClosedException.class);
   }
 
   @Test
@@ -206,11 +224,13 @@ public class PersistenceInitialImageAdvisorTest {
 
     when(cacheDistributionAdvisor.adviseInitialImage(isNull(), anyBoolean()))
         .thenReturn(adviceFromCacheDistributionAdvisor);
-    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers()).thenReturn(new HashSet<>());
+    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers())
+        .thenReturn(new HashSet<>());
 
     InitialImageAdvice result = persistenceInitialImageAdvisor.getAdvice(null);
 
-    assertThat(result).isSameAs(adviceFromCacheDistributionAdvisor);
+    assertThat(result)
+        .isSameAs(adviceFromCacheDistributionAdvisor);
   }
 
   @Test
@@ -220,52 +240,70 @@ public class PersistenceInitialImageAdvisorTest {
     InitialImageAdvice adviceBeforeAcquiringTieLock = new InitialImageAdvice();
     InitialImageAdvice adviceAfterAcquiringTieLock = adviceWithReplicates(4);
 
-    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers()).thenReturn(persistentMemberIDs(1));
-    when(persistenceAdvisor.getMembersToWaitFor(any(), any())).thenReturn(emptySet());
-    when(persistenceAdvisor.acquireTieLock()).thenReturn(true);
+    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers())
+        .thenReturn(persistentMemberIDs(1));
+    when(persistenceAdvisor.getMembersToWaitFor(any(), any()))
+        .thenReturn(emptySet());
+    when(persistenceAdvisor.acquireTieLock())
+        .thenReturn(true);
 
     when(cacheDistributionAdvisor.adviseInitialImage(any(), anyBoolean()))
         .thenReturn(adviceBeforeAcquiringTieLock, adviceAfterAcquiringTieLock);
 
     InitialImageAdvice result = persistenceInitialImageAdvisor.getAdvice(null);
 
-    assertThat(result.getReplicates()).isEqualTo(adviceAfterAcquiringTieLock.getReplicates());
+    assertThat(result.getReplicates())
+        .isEqualTo(adviceAfterAcquiringTieLock.getReplicates());
   }
 
-  @Test(expected = ConflictingPersistentDataException.class)
+  @Test
   public void propagatesException_ifIncompatibleWithReplicateThatAppearsWhileAcquiringTieLock() {
     persistenceInitialImageAdvisor = persistenceInitialImageAdvisorWithDiskImage();
 
     InitialImageAdvice adviceBeforeAcquiringTieLock = new InitialImageAdvice();
     InitialImageAdvice adviceAfterAcquiringTieLock = adviceWithReplicates(4);
 
-    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers()).thenReturn(persistentMemberIDs(1));
-    when(persistenceAdvisor.getMembersToWaitFor(any(), any())).thenReturn(emptySet());
-    when(persistenceAdvisor.acquireTieLock()).thenReturn(true);
+    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers())
+        .thenReturn(persistentMemberIDs(1));
+    when(persistenceAdvisor.getMembersToWaitFor(any(), any()))
+        .thenReturn(emptySet());
+    when(persistenceAdvisor.acquireTieLock())
+        .thenReturn(true);
 
     when(cacheDistributionAdvisor.adviseInitialImage(any(), anyBoolean()))
         .thenReturn(adviceBeforeAcquiringTieLock, adviceAfterAcquiringTieLock);
 
-    doThrow(ConflictingPersistentDataException.class).when(persistenceAdvisor)
-        .checkMyStateOnMembers(any());
+    doThrow(ConflictingPersistentDataException.class)
+        .when(persistenceAdvisor).checkMyStateOnMembers(any());
 
-    persistenceInitialImageAdvisor.getAdvice(null);
+    Throwable thrown = catchThrowable(() -> persistenceInitialImageAdvisor.getAdvice(null));
+
+    assertThat(thrown)
+        .isInstanceOf(ConflictingPersistentDataException.class);
   }
 
   @Test
   public void announcesProgressToPersistenceAdvisor_whenWaitingForMissingMembers() {
-    persistenceInitialImageAdvisor = persistenceInitialImageAdvisorWithDiskImage();
+    persistenceInitialImageAdvisor = new PersistenceInitialImageAdvisor(persistenceAdvisor,
+        "short disk store ID", "region path", cacheDistributionAdvisor, true,
+        advisor -> new MembershipChangeListenerFactory()
+            .setWarningDelay(ofSeconds(0))
+            .setPollDuration(ofSeconds(1))
+            .setCancelCondition(cancelCondition(advisor, mock(CancelCriterion.class)))
+            .setWarning(advisor::logWaitingForMembers)
+            .create());
 
-    setMembershipChangePollDuration(Duration.ofSeconds(0));
     HashSet<PersistentMemberID> offlineMembersToWaitFor = memberIDs("offline member", 1);
     Set<PersistentMemberID> membersToWaitFor = new HashSet<>(offlineMembersToWaitFor);
 
-    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers()).thenReturn(offlineMembersToWaitFor);
-    when(persistenceAdvisor.getMembersToWaitFor(any(), any())).thenAnswer(invocation -> {
-      Set<PersistentMemberID> offlineMembers = invocation.getArgument(1);
-      offlineMembers.addAll(offlineMembersToWaitFor);
-      return membersToWaitFor;
-    });
+    when(persistenceAdvisor.getPersistedOnlineOrEqualMembers())
+        .thenReturn(offlineMembersToWaitFor);
+    when(persistenceAdvisor.getMembersToWaitFor(any(), any()))
+        .thenAnswer(invocation -> {
+          Set<PersistentMemberID> offlineMembers = invocation.getArgument(1);
+          offlineMembers.addAll(offlineMembersToWaitFor);
+          return membersToWaitFor;
+        });
 
     when(cacheDistributionAdvisor.adviseInitialImage(null, true))
         .thenReturn(adviceWithReplicates(0), adviceWithReplicates(1));
@@ -273,15 +311,25 @@ public class PersistenceInitialImageAdvisorTest {
     persistenceInitialImageAdvisor.getAdvice(null);
 
     InOrder inOrder = inOrder(persistenceAdvisor);
-    inOrder.verify(persistenceAdvisor, times(1)).beginWaitingForMembershipChange(membersToWaitFor);
-    inOrder.verify(persistenceAdvisor, times(1)).setWaitingOnMembers(isNotNull(),
-        eq(offlineMembersToWaitFor));
-    inOrder.verify(persistenceAdvisor, times(1)).endWaitingForMembershipChange();
-    inOrder.verify(persistenceAdvisor, times(1)).setWaitingOnMembers(isNull(), isNull());
-    inOrder.verify(persistenceAdvisor, times(0)).setWaitingOnMembers(any(), any());
+
+    inOrder.verify(persistenceAdvisor, times(1))
+        .beginWaitingForMembershipChange(membersToWaitFor);
+    inOrder.verify(persistenceAdvisor, times(1))
+        .setWaitingOnMembers(isNotNull(), eq(offlineMembersToWaitFor));
+    inOrder.verify(persistenceAdvisor, times(1))
+        .endWaitingForMembershipChange();
+    inOrder.verify(persistenceAdvisor, times(1))
+        .setWaitingOnMembers(isNull(), isNull());
+    inOrder.verify(persistenceAdvisor, times(0))
+        .setWaitingOnMembers(any(), any());
   }
 
   private PersistenceInitialImageAdvisor persistenceInitialImageAdvisor(boolean hasDiskImage) {
+    when(cacheDistributionAdvisor.getDistributionManager().getConfig().getAckWaitThreshold())
+        .thenReturn(15);
+    when(persistenceAdvisor.getCacheDistributionAdvisor())
+        .thenReturn(cacheDistributionAdvisor);
+
     return new PersistenceInitialImageAdvisor(persistenceAdvisor, "short disk store ID",
         "region path", cacheDistributionAdvisor, hasDiskImage);
   }
@@ -304,23 +352,22 @@ public class PersistenceInitialImageAdvisorTest {
   }
 
   private static Set<InternalDistributedMember> members(String namePrefix, int count) {
-    return IntStream.range(0, count).mapToObj(i -> namePrefix + ' ' + i)
-        .map(name -> mock(InternalDistributedMember.class, name)).collect(toSet());
+    return IntStream
+        .range(0, count)
+        .mapToObj(i -> namePrefix + ' ' + i)
+        .map(name -> mock(InternalDistributedMember.class, name))
+        .collect(toSet());
   }
 
   private static HashSet<PersistentMemberID> memberIDs(String namePrefix, int count) {
-    return IntStream.range(0, count).mapToObj(i -> namePrefix + ' ' + i)
-        .map(name -> mock(PersistentMemberID.class, name)).collect(toCollection(HashSet::new));
+    return IntStream
+        .range(0, count)
+        .mapToObj(i -> namePrefix + ' ' + i)
+        .map(name -> mock(PersistentMemberID.class, name))
+        .collect(toCollection(HashSet::new));
   }
 
   private static HashSet<PersistentMemberID> persistentMemberIDs(int count) {
     return memberIDs("persisted online or equal member", count);
-  }
-
-  private static void setMembershipChangePollDuration(Duration timeout) {
-    System.setProperty(
-        SystemPropertyHelper.GEODE_PREFIX
-            + SystemPropertyHelper.PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS,
-        String.valueOf(timeout.getSeconds()));
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/process/ProcessLauncherContextTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/ProcessLauncherContextTest.java
@@ -32,7 +32,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
 /**
  * Unit tests for {@link ProcessLauncherContext}.
  */
@@ -44,7 +43,7 @@ public class ProcessLauncherContextTest {
   private List<String> statusMessageList;
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     redirectOutput = false;
     overriddenDefaults = new Properties();
     startupListener = mock(StartupStatusListener.class);
@@ -52,27 +51,27 @@ public class ProcessLauncherContextTest {
   }
 
   @After
-  public void after() throws Exception {
+  public void after() {
     remove();
   }
 
   @Test
-  public void isRedirectingOutput_defaultsToFalse() throws Exception {
+  public void isRedirectingOutput_defaultsToFalse() {
     assertThat(isRedirectingOutput()).isFalse();
   }
 
   @Test
-  public void getOverriddenDefaults_defaultsToEmpty() throws Exception {
+  public void getOverriddenDefaults_defaultsToEmpty() {
     assertThat(getOverriddenDefaults()).isEmpty();
   }
 
   @Test
-  public void getStartupListener_defaultsToNull() throws Exception {
+  public void getStartupListener_defaultsToNull() {
     assertThat(getStartupListener()).isNull();
   }
 
   @Test
-  public void null_overriddenDefaults_throwsIllegalArgumentException() throws Exception {
+  public void null_overriddenDefaults_throwsIllegalArgumentException() {
     // arrange
     overriddenDefaults = null;
 
@@ -83,7 +82,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void null_startupListener_isAllowed() throws Exception {
+  public void null_startupListener_isAllowed() {
     // arrange
     startupListener = null;
 
@@ -95,7 +94,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void empty_overriddenDefaults_isAllowed() throws Exception {
+  public void empty_overriddenDefaults_isAllowed() {
     // act
     set(redirectOutput, overriddenDefaults, startupListener);
 
@@ -104,7 +103,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void isRedirectingOutput_returnsPassedValue() throws Exception {
+  public void isRedirectingOutput_returnsPassedValue() {
     // arrange
     redirectOutput = true;
 
@@ -116,7 +115,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void getOverriddenDefaults_returnsPassedInProps() throws Exception {
+  public void getOverriddenDefaults_returnsPassedInProps() {
     // arrange
     overriddenDefaults.setProperty("key", "value");
 
@@ -128,7 +127,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void getStartupListener_returnsPassedInListener() throws Exception {
+  public void getStartupListener_returnsPassedInListener() {
     // arrange
     overriddenDefaults.setProperty("key", "value");
 
@@ -140,7 +139,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void remove_clearsOverriddenDefaults() throws Exception {
+  public void remove_clearsOverriddenDefaults() {
     // arrange
     overriddenDefaults.setProperty("key", "value");
     set(false, overriddenDefaults, startupListener);
@@ -153,7 +152,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void remove_unsetsRedirectOutput() throws Exception {
+  public void remove_unsetsRedirectOutput() {
     // arrange
     redirectOutput = true;
     set(redirectOutput, overriddenDefaults, startupListener);
@@ -166,7 +165,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void remove_clearsStartupListener() throws Exception {
+  public void remove_clearsStartupListener() {
     // arrange
     startupListener = statusMessage -> statusMessageList.add(statusMessage);
     set(redirectOutput, overriddenDefaults, startupListener);
@@ -179,7 +178,7 @@ public class ProcessLauncherContextTest {
   }
 
   @Test
-  public void startupListener_installsInStartupStatus() throws Exception {
+  public void startupListener_installsInStartupStatus() {
     // arrange
     startupListener = statusMessage -> statusMessageList.add(statusMessage);
 
@@ -187,11 +186,11 @@ public class ProcessLauncherContextTest {
     set(redirectOutput, overriddenDefaults, startupListener);
 
     // assert
-    assertThat(StartupStatus.getStartupListener()).isSameAs(startupListener);
+    assertThat(StartupStatusListenerRegistry.getStartupListener()).isSameAs(startupListener);
   }
 
   @Test
-  public void remove_uninstallsInStartupStatus() throws Exception {
+  public void remove_uninstallsInStartupStatus() {
     // arrange
     startupListener = statusMessage -> statusMessageList.add(statusMessage);
     set(redirectOutput, overriddenDefaults, startupListener);
@@ -200,6 +199,6 @@ public class ProcessLauncherContextTest {
     remove();
 
     // assert
-    assertThat(StartupStatus.getStartupListener()).isNull();
+    assertThat(StartupStatusListenerRegistry.getStartupListener()).isNull();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/process/StartupStatusTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/process/StartupStatusTest.java
@@ -15,12 +15,11 @@
 package org.apache.geode.internal.process;
 
 import static java.util.Collections.synchronizedList;
-import static org.apache.geode.internal.process.StartupStatus.clearListener;
-import static org.apache.geode.internal.process.StartupStatus.getStartupListener;
-import static org.apache.geode.internal.process.StartupStatus.setListener;
-import static org.apache.geode.internal.process.StartupStatus.startup;
+import static org.apache.geode.internal.process.StartupStatusListenerRegistry.clearListener;
+import static org.apache.geode.internal.process.StartupStatusListenerRegistry.getStartupListener;
+import static org.apache.geode.internal.process.StartupStatusListenerRegistry.setListener;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
@@ -30,31 +29,31 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class StartupStatusTest {
 
   private StartupStatusListener listener;
   private List<String> statusMessageList;
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     listener = mock(StartupStatusListener.class);
     statusMessageList = synchronizedList(new ArrayList<>());
   }
 
   @After
-  public void after() throws Exception {
+  public void after() {
     clearListener();
   }
 
   @Test
-  public void getStartupListener_returnsNullByDefault() throws Exception {
+  public void getStartupListener_returnsNullByDefault() {
     // act/assert
-    assertThat(getStartupListener()).isNull();
+    assertThat(getStartupListener())
+        .isNull();
   }
 
   @Test
-  public void setListener_null_clearsStartupListener() throws Exception {
+  public void setListener_null_clearsStartupListener() {
     // arrange
     listener = null;
 
@@ -62,111 +61,133 @@ public class StartupStatusTest {
     setListener(listener);
 
     // assert
-    assertThat(getStartupListener()).isNull();
+    assertThat(getStartupListener())
+        .isNull();
   }
 
   @Test
-  public void getStartupListener_returnsSetListener() throws Exception {
+  public void getStartupListener_returnsSetListener() {
     // arrange
     setListener(listener);
 
     // act/assert
-    assertThat(getStartupListener()).isSameAs(listener);
+    assertThat(getStartupListener())
+        .isSameAs(listener);
   }
 
   @Test
-  public void clearListener_doesNothingIfNull() throws Exception {
+  public void clearListener_doesNothingIfNull() {
     // arrange
     listener = null;
     setListener(listener);
-    assertThat(getStartupListener()).isNull();
+    assertThat(getStartupListener())
+        .isNull();
 
     // act
     clearListener();
 
     // assert
-    assertThat(getStartupListener()).isNull();
+    assertThat(getStartupListener())
+        .isNull();
   }
 
   @Test
-  public void clearListener_unsetsListener() throws Exception {
+  public void clearListener_unsetsListener() {
     // arrange
     setListener(listener);
-    assertThat(getStartupListener()).isNotNull();
+    assertThat(getStartupListener())
+        .isNotNull();
 
     // act
     clearListener();
 
     // assert
-    assertThat(getStartupListener()).isNull();
+    assertThat(getStartupListener())
+        .isNull();
   }
 
   @Test
-  public void startup_nullStringId_throwsIllegalArgumentException() throws Exception {
+  public void startup_nullStringId_throwsIllegalArgumentException() {
     // arrange
     String stringId = null;
     Object[] params = new Object[0];
+    StartupStatus startupStatus = new StartupStatus();
 
-    // act/assert
-    assertThatThrownBy(() -> startup(stringId, params)).isInstanceOf(NullPointerException.class)
-        .hasMessage("Invalid msgId 'null' specified");
+    // act
+    Throwable thrown = catchThrowable(() -> startupStatus.startup(stringId, params));
+
+    // assert
+    assertThat(thrown)
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("Invalid message 'null' specified");
   }
 
   @Test
-  public void startup_emptyParams() throws Exception {
+  public void startup_emptyParams() {
     // arrange
     String stringId = "my string";
     Object[] params = new Object[0];
+    StartupStatus startupStatus = new StartupStatus();
 
     // act
-    startup(stringId, params);
+    startupStatus.startup(stringId, params);
 
     // assert (does not throw)
-    assertThat(getStartupListener()).isNull();
+    assertThat(getStartupListener())
+        .isNull();
   }
 
   @Test
-  public void startup_doesNothingIfNoListener() throws Exception {
+  public void startup_doesNothingIfNoListener() {
     // arrange
     String stringId = "my string";
     Object[] params = new Object[0];
+    StartupStatus startupStatus = new StartupStatus();
 
     // act
-    startup(stringId, params);
+    startupStatus.startup(stringId, params);
 
     // assert (does nothing)
-    assertThat(getStartupListener()).isNull();
+    assertThat(getStartupListener())
+        .isNull();
   }
 
   @Test
-  public void startup_invokesListener() throws Exception {
+  public void startup_invokesListener() {
     // arrange
     listener = statusMessage -> statusMessageList.add(statusMessage);
     String stringId = "my string";
     Object[] params = new Object[0];
     setListener(listener);
+    StartupStatus startupStatus = new StartupStatus();
 
     // act
-    startup(stringId, params);
+    startupStatus.startup(stringId, params);
 
     // assert
-    assertThat(statusMessageList).hasSize(1).contains("my string");
+    assertThat(statusMessageList)
+        .hasSize(1)
+        .contains("my string");
   }
 
   @Test
-  public void startupTwice_invokesListenerTwice() throws Exception {
+  public void startupTwice_invokesListenerTwice() {
     // arrange
     listener = statusMessage -> statusMessageList.add(statusMessage);
     String stringIdOne = "my string";
     String stringIdTwo = "other string";
     Object[] params = new Object[0];
     setListener(listener);
+    StartupStatus startupStatus = new StartupStatus();
 
     // act
-    startup(stringIdOne, params);
-    startup(stringIdTwo, params);
+    startupStatus.startup(stringIdOne, params);
+    startupStatus.startup(stringIdTwo, params);
 
     // assert
-    assertThat(statusMessageList).hasSize(2).contains("my string").contains("other string");
+    assertThat(statusMessageList)
+        .hasSize(2)
+        .contains("my string")
+        .contains("other string");
   }
 }


### PR DESCRIPTION
GEODE-4267: Fix PersistentRecoveryOrderOldConfigDUnitTest

This started out trying to fix flaky failures in PersistentRecoveryOrderOldConfigDUnitTest and PersistentRecoveryOrderDUnitTest (GEODE-4267). I found that the log statement about waiting for missing persistent members was no longer working, so I ended up filing GEODE-7577 and fixing that as well.

New tests:
* MissingDiskStoreAcceptanceTest -- acceptance test to verify that a server logs when it is waiting for missing persistent members
* MembershipChangeListenerFactoryTest -- unit test for the new MembershipChangeListenerFactory
* New test methods in PersistenceAdvisorImplTest for the formatting of the messages

Changes:
* Separate StartupStatusListenerRegistry from StartupStatus to allow non-static injection of StartupStatus into classes that use it
* Add CollectionTransformer interface to TransformUtils to facilitate unit testing of classes depending on it
* Add new MembershipChangeListenerFactory with validation to ensure that warningDelay and pollDuration have correct values in relation to each other (to prevent recurrences of GEODE-7577)
* Fixed the formatting of missing persistent members messages in PersistenceAdvisorImpl
* Fixed warnings and minor issues primarily for readability and testability in every class touched
* Added 'boolean shouldSyncForCrashedMember(InternalDistributedMember id)' to InternalRegion and pulled the javadocs up to the interface
* Major cleanup of PersistentRecoveryOrderDUnitTest including replace usage of Admin API with usage of DistributedSystemMXBean
* Replace Region close with Cache close in PersistentRecoveryOrderDUnitTest test that needs to list and revoke missing disk-stores

Fixes to PersistentRecoveryOrderDUnitTest:
* Replace thread sleeps with CountDownLatch
* Add a couple await calls
* Actual fix involved preventing late-running asynchronous actions that resulted in logging DistributedSystemDisconnectedException AFTER the test already removed the IgnoredException

The changes to the formatting of the messages about missing persistent members restores the old format that was correct. The formatting was broken when LocalizedStrings was removed.