### PR TITLE
GEODE-7590 - Use GCESysprep as last-step in Windows Packer build.

### DIFF
--- a/ci/images/alpine-tools/Dockerfile
+++ b/ci/images/alpine-tools/Dockerfile
@@ -16,8 +16,8 @@
 FROM openjdk:8-jdk-alpine
 
 COPY --from=google/cloud-sdk:alpine /google-cloud-sdk /google-cloud-sdk
-COPY --from=hashicorp/packer:latest /bin/packer /usr/local/bin/packer
-COPY --from=hashicorp/packer:1.3.5 /bin/packer /usr/local/bin/packer135
+#COPY --from=hashicorp/packer:latest /bin/packer /usr/local/bin/packer
+COPY --from=hashicorp/packer:1.4.5 /bin/packer /usr/local/bin/packer
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk --no-cache add \
       bash \

--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -44,9 +44,6 @@
       ]
     },
     {
-      "type": "windows-restart"
-    },
-    {
       "type": "powershell",
       "inline": [
         "$ErrorActionPreference = \"Stop\"",
@@ -61,18 +58,12 @@
       ]
     },
     {
-      "type": "windows-restart"
-    },
-    {
       "type": "powershell",
       "inline": [
         "$ErrorActionPreference = \"Stop\"",
         "Set-ExecutionPolicy Bypass -Scope Process -Force",
         "Invoke-WebRequest https://chocolatey.org/install.ps1 -UseBasicParsing | Invoke-Expression"
       ]
-    },
-    {
-      "type": "windows-restart"
     },
     {
       "type": "powershell",
@@ -104,9 +95,6 @@
       ]
     },
     {
-      "type": "windows-restart"
-    },
-    {
       "type": "powershell",
       "inline": [
 
@@ -129,7 +117,14 @@
       ]
     },
     {
-      "type": "windows-restart"
+      "type": "windows-restart",
+      "restart_timeout": "30m"
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "GCESysprep -NoShutDown"
+      ]
     }
   ]
 }

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -281,7 +281,7 @@ jobs:
         - name: attempts-log
           path: new
         - name: instance-data
-      timeout: 15m
+      timeout: 20m
       attempts: 5
       on_failure:
         task: delete_instance
@@ -560,7 +560,7 @@ jobs:
       - name: instance-data
       - name: attempts-log
         path: new
-    timeout: 15m
+    timeout: 20m
     attempts: 5
   - task: rsync_code_up
     image: alpine-tools-image
@@ -648,7 +648,7 @@ jobs:
             path: instance-data
           - name: attempts-log
             path: new
-        timeout: 15m
+        timeout: 20m
         attempts: 5
       - do:
         - task: rsync_code_up-{{java_test_version.name}}

--- a/ci/scripts/delete_instance.sh
+++ b/ci/scripts/delete_instance.sh
@@ -30,11 +30,11 @@ done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 INSTANCE_NAME="$(cat instance-data/instance-name)"
-ZONE="$(cat instance-data/zone)"
-
+PERMITTED_ZONES=($(gcloud compute zones list --filter="name~'us-central.*'" --format=json | jq -r .[].name))
 
 echo 'StrictHostKeyChecking no' >> /etc/ssh/ssh_config
 
-gcloud compute instances delete ${INSTANCE_NAME} \
-  --zone=${ZONE} \
-  --quiet || true
+# Ensure no existing instance with this name in any zone
+for KILL_ZONE in $(echo ${PERMITTED_ZONES[*]}); do
+  gcloud compute instances delete ${INSTANCE_NAME} --zone=${KILL_ZONE} --quiet &>/dev/null || true
+done


### PR DESCRIPTION
* Fix instance cleanup per zone.
* delete_instanch.sh deletes in all zones just in case.
* Ask for zones, don't assume.
* Use Packer release 1.4.5, not latest prerelease.
* Need reboot before running GCESysPrep in case of windows update.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
