### PR TITLE
GEODE-7623: Preventing recursion in alert generation

### DIFF
--- a/geode-log4j/src/main/java/org/apache/geode/alerting/log4j/internal/impl/AlertAppender.java
+++ b/geode-log4j/src/main/java/org/apache/geode/alerting/log4j/internal/impl/AlertAppender.java
@@ -149,7 +149,7 @@ public class AlertAppender extends AbstractAppender
       LOGGER.trace("Skipping append of {} because {} is alerting.", event, Thread.currentThread());
       return;
     }
-    AlertingAction.execute(() -> doAppend(event));
+    doAppend(event);
   }
 
   private void doAppend(final LogEvent event) {


### PR DESCRIPTION
After the change to send alerts in a executor, there was a possibiltiy for
sending alerts to generate new alerts, resulting an in infinite loop.

Setting the AlertingAction threadlocal in the executor thread that is sending
alerts, to prevent recursion.

Adding a test that we do not generate recursive alert messages.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
