### PR TITLE
GEODE-7655:Restore context with distinct state after a recursion step.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledSelect.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledSelect.java
@@ -393,6 +393,7 @@ public class CompiledSelect extends AbstractCompiledValue {
       TypeMismatchException, NameResolutionException, QueryInvocationTargetException {
     context.newScope((Integer) context.cacheGet(scopeID));
     context.pushExecCache((Integer) context.cacheGet(scopeID));
+    boolean prevDistinctState = context.isDistinct();
     context.setDistinct(this.distinct);
     if (this.hasUnmappedOrderByCols && context.getBucketList() != null) {
       throw new QueryInvalidException(
@@ -615,6 +616,7 @@ public class CompiledSelect extends AbstractCompiledValue {
       }
       return result;
     } finally {
+      context.setDistinct(prevDistinctState);
       context.popScope();
       context.popExecCache();
     }
@@ -1311,6 +1313,8 @@ public class CompiledSelect extends AbstractCompiledValue {
           } else if (values[i] instanceof PdxString) {
             values[i] = values[i].toString();
           }
+        } else if (values[i] instanceof PdxString) {
+          values[i] = values[i].toString();
         }
       }
       // if order by is present

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/Functions.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/Functions.java
@@ -18,8 +18,6 @@ package org.apache.geode.cache.query.internal;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
-import java.util.HashSet;
-import java.util.Set;
 
 import org.apache.geode.cache.query.FunctionDomainException;
 import org.apache.geode.cache.query.NameResolutionException;
@@ -93,21 +91,6 @@ public class Functions {
 
     if (arg instanceof Collection) {
       Collection c = (Collection) arg;
-      // for remote distinct queries, the result of sub query could contain a
-      // mix of String and PdxString which could be duplicates, so convert all
-      // PdxStrings to String
-      if (context.isDistinct() && ((DefaultQuery) context.getQuery()).isRemoteQuery()) {
-        Set tempResults = new HashSet();
-        for (Object o : c) {
-          if (o instanceof PdxString) {
-            o = ((PdxString) o).toString();
-          }
-          tempResults.add(o);
-        }
-        c.clear();
-        c.addAll(tempResults);
-        tempResults = null;
-      }
       checkSingleton(c.size());
       return c.iterator().next();
     }

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/NestedQueryClassCastExceptionFailureDUnitTest.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/NestedQueryClassCastExceptionFailureDUnitTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+import java.util.TreeMap;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.version.VersionManager;
+
+public class NestedQueryClassCastExceptionFailureDUnitTest {
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Test
+  public void classCastExceptionShouldNotBeThrownWhileExecutionNestedQueries() {
+    Host host = Host.getHost(0);
+    VM server = host.getVM(VersionManager.CURRENT_VERSION, 0);
+    server.invoke(() -> {
+      Properties properties = new Properties();
+      properties.put(SERIALIZABLE_OBJECT_FILTER,
+          "org.apache.geode.management.internal.cli.commands.*");
+      Cache cache = new CacheFactory(properties)
+          .setPdxSerializer(new ReflectionBasedAutoSerializer(
+              "org.apache.geode.management.internal.cli.commands.*"))
+          .create();
+
+      CacheServer cacheServer = cache.addCacheServer();
+      cacheServer.setPort(0);
+      cacheServer.start();
+      Region region = cache.createRegionFactory(RegionShortcut.REPLICATE).create("product");
+      QueryService queryService = cache.getQueryService();
+      queryService.createKeyIndex("productIDPKIndex", "productID", "/product");
+      queryService.createIndex("productIdIndex", "productId", "/product");
+      queryService
+          .createIndex("productCodesGMIIndex", "productCodes['GMI']", "/product");
+      TreeMap<String, String> tempMap = new TreeMap<>();
+      tempMap.put("GMI", "GMI");
+      region.put(1, new Product(1L, tempMap, "2L", "ACTIVE"));
+      region.put(2, new Product(2L, tempMap, null, "ACTIVE"));
+      region.put(3, new Product(3L, tempMap, "2L", "ACTIVE"));
+      region.put(4, new Product(4L, tempMap, null, "ACTIVE"));
+      SelectResults results =
+          (SelectResults) cache.getQueryService()
+              .newQuery(
+                  "select  productId, productCodes['GMI'], contractSize from /product where contractSize = null and productCodes['GMI'] in (select  distinct b.productCodes['GMI'] from /product b where b.contractSize != null and b.status='ACTIVE') LIMIT 2000")
+              .execute();
+      assertEquals(2, results.size());
+    });
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/Product.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/Product.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import java.io.Serializable;
+import java.util.TreeMap;
+
+public class Product implements Serializable/* , PdxSerializable */ {
+  Long productID;
+
+  public long getProductID() {
+    return productID;
+  }
+
+  public void setProductID(Long productID) {
+    this.productID = productID;
+  }
+
+  public TreeMap<String, String> getProductCodes() {
+    return productCodes;
+  }
+
+  public void setProductCodes(TreeMap<String, String> productCodes) {
+    this.productCodes = productCodes;
+  }
+
+  public String getContractSize() {
+    return contractSize;
+  }
+
+  public void setContractSize(String contractSize) {
+    this.contractSize = contractSize;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  TreeMap<String, String> productCodes;
+  String contractSize;
+  String status;
+
+  public Product(Long productID, TreeMap<String, String> productCodes, String contractSize,
+      String status) {
+    this.productID = productID;
+    this.productCodes = productCodes;
+    this.contractSize = contractSize;
+    this.status = status;
+  }
+
+  public Product() {}
+
+  @Override
+  public String toString() {
+    return "Product{" +
+        "productID=" + productID +
+        ", productCodes=" + productCodes +
+        ", contractSize='" + contractSize + '\'' +
+        ", status='" + status + '\'' +
+        '}';
+  }
+}


### PR DESCRIPTION
	* After a recursion step within Compiled Select's evaluate statement, the distinct flag was lost for the outer query.
	* The solution was to reset the distinct state back using a temp variable to store the initial distinct flag value.
	* Also, in this diff a else part section was missing converting PDX strings to normal strings for comparison of distinct.
	* When we place this else section converting the PDX string to string for distinct comparison, we don't need to perform this check in the 'element' query function.

Removing the JPMC related configurations

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
