### PR TITLE
GEODE-7711: remove unnecessary decoding step after server receives th…

### DIFF
--- a/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
+++ b/geode-web/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/CommandOverHttpTest.java
@@ -16,6 +16,8 @@
 package org.apache.geode.management.internal.cli.commands;
 
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.nio.file.Paths;
 
@@ -26,6 +28,8 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.test.compiler.ClassBuilder;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
@@ -88,5 +92,16 @@ public class CommandOverHttpTest {
     gfshRule.executeAndAssertThat("export config --dir=" + dir).statusIsSuccess()
         .containsOutput("File saved to " + Paths.get(dir, "server-cache.xml").toString())
         .containsOutput("File saved to " + Paths.get(dir, "server-gf.properties").toString());
+  }
+
+  @Test
+  public void commandEncodeDecodeProperly() throws Exception {
+    Region<Object, Object> testRegion =
+        server.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("test");
+    // this command would not fail because of parameter url encoding/decoding
+    gfshRule.executeAndAssertThat("put --region=test --key='k 1' --value=#abdf%dgadf")
+        .statusIsSuccess();
+
+    assertThat(testRegion.get("k 1")).isEqualTo("#abdf%dgadf");
   }
 }

--- a/geode-web/src/main/java/org/apache/geode/management/internal/web/controllers/ShellCommandsController.java
+++ b/geode-web/src/main/java/org/apache/geode/management/internal/web/controllers/ShellCommandsController.java
@@ -83,7 +83,7 @@ public class ShellCommandsController extends AbstractCommandsController {
   public ResponseEntity<InputStreamResource> command(@RequestParam(value = "cmd") String command,
       @RequestParam(value = "resources", required = false) MultipartFile[] fileResource)
       throws IOException {
-    String result = processCommand(decode(command), getEnvironment(), fileResource);
+    String result = processCommand(command, getEnvironment(), fileResource);
     return getResponse(result);
   }
 


### PR DESCRIPTION
…e command

* url encoding/decoming should have been done by spring framework

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
