### PR TITLE
GEODE-7687: User Guide - Remove time-based statistics caveat

### DIFF
--- a/geode-docs/managing/statistics/how_statistics_work.html.md.erb
+++ b/geode-docs/managing/statistics/how_statistics_work.html.md.erb
@@ -30,6 +30,6 @@ When Java applications and servers join a cluster, they can be configured via th
 **Note:**
 <%=vars.product_name%> statistics use the Java `System.nanoTimer` for nanosecond timing. This method provides nanosecond precision, but not necessarily nanosecond accuracy. For more information, see the online Java documentation for `System.nanoTimer` for the JRE you are using with <%=vars.product_name%>.
 
-Statistics sampling provides valuable information for ongoing system tuning and troubleshooting. Sampling statistics (not including time-based statistics) at the default sample rate does not impact overall cluster performance. We recommend enabling statistics sampling in production environments. We do not recommend enabling time-based statistics (configured with the enable-time-statistics property) in production environments.
+Statistics sampling provides valuable information for ongoing system tuning and troubleshooting. Sampling statistics at the default sample rate does not impact overall cluster performance. We recommend enabling statistics sampling in production environments.
 
 

--- a/geode-docs/managing/statistics/setting_up_statistics.html.md.erb
+++ b/geode-docs/managing/statistics/setting_up_statistics.html.md.erb
@@ -73,9 +73,6 @@ Alternately, if you are not using the cluster configuration service, configure `
     enable-time-statistics=true
     ```
 
-    **Note:**
-    Time-based statistics can impact system performance and are not recommended for production environments.
-
 If these statistics are on, you are able to access archived statistics through the `gfsh show metrics` command.
 
 


### PR DESCRIPTION
The User Guide advises against enabling time-based statistics in production environments. As of Geode v1.9, this limitation is no longer significant, so the warning against it should be removed from the user guide.