### PR TITLE
GEODE-7647: Removing unused code from GMSJoinLeave

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1218,27 +1218,6 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
       }
       state.possibleCoordinator = oldest;
     }
-    ID coord = null;
-    boolean coordIsNoob = true;
-    for (; it.hasNext();) {
-      ID mbr = it.next();
-      if (!state.alreadyTried.contains(mbr)) {
-        boolean mbrIsNoob = (mbr.getVmViewId() < 0);
-        if (mbrIsNoob) {
-          // member has not yet joined
-          if (coordIsNoob && (coord == null
-              || services.getMemberFactory().getComparator().compare(coord, mbr) > 0)) {
-            coord = mbr;
-          }
-        } else {
-          // member has already joined
-          if (coordIsNoob || mbr.getVmViewId() > coord.getVmViewId()) {
-            coord = mbr;
-            coordIsNoob = false;
-          }
-        }
-      }
-    }
     logger.info("findCoordinator chose {} out of these possible coordinators: {}",
         state.possibleCoordinator, possibleCoordinators);
     return true;


### PR DESCRIPTION
Removing some code which set the coord and coordIsNoob local variables but
never used them.
