### PR TITLE
GEODE-7606 Break dependency on InternalDataSerializer

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorIntegrationTest.java
@@ -86,7 +86,9 @@ public class GMSLocatorIntegrationTest {
                     SocketCreatorFactory
                         .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
                 InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
-                InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
+                InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()),
+            InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     GMSMembership membership = mock(GMSMembership.class);
     when(membership.getServices()).thenReturn(services);
     gmsLocator.setMembership(membership);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -99,7 +99,9 @@ public class GMSLocatorRecoveryIntegrationTest {
                 SocketCreatorFactory
                     .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR)),
             InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
-            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()));
+            InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer()),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     gmsLocator.setViewFile(stateFile);
   }
 
@@ -199,7 +201,9 @@ public class GMSLocatorRecoveryIntegrationTest {
 
     GMSLocator gmsLocator = new GMSLocator(localHost,
         distribution.getLocalMember().getHost() + "[" + port + "]", true, true,
-        new LocatorStats(), "", temporaryFolder.getRoot().toPath(), locatorClient);
+        new LocatorStats(), "", temporaryFolder.getRoot().toPath(), locatorClient,
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     gmsLocator.setViewFile(new File(temporaryFolder.getRoot(), "locator2.dat"));
     gmsLocator.init(null);
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/GMSLocatorAdapter.java
@@ -67,7 +67,9 @@ public class GMSLocatorAdapter implements RestartableTcpHandler, NetLocator {
       gmsLocator =
           new GMSLocator<>(bindAddress, locatorString, usePreferredCoordinators,
               networkPartitionDetectionEnabled,
-              locatorStats, securityUDPDHAlgo, workingDirectory, locatorClient);
+              locatorStats, securityUDPDHAlgo, workingDirectory, locatorClient,
+              InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+              InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer());
     } catch (MembershipConfigurationException e) {
       throw new GemFireConfigException(e.getMessage());
     }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -33,7 +33,6 @@ import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.adapter.LocalViewMessage;
 import org.apache.geode.internal.ClassPathLoader;
-import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.net.SocketCreatorFactory;
@@ -106,9 +105,6 @@ public class MembershipDependenciesJUnitTest {
 
               // TODO: Create a new stats interface for membership
               .or(type(LocatorStats.class))
-
-              // TODO: Serialization needs to become its own module
-              .or(type(InternalDataSerializer.class)) // still used by GMSLocator
 
               // TODO:
               .or(type(SocketCreator.class))

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataJUnitTest.java
@@ -31,11 +31,13 @@ import java.io.DataOutputStream;
 import java.net.InetAddress;
 
 import org.jgroups.util.UUID;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.serialization.BufferDataOutputStream;
+import org.apache.geode.internal.serialization.DSFIDSerializer;
+import org.apache.geode.internal.serialization.DSFIDSerializerFactory;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.Version;
@@ -44,6 +46,14 @@ import org.apache.geode.test.junit.categories.SecurityTest;
 
 @Category({SecurityTest.class})
 public class GMSMemberDataJUnitTest {
+
+  private DSFIDSerializer dsfidSerializer;
+
+  @Before
+  public void setup() {
+    dsfidSerializer = new DSFIDSerializerFactory().create();
+    Services.registerSerializables(dsfidSerializer);
+  }
 
   @Test
   public void testEqualsNotSameType() {
@@ -195,14 +205,14 @@ public class GMSMemberDataJUnitTest {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     GMSMemberData member = new GMSMemberData();
     DataOutput dataOutput = new DataOutputStream(baos);
-    SerializationContext serializationContext = InternalDataSerializer.getDSFIDSerializer()
+    SerializationContext serializationContext = dsfidSerializer
         .createSerializationContext(dataOutput);
     member.writeEssentialData(dataOutput, serializationContext);
 
     // vmKind should be transmitted to a member with the current version
     ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
     DataInput dataInput = new DataInputStream(bais);
-    DeserializationContext deserializationContext = InternalDataSerializer.getDSFIDSerializer()
+    DeserializationContext deserializationContext = dsfidSerializer
         .createDeserializationContext(dataInput);
     GMSMemberData newMember = new GMSMemberData();
     newMember.readEssentialData(dataInput, deserializationContext);
@@ -213,8 +223,7 @@ public class GMSMemberDataJUnitTest {
     member.writeEssentialData(dataOutput, serializationContext);
     bais = new ByteArrayInputStream(baos.toByteArray());
     DataInputStream stream = new DataInputStream(bais);
-    deserializationContext =
-        InternalDataSerializer.createDeserializationContext(stream);
+    deserializationContext = dsfidSerializer.createDeserializationContext(stream);
     dataInput = new VersionedDataInputStream(stream, Version.GFE_90);
     newMember = new GMSMemberData();
     newMember.readEssentialData(dataInput, deserializationContext);


### PR DESCRIPTION
Inject a serializer and deserializer into GMSLocator for use in reading
and writing its persistent membership view.

Note to reviewers: there are already unit tests for creating and recovering a locator persistent view.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
