### PR TITLE
GEODE-7605: Fix PersistentRecoveryOrderDUnitTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
@@ -1003,7 +1003,7 @@ public class PersistentRecoveryOrderDUnitTest extends CacheTestCase {
 
     vm1.invoke(() -> {
       SLEEP.get().countDown();
-      await().untilAsserted(() -> {
+      await().ignoreException(RegionDestroyedException.class).untilAsserted(() -> {
         assertThat(getCache().getRegion(regionName)).isNull();
       });
     });


### PR DESCRIPTION
Ignore RegionDestroyedException while waiting for region to be
destroyed.
