### PR TITLE
GEODE-7719: no need to release examples as both .tgz AND .zip

### DIFF
--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -385,7 +385,6 @@ jobs:
               verifyArtifactSignature apache-geode-${VERSION}-src.tgz 256 
               verifyArtifactSignature apache-geode-${VERSION}.tgz 256
               verifyArtifactSignature apache-geode-examples-${VERSION}.tar.gz 256
-              verifyArtifactSignature apache-geode-examples-${VERSION}.zip 256
               verifyArtifactSignature apache-geode-native-${VERSION}-src.tar.gz 512
 EOF
 fly -t concourse.apachegeode-ci.info-main login --team-name main --concourse-url https://concourse.apachegeode-ci.info/

--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -227,7 +227,6 @@ cp ${GEODE}/KEYS .
 mkdir ${FULL_VERSION}
 cp ${GEODE}/geode-assembly/build/distributions/* ${FULL_VERSION}
 cp ${GEODE_EXAMPLES}/build/distributions/* ${FULL_VERSION}
-rm ${FULL_VERSION}/apache-geode-examples-*.zip*
 cp ${GEODE_NATIVE}/build/apache-geode-native-${VERSION}* ${FULL_VERSION}
 set +x
 

--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -227,11 +227,12 @@ cp ${GEODE}/KEYS .
 mkdir ${FULL_VERSION}
 cp ${GEODE}/geode-assembly/build/distributions/* ${FULL_VERSION}
 cp ${GEODE_EXAMPLES}/build/distributions/* ${FULL_VERSION}
+rm ${FULL_VERSION}/apache-geode-examples-*.zip*
 cp ${GEODE_NATIVE}/build/apache-geode-native-${VERSION}* ${FULL_VERSION}
 set +x
 
 # verify all files are signed.  sometimes gradle "forgets" to make the .asc file
-for f in ${FULL_VERSION}/*.tgz ${FULL_VERSION}/*.tar.gz ${FULL_VERSION}/*.zip ; do
+for f in ${FULL_VERSION}/*.tgz ${FULL_VERSION}/*.tar.gz ; do
   if ! [ -r $f.sha256 ] && ! [ -r $f.sha512 ] ; then
     echo missing $f.sha256 or $f.sha512
     exit 1


### PR DESCRIPTION
as requested here: https://lists.apache.org/thread.html/c7bd84b6e6f5464ed674ed447fe8922097237932967b4ed1966e79d3%40%3Cdev.geode.apache.org%3E

Since Geode 1.8.0, we stopped distributing both .tgz AND .zip for Geode, instead favoring .tgz only. However, geode-examples is still shipping both.

For the same reasons cited in GEODE-5694, we only need to ship examples as a .tar.gz, no need for multiple archive formats.

DO NOT MERGE unless consensus has been reached and/or a vote has passed on the dev list. Until then, this PR is provided only as an exhibit of the changes being proposed.
