### PR TITLE
GEODE-7662: don't automatically enable metrics and examples if not public

### DIFF
--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -278,8 +278,10 @@ unpausePipeline ${PIPELINE_PREFIX}main
 
 if [[ "$GEODE_FORK" == "${UPSTREAM_FORK}" ]]; then
   exposePipelines ${PIPELINE_PREFIX}main ${PIPELINE_PREFIX}images
-  enableFeature metrics
-  enableFeature examples
+  if [[ "${PUBLIC}" == "true" ]]; then
+    enableFeature metrics
+    enableFeature examples
+  fi
   if [[ "$GEODE_BRANCH" == "develop" ]]; then
     enableFeature pr
   fi


### PR DESCRIPTION
for any context other than the public apache-develop-main or release pipelines, metrics and examples aren't going to work, so don't insist on enabling them just to create a sea of red