### PR TITLE
GEODE-7648: elide hostname resolution if bind addy not loopback

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSUtil.java
@@ -90,8 +90,7 @@ public class GMSUtil {
     List<HostAddress> result = new ArrayList<>(2);
     Set<InetSocketAddress> inetAddresses = new HashSet<>();
     String host;
-    boolean checkLoopback = (bindAddress != null);
-    boolean isLoopback = (checkLoopback && bindAddress.isLoopbackAddress());
+    final boolean isLoopback = ((bindAddress != null) && bindAddress.isLoopbackAddress());
 
     StringTokenizer parts = new StringTokenizer(locatorsString, ",");
     while (parts.hasMoreTokens()) {
@@ -134,7 +133,7 @@ public class GMSUtil {
 
       final InetSocketAddress isa = new InetSocketAddress(host, port);
 
-      if (checkLoopback) {
+      if (isLoopback) {
         final InetAddress locatorAddress = isa.getAddress();
 
         if (locatorAddress == null) {
@@ -142,7 +141,7 @@ public class GMSUtil {
               " at an unknown address or FQDN: " + host);
         }
 
-        if (isLoopback && !locatorAddress.isLoopbackAddress()) {
+        if (!locatorAddress.isLoopbackAddress()) {
           throw new MembershipConfigurationException(
               "This process is attempting to join with a loopback address (" + bindAddress
                   + ") using a locator that does not have a local address (" + isa

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/GMSUtilTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/GMSUtilTest.java
@@ -119,4 +119,42 @@ public class GMSUtilTest {
                 "fdf0:76cf:a0ed:9449::5"));
   }
 
+  @Test
+  public void multipleHosts() throws MembershipConfigurationException {
+    final List<HostAddress> addys =
+        parseLocators(
+            "geodecluster-sample-locator-0.geodecluster-sample-locator[10334],"
+                + "geodecluster-sample-locator-1.geodecluster-sample-locator[10334],"
+                + "geodecluster-sample-locator-2.geodecluster-sample-locator[10334]",
+            (InetAddress) null);
+    assertThat(addys).contains(
+        new HostAddress(
+            new InetSocketAddress("geodecluster-sample-locator-2.geodecluster-sample-locator",
+                10334),
+            "geodecluster-sample-locator-2.geodecluster-sample-locator"));
+    assertThat(addys).hasSize(3);
+  }
+
+  @Test
+  public void multipleHostsWithBindAddress() throws MembershipConfigurationException {
+    assertThatThrownBy(() -> parseLocators(
+        "geodecluster-sample-locator-0.geodecluster-sample-locator[10334],"
+            + "geodecluster-sample-locator-1.geodecluster-sample-locator[10334],"
+            + "geodecluster-sample-locator-2.geodecluster-sample-locator[10334]",
+        "127.0.0.1"))
+            .isInstanceOf(MembershipConfigurationException.class)
+            .hasMessageContaining("unknown address or FQDN");
+  }
+
+  @Test
+  public void nonLoopbackBindAddressDoesNotResolveLocatorAddress()
+      throws MembershipConfigurationException {
+    final List<HostAddress> hostAddresses =
+        parseLocators(UNRESOLVEABLE_HOST + "[" + PORT + "]",
+            RESOLVEABLE_NON_LOOPBACK_HOST);
+    assertThat(hostAddresses)
+        .contains(new HostAddress(new InetSocketAddress(UNRESOLVEABLE_HOST, PORT),
+            UNRESOLVEABLE_HOST));
+  }
+
 }


### PR DESCRIPTION
[GEODE-7648](https://issues.apache.org/jira/browse/GEODE-7648) second try at a fix

The original fix (already merged to `develop`) failed to condition resolving the locator address, on the bind addy being a loopback addy. That is a particular problem when starting a locator in a Docker container where other locators are in neighboring containers that might not be running yet, and so, might not have their names in the DNS.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
