### PR TITLE
GEODE-7545: Remove dependency on AltertingAction from membership

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -67,7 +67,6 @@ import org.jgroups.stack.IpAddress;
 import org.jgroups.util.Digest;
 import org.jgroups.util.UUID;
 
-import org.apache.geode.alerting.internal.spi.AlertingAction;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.membership.gms.GMSMemberData;
@@ -994,7 +993,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     // which is fairly rare
     msg.setFlag(Flag.DONT_BUNDLE);
 
-    if (gfmsg.isHighPriority() || AlertingAction.isThreadAlerting()) {
+    if (gfmsg.isHighPriority()) {
       msg.setFlag(Flag.OOB);
       msg.setFlag(Flag.NO_FC);
       msg.setFlag(Flag.SKIP_BARRIER);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AlertListenerMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AlertListenerMessage.java
@@ -128,6 +128,11 @@ public class AlertListenerMessage extends PooledDistributionMessage implements A
   }
 
   @Override
+  public boolean isHighPriority() {
+    return true;
+  }
+
+  @Override
   public int getDSFID() {
     return ALERT_LISTENER_MESSAGE;
   }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/MembershipDependenciesJUnitTest.java
@@ -28,7 +28,6 @@ import com.tngtech.archunit.junit.CacheMode;
 import com.tngtech.archunit.lang.ArchRule;
 import org.junit.runner.RunWith;
 
-import org.apache.geode.alerting.internal.spi.AlertingAction;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.LocatorStats;
 import org.apache.geode.distributed.internal.membership.adapter.LocalViewMessage;
@@ -114,9 +113,6 @@ public class MembershipDependenciesJUnitTest {
 
               // TODO:
               .or(type(OSProcess.class))
-
-              // TODO:
-              .or(type(AlertingAction.class))
 
               // TODO:
               .or(type(LocalViewMessage.class)));


### PR DESCRIPTION
The only place where JGroupsMessenger called AlertingAction was when
sending a message. The only message that could be sent while that thread
local is true is AlertListenerMessage.

Setting isHighPriority to true on AlertListenerMessage instead.
JGroupsMessenger is the only place that flag is checked, so this should
have the same effect as testing the thread local.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
