### PR TITLE
GEODE-7649 upgrade tests fail when v1.11 is added to geode-old-versions

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocatorRecoveryIntegrationTest.java
@@ -232,7 +232,7 @@ public class GMSLocatorRecoveryIntegrationTest {
       oos.writeInt(fileStamp);
       oos.writeInt(ordinal);
       oos.flush();
-      DataOutput dataOutput = new DataOutputStream(fileStream);
+      DataOutput dataOutput = new DataOutputStream(oos);
       DataSerializer.writeObject(object, dataOutput);
       fileStream.flush();
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -459,7 +459,7 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
         Version geodeVersion = Version.fromOrdinalNoThrow((short) version, false);
         logger.info("Peer locator found that persistent view was written with version {}",
             geodeVersion);
-        if (geodeVersion.equals(Version.GEODE_1_11_0)) {
+        if (Version.GEODE_1_11_0.equals(geodeVersion)) {
           // v1.11 did not create the file with an ObjectOutputStream, so don't use one here
           input = new VersionedDataInputStream(fileInputStream, geodeVersion);
         } else {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/GMSLocator.java
@@ -362,7 +362,7 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
       oos.writeInt(LOCATOR_FILE_STAMP);
       oos.writeInt(Version.getCurrentVersion().ordinal());
       oos.flush();
-      DataOutputStream dataOutputStream = new DataOutputStream(fileStream);
+      DataOutputStream dataOutputStream = new DataOutputStream(oos);
       objectSerializer.writeObject(view, dataOutputStream);
     } catch (Exception e) {
       logger.warn(
@@ -439,7 +439,8 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
       return false;
     }
 
-    logger.info("Peer locator recovering from {}", file.getAbsolutePath());
+    logger.info("Peer locator recovering from {} with size {}",
+        file.getAbsolutePath(), file.length());
     try (FileInputStream fileInputStream = new FileInputStream(file);
         ObjectInputStream ois = new ObjectInputStream(fileInputStream)) {
       int stamp = ois.readInt();
@@ -449,15 +450,21 @@ public class GMSLocator<ID extends MemberIdentifier> implements Locator<ID> {
 
       int version = ois.readInt();
       int currentVersion = Version.getCurrentVersion().ordinal();
-      DataInputStream input = new DataInputStream(fileInputStream);
-      if (version != currentVersion) {
+      DataInputStream input;
+      if (version == currentVersion) {
+        input = new DataInputStream(ois);
+      } else if (version > currentVersion) {
+        return false;
+      } else {
         Version geodeVersion = Version.fromOrdinalNoThrow((short) version, false);
         logger.info("Peer locator found that persistent view was written with version {}",
             geodeVersion);
-        if (version > currentVersion) {
-          return false;
+        if (geodeVersion.equals(Version.GEODE_1_11_0)) {
+          // v1.11 did not create the file with an ObjectOutputStream, so don't use one here
+          input = new VersionedDataInputStream(fileInputStream, geodeVersion);
+        } else {
+          input = new VersionedDataInputStream(ois, geodeVersion);
         }
-        input = new VersionedDataInputStream(ois, geodeVersion);
       }
 
       // TBD - services isn't available when we recover from disk so this will throw an NPE


### PR DESCRIPTION
Geode v1.11 inadvertently changed the form of its saved membership view
by using a FileOutputStream to write it to disk instead of using
an ObjectOutputStream.  The latter writes additional information during
serialization.

Note: there is already a test for this change that will start running
when v1.12 is created and v1.11 is added as a geode-old-version in
settings.gradle.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
