### PR TITLE
GEODE-7658: Removing hostname resolution from TcpSocketCreatorAdapter

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
@@ -182,7 +182,7 @@ public class JGroupsMessengerJUnitTest {
 
     socketCreator = asTcpSocketCreator(SocketCreatorFactory.setDistributionConfig(config)
         .getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER));
-    messenger = new JGroupsMessenger<MemberIdentifier>(socketCreator);
+    messenger = new JGroupsMessenger<MemberIdentifier>();
     messenger.init(services);
 
     // if I do this earlier then test this return messenger as null
@@ -878,7 +878,7 @@ public class JGroupsMessengerJUnitTest {
     JChannel channel = messenger.myChannel;
     tconfig.setOldDSMembershipInfo(new MembershipInformationImpl(channel,
         new ConcurrentLinkedQueue<>()));
-    JGroupsMessenger newMessenger = new JGroupsMessenger(socketCreator);
+    JGroupsMessenger newMessenger = new JGroupsMessenger();
     newMessenger.init(services);
     newMessenger.start();
     newMessenger.started();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/TcpSocketCreatorAdapter.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/adapter/TcpSocketCreatorAdapter.java
@@ -19,12 +19,10 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.UnknownHostException;
 import java.util.Objects;
 
 import org.apache.geode.distributed.internal.tcpserver.ConnectionWatcher;
 import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
-import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.internal.net.SocketCreator;
 
 /**
@@ -62,16 +60,6 @@ public class TcpSocketCreatorAdapter implements TcpSocketCreator {
   }
 
   @Override
-  public InetAddress getLocalHost() throws UnknownHostException {
-    return LocalHostUtil.getLocalHost();
-  }
-
-  @Override
-  public String getHostName(final InetAddress addr) {
-    return SocketCreator.getHostName(addr);
-  }
-
-  @Override
   public ServerSocket createServerSocketUsingPortRange(final InetAddress ba, final int backlog,
       final boolean isBindAddress, final boolean useNIO, final int tcpBufferSize,
       final int[] tcpPortRange, final boolean sslConnection) throws IOException {
@@ -99,8 +87,4 @@ public class TcpSocketCreatorAdapter implements TcpSocketCreator {
     socketCreator.handshakeIfSocketIsSSL(socket, timeout);
   }
 
-  @Override
-  public boolean resolveDns() {
-    return socketCreator.resolve_dns;
-  }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
@@ -150,7 +150,7 @@ public class Services<ID extends MemberIdentifier> {
     this.manager = membershipManager;
     this.joinLeave = new GMSJoinLeave<>(locatorClient);
     this.healthMon = new GMSHealthMonitor<>(socketCreator);
-    this.messenger = new JGroupsMessenger<>(socketCreator);
+    this.messenger = new JGroupsMessenger<>();
     this.auth = authenticator;
     this.serializer = serializer;
     this.memberFactory = memberFactory;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -89,8 +89,8 @@ import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordina
 import org.apache.geode.distributed.internal.membership.gms.locator.FindCoordinatorResponse;
 import org.apache.geode.distributed.internal.membership.gms.messages.JoinRequestMessage;
 import org.apache.geode.distributed.internal.membership.gms.messages.JoinResponseMessage;
-import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.internal.cache.DistributedCacheOperation;
+import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.internal.serialization.BufferDataOutputStream;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
@@ -135,11 +135,8 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
   ID localAddress;
   JGAddress jgAddress;
   private Services<ID> services;
-  private TcpSocketCreator socketCreator;
 
-  public JGroupsMessenger(final TcpSocketCreator socketCreator) {
-    this.socketCreator = socketCreator;
-  }
+  public JGroupsMessenger() {}
 
   /** handlers that receive certain classes of messages instead of the Manager */
   private final Map<Class<?>, MessageHandler<?>> handlers = new ConcurrentHashMap<>();
@@ -285,7 +282,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     // JGroups UDP protocol requires a bind address
     if (str == null || str.length() == 0) {
       try {
-        str = socketCreator.getLocalHost().getHostAddress();
+        str = LocalHostUtil.getLocalHost().getHostAddress();
       } catch (UnknownHostException e) {
         throw new MembershipConfigurationException(e.getMessage(), e);
       }
@@ -552,7 +549,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
 
     // establish the DistributedSystem's address
     String hostname =
-        socketCreator.resolveDns() ? socketCreator.getHostName(jgAddress.getInetAddress())
+        !config.isNetworkPartitionDetectionEnabled() ? jgAddress.getInetAddress().getHostName()
             : jgAddress.getInetAddress().getHostAddress();
     GMSMemberData gmsMember = new GMSMemberData(jgAddress.getInetAddress(),
         hostname, jgAddress.getPort(),

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/messenger/StatRecorderJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/gms/messenger/StatRecorderJUnitTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.net.InetAddress;
 import java.util.Properties;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -42,7 +41,6 @@ import org.apache.geode.distributed.internal.membership.api.MembershipConfig;
 import org.apache.geode.distributed.internal.membership.api.MembershipStatistics;
 import org.apache.geode.distributed.internal.membership.gms.Services;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Manager;
-import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
 /**
@@ -172,11 +170,9 @@ public class StatRecorderJUnitTest {
     when(mockConfig.getMembershipPortRange()).thenReturn(new int[] {0, 10});
     when(mockConfig.getSecurityUDPDHAlgo()).thenReturn("");
     when(mockServices.getConfig()).thenReturn(mockConfig);
-    TcpSocketCreator socketCreator = mock(TcpSocketCreator.class);
-    when(socketCreator.getLocalHost()).thenReturn(InetAddress.getLocalHost());
 
 
-    JGroupsMessenger messenger = new JGroupsMessenger(socketCreator);
+    JGroupsMessenger messenger = new JGroupsMessenger();
     messenger.init(mockServices);
     String jgroupsConfig = messenger.jgStackConfig;
     System.out.println(jgroupsConfig);
@@ -187,7 +183,7 @@ public class StatRecorderJUnitTest {
     when(mockServices.getConfig()).thenReturn(mockConfig);
 
 
-    messenger = new JGroupsMessenger(socketCreator);
+    messenger = new JGroupsMessenger();
     messenger.init(mockServices);
     assertTrue(jgroupsConfig.contains("gms.messenger.StatRecorder"));
   }

--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpSocketCreator.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpSocketCreator.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.UnknownHostException;
 
 
 /**
@@ -32,10 +31,6 @@ public interface TcpSocketCreator {
 
   ServerSocket createServerSocket(int nport, int backlog, InetAddress bindAddr)
       throws IOException;
-
-  InetAddress getLocalHost() throws UnknownHostException;
-
-  String getHostName(InetAddress addr);
 
   ServerSocket createServerSocketUsingPortRange(InetAddress ba, int backlog,
       boolean isBindAddress, boolean useNIO, int tcpBufferSize, int[] tcpPortRange,
@@ -50,5 +45,4 @@ public interface TcpSocketCreator {
 
   void handshakeIfSocketIsSSL(Socket socket, int timeout) throws IOException;
 
-  boolean resolveDns();
 }


### PR DESCRIPTION
We didn't need these methods on TcpSocketCreatorAdapter.
* resolveDns is based on whether network partition detection is enabled, which
we can access directly in membership.

* getHostName uses a static hostname cache that we don't need to use
for membership when creating the local address.

* getLocalHost has moved to a utility in geode-common.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
