### PR TITLE
GEODE-7661: Check for null membershipID when serializing EventID

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -977,7 +977,7 @@ toData,22
 org/apache/geode/internal/cache/EventID,4
 fromData,53
 fromDataPre_GFE_8_0_0_0,33
-toData,99
+toData,106
 toDataPre_GFE_8_0_0_0,24
 
 org/apache/geode/internal/cache/EvictionAttributesImpl,2

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EventID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EventID.java
@@ -356,7 +356,7 @@ public class EventID implements DataSerializableFixedID, Serializable, Externali
     // using the client's version to ensure it gets the proper on-wire form
     // of the identifier
     // See GEODE-3072
-    if (version.compareTo(Version.GEODE_1_1_0) < 0) {
+    if (membershipID != null && version.compareTo(Version.GEODE_1_1_0) < 0) {
       InternalDistributedMember member = getDistributedMember(Version.GFE_90);
       // reserialize with the client's version so that we write the UUID
       // bytes

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EventIDTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EventIDTest.java
@@ -1,0 +1,40 @@
+package org.apache.geode.internal.cache;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import org.apache.geode.DataSerializer;
+import org.apache.geode.internal.HeapDataOutputStream;
+import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionedDataInputStream;
+
+public class EventIDTest {
+
+  @Test
+  public void emptyEventIdCanBeSerializedWithCurrentVersion()
+      throws IOException, ClassNotFoundException {
+    emptyEventIdCanBeSerialized(Version.CURRENT);
+
+  }
+
+  @Test
+  public void emptyEventIdCanBeSerializedToGeode100() throws IOException, ClassNotFoundException {
+    emptyEventIdCanBeSerialized(Version.GFE_90);
+  }
+
+  private void emptyEventIdCanBeSerialized(Version version)
+      throws IOException, ClassNotFoundException {
+    EventID eventID = new EventID();
+    HeapDataOutputStream out = new HeapDataOutputStream(version);
+    DataSerializer.writeObject(eventID, out);
+
+    EventID result = DataSerializer.readObject(
+        new VersionedDataInputStream(new ByteArrayInputStream(out.toByteArray()), version));
+
+    Assertions.assertThat(result.getMembershipID()).isEqualTo(eventID.getMembershipID());
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EventIDTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EventIDTest.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.internal.cache;
 
 import java.io.ByteArrayInputStream;


### PR DESCRIPTION
We create an serialize an EventID with a null membershipID. When serializing to
a Geode 1.0.0 member, this resulted in an NPE in some version transalation
logic. Fixing the version translation logic to check for null.
