### PR TITLE
GEODE-7690: make it less difficult to run benchmarks against a PR

### DIFF
--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -37,6 +37,9 @@ RESULTS_DIR=$(pwd)/results/benchmarks-${CLUSTER_TAG}
 CLUSTER_COUNT=4
 BENCHMARKS_BRANCH=${BENCHMARKS_BRANCH:-develop}
 
+GEODE_REPO=${GEODE_REPO:-apache/geode}
+BASELINE_REPO=${BASELINE_REPO:-${GEODE_REPO}}
+
 pushd geode
 GEODE_SHA=$(git rev-parse --verify HEAD)
 popd
@@ -68,7 +71,7 @@ do
   fi
 
   if [ -z "${BASELINE_VERSION}" ]; then
-    BASELINE_OPTION="-B ${BASELINE_BRANCH}"
+    BASELINE_OPTION="-B ${BASELINE_BRANCH} -R ${BASELINE_REPO}"
     METADATA_BASELINE="'benchmark_branch':'${BASELINE_BRANCH}'"
   else
     BASELINE_OPTION="-V ${BASELINE_VERSION}"
@@ -77,7 +80,7 @@ do
 
   ./run_on_cluster.sh -t ${CLUSTER_TAG} -- pkill -9 java
   ./run_on_cluster.sh -t ${CLUSTER_TAG} -- rm /home/geode/locator10334view.dat;
-  ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} ${BASELINE_OPTION} -e ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR} -m "'source':'geode-ci',${METADATA_BASELINE},'baseline_branch':'${BASELINE_BRANCH}','geode_branch':'${GEODE_SHA}'" --ci -- ${FLAGS} ${TEST_OPTIONS}
+  ./run_against_baseline.sh -t ${CLUSTER_TAG} -b ${GEODE_SHA} -r ${GEODE_REPO} ${BASELINE_OPTION} -e ${BENCHMARKS_BRANCH} -o ${RESULTS_DIR} -m "'source':'geode-ci',${METADATA_BASELINE},'baseline_branch':'${BASELINE_BRANCH}','geode_branch':'${GEODE_SHA}'" --ci -- ${FLAGS} ${TEST_OPTIONS}
 
   if [[ $? -eq 0 ]]; then
     break;

--- a/ci/scripts/run_benchmarks.sh
+++ b/ci/scripts/run_benchmarks.sh
@@ -37,7 +37,7 @@ RESULTS_DIR=$(pwd)/results/benchmarks-${CLUSTER_TAG}
 CLUSTER_COUNT=4
 BENCHMARKS_BRANCH=${BENCHMARKS_BRANCH:-develop}
 
-GEODE_REPO=${GEODE_REPO:-apache/geode}
+GEODE_REPO=${GEODE_REPO:-$(cd geode && git remote get-url origin)}
 BASELINE_REPO=${BASELINE_REPO:-${GEODE_REPO}}
 
 pushd geode


### PR DESCRIPTION
To run Benchmarks against a personal fork, it's not immediately obvious where to override the repo default of "apache/geode"

This PR adds variables for this at the top of run_benchmarks.sh so they can be easily set in your environment without having to figure out how to update the very long run_against_baseline commandline.