### PR TITLE
GEODE-7726: remove obsolete references from LICENSE file

### DIFF
--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -227,16 +227,8 @@ Apache Geode bundles the following files under the BSD 3-Clause License:
     Marc Prud'hommeaux <mwp1@cornell.edu>
   - jQuery Sparklines v2.0 (http://omnipotent.net/jquery.sparkline/),
     Copyright (c) 2012 Splunk Inc.
-  - Paranamer v2.3 (http://github.com/paul-hammant/paranamer), Copyright
-    (c) 2006 Paul Hammant and Thoughtworks Inc.
   - Protocol Buffers (https://github.com/google/protobuf), Copyright (c)
     2014 Google Inc.
-  - scala-library v2.10.0 (http://www.scala-lang.org), Copyright (c)
-    2002-2016 EPFL, Copyright (c) 2011-2016 Lightbend, Inc. (formerly
-    Typesafe, Inc.)
-  - scala-reflect v2.10.0 (http://www.scala-lang.org), Copyright (c)
-    2002-2016 EPFL, Copyright (c) 2011-2016 Lightbend, Inc. (formerly
-    Typesafe, Inc.)
 
 All rights reserved.
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Updates geode-assembly/src/main/dist/LICENSE to remove obsolete references to:
paranamer
scala-reflect
scala-library
as requested on the dev list here: https://lists.apache.org/thread.html/c9c73e726742c78a1ff9739379a51f7eeab33a05d99531a38b537670%40%3Cdev.geode.apache.org%3E