### PR TITLE
GEODE-7590 - More Packer restarts to fix Windows image.

### DIFF
--- a/ci/images/google-windows-geode-builder/build_image.sh
+++ b/ci/images/google-windows-geode-builder/build_image.sh
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PACKER=${PACKER:-packer135}
+PACKER=${PACKER:-packer}
 PACKER_ARGS="${*}"
 INTERNAL=${INTERNAL:-true}
 SOURCE="${BASH_SOURCE[0]}"

--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -54,7 +54,7 @@
         "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force",
         "Install-Module DockerMsftProvider -Force",
         "Install-Package Docker -ProviderName DockerMsftProvider -Force",
-        "New-Item \"C:\\ProgramData\\Docker\\config\\daemon.json\"",
+        "New-Item \"C:\\ProgramData\\Docker\\config\\daemon.json\" -Force",
         "Set-Content \"C:\\ProgramData\\Docker\\config\\daemon.json\" '{\"registry-mirrors\": [\"https://mirror.gcr.io\"]}'",
         "Set-Service wuauserv -StartupType Disabled",
         "Stop-Service wuauserv"

--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -54,6 +54,7 @@
         "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force",
         "Install-Module DockerMsftProvider -Force",
         "Install-Package Docker -ProviderName DockerMsftProvider -Force",
+        "New-Item \"C:\\ProgramData\\Docker\\config\\daemon.json\"",
         "Set-Content \"C:\\ProgramData\\Docker\\config\\daemon.json\" '{\"registry-mirrors\": [\"https://mirror.gcr.io\"]}'",
         "Set-Service wuauserv -StartupType Disabled",
         "Stop-Service wuauserv"

--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -40,13 +40,8 @@
       "inline": [
         "$ErrorActionPreference = \"Stop\"",
         "Set-ExecutionPolicy Bypass -Scope Process -Force",
-        "Install-WindowsFeature Containers",
-        "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force",
-        "Install-Module DockerMsftProvider -Force",
-        "Install-Package Docker -ProviderName DockerMsftProvider -Force",
-        "Set-Service wuauserv -StartupType Disabled",
-        "Stop-Service wuauserv"
-        ]
+        "Install-WindowsFeature Containers"
+      ]
     },
     {
       "type": "windows-restart"
@@ -56,7 +51,33 @@
       "inline": [
         "$ErrorActionPreference = \"Stop\"",
         "Set-ExecutionPolicy Bypass -Scope Process -Force",
-        "Invoke-WebRequest https://chocolatey.org/install.ps1 -UseBasicParsing | Invoke-Expression",
+        "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force",
+        "Install-Module DockerMsftProvider -Force",
+        "Install-Package Docker -ProviderName DockerMsftProvider -Force",
+        "Set-Content \"C:\\ProgramData\\Docker\\config\\daemon.json\" '{\"registry-mirrors\": [\"https://mirror.gcr.io\"]}'",
+        "Set-Service wuauserv -StartupType Disabled",
+        "Stop-Service wuauserv"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "$ErrorActionPreference = \"Stop\"",
+        "Set-ExecutionPolicy Bypass -Scope Process -Force",
+        "Invoke-WebRequest https://chocolatey.org/install.ps1 -UseBasicParsing | Invoke-Expression"
+      ]
+    },
+    {
+      "type": "windows-restart"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "$ErrorActionPreference = \"Stop\"",
+        "Set-ExecutionPolicy Bypass -Scope Process -Force",
         "choco install -y git cygwin cyg-get adoptopenjdk11",
         "Move-Item \"C:\\Program Files\\AdoptOpenJDK\\jdk-11*\" c:\\java11",
         "choco install -y jdk8 -params 'installdir=c:\\\\java8tmp;source=false'",
@@ -67,7 +88,12 @@
         "$NewPath = $OldPath + ';' + 'c:\\Program Files\\Git\\bin' + ';' + 'c:\\tools\\cygwin\\bin'",
         "Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\\Environment' -Name PATH -Value $NewPath",
         "refreshenv",
-        "cyg-get rsync",
+        "cyg-get rsync"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
         "winrm set winrm/config/service '@{AllowUnencrypted=\"true\"}'",
         "New-NetFirewallRule -DisplayName sshd -Direction inbound -Action allow -Protocol tcp -LocalPort 22",
         "New-NetFirewallRule -DisplayName \"Docker containers\" -LocalAddress 172.0.0.0/8 -Action allow -Direction inbound",
@@ -77,19 +103,10 @@
       ]
     },
     {
-      "type":  "powershell",
-      "elevated_user": "geode",
-      "elevated_password": "{{.WinRMPassword}}",
-      "inline": [
-        "net start \"Docker Engine\"",
-        "write-output '>>>>>>>>>> Adding openjdk docker image <<<<<<<<<<'",
-        "docker pull openjdk:8",
-        "write-output '>>>>>>>>>> Removing unused docker images <<<<<<<<<<'",
-        "Set-Content -Path c:\\ProgramData\\docker\\config\\daemon.json -Value '{ \"hosts\": [\"tcp://0.0.0.0:2375\", \"npipe://\"] }'"
-      ]
+      "type": "windows-restart"
     },
     {
-      "type":  "powershell",
+      "type": "powershell",
       "inline": [
 
         "write-output '>>>>>>>>>> Cloning geode repo <<<<<<<<<<'",
@@ -109,6 +126,9 @@
         "write-output '>>>>>>>>>> Final cleanup <<<<<<<<<<'",
         "rm -force -recurse geode"
       ]
+    },
+    {
+      "type": "windows-restart"
     }
   ]
 }


### PR DESCRIPTION
Trying to have Packer be more careful (lots of restarts) when creating
the Windows heavy-lifter image.
* Move from Packer v1.3.5 to latest, v1.4.5
* Drop unused openjdk:8 docker image from Windows compute image.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Scott Jewell <sjewell@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
