### PR TITLE
GEODE-7541: Revert back to SocketCreator in GMSUtil

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
 import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.membership.HostAddress;
+import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
@@ -52,7 +53,7 @@ public class GMSUtil {
 
     try {
       if (bindAddress == null || bindAddress.trim().length() == 0) {
-        addr = InetAddress.getLocalHost();
+        addr = SocketCreator.getLocalHost();
       } else {
         addr = InetAddress.getByName(bindAddress);
       }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -33,6 +33,7 @@ import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.adapter.LocalViewMessage;
 import org.apache.geode.internal.OSProcess;
+import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.internal.util.JavaWorkarounds;
 
@@ -105,6 +106,9 @@ public class MembershipDependenciesJUnitTest {
 
               // TODO: break dependencies on locator-related classes
               .or(type(Locator.class))
+
+              // TODO:
+              .or(type(SocketCreator.class))
 
               // TODO: break dependency on internal.security
               .or(type(SecurableCommunicationChannel.class))


### PR DESCRIPTION
One of the changes for this ticket is causing unit test failures on
some machines - especially Macs - in the form of

java.lang.RuntimeException: Failed to start locator
      Caused by:
      org.apache.geode.GemFireConfigException: This process is attempting to join with a loopback address (gzhou-mbpro/127.0.0.1) using a locator that does not have a local address (/10.255.200.197:60167). On Unix this usually means that /etc/hosts is misconfigured.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
