### PR TITLE
GEODE-7703: Catch IndexWriter Exceptions

### DIFF
--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryDistributedTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryDistributedTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.lucene.internal;
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.core.ConditionTimeoutException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.DataSerializable;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.lucene.LuceneService;
+import org.apache.geode.cache.lucene.LuceneServiceProvider;
+import org.apache.geode.cache.lucene.test.LuceneTestUtilities;
+import org.apache.geode.distributed.DistributedLockService;
+import org.apache.geode.internal.cache.BucketRegion;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionDataStore;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+
+@RunWith(JUnitParamsRunner.class)
+public class IndexRepositoryFactoryDistributedTest implements Serializable {
+  private static final String INDEX_NAME = "index";
+  private static final String REGION_NAME = "region";
+  private static final String DEFAULT_FIELD = "text";
+  protected int locatorPort;
+  protected MemberVM locator, dataStore1, dataStore2;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule(5);
+
+  @Before
+  public void setUp() {
+    locator = cluster.startLocatorVM(0);
+    locatorPort = locator.getPort();
+    dataStore1 = cluster.startServerVM(1, locatorPort);
+    dataStore2 = cluster.startServerVM(2, locatorPort);
+  }
+
+  private Cache getCache() {
+    Cache cache = ClusterStartupRule.getCache();
+    assertThat(cache).isNotNull();
+
+    return cache;
+  }
+
+  private void initDataStoreAndLuceneIndex(RegionShortcut regionShortcut) {
+    Cache cache = getCache();
+    LuceneService luceneService = LuceneServiceProvider.get(cache);
+    luceneService.createIndexFactory().setFields(DEFAULT_FIELD).create(INDEX_NAME, REGION_NAME);
+
+    cache.<Integer, TestObject>createRegionFactory(regionShortcut)
+        .setPartitionAttributes(new PartitionAttributesFactory<Integer, TestObject>()
+            .setTotalNumBuckets(1).create())
+        .create(REGION_NAME);
+  }
+
+  private void insertEntries() {
+    Cache cache = getCache();
+    Region<Integer, TestObject> region = cache.getRegion(REGION_NAME);
+    IntStream.range(0, 1000).forEach(i -> region.put(i, new TestObject("hello world" + i)));
+  }
+
+  private void assertPrimariesAndSecondaries(int primaries, int secondaries) {
+    Cache cache = getCache();
+    PartitionedRegionDataStore partitionedRegionDataStore =
+        ((PartitionedRegion) cache.getRegion(REGION_NAME)).getDataStore();
+    assertThat(partitionedRegionDataStore.getAllLocalPrimaryBucketIds().size())
+        .isEqualTo(primaries);
+    assertThat((partitionedRegionDataStore.getAllLocalBucketIds().size()
+        - partitionedRegionDataStore.getAllLocalPrimaryBucketIds().size())).isEqualTo(secondaries);
+  }
+
+  private BucketRegion getFileAndChunkBucket() {
+    Cache cache = getCache();
+    LuceneServiceImpl luceneService = (LuceneServiceImpl) LuceneServiceProvider.get(cache);
+    InternalLuceneIndex index =
+        (InternalLuceneIndex) luceneService.getIndex(INDEX_NAME, REGION_NAME);
+    LuceneIndexForPartitionedRegion indexForPR = (LuceneIndexForPartitionedRegion) index;
+    PartitionedRegion fileRegion = indexForPR.getFileAndChunkRegion();
+
+    return PartitionedRepositoryManager.indexRepositoryFactory.getMatchingBucket(fileRegion, 0);
+  }
+
+  @Test
+  @Parameters({"PARTITION_REDUNDANT"})
+  public void lockedBucketShouldPreventPrimaryFromMoving(RegionShortcut regionShortcut) {
+    dataStore1.invoke(() -> initDataStoreAndLuceneIndex(regionShortcut));
+    dataStore1.invoke(() -> LuceneTestUtilities.pauseSender(getCache()));
+    dataStore1.invoke(this::insertEntries);
+    dataStore2.invoke(() -> initDataStoreAndLuceneIndex(regionShortcut));
+    dataStore1.invoke(() -> LuceneTestUtilities.resumeSender(getCache()));
+
+    dataStore1.invoke(() -> {
+      Cache cache = getCache();
+      LuceneService service = LuceneServiceProvider.get(cache);
+      await().untilAsserted(
+          () -> assertThat(service.waitUntilFlushed(INDEX_NAME, REGION_NAME, 1, TimeUnit.MINUTES))
+              .isTrue());
+    });
+    dataStore1.invoke(() -> assertPrimariesAndSecondaries(1, 0));
+    dataStore2.invoke(() -> assertPrimariesAndSecondaries(0, 1));
+
+    // Lock is already held by server1.
+    dataStore1.invoke(() -> {
+      BucketRegion fileAndChunkBucket = getFileAndChunkBucket();
+      String lockName =
+          PartitionedRepositoryManager.indexRepositoryFactory.getLockName(fileAndChunkBucket);
+      DistributedLockService lockService =
+          PartitionedRepositoryManager.indexRepositoryFactory.getLockService();
+      assertThat(lockService.lock(lockName, 10000, -1)).isFalse();
+    });
+
+    // Try to become primary on server2, it should fail.
+    dataStore2.invoke(() -> {
+      BucketRegion fileAndChunkBucket = getFileAndChunkBucket();
+      try {
+        await().atMost(30, TimeUnit.SECONDS).untilAsserted(
+            () -> assertThat(fileAndChunkBucket.getBucketAdvisor().becomePrimary(false)).isTrue());
+        fail("Bucket must not become primary while other member holds the lock.");
+      } catch (ConditionTimeoutException ignore) {
+      }
+    });
+
+    dataStore1.invoke(() -> assertPrimariesAndSecondaries(1, 0));
+    dataStore2.invoke(() -> assertPrimariesAndSecondaries(0, 1));
+  }
+
+  protected static class TestObject implements DataSerializable {
+    private static final long serialVersionUID = 1L;
+    private String text;
+
+    public TestObject() {}
+
+    public TestObject(String text) {
+      this.text = text + RandomStringUtils.randomAlphanumeric(100, 10000);
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((text == null) ? 0 : text.hashCode());
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      TestObject other = (TestObject) obj;
+      if (text == null) {
+        return other.text == null;
+      } else {
+        return text.equals(other.text);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "TestObject[" + text + "]";
+    }
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+      out.writeUTF(text);
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException {
+      text = in.readUTF();
+    }
+  }
+}

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryDistributedTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryDistributedTest.java
@@ -146,7 +146,7 @@ public class IndexRepositoryFactoryDistributedTest implements Serializable {
     dataStore2.invoke(() -> {
       BucketRegion fileAndChunkBucket = getFileAndChunkBucket();
       try {
-        await().atMost(30, TimeUnit.SECONDS).untilAsserted(
+        await().atMost(10, TimeUnit.SECONDS).untilAsserted(
             () -> assertThat(fileAndChunkBucket.getBucketAdvisor().becomePrimary(false)).isTrue());
         fail("Bucket must not become primary while other member holds the lock.");
       } catch (ConditionTimeoutException ignore) {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactory.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactory.java
@@ -127,8 +127,8 @@ public class IndexRepositoryFactory {
       }
       return repo;
     } catch (IOException e) {
-      logger.info("Exception thrown while constructing Lucene Index for bucket:" + bucketId
-          + " for file region:" + fileAndChunkBucket.getFullPath());
+      logger.warn("Exception thrown while constructing Lucene Index for bucket:" + bucketId
+          + " for file region:" + fileAndChunkBucket.getFullPath(), e);
       return null;
     } catch (CacheClosedException e) {
       logger.info("CacheClosedException thrown while constructing Lucene Index for bucket:"

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactory.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactory.java
@@ -41,7 +41,6 @@ import org.apache.geode.internal.cache.PartitionedRegionHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 public class IndexRepositoryFactory {
-
   private static final Logger logger = LogService.getLogger();
   public static final String FILE_REGION_LOCK_FOR_BUCKET_ID = "FileRegionLockForBucketId:";
   public static final String APACHE_GEODE_INDEX_COMPLETE = "APACHE_GEODE_INDEX_COMPLETE";
@@ -74,9 +73,8 @@ public class IndexRepositoryFactory {
    * conditions.
    * This is a util function just to not let computeIndexRepository be a huge chunk of code.
    */
-  private IndexRepository finishComputingRepository(Integer bucketId, LuceneSerializer serializer,
-      PartitionedRegion userRegion, IndexRepository oldRepository, InternalLuceneIndex index)
-      throws IOException {
+  protected IndexRepository finishComputingRepository(Integer bucketId, LuceneSerializer serializer,
+      PartitionedRegion userRegion, IndexRepository oldRepository, InternalLuceneIndex index) {
     LuceneIndexForPartitionedRegion indexForPR = (LuceneIndexForPartitionedRegion) index;
     final PartitionedRegion fileRegion = indexForPR.getFileAndChunkRegion();
     BucketRegion fileAndChunkBucket = getMatchingBucket(fileRegion, bucketId);
@@ -115,15 +113,11 @@ public class IndexRepositoryFactory {
     boolean initialPdxReadSerializedFlag = cache.getPdxReadSerializedOverride();
     cache.setPdxReadSerializedOverride(true);
     try {
-      // bucketTargetingMap handles partition resolver (via bucketId as callbackArg)
-      Map bucketTargetingMap = getBucketTargetingMap(fileAndChunkBucket, bucketId);
-      RegionDirectory dir =
-          new RegionDirectory(bucketTargetingMap, indexForPR.getFileSystemStats());
-      IndexWriterConfig config = new IndexWriterConfig(indexForPR.getAnalyzer());
-      IndexWriter writer = new IndexWriter(dir, config);
+      IndexWriter writer = buildIndexWriter(bucketId, fileAndChunkBucket, indexForPR);
       repo = new IndexRepositoryImpl(fileAndChunkBucket, writer, serializer,
           indexForPR.getIndexStats(), dataBucket, lockService, lockName, indexForPR);
       success = false;
+
       // fileRegion ops (get/put) need bucketId as a callbackArg for PartitionResolver
       if (null != fileRegion.get(APACHE_GEODE_INDEX_COMPLETE, bucketId)) {
         success = true;
@@ -135,7 +129,7 @@ public class IndexRepositoryFactory {
     } catch (IOException e) {
       logger.info("Exception thrown while constructing Lucene Index for bucket:" + bucketId
           + " for file region:" + fileAndChunkBucket.getFullPath());
-      throw e;
+      return null;
     } catch (CacheClosedException e) {
       logger.info("CacheClosedException thrown while constructing Lucene Index for bucket:"
           + bucketId + " for file region:" + fileAndChunkBucket.getFullPath());
@@ -148,10 +142,20 @@ public class IndexRepositoryFactory {
     }
   }
 
+  protected IndexWriter buildIndexWriter(int bucketId, BucketRegion fileAndChunkBucket,
+      LuceneIndexForPartitionedRegion indexForPR) throws IOException {
+    // bucketTargetingMap handles partition resolver (via bucketId as callbackArg)
+    Map bucketTargetingMap = getBucketTargetingMap(fileAndChunkBucket, bucketId);
+    RegionDirectory dir = new RegionDirectory(bucketTargetingMap, indexForPR.getFileSystemStats());
+    IndexWriterConfig config = new IndexWriterConfig(indexForPR.getAnalyzer());
+
+    return new IndexWriter(dir, config);
+  }
+
   private boolean reindexUserDataRegion(Integer bucketId, PartitionedRegion userRegion,
       PartitionedRegion fileRegion, BucketRegion dataBucket, IndexRepository repo)
       throws IOException {
-    Set<IndexRepository> affectedRepos = new HashSet<IndexRepository>();
+    Set<IndexRepository> affectedRepos = new HashSet<>();
 
     for (Object key : dataBucket.keySet()) {
       Object value = getValue(userRegion.getEntry(key));
@@ -182,15 +186,15 @@ public class IndexRepositoryFactory {
     return value;
   }
 
-  private Map getBucketTargetingMap(BucketRegion region, int bucketId) {
+  protected Map getBucketTargetingMap(BucketRegion region, int bucketId) {
     return new BucketTargetingMap(region, bucketId);
   }
 
-  private String getLockName(final BucketRegion fileAndChunkBucket) {
+  protected String getLockName(final BucketRegion fileAndChunkBucket) {
     return FILE_REGION_LOCK_FOR_BUCKET_ID + fileAndChunkBucket.getFullPath();
   }
 
-  private DistributedLockService getLockService() {
+  protected DistributedLockService getLockService() {
     return DistributedLockService
         .getServiceNamed(PartitionedRegionHelper.PARTITION_LOCK_SERVICE_NAME);
   }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryTest.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.lucene.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.lucene.LuceneSerializer;
+import org.apache.geode.cache.lucene.internal.repository.IndexRepository;
+import org.apache.geode.distributed.DistributedLockService;
+import org.apache.geode.internal.cache.BucketAdvisor;
+import org.apache.geode.internal.cache.BucketRegion;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.PartitionedRegion;
+
+public class IndexRepositoryFactoryTest {
+  private Integer bucketId;
+  private LuceneSerializer<?> serializer;
+  private PartitionedRegion userRegion;
+  private PartitionedRegion fileRegion;
+  private IndexRepository oldRepository;
+  private BucketRegion fileAndChunkBucket;
+  private BucketAdvisor fileAndChunkBucketAdvisor;
+  private LuceneIndexForPartitionedRegion luceneIndex;
+  private IndexRepositoryFactory indexRepositoryFactory;
+  private DistributedLockService distributedLockService;
+
+  @Before
+  public void setUp() {
+    bucketId = 0;
+    serializer = mock(LuceneSerializer.class);
+    userRegion = mock(PartitionedRegion.class);
+    fileRegion = mock(PartitionedRegion.class);
+    oldRepository = mock(IndexRepository.class);
+    fileAndChunkBucket = mock(BucketRegion.class);
+    fileAndChunkBucketAdvisor = mock(BucketAdvisor.class);
+    luceneIndex = mock(LuceneIndexForPartitionedRegion.class);
+    indexRepositoryFactory = spy(IndexRepositoryFactory.class);
+    distributedLockService = mock(DistributedLockService.class);
+
+    when(luceneIndex.getFileAndChunkRegion()).thenReturn(fileRegion);
+    when(userRegion.getCache()).thenReturn(mock(InternalCache.class));
+    when(userRegion.getRegionService()).thenReturn(mock(InternalCache.class));
+    when(indexRepositoryFactory.getLockService()).thenReturn(distributedLockService);
+    when(fileAndChunkBucket.getBucketAdvisor()).thenReturn(fileAndChunkBucketAdvisor);
+
+    doReturn(fileAndChunkBucket).when(indexRepositoryFactory).getMatchingBucket(fileRegion,
+        bucketId);
+    doReturn(mock(BucketRegion.class)).when(indexRepositoryFactory).getMatchingBucket(userRegion,
+        bucketId);
+  }
+
+  @Test
+  public void finishComputingRepositoryShouldReturnNullAndCleanOldRepositoryWhenFileAndChunkBucketIsNull() {
+    doReturn(null).when(indexRepositoryFactory).getMatchingBucket(fileRegion, bucketId);
+
+    IndexRepository indexRepository = indexRepositoryFactory.finishComputingRepository(0,
+        serializer, userRegion, oldRepository, luceneIndex);
+    assertThat(indexRepository).isNull();
+    verify(oldRepository).cleanup();
+  }
+
+  @Test
+  public void finishComputingRepositoryShouldReturnNullAndCleanOldRepositoryWhenFileAndChunkBucketIsNotPrimary() {
+    when(fileAndChunkBucketAdvisor.isPrimary()).thenReturn(false);
+
+    IndexRepository indexRepository = indexRepositoryFactory.finishComputingRepository(0,
+        serializer, userRegion, oldRepository, luceneIndex);
+    assertThat(indexRepository).isNull();
+    verify(oldRepository).cleanup();
+  }
+
+  @Test
+  public void finishComputingRepositoryShouldReturnOldRepositoryWhenNotNullAndNotClosed() {
+    when(oldRepository.isClosed()).thenReturn(false);
+    when(fileAndChunkBucketAdvisor.isPrimary()).thenReturn(true);
+
+    IndexRepository indexRepository = indexRepositoryFactory.finishComputingRepository(0,
+        serializer, userRegion, oldRepository, luceneIndex);
+    assertThat(indexRepository).isNotNull();
+    assertThat(indexRepository).isSameAs(oldRepository);
+  }
+
+  @Test
+  public void finishComputingRepositoryShouldReturnNullWhenLockCanNotBeAcquiredAndFileAndChunkBucketIsNotPrimary() {
+    when(oldRepository.isClosed()).thenReturn(true);
+    when(fileAndChunkBucketAdvisor.isPrimary()).thenReturn(true).thenReturn(false);
+    when(distributedLockService.lock(any(), anyLong(), anyLong())).thenReturn(false);
+
+    IndexRepository indexRepository = indexRepositoryFactory.finishComputingRepository(0,
+        serializer, userRegion, oldRepository, luceneIndex);
+    assertThat(indexRepository).isNull();
+  }
+
+  @Test
+  public void finishComputingRepositoryShouldReturnNullAndReleaseLockWhenIOExceptionIsThrownWhileBuildingTheIndex()
+      throws IOException {
+    when(oldRepository.isClosed()).thenReturn(true);
+    when(fileAndChunkBucketAdvisor.isPrimary()).thenReturn(true);
+    when(distributedLockService.lock(any(), anyLong(), anyLong())).thenReturn(true);
+    doThrow(new IOException("Test Exception")).when(indexRepositoryFactory)
+        .buildIndexWriter(bucketId, fileAndChunkBucket, luceneIndex);
+
+    IndexRepository indexRepository = indexRepositoryFactory.finishComputingRepository(0,
+        serializer, userRegion, oldRepository, luceneIndex);
+    assertThat(indexRepository).isNull();
+    verify(distributedLockService).unlock(any());
+  }
+
+  @Test
+  public void finishComputingRepositoryShouldThrowExceptionAndReleaseLockWhenCacheClosedExceptionIsThrownWhileBuildingTheIndex()
+      throws IOException {
+    when(oldRepository.isClosed()).thenReturn(true);
+    when(fileAndChunkBucketAdvisor.isPrimary()).thenReturn(true);
+    when(distributedLockService.lock(any(), anyLong(), anyLong())).thenReturn(true);
+    doThrow(new CacheClosedException("Test Exception")).when(indexRepositoryFactory)
+        .buildIndexWriter(bucketId, fileAndChunkBucket, luceneIndex);
+
+    assertThatThrownBy(() -> indexRepositoryFactory.finishComputingRepository(0, serializer,
+        userRegion, oldRepository, luceneIndex)).isInstanceOf(CacheClosedException.class);
+    verify(distributedLockService).unlock(any());
+  }
+}


### PR DESCRIPTION
The IndexWriter initialization might fail when other threads are
updating the fileAndChunkRegion, which can be triggered by other normal
operations (query, event listener, close, reindex, etc.). This doesn't
happen often and, instead of propagating the exception to the caller
and failing, Geode now catches it and returns null to let the callers
retry.

- Added unit and distrbuted tests.
- Return null instead of re-throwing the IOException while building
  the Lucene IndexWriter.

Co-authored-by: Xiaojian Zhou <gzhou@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
