### PR TITLE
GEODE-7544 Break dependency on ClassPathLoader

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -91,7 +91,6 @@ import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordina
 import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordinatorResponse;
 import org.apache.geode.distributed.internal.membership.gms.messages.JoinRequestMessage;
 import org.apache.geode.distributed.internal.membership.gms.messages.JoinResponseMessage;
-import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.cache.DistributedCacheOperation;
 import org.apache.geode.internal.net.SocketCreator;
@@ -201,7 +200,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     boolean enableNetworkPartitionDetection = config.getEnableNetworkPartitionDetection();
     System.setProperty("jgroups.resolve_dns", String.valueOf(!enableNetworkPartitionDetection));
 
-    InputStream is;
+    InputStream is = null;
 
     String r;
     if (config.isMcastEnabled()) {
@@ -209,7 +208,16 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     } else {
       r = DEFAULT_JGROUPS_TCP_CONFIG;
     }
-    is = ClassPathLoader.getLatest().getResourceAsStream(getClass(), r);
+    ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+    if (contextClassLoader != null) {
+      is = contextClassLoader.getResourceAsStream(r);
+    }
+    if (is == null) {
+      is = getClass().getResourceAsStream(r);
+    }
+    if (is == null) {
+      is = ClassLoader.getSystemResourceAsStream(r);
+    }
     if (is == null) {
       throw new MembershipConfigurationException(
           String.format("Cannot find %s", r));

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -32,7 +32,6 @@ import org.apache.geode.alerting.internal.spi.AlertingAction;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.adapter.LocalViewMessage;
-import org.apache.geode.internal.ClassPathLoader;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.OSProcess;
 import org.apache.geode.internal.net.SocketCreator;
@@ -125,9 +124,6 @@ public class MembershipDependenciesJUnitTest {
 
               // TODO:
               .or(type(OSProcess.class))
-
-              // TODO:
-              .or(type(ClassPathLoader.class))
 
               // TODO:
               .or(type(AlertingAction.class))


### PR DESCRIPTION
Look for the jgroups configuration file using regular class loaders
instead of geode-core's ClassPathLoader.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [tests already exist] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
