### PR TITLE
GEODE-7600-2: ConnectionPoolDUnitTest Cleanup.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolAutoDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolAutoDUnitTest.java
@@ -14,40 +14,26 @@
  */
 package org.apache.geode.cache;
 
-import static org.junit.runners.MethodSorters.NAME_ASCENDING;
-
-import org.junit.FixMethodOrder;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache30.ClientServerTestCase;
 import org.apache.geode.test.dunit.Invoke;
-import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
-@FixMethodOrder(NAME_ASCENDING)
 @Category({ClientServerTest.class})
 public class ConnectionPoolAutoDUnitTest extends ConnectionPoolDUnitTest {
 
-  @Override
-  protected final void postSetUpConnectionPoolDUnitTest() throws Exception {
+  @Before
+  public final void setUpConnectionPoolDUnitTest() {
     ClientServerTestCase.AUTO_LOAD_BALANCE = true;
-    Invoke.invokeInEveryVM(new SerializableRunnable("setupAutoMode") {
-      @Override
-      public void run() {
-        ClientServerTestCase.AUTO_LOAD_BALANCE = true;
-      }
-    });
+    Invoke.invokeInEveryVM("setupAutoMode", () -> ClientServerTestCase.AUTO_LOAD_BALANCE = true);
   }
 
-  @Override
-  protected final void postTearDownConnectionPoolDUnitTest() throws Exception {
+  @After
+  public final void tearDownConnectionPoolDUnitTest() {
     ClientServerTestCase.AUTO_LOAD_BALANCE = false;
-    Invoke.invokeInEveryVM(new SerializableRunnable("disableAutoMode") {
-      @Override
-      public void run() {
-        ClientServerTestCase.AUTO_LOAD_BALANCE = false;
-      }
-    });
+    Invoke.invokeInEveryVM("disableAutoMode", () -> ClientServerTestCase.AUTO_LOAD_BALANCE = false);
   }
-
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
@@ -136,15 +136,10 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
   public final void postTearDownCacheTestCase() {
     Invoke.invokeInEveryVM(() -> {
       Map pools = PoolManager.getAll();
-      if (!pools.isEmpty()) {
-        logger.warn("found pools remaining after teardown: " + pools);
-        assertThat(pools.size()).isEqualTo(0);
-      }
+      assertThat(pools).describedAs("found pools remaining after teardown: " + pools).isEmpty();
     });
-    postTearDownConnectionPoolDUnitTest();
   }
 
-  private void postTearDownConnectionPoolDUnitTest() {}
 
   private static PoolImpl getPool(Region r) {
     PoolImpl result = null;
@@ -165,9 +160,6 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
     Cache cache = getCache();
     CacheServer bridge = cache.addCacheServer();
     bridge.setPort(port);
-    if (-1 != -1) {
-      bridge.setSocketBufferSize(-1);
-    }
     bridge.setMaxThreads(0);
     bridge.setLoadPollInterval(CacheServer.DEFAULT_LOAD_POLL_INTERVAL);
     bridge.start();
@@ -188,7 +180,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
   private void createLonerDS() {
     disconnectFromDS();
     InternalDistributedSystem ds = getLonerSystem();
-    assertThat(0).isEqualTo(ds.getDistributionManager().getOtherDistributionManagerIds().size());
+    assertThat(ds.getDistributionManager().getOtherDistributionManagerIds()).isEmpty();
   }
 
   /**
@@ -498,8 +490,8 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
     AsyncInvocation inv2 = vm2.invokeAsync("Initialize Client", initializeClient);
     AsyncInvocation inv3 = vm3.invokeAsync("Initialize Client", initializeClient);
 
-    inv2.get();
-    inv3.get();
+    inv2.await();
+    inv3.await();
   }
 
   /**
@@ -676,7 +668,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       }
       region.localDestroyRegion();
       assertThat(p.isDestroyed()).isFalse();
-      assertThat(0).isEqualTo(p.getAttachCount());
+      assertThat(p.getAttachCount()).isEqualTo(0);
     });
 
     vm0.invoke("Stop CacheServer", () -> stopBridgeServer(getCache()));
@@ -932,12 +924,12 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       try {
         if (putAI != null) {
           // Verify that no exception has occurred in the putter thread
-          putAI.get();
+          putAI.await();
         }
 
         if (putAI2 != null) {
           // Verify that no exception has occurred in the putter thread
-          putAI.get();
+          putAI.await();
         }
       } finally {
         vm2.invoke("Stop Putters", () -> stopTestLifetimeExpire = false);
@@ -1101,7 +1093,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       for (int i = 0; i < 10; i++) {
         Object value = region.get("key-bytes-" + i);
         assertThat(value).isNotNull();
-        assertThat(value instanceof byte[]).isTrue();
+        assertThat(value).isInstanceOf(byte[].class);
         assertThat("value-" + i).isEqualTo(new String((byte[]) value));
       }
     });
@@ -1290,7 +1282,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
         for (int i = 0; i < 10; i++) {
           Object key = i;
           EntryEvent ee = (EntryEvent) list.get(i);
-          assertThat(key).isEqualTo(ee.getKey());
+          assertThat(ee.getKey()).isEqualTo(key);
           assertThat("old" + i).isEqualTo(ee.getOldValue());
           assertThat(Operation.INVALIDATE).isEqualTo(ee.getOperation());
           assertThat("callbackArg" + i).isEqualTo(ee.getCallbackArgument());
@@ -1325,7 +1317,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
         for (int i = 0; i < 10; i++) {
           Object key = i;
           EntryEvent ee = (EntryEvent) list.get(i);
-          assertThat(key).isEqualTo(ee.getKey());
+          assertThat(ee.getKey()).isEqualTo(key);
           assertThat(ee.getOldValue()).isNull();
           assertThat(Operation.DESTROY).isEqualTo(ee.getOperation());
           assertThat("destroyCB" + i).isEqualTo(ee.getCallbackArgument());
@@ -1349,7 +1341,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       List<CacheEvent<Object, Object>> list = ctl.getEventHistory();
       logger
           .info("history (should be empty): " + list);
-      assertThat(0).isEqualTo(list.size());
+      assertThat(list).isEmpty();
       // now see if we can get it from the server
       for (int i = 0; i < 10; i++) {
         Object key = i;
@@ -1361,9 +1353,9 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
         Object key = i;
         EntryEvent ee = (EntryEvent) list.get(i);
         logger.info("processing " + ee);
-        assertThat(key).isEqualTo(ee.getKey());
+        assertThat(ee.getKey()).isEqualTo(key);
         assertThat(ee.getOldValue()).isNull();
-        assertThat("create" + i).isEqualTo(ee.getNewValue());
+        assertThat(ee.getNewValue()).isEqualTo("create" + i);
         assertThat(Operation.LOCAL_LOAD_CREATE).isEqualTo(ee.getOperation());
         assertThat("loadCB" + i).isEqualTo(ee.getCallbackArgument());
         assertThat(ee.isOriginRemote()).isFalse();
@@ -1451,7 +1443,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       Region<Object, Object> region = getRootRegion().getSubregion(name);
       await().untilAsserted(() -> {
         for (int i = 0; i < 10; i++) {
-          assertThat(region.get("new" + i) == ("callbackArg" + i));
+          assertThat(region.get("new" + i)).isEqualTo("callbackArg" + i);
         }
       });
 
@@ -1469,7 +1461,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
         for (int i = 0; i < 10; i++) {
           Object key = i;
           EntryEvent ee = (EntryEvent) list.get(i);
-          assertThat(key).isEqualTo(ee.getKey());
+          assertThat(ee.getKey()).isEqualTo(key);
           assertThat(ee.getOldValue()).isNull();
           assertThat(ee.isOldValueAvailable()).isFalse(); // failure
           assertThat(Operation.INVALIDATE).isEqualTo(ee.getOperation());
@@ -1504,7 +1496,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
         for (int i = 0; i < 10; i++) {
           Object key = i;
           EntryEvent ee = (EntryEvent) list.get(i);
-          assertThat(key).isEqualTo(ee.getKey());
+          assertThat(ee.getKey()).isEqualTo(key);
           assertThat(ee.getOldValue()).isNull();
           assertThat(ee.isOldValueAvailable()).isFalse();
           assertThat(Operation.DESTROY).isEqualTo(ee.getOperation());
@@ -1536,7 +1528,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       for (int i = 0; i < 10; i++) {
         Object key = i;
         EntryEvent ee = (EntryEvent) list.get(i);
-        assertThat(key).isEqualTo(ee.getKey());
+        assertThat(ee.getKey()).isEqualTo(key);
         assertThat(ee.getOldValue()).isNull();
         assertThat(ee.isOldValueAvailable()).isFalse();
         assertThat(Operation.INVALIDATE).isEqualTo(ee.getOperation());
@@ -1554,9 +1546,9 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       for (int i = 0; i < 10; i++) {
         Object key = i;
         EntryEvent ee = (EntryEvent) list.get(i);
-        assertThat(key).isEqualTo(ee.getKey());
+        assertThat(ee.getKey()).isEqualTo(key);
         assertThat(ee.getOldValue()).isNull();
-        assertThat("create" + i).isEqualTo(ee.getNewValue());
+        assertThat(ee.getNewValue()).isEqualTo("create" + i);
         assertThat(Operation.LOCAL_LOAD_CREATE).isEqualTo(ee.getOperation());
         assertThat("loadCB" + i).isEqualTo(ee.getCallbackArgument());
         assertThat(ee.isOriginRemote()).isFalse();
@@ -1678,7 +1670,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       await().until(() -> ctl.getEventHistory().size() == 0);
 
       List<CacheEvent<Object, Object>> list = ctl.getEventHistory();
-      assertThat(0).isEqualTo(list.size());
+      assertThat(list).isEmpty();
       // now see if we can get it from the server
       for (int i = 0; i < 10; i++) {
         Object key = i;
@@ -1689,9 +1681,9 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       for (int i = 0; i < 10; i++) {
         Object key = i;
         EntryEvent ee = (EntryEvent) list.get(i);
-        assertThat(key).isEqualTo(ee.getKey());
+        assertThat(ee.getKey()).isEqualTo(key);
         assertThat(ee.getOldValue()).isNull();
-        assertThat("create" + i).isEqualTo(ee.getNewValue());
+        assertThat(ee.getNewValue()).isEqualTo("create" + i);
         assertThat(Operation.LOCAL_LOAD_CREATE).isEqualTo(ee.getOperation());
         assertThat("loadCB" + i).isEqualTo(ee.getCallbackArgument());
         assertThat(ee.isOriginRemote()).isFalse();
@@ -1819,9 +1811,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
     if (cl != null) {
       regionFactory.setCacheLoader(cl);
     }
-    if (null != null) {
-      regionFactory.setCacheWriter(null);
-    }
+
     regionFactory.setScope(Scope.DISTRIBUTED_ACK);
     regionFactory.setConcurrencyChecksEnabled(false);
     regionFactory.setDataPolicy(DataPolicy.REPLICATE);
@@ -1906,12 +1896,12 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       Region<Object, Object> region1 = getRootRegion().getSubregion(name1);
       for (int i = 0; i < 10; i++) {
         final int testInt = i;
-        await().until(() -> ("Region1New" + testInt).compareTo((String) region1.get(testInt)) == 0);
+        await().until(() -> (region1.get(testInt).equals("Region1New" + testInt)));
       }
       Region<Object, Object> region2 = getRootRegion().getSubregion(name2);
       for (int i = 0; i < 10; i++) {
         final int testInt = i;
-        await().until(() -> ("Region2Old" + testInt).compareTo((String) region2.get(testInt)) == 0);
+        await().until(() -> region2.get(testInt).equals(("Region2Old" + testInt)));
       }
     });
 
@@ -3284,7 +3274,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
         assertThat(entry).isNotNull();
         byte[] value = (byte[]) entry.getValue();
         assertThat(value).isNotNull();
-        assertThat(0).isEqualTo(value.length);
+        assertThat(value.length).isEqualTo(0);
       }
     });
 
@@ -3295,7 +3285,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
         assertThat(entry).isNotNull();
         byte[] value = (byte[]) entry.getValue();
         assertThat(value).isNotNull();
-        assertThat(0).isEqualTo(value.length);
+        assertThat(value.length).isEqualTo(0);
       }
     });
 
@@ -3455,7 +3445,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       Region<Object, Object> region = getRootRegion().getSubregion(name);
       Set keySet = region.keySetOnServer();
       assertThat(keySet).isNotNull();
-      assertThat(0).isEqualTo(keySet.size());
+      assertThat(keySet).isEmpty();
     });
 
     vm1.invoke("Put values", () -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
@@ -1425,6 +1425,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       Region rgn = createRegion(name, factory);
       rgn.registerInterestRegex(".*", false, false);
     });
+
     vm1.invoke("Turn on history", () -> {
       Region<Object, Object> region = getRootRegion().getSubregion(name);
       CertifiableTestCacheListener<Object, Object> ctl =
@@ -1432,6 +1433,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
               .getCacheListeners()[0];
       ctl.enableEventHistory();
     });
+
     vm2.invoke("Update region", () -> {
       Region<Object, Object> region = getRootRegion().getSubregion(name);
       for (int i = 0; i < 10; i++) {
@@ -1441,15 +1443,10 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
 
     vm1.invoke("Verify invalidates", () -> {
       Region<Object, Object> region = getRootRegion().getSubregion(name);
-      await().untilAsserted(() -> {
-        for (int i = 0; i < 10; i++) {
-          assertThat(region.get("new" + i)).isEqualTo("callbackArg" + i);
-        }
-      });
-
       CertifiableTestCacheListener<Object, Object> ctl =
           (CertifiableTestCacheListener<Object, Object>) region.getAttributes()
               .getCacheListeners()[0];
+
       for (int i = 0; i < 10; i++) {
         Object key = i;
         ctl.waitForInvalidated(key);
@@ -1457,7 +1454,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       }
       {
         List<CacheEvent<Object, Object>> list = ctl.getEventHistory();
-        assertThat(10).isEqualTo(list.size());
+        assertThat(list.size()).isEqualTo(10);
         for (int i = 0; i < 10; i++) {
           Object key = i;
           EntryEvent ee = (EntryEvent) list.get(i);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClientMembershipDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClientMembershipDUnitTest.java
@@ -1386,8 +1386,10 @@ public class ClientMembershipDUnitTest extends ClientServerTestCase {
       System.out.println("[testGetConnectedServers] creating connectionpool for "
           + NetworkUtils.getServerHostName(host) + " " + ports[i]);
       int[] thisServerPorts = new int[] {ports[i]};
-      ClientServerTestCase.configureConnectionPoolWithName(factory,
-          NetworkUtils.getServerHostName(host), thisServerPorts, false, -1, -1, null, "pooly" + i);
+      configureConnectionPoolWithNameAndFactory(factory, NetworkUtils.getServerHostName(host),
+          thisServerPorts, false, -1,
+          -1, null, "pooly" + i, PoolManager.createFactory(), -1, -1, -2,
+          -1);
       Region region = createRegion(name + "_" + i, factory.create());
       assertNotNull(getRootRegion().getSubregion(name + "_" + i));
       region.get("KEY-1");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
@@ -17,11 +17,9 @@ package org.apache.geode.internal.cache;
 import static org.apache.geode.distributed.ConfigurationProperties.DELTA_PROPAGATION;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
-import static org.apache.geode.test.dunit.Assert.assertEquals;
-import static org.apache.geode.test.dunit.Assert.assertSame;
-import static org.apache.geode.test.dunit.Assert.assertTrue;
-import static org.apache.geode.test.dunit.Assert.fail;
-import static org.apache.geode.test.dunit.Host.getHost;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -49,24 +47,18 @@ import org.apache.geode.cache.InterestResultPolicy;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.cache30.ClientServerTestCase;
-import org.apache.geode.internal.NanoTimer;
 import org.apache.geode.internal.cache.BucketRegion.RawValue;
-import org.apache.geode.internal.cache.PartitionedRegionDataStore.BucketVisitor;
 import org.apache.geode.internal.cache.ha.HARegionQueue;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.Assert;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.Wait;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
@@ -90,7 +82,7 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
   private VM client;
   private VM server;
   private String rName;
-  private int ports[];
+  private int[] ports;
 
   @Rule
   public DistributedRestoreSystemProperties restoreSystemProperties =
@@ -98,10 +90,10 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
 
   @Before
   public void setUp() {
-    client = getHost(0).getVM(2);
-    server = getHost(0).getVM(3);
+    client = VM.getVM(2);
+    server = VM.getVM(3);
     rName = getUniqueName();
-    ports = createUniquePorts(1);
+    ports = createUniquePorts();
   }
 
   @Override
@@ -125,7 +117,8 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
   @Test
   @Parameters({"true", "false"})
   @TestCaseName("{method}({params})")
-  public void testCopyOnReadWithBridgeServer(final boolean serializeEarlyEnabled) throws Exception {
+  public void testCopyOnReadWithBridgeServer(
+      @SuppressWarnings("unused") final boolean serializeEarlyEnabled) {
     System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
     Invoke.invokeInEveryVM(
         () -> System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true"));
@@ -133,8 +126,8 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
     createBridgeServer(server, rName, ports[0]);
     // Put an instance of SerializationCounter to assert copy-on-read behavior
     // when notifyBySubscription is true
-    server.invoke(
-        new CacheSerializableRunnable("Enable copy on read and assert server copy behavior") {
+    server.invoke("Enable copy on read and assert server copy behavior",
+        new CacheSerializableRunnable() {
           @Override
           public void run2() throws CacheException {
             final LocalRegion r = (LocalRegion) getRootRegion(rName);
@@ -146,31 +139,31 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
             SerializationCountingKey key = new SerializationCountingKey(k1);
             byte[] val = new byte[1];
             byte valIsObj = 0x01;
-            Integer cb = new Integer(0);
+            Integer cb = 0;
             ClientProxyMembershipID cpmi = null;
             EventID eid = null;
             ClientUpdateMessageImpl cui = new ClientUpdateMessageImpl(
                 EnumListenerEvent.AFTER_CREATE, r, key, val, valIsObj, cb, cpmi, eid);
-            ClientUpdateMessageImpl cuiCopy = (ClientUpdateMessageImpl) CopyHelper.copy(cui);
-            assertSame(key, cui.getKeyOfInterest());
-            assertEquals(1, key.count.get());
+            ClientUpdateMessageImpl cuiCopy = CopyHelper.copy(cui);
+            assertThat(key).isSameAs(cui.getKeyOfInterest());
+            assertThat(key.count.get()).isEqualTo(1);
             key = (SerializationCountingKey) cuiCopy.getKeyOfInterest();
-            assertEquals(cui.getKeyOfInterest(), cuiCopy.getKeyOfInterest());
-            assertEquals(1, key.count.get());
+            assertThat(cuiCopy.getKeyOfInterest()).isEqualTo(cui.getKeyOfInterest());
+            assertThat(key.count.get()).isEqualTo(1);
 
             SerializationCountingKey ks1 = new SerializationCountingKey(k1);
             { // AbstractRegionMap basicPut now serializes newValue in EntryEventImpl
               // which can be used for delivering client update message later
               SerializationCountingValue sc = new SerializationCountingValue();
               r.put(ks1, sc);
-              assertEquals(1, sc.count.get());
-              assertEquals(0, ks1.count.get());
+              assertThat(sc.count.get()).isEqualTo(1);
+              assertThat(ks1.count.get()).isEqualTo(0);
             }
 
             { // No copy should be made upon get (assert standard no copy behavior)
               SerializationCountingValue sc = (SerializationCountingValue) r.get(ks1);
-              assertEquals(1, sc.count.get());
-              assertEquals(0, ks1.count.get());
+              assertThat(sc.count.get()).isEqualTo(1);
+              assertThat(ks1.count.get()).isEqualTo(0);
             }
 
             // enable copy on read
@@ -178,8 +171,8 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
 
             { // Assert standard copy on read behavior and basicPut in AbstractRegionMap
               SerializationCountingValue sc = (SerializationCountingValue) r.get(ks1);
-              assertEquals(2, sc.count.get());
-              assertEquals(0, ks1.count.get());
+              assertThat(sc.count.get()).isEqualTo(2);
+              assertThat(ks1.count.get()).isEqualTo(0);
             }
 
             { // Put another counter with copy-on-read true
@@ -187,8 +180,8 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
               SerializationCountingValue sc = new SerializationCountingValue();
               SerializationCountingKey ks3 = new SerializationCountingKey(k3);
               r.put(ks3, sc);
-              assertEquals(1, sc.count.get());
-              assertEquals(0, ks3.count.get());
+              assertThat(sc.count.get()).isEqualTo(1);
+              assertThat(ks3.count.get()).isEqualTo(0);
             }
           }
         });
@@ -196,64 +189,55 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
     // Setup a client which subscribes to the server region, registers (aka pulls)
     // interest in keys which creates an assumed HARegionQueue on the server
     // (in the event that the above code didn't already create a HARegion)
-    final String serverHostName = NetworkUtils.getServerHostName(server.getHost());
-    client.invoke(new CacheSerializableRunnable("Assert server copy behavior from client") {
+    final String serverHostName = NetworkUtils.getServerHostName();
+    client.invoke("Assert server copy behavior from client", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
         getCache();
 
-        AttributesFactory factory = new AttributesFactory();
+        RegionFactory<Object, Object> factory = getCache().createRegionFactory();
         ClientServerTestCase.configureConnectionPool(factory, serverHostName, ports, true, -1, 1,
             null);
         factory.setScope(Scope.LOCAL);
-        Region r = createRootRegion(rName, factory.create());
+        Region<Object, Object> rootRegion = createRootRegion(rName, factory);
         SerializationCountingKey ks1 = new SerializationCountingKey(k1);
         SerializationCountingKey ks3 = new SerializationCountingKey(k3);
         // original two serializations on server and one serialization for register interest
-        r.registerInterest(ks1, InterestResultPolicy.KEYS_VALUES);
+        rootRegion.registerInterest(ks1, InterestResultPolicy.KEYS_VALUES);
         // entry shouldn't exist yet
-        r.registerInterest(new SerializationCountingKey(k2), InterestResultPolicy.KEYS_VALUES);
+        rootRegion.registerInterest(new SerializationCountingKey(k2),
+            InterestResultPolicy.KEYS_VALUES);
         // original one serializations on server and one serialization for register interest
-        r.registerInterest(ks3, InterestResultPolicy.KEYS_VALUES);
+        rootRegion.registerInterest(ks3, InterestResultPolicy.KEYS_VALUES);
 
         { // get from local cache.
           // original two serializations on server and one for previous register interest
-          SerializationCountingValue sc = (SerializationCountingValue) r.get(ks1);
-          assertEquals(3, sc.count.get());
+          SerializationCountingValue sc = (SerializationCountingValue) rootRegion.get(ks1);
+          assertThat(sc.count.get()).isEqualTo(3);
         }
 
         { // get from local cache,
           // one from register interest key and one original put into AbstractRegionMap
-          SerializationCountingValue sc = (SerializationCountingValue) r.get(ks3);
-          assertEquals(2, sc.count.get());
+          SerializationCountingValue sc = (SerializationCountingValue) rootRegion.get(ks3);
+          assertThat(sc.count.get()).isEqualTo(2);
         }
       }
     });
 
     // Put an instance of SerializationCounter to assert copy-on-read behavior
     // once a client has registered interest
-    server.invoke(new CacheSerializableRunnable("Assert copy behavior after client is setup") {
+    server.invoke("Assert copy behavior after client is setup", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        Region r = getRootRegion(rName);
+        Region<Object, Object> rootRegion = getRootRegion(rName);
         CacheServerImpl bsi = (CacheServerImpl) getCache().getCacheServers().iterator().next();
         Collection cp = bsi.getAcceptor().getCacheClientNotifier().getClientProxies();
         // Should only be one because only one client is connected
-        assertEquals(1, cp.size());
+        assertThat(cp.size()).isEqualTo(1);
         final CacheClientProxy ccp = (CacheClientProxy) cp.iterator().next();
         // Wait for messages to drain to capture a stable "processed message count"
-        WaitCriterion ev = new WaitCriterion() {
-          @Override
-          public boolean done() {
-            return ccp.getHARegionQueue().size() == 0;
-          }
-
-          @Override
-          public String description() {
-            return "region queue never became empty";
-          }
-        };
-        GeodeAwaitility.await().untilAsserted(ev);
+        await("region queue never became empty")
+            .until(() -> ccp.getHARegionQueue().size() == 0);
 
         // Capture the current processed message count to know
         // when the next message has been serialized
@@ -263,50 +247,36 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
         SerializationCountingValue sc = new SerializationCountingValue();
         // Update a key upon which the client has expressed interest,
         // expect it to send an update message to the client
-        r.put(ks2, sc);
+        rootRegion.put(ks2, sc);
 
         // Wait to know that the data has been at least serialized (possibly sent)
-        ev = new WaitCriterion() {
-          @Override
-          public boolean done() {
-            return ccp.getStatistics().getMessagesProcessed() != currMesgCount;
-          }
-
-          @Override
-          public String description() {
-            return null;
-          }
-        };
-        GeodeAwaitility.await().untilAsserted(ev);
+        await()
+            .until(() -> ccp.getStatistics().getMessagesProcessed() != currMesgCount);
 
         // assert one serialization to send value to interested client
         // more than one implies copy-on-read behavior (bad)
-        assertEquals(1, sc.count.get());
-        assertEquals(1, ks2.count.get());
+        assertThat(sc.count.get()).isEqualTo(1);
+        assertThat(ks2.count.get()).isEqualTo(1);
       }
     });
 
     // Double-check the serialization count in the event that the previous check
     // missed the copy due to race conditions
-    client.invoke(new CacheSerializableRunnable("Assert copy behavior from client after update") {
+    client.invoke("Assert copy behavior from client after update", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        Region r = getRootRegion(rName);
+        Region rootRegion = getRootRegion(rName);
         { // Once to send the value to this client via the updater thread
 
           SerializationCountingKey ks2 = new SerializationCountingKey(k2);
           // Wait for the update to arrive on to the Cache Client Updater
-          long start = NanoTimer.getTime();
           final int maxSecs = 30;
-          while (!r.containsKey(ks2)) {
-            Wait.pause(100);
-            if ((NanoTimer.getTime() - start) > TimeUnit.SECONDS.toNanos(maxSecs)) {
-              fail("Waited over " + maxSecs + "s");
-            }
-          }
+          await("Waited over " + maxSecs + "s").timeout(maxSecs, TimeUnit.SECONDS)
+              .until(() -> rootRegion.containsKey(ks2));
 
-          SerializationCountingValue sc = (SerializationCountingValue) r.getEntry(ks2).getValue();
-          assertEquals(1, sc.count.get());
+          SerializationCountingValue sc =
+              (SerializationCountingValue) rootRegion.getEntry(ks2).getValue();
+          assertThat(sc.count.get()).isEqualTo(1);
         }
       }
     });
@@ -317,44 +287,43 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
    * when copy-on-read is set to true
    */
   @Test
-  public void testPartitionedRegionAndCopyOnRead() throws Exception {
-    final Host h = getHost(0);
-    final VM accessor = h.getVM(2);
-    final VM datastore = h.getVM(3);
+  public void testPartitionedRegionAndCopyOnRead() {
+    final VM accessor = VM.getVM(2);
+    final VM datastore = VM.getVM(3);
     final String rName = getUniqueName();
     final String k1 = "k1";
 
-    datastore.invoke(new CacheSerializableRunnable("Create PR DataStore") {
+    datastore.invoke("Create PR DataStore", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        AttributesFactory factory = new AttributesFactory();
+        RegionFactory<Object, Object> factory = getCache().createRegionFactory();
         factory.setPartitionAttributes(
             new PartitionAttributesFactory().setRedundantCopies(0).create());
-        createRootRegion(rName, factory.create());
+        createRootRegion(rName, factory);
       }
     });
 
-    accessor.invoke(new CacheSerializableRunnable("Create PR Accessor and put new value") {
+    accessor.invoke("Create PR Accessor and put new value", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        AttributesFactory factory = new AttributesFactory();
+        RegionFactory<Object, Object> factory = getCache().createRegionFactory();
         factory.setPartitionAttributes(
             new PartitionAttributesFactory().setLocalMaxMemory(0).setRedundantCopies(0).create());
-        Region r = createRootRegion(rName, factory.create());
+        Region<Object, Object> rootRegion = createRootRegion(rName, factory);
         SerializationCountingValue val = new SerializationCountingValue();
-        r.put(k1, val);
+        rootRegion.put(k1, val);
         // First put to a bucket will serialize once to determine the size of the value
         // to know how much extra space the new bucket with the new entry will consume
         // and serialize again to send the bytes
-        assertEquals(2, val.count.get());
+        assertThat(val.count.get()).isEqualTo(2);
         // A put to an already created bucket should only be serialized once
         val = new SerializationCountingValue();
-        r.put(k1, val);
-        assertEquals(1, val.count.get());
+        rootRegion.put(k1, val);
+        assertThat(val.count.get()).isEqualTo(1);
       }
     });
 
-    datastore.invoke(new CacheSerializableRunnable("assert datastore entry serialization count") {
+    datastore.invoke("assert datastore entry serialization count", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
         PartitionedRegion pr = (PartitionedRegion) getRootRegion(rName);
@@ -363,56 +332,53 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
         // All this extra work is to assure the serialization count does not increase
         // (by de-serializing the value stored in the map, which would then have to be
         // re-serialized).
-        pr.getDataStore().visitBuckets(new BucketVisitor() {
-          @Override
-          public void visit(Integer bucketId, Region r) {
-            BucketRegion br = (BucketRegion) r;
-            try {
-              KeyInfo keyInfo = new KeyInfo(k1, null, bucketId);
-              RawValue rv = br.getSerialized(keyInfo, false, false, null, null, false);
-              Object val = rv.getRawValue();
-              assertTrue(val instanceof CachedDeserializable);
-              CachedDeserializable cd = (CachedDeserializable) val;
-              SerializationCountingValue scv =
-                  (SerializationCountingValue) cd.getDeserializedForReading();
-              assertEquals(1, scv.count.get());
-            } catch (IOException fail) {
-              Assert.fail("Unexpected IOException", fail);
-            }
+        pr.getDataStore().visitBuckets((bucketId, r) -> {
+          BucketRegion br = (BucketRegion) r;
+          try {
+            KeyInfo keyInfo = new KeyInfo(k1, null, bucketId);
+            RawValue rv = br.getSerialized(keyInfo, false, false, null, null, false);
+            Object val = rv.getRawValue();
+            assertThat(val).isInstanceOf(CachedDeserializable.class);
+            CachedDeserializable cd = (CachedDeserializable) val;
+            SerializationCountingValue scv =
+                (SerializationCountingValue) cd.getDeserializedForReading();
+            assertThat(scv.count.get()).isEqualTo(1);
+          } catch (IOException fail) {
+            fail("Unexpected IOException", fail);
           }
         });
       }
     });
 
-    accessor.invoke(new CacheSerializableRunnable("assert accessor entry serialization count") {
+    accessor.invoke("assert accessor entry serialization count", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        Region r = getRootRegion(rName);
-        SerializationCountingValue v1 = (SerializationCountingValue) r.get(k1);
+        Region<Object, Object> rootRegion = getRootRegion(rName);
+        SerializationCountingValue value1 = (SerializationCountingValue) rootRegion.get(k1);
         // The counter was incremented once to send the data to the datastore
-        assertEquals(1, v1.count.get());
+        assertThat(value1.count.get()).isEqualTo(1);
         getCache().setCopyOnRead(true);
         // Once to send the data to the datastore, no need to do a serialization
         // when we make copy since it is serialized from datastore to us.
-        SerializationCountingValue v2 = (SerializationCountingValue) r.get(k1);
-        assertEquals(1, v2.count.get());
-        assertTrue(v1 != v2);
+        SerializationCountingValue value2 = (SerializationCountingValue) rootRegion.get(k1);
+        assertThat(value2.count.get()).isEqualTo(1);
+        assertThat(value2).isNotEqualTo(value1);
       }
     });
 
-    datastore.invoke(new CacheSerializableRunnable("assert value serialization") {
+    datastore.invoke("assert value serialization", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        Region r = getRootRegion(rName);
-        SerializationCountingValue v1 = (SerializationCountingValue) r.get(k1);
+        Region rootRegion = getRootRegion(rName);
+        SerializationCountingValue value1 = (SerializationCountingValue) rootRegion.get(k1);
         // Once to send the value from the accessor to the data store
-        assertEquals(1, v1.count.get());
+        assertThat(value1.count.get()).isEqualTo(1);
         getCache().setCopyOnRead(true);
         // Once to send the value from the accessor to the data store
         // once to make a local copy
-        SerializationCountingValue v2 = (SerializationCountingValue) r.get(k1);
-        assertEquals(2, v2.count.get());
-        assertTrue(v1 != v2);
+        SerializationCountingValue value2 = (SerializationCountingValue) rootRegion.get(k1);
+        assertThat(value2.count.get()).isEqualTo(2);
+        assertThat(value2).isNotEqualTo(value1);
       }
     });
   }
@@ -420,6 +386,7 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
   private static class SerializationCountingValue implements DataSerializable {
     public final AtomicInteger count = new AtomicInteger();
 
+    @SuppressWarnings("WeakerAccess")
     public SerializationCountingValue() {
       // nothing
     }
@@ -443,10 +410,12 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
   private static class SerializationCountingKey extends SerializationCountingValue {
     private String k;
 
+    @SuppressWarnings("WeakerAccess")
     public SerializationCountingKey(String k) {
       this.k = k;
     }
 
+    @SuppressWarnings("unused")
     public SerializationCountingKey() {
       super();
     }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/HAOverflowMemObjectSizerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/HAOverflowMemObjectSizerDUnitTest.java
@@ -162,8 +162,9 @@ public class HAOverflowMemObjectSizerDUnitTest extends JUnit4DistributedTestCase
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setDataPolicy(DataPolicy.NORMAL);
-    ClientServerTestCase.configureConnectionPool(factory, host, port1.intValue(), -1, true, -1, 2,
-        null, -1, -1);
+    int[] ports = {port1};
+    ClientServerTestCase.configureConnectionPool(factory, host, ports, true, -1,
+        2, (String) null);
     RegionAttributes attrs = factory.create();
     Region region = cache.createRegion(regionName, attrs);
     assertNotNull(region);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionHAFailureAndRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionHAFailureAndRecoveryDUnitTest.java
@@ -19,7 +19,6 @@ import static java.lang.Boolean.TRUE;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
-import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -362,7 +361,7 @@ public class PartitionedRegionHAFailureAndRecoveryDUnitTest extends CacheTestCas
   private void addConfigListener() {
     Region partitionedRootRegion = PartitionedRegionHelper.getPRRoot(getCache());
     partitionedRootRegion.getAttributesMutator()
-        .addCacheListener(new CertifiableTestCacheListener(getLogWriter()));
+        .addCacheListener(new CertifiableTestCacheListener());
   }
 
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/FailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/FailoverDUnitTest.java
@@ -134,8 +134,11 @@ public class FailoverDUnitTest extends JUnit4DistributedTestCase {
 
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);
-    ClientServerTestCase.configureConnectionPoolWithName(factory, hostName,
-        new int[] {PORT1, PORT2}, true, -1, 2, null, "FailoverPool");
+    ClientServerTestCase
+        .configureConnectionPoolWithNameAndFactory(factory, hostName, new int[] {PORT1, PORT2},
+            true, -1,
+            2, (String) null, "FailoverPool", PoolManager.createFactory(), -1, -1, -2,
+            -1);
     factory.setCacheListener(new CacheListenerAdapter() {
       @Override
       public void afterUpdate(EntryEvent event) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
@@ -206,8 +206,11 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
     props.setProperty(LOCATORS, "");
     new HARQueueNewImplDUnitTest().createCache(props);
     AttributesFactory factory = new AttributesFactory();
-    ClientServerTestCase.configureConnectionPool(factory, host, port1.intValue(), port2.intValue(),
-        true, Integer.parseInt(rLevel), 2, null, 1000, 250);
+    ClientServerTestCase
+        .configureConnectionPool(factory, host, port1.intValue(), port2.intValue(), true,
+            Integer.parseInt(rLevel),
+            2, (String) null, 1000, 250,
+            -2/* lifetimeTimeout */);
 
     factory.setScope(Scope.LOCAL);
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DestroyEntryPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DestroyEntryPropagationDUnitTest.java
@@ -437,7 +437,7 @@ public class DestroyEntryPropagationDUnitTest extends JUnit4DistributedTestCase 
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setPoolName(p.getName());
-    factory.setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+    factory.setCacheListener(new CertifiableTestCacheListener());
     RegionAttributes attrs = factory.create();
     cache.createRegion(REGION_NAME, attrs);
 
@@ -448,7 +448,7 @@ public class DestroyEntryPropagationDUnitTest extends JUnit4DistributedTestCase 
     AttributesFactory factory = new AttributesFactory();
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setDataPolicy(DataPolicy.REPLICATE);
-    factory.setCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+    factory.setCacheListener(new CertifiableTestCacheListener());
     RegionAttributes attrs = factory.create();
     cache.createRegion(REGION_NAME, attrs);
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataDUnitTest.java
@@ -461,7 +461,7 @@ public class CqDataDUnitTest extends JUnit4CacheTestCase {
           Region region = createRegion(cqDUnitTest.regions[i], factory.createRegionAttributes());
           // Set CacheListener.
           region.getAttributesMutator()
-              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener());
         }
         Wait.pause(2000);
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
@@ -485,7 +485,7 @@ public class CqDataUsingPoolDUnitTest extends JUnit4CacheTestCase {
           Region region = createRegion(cqDUnitTest.regions[i], factory.createRegionAttributes());
           // Set CacheListener.
           region.getAttributesMutator()
-              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener());
         }
         Wait.pause(2000);
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
@@ -46,6 +46,7 @@ import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.client.PoolManager;
 import org.apache.geode.cache.query.CqAttributes;
 import org.apache.geode.cache.query.CqAttributesFactory;
 import org.apache.geode.cache.query.CqAttributesMutator;
@@ -375,24 +376,30 @@ public class CqQueryDUnitTest extends JUnit4CacheTestCase {
       regionFactory0.setScope(Scope.LOCAL);
       regionFactory1.setScope(Scope.LOCAL);
       if (redundancyLevel != null) {
-        ClientServerTestCase.configureConnectionPoolWithName(regionFactory0, serverHost,
+        ClientServerTestCase.configureConnectionPoolWithNameAndFactory(regionFactory0, serverHost,
             serverPorts1, true,
-            Integer.parseInt(redundancyLevel), -1,
-            null, "testPoolA");
-        ClientServerTestCase.configureConnectionPoolWithName(regionFactory1, serverHost,
+            Integer.parseInt(redundancyLevel),
+            -1, (String) null, "testPoolA", PoolManager.createFactory(), -1, -1, -2,
+            -1);
+        ClientServerTestCase.configureConnectionPoolWithNameAndFactory(regionFactory1, serverHost,
             serverPorts2, true,
-            Integer.parseInt(redundancyLevel), -1,
-            null, "testPoolB");
+            Integer.parseInt(redundancyLevel),
+            -1, (String) null, "testPoolB", PoolManager.createFactory(), -1, -1, -2,
+            -1);
       } else {
-        ClientServerTestCase.configureConnectionPoolWithName(regionFactory0, serverHost,
-            serverPorts1, true, -1, -1, null,
-            "testPoolA");
-        ClientServerTestCase.configureConnectionPoolWithName(regionFactory1, serverHost,
-            serverPorts2, true, -1, -1, null,
-            "testPoolB");
+        ClientServerTestCase.configureConnectionPoolWithNameAndFactory(regionFactory0, serverHost,
+            serverPorts1, true,
+            -1,
+            -1, (String) null, "testPoolA", PoolManager.createFactory(), -1, -1, -2,
+            -1);
+        ClientServerTestCase.configureConnectionPoolWithNameAndFactory(regionFactory1, serverHost,
+            serverPorts2, true,
+            -1,
+            -1, (String) null, "testPoolB", PoolManager.createFactory(), -1, -1, -2,
+            -1);
       }
-      createRegion(regions[0], regionFactory0.createRegionAttributes());
-      createRegion(regions[1], regionFactory1.createRegionAttributes());
+      createRegion(regions[0], regionFactory0.create());
+      createRegion(regions[1], regionFactory1.create());
       logger.info("### Successfully Created Region on Client :" + regions[0]);
       logger.info("### Successfully Created Region on Client :" + regions[1]);
 
@@ -788,7 +795,7 @@ public class CqQueryDUnitTest extends JUnit4CacheTestCase {
     vm.invoke(() -> {
       Region region = getRootRegion().getSubregion(regionName);
       region.getAttributesMutator()
-          .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+          .addCacheListener(new CertifiableTestCacheListener());
 
       List list = new ArrayList();
       for (int i = 1; i <= 10; i++) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryUsingPoolDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryUsingPoolDUnitTest.java
@@ -849,7 +849,7 @@ public class CqQueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
         try {
           region = getRootRegion().getSubregion(regionName);
           region.getAttributesMutator()
-              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener());
         } catch (Exception cqe) {
           fail("Failed to get Region.", cqe);
         }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexUpdateRIDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexUpdateRIDUnitTest.java
@@ -486,7 +486,7 @@ public class QueryIndexUpdateRIDUnitTest extends JUnit4CacheTestCase {
             region = getRootRegion().getSubregion(regionName);
           }
           region.getAttributesMutator()
-              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener());
         } catch (Exception cqe) {
           AssertionError err = new AssertionError("Failed to get Region.");
           err.initCause(cqe);
@@ -532,7 +532,7 @@ public class QueryIndexUpdateRIDUnitTest extends JUnit4CacheTestCase {
             region = getRootRegion().getSubregion(regionName);
           }
           region.getAttributesMutator()
-              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener());
         } catch (Exception cqe) {
           AssertionError err = new AssertionError("Failed to get Region.");
           err.initCause(cqe);
@@ -796,7 +796,7 @@ public class QueryIndexUpdateRIDUnitTest extends JUnit4CacheTestCase {
             region = getRootRegion().getSubregion(regionName);
           }
           region.getAttributesMutator()
-              .addCacheListener(new CertifiableTestCacheListener(LogWriterUtils.getLogWriter()));
+              .addCacheListener(new CertifiableTestCacheListener());
         } catch (Exception cqe) {
           AssertionError err = new AssertionError("Failed to get Region.");
           err.initCause(cqe);

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
@@ -426,8 +426,7 @@ public class CQListGIIDUnitTest extends JUnit4DistributedTestCase {
     Region region = null;
     try {
       region = cache.getRegion("root").getSubregion(regionName);
-      region.getAttributesMutator().addCacheListener(new CertifiableTestCacheListener(
-          org.apache.geode.test.dunit.LogWriterUtils.getLogWriter()));
+      region.getAttributesMutator().addCacheListener(new CertifiableTestCacheListener());
     } catch (Exception e) {
       fail("Failed to get Region.", e);
     }

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/ClientServerTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/ClientServerTestCase.java
@@ -146,7 +146,6 @@ public abstract class ClientServerTestCase extends JUnit4CacheTestCase {
   public static Pool configureConnectionPool(AttributesFactory factory, String host, int[] ports,
       boolean establish, int redundancy, int connectionsPerServer, String serverGroup,
       int pingInterval, int idleTimeout, int lifetimeTimeout) {
-    /* poolName */
     return configureConnectionPoolWithNameAndFactory(factory, host, ports, establish, redundancy,
         connectionsPerServer, serverGroup, null, PoolManager.createFactory(), pingInterval,
         idleTimeout, lifetimeTimeout, -1);
@@ -155,7 +154,6 @@ public abstract class ClientServerTestCase extends JUnit4CacheTestCase {
   public static Pool configureConnectionPool(AttributesFactory factory, String host, int[] ports,
       boolean establish, int redundancy, int connectionsPerServer, String serverGroup,
       int pingInterval, int idleTimeout, int lifetimeTimeout, int statisticInterval) {
-    /* poolName */
     return configureConnectionPoolWithNameAndFactory(factory, host, ports, establish, redundancy,
         connectionsPerServer, serverGroup, null, PoolManager.createFactory(), pingInterval,
         idleTimeout, lifetimeTimeout, statisticInterval);

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/TestCacheCallback.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/TestCacheCallback.java
@@ -16,7 +16,6 @@ package org.apache.geode.cache30;
 
 import org.apache.geode.cache.CacheCallback;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.WaitCriterion;
 
 /**
  * An abstract superclass of implementation of GemFire cache callbacks that are used for testing.
@@ -58,18 +57,7 @@ public abstract class TestCacheCallback implements CacheCallback {
 
   public boolean waitForInvocation(int timeoutMs, long interval) {
     if (!this.invoked) {
-      WaitCriterion ev = new WaitCriterion() {
-        @Override
-        public boolean done() {
-          return invoked;
-        }
-
-        @Override
-        public String description() {
-          return "listener was never invoked";
-        }
-      };
-      GeodeAwaitility.await().untilAsserted(ev);
+      GeodeAwaitility.await("listener was never invoked").until(() -> invoked);
     }
     return wasInvoked();
   }


### PR DESCRIPTION
- Changes to ClientServerTestCase to allow for the use of RegionFactory
- Removing Wait.pauses from run-time for testing.
- clean out a bunch of runnables
