### PR TITLE
GEODE-5816: Don't set the JMX Port multiple ways in RegionMembership.…

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/RegionMembershipMBeanDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/RegionMembershipMBeanDUnitTestBase.java
@@ -372,12 +372,10 @@ public class RegionMembershipMBeanDUnitTestBase {
   }
 
   private Properties locatorProperties() {
-    int jmxPort = AvailablePortHelper.getRandomAvailableTCPPort();
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOG_LEVEL, "fine");
     props.setProperty(ConfigurationProperties.JMX_MANAGER_HOSTNAME_FOR_CLIENTS, "localhost");
-    props.setProperty(ConfigurationProperties.JMX_MANAGER_PORT, "" + jmxPort);
 
     return props;
   }

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/RegionMembershipMBeanDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/RegionMembershipMBeanDUnitTestBase.java
@@ -37,7 +37,6 @@ import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.ManagementService;


### PR DESCRIPTION
….Test

This test was setting the JMX_MANAGER_HTTP_PORT using AvailablePortHelper
before starting up. However, we also later set the jmx port through the
LocatorStarterRule. By setting the port early in this way, we were preventing
some duplicate port prevention logic from kicking in.

Removing this extra set of JMX_MANAGER_HTTP_PORT. Now, when withJmxManager is
called later, it will generate a port that does not conflict with the http
port.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
