### PR TITLE
GEODE-7609: allow "Squash And Merge" only in GitHub

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,5 +23,5 @@ github:
     merge:   false
     # enable squash button:
     squash:  true
-    # enable rebase button:
-    rebase:  true
+    # disable rebase button:
+    rebase:  false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+---
+github:
+  enabled_merge_buttons:
+    # disable merge button:
+    merge:   false
+    # enable squash button:
+    squash:  true
+    # enable rebase button:
+    rebase:  true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ to ensure the following steps have been taken:
 
 - [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
 
-- [ ] Is your initial contribution a single, squashed commit?
+- [ ] Is your initial contribution squashed for ease of review (e.g. a single commit, or a 'refactoring' commit plus a 'fix' commit)
 
 - [ ] Does `gradlew build` run cleanly?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ to ensure the following steps have been taken:
 
 - [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
 
-- [ ] Is your initial contribution squashed for ease of review (e.g. a single commit, or a 'refactoring' commit plus a 'fix' commit)
+- [ ] Is your initial contribution squashed for ease of review (e.g. a single commit, or a 'refactoring' commit plus a 'fix' commit)?
 
 - [ ] Does `gradlew build` run cleanly?
 
@@ -17,6 +17,6 @@ to ensure the following steps have been taken:
 - [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
 
 ### Note:
-Please ensure that once the PR is submitted, check Concourse for build issues and
-submit an update to your PR as soon as possible. If you need help, please send an
-email to dev@geode.apache.org.
+After your PR is submitted, monitor the PR checks for any issues and
+submit an update to your PR as soon as possible.  If you need help,
+please send an email to dev@geode.apache.org.


### PR DESCRIPTION
DO NOT MERGE yet.  This proposal is still being discussed on the dev list and has not been voted on yet.

This PR changes GitHub settings to make "Squash and merge" the only option for merging a PR.  The other options could be used to bypass our branch protection rules requiring every commit landing on develop to have passed required PR checks.

It also updates the language in the the PR template to relax the mandate to always _initially_ create PRs from a single, squashed commit; instead emphasizing to initially create PRs in whatever way is most amenable to review (such as separating out refactor/rename commits from the actual fix).