### PR TITLE
GEODE-7653: move required settings to MembershipBuilder constructor

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 import org.junit.After;
 import org.junit.Before;
@@ -66,13 +68,15 @@ public class MembershipOnlyTest {
     // TODO - using geode-core socket creator
     socketCreator = asTcpSocketCreator(new SocketCreator(new SSLConfig.Builder().build()));
 
-    membershipLocator = MembershipLocatorBuilder.<InternalDistributedMember>newLocatorBuilder()
-        .setExecutorServiceSupplier(() -> LoggingExecutors.newCachedThreadPool("membership", false))
-        .setSocketCreator(socketCreator)
-        .setObjectSerializer(dsfidSerializer.getObjectSerializer())
-        .setObjectDeserializer(dsfidSerializer.getObjectDeserializer())
-        .setWorkingDirectory(temporaryFolder.newFile("locator").toPath())
-        .setConfig(new MembershipConfig() {})
+    final Supplier<ExecutorService> executorServiceSupplier =
+        () -> LoggingExecutors.newCachedThreadPool("membership", false);
+    membershipLocator = MembershipLocatorBuilder.<InternalDistributedMember>newLocatorBuilder(
+        socketCreator,
+        dsfidSerializer.getObjectSerializer(),
+        dsfidSerializer.getObjectDeserializer(),
+        temporaryFolder.newFile("locator").toPath(),
+        new MembershipConfig() {},
+        executorServiceSupplier)
         .create();
 
     membershipLocator.start();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
@@ -75,7 +75,6 @@ public class MembershipOnlyTest {
         dsfidSerializer.getObjectSerializer(),
         dsfidSerializer.getObjectDeserializer(),
         temporaryFolder.newFile("locator").toPath(),
-        new MembershipConfig() {},
         executorServiceSupplier)
         .create();
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
@@ -109,19 +109,16 @@ public class MembershipOnlyTest {
     MemberIdentifierFactoryImpl memberIdFactory = new MemberIdentifierFactoryImpl();
 
 
-    TcpClient client = new TcpClient(socketCreator, dsfidSerializer.getObjectSerializer(),
+    TcpClient locatorClient = new TcpClient(socketCreator, dsfidSerializer.getObjectSerializer(),
         dsfidSerializer.getObjectDeserializer());
 
     LifecycleListener<InternalDistributedMember> lifeCycleListener = mock(LifecycleListener.class);
 
     final Membership<InternalDistributedMember> membership =
-        MembershipBuilder.<InternalDistributedMember>newMembershipBuilder()
+        MembershipBuilder.<InternalDistributedMember>newMembershipBuilder(
+            socketCreator, locatorClient, dsfidSerializer, memberIdFactory)
             .setConfig(config)
-            .setSerializer(dsfidSerializer)
             .setLifecycleListener(lifeCycleListener)
-            .setMemberIDFactory(memberIdFactory)
-            .setLocatorClient(client)
-            .setSocketCreator(socketCreator)
             .create();
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -549,8 +549,8 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
               InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
               InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer(),
               workingDirectory,
-              config,
               executor)
+              .setConfig(config)
               .setPort(port)
               .setBindAddress(bindAddress)
               .setProtocolChecker(new ProtocolCheckerImpl(this, new ClientProtocolServiceLoader()))

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipBuilder.java
@@ -36,19 +36,15 @@ public interface MembershipBuilder<ID extends MemberIdentifier> {
 
   MembershipBuilder<ID> setConfig(MembershipConfig membershipConfig);
 
-  MembershipBuilder<ID> setSerializer(DSFIDSerializer serializer);
-
-  MembershipBuilder<ID> setMemberIDFactory(MemberIdentifierFactory<ID> memberFactory);
-
   MembershipBuilder<ID> setLifecycleListener(LifecycleListener<ID> lifecycleListener);
-
-  MembershipBuilder<ID> setLocatorClient(final TcpClient tcpClient);
-
-  MembershipBuilder<ID> setSocketCreator(final TcpSocketCreator socketCreator);
 
   Membership<ID> create() throws MembershipConfigurationException;
 
-  static <ID extends MemberIdentifier> MembershipBuilder<ID> newMembershipBuilder() {
-    return new MembershipBuilderImpl<>();
+  static <ID extends MemberIdentifier> MembershipBuilder<ID> newMembershipBuilder(
+      final TcpSocketCreator socketCreator,
+      final TcpClient locatorClient,
+      final DSFIDSerializer serializer,
+      final MemberIdentifierFactory<ID> memberFactory) {
+    return new MembershipBuilderImpl<>(socketCreator, locatorClient, serializer, memberFactory);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipLocatorBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipLocatorBuilder.java
@@ -32,6 +32,8 @@ public interface MembershipLocatorBuilder<ID extends MemberIdentifier> {
 
   MembershipLocatorBuilder<ID> setBindAddress(InetAddress bindAddress);
 
+  MembershipLocatorBuilder<ID> setConfig(MembershipConfig membershipConfig);
+
   MembershipLocatorBuilder<ID> setProtocolChecker(ProtocolChecker protocolChecker);
 
   MembershipLocatorBuilder<ID> setFallbackHandler(TcpHandler fallbackHandler);
@@ -48,9 +50,8 @@ public interface MembershipLocatorBuilder<ID extends MemberIdentifier> {
       final ObjectSerializer objectSerializer,
       final ObjectDeserializer objectDeserializer,
       final Path workingDirectory,
-      final MembershipConfig config,
       final Supplier<ExecutorService> executorServiceSupplier) {
     return new MembershipLocatorBuilderImpl<ID>(socketCreator, objectSerializer, objectDeserializer,
-        workingDirectory, config, executorServiceSupplier);
+        workingDirectory, executorServiceSupplier);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipLocatorBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipLocatorBuilder.java
@@ -34,29 +34,23 @@ public interface MembershipLocatorBuilder<ID extends MemberIdentifier> {
 
   MembershipLocatorBuilder<ID> setProtocolChecker(ProtocolChecker protocolChecker);
 
-  MembershipLocatorBuilder<ID> setExecutorServiceSupplier(
-      Supplier<ExecutorService> executorServiceSupplier);
-
-  MembershipLocatorBuilder<ID> setSocketCreator(TcpSocketCreator socketCreator);
-
-  MembershipLocatorBuilder<ID> setObjectSerializer(ObjectSerializer objectSerializer);
-
-  MembershipLocatorBuilder<ID> setObjectDeserializer(ObjectDeserializer objectDeserializer);
-
   MembershipLocatorBuilder<ID> setFallbackHandler(TcpHandler fallbackHandler);
 
   MembershipLocatorBuilder<ID> setLocatorsAreCoordinators(boolean locatorsAreCoordinators);
 
   MembershipLocatorBuilder<ID> setLocatorStats(MembershipLocatorStatistics locatorStats);
 
-  MembershipLocatorBuilder<ID> setWorkingDirectory(Path workingDirectory);
-
-  MembershipLocatorBuilder<ID> setConfig(MembershipConfig config);
-
   MembershipLocator<ID> create()
       throws UnknownHostException, MembershipConfigurationException;
 
-  static <ID extends MemberIdentifier> MembershipLocatorBuilder<ID> newLocatorBuilder() {
-    return new MembershipLocatorBuilderImpl<ID>();
+  static <ID extends MemberIdentifier> MembershipLocatorBuilder<ID> newLocatorBuilder(
+      final TcpSocketCreator socketCreator,
+      final ObjectSerializer objectSerializer,
+      final ObjectDeserializer objectDeserializer,
+      final Path workingDirectory,
+      final MembershipConfig config,
+      final Supplier<ExecutorService> executorServiceSupplier) {
+    return new MembershipLocatorBuilderImpl<ID>(socketCreator, objectSerializer, objectDeserializer,
+        workingDirectory, config, executorServiceSupplier);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -98,7 +98,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
   private final ManagerImpl gmsManager;
 
 
-  private LifecycleListener<ID> lifecycleListener;
+  private final LifecycleListener<ID> lifecycleListener;
 
   private volatile boolean isCloseInProgress;
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipBuilderImpl.java
@@ -35,19 +35,28 @@ import org.apache.geode.internal.serialization.DSFIDSerializer;
  * a GMSMembership.
  */
 public class MembershipBuilderImpl<ID extends MemberIdentifier> implements MembershipBuilder<ID> {
-  private TcpSocketCreator socketCreator;
-  private TcpClient locatorClient;
+  private final TcpSocketCreator socketCreator;
+  private final TcpClient locatorClient;
   private MembershipListener<ID> membershipListener = new MembershipListenerNoOp();
   private MessageListener<ID> messageListener = message -> {
   };
   private MembershipStatistics statistics = new MembershipStatisticsNoOp();
   private Authenticator<ID> authenticator = new AuthenticatorNoOp();
   private MembershipConfig membershipConfig = new MembershipConfig() {};
-  private DSFIDSerializer serializer;
-  private MemberIdentifierFactory<ID> memberFactory;
+  private final DSFIDSerializer serializer;
+  private final MemberIdentifierFactory<ID> memberFactory;
   private LifecycleListener<ID> lifecycleListener = new LifecycleListenerNoOp();
 
-  public MembershipBuilderImpl() {}
+  public MembershipBuilderImpl(
+      final TcpSocketCreator socketCreator,
+      final TcpClient locatorClient,
+      final DSFIDSerializer serializer,
+      final MemberIdentifierFactory<ID> memberFactory) {
+    this.socketCreator = socketCreator;
+    this.locatorClient = locatorClient;
+    this.serializer = serializer;
+    this.memberFactory = memberFactory;
+  }
 
   @Override
   public MembershipBuilder<ID> setAuthenticator(Authenticator<ID> authenticator) {
@@ -76,30 +85,6 @@ public class MembershipBuilderImpl<ID extends MemberIdentifier> implements Membe
   @Override
   public MembershipBuilder<ID> setConfig(MembershipConfig membershipConfig) {
     this.membershipConfig = membershipConfig;
-    return this;
-  }
-
-  @Override
-  public MembershipBuilder<ID> setSerializer(DSFIDSerializer serializer) {
-    this.serializer = serializer;
-    return this;
-  }
-
-  @Override
-  public MembershipBuilder<ID> setMemberIDFactory(MemberIdentifierFactory<ID> memberFactory) {
-    this.memberFactory = memberFactory;
-    return this;
-  }
-
-  @Override
-  public MembershipBuilder<ID> setLocatorClient(final TcpClient locatorClient) {
-    this.locatorClient = locatorClient;
-    return this;
-  }
-
-  @Override
-  public MembershipBuilder<ID> setSocketCreator(final TcpSocketCreator socketCreator) {
-    this.socketCreator = socketCreator;
     return this;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipLocatorBuilderImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipLocatorBuilderImpl.java
@@ -45,7 +45,7 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
   private final ObjectSerializer objectSerializer;
   private final ObjectDeserializer objectDeserializer;
   private final Path workingDirectory;
-  private final MembershipConfig config;
+  private MembershipConfig config = new MembershipConfig() {};
   private final Supplier<ExecutorService> executorServiceSupplier;
 
   public MembershipLocatorBuilderImpl(
@@ -53,13 +53,11 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
       final ObjectSerializer objectSerializer,
       final ObjectDeserializer objectDeserializer,
       final Path workingDirectory,
-      final MembershipConfig config,
       final Supplier<ExecutorService> executorServiceSupplier) {
     this.socketCreator = socketCreator;
     this.objectSerializer = objectSerializer;
     this.objectDeserializer = objectDeserializer;
     this.workingDirectory = workingDirectory;
-    this.config = config;
     this.executorServiceSupplier = executorServiceSupplier;
   }
 
@@ -72,6 +70,12 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
   @Override
   public MembershipLocatorBuilder<ID> setBindAddress(InetAddress bindAddress) {
     this.bindAddress = bindAddress;
+    return this;
+  }
+
+  @Override
+  public MembershipLocatorBuilder<ID> setConfig(final MembershipConfig config) {
+    this.config = config;
     return this;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipLocatorBuilderImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipLocatorBuilderImpl.java
@@ -41,12 +41,27 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
   private TcpHandler fallbackHandler = new TcpHandlerNoOp();
   private MembershipLocatorStatistics locatorStats = new MembershipLocatorStatisticsNoOp();
   private boolean locatorsAreCoordinators = true;
-  private TcpSocketCreator socketCreator;
-  private ObjectSerializer objectSerializer;
-  private ObjectDeserializer objectDeserializer;
-  private Path workingDirectory;
-  private MembershipConfig config;
-  private Supplier<ExecutorService> executorServiceSupplier;
+  private final TcpSocketCreator socketCreator;
+  private final ObjectSerializer objectSerializer;
+  private final ObjectDeserializer objectDeserializer;
+  private final Path workingDirectory;
+  private final MembershipConfig config;
+  private final Supplier<ExecutorService> executorServiceSupplier;
+
+  public MembershipLocatorBuilderImpl(
+      final TcpSocketCreator socketCreator,
+      final ObjectSerializer objectSerializer,
+      final ObjectDeserializer objectDeserializer,
+      final Path workingDirectory,
+      final MembershipConfig config,
+      final Supplier<ExecutorService> executorServiceSupplier) {
+    this.socketCreator = socketCreator;
+    this.objectSerializer = objectSerializer;
+    this.objectDeserializer = objectDeserializer;
+    this.workingDirectory = workingDirectory;
+    this.config = config;
+    this.executorServiceSupplier = executorServiceSupplier;
+  }
 
   @Override
   public MembershipLocatorBuilder<ID> setPort(int port) {
@@ -67,31 +82,6 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
   }
 
   @Override
-  public MembershipLocatorBuilder<ID> setExecutorServiceSupplier(
-      Supplier<ExecutorService> executorServiceSupplier) {
-    this.executorServiceSupplier = executorServiceSupplier;
-    return this;
-  }
-
-  @Override
-  public MembershipLocatorBuilder<ID> setSocketCreator(TcpSocketCreator socketCreator) {
-    this.socketCreator = socketCreator;
-    return this;
-  }
-
-  @Override
-  public MembershipLocatorBuilder<ID> setObjectSerializer(ObjectSerializer objectSerializer) {
-    this.objectSerializer = objectSerializer;
-    return this;
-  }
-
-  @Override
-  public MembershipLocatorBuilder<ID> setObjectDeserializer(ObjectDeserializer objectDeserializer) {
-    this.objectDeserializer = objectDeserializer;
-    return this;
-  }
-
-  @Override
   public MembershipLocatorBuilder<ID> setFallbackHandler(TcpHandler fallbackHandler) {
     this.fallbackHandler = fallbackHandler;
     return this;
@@ -106,18 +96,6 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
   @Override
   public MembershipLocatorBuilder<ID> setLocatorStats(MembershipLocatorStatistics locatorStats) {
     this.locatorStats = locatorStats;
-    return this;
-  }
-
-  @Override
-  public MembershipLocatorBuilder<ID> setWorkingDirectory(Path workingDirectory) {
-    this.workingDirectory = workingDirectory;
-    return this;
-  }
-
-  @Override
-  public MembershipLocatorBuilder<ID> setConfig(MembershipConfig config) {
-    this.config = config;
     return this;
   }
 


### PR DESCRIPTION
[GEODE-7653](https://issues.apache.org/jira/browse/GEODE-7653)

> Right now it is not clear from the API which attributes of MembershipBuilder and MembershipLocatorBuilder are required vs. which ones are optional.
> Ideally, it should be enforced at compile time that all required fields are specified, maybe by passing all required fields to the constructor

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
