### PR TITLE
add missing variable

### DIFF
--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -122,6 +122,7 @@ YML
     --config ${SCRIPTDIR}/generated-pipeline.yml \
     --var artifact-bucket=${ARTIFACT_BUCKET} \
     --var concourse-team=${CONCOURSE_TEAM} \
+    --var concourse-host=${CONCOURSE_HOST} \
     --var concourse-url=${CONCOURSE_URL} \
     --var gcp-project=${GCP_PROJECT} \
     --var geode-build-branch=${GEODE_BRANCH} \

--- a/ci/pipelines/meta/jinja.template.yml
+++ b/ci/pipelines/meta/jinja.template.yml
@@ -303,6 +303,7 @@ jobs:
           GCP_PROJECT: ((gcp-project))
           PUBLIC_PIPELINES: ((public-pipelines))
           CONCOURSE_URL: ((concourse-url))
+          CONCOURSE_HOST: ((concourse-host))
           CONCOURSE_TEAM: ((concourse-team))
         run:
           path: geode-metrics-pipeline/ci/pipelines/metrics/deploy_metrics_pipeline.sh


### PR DESCRIPTION
CONCOURSE_HOST is referenced in deploy_metrics.sh but was not defined when deploying the meta pipeline.