### PR TITLE
GEODE-7586: Fix NPE in RemoteGfManagerAgentTest

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgent.java
@@ -940,6 +940,11 @@ public class RemoteGfManagerAgent implements GfManagerAgent {
     return system;
   }
 
+  @VisibleForTesting
+  void setDSConnection(InternalDistributedSystem system) {
+    this.system = system;
+  }
+
   /**
    * Handles a membership join asynchronously from the memberJoined notification. Sets and clears
    * current join. Also makes several checks to support aborting of the current join.

--- a/geode-core/src/test/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgentTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgentTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.admin.GfManagerAgentConfig;
@@ -55,10 +56,13 @@ public class RemoteGfManagerAgentTest {
 
     when(config.getLogWriter()).thenReturn(mock(InternalLogWriter.class));
     when(config.getTransport()).thenReturn(mock(RemoteTransportConfig.class));
+    when(system.getCancelCriterion()).thenReturn(mock(CancelCriterion.class));
 
     agent = new RemoteGfManagerAgent(config, props -> system, agent -> mock(JoinProcessor.class),
         agent -> mock(SnapshotResultDispatcher.class), agent -> mock(DSConnectionDaemon.class),
         agent -> mock(MyMembershipListener.class));
+
+    agent.setDSConnection(system);
   }
 
   @Test


### PR DESCRIPTION
If the thread invoking disconnect gets enough cpu cycles before the
thread invoking removeMember, then it tries to invoke listApplications
with null for system.

The fix sets the system so the field is non-null which also simulates a 
real run more closely as well.
