### PR TITLE
GEODE-7686: Update the vMotion recommendations in the User Guide

### DIFF
--- a/geode-docs/managing/monitor_tune/performance_on_vsphere.html.md.erb
+++ b/geode-docs/managing/monitor_tune/performance_on_vsphere.html.md.erb
@@ -88,7 +88,7 @@ When vMotion migrations occur, there is an expected temporary drop in the perfor
 These workloads resume their normal rate of operation once the vMotion migration of the servers is completed.
 
 VMware recommends that all vMotion migration activity of <%=vars.product_name_long%> members occurs over 10GbE, during periods of low activity and scheduled maintenance windows.
-Test vMotion migrations in your own environment to assess differences in workload, networking and scale.
+Test vMotion migrations in your own environment to assess differences in workload, networking, and scale.
 
 If you wish to prevent automatic VMware vSphere vMotion® operations that can affect response times, place VMware vSphere Distributed Resource Scheduler™ (DRS) in manual mode when you first commission the data management system.
 

--- a/geode-docs/managing/monitor_tune/performance_on_vsphere.html.md.erb
+++ b/geode-docs/managing/monitor_tune/performance_on_vsphere.html.md.erb
@@ -32,7 +32,7 @@ Use the latest supported version of the guest OS, and use Java large paging.
 
 ## <a id="topic_D8393B1A75364E46B0F959F0DE820E9E" class="no-quick-link"></a>NUMA, CPU, and BIOS Settings
 
-This section provides VMware- recommended NUMA, CPU, and BIOS settings for your hardware and virtual machines.
+This section provides VMware-recommended NUMA, CPU, and BIOS settings for your hardware and virtual machines.
 
 -   Always enable hyper-threading, and do not overcommit CPU.
 -   For most production <%=vars.product_name_long%> servers, always use virtual machines with at least two vCPUs .
@@ -70,8 +70,11 @@ These guidelines help you reduce latency.
 
     If you restart the ESXi host, the above configuration must be reapplied.
 
+
     **Note:**
-    Disabling interrupt coalescing can reduce latency in virtual machines; however, it can impact performance and cause higher CPU utilization. It can also defeat the benefits of Large Receive Offloads (LRO) because some physical NICs (such as Intel 10GbE NICs) automatically disable LRO when interrupt coalescing is disabled. See [http://kb.vmware.com/kb/1027511](http://kb.vmware.com/kb/1027511) for more details.
+    Disabling interrupt coalescing can reduce latency in virtual machines; however, it can impact performance and cause higher CPU utilization. It can also defeat the benefits of Large Receive Offloads (LRO) because some physical NICs (such as Intel 10GbE NICs) automatically disable LRO when interrupt coalescing is disabled.
+This type of tuning benefits <%=vars.product_name%> workloads, but it can hurt other non-<%=vars.product_name_long%> workloads that are memory throughput-bound, as opposed to latency sensitive as in the case of <%=vars.product_name%> workloads.
+See [http://kb.vmware.com/kb/1027511](http://kb.vmware.com/kb/1027511) for more details.
 
 -   **Virtual NIC:** Use the following guidelines when configuring your virtual NICs:
     -   Use VMXNET3 virtual NICs for your latency-sensitive or otherwise performance-critical virtual machines. See [http://kb.vmware.com/kb/1001805](http://kb.vmware.com/kb/1001805) for details on selecting the appropriate type of virtual NIC for your virtual machine.
@@ -79,14 +82,15 @@ These guidelines help you reduce latency.
 
 ## <a id="topic_E6EB8AB6CCEF435A98B48B867FE9BFEB" class="no-quick-link"></a>VMware vSphere vMotion and DRS Cluster Usage
 
-This topic discusses use limitations of vSphere vMotion, including the use of it with DRS.
+This topic discusses use limitations of vSphere vMotion, including its use with DRS.
 
--   When you first commission the data management system, place VMware vSphere Distributed Resource Scheduler™ (DRS) in manual mode to prevent an automatic VMware vSphere vMotion® operation that can affect response times.
--   Reduce or eliminate the use of vMotion to migrate <%=vars.product_name%> virtual machines when they are under heavy load.
--   Do not allow vMotion migrations with <%=vars.product_name_long%> locator processes, as the latency introduced to this process can cause other members of the <%=vars.product_name_long%> servers to falsely suspect that other members are dead.
--   Use dedicated <%=vars.product_name_long%> vSphere DRS clusters. This is especially important when you consider that the physical NIC and virtual NIC are specifically tuned to disable Interrupt Coalescing on every NIC of an ESXi host in the cluster. This type of tuning benefits <%=vars.product_name%> workloads, but it can hurt other non-<%=vars.product_name_long%> workloads that are memory throughput-bound as opposed to latency sensitive as in the case of <%=vars.product_name_long%> workloads.
--   If using a dedicated vSphere DRS cluster is not an option, and <%=vars.product_name_long%> must run in a shared DRS cluster, make sure that DRS rules are set up not to perform vMotion migrations on <%=vars.product_name%> virtual machines.
--   If you must use vMotion for migration, VMware recommends that all vMotion migration activity of <%=vars.product_name_long%> members occurs over 10GbE, during periods of low activity and scheduled maintenance windows.
+When vMotion migrations occur, there is an expected temporary drop in the performance of both read-operation and write-operation workloads.
+These workloads resume their normal rate of operation once the vMotion migration of the servers is completed.
+
+VMware recommends that all vMotion migration activity of <%=vars.product_name_long%> members occurs over 10GbE, during periods of low activity and scheduled maintenance windows.
+Test vMotion migrations in your own environment to assess differences in workload, networking and scale.
+
+If you wish to prevent automatic VMware vSphere vMotion® operations that can affect response times, place VMware vSphere Distributed Resource Scheduler™ (DRS) in manual mode when you first commission the data management system.
 
 ## <a id="topic_E53BBF3D09A54953B02DCE2BD00D51E0" class="no-quick-link"></a>Placement and Organization of Virtual Machines
 

--- a/geode-docs/managing/monitor_tune/performance_on_vsphere.html.md.erb
+++ b/geode-docs/managing/monitor_tune/performance_on_vsphere.html.md.erb
@@ -72,7 +72,7 @@ These guidelines help you reduce latency.
 
 
     **Note:**
-    Disabling interrupt coalescing can reduce latency in virtual machines; however, it can impact performance and cause higher CPU utilization. It can also defeat the benefits of Large Receive Offloads (LRO) because some physical NICs (such as Intel 10GbE NICs) automatically disable LRO when interrupt coalescing is disabled.
+    Disabling interrupt coalescing can reduce latency in virtual machines; however, it can impact performance and cause higher CPU utilization. It can also defeat the benefits of large receive offloads (LRO) because some physical NICs (such as Intel 10GbE NICs) automatically disable LRO when interrupt coalescing is disabled.
 This type of tuning benefits <%=vars.product_name%> workloads, but it can hurt other non-<%=vars.product_name_long%> workloads that are memory throughput-bound, as opposed to latency sensitive as in the case of <%=vars.product_name%> workloads.
 See [http://kb.vmware.com/kb/1027511](http://kb.vmware.com/kb/1027511) for more details.
 


### PR DESCRIPTION
Removed some blanket prohibitions.
Acknowledged that vMotion migration introduces a performance hit, but it's temporary.
Recommended that users conduct tests to evaluate the impacts on their specific configurations.