### PR TITLE
GEODE-7617: CI failure: GeodeClientClusterManagementSSLTest. getServi…

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GeodeClientClusterManagementSSLTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GeodeClientClusterManagementSSLTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.SSL_KEYSTORE_
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTORE;
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_TRUSTSTORE_PASSWORD;
 import static org.apache.geode.management.builder.ClusterManagementServiceBuilder.buildWithCache;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -65,9 +66,11 @@ public class GeodeClientClusterManagementSSLTest {
   @Test
   public void getServiceUseClientSSLConfig() throws Exception {
     client.invoke(() -> {
-      ClusterManagementService service = buildWithCache()
-          .setCache(ClusterStartupRule.getClientCache()).build();
-      assertThat(service.isConnected()).isTrue();
+      await().untilAsserted(() -> {
+        ClusterManagementService service = buildWithCache()
+            .setCache(ClusterStartupRule.getClientCache()).build();
+        assertThat(service.isConnected()).isTrue();
+      });
     });
   }
 }


### PR DESCRIPTION
…ceUseClientSSLConfig

add an await() so that the cluster configuration service has time to
spin up.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
