### PR TITLE
GEODE-7663: Fix delta update inconsistency in client cache.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PutOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PutOp.java
@@ -315,7 +315,7 @@ public class PutOp {
         return;
       }
       VersionStamp versionStamp = regionEntry.getVersionStamp();
-      if (deltaSent && versionTag.getEntryVersion() != versionStamp.getEntryVersion() + 1) {
+      if (deltaSent && versionTag.getEntryVersion() > versionStamp.getEntryVersion() + 1) {
         // Delta can't be applied, need to get full value.
         if (logger.isDebugEnabled()) {
           logger.debug("Version is out of order. Need to get from server to perform delta update.");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -1675,7 +1675,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
     this.re = re;
   }
 
-  RegionEntry getRegionEntry() {
+  public RegionEntry getRegionEntry() {
     return this.re;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/PutOpJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/PutOpJUnitTest.java
@@ -45,17 +45,10 @@ public class PutOpJUnitTest {
     when(entry.getVersionStamp()).thenReturn(versionStamp);
   }
 
-  private EntryEventImpl getEntryEvent() {
-    EntryEventImpl entryEvent = mock(EntryEventImpl.class);
-    when(entryEvent.getEventId()).thenReturn(new EventID());
-    return entryEvent;
-  }
-
   @Test
   public void regularDeltaPutShouldNotRetryFlagInMessage() {
     PutOp.PutOpImpl putOp = new PutOp.PutOpImpl("testRegion", "testKey", "testValue", new byte[10],
-        getEntryEvent(), Operation.UPDATE,
-        false, false, null, false, false);
+        event, Operation.UPDATE, false, false, null, false, false);
     assertFalse(putOp.getMessage().isRetry());
   }
 
@@ -63,16 +56,14 @@ public class PutOpJUnitTest {
   public void regularPutShouldNotRetryFlagInMessage() {
 
     PutOp.PutOpImpl putOp = new PutOp.PutOpImpl("testRegion", "testKey", "testValue", null,
-        getEntryEvent(), Operation.UPDATE,
-        false, false, null, false, false);
+        event, Operation.UPDATE, false, false, null, false, false);
     assertFalse(putOp.getMessage().isRetry());
   }
 
   @Test
   public void failedDeltaPutShouldSetRetryFlagInMessage() {
     PutOp.PutOpImpl putOp = new PutOp.PutOpImpl("testRegion", "testKey", "testValue", new byte[10],
-        getEntryEvent(), Operation.UPDATE,
-        false, false, null, true, false);
+        event, Operation.UPDATE, false, false, null, true, false);
     assertTrue(putOp.getMessage().isRetry());
   }
 


### PR DESCRIPTION
 * When performing delta update on client, there is a possibility that
   some delta update is not yet applied on client cache.
 * If apply delta update, some queued delta update would be lost -- as
   entry versioning will discard these delta updates when received later.
 * Now it will check if there is a versioning mismatch, if it happened,
   the full value from server will be applied instead of just the delta.

