### PR TITLE
GEODE-5407: Fix JMXMBeanReconnectDUnitTest

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -2212,7 +2212,9 @@ public class InternalDistributedSystem extends DistributedSystem
      * @param oldSystem the old DS, which is in a partially disconnected state and cannot be used
      *        for messaging
      */
-    void reconnecting(InternalDistributedSystem oldSystem);
+    default void reconnecting(InternalDistributedSystem oldSystem) {
+      // nothing
+    }
 
     /**
      * Invoked after a reconnect to the distributed system
@@ -2220,7 +2222,10 @@ public class InternalDistributedSystem extends DistributedSystem
      * @param oldSystem the old DS
      * @param newSystem the new DS
      */
-    void onReconnect(InternalDistributedSystem oldSystem, InternalDistributedSystem newSystem);
+    default void onReconnect(InternalDistributedSystem oldSystem,
+        InternalDistributedSystem newSystem) {
+      // nothing
+    }
   }
 
   /**

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
@@ -84,11 +84,11 @@ public class GfshCommandRule extends DescribedExternalResource {
   private CommandResult commandResult;
 
   public GfshCommandRule() {
-    createTempFolder();
+    this(null, null);
   }
 
   public GfshCommandRule(Supplier<Integer> portSupplier, PortType portType) {
-    this();
+    createTempFolder();
     this.portType = portType;
     this.portSupplier = portSupplier;
   }


### PR DESCRIPTION
```
GEODE-5407: Fix JMXMBeanReconnectDUnitTest
```
```
* Rewrite test with standard Geode and JMX APIs
* Use CountDownLatch instead of Blackboard
* Use SharedErrorCollector for remote listener errors
* Always consistently use Awaitility before checking GemFire MXBeans
    
Co-authored-by: Ivan Godwin <igodwin@pivotal.io>
```