### PR TITLE
GEODE-7581: Run SSL Benchmarks with JDK11

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -24,7 +24,7 @@ benchmarks:
     flag: ''
     options: ''
   - title: '_with_ssl'
-    flag: '-PwithSsl'
+    flag: '-PwithSsl -PtestJVM=/usr/lib/jvm/java-11-openjdk-amd64/'
     options: '--tests=*GetBenchmark --tests=*PutBenchmark'
   - title: '_with_security_manager'
     flag: '-PwithSecurityManager'

--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -17,7 +17,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e -o pipefail
+set -e -x -o pipefail
 
 BASE_DIR=$(pwd)
 


### PR DESCRIPTION
Running SSL benchmarks with JDK12 improves their stability. This change
only supports using JDK11 as an alternative JDK since each different JDK
option that Benchmarks supports would have to be installed individually
on the cluster.

* Add flag to SSL Benchmark jinja variables for using JDK11
* Use jdk11 baked into the image

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
