### PR TITLE
GEODE-7688: clean up temp files after deploy meta

### DIFF
--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -289,6 +289,6 @@ fi
 
 echo "Successfully deployed ${CONCOURSE_URL}/teams/${CONCOURSE_TEAM}/pipelines/${PIPELINE_PREFIX}main"
 
-rm ci/pipelines/meta/generated-pipeline.yml
-rm ci/pipelines/meta/pipelineProperties.yml
-rm ci/pipelines/meta/repository.yml
+rm -f ${SCRIPTDIR}/generated-pipeline.yml
+rm -f ${SCRIPTDIR}/pipelineProperties.yml
+rm -f ${SCRIPTDIR}/repository.yml


### PR DESCRIPTION
some people run deploy_meta.sh from the meta directory, so hardcoding the paths relative to the top of the repo doesn't work for them.