### PR TITLE
GEODE-7627: Moving defaults to MembershipConfig

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipOnlyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/MembershipOnlyTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.membership;
+
+import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.distributed.internal.membership.gms.MemberIdentifierFactoryImpl;
+import org.apache.geode.distributed.internal.membership.gms.api.LifecycleListener;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
+import org.apache.geode.distributed.internal.membership.gms.api.Membership;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipBuilder;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig;
+import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
+import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.admin.SSLConfig;
+import org.apache.geode.internal.net.SocketCreator;
+import org.apache.geode.internal.serialization.DSFIDSerializer;
+
+public class MembershipOnlyTest {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  private InternalLocator locator;
+  private InetAddress localHost;
+
+  @Before
+  public void before() throws IOException {
+    localHost = InetAddress.getLocalHost();
+
+    // TODO - using a geode-core locator
+    locator = InternalLocator.startLocator(0, new File(""), null, null, localHost, false,
+        new Properties(), null, temporaryFolder.getRoot().toPath());
+  }
+
+  @After
+  public void after() {
+    locator.stop();
+  }
+
+  @Test
+  public void locatorStarts() {
+    assertThat(locator.getPort()).isGreaterThan(0);
+  }
+
+  @Test
+  public void memberCanConnectToLocator() throws MemberStartupException {
+
+    final MembershipConfig config = new MembershipConfig() {
+      public String getLocators() {
+        return localHost.getHostName() + '[' + locator.getPort() + ']';
+      }
+    };
+
+    // TODO - using geode-core InternalDistributedMember
+    MemberIdentifierFactoryImpl memberIdFactory = new MemberIdentifierFactoryImpl();
+
+    // TODO - using geode-core serializer. This is needed to have be able to
+    // read InternalDistributedMember.
+    DSFIDSerializer dsfidSerializer = InternalDataSerializer.getDSFIDSerializer();
+
+    // TODO - using geode-core socket creator
+    final TcpSocketCreator socketCreator =
+        asTcpSocketCreator(new SocketCreator(new SSLConfig.Builder().build()));
+
+    TcpClient client = new TcpClient(socketCreator, dsfidSerializer.getObjectSerializer(),
+        dsfidSerializer.getObjectDeserializer());
+
+    LifecycleListener<InternalDistributedMember> lifeCycleListener = mock(LifecycleListener.class);
+
+    final Membership<InternalDistributedMember> membership =
+        MembershipBuilder.<InternalDistributedMember>newMembershipBuilder()
+            .setConfig(config)
+            .setSerializer(dsfidSerializer)
+            .setLifecycleListener(lifeCycleListener)
+            .setMemberIDFactory(memberIdFactory)
+            .setLocatorClient(client)
+            .setSocketCreator(socketCreator)
+            .create();
+
+
+    // TODO - the membership *must* be installed in the locator at this special
+    // point during membership startup for the start to succeed
+    doAnswer(invocation -> {
+      locator.getLocatorHandler().setMembership(membership);
+      return null;
+    }).when(lifeCycleListener).started();
+
+
+    membership.start();
+    assertThat(membership.getView().getMembers()).hasSize(1);
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.distributed.internal.membership;
+package org.apache.geode.distributed.internal.membership.gms;
 
 import static org.apache.geode.distributed.internal.membership.adapter.TcpSocketCreatorAdapter.asTcpSocketCreator;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.distributed.internal.membership.gms.MemberIdentifierFactoryImpl;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.gms.api.LifecycleListener;
 import org.apache.geode.distributed.internal.membership.gms.api.MemberStartupException;
 import org.apache.geode.distributed.internal.membership.gms.api.Membership;

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -118,7 +118,7 @@ public class GMSJoinLeaveJUnitTest {
   public void initMocks(boolean enableNetworkPartition, boolean useTestGMSJoinLeave)
       throws Exception {
     mockConfig = mock(ServiceConfig.class);
-    when(mockConfig.getEnableNetworkPartitionDetection()).thenReturn(enableNetworkPartition);
+    when(mockConfig.isNetworkPartitionDetectionEnabled()).thenReturn(enableNetworkPartition);
     when(mockConfig.getSecurityUDPDHAlgo()).thenReturn("");
     when(mockConfig.getStartLocator()).thenReturn("localhost[12345]");
     when(mockConfig.getLocators()).thenReturn("localhost[12345]");

--- a/geode-core/src/main/java/org/apache/geode/distributed/Locator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/Locator.java
@@ -145,7 +145,7 @@ public abstract class Locator {
    * gemfire.properties file, or equivalent system properties to fill in the gaps in its
    * configuration.
    * <p>
-   * The locator will not start a distributed system. The locator will provice peer location
+   * The locator will not start a distributed system. The locator will provide peer location
    * services only.
    *
    * @param port The port on which the locator will listen for membership information requests from
@@ -175,7 +175,7 @@ public abstract class Locator {
    * <p>
    * The locator starts a AdminDistributedSystem configured with the given properties to provide the
    * system with a long-running process that can be relied on for stable membership information. The
-   * locator will provide provide peer and cache server location services.
+   * locator will provide peer and cache server location services.
    *
    * @since GemFire 5.0
    *

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -202,6 +202,7 @@ import org.apache.geode.annotations.Immutable;
 import org.apache.geode.annotations.internal.MakeImmutable;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig;
 import org.apache.geode.internal.Config;
 import org.apache.geode.internal.ConfigSource;
 import org.apache.geode.internal.logging.LogWriterImpl;
@@ -270,7 +271,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * <p>
    * Actual value of this constant is <code>""</code>.
    */
-  String DEFAULT_NAME = "";
+  String DEFAULT_NAME = MembershipConfig.DEFAULT_NAME;
 
   /**
    * Returns the value of the {@link ConfigurationProperties#MCAST_PORT}</a> property
@@ -287,7 +288,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#MCAST_PORT} property
    */
-  int DEFAULT_MCAST_PORT = 0;
+  int DEFAULT_MCAST_PORT = MembershipConfig.DEFAULT_MCAST_PORT;
 
   /**
    * The minimum {@link ConfigurationProperties#MCAST_PORT}.
@@ -374,7 +375,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
     // Default MCast address can be just IPv4 address.
     // On IPv6 machines, JGroups converts IPv4 address to equivalent IPv6 address.
     try {
-      String ipLiteral = "239.192.81.1";
+      String ipLiteral = MembershipConfig.DEFAULT_MCAST_ADDRESS;
       return InetAddress.getByName(ipLiteral);
     } catch (UnknownHostException ex) {
       // this should never happen
@@ -400,7 +401,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#MCAST_TTL} property
    */
-  int DEFAULT_MCAST_TTL = 32;
+  int DEFAULT_MCAST_TTL = MembershipConfig.DEFAULT_MCAST_TTL;
 
   /**
    * The minimum {@link ConfigurationProperties#MCAST_TTL}.
@@ -444,7 +445,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * The default value of the {@link ConfigurationProperties#BIND_ADDRESS} property. Current value
    * is an empty string <code>""</code>
    */
-  String DEFAULT_BIND_ADDRESS = "";
+  String DEFAULT_BIND_ADDRESS = MembershipConfig.DEFAULT_BIND_ADDRESS;
 
   /**
    * Returns the value of the {@link ConfigurationProperties#SERVER_BIND_ADDRESS} property
@@ -500,7 +501,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#LOCATORS} property
    */
-  String DEFAULT_LOCATORS = "";
+  String DEFAULT_LOCATORS = MembershipConfig.DEFAULT_LOCATORS;
 
   /**
    * Locator wait time - how long to wait for a locator to start before giving up & throwing a
@@ -509,7 +510,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttribute(type = Integer.class)
   String LOCATOR_WAIT_TIME_NAME = LOCATOR_WAIT_TIME;
 
-  int DEFAULT_LOCATOR_WAIT_TIME = 0;
+  int DEFAULT_LOCATOR_WAIT_TIME = MembershipConfig.DEFAULT_LOCATOR_WAIT_TIME;
 
   @ConfigAttributeGetter(name = LOCATOR_WAIT_TIME)
   int getLocatorWaitTime();
@@ -541,7 +542,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#START_LOCATOR} property
    */
-  String DEFAULT_START_LOCATOR = "";
+  String DEFAULT_START_LOCATOR = MembershipConfig.DEFAULT_START_LOCATOR;
 
   /**
    * Returns the value of the {@link ConfigurationProperties#DEPLOY_WORKING_DIR} property
@@ -813,7 +814,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * <p>
    * Actual value of this constant is <code>15</code> seconds.
    */
-  int DEFAULT_ACK_WAIT_THRESHOLD = 15;
+  int DEFAULT_ACK_WAIT_THRESHOLD = MembershipConfig.DEFAULT_ACK_WAIT_THRESHOLD;
   /**
    * The minimum {@link ConfigurationProperties#ACK_WAIT_THRESHOLD}.
    * <p>
@@ -850,7 +851,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * <p>
    * Actual value of this constant is <code>0</code> seconds, which turns off shunning.
    */
-  int DEFAULT_ACK_SEVERE_ALERT_THRESHOLD = 0;
+  int DEFAULT_ACK_SEVERE_ALERT_THRESHOLD = MembershipConfig.DEFAULT_ACK_SEVERE_ALERT_THRESHOLD;
   /**
    * The minimum {@link ConfigurationProperties#ACK_SEVERE_ALERT_THRESHOLD}.
    * <p>
@@ -1428,7 +1429,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value for {@link ConfigurationProperties#MCAST_SEND_BUFFER_SIZE} property
    */
-  int DEFAULT_MCAST_SEND_BUFFER_SIZE = 65535;
+  int DEFAULT_MCAST_SEND_BUFFER_SIZE = MembershipConfig.DEFAULT_MCAST_SEND_BUFFER_SIZE;
 
   /**
    * The minimum size of the {@link ConfigurationProperties#MCAST_SEND_BUFFER_SIZE}, in bytes.
@@ -1458,7 +1459,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#MCAST_RECV_BUFFER_SIZE} property
    */
-  int DEFAULT_MCAST_RECV_BUFFER_SIZE = 1048576;
+  int DEFAULT_MCAST_RECV_BUFFER_SIZE = MembershipConfig.DEFAULT_MCAST_RECV_BUFFER_SIZE;
 
   /**
    * The minimum size of the {@link ConfigurationProperties#MCAST_RECV_BUFFER_SIZE}, in bytes.
@@ -1495,7 +1496,10 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * The default value of the {@link ConfigurationProperties#MCAST_FLOW_CONTROL} property
    */
   @Immutable
-  FlowControlParams DEFAULT_MCAST_FLOW_CONTROL = new FlowControlParams(1048576, (float) 0.25, 5000);
+  FlowControlParams DEFAULT_MCAST_FLOW_CONTROL = new FlowControlParams(
+      MembershipConfig.DEFAULT_MCAST_BYTE_ALLOWANCE,
+      MembershipConfig.DEFAULT_MCAST_RECHARGE_THRESHOLD,
+      MembershipConfig.DEFAULT_MCAST_RECHARGE_BLOCKING_MS);
 
   /**
    * The minimum byteAllowance for the{@link ConfigurationProperties#MCAST_FLOW_CONTROL} setting of
@@ -1542,7 +1546,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#UDP_FRAGMENT_SIZE} property
    */
-  int DEFAULT_UDP_FRAGMENT_SIZE = 60000;
+  int DEFAULT_UDP_FRAGMENT_SIZE = MembershipConfig.DEFAULT_UDP_FRAGMENT_SIZE;
 
   /**
    * The minimum allowed {@link ConfigurationProperties#UDP_FRAGMENT_SIZE} setting of 1000
@@ -1575,7 +1579,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#UDP_SEND_BUFFER_SIZE} property
    */
-  int DEFAULT_UDP_SEND_BUFFER_SIZE = 65535;
+  int DEFAULT_UDP_SEND_BUFFER_SIZE = MembershipConfig.DEFAULT_UDP_SEND_BUFFER_SIZE;
 
   /**
    * The minimum size of the {@link ConfigurationProperties#UDP_SEND_BUFFER_SIZE}, in bytes.
@@ -1605,7 +1609,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#UDP_RECV_BUFFER_SIZE} property
    */
-  int DEFAULT_UDP_RECV_BUFFER_SIZE = 1048576;
+  int DEFAULT_UDP_RECV_BUFFER_SIZE = MembershipConfig.DEFAULT_UDP_RECV_BUFFER_SIZE;
 
   /**
    * The default size of the {@link ConfigurationProperties#UDP_RECV_BUFFER_SIZE} if tcp/ip sockets
@@ -1647,7 +1651,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#DISABLE_TCP} property
    */
-  boolean DEFAULT_DISABLE_TCP = false;
+  boolean DEFAULT_DISABLE_TCP = MembershipConfig.DEFAULT_DISABLE_TCP;
 
   /**
    * Returns the value of the {@link ConfigurationProperties#DISABLE_JMX} property
@@ -1833,7 +1837,8 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    */
   @ConfigAttribute(type = Boolean.class)
   String ENABLE_NETWORK_PARTITION_DETECTION_NAME = ENABLE_NETWORK_PARTITION_DETECTION;
-  boolean DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION = true;
+  boolean DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION =
+      MembershipConfig.DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION;
 
   /**
    * Get the value of the {@link ConfigurationProperties#MEMBER_TIMEOUT} property
@@ -1850,7 +1855,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#MEMBER_TIMEOUT} property
    */
-  int DEFAULT_MEMBER_TIMEOUT = 5000;
+  int DEFAULT_MEMBER_TIMEOUT = MembershipConfig.DEFAULT_MEMBER_TIMEOUT;
 
   /**
    * The minimum {@link ConfigurationProperties#MEMBER_TIMEOUT} setting of 1000 milliseconds
@@ -1876,7 +1881,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   String RESTRICT_MEMBERSHIP_PORT_RANGE = GEMFIRE_PREFIX + "use-ephemeral-ports";
 
   @MakeImmutable
-  int[] DEFAULT_MEMBERSHIP_PORT_RANGE = new int[] {41000, 61000};
+  int[] DEFAULT_MEMBERSHIP_PORT_RANGE = MembershipConfig.DEFAULT_MEMBERSHIP_PORT_RANGE;
 
   @ConfigAttributeGetter(name = MEMBERSHIP_PORT_RANGE)
   int[] getMembershipPortRange();
@@ -1928,7 +1933,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#ROLES} property
    */
-  String DEFAULT_ROLES = "";
+  String DEFAULT_ROLES = MembershipConfig.DEFAULT_ROLES;
 
   /**
    * The name of the {@link ConfigurationProperties#MAX_WAIT_TIME_RECONNECT} property
@@ -2216,7 +2221,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * <p>
    * Actual value of this constant is <code>""</code>.
    */
-  String DEFAULT_DURABLE_CLIENT_ID = "";
+  String DEFAULT_DURABLE_CLIENT_ID = MembershipConfig.DEFAULT_DURABLE_CLIENT_ID;
 
   /**
    * Returns the value of the {@link ConfigurationProperties#DURABLE_CLIENT_TIMEOUT} property.
@@ -2241,7 +2246,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * <p>
    * Actual value of this constant is <code>"300"</code>.
    */
-  int DEFAULT_DURABLE_CLIENT_TIMEOUT = 300;
+  int DEFAULT_DURABLE_CLIENT_TIMEOUT = MembershipConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT;
 
   /**
    * Returns user module name for client authentication initializer in
@@ -2408,7 +2413,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * Actual value of this is one of the available symmetric algorithm names in JDK like "AES:128" or
    * "Blowfish".
    */
-  String DEFAULT_SECURITY_UDP_DHALGO = "";
+  String DEFAULT_SECURITY_UDP_DHALGO = MembershipConfig.DEFAULT_SECURITY_UDP_DHALGO;
 
   /**
    * Returns user defined method name for peer authentication initializer in
@@ -2434,7 +2439,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * <p>
    * Actual value of this is fully qualified <code>"method name"</code>.
    */
-  String DEFAULT_SECURITY_PEER_AUTH_INIT = "";
+  String DEFAULT_SECURITY_PEER_AUTH_INIT = MembershipConfig.DEFAULT_SECURITY_PEER_AUTH_INIT;
 
   /**
    * Returns user defined method name authenticating peer's credentials in
@@ -2608,7 +2613,9 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default peer membership check timeout is 1 second.
    */
-  int DEFAULT_SECURITY_PEER_VERIFYMEMBER_TIMEOUT = 1000;
+  int DEFAULT_SECURITY_PEER_VERIFYMEMBER_TIMEOUT =
+      MembershipConfig.DEFAULT_SECURITY_PEER_VERIFYMEMBER_TIMEOUT;
+
 
   /**
    * Max membership timeout must be less than max peer handshake timeout. Currently this is set to
@@ -2649,7 +2656,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
 
   /**
    * Returns the value of
-   * {@link ConfigurationProperties#SSECURITY_AUTH_TOKEN_ENABLED_COMPONENTS} property
+   * {@link ConfigurationProperties#SECURITY_AUTH_TOKEN_ENABLED_COMPONENTS} property
    */
   @ConfigAttributeGetter(name = SECURITY_AUTH_TOKEN_ENABLED_COMPONENTS)
   String[] getSecurityAuthTokenEnabledComponents();
@@ -2865,7 +2872,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    *
    * @since GemFire 7.0
    */
-  String DEFAULT_GROUPS = "";
+  String DEFAULT_GROUPS = MembershipConfig.DEFAULT_GROUPS;
 
   /**
    * Any cleanup required before closing the distributed system
@@ -4051,7 +4058,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#DISABLE_AUTO_RECONNECT} property
    */
-  boolean DEFAULT_DISABLE_AUTO_RECONNECT = false;
+  boolean DEFAULT_DISABLE_AUTO_RECONNECT = MembershipConfig.DEFAULT_DISABLE_AUTO_RECONNECT;
 
   /**
    * Gets the value of {@link ConfigurationProperties#DISABLE_AUTO_RECONNECT}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/ServiceConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/ServiceConfig.java
@@ -15,8 +15,6 @@
 package org.apache.geode.distributed.internal.membership.adapter;
 
 
-import java.net.InetAddress;
-
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
@@ -24,6 +22,10 @@ import org.apache.geode.distributed.internal.membership.gms.api.MembershipConfig
 import org.apache.geode.internal.admin.remote.RemoteTransportConfig;
 import org.apache.geode.internal.net.SocketCreator;
 
+/**
+ * This is a MembershipConfig built from the Geode core RemoteTransportConfig and
+ * DistributionConfig objects.
+ */
 public class ServiceConfig implements MembershipConfig {
 
   /** various settings from Geode configuration */
@@ -77,7 +79,8 @@ public class ServiceConfig implements MembershipConfig {
     memberTimeout = theConfig.getMemberTimeout();
 
     int configuredLossThreshold =
-        Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "network-partition-threshold", 51);
+        Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "network-partition-threshold",
+            DEFAULT_LOSS_THRESHOLD);
     if (configuredLossThreshold < 51) {
       lossThreshold = 51;
     } else if (configuredLossThreshold > 100) {
@@ -86,7 +89,8 @@ public class ServiceConfig implements MembershipConfig {
       lossThreshold = configuredLossThreshold;
     }
 
-    memberWeight = Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "member-weight", 0);
+    memberWeight = Integer.getInteger(DistributionConfig.GEMFIRE_PREFIX + "member-weight",
+        DEFAULT_MEMBER_WEIGHT);
     locatorWaitTime = theConfig.getLocatorWaitTime();
 
     networkPartitionDetectionEnabled = theConfig.getEnableNetworkPartitionDetection();
@@ -193,7 +197,6 @@ public class ServiceConfig implements MembershipConfig {
     return dconfig.getStartLocator();
   }
 
-  @Override
   public boolean getEnableNetworkPartitionDetection() {
     return dconfig.getEnableNetworkPartitionDetection();
   }
@@ -239,8 +242,8 @@ public class ServiceConfig implements MembershipConfig {
   }
 
   @Override
-  public InetAddress getMcastAddress() {
-    return dconfig.getMcastAddress();
+  public String getMcastAddress() {
+    return dconfig.getMcastAddress().getHostAddress();
   }
 
   @Override
@@ -311,16 +314,6 @@ public class ServiceConfig implements MembershipConfig {
   @Override
   public int getVmKind() {
     return transport.getVmKind();
-  }
-
-  @Override
-  public boolean isMcastEnabled() {
-    return transport.isMcastEnabled();
-  }
-
-  @Override
-  public boolean isTcpDisabled() {
-    return transport.isTcpDisabled();
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/AuthenticatorNoOp.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/AuthenticatorNoOp.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.membership.gms;
+
+import java.util.Properties;
+
+import org.apache.geode.distributed.internal.membership.gms.api.Authenticator;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+
+public class AuthenticatorNoOp<ID extends MemberIdentifier> implements Authenticator<ID> {
+  @Override
+  public String authenticate(final ID member, final Properties credentials) {
+    return null;
+  }
+
+  @Override
+  public Properties getCredentials(final ID member) {
+    return null;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -208,7 +208,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
   }
 
   private int membershipCheckTimeout =
-      DistributionConfig.DEFAULT_SECURITY_PEER_VERIFYMEMBER_TIMEOUT;
+      MembershipConfig.DEFAULT_SECURITY_PEER_VERIFYMEMBER_TIMEOUT;
 
   /**
    * This object synchronizes threads waiting for startup to finish. Updates to

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/LifecycleListenerNoOp.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/LifecycleListenerNoOp.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.membership.gms;
+
+import org.apache.geode.distributed.internal.membership.gms.api.LifecycleListener;
+import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+
+public class LifecycleListenerNoOp<ID extends MemberIdentifier> implements LifecycleListener<ID> {
+  @Override
+  public void start(final ID memberID) {
+
+  }
+
+  @Override
+  public boolean disconnect(final Exception exception) {
+    return false;
+  }
+
+  @Override
+  public void setLocalAddress(final ID address) {
+
+  }
+
+  @Override
+  public void destroyMember(final ID member, final String reason) {
+
+  }
+
+  @Override
+  public void started() {
+
+  }
+
+  @Override
+  public void forcedDisconnect() {
+
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
@@ -33,14 +33,15 @@ import org.apache.geode.internal.serialization.DSFIDSerializer;
 public class MembershipBuilderImpl<ID extends MemberIdentifier> implements MembershipBuilder<ID> {
   private TcpSocketCreator socketCreator;
   private TcpClient locatorClient;
-  private MembershipListener<ID> membershipListener;
-  private MessageListener<ID> messageListener;
-  private MembershipStatistics statistics;
-  private Authenticator<ID> authenticator;
-  private MembershipConfig membershipConfig;
+  private MembershipListener<ID> membershipListener = new MembershipListenerNoOp();
+  private MessageListener<ID> messageListener = message -> {
+  };
+  private MembershipStatistics statistics = new MembershipStatisticsNoOp();
+  private Authenticator<ID> authenticator = new AuthenticatorNoOp();
+  private MembershipConfig membershipConfig = new MembershipConfig() {};
   private DSFIDSerializer serializer;
   private MemberIdentifierFactory<ID> memberFactory;
-  private LifecycleListener<ID> lifecycleListener;
+  private LifecycleListener<ID> lifecycleListener = new LifecycleListenerNoOp();
 
   public MembershipBuilderImpl() {}
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipListenerNoOp.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipListenerNoOp.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.membership.gms;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.geode.distributed.internal.membership.gms.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipListener;
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipView;
+
+public class MembershipListenerNoOp<ID extends MemberIdentifier> implements MembershipListener<ID> {
+  @Override
+  public void viewInstalled(final MembershipView<ID> view) {
+
+  }
+
+  @Override
+  public void quorumLost(final Set<ID> failures, final List<ID> remainingMembers) {
+
+  }
+
+  @Override
+  public void newMemberConnected(final ID m) {
+
+  }
+
+  @Override
+  public void memberDeparted(final ID id, final boolean crashed, final String reason) {
+
+  }
+
+  @Override
+  public void memberSuspect(final ID suspect, final ID whoSuspected, final String reason) {
+
+  }
+
+  @Override
+  public void membershipFailure(final String reason, final Throwable t) {
+
+  }
+
+  @Override
+  public void saveConfig() {
+
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipStatisticsNoOp.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipStatisticsNoOp.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal.membership.gms;
+
+import org.apache.geode.distributed.internal.membership.gms.api.MembershipStatistics;
+
+public class MembershipStatisticsNoOp implements MembershipStatistics {
+  @Override
+  public long startMsgSerialization() {
+    return 0;
+  }
+
+  @Override
+  public void endMsgSerialization(final long start) {
+
+  }
+
+  @Override
+  public long startUDPMsgEncryption() {
+    return 0;
+  }
+
+  @Override
+  public void endUDPMsgEncryption(final long start) {
+
+  }
+
+  @Override
+  public long startUDPMsgDecryption() {
+    return 0;
+  }
+
+  @Override
+  public void endUDPMsgDecryption(final long start) {
+
+  }
+
+  @Override
+  public long startMsgDeserialization() {
+    return 0;
+  }
+
+  @Override
+  public void endMsgDeserialization(final long start) {
+
+  }
+
+  @Override
+  public void incSentBytes(final long bytes) {
+
+  }
+
+  @Override
+  public long startUDPDispatchRequest() {
+    return 0;
+  }
+
+  @Override
+  public void endUDPDispatchRequest(final long start) {
+
+  }
+
+  @Override
+  public void incUcastWriteBytes(final int bytesWritten) {
+
+  }
+
+  @Override
+  public void incUcastReadBytes(final int amount) {
+
+  }
+
+  @Override
+  public void incMcastWriteBytes(final int bytesWritten) {
+
+  }
+
+  @Override
+  public void incMcastReadBytes(final int amount) {
+
+  }
+
+  @Override
+  public void incUcastRetransmits() {
+
+  }
+
+  @Override
+  public void incMcastRetransmits() {
+
+  }
+
+  @Override
+  public void incMcastRetransmitRequests() {
+
+  }
+
+  @Override
+  public void incHeartbeatRequestsSent() {
+
+  }
+
+  @Override
+  public void incHeartbeatRequestsReceived() {
+
+  }
+
+  @Override
+  public void incHeartbeatsSent() {
+
+  }
+
+  @Override
+  public void incHeartbeatsReceived() {
+
+  }
+
+  @Override
+  public void incSuspectsSent() {
+
+  }
+
+  @Override
+  public void incSuspectsReceived() {
+
+  }
+
+  @Override
+  public void incFinalCheckRequestsSent() {
+
+  }
+
+  @Override
+  public void incFinalCheckRequestsReceived() {
+
+  }
+
+  @Override
+  public void incFinalCheckResponsesSent() {
+
+  }
+
+  @Override
+  public void incFinalCheckResponsesReceived() {
+
+  }
+
+  @Override
+  public void incTcpFinalCheckRequestsSent() {
+
+  }
+
+  @Override
+  public void incTcpFinalCheckRequestsReceived() {
+
+  }
+
+  @Override
+  public void incTcpFinalCheckResponsesSent() {
+
+  }
+
+  @Override
+  public void incTcpFinalCheckResponsesReceived() {
+
+  }
+
+  @Override
+  public void incUdpFinalCheckRequestsSent() {
+
+  }
+
+  @Override
+  public long getUdpFinalCheckRequestsSent() {
+    return 0;
+  }
+
+  @Override
+  public void incUdpFinalCheckResponsesReceived() {
+
+  }
+
+  @Override
+  public long getHeartbeatRequestsReceived() {
+    return 0;
+  }
+
+  @Override
+  public long getHeartbeatsSent() {
+    return 0;
+  }
+
+  @Override
+  public long getSuspectsSent() {
+    return 0;
+  }
+
+  @Override
+  public long getSuspectsReceived() {
+    return 0;
+  }
+
+  @Override
+  public long getFinalCheckRequestsSent() {
+    return 0;
+  }
+
+  @Override
+  public long getFinalCheckRequestsReceived() {
+    return 0;
+  }
+
+  @Override
+  public long getFinalCheckResponsesSent() {
+    return 0;
+  }
+
+  @Override
+  public long getFinalCheckResponsesReceived() {
+    return 0;
+  }
+
+  @Override
+  public long getTcpFinalCheckRequestsSent() {
+    return 0;
+  }
+
+  @Override
+  public long getTcpFinalCheckRequestsReceived() {
+    return 0;
+  }
+
+  @Override
+  public long getTcpFinalCheckResponsesSent() {
+    return 0;
+  }
+
+  @Override
+  public long getTcpFinalCheckResponsesReceived() {
+    return 0;
+  }
+
+  @Override
+  public long getHeartbeatRequestsSent() {
+    return 0;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/api/MembershipConfig.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.distributed.internal.membership.gms.api;
 
-import java.net.InetAddress;
 
+import org.apache.geode.annotations.internal.MakeImmutable;
 import org.apache.geode.distributed.internal.DistributionConfig;
 
 public interface MembershipConfig {
@@ -25,89 +25,201 @@ public interface MembershipConfig {
   /** in a small cluster we might want to involve all members in operations */
   int SMALL_CLUSTER_SIZE = 9;
 
-  boolean isReconnecting();
+  @MakeImmutable
+  int[] DEFAULT_MEMBERSHIP_PORT_RANGE = {41000, 61000};
 
-  int getLocatorWaitTime();
+  int DEFAULT_LOCATOR_WAIT_TIME = 0;
+  String DEFAULT_SECURITY_UDP_DHALGO = "";
+  int DEFAULT_UDP_FRAGMENT_SIZE = 60000;
+  String DEFAULT_START_LOCATOR = "";
+  int DEFAULT_MEMBER_TIMEOUT = 5000;
+  int DEFAULT_LOSS_THRESHOLD = 51;
+  int DEFAULT_MEMBER_WEIGHT = 0;
+  boolean DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION = true;
+  int DEFAULT_MCAST_PORT = 0;
+  String DEFAULT_LOCATORS = "";
+  String DEFAULT_BIND_ADDRESS = "";
+  String DEFAULT_SECURITY_PEER_AUTH_INIT = "";
+  boolean DEFAULT_DISABLE_TCP = false;
+  String DEFAULT_NAME = "";
+  String DEFAULT_ROLES = "";
+  String DEFAULT_GROUPS = "";
+  String DEFAULT_DURABLE_CLIENT_ID = "";
+  int DEFAULT_DURABLE_CLIENT_TIMEOUT = 300;
+  String DEFAULT_MCAST_ADDRESS = "239.192.81.1";
+  int DEFAULT_MCAST_TTL = 32;
+  int DEFAULT_MCAST_SEND_BUFFER_SIZE = 65535;
+  int DEFAULT_MCAST_RECV_BUFFER_SIZE = 1048576;
+  int DEFAULT_UDP_RECV_BUFFER_SIZE = 1048576;
+  int DEFAULT_UDP_SEND_BUFFER_SIZE = 65535;
+  int DEFAULT_MCAST_BYTE_ALLOWANCE = 1048576;
+  float DEFAULT_MCAST_RECHARGE_THRESHOLD = (float) 0.25;
+  int DEFAULT_MCAST_RECHARGE_BLOCKING_MS = 5000;
+  int DEFAULT_ACK_WAIT_THRESHOLD = 51;
+  boolean DEFAULT_DISABLE_AUTO_RECONNECT = false;
+  int DEFAULT_SECURITY_PEER_VERIFYMEMBER_TIMEOUT = 1000;
+  int DEFAULT_ACK_SEVERE_ALERT_THRESHOLD = 0;
+  Object DEFAULT_OLD_MEMBERSHIP_INFO = null;
+  boolean DEFAULT_IS_RECONNECTING_DS = false;
+  int DEFAULT_JOIN_TIMEOUT = 24000;
 
-  long getJoinTimeout();
+  default boolean isReconnecting() {
+    return false;
+  }
 
-  int[] getMembershipPortRange();
+  default int getLocatorWaitTime() {
+    return DEFAULT_LOCATOR_WAIT_TIME;
+  }
 
-  long getMemberTimeout();
+  default long getJoinTimeout() {
+    return DEFAULT_JOIN_TIMEOUT;
+  }
 
-  int getLossThreshold();
+  default int[] getMembershipPortRange() {
+    return DEFAULT_MEMBERSHIP_PORT_RANGE;
+  }
 
-  int getMemberWeight();
+  default long getMemberTimeout() {
+    return DEFAULT_MEMBER_TIMEOUT;
+  }
 
-  boolean isMulticastEnabled();
+  default int getLossThreshold() {
+    return DEFAULT_LOSS_THRESHOLD;
+  }
 
-  boolean isNetworkPartitionDetectionEnabled();
+  default int getMemberWeight() {
+    return DEFAULT_MEMBER_WEIGHT;
+  }
 
-  boolean isUDPSecurityEnabled();
+  default boolean isMulticastEnabled() {
+    return getMcastPort() > 0;
+  }
 
-  boolean areLocatorsPreferredAsCoordinators();
+  default boolean isNetworkPartitionDetectionEnabled() {
+    return DEFAULT_ENABLE_NETWORK_PARTITION_DETECTION;
+  }
 
-  String getSecurityUDPDHAlgo();
+  default boolean isUDPSecurityEnabled() {
+    return !getSecurityUDPDHAlgo().isEmpty();
+  }
 
-  int getMcastPort();
+  default boolean areLocatorsPreferredAsCoordinators() {
+    return isNetworkPartitionDetectionEnabled();
+  }
 
-  String getLocators();
+  default String getSecurityUDPDHAlgo() {
+    return DEFAULT_SECURITY_UDP_DHALGO;
+  }
 
-  String getStartLocator();
+  default int getMcastPort() {
+    return DEFAULT_MCAST_PORT;
+  }
 
-  boolean getEnableNetworkPartitionDetection();
+  default String getLocators() {
+    return DEFAULT_LOCATORS;
+  }
 
-  String getBindAddress();
+  default String getStartLocator() {
+    return DEFAULT_START_LOCATOR;
+  }
 
-  String getSecurityPeerAuthInit();
+  default String getBindAddress() {
+    return DEFAULT_BIND_ADDRESS;
+  };
 
-  boolean getDisableTcp();
+  default String getSecurityPeerAuthInit() {
+    return DEFAULT_SECURITY_PEER_AUTH_INIT;
+  }
 
-  String getName();
+  default boolean getDisableTcp() {
+    return DEFAULT_DISABLE_TCP;
+  }
 
-  String getRoles();
+  default String getName() {
+    return DEFAULT_NAME;
+  }
 
-  String getGroups();
+  default String getRoles() {
+    return DEFAULT_ROLES;
+  }
 
-  String getDurableClientId();
+  default String getGroups() {
+    return DEFAULT_GROUPS;
+  }
 
-  int getDurableClientTimeout();
+  default String getDurableClientId() {
+    return DEFAULT_DURABLE_CLIENT_ID;
+  }
 
-  InetAddress getMcastAddress();
+  default int getDurableClientTimeout() {
+    return DEFAULT_DURABLE_CLIENT_TIMEOUT;
+  }
 
-  int getMcastTtl();
+  default String getMcastAddress() {
+    return DEFAULT_MCAST_ADDRESS;
+  }
 
-  int getMcastSendBufferSize();
+  default int getMcastTtl() {
+    return DEFAULT_MCAST_TTL;
+  }
 
-  int getMcastRecvBufferSize();
+  default int getMcastSendBufferSize() {
+    return DEFAULT_MCAST_SEND_BUFFER_SIZE;
+  }
 
-  int getUdpFragmentSize();
+  default int getMcastRecvBufferSize() {
+    return DEFAULT_MCAST_RECV_BUFFER_SIZE;
+  }
 
-  int getUdpRecvBufferSize();
+  default int getUdpFragmentSize() {
+    return DEFAULT_UDP_FRAGMENT_SIZE;
+  }
 
-  int getUdpSendBufferSize();
+  default int getUdpRecvBufferSize() {
+    return DEFAULT_UDP_RECV_BUFFER_SIZE;
+  }
 
-  int getMcastByteAllowance();
+  default int getUdpSendBufferSize() {
+    return DEFAULT_UDP_SEND_BUFFER_SIZE;
+  }
 
-  float getMcastRechargeThreshold();
+  default int getMcastByteAllowance() {
+    return DEFAULT_MCAST_BYTE_ALLOWANCE;
+  }
 
-  int getMcastRechargeBlockMs();
+  default float getMcastRechargeThreshold() {
+    return DEFAULT_MCAST_RECHARGE_THRESHOLD;
+  }
 
-  long getAckWaitThreshold();
+  default int getMcastRechargeBlockMs() {
+    return DEFAULT_MCAST_RECHARGE_BLOCKING_MS;
+  }
 
-  boolean getDisableAutoReconnect();
+  default long getAckWaitThreshold() {
+    return DEFAULT_ACK_WAIT_THRESHOLD;
+  }
 
-  int getSecurityPeerMembershipTimeout();
+  default boolean getDisableAutoReconnect() {
+    return DEFAULT_DISABLE_AUTO_RECONNECT;
+  }
 
-  long getAckSevereAlertThreshold();
+  default int getSecurityPeerMembershipTimeout() {
+    return DEFAULT_SECURITY_PEER_VERIFYMEMBER_TIMEOUT;
+  }
 
-  int getVmKind();
+  default long getAckSevereAlertThreshold() {
+    return DEFAULT_ACK_SEVERE_ALERT_THRESHOLD;
+  }
 
-  boolean isMcastEnabled();
+  default int getVmKind() {
+    return MemberIdentifier.NORMAL_DM_TYPE;
+  }
 
-  boolean isTcpDisabled();
+  default Object getOldDSMembershipInfo() {
+    return DEFAULT_OLD_MEMBERSHIP_INFO;
+  }
 
-  Object getOldDSMembershipInfo();
-
-  boolean getIsReconnectingDS();
+  default boolean getIsReconnectingDS() {
+    return DEFAULT_IS_RECONNECTING_DS;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1853,7 +1853,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
     this.viewAckTimeout = ackCollectionTimeout;
 
     this.quorumRequired =
-        config.getEnableNetworkPartitionDetection();
+        config.isNetworkPartitionDetectionEnabled();
 
     String bindAddr = config.getBindAddress();
     locators = GMSUtil.parseLocators(config.getLocators(), bindAddr);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -200,14 +200,13 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
 
     MembershipConfig config = services.getConfig();
 
-
-    boolean enableNetworkPartitionDetection = config.getEnableNetworkPartitionDetection();
+    boolean enableNetworkPartitionDetection = config.isNetworkPartitionDetectionEnabled();
     System.setProperty("jgroups.resolve_dns", String.valueOf(!enableNetworkPartitionDetection));
 
     InputStream is = null;
 
     String r;
-    if (config.isMcastEnabled()) {
+    if (config.isMulticastEnabled()) {
       r = JGROUPS_MCAST_CONFIG_FILE_NAME;
     } else {
       r = DEFAULT_JGROUPS_TCP_CONFIG;
@@ -249,12 +248,11 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
       properties = properties.substring(commentEnd + 3);
     }
 
-
-    if (config.isMcastEnabled()) {
+    if (config.isMulticastEnabled()) {
       properties = replaceStrings(properties, "MCAST_PORT",
           String.valueOf(config.getMcastPort()));
       properties =
-          replaceStrings(properties, "MCAST_ADDRESS", config.getMcastAddress().getHostAddress());
+          replaceStrings(properties, "MCAST_ADDRESS", config.getMcastAddress());
       properties = replaceStrings(properties, "MCAST_TTL", String.valueOf(config.getMcastTtl()));
       properties = replaceStrings(properties, "MCAST_SEND_BUFFER_SIZE",
           String.valueOf(config.getMcastSendBufferSize()));
@@ -266,7 +264,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
           String.valueOf(config.getUdpFragmentSize() - 256));
     }
 
-    if (config.isMcastEnabled() || config.isTcpDisabled()
+    if (config.isMulticastEnabled() || config.getDisableTcp()
         || (config.getUdpRecvBufferSize() != DistributionConfig.DEFAULT_UDP_RECV_BUFFER_SIZE)) {
       properties =
           replaceStrings(properties, "UDP_RECV_BUFFER_SIZE", "" + config.getUdpRecvBufferSize());
@@ -561,7 +559,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
         -1 /* directport */, -1 /* viewID */, config.getName(),
         GMSUtil.parseGroups(config.getRoles(), config.getGroups()), config.getDurableClientId(),
         config.getDurableClientTimeout(),
-        config.getEnableNetworkPartitionDetection(), isLocator,
+        config.isNetworkPartitionDetectionEnabled(), isLocator,
         Version.getCurrentVersion().ordinal(),
         jgAddress.getUUIDMsbs(), jgAddress.getUUIDLsbs(),
         (byte) (services.getConfig().getMemberWeight() & 0xff));
@@ -695,7 +693,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     boolean allDestinations = msg.forAll();
 
     boolean useMcast = false;
-    if (services.getConfig().isMcastEnabled()) {
+    if (services.getConfig().isMulticastEnabled()) {
       if (msg.getMulticast() || allDestinations) {
         useMcast = services.getManager().isMulticastAllowed();
       }


### PR DESCRIPTION
Moving the defaults of membership related settings to the
MembershipConfig class, and referencing them from DistributionConfig.
This makes it easier to create a Membership with the correct default
values.

Adding default implementations of many of the Membership colaborators,
such as AuthenticatorNoOp and MembershipStatisticsNoOp.

Adding a test of creating a Membership using only membership classes.
This test still has several TODOs related to core classes which were
necessary or helpful to make this work.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
