### PR TITLE
GEODE-7599 - Use Google Compute Image resource in Concourse.

### DIFF
--- a/ci/images/google-geode-builder/packer.json
+++ b/ci/images/google-geode-builder/packer.json
@@ -35,7 +35,7 @@
       "source_image_family": "{{ user `base_family`}}",
       "ssh_username": "packer",
       "zone": "us-central1-f",
-      "image_family": "{{user `pipeline_prefix`}}geode-builder",
+      "image_family": "{{user `pipeline_prefix`}}linux-geode-builder",
       "image_name": "{{user `hashed_pipeline_prefix`}}gb-{{timestamp}}",
       "tags": ["packer"]
     }

--- a/ci/pipelines/examples/jinja.template.yml
+++ b/ci/pipelines/examples/jinja.template.yml
@@ -35,6 +35,10 @@ SERVICE_ACCOUNT: ((!concourse-gcp-account))
 ---
 
 resource_types:
+- name: gci
+  type: registry-image
+  source:
+    repository: smgoller/gci-resource
 - name: maven-resource
   type: docker-image
   source:
@@ -76,6 +80,13 @@ resources:
     password: ((docker-password))
     repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
     tag: latest
+- name: linux-builder-image-family
+  type: gci
+  source:
+    key: ((concourse-gcp-key))
+    family_project: ((gcp-project))
+    family: ((pipeline-prefix))linux-geode-builder
+
 
 jobs:
 - name: {{examples_test.name}}
@@ -85,6 +96,7 @@ jobs:
   - aggregate:
     - get: geode-ci
     - get: alpine-tools-image
+    - get: linux-builder-image-family
   - aggregate:
     - get: geode-examples
       trigger: true
@@ -101,6 +113,7 @@ jobs:
             {{ common_instance_params(examples_test) | indent(12) }}
             GEODE_BRANCH: {{repository.branch}}
             GEODE_FORK: {{repository.fork}}
+            IMAGE_FAMILY_NAME: ((pipeline-prefix))linux-geode-builder
           run:
             path: geode-ci/ci/scripts/create_instance.sh
           inputs:

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -201,7 +201,26 @@ resources:
     repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
     tag: latest
 
+- name: windows-builder-image-family
+  type: gci
+  source:
+    key: ((concourse-gcp-key))
+    family_project: ((gcp-project))
+    family: ((pipeline-prefix))windows-geode-builder
+
+- name: linux-builder-image-family
+  type: gci
+  source:
+    key: ((concourse-gcp-key))
+    family_project: ((gcp-project))
+    family: ((pipeline-prefix))linux-geode-builder
+
+
 resource_types:
+- name: gci
+  type: registry-image
+  source:
+    repository: smgoller/gci-resource
 - name: concourse-metadata-resource
   type: docker-image
   source:
@@ -236,6 +255,7 @@ jobs:
     - get: geode-build-version
       params:
         pre: ((semver-prerelease-token))
+    - get: {{ build_test.PLATFORM }}-builder-image-family
   - do:
     - put: concourse-metadata-resource
     {{ init_retry()|indent(4) }}
@@ -248,6 +268,7 @@ jobs:
           GEODE_BRANCH: {{repository.branch}}
           GEODE_FORK: {{repository.fork}}
           JAVA_BUILD_VERSION: {{ java_build_version.version }}
+          IMAGE_FAMILY_NAME: ((pipeline-prefix))linux-geode-builder
         run:
           path: geode-ci/ci/scripts/create_instance.sh
         inputs:
@@ -262,6 +283,17 @@ jobs:
         - name: instance-data
       timeout: 15m
       attempts: 5
+      on_failure:
+        task: delete_instance
+        image: alpine-tools-image
+        config:
+          platform: linux
+          run:
+            path: geode-ci/ci/scripts/delete_instance.sh
+          inputs:
+          - name: geode-ci
+          - name: instance-data
+        timeout: 1h
   - aggregate:
     - put: geode-build-version
       params:
@@ -278,17 +310,16 @@ jobs:
         - name: instance-data
     timeout: 10m
     on_failure:
-      do:
-      - task: delete_instance
-        image: alpine-tools-image
-        config:
-          platform: linux
-          run:
-            path: geode-ci/ci/scripts/delete_instance.sh
-          inputs:
-          - name: geode-ci
-          - name: instance-data
-        timeout: 1h
+      task: delete_instance
+      image: alpine-tools-image
+      config:
+        platform: linux
+        run:
+          path: geode-ci/ci/scripts/delete_instance.sh
+        inputs:
+        - name: geode-ci
+        - name: instance-data
+      timeout: 1h
   - task: build
     image: alpine-tools-image
     config:
@@ -500,6 +531,7 @@ jobs:
     - get: geode
       passed: *publish-passed-inputs
       trigger: true
+    - get: linux-builder-image-family
   - aggregate:
     - get: geode-build-version
       trigger: true
@@ -515,6 +547,7 @@ jobs:
         GEODE_BRANCH: {{repository.branch}}
         GEODE_FORK: {{repository.fork}}
         JAVA_BUILD_VERSION: {{ java_build_version.version }}
+        IMAGE_FAMILY_NAME: ((pipeline-prefix))linux-geode-builder
       run:
         path: geode-ci/ci/scripts/create_instance.sh
       inputs:
@@ -588,34 +621,36 @@ jobs:
     {{- plan_resource_gets(test) |indent(4) }}
       - put: concourse-metadata-resource
       - get: alpine-tools-image
-    - aggregate:
+      - get: {{ test.PLATFORM}}-builder-image-family
+    - do:
+      {{ init_retry()|indent(6) }}
+      - task: create_instance-{{java_test_version.name}}
+        image: alpine-tools-image
+        config:
+          platform: linux
+          params:
+            {{ common_instance_params(parameters) | indent(12) }}
+            GEODE_BRANCH: {{repository.branch}}
+            GEODE_FORK: {{repository.fork}}
+            JAVA_BUILD_VERSION: {{ java_build_version.version }}
+            JAVA_TEST_VERSION: {{ java_test_version.version }}
+            IMAGE_FAMILY_NAME: ((pipeline-prefix)){{ test.PLATFORM }}-geode-builder
+          run:
+            path: geode-ci/ci/scripts/create_instance.sh
+          inputs:
+          - name: concourse-metadata-resource
+          - name: geode-ci
+          - name: geode
+          - name: attempts-log
+            path: old
+          outputs:
+          - name: instance-data-{{java_test_version.name}}
+            path: instance-data
+          - name: attempts-log
+            path: new
+        timeout: 15m
+        attempts: 5
       - do:
-        {{ init_retry()|indent(8) }}
-        - task: create_instance-{{java_test_version.name}}
-          image: alpine-tools-image
-          config:
-            platform: linux
-            params:
-              {{ common_instance_params(parameters) | indent(14) }}
-              GEODE_BRANCH: {{repository.branch}}
-              GEODE_FORK: {{repository.fork}}
-              JAVA_BUILD_VERSION: {{ java_build_version.version }}
-              JAVA_TEST_VERSION: {{ java_test_version.version }}
-            run:
-              path: geode-ci/ci/scripts/create_instance.sh
-            inputs:
-            - name: concourse-metadata-resource
-            - name: geode-ci
-            - name: geode
-            - name: attempts-log
-              path: old
-            outputs:
-            - name: instance-data-{{java_test_version.name}}
-              path: instance-data
-            - name: attempts-log
-              path: new
-          timeout: 15m
-          attempts: 5
         - task: rsync_code_up-{{java_test_version.name}}
           image: alpine-tools-image
           config:

--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -286,3 +286,7 @@ if [[ "$GEODE_FORK" == "${UPSTREAM_FORK}" ]]; then
 fi
 
 echo "Successfully deployed ${CONCOURSE_URL}/teams/main/pipelines/${PIPELINE_PREFIX}main"
+
+rm ci/pipelines/meta/generated-pipeline.yml
+rm ci/pipelines/meta/pipelineProperties.yml
+rm ci/pipelines/meta/repository.yml

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -61,7 +61,18 @@ resources:
     repository: gcr.io/((gcp-project))/((pipeline-prefix))alpine-tools
     tag: latest
 
+- name: linux-builder-image-family
+  type: gci
+  source:
+    key: ((concourse-gcp-key))
+    family_project: ((gcp-project))
+    family: ((pipeline-prefix))linux-geode-builder
+
 resource_types:
+- name: gci
+  type: registry-image
+  source:
+    repository: smgoller/gci-resource
 - name: gcs-resource
   type: docker-image
   source:
@@ -88,6 +99,7 @@ jobs:
         trigger: true
         version: every
       - get: geode-ci
+      - get: {{ build_test.PLATFORM }}-builder-image-family
     - aggregate:
       - do:
         - put: pull-request-job-pending
@@ -112,6 +124,7 @@ jobs:
               GEODE_FORK: {{repository.fork}}
               JAVA_BUILD_VERSION: 8
               JAVA_TEST_VERSION: 8
+              IMAGE_FAMILY_NAME: ((pipeline-prefix))linux-geode-builder
             run:
               path: geode-ci/ci/scripts/create_instance.sh
             inputs:
@@ -242,6 +255,7 @@ jobs:
         trigger: true
         version: every
       - get: geode-ci
+      - get: {{ test.PLATFORM }}-builder-image-family
     - aggregate:
       - do:
         - put: pull-request-job-pending
@@ -266,6 +280,7 @@ jobs:
               RAM: {{test.RAM}}
               JAVA_BUILD_VERSION: {{ java_build_version.version }}
               JAVA_TEST_VERSION: {{ java_test_version.version }}
+              IMAGE_FAMILY_NAME: ((pipeline-prefix)){{ test.PLATFORM }}-geode-builder
             run:
               path: geode-ci/ci/scripts/create_instance.sh
             inputs:

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -40,6 +40,7 @@ build_test:
   MAX_IN_FLIGHT: 2
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
+  PLATFORM: linux
   RAM: '16'
   name: Build
 

--- a/ci/scripts/rsync_code_down.sh
+++ b/ci/scripts/rsync_code_down.sh
@@ -30,7 +30,9 @@ done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 SSHKEY_FILE="instance-data/sshkey"
-SSH_OPTIONS="-i ${SSHKEY_FILE} -o ConnectionAttempts=60 -o StrictHostKeyChecking=no"
+
+test -e ${SSHKEY_FILE}
+SSH_OPTIONS="-i ${SSHKEY_FILE} -o ConnectTimeout=5 -o ConnectionAttempts=60 -o StrictHostKeyChecking=no"
 
 INSTANCE_IP_ADDRESS="$(cat instance-data/instance-ip-address)"
 


### PR DESCRIPTION
* Parameterize gcp image-family-name.
* Change geode-build template to set image-family-name.
* Remove reduntant 'do' in pipeline definition.
* Add image-family-name for pr and examples pipelines.
* Remove intermediatary files when deploying meta pipeline.
* Test jobs track when new compute image is used.
* Use gci-resource correctly per platform image family

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
