### PR TITLE
GEODE-7730: Remove strict stubbing from RemoteGfManagerAgentTest

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgentTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/admin/remote/RemoteGfManagerAgentTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.internal.admin.remote;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.mockito.quality.Strictness.STRICT_STUBS;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +46,7 @@ public class RemoteGfManagerAgentTest {
   public ExecutorServiceRule executorServiceRule = new ExecutorServiceRule();
 
   @Rule
-  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(STRICT_STUBS);
+  public MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Before
   public void setUp() {


### PR DESCRIPTION
RemoteGfManagerAgentTest intermittently fails strict stubbing for
system.getCancelCriterion. Strict stubbing isn't necessary and it looks
like RemoteGfManagerAgent would require more refactoring and other
changes to make this more deterministic.
