### PR TITLE
GEODE-7556: remove membership dependencies on geode-core exeptions

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithCacheXMLDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithCacheXMLDUnitTest.java
@@ -14,11 +14,14 @@
  */
 package org.apache.geode.cache30;
 
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave.BYPASS_DISCOVERY_PROPERTY;
 import static org.apache.geode.internal.Assert.assertTrue;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.util.ResourceUtils.createTempFileFromResource;
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -29,12 +32,15 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.ServerLauncherParameters;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
-import org.apache.geode.distributed.internal.membership.gms.api.MembershipTestHook;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.test.dunit.Invoke;
+import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.junit.categories.ClientServerTest;
@@ -55,10 +61,22 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
   @Rule
   public DistributedRestoreSystemProperties restoreSystemProperties =
       new DistributedRestoreSystemProperties();
+  private int locatorPort;
 
   @Override
   public final void postSetUp() {
     oldPropertySetting = System.setProperty(xmlProperty, "true");
+    // stress testing needs this so that join attempts don't give up too soon
+    Invoke.invokeInEveryVM(() -> System.setProperty("p2p.joinTimeout", "120000"));
+    // reconnect tests should create their own locator so as to not impact other tests
+    VM locatorVM = VM.getVM(0);
+    final int port = locatorVM.invoke(() -> {
+      System.setProperty(BYPASS_DISCOVERY_PROPERTY, "true");
+      System.setProperty(DistributionConfig.GEMFIRE_PREFIX + "member-weight", "100");
+      return Locator.startLocatorAndDS(0, new File(""), new Properties()).getPort();
+    });
+    locatorPort = port;
+
   }
 
   @Override
@@ -68,6 +86,7 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
     } else {
       System.setProperty(xmlProperty, oldPropertySetting);
     }
+    disconnectAllFromDS();
   }
 
   @Override
@@ -79,7 +98,9 @@ public class ReconnectWithCacheXMLDUnitTest extends JUnit4CacheTestCase {
     result.setProperty(ConfigurationProperties.CACHE_XML_FILE, fileName);
     result.setProperty(ConfigurationProperties.ENABLE_NETWORK_PARTITION_DETECTION, "true");
     result.setProperty(ConfigurationProperties.DISABLE_AUTO_RECONNECT, "false");
-    result.setProperty(ConfigurationProperties.MAX_WAIT_TIME_RECONNECT, "2000");
+    result.setProperty(ConfigurationProperties.MAX_WAIT_TIME_RECONNECT, "3000");
+    result.setProperty(ConfigurationProperties.MEMBER_TIMEOUT, "2000");
+    result.put(LOCATORS, "localhost[" + locatorPort + "]");
     return result;
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -89,14 +89,17 @@ import org.apache.geode.distributed.internal.HighPriorityAckedMessage;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.MembershipListener;
+import org.apache.geode.distributed.internal.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
-import org.apache.geode.distributed.internal.membership.gms.api.MembershipTestHook;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberDisconnectedException;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipView;
 import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.tcp.Connection;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DUnitBlackboard;
 import org.apache.geode.test.dunit.DistributedTestUtils;
@@ -163,6 +166,8 @@ public class LocatorDUnitTest implements Serializable {
     port3 = ports[2];
     port4 = ports[3];
     Invoke.invokeInEveryVM(() -> deleteLocatorStateFile(port1, port2, port3, port4));
+    addIgnoredException(MemberDisconnectedException.class); // ignore this suspect string
+    addIgnoredException(MembershipConfigurationException.class); // ignore this suspect string
   }
 
   @After
@@ -765,7 +770,7 @@ public class LocatorDUnitTest implements Serializable {
         addIgnoredException(ForcedDisconnectException.class);
 
         hook = new TestHook();
-        MembershipManagerHelper.getDistribution(system).registerTestHook(hook);
+        MembershipManagerHelper.addTestHook(system, hook);
         try {
           MembershipManagerHelper.crashDistributedSystem(system);
         } finally {
@@ -793,8 +798,6 @@ public class LocatorDUnitTest implements Serializable {
 
     vm2.invokeAsync(crashSystem);
 
-    Wait.pause(1000); // 4 x the member-timeout
-
     // request member removal for first peer from second peer.
     vm2.invoke(new SerializableRunnable("Request Member Removal") {
 
@@ -805,11 +808,12 @@ public class LocatorDUnitTest implements Serializable {
         // check for shutdown cause in Distribution. Following call should
         // throw DistributedSystemDisconnectedException which should have cause as
         // ForceDisconnectException.
+        await().until(() -> !mmgr.getMembership().isConnected());
         try (IgnoredException i = addIgnoredException("Membership: requesting removal of")) {
           mmgr.requestMemberRemoval((InternalDistributedMember) mem1, "test reasons");
           fail("It should have thrown exception in requestMemberRemoval");
         } catch (DistributedSystemDisconnectedException e) {
-          assertThat(e).hasRootCauseInstanceOf(ForcedDisconnectException.class);
+          // expected
         } finally {
           hook.reset();
         }
@@ -1306,13 +1310,15 @@ public class LocatorDUnitTest implements Serializable {
     vm2.invoke("waitUntilLocatorBecomesCoordinator", this::waitUntilLocatorBecomesCoordinator);
 
     if (vm1.invoke(() -> system.getDistributedMember().equals(getView().getCreator()))) {
-      assertFalse(
-          vm2.invoke("Checking ViewCreator",
-              () -> system.getDistributedMember().equals(getView().getCreator())));
+      vm2.invoke(() -> {
+        GeodeAwaitility.await()
+            .until(() -> !system.getDistributedMember().equals(getView().getCreator()));
+      });
     } else {
-      assertTrue(
-          vm2.invoke("Checking ViewCreator",
-              () -> system.getDistributedMember().equals(getView().getCreator())));
+      vm2.invoke(() -> {
+        GeodeAwaitility.await()
+            .until(() -> system.getDistributedMember().equals(getView().getCreator()));
+      });
     }
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ClusterDistributionManagerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ClusterDistributionManagerDUnitTest.java
@@ -20,6 +20,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.internal.DistributionConfig.GEMFIRE_PREFIX;
+import static org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave.BYPASS_DISCOVERY_PROPERTY;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -29,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.File;
 import java.net.InetAddress;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -56,10 +58,14 @@ import org.apache.geode.cache.RegionEvent;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.gms.MembershipManagerHelper;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberDisconnectedException;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipView;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.CacheTestCase;
@@ -80,6 +86,7 @@ public class ClusterDistributionManagerDUnitTest extends CacheTestCase {
 
   private transient ExecutorService executorService;
 
+  private VM locatorvm;
   private VM vm1;
 
   @Rule
@@ -88,11 +95,28 @@ public class ClusterDistributionManagerDUnitTest extends CacheTestCase {
 
   @Rule
   public SharedErrorCollector errorCollector = new SharedErrorCollector();
+  private int locatorPort;
 
   @Before
   public void setUp() {
     executorService = Executors.newSingleThreadExecutor();
+
+    locatorvm = VM.getVM(0);
     vm1 = VM.getVM(1);
+    Invoke.invokeInEveryVM(() -> System.setProperty("p2p.joinTimeout", "120000"));
+    final int port = locatorvm.invoke(() -> {
+      System.setProperty(BYPASS_DISCOVERY_PROPERTY, "true");
+      return Locator.startLocatorAndDS(0, new File(""), new Properties()).getPort();
+    });
+    vm1.invoke(() -> locatorPort = port);
+    locatorPort = port;
+  }
+
+  @Override
+  public Properties getDistributedSystemProperties() {
+    Properties result = super.getDistributedSystemProperties();
+    result.put(ConfigurationProperties.LOCATORS, "localhost[" + locatorPort + "]");
+    return result;
   }
 
   @After
@@ -237,6 +261,7 @@ public class ClusterDistributionManagerDUnitTest extends CacheTestCase {
   @Test
   public void testKickOutSickMember() {
     addIgnoredException("10 seconds have elapsed while waiting");
+    addIgnoredException(MemberDisconnectedException.class);
 
     // in order to set a small ack-wait-threshold, we have to remove the
     // system property established by the dunit harness
@@ -321,7 +346,7 @@ public class ClusterDistributionManagerDUnitTest extends CacheTestCase {
    */
   @Test
   public void testWaitForViewInstallation() {
-    InternalDistributedSystem system = getSystem(new Properties());
+    InternalDistributedSystem system = getSystem();
     ClusterDistributionManager dm = (ClusterDistributionManager) system.getDM();
     MembershipView<InternalDistributedMember> view = dm.getDistribution().getView();
 
@@ -337,8 +362,8 @@ public class ClusterDistributionManagerDUnitTest extends CacheTestCase {
 
     pause(2000);
 
-    VM.getVM(1).invoke("create another member to initiate a new view", () -> {
-      getSystem(new Properties());
+    vm1.invoke("create another member to initiate a new view", () -> {
+      getSystem();
     });
 
     await()

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/RestartOfMemberDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/RestartOfMemberDistributedTest.java
@@ -27,6 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.ForcedDisconnectException;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberDisconnectedException;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 
 public class RestartOfMemberDistributedTest {
@@ -54,6 +55,7 @@ public class RestartOfMemberDistributedTest {
     clusterStartupRule.startServerVM(server2, properties, locatorPort1);
 
     addIgnoredException(ForcedDisconnectException.class.getName());
+    addIgnoredException(MemberDisconnectedException.class.getName());
     addIgnoredException("Possible loss of quorum due to the loss");
     addIgnoredException("Received invalid result from");
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/metrics/MeterSubregistryReconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/metrics/MeterSubregistryReconnectDistributedTest.java
@@ -48,6 +48,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.internal.Distribution;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberDisconnectedException;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
@@ -87,6 +88,7 @@ public class MeterSubregistryReconnectDistributedTest implements Serializable {
     otherServer.invoke(() -> createServer(OTHER_SERVER_NAME));
 
     addIgnoredException(ForcedDisconnectException.class);
+    addIgnoredException(MemberDisconnectedException.class);
     addIgnoredException("Possible loss of quorum");
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/logging/internal/LoggingWithReconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/logging/internal/LoggingWithReconnectDistributedTest.java
@@ -48,6 +48,7 @@ import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.distributed.internal.Distribution;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberDisconnectedException;
 import org.apache.geode.test.assertj.LogFileAssert;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
@@ -109,6 +110,7 @@ public class LoggingWithReconnectDistributedTest implements Serializable {
     server2VM.invoke(() -> createServer(server2Name, server2Dir, locatorPort));
 
     addIgnoredException(ForcedDisconnectException.class);
+    addIgnoredException(MemberDisconnectedException.class);
     addIgnoredException("Possible loss of quorum");
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipJUnitTest.java
@@ -44,7 +44,6 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import org.apache.geode.GemFireConfigException;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
@@ -65,9 +64,11 @@ import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.LifecycleListener;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifierFactory;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipBuilder;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipListener;
 import org.apache.geode.distributed.internal.membership.gms.api.MessageListener;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.JoinLeave;
@@ -256,7 +257,7 @@ public class MembershipJUnitTest {
 
   private Pair<Membership, MessageListener> createMembershipManager(
       final DistributionConfigImpl config,
-      final RemoteTransportConfig transport) {
+      final RemoteTransportConfig transport) throws MemberStartupException {
     final MembershipListener listener = mock(MembershipListener.class);
     final MessageListener messageListener = mock(MessageListener.class);
     final DMStats stats1 = mock(DMStats.class);
@@ -490,7 +491,7 @@ public class MembershipJUnitTest {
       joinLeave.init(services);
       throw new Error(
           "expected a GemFireConfigException to be thrown because no locators are configured");
-    } catch (GemFireConfigException e) {
+    } catch (MembershipConfigurationException e) {
       // expected
     }
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
@@ -63,6 +63,8 @@ import org.apache.geode.distributed.internal.membership.gms.Services.Stopper;
 import org.apache.geode.distributed.internal.membership.gms.api.Authenticator;
 import org.apache.geode.distributed.internal.membership.gms.api.LifecycleListener;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberShunnedException;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipListener;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipView;
@@ -314,7 +316,7 @@ public class GMSMembershipJUnitTest {
   }
 
   @Test
-  public void noDispatchWhenSick() {
+  public void noDispatchWhenSick() throws MemberShunnedException, MemberStartupException {
     final DistributionMessage msg = mock(DistributionMessage.class);
     when(msg.dropMessageWhenMembershipIsPlayingDead()).thenReturn(true);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -83,6 +83,7 @@ import org.apache.geode.distributed.internal.membership.gms.Services.Stopper;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberData;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberDataBuilder;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig;
 import org.apache.geode.distributed.internal.membership.gms.fd.GMSHealthMonitor.ClientSocketHandler;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.JoinLeave;
@@ -119,7 +120,7 @@ public class GMSHealthMonitorJUnitTest {
   private final int myAddressIndex = 3;
 
   @Before
-  public void initMocks() throws UnknownHostException {
+  public void initMocks() throws UnknownHostException, MemberStartupException {
     // ensure that Geode's serialization and version are initialized
     Version currentVersion = Version.CURRENT;
     InternalDataSerializer.getDSFIDSerializer();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.Services;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.JoinLeave;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Messenger;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
@@ -59,7 +60,7 @@ public class GMSLocatorIntegrationTest {
   private Messenger messenger;
 
   @Before
-  public void setUp() {
+  public void setUp() throws MembershipConfigurationException {
 
     SocketCreatorFactory.setDistributionConfig(new DistributionConfigImpl(new Properties()));
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -42,7 +42,6 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 import org.apache.geode.DataSerializer;
-import org.apache.geode.InternalGemFireException;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DMStats;
@@ -154,7 +153,7 @@ public class GMSLocatorRecoveryIntegrationTest {
     Throwable thrown = catchThrowable(() -> gmsLocator.recoverFromFile(stateFile));
 
     assertThat(thrown)
-        .isInstanceOf(InternalGemFireException.class)
+        .isInstanceOf(IllegalStateException.class)
         .hasMessageStartingWith("Unable to recover previous membership view from");
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
@@ -25,7 +25,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
-import org.apache.geode.distributed.internal.membership.gms.api.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipView;
 import org.apache.geode.distributed.internal.membership.gms.api.QuorumChecker;
 
@@ -48,7 +47,7 @@ public interface Distribution {
       DistributedMember member, boolean includeMulticast);
 
   void waitForMessageState(InternalDistributedMember member,
-      Map<String, Long> state) throws InterruptedException;
+      Map<String, Long> state) throws InterruptedException, java.util.concurrent.TimeoutException;
 
   boolean requestMemberRemoval(InternalDistributedMember member,
       String reason);
@@ -99,12 +98,6 @@ public interface Distribution {
       String reason);
 
   Throwable getShutdownCause();
-
-  void registerTestHook(
-      MembershipTestHook mth);
-
-  void unregisterTestHook(
-      MembershipTestHook mth);
 
   boolean addSurpriseMember(InternalDistributedMember mbr);
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -376,7 +376,7 @@ public class DistributionImpl implements Distribution {
       }
 
       if (sentBytes == 0) {
-        membership.checkCancelled();
+        checkCancelled();
       }
     } catch (MembershipClosedException e) {
       throw new DistributedSystemDisconnectedException(e.getMessage(), e.getCause());
@@ -385,7 +385,7 @@ public class DistributionImpl implements Distribution {
     } catch (ConnectExceptions ex) {
       // Check if the connect exception is due to system shutting down.
       if (membership.shutdownInProgress()) {
-        membership.checkCancelled();
+        checkCancelled();
         throw new DistributedSystemDisconnectedException();
       }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -34,6 +34,9 @@ import java.util.function.Supplier;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
+import org.apache.geode.ForcedDisconnectException;
+import org.apache.geode.GemFireConfigException;
+import org.apache.geode.SystemConnectException;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.ToDataException;
 import org.apache.geode.annotations.Immutable;
@@ -51,12 +54,16 @@ import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.LifecycleListener;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberDisconnectedException;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberShunnedException;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipBuilder;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipClosedException;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipListener;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipStatistics;
-import org.apache.geode.distributed.internal.membership.gms.api.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipView;
 import org.apache.geode.distributed.internal.membership.gms.api.Message;
 import org.apache.geode.distributed.internal.membership.gms.api.MessageListener;
@@ -72,8 +79,11 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.internal.tcp.ConnectExceptions;
+import org.apache.geode.internal.tcp.ConnectionException;
 import org.apache.geode.internal.util.Breadcrumbs;
 import org.apache.geode.logging.internal.executors.LoggingThread;
+import org.apache.geode.security.AuthenticationRequiredException;
+import org.apache.geode.security.GemFireSecurityException;
 
 public class DistributionImpl implements Distribution {
   private static final Logger logger = Services.getLogger();
@@ -127,24 +137,33 @@ public class DistributionImpl implements Distribution {
     }
 
     memberTimeout = system.getConfig().getMemberTimeout();
-    membership = MembershipBuilder.<InternalDistributedMember>newMembershipBuilder()
-        .setAuthenticator(
-            new GMSAuthenticator(system.getSecurityProperties(), system.getSecurityService(),
-                system.getSecurityLogWriter(), system.getInternalLogWriter()))
-        .setStatistics(clusterDistributionManager.stats)
-        .setMessageListener(messageListener)
-        .setMembershipListener(listener)
-        .setConfig(new ServiceConfig(transport, system.getConfig()))
-        .setSerializer(InternalDataSerializer.getDSFIDSerializer())
-        .setLifecycleListener(new LifecycleListenerImpl(this))
-        .setMemberIDFactory(new ClusterDistributionManager.ClusterDistributionManagerIDFactory())
-        .setLocatorClient(new TcpClient(
-            asTcpSocketCreator(
-                SocketCreatorFactory
-                    .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
-            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
-            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()))
-        .create();
+    try {
+      membership = MembershipBuilder.<InternalDistributedMember>newMembershipBuilder()
+          .setAuthenticator(
+              new GMSAuthenticator(system.getSecurityProperties(), system.getSecurityService(),
+                  system.getSecurityLogWriter(), system.getInternalLogWriter()))
+          .setStatistics(clusterDistributionManager.stats)
+          .setMessageListener(messageListener)
+          .setMembershipListener(listener)
+          .setConfig(new ServiceConfig(transport, system.getConfig()))
+          .setSerializer(InternalDataSerializer.getDSFIDSerializer())
+          .setLifecycleListener(new LifecycleListenerImpl(this))
+          .setMemberIDFactory(new ClusterDistributionManager.ClusterDistributionManagerIDFactory())
+          .setLocatorClient(new TcpClient(
+              asTcpSocketCreator(
+                  SocketCreatorFactory
+                      .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
+              InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+              InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()))
+          .create();
+    } catch (MembershipConfigurationException e) {
+      throw new GemFireConfigException(e.getMessage(), e.getCause());
+    } catch (GemFireSecurityException e) {
+      throw e;
+    } catch (RuntimeException e) {
+      Services.getLogger().error("Unexpected problem starting up membership services", e);
+      throw new SystemConnectException("Problem starting up membership services", e);
+    }
   }
 
   /**
@@ -176,7 +195,28 @@ public class DistributionImpl implements Distribution {
 
   @Override
   public void start() {
-    membership.start();
+    try {
+      membership.start();
+    } catch (ConnectionException e) {
+      throw new DistributionException(
+          "Unable to create membership manager",
+          e);
+    } catch (SecurityException e) {
+      String failReason = e.getMessage();
+      if (failReason.contains("Failed to find credentials")) {
+        throw new AuthenticationRequiredException(failReason);
+      }
+      throw new GemFireSecurityException(e.getMessage(),
+          e);
+    } catch (MembershipConfigurationException e) {
+      throw new GemFireConfigException(e.getMessage());
+    } catch (MemberStartupException e) {
+      throw new SystemConnectException(e.getMessage());
+    } catch (RuntimeException e) {
+      logger.error("Unexpected problem starting up membership services", e);
+      throw new SystemConnectException("Problem starting up membership services: " + e.getMessage()
+          + ".  Consult log file for more details");
+    }
   }
 
   @VisibleForTesting
@@ -227,7 +267,7 @@ public class DistributionImpl implements Distribution {
     Set<InternalDistributedMember> result;
     boolean allDestinations = msg.forAll();
 
-    membership.checkCancelled();
+    checkCancelled();
 
     membership.waitIfPlayingDead();
 
@@ -289,6 +329,19 @@ public class DistributionImpl implements Distribution {
   }
 
   /**
+   * This method catches membership exceptions that need to be translated into
+   * exceptions implementing CancelException in order to satisfy geode-core
+   * error handling.
+   */
+  private void checkCancelled() {
+    try {
+      membership.checkCancelled();
+    } catch (MembershipClosedException e) {
+      throw new DistributedSystemDisconnectedException(e.getMessage());
+    }
+  }
+
+  /**
    * Perform the grossness associated with sending a message over a DirectChannel
    *
    * @param destinations the list of destinations
@@ -325,9 +378,10 @@ public class DistributionImpl implements Distribution {
       if (sentBytes == 0) {
         membership.checkCancelled();
       }
+    } catch (MembershipClosedException e) {
+      throw new DistributedSystemDisconnectedException(e.getMessage(), e.getCause());
     } catch (DistributedSystemDisconnectedException ex) {
-      membership.checkCancelled();
-      throw ex; // see bug 41416
+      throw ex;
     } catch (ConnectExceptions ex) {
       // Check if the connect exception is due to system shutting down.
       if (membership.shutdownInProgress()) {
@@ -391,7 +445,7 @@ public class DistributionImpl implements Distribution {
 
   @Override
   public void waitForMessageState(InternalDistributedMember member,
-      Map<String, Long> state) throws InterruptedException {
+      Map<String, Long> state) throws InterruptedException, TimeoutException {
     if (Thread.interrupted())
       throw new InterruptedException();
     DirectChannel dc = directChannel;
@@ -409,7 +463,16 @@ public class DistributionImpl implements Distribution {
 
   @Override
   public boolean requestMemberRemoval(InternalDistributedMember member, String reason) {
-    return membership.requestMemberRemoval(member, reason);
+    try {
+      return membership.requestMemberRemoval(member, reason);
+    } catch (MemberDisconnectedException | MembershipClosedException e) {
+      throw new DistributedSystemDisconnectedException("Distribution is closed");
+    } catch (RuntimeException e) {
+      if (!membership.isConnected()) {
+        throw new DistributedSystemDisconnectedException("Distribution is closed", e);
+      }
+      throw e;
+    }
   }
 
   @Override
@@ -522,18 +585,6 @@ public class DistributionImpl implements Distribution {
   @Override
   public Throwable getShutdownCause() {
     return membership.getShutdownCause();
-  }
-
-  @Override
-  public void registerTestHook(
-      MembershipTestHook mth) {
-    membership.registerTestHook(mth);
-  }
-
-  @Override
-  public void unregisterTestHook(
-      MembershipTestHook mth) {
-    membership.unregisterTestHook(mth);
   }
 
   @Override
@@ -831,7 +882,8 @@ public class DistributionImpl implements Distribution {
     }
 
     @Override
-    public void messageReceived(Message<InternalDistributedMember> msg) {
+    public void messageReceived(Message<InternalDistributedMember> msg)
+        throws MemberShunnedException {
       membership.processMessage(msg);
 
     }
@@ -899,7 +951,15 @@ public class DistributionImpl implements Distribution {
     }
 
     @Override
-    public boolean disconnect(Exception exception) {
+    public boolean disconnect(Exception cause) {
+      Exception exception = cause;
+      // translate into a ForcedDisconnectException if necessary
+      if (cause instanceof MemberDisconnectedException) {
+        exception = new ForcedDisconnectException(cause.getMessage());
+        if (cause.getCause() != null) {
+          exception.initCause(cause.getCause());
+        }
+      }
       return distribution.disconnectDirectChannel(exception);
     }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionManager.java
@@ -452,4 +452,18 @@ public interface DistributionManager extends ReplySender {
    * Returns the {@link AlertingService}.
    */
   AlertingService getAlertingService();
+
+  /**
+   * register a test hook for membership events
+   *
+   * @see MembershipTestHook
+   */
+  void registerTestHook(MembershipTestHook mth);
+
+  /**
+   * remove a test hook previously registered with the manager
+   */
+  void unregisterTestHook(MembershipTestHook mth);
+
+
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
@@ -1478,4 +1478,14 @@ public class LonerDistributionManager implements DistributionManager {
   public AlertingService getAlertingService() {
     return NullAlertingService.get();
   }
+
+  @Override
+  public void registerTestHook(MembershipTestHook mth) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void unregisterTestHook(MembershipTestHook mth) {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipTestHook.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/MembershipTestHook.java
@@ -12,25 +12,24 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
-package org.apache.geode.internal.tcp;
-
-import org.apache.geode.GemFireException;
+package org.apache.geode.distributed.internal;
 
 /**
- * MemberShunnedException may be thrown to prevent ack-ing a message received from a member that has
- * been removed from membership. It is currently only thrown by
- * JGroupMembershipManager.processMessage()
+ * Test hook for membership test development
  */
-public class MemberShunnedException extends GemFireException {
-  private static final long serialVersionUID = -8453126202477831557L;
+public interface MembershipTestHook {
 
   /**
-   * constructor
-   *
+   * test hook invoked prior to shutting down distributed system
    */
-  public MemberShunnedException() {
-    super("");
+  default void beforeMembershipFailure(String reason, Throwable cause) {
+    // nothing
   }
 
+  /**
+   * test hook invoked after shutting down distributed system
+   */
+  default void afterMembershipFailure(String reason, Throwable cause) {
+    // nothing
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
@@ -45,6 +45,7 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.ReplyProcessor21;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberShunnedException;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.distributed.internal.membership.gms.api.MessageListener;
 import org.apache.geode.internal.cache.DirectReplyMessage;
@@ -54,7 +55,6 @@ import org.apache.geode.internal.tcp.BaseMsgStreamer;
 import org.apache.geode.internal.tcp.ConnectExceptions;
 import org.apache.geode.internal.tcp.Connection;
 import org.apache.geode.internal.tcp.ConnectionException;
-import org.apache.geode.internal.tcp.MemberShunnedException;
 import org.apache.geode.internal.tcp.MsgStreamer;
 import org.apache.geode.internal.tcp.TCPConduit;
 import org.apache.geode.internal.util.Breadcrumbs;
@@ -699,7 +699,7 @@ public class DirectChannel {
     }
   }
 
-  public void receive(DistributionMessage msg, int bytesRead) {
+  public void receive(DistributionMessage msg, int bytesRead) throws MemberShunnedException {
     if (disconnected) {
       return;
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.file.Path;
 
+import org.apache.geode.GemFireConfigException;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.Distribution;
@@ -30,6 +31,7 @@ import org.apache.geode.distributed.internal.RestartableTcpHandler;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.NetLocator;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Locator;
 import org.apache.geode.distributed.internal.membership.gms.locator.GMSLocator;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
@@ -61,10 +63,14 @@ public class GMSLocatorAdapter implements RestartableTcpHandler, NetLocator {
                 .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
         InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
         InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
-    gmsLocator =
-        new GMSLocator<>(bindAddress, locatorString, usePreferredCoordinators,
-            networkPartitionDetectionEnabled,
-            locatorStats, securityUDPDHAlgo, workingDirectory, locatorClient);
+    try {
+      gmsLocator =
+          new GMSLocator<>(bindAddress, locatorString, usePreferredCoordinators,
+              networkPartitionDetectionEnabled,
+              locatorStats, securityUDPDHAlgo, workingDirectory, locatorClient);
+    } catch (MembershipConfigurationException e) {
+      throw new GemFireConfigException(e.getMessage());
+    }
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
@@ -28,8 +28,8 @@ import java.util.StringTokenizer;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.GemFireConfigException;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.DeserializationContext;
@@ -47,7 +47,8 @@ public class GMSUtil {
    * @param bindAddress optional address to check for loopback compatibility
    * @return addresses of locators
    */
-  public static List<HostAddress> parseLocators(String locatorsString, String bindAddress) {
+  public static List<HostAddress> parseLocators(String locatorsString, String bindAddress)
+      throws MembershipConfigurationException {
     InetAddress addr = null;
 
     try {
@@ -85,7 +86,8 @@ public class GMSUtil {
    *
    * @see org.apache.geode.distributed.ConfigurationProperties#LOCATORS for format
    */
-  public static List<HostAddress> parseLocators(String locatorsString, InetAddress bindAddress) {
+  public static List<HostAddress> parseLocators(String locatorsString, InetAddress bindAddress)
+      throws MembershipConfigurationException {
     List<HostAddress> result = new ArrayList<>(2);
     Set<InetSocketAddress> inetAddresses = new HashSet<>();
     String host;
@@ -136,12 +138,12 @@ public class GMSUtil {
       final InetAddress locatorAddress = isa.getAddress();
 
       if (locatorAddress == null) {
-        throw new GemFireConfigException("This process is attempting to use a locator" +
+        throw new MembershipConfigurationException("This process is attempting to use a locator" +
             " at an unknown address or FQDN: " + host);
       }
 
       if (checkLoopback && isLoopback && !locatorAddress.isLoopbackAddress()) {
-        throw new GemFireConfigException(
+        throw new MembershipConfigurationException(
             "This process is attempting to join with a loopback address (" + bindAddress
                 + ") using a locator that does not have a local address (" + isa
                 + ").  On Unix this usually means that /etc/hosts is misconfigured.");
@@ -157,8 +159,8 @@ public class GMSUtil {
     return result;
   }
 
-  private static GemFireConfigException createBadPortException(final String str) {
-    return new GemFireConfigException("This process is attempting to use a locator" +
+  private static MembershipConfigurationException createBadPortException(final String str) {
+    return new MembershipConfigurationException("This process is attempting to use a locator" +
         " with a malformed port specification: " + str);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberDisconnectedException.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberDisconnectedException.java
@@ -14,14 +14,17 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.api;
 
-public interface MessageListener<ID extends MemberIdentifier> {
+/**
+ * MemberDisconnectedException indicates that we've been kicked out of the cluster.
+ * Geode-core generally translates this into a ForcedDisconnectException, which is
+ * part of its public API.
+ */
+public class MemberDisconnectedException extends Exception {
+  private static final long serialVersionUID = -3649273301807236514L;
 
-  /**
-   * Event indicating a message has been delivered that we need to process.
-   *
-   * @param o the message that should be processed.
-   */
-  void messageReceived(Message<ID> o) throws MemberShunnedException;
+  public MemberDisconnectedException() {}
 
-
+  public MemberDisconnectedException(String reason) {
+    super(reason);
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberShunnedException.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberShunnedException.java
@@ -12,16 +12,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
+
 package org.apache.geode.distributed.internal.membership.gms.api;
 
-public interface MessageListener<ID extends MemberIdentifier> {
+/**
+ * MemberShunnedException may be thrown to prevent ack-ing a message received from a member that has
+ * been removed from membership. It is currently only thrown by
+ * JGroupMembershipManager.processMessage()
+ */
+public class MemberShunnedException extends Exception {
+  private static final long serialVersionUID = -8453126202477831557L;
 
   /**
-   * Event indicating a message has been delivered that we need to process.
+   * constructor
    *
-   * @param o the message that should be processed.
    */
-  void messageReceived(Message<ID> o) throws MemberShunnedException;
-
+  public MemberShunnedException() {
+    super("");
+  }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberStartupException.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MemberStartupException.java
@@ -14,14 +14,22 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.api;
 
-public interface MessageListener<ID extends MemberIdentifier> {
+/**
+ * MemberStartupException is thrown if there is a problem starting up membership
+ * services or joining the cluster. A subclass of MemberStartupException,
+ * MembershipConfigurationException, may also be thrown during startup and indicates a
+ * problem with configuration parameters.
+ */
+public class MemberStartupException extends Exception {
+  private static final long serialVersionUID = 6610743861046044144L;
 
-  /**
-   * Event indicating a message has been delivered that we need to process.
-   *
-   * @param o the message that should be processed.
-   */
-  void messageReceived(Message<ID> o) throws MemberShunnedException;
+  public MemberStartupException() {}
 
+  public MemberStartupException(String reason) {
+    super(reason);
+  }
 
+  public MemberStartupException(String reason, Throwable cause) {
+    super(reason, cause);
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/Membership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/Membership.java
@@ -17,6 +17,7 @@ package org.apache.geode.distributed.internal.membership.gms.api;
 import java.io.NotSerializableException;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
 import org.apache.geode.SystemFailure;
@@ -71,12 +72,12 @@ public interface Membership<ID extends MemberIdentifier> {
    * @since GemFire 5.1
    */
   void waitForMessageState(ID member, Map<String, Long> state)
-      throws InterruptedException;
+      throws InterruptedException, TimeoutException;
 
   /**
    * Request the current membership coordinator to remove the given member
    */
-  boolean requestMemberRemoval(ID member, String reason);
+  boolean requestMemberRemoval(ID member, String reason) throws MemberDisconnectedException;
 
   /**
    * like memberExists() this checks to see if the given ID is in the current membership view. If it
@@ -235,18 +236,6 @@ public interface Membership<ID extends MemberIdentifier> {
   Throwable getShutdownCause();
 
   /**
-   * register a test hook for membership events
-   *
-   * @see MembershipTestHook
-   */
-  void registerTestHook(MembershipTestHook mth);
-
-  /**
-   * remove a test hook previously registered with the manager
-   */
-  void unregisterTestHook(MembershipTestHook mth);
-
-  /**
    * If this member is shunned, ensure that a warning is generated at least once.
    *
    * @param mbr the member that may be shunned
@@ -301,9 +290,9 @@ public interface Membership<ID extends MemberIdentifier> {
    * takes care of queueing up the message during startup and filtering out messages
    * from shunned members, before calling the message listener.
    */
-  void processMessage(Message<ID> msg);
+  void processMessage(Message<ID> msg) throws MemberShunnedException;
 
-  void checkCancelled();
+  void checkCancelled() throws MembershipClosedException;
 
   void waitIfPlayingDead();
 
@@ -318,7 +307,7 @@ public interface Membership<ID extends MemberIdentifier> {
    */
   boolean hasMember(ID member);
 
-  void start();
+  void start() throws MemberStartupException;
 
   void setCloseInProgress();
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipBuilder.java
@@ -43,7 +43,7 @@ public interface MembershipBuilder<ID extends MemberIdentifier> {
   MembershipBuilder<ID> setLocatorClient(final TcpClient tcpClient);
 
 
-  Membership<ID> create();
+  Membership<ID> create() throws MembershipConfigurationException;
 
   static <ID extends MemberIdentifier> MembershipBuilder<ID> newMembershipBuilder() {
     return new MembershipBuilderImpl<>();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipClosedException.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipClosedException.java
@@ -14,14 +14,21 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.api;
 
-public interface MessageListener<ID extends MemberIdentifier> {
+/**
+ * MembershipClosedException is thrown if membership services are no longer
+ * available. This exception may be thrown by any membership API and does
+ * not appear in API interfaces.
+ */
+public class MembershipClosedException extends RuntimeException {
+  private static final long serialVersionUID = 6112938405434046127L;
 
-  /**
-   * Event indicating a message has been delivered that we need to process.
-   *
-   * @param o the message that should be processed.
-   */
-  void messageReceived(Message<ID> o) throws MemberShunnedException;
+  public MembershipClosedException() {}
 
+  public MembershipClosedException(String reason) {
+    super(reason);
+  }
 
+  public MembershipClosedException(String reason, Throwable cause) {
+    super(reason, cause);
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipConfigurationException.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipConfigurationException.java
@@ -14,22 +14,24 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.api;
 
-/**
- * Test hook for membership test development
- */
-public interface MembershipTestHook {
 
-  /**
-   * test hook invoked prior to shutting down distributed system
-   */
-  default void beforeMembershipFailure(String reason, Throwable cause) {
-    // nothing
+/**
+ * MembershipConfigurationException may be thrown during startup and indicates a
+ * problem with configuration parameters. MembershipConfigurationException is a
+ * subclass of MemberStartupException, which may also be thrown during startup but
+ * indicates a problem connecting to the cluster after membership configuration has
+ * completed.
+ */
+public class MembershipConfigurationException extends MemberStartupException {
+  private static final long serialVersionUID = 5633602142465129621L;
+
+  public MembershipConfigurationException() {}
+
+  public MembershipConfigurationException(String reason) {
+    super(reason);
   }
 
-  /**
-   * test hook invoked after shutting down distributed system
-   */
-  default void afterMembershipFailure(String reason, Throwable cause) {
-    // nothing
+  public MembershipConfigurationException(String reason, Throwable cause) {
+    super(reason, cause);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/JoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/JoinLeave.java
@@ -16,14 +16,15 @@ package org.apache.geode.distributed.internal.membership.gms.interfaces;
 
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
 
 public interface JoinLeave<ID extends MemberIdentifier> extends Service<ID> {
 
   /**
    * joins the distributed system and returns true if successful, false if not. Throws
-   * SystemConnectException and GemFireConfigException
+   * MemberStartupException and MemberConfigurationException
    */
-  boolean join();
+  boolean join() throws MemberStartupException;
 
   /**
    * leaves the distributed system. Should be invoked before stop()

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Manager.java
@@ -19,6 +19,7 @@ import java.util.Collection;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
 import org.apache.geode.distributed.internal.membership.gms.api.Message;
 
 /**
@@ -31,7 +32,7 @@ public interface Manager<ID extends MemberIdentifier>
   /**
    * After all services have been started this is used to join the distributed system
    */
-  void joinDistributedSystem();
+  void joinDistributedSystem() throws MemberStartupException;
 
   /**
    * initiates a Forced Disconnect, shutting down the distributed system and closing the cache

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/MessageHandler.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/MessageHandler.java
@@ -15,12 +15,14 @@
 package org.apache.geode.distributed.internal.membership.gms.interfaces;
 
 
+import org.apache.geode.distributed.internal.membership.gms.api.MemberShunnedException;
+
 /**
  * MessageHandler processes a message received by Messenger. Handlers are registered with Messenger
  * to consume specific classes of message.
  */
 public interface MessageHandler<T> {
 
-  void processMessage(T m);
+  void processMessage(T m) throws MemberShunnedException;
 
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Messenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Messenger.java
@@ -16,6 +16,7 @@ package org.apache.geode.distributed.internal.membership.gms.interfaces;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
@@ -83,7 +84,7 @@ public interface Messenger<ID extends MemberIdentifier> extends Service<ID> {
    * @param state the state of that member's outgoing messaging to this member
    */
   void waitForMessageState(ID member, Map<String, Long> state)
-      throws InterruptedException;
+      throws InterruptedException, TimeoutException;
 
   /**
    * Get the public key of member.

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Service.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/Service.java
@@ -17,19 +17,21 @@ package org.apache.geode.distributed.internal.membership.gms.interfaces;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 
 /**
  * Services in GMS all implement this interface
  *
  */
 public interface Service<ID extends MemberIdentifier> {
-  void init(Services<ID> s);
+  void init(Services<ID> s) throws MembershipConfigurationException;
 
   /**
    * called after all services have been initialized with init() and all services are available via
    * Services
    */
-  void start();
+  void start() throws MemberStartupException;
 
   /**
    * called after all servers have been started

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.InternalGemFireException;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
@@ -46,6 +45,7 @@ import org.apache.geode.distributed.internal.membership.gms.GMSUtil;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Locator;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
 import org.apache.geode.distributed.internal.membership.gms.messenger.GMSMemberWrapper;
@@ -98,7 +98,8 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
    */
   public GMSLocator(InetAddress bindAddress, String locatorString, boolean usePreferredCoordinators,
       boolean networkPartitionDetectionEnabled, LocatorStats locatorStats,
-      String securityUDPDHAlgo, Path workingDirectory, final TcpClient locatorClient) {
+      String securityUDPDHAlgo, Path workingDirectory, final TcpClient locatorClient)
+      throws MembershipConfigurationException {
     this.usePreferredCoordinators = usePreferredCoordinators;
     this.networkPartitionDetectionEnabled = networkPartitionDetectionEnabled;
     this.securityUDPDHAlgo = securityUDPDHAlgo;
@@ -160,7 +161,7 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
     return viewFile;
   }
 
-  public void init(String persistentFileIdentifier) throws InternalGemFireException {
+  public void init(String persistentFileIdentifier) {
     if (viewFile == null) {
       viewFile =
           workingDirectory.resolve("locator" + persistentFileIdentifier + "view.dat").toFile();
@@ -219,7 +220,7 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
     if (!findRequest.getDHAlgo().equals(securityUDPDHAlgo)) {
       return new FindCoordinatorResponse<>(
           "Rejecting findCoordinatorRequest, as member not configured same udp security("
-              + findRequest.getDHAlgo() + " )as locator (" + securityUDPDHAlgo + ")");
+              + findRequest.getDHAlgo() + ") as locator (" + securityUDPDHAlgo + ")");
     }
 
     if (services == null) {
@@ -382,7 +383,7 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
     }
   }
 
-  private void recover() throws InternalGemFireException {
+  private void recover() {
     if (!recoverFromOtherLocators()) {
       recoverFromFile(viewFile);
     }
@@ -416,7 +417,7 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
     return false;
   }
 
-  boolean recoverFromFile(File file) throws InternalGemFireException {
+  boolean recoverFromFile(File file) {
     if (!file.exists()) {
       logger.info("recovery file not found: {}", file.getAbsolutePath());
       return false;
@@ -469,7 +470,7 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
         logger.warn("Peer locator was unable to recover from or delete {}", file);
         viewFile = null;
       }
-      throw new InternalGemFireException(message, e);
+      throw new IllegalStateException(message, e);
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -43,10 +43,7 @@ import java.util.concurrent.Future;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.GemFireConfigException;
-import org.apache.geode.SystemConnectException;
 import org.apache.geode.annotations.VisibleForTesting;
-import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionConfig;
@@ -54,7 +51,10 @@ import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 import org.apache.geode.distributed.internal.membership.gms.GMSUtil;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipClosedException;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.JoinLeave;
 import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordinatorRequest;
 import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordinatorResponse;
@@ -71,8 +71,6 @@ import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
 import org.apache.geode.logging.internal.executors.LoggingThread;
-import org.apache.geode.security.AuthenticationRequiredException;
-import org.apache.geode.security.GemFireSecurityException;
 
 /**
  * GMSJoinLeave handles membership communication with other processes in the distributed system. It
@@ -304,7 +302,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
    * @return true if successful, false if not
    */
   @Override
-  public boolean join() {
+  public boolean join() throws MemberStartupException {
 
     try {
       if (Boolean.getBoolean(BYPASS_DISCOVERY_PROPERTY)) {
@@ -397,10 +395,10 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
             + (System.currentTimeMillis() - startTime) + "ms");
       }
 
-      // to preserve old behavior we need to throw a SystemConnectException if
+      // to preserve old behavior we need to throw a MemberStartupException if
       // unable to contact any of the locators
       if (!this.isJoined && state.hasContactedAJoinedLocator) {
-        throw new SystemConnectException("Unable to join the distributed system in "
+        throw new MemberStartupException("Unable to join the distributed system in "
             + (System.currentTimeMillis() - startTime) + "ms");
       }
 
@@ -418,12 +416,12 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
 
   /**
    * send a join request and wait for a reply. Process the reply. This may throw a
-   * SystemConnectException or an AuthenticationFailedException
+   * MemberStartupException or an exception from the authenticator, if present.
    *
    * @return true if the attempt succeeded, false if it timed out
    */
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "WA_NOT_IN_LOOP")
-  boolean attemptToJoin() {
+  boolean attemptToJoin() throws MemberStartupException {
     SearchState<ID> state = searchState;
 
     // send a join request to the coordinator and wait for a response
@@ -462,11 +460,9 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
       if (failReason.contains("Rejecting the attempt of a member using an older version")
           || failReason.contains("15806")
           || failReason.contains("ForcedDisconnectException")) {
-        throw new SystemConnectException(failReason);
-      } else if (failReason.contains("Failed to find credentials")) {
-        throw new AuthenticationRequiredException(failReason);
+        throw new MemberStartupException(failReason);
       }
-      throw new GemFireSecurityException(failReason);
+      throw new SecurityException(failReason);
     }
 
     throw new RuntimeException("Join Request Failed with response " + response);
@@ -1110,7 +1106,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
    * This contacts the locators to find out who the current coordinator is. All locators are
    * contacted. If they don't agree then we choose the oldest coordinator and return it.
    */
-  boolean findCoordinator() {
+  boolean findCoordinator() throws MemberStartupException {
     SearchState<ID> state = searchState;
 
     assert this.localAddress != null;
@@ -1149,7 +1145,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
               (o instanceof FindCoordinatorResponse) ? (FindCoordinatorResponse<ID>) o : null;
           if (response != null) {
             if (response.getRejectionMessage() != null) {
-              throw new GemFireConfigException(response.getRejectionMessage());
+              throw new MembershipConfigurationException(response.getRejectionMessage());
             }
             setCoordinatorPublicKey(response);
             state.locatorsContacted++;
@@ -1195,7 +1191,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
               services.getCancelCriterion().checkCancelInProgress(e);
-              throw new SystemConnectException("Interrupted while trying to contact locators");
+              throw new MemberStartupException("Interrupted while trying to contact locators");
             }
           }
         }
@@ -1680,7 +1676,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
   }
 
   @Override
-  public void start() {}
+  public void start() throws MemberStartupException {}
 
   @Override
   public void started() {}
@@ -1823,15 +1819,16 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
   }
 
   @Override
-  public void init(Services<ID> s) {
+  public void init(Services<ID> s) throws MembershipConfigurationException {
     this.services = s;
 
     MembershipConfig config = services.getConfig();
     if (config.getMcastPort() != 0 && StringUtils.isBlank(config.getLocators())
         && StringUtils.isBlank(config.getStartLocator())) {
-      throw new GemFireConfigException("Multicast cannot be configured for a non-distributed cache."
-          + "  Please configure the locator services for this cache using " + LOCATORS + " or "
-          + START_LOCATOR + ".");
+      throw new MembershipConfigurationException(
+          "Multicast cannot be configured for a non-distributed cache."
+              + "  Please configure the locator services for this cache using " + LOCATORS + " or "
+              + START_LOCATOR + ".");
     }
 
     services.getMessenger().addHandler(JoinRequestMessage.class, this::processMessage);
@@ -2187,7 +2184,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
           }
         } catch (InterruptedException e) {
           setShutdownFlag();
-        } catch (DistributedSystemDisconnectedException e) {
+        } catch (MembershipClosedException e) {
           setShutdownFlag();
         }
       } while (retry);
@@ -2322,7 +2319,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
               } catch (InterruptedException e2) {
                 setShutdownFlag();
               }
-            } catch (DistributedSystemDisconnectedException e) {
+            } catch (MembershipClosedException e) {
               setShutdownFlag();
             } catch (InterruptedException e) {
               logger.info("View Creator thread interrupted");

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
@@ -81,6 +81,7 @@ public class GMSQuorumChecker<ID extends MemberIdentifier> implements QuorumChec
   }
 
 
+  @Override
   public synchronized boolean checkForQuorum(long timeout) throws InterruptedException {
     if (quorumAchieved) {
       return true;
@@ -98,6 +99,7 @@ public class GMSQuorumChecker<ID extends MemberIdentifier> implements QuorumChec
     return quorumAchieved;
   }
 
+  @Override
   public void close() {
     if (channel != null && !channel.isClosed()) {
       channel.close();
@@ -109,7 +111,7 @@ public class GMSQuorumChecker<ID extends MemberIdentifier> implements QuorumChec
     JGroupsMessenger.setChannelReceiver(channel, new QuorumCheckerReceiver());
   }
 
-
+  @Override
   public MembershipInformation getMembershipInfo() {
     return new MembershipInformationImpl(channel, messageQueue);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -72,6 +72,7 @@ import org.apache.geode.distributed.internal.ReplyProcessor21;
 import org.apache.geode.distributed.internal.ReplySender;
 import org.apache.geode.distributed.internal.direct.DirectChannel;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberShunnedException;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.DSFIDFactory;
@@ -2654,8 +2655,6 @@ public class Connection implements Runnable {
       stats.incMessageChannelTime(msg.resetTimestamp());
       msg.process(dm, processor);
       // dispatchMessage(msg, len, false);
-    } catch (MemberShunnedException e) {
-      // do nothing
     } catch (SocketTimeoutException timeout) {
       throw timeout;
     } catch (IOException e) {
@@ -3171,7 +3170,8 @@ public class Connection implements Runnable {
     }
   }
 
-  private boolean dispatchMessage(DistributionMessage msg, int bytesRead, boolean directAck) {
+  private boolean dispatchMessage(DistributionMessage msg, int bytesRead, boolean directAck)
+      throws MemberShunnedException {
     try {
       msg.setDoDecMessagesBeingReceived(true);
       if (directAck) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -48,6 +48,7 @@ import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.LonerDistributionManager;
 import org.apache.geode.distributed.internal.direct.DirectChannel;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberShunnedException;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.net.BufferPool;
@@ -655,7 +656,8 @@ public class TCPConduit implements Runnable {
    *
    * @param bytesRead number of bytes read off of network to get this message
    */
-  void messageReceived(Connection receiver, DistributionMessage message, int bytesRead) {
+  void messageReceived(Connection receiver, DistributionMessage message, int bytesRead)
+      throws MemberShunnedException {
     if (logger.isTraceEnabled()) {
       logger.trace("{} received {} from {}", id, message, receiver);
     }

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -259,6 +259,11 @@ org/apache/geode/distributed/internal/deadlock/MessageDependencyMonitor$MessageK
 org/apache/geode/distributed/internal/direct/ShunnedMemberException,true,-6455664684151074915
 org/apache/geode/distributed/internal/locks/DistributedMemberLock$LockReentryPolicy,false
 org/apache/geode/distributed/internal/locks/LockGrantorDestroyedException,true,-3540124531032570817
+org/apache/geode/distributed/internal/membership/gms/api/MemberDisconnectedException,true,-3649273301807236514
+org/apache/geode/distributed/internal/membership/gms/api/MemberShunnedException,true,-8453126202477831557
+org/apache/geode/distributed/internal/membership/gms/api/MemberStartupException,true,6610743861046044144
+org/apache/geode/distributed/internal/membership/gms/api/MembershipClosedException,true,6112938405434046127
+org/apache/geode/distributed/internal/membership/gms/api/MembershipConfigurationException,true,5633602142465129621
 org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave$ViewAbandonedException,false
 org/apache/geode/distributed/internal/membership/gms/messages/InstallViewMessage$messageType,false
 org/apache/geode/internal/ConfigSource,true,-4097017272431018553,description:java/lang/String,type:org/apache/geode/internal/ConfigSource$Type
@@ -411,7 +416,6 @@ org/apache/geode/internal/tcp/ByteBufferInputStream,false,buffer:org/apache/geod
 org/apache/geode/internal/tcp/ConnectExceptions,true,-4173688946448867706,causes:java/util/List,members:java/util/List
 org/apache/geode/internal/tcp/ConnectionException,true,-1977443644277412122
 org/apache/geode/internal/tcp/ImmutableByteBufferInputStream,false
-org/apache/geode/internal/tcp/MemberShunnedException,true,-8453126202477831557
 org/apache/geode/internal/tcp/ReenteredConnectException,true,2878977454669428469
 org/apache/geode/internal/util/Breadcrumbs$CrumbType,false
 org/apache/geode/internal/util/SunAPINotFoundException,true,75895915344106684

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
@@ -45,6 +45,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 import org.apache.geode.distributed.internal.membership.gms.GMSMemberData;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipClosedException;
 import org.apache.geode.internal.admin.remote.AlertListenerMessage;
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.tcp.ConnectExceptions;
@@ -138,7 +139,7 @@ public class DistributionTest {
         .directChannelSend(recipients, m);
     when(dc.send(any(), any(mockMembers.getClass()),
         any(DistributionMessage.class), anyInt(), anyInt())).thenReturn(0);
-    doThrow(DistributedSystemDisconnectedException.class).when(membership).checkCancelled();
+    doThrow(MembershipClosedException.class).when(membership).checkCancelled();
 
     try {
       distribution.directChannelSend(recipients, m);

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.distributed.internal.membership;
 
 import static com.tngtech.archunit.base.DescribedPredicate.not;
-import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.type;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
@@ -29,9 +28,6 @@ import com.tngtech.archunit.junit.CacheMode;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
-import org.apache.geode.CancelCriterion;
-import org.apache.geode.GemFireException;
-import org.apache.geode.InternalGemFireError;
 import org.apache.geode.alerting.internal.spi.AlertingAction;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.LocatorStats;
@@ -111,15 +107,8 @@ public class MembershipDependenciesJUnitTest {
               // TODO: Create a new stats interface for membership
               .or(type(LocatorStats.class))
 
-              // TODO: Figure out what to do with exceptions
-              .or(assignableTo(GemFireException.class))
-              .or(type(InternalGemFireError.class))
-
               // TODO: Serialization needs to become its own module
               .or(type(InternalDataSerializer.class)) // still used by GMSLocator
-
-              // TODO
-              .or(assignableTo(CancelCriterion.class))
 
               // TODO:
               .or(type(SocketCreator.class))

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/GMSUtilTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/GMSUtilTest.java
@@ -27,7 +27,7 @@ import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.apache.geode.GemFireConfigException;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
 
 @RunWith(JUnitParamsRunner.class)
@@ -43,7 +43,7 @@ public class GMSUtilTest {
 
 
   @Test
-  public void resolveableLoopBackAddress() {
+  public void resolveableLoopBackAddress() throws MembershipConfigurationException {
     assertThat(
         parseLocators(RESOLVEABLE_LOOPBACK_HOST + "[" + PORT + "]",
             InetAddress.getLoopbackAddress()))
@@ -57,7 +57,7 @@ public class GMSUtilTest {
     assertThatThrownBy(
         () -> parseLocators(RESOLVEABLE_NON_LOOPBACK_HOST + "[" + PORT + "]",
             InetAddress.getLoopbackAddress()))
-                .isInstanceOf(GemFireConfigException.class)
+                .isInstanceOf(MembershipConfigurationException.class)
                 .hasMessageContaining("does not have a local address");
   }
 
@@ -66,13 +66,13 @@ public class GMSUtilTest {
     assertThatThrownBy(
         () -> parseLocators(UNRESOLVEABLE_HOST + "[" + PORT + "]",
             InetAddress.getLoopbackAddress()))
-                .isInstanceOf(GemFireConfigException.class)
+                .isInstanceOf(MembershipConfigurationException.class)
                 .hasMessageContaining("unknown address or FQDN: " + UNRESOLVEABLE_HOST);
   }
 
   @Test
   @Parameters({"1234", "0"})
-  public void validPortSpecified(final int validPort) {
+  public void validPortSpecified(final int validPort) throws MembershipConfigurationException {
     final String locatorsString = RESOLVEABLE_LOOPBACK_HOST + "[" + validPort + "]";
     assertThat(parseLocators(locatorsString, InetAddress.getLoopbackAddress()))
         .contains(
@@ -86,13 +86,14 @@ public class GMSUtilTest {
     final String locatorsString = RESOLVEABLE_LOOPBACK_HOST + portSpecification;
     assertThatThrownBy(
         () -> parseLocators(locatorsString, InetAddress.getLoopbackAddress()))
-            .isInstanceOf(GemFireConfigException.class)
+            .isInstanceOf(MembershipConfigurationException.class)
             .hasMessageContaining("malformed port specification: " + locatorsString);
   }
 
   @Test
   @Parameters({"host@127.0.0.1[1234]", "host:127.0.0.1[1234]"})
-  public void validHostSpecified(final String locatorsString) {
+  public void validHostSpecified(final String locatorsString)
+      throws MembershipConfigurationException {
     assertThat(parseLocators(locatorsString, (InetAddress) null))
         .contains(
             new HostAddress(new InetSocketAddress("127.0.0.1", 1234), "127.0.0.1"));
@@ -100,7 +101,8 @@ public class GMSUtilTest {
 
   @Test
   @Parameters({"server1@fdf0:76cf:a0ed:9449::5[12233]", "fdf0:76cf:a0ed:9449::5[12233]"})
-  public void validIPV6AddySpecified(final String locatorsString) {
+  public void validIPV6AddySpecified(final String locatorsString)
+      throws MembershipConfigurationException {
     assertThat(parseLocators(locatorsString, (InetAddress) null))
         .contains(
             new HostAddress(new InetSocketAddress("fdf0:76cf:a0ed:9449::5", 12233),

--- a/geode-dunit/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipManagerHelper.java
+++ b/geode-dunit/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipManagerHelper.java
@@ -24,8 +24,8 @@ import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.Distribution;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.MembershipTestHook;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.distributed.internal.membership.gms.api.MembershipTestHook;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.WaitCriterion;
 
@@ -78,12 +78,12 @@ public class MembershipManagerHelper {
 
   /** register a test hook with the manager */
   public static void addTestHook(DistributedSystem sys, MembershipTestHook hook) {
-    getDistribution(sys).registerTestHook(hook);
+    ((InternalDistributedSystem) sys).getDistributionManager().registerTestHook(hook);
   }
 
   /** remove a registered test hook */
   public static void removeTestHook(DistributedSystem sys, MembershipTestHook hook) {
-    getDistribution(sys).unregisterTestHook(hook);
+    ((InternalDistributedSystem) sys).getDistributionManager().unregisterTestHook(hook);
   }
 
   /**


### PR DESCRIPTION
Removed use of geode-core exceptions from membership. DistributionImpl now converts membership exceptions into geode-core exceptions where necessary.

Except for MembershipClosedException the new membership exceptions are all checked exceptions. This let me isolate where the exceptions are used and ensure that they're changed into appropriate geode-core exceptions.

MemberShunnedException is now in the membership module instead of the TcpConduit module. It, too, is a checked exception.

CancelCriterion is also removed from use in the membership module. The Stopper in Services.java doesn't need to be a CancelCriterion to function properly.

Several tests had to be modified to handle our stress-test environement.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
