### PR TITLE
GEODE-7541: Removing dependency on SocketCreator/Factory

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/LocatorLoadBalancingDUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.client.internal;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 
 import java.io.IOException;

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.cache.client.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorIntegrationTest.java
@@ -22,7 +22,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATOR_WAIT_
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.internal.AvailablePort.SOCKET;
 import static org.apache.geode.internal.AvailablePort.getRandomAvailablePort;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -21,7 +21,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -289,6 +289,8 @@ public class MembershipJUnitTest {
                         .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
                 InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
                 InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()))
+            .setSocketCreator(asTcpSocketCreator(SocketCreatorFactory
+                .getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER)))
             .create();
     doAnswer(invocation -> {
       DistributionImpl.connectLocatorToServices(m1);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -197,7 +197,11 @@ public class GMSHealthMonitorJUnitTest {
         new InternalDistributedMember("localhost", 12345);
     mbr.setVmViewId(1);
     when(messenger.getMemberID()).thenReturn(mbr);
-    gmsHealthMonitor.started();
+    try {
+      gmsHealthMonitor.started();
+    } catch (MemberStartupException e) {
+      e.printStackTrace();
+    }
 
     GMSMembershipView v = new GMSMembershipView(mbr, 1, mockMembers);
 
@@ -213,7 +217,11 @@ public class GMSHealthMonitorJUnitTest {
     // stopServices call will attempt to shut down the socket during a normal close. This test tries
     // to create a problematic ordering to make sure we still shutdown properly.
     ((GMSHealthMonitorTest) gmsHealthMonitor).useBlockingSocket = true;
-    gmsHealthMonitor.started();
+    try {
+      gmsHealthMonitor.started();
+    } catch (MemberStartupException e) {
+      e.printStackTrace();
+    }
     gmsHealthMonitor.stop();
   }
 
@@ -290,7 +298,11 @@ public class GMSHealthMonitorJUnitTest {
 
     // 3rd is current member
     when(messenger.getMemberID()).thenReturn(mockMembers.get(myAddressIndex));
-    gmsHealthMonitor.started();
+    try {
+      gmsHealthMonitor.started();
+    } catch (MemberStartupException e) {
+      e.printStackTrace();
+    }
 
     gmsHealthMonitor.installView(v);
 
@@ -394,7 +406,11 @@ public class GMSHealthMonitorJUnitTest {
     // 3rd is current member
     when(messenger.getMemberID()).thenReturn(mockMembers.get(0)); // coordinator and local member
     when(joinLeave.getMemberID()).thenReturn(mockMembers.get(0)); // coordinator and local member
-    gmsHealthMonitor.started();
+    try {
+      gmsHealthMonitor.started();
+    } catch (MemberStartupException e) {
+      e.printStackTrace();
+    }
 
     gmsHealthMonitor.installView(v);
 
@@ -1042,7 +1058,7 @@ public class GMSHealthMonitorJUnitTest {
     }
 
     @Override
-    ServerSocket createServerSocket(InetAddress socketAddress, int[] portRange) {
+    ServerSocket createServerSocket(InetAddress socketAddress, int[] portRange) throws IOException {
       final ServerSocket serverSocket = super.createServerSocket(socketAddress, portRange);
       if (useBlockingSocket) {
         try {

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -23,6 +23,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_TTL;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -97,6 +98,7 @@ import org.apache.geode.distributed.internal.membership.gms.messages.SuspectRequ
 import org.apache.geode.internal.HeapDataOutputStream;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.net.SocketCreatorFactory;
+import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
@@ -1015,6 +1017,11 @@ public class GMSHealthMonitorJUnitTest {
   public class GMSHealthMonitorTest extends GMSHealthMonitor {
     public boolean useBlockingSocket = false;
     public Set<MemberIdentifier> availabilityCheckedMembers = new HashSet<>();
+
+    public GMSHealthMonitorTest() {
+      super(asTcpSocketCreator(SocketCreatorFactory
+          .getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER)));
+    }
 
     @Override
     boolean doTCPCheckMember(MemberIdentifier suspectMember, int port,

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.locator;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.distributed.internal.membership.gms.locator;
 import static org.apache.geode.distributed.ConfigurationProperties.BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_TCP;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator.LOCATOR_FILE_STAMP;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPClientSSLIntegrationTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.distributed.internal.tcpserver;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.security.SecurableCommunicationChannels.LOCATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLJUnitTest.java
@@ -22,7 +22,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.SSL_KEYSTORE_
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_PROTOCOLS;
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTORE;
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTORE_PASSWORD;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.test.util.ResourceUtils.createTempFileFromResource;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorConfigImpl.java
@@ -15,7 +15,7 @@
 package org.apache.geode.admin.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.internal.net.InetAddressUtilsWithLogging.toInetAddress;
 import static org.apache.geode.internal.net.InetAddressUtilsWithLogging.validateHost;
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImpl.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.client.internal;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.IOException;
 import java.net.ConnectException;

--- a/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/LocatorLauncher.java
@@ -20,7 +20,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.lowerCase;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.internal.lang.StringUtils.wrap;
 import static org.apache.geode.internal.lang.SystemUtils.CURRENT_DIRECTORY;
 import static org.apache.geode.internal.util.IOUtils.tryGetCanonicalPathElseGetAbsolutePath;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.distributed.internal;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -155,6 +155,8 @@ public class DistributionImpl implements Distribution {
                       .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
               InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
               InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()))
+          .setSocketCreator(asTcpSocketCreator(SocketCreatorFactory
+              .getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER)))
           .create();
     } catch (MembershipConfigurationException e) {
       throw new GemFireConfigException(e.getMessage(), e.getCause());

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -19,7 +19,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.apache.geode.internal.admin.remote.DistributionLocatorId.asDistributionLocatorIds;
 
 import java.io.File;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.distributed.internal.membership.adapter;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.IOException;
 import java.net.InetAddress;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
@@ -22,9 +22,7 @@ import java.net.InetAddress;
 
 import org.jgroups.util.UUID;
 
-import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberData;
-import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
@@ -72,32 +70,6 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
   }
 
   public GMSMemberData() {}
-
-  @VisibleForTesting
-  public GMSMemberData(String localhost, int udpPort, Version version) {
-    this.hostName = localhost;
-    this.inetAddr = SocketCreator.toInetAddress(localhost);
-    this.udpPort = udpPort;
-    this.versionOrdinal = version.ordinal();
-    this.vmKind = NORMAL_DM_TYPE;
-    this.preferredForCoordinator = true;
-    this.vmViewId = -1;
-    this.processId = -1;
-    this.directPort = -1;
-    setUUID(UUID.randomUUID());
-  }
-
-
-  /**
-   * Create a CacheMember referring to the current host (as defined by the given string).
-   *
-   * @param i the hostname, must be for the current host
-   * @param p the membership listening port
-   */
-  @VisibleForTesting
-  public GMSMemberData(String i, int p) {
-    this(i, p, Version.getCurrentVersion());
-  }
 
   /**
    * Create a CacheMember referring to the current host (as defined by the given string).
@@ -573,9 +545,7 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
 
     this.inetAddr = StaticSerialization.readInetAddress(in);
     if (this.inetAddr != null) {
-      this.hostName =
-          SocketCreator.resolve_dns ? SocketCreator.getHostName(inetAddr)
-              : inetAddr.getHostAddress();
+      this.hostName = inetAddr.getHostName();
     }
     this.udpPort = in.readInt();
     this.vmViewId = in.readInt();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -1889,7 +1889,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
 
     /* Service interface */
     @Override
-    public void started() {
+    public void started() throws MemberStartupException {
       startCleanupTimer();
       lifecycleListener.started();
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
-import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
@@ -53,7 +52,7 @@ public class GMSUtil {
 
     try {
       if (bindAddress == null || bindAddress.trim().length() == 0) {
-        addr = SocketCreator.getLocalHost();
+        addr = InetAddress.getLocalHost();
       } else {
         addr = InetAddress.getByName(bindAddress);
       }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MemberDataBuilderImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MemberDataBuilderImpl.java
@@ -20,7 +20,6 @@ import java.net.UnknownHostException;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberData;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberDataBuilder;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
-import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.Version;
 
 public class MemberDataBuilderImpl implements MemberDataBuilder {
@@ -71,7 +70,7 @@ public class MemberDataBuilderImpl implements MemberDataBuilder {
 
   private MemberDataBuilderImpl(String fakeHostName) {
     try {
-      inetAddress = SocketCreator.getLocalHost();
+      inetAddress = InetAddress.getLocalHost();
     } catch (UnknownHostException e2) {
       throw new RuntimeException("Unable to resolve local host address", e2);
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
@@ -27,9 +27,11 @@ import org.apache.geode.distributed.internal.membership.gms.api.MembershipListen
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipStatistics;
 import org.apache.geode.distributed.internal.membership.gms.api.MessageListener;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 
 public class MembershipBuilderImpl<ID extends MemberIdentifier> implements MembershipBuilder<ID> {
+  private TcpSocketCreator socketCreator;
   private TcpClient locatorClient;
   private MembershipListener<ID> membershipListener;
   private MessageListener<ID> messageListener;
@@ -91,6 +93,12 @@ public class MembershipBuilderImpl<ID extends MemberIdentifier> implements Membe
   }
 
   @Override
+  public MembershipBuilder<ID> setSocketCreator(final TcpSocketCreator socketCreator) {
+    this.socketCreator = socketCreator;
+    return this;
+  }
+
+  @Override
   public MembershipBuilder<ID> setLifecycleListener(
       LifecycleListener<ID> lifecycleListener) {
     this.lifecycleListener = lifecycleListener;
@@ -103,7 +111,7 @@ public class MembershipBuilderImpl<ID extends MemberIdentifier> implements Membe
         new GMSMembership<>(membershipListener, messageListener, lifecycleListener);
     Services<ID> services =
         new Services<>(gmsMembership.getGMSManager(), statistics, authenticator,
-            membershipConfig, serializer, memberFactory, locatorClient);
+            membershipConfig, serializer, memberFactory, locatorClient, socketCreator);
     services.init();
     return gmsMembership;
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
@@ -199,6 +199,11 @@ public class Services<ID extends MemberIdentifier> {
       this.healthMon.start();
       logger.debug("starting Manager");
       this.manager.start();
+      this.messenger.started();
+      this.joinLeave.started();
+      this.healthMon.started();
+      this.manager.started();
+      logger.debug("All membership services have been started");
       started = true;
     } catch (RuntimeException e) {
       logger.fatal("Unexpected exception while booting membership services", e);
@@ -212,11 +217,7 @@ public class Services<ID extends MemberIdentifier> {
         this.timer.cancel();
       }
     }
-    this.messenger.started();
-    this.joinLeave.started();
-    this.healthMon.started();
-    this.manager.started();
-    logger.debug("All membership services have been started");
+
     try {
       this.manager.joinDistributedSystem();
     } catch (Throwable e) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
@@ -71,6 +71,7 @@ import org.apache.geode.distributed.internal.membership.gms.messages.SuspectMemb
 import org.apache.geode.distributed.internal.membership.gms.messages.ViewAckMessage;
 import org.apache.geode.distributed.internal.membership.gms.messenger.JGroupsMessenger;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -136,14 +137,14 @@ public class Services<ID extends MemberIdentifier> {
   public Services(Manager<ID> membershipManager, MembershipStatistics stats,
       final Authenticator<ID> authenticator, MembershipConfig membershipConfig,
       DSFIDSerializer serializer, MemberIdentifierFactory<ID> memberFactory,
-      final TcpClient locatorClient) {
+      final TcpClient locatorClient, final TcpSocketCreator socketCreator) {
     this.cancelCriterion = new Stopper();
     this.stats = stats;
     this.config = membershipConfig;
     this.manager = membershipManager;
     this.joinLeave = new GMSJoinLeave<>(locatorClient);
-    this.healthMon = new GMSHealthMonitor<>();
-    this.messenger = new JGroupsMessenger<>();
+    this.healthMon = new GMSHealthMonitor<>(socketCreator);
+    this.messenger = new JGroupsMessenger<>(socketCreator);
     this.auth = authenticator;
     this.serializer = serializer;
     this.memberFactory = memberFactory;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipBuilder.java
@@ -17,6 +17,7 @@ package org.apache.geode.distributed.internal.membership.gms.api;
 
 import org.apache.geode.distributed.internal.membership.gms.MembershipBuilderImpl;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 
 /**
@@ -42,6 +43,7 @@ public interface MembershipBuilder<ID extends MemberIdentifier> {
 
   MembershipBuilder<ID> setLocatorClient(final TcpClient tcpClient);
 
+  MembershipBuilder<ID> setSocketCreator(final TcpSocketCreator socketCreator);
 
   Membership<ID> create() throws MembershipConfigurationException;
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -35,6 +35,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -69,8 +70,7 @@ import org.apache.geode.distributed.internal.membership.gms.messages.HeartbeatRe
 import org.apache.geode.distributed.internal.membership.gms.messages.SuspectMembersMessage;
 import org.apache.geode.distributed.internal.membership.gms.messages.SuspectRequest;
 import org.apache.geode.distributed.internal.tcpserver.ConnectionWatcher;
-import org.apache.geode.internal.net.SocketCreatorFactory;
-import org.apache.geode.internal.security.SecurableCommunicationChannel;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.internal.util.JavaWorkarounds;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
@@ -96,6 +96,7 @@ import org.apache.geode.logging.internal.executors.LoggingExecutors;
 @SuppressWarnings({"SynchronizationOnLocalVariableOrMethodParameter", "NullableProblems"})
 public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMonitor<ID> {
 
+  private final TcpSocketCreator socketCreator;
   private Services<ID> services;
   private volatile GMSMembershipView<ID> currentView;
   private volatile ID nextNeighbor;
@@ -402,8 +403,9 @@ public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMoni
     }
   }
 
-  public GMSHealthMonitor() {
-
+  public GMSHealthMonitor(final TcpSocketCreator socketCreator) {
+    Objects.requireNonNull(socketCreator);
+    this.socketCreator = socketCreator;
   }
 
   @SuppressWarnings("EmptyMethod")
@@ -575,7 +577,7 @@ public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMoni
         logger.debug("Checking member {} with TCP socket connection {}:{}.", suspectMember,
             suspectMember.getInetAddress(), port);
         clientSocket =
-            SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER)
+            socketCreator
                 .connect(suspectMember.getInetAddress(), port, (int) memberTimeout,
                     new ConnectTimeoutTask(services.getTimer(), memberTimeout), false, -1, false);
         clientSocket.setTcpNoDelay(true);
@@ -682,8 +684,7 @@ public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMoni
   }
 
   ServerSocket createServerSocket(InetAddress socketAddress, int[] portRange) {
-    ServerSocket newSocket = SocketCreatorFactory
-        .getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER)
+    ServerSocket newSocket =socketCreator
         .createServerSocketUsingPortRange(socketAddress, 50/* backlog */, true/* isBindAddress */,
             false/* useNIO */, 65536/* tcpBufferSize */, portRange, false);
     socketPort = newSocket.getLocalPort();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Service.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Service.java
@@ -36,7 +36,7 @@ public interface Service<ID extends MemberIdentifier> {
   /**
    * called after all servers have been started
    */
-  void started();
+  void started() throws MemberStartupException;
 
   /**
    * called when the GMS is stopping

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1679,7 +1679,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
   public void start() throws MemberStartupException {}
 
   @Override
-  public void started() {}
+  public void started() throws MemberStartupException {}
 
   public void setLocalAddress(ID address) {
     this.localAddress = address;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGAddress.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGAddress.java
@@ -30,7 +30,6 @@ import org.jgroups.util.UUID;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberData;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
-import org.apache.geode.internal.net.SocketCreator;
 
 /**
  * This is a copy of JGroups 3.6.4 IpAddress (Apache 2.0 License) that is repurposed to be a Logical
@@ -96,11 +95,7 @@ public class JGAddress extends UUID {
     if (ip_addr == null)
       sb.append("<null>");
     else {
-      if (SocketCreator.resolve_dns) {
-        sb.append(SocketCreator.getHostName(ip_addr));
-      } else {
-        sb.append(ip_addr.getHostAddress());
-      }
+      sb.append(ip_addr.getHostName());
     }
     if (vmViewId >= 0) {
       sb.append("<v").append(vmViewId).append('>');

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -91,10 +91,10 @@ import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordina
 import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordinatorResponse;
 import org.apache.geode.distributed.internal.membership.gms.messages.JoinRequestMessage;
 import org.apache.geode.distributed.internal.membership.gms.messages.JoinResponseMessage;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.cache.DistributedCacheOperation;
-import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.BufferDataOutputStream;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
@@ -131,6 +131,11 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
   ID localAddress;
   JGAddress jgAddress;
   private Services<ID> services;
+  private TcpSocketCreator socketCreator;
+
+  public JGroupsMessenger(final TcpSocketCreator socketCreator) {
+    this.socketCreator = socketCreator;
+  }
 
   /** handlers that receive certain classes of messages instead of the Manager */
   private final Map<Class<?>, MessageHandler<?>> handlers = new ConcurrentHashMap<>();
@@ -269,7 +274,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     // JGroups UDP protocol requires a bind address
     if (str == null || str.length() == 0) {
       try {
-        str = SocketCreator.getLocalHost().getHostAddress();
+        str = socketCreator.getLocalHost().getHostAddress();
       } catch (UnknownHostException e) {
         throw new MembershipConfigurationException(e.getMessage(), e);
       }
@@ -541,7 +546,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
 
     // establish the DistributedSystem's address
     String hostname =
-        SocketCreator.resolve_dns ? SocketCreator.getHostName(jgAddress.getInetAddress())
+        socketCreator.resolveDns() ? socketCreator.getHostName(jgAddress.getInetAddress())
             : jgAddress.getInetAddress().getHostAddress();
     GMSMemberData gmsMember = new GMSMemberData(jgAddress.getInetAddress(),
         hostname, jgAddress.getPort(),

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -415,7 +415,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
   }
 
   @Override
-  public void started() {
+  public void started() throws MemberStartupException {
     if (queuedMessagesFromReconnect != null && !services.getConfig().isUDPSecurityEnabled()) {
       logger.info("Delivering {} messages queued by quorum checker",
           queuedMessagesFromReconnect.size());

--- a/geode-core/src/main/java/org/apache/geode/internal/DistributionLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DistributionLocator.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.File;
 import java.io.IOException;

--- a/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/SystemAdmin.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/TcpServerFactory.java
@@ -15,7 +15,7 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.net.InetAddress;
 import java.util.concurrent.ExecutorService;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocatorRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/JmxManagerLocatorRequest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.management.internal;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/GeodeClusterManagementServiceBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/GeodeClusterManagementServiceBuilder.java
@@ -15,7 +15,7 @@
 
 package org.apache.geode.management.internal.api;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.net.InetSocketAddress;
 import java.util.List;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/utils/ClusterConfigurationStatusRetriever.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/utils/ClusterConfigurationStatusRetriever.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.management.internal.configuration.utils;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.IOException;
 import java.net.InetAddress;

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -35,8 +35,6 @@ import org.apache.geode.distributed.internal.membership.adapter.LocalViewMessage
 import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.OSProcess;
-import org.apache.geode.internal.net.SocketCreator;
-import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.util.JavaWorkarounds;
 
@@ -110,9 +108,6 @@ public class MembershipDependenciesJUnitTest {
               // TODO: Serialization needs to become its own module
               .or(type(InternalDataSerializer.class)) // still used by GMSLocator
 
-              // TODO:
-              .or(type(SocketCreator.class))
-              .or(type(SocketCreatorFactory.class))
 
               // TODO: break dependencies on locator-related classes
               .or(type(Locator.class))

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/MemberDataBuilderImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/MemberDataBuilderImplTest.java
@@ -24,14 +24,13 @@ import org.junit.Test;
 
 import org.apache.geode.distributed.internal.membership.gms.api.MemberData;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberDataBuilder;
-import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.Version;
 
 public class MemberDataBuilderImplTest {
 
   @Test
   public void testNewBuilder() throws UnknownHostException {
-    InetAddress localhost = SocketCreator.getLocalHost();
+    InetAddress localhost = InetAddress.getLocalHost();
     MemberData data = MemberDataBuilder.newBuilder(localhost, localhost.getHostName()).build();
     assertThat(data.getInetAddress()).isEqualTo(localhost);
     assertThat(data.getHostName()).isEqualTo(localhost.getHostName());
@@ -39,7 +38,7 @@ public class MemberDataBuilderImplTest {
 
   @Test
   public void testNewBuilderForLocalHost() throws UnknownHostException {
-    InetAddress localhost = SocketCreator.getLocalHost();
+    InetAddress localhost = InetAddress.getLocalHost();
     MemberData data = MemberDataBuilder.newBuilderForLocalHost("hostname").build();
     assertThat(data.getInetAddress()).isEqualTo(localhost);
     assertThat(data.getHostName()).isEqualTo("hostname");

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipAPIArchUnitTest.java
@@ -47,6 +47,7 @@ public class MembershipAPIArchUnitTest {
               .or(not(resideInAPackage("org.apache.geode..")))
               // Serialization is a dependency of membership
               .or(resideInAPackage("org.apache.geode.internal.serialization.."))
+              .or(resideInAPackage("org.apache.geode.distributed.internal.tcpserver.."))
 
               // TODO: replace this with a rule allowing dependencies on geode-tcp-server module
               .or(type(TcpClient.class))

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/messenger/StatRecorderJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/messenger/StatRecorderJUnitTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
 import java.util.Properties;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -41,6 +42,7 @@ import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipStatistics;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Manager;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
 /**
@@ -170,9 +172,11 @@ public class StatRecorderJUnitTest {
     when(mockConfig.getMembershipPortRange()).thenReturn(new int[] {0, 10});
     when(mockConfig.getSecurityUDPDHAlgo()).thenReturn("");
     when(mockServices.getConfig()).thenReturn(mockConfig);
+    TcpSocketCreator socketCreator = mock(TcpSocketCreator.class);
+    when(socketCreator.getLocalHost()).thenReturn(InetAddress.getLocalHost());
 
 
-    JGroupsMessenger messenger = new JGroupsMessenger();
+    JGroupsMessenger messenger = new JGroupsMessenger(socketCreator);
     messenger.init(mockServices);
     String jgroupsConfig = messenger.jgStackConfig;
     System.out.println(jgroupsConfig);
@@ -183,7 +187,7 @@ public class StatRecorderJUnitTest {
     when(mockServices.getConfig()).thenReturn(mockConfig);
 
 
-    messenger = new JGroupsMessenger();
+    messenger = new JGroupsMessenger(socketCreator);
     messenger.init(mockServices);
     assertTrue(jgroupsConfig.contains("gms.messenger.StatRecorder"));
   }

--- a/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerGossipVersionDUnitTest.java
+++ b/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerGossipVersionDUnitTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.distributed.internal.tcpserver;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 

--- a/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.distributed.internal.tcpserver;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;

--- a/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionDUnitTest.java
+++ b/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionDUnitTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.distributed.internal.tcpserver;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;

--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpSocketCreator.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpSocketCreator.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.UnknownHostException;
 
 
 /**
@@ -32,8 +33,22 @@ public interface TcpSocketCreator {
   ServerSocket createServerSocket(int nport, int backlog, InetAddress bindAddr)
       throws IOException;
 
+  InetAddress getLocalHost() throws UnknownHostException;
+
+  String getHostName(InetAddress addr);
+
+  ServerSocket createServerSocketUsingPortRange(InetAddress ba, int backlog,
+      boolean isBindAddress, boolean useNIO, int tcpBufferSize, int[] tcpPortRange,
+      boolean sslConnection) throws IOException;
+
   Socket connect(InetAddress inetadd, int port, int timeout,
       ConnectionWatcher optionalWatcher, boolean clientSide) throws IOException;
 
+  Socket connect(InetAddress inetadd, int port, int timeout,
+      ConnectionWatcher optionalWatcher, boolean clientSide, int socketBufferSize,
+      boolean sslConnection) throws IOException;
+
   void handshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException;
+
+  boolean resolveDns();
 }

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorDiscovery.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorDiscovery.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.client.internal.locator.wan;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;

--- a/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/client/internal/locator/wan/LocatorMembershipListenerImpl.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.client.internal.locator.wan;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/AbstractRemoteGatewaySender.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.internal.cache.wan;
 
-import static org.apache.geode.distributed.internal.membership.adapter.SocketCreatorAdapter.asTcpSocketCreator;
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 
 import java.io.IOException;
 import java.net.ConnectException;


### PR DESCRIPTION
- Pushed static call to SocketCreatorFactory up to DistributionImpl
- SocketCreator is now a parameter to MembershipBuilder
- extracted MembershipSocketCreator interface from SocketCreator
- created adapter layer to handle passthru of SocketCreator calls
- renamed with "Tcp" prefix previously refactored socket creator efforts
- Use InetAddress directly from the JDK.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
