### PR TITLE
GEOE-7617: Retry awaits in GeodeClientClusterManagementSSLTest

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GeodeClientClusterManagementSSLTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/GeodeClientClusterManagementSSLTest.java
@@ -67,9 +67,13 @@ public class GeodeClientClusterManagementSSLTest {
   public void getServiceUseClientSSLConfig() throws Exception {
     client.invoke(() -> {
       await().untilAsserted(() -> {
-        ClusterManagementService service = buildWithCache()
-            .setCache(ClusterStartupRule.getClientCache()).build();
-        assertThat(service.isConnected()).isTrue();
+        try {
+          ClusterManagementService service = buildWithCache()
+              .setCache(ClusterStartupRule.getClientCache()).build();
+          assertThat(service.isConnected()).isTrue();
+        } catch (IllegalStateException e) {
+          throw new AssertionError(e);
+        }
       });
     });
   }


### PR DESCRIPTION
This test had an awaitility clause, but it fails because within the
clause an IllegalStateException was thrown, which is not handled by
awaitility.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
