### PR TITLE
GEODE-7736: Remove depencies on core from MembershipOnlyTest and add two member test

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
@@ -65,11 +65,6 @@ public class MembershipOnlyTest {
 
     dsfidSerializer = new DSFIDSerializerFactory().create();
 
-    // TODO -if we don't do this, the serializer doesn't know how to deserialize
-    // membership classes. Seems like this should happen during membership initialization
-    // or using a ServiceLoader?
-    Services.registerSerializables(dsfidSerializer);
-
     // TODO - MemberIdentiferImpl probably needs it's own DSFID, or it should be BasicSerializable
     // Or ... ? Right now it has the same ID as InternalDistributedMember
     dsfidSerializer.registerDSFID(DataSerializableFixedID.DISTRIBUTED_MEMBER,
@@ -82,8 +77,7 @@ public class MembershipOnlyTest {
         () -> LoggingExecutors.newCachedThreadPool("membership", false);
     membershipLocator = MembershipLocatorBuilder.<MemberIdentifierImpl>newLocatorBuilder(
         socketCreator,
-        dsfidSerializer.getObjectSerializer(),
-        dsfidSerializer.getObjectDeserializer(),
+        dsfidSerializer,
         temporaryFolder.newFile("locator").toPath(),
         executorServiceSupplier)
         .create();

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipOnlyTest.java
@@ -47,7 +47,6 @@ import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.internal.net.SocketCreator;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 import org.apache.geode.internal.serialization.DSFIDSerializerFactory;
-import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
 
 public class MembershipOnlyTest {
@@ -64,11 +63,6 @@ public class MembershipOnlyTest {
     localHost = InetAddress.getLocalHost();
 
     dsfidSerializer = new DSFIDSerializerFactory().create();
-
-    // TODO - MemberIdentiferImpl probably needs it's own DSFID, or it should be BasicSerializable
-    // Or ... ? Right now it has the same ID as InternalDistributedMember
-    dsfidSerializer.registerDSFID(DataSerializableFixedID.DISTRIBUTED_MEMBER,
-        MemberIdentifierImpl.class);
 
     // TODO - using geode-core socket creator
     socketCreator = asTcpSocketCreator(new SocketCreator(new SSLConfig.Builder().build()));

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -546,8 +546,7 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       membershipLocator =
           MembershipLocatorBuilder.<InternalDistributedMember>newLocatorBuilder(
               socketCreator,
-              InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
-              InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer(),
+              InternalDataSerializer.getDSFIDSerializer(),
               workingDirectory,
               executor)
               .setConfig(config)

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -60,11 +60,6 @@ public class InternalDistributedMember extends MemberIdentifierImpl
   // Used only by deserialization
   public InternalDistributedMember() {}
 
-  @Override
-  public int getDSFID() {
-    return DISTRIBUTED_MEMBER;
-  }
-
   /**
    * Construct a InternalDistributedMember
    * <p>
@@ -298,6 +293,11 @@ public class InternalDistributedMember extends MemberIdentifierImpl
     } catch (UnknownHostException ee) {
       throw new InternalGemFireError(ee);
     }
+  }
+
+  @Override
+  public int getDSFID() {
+    return DISTRIBUTED_MEMBER;
   }
 
   @Override

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberIdentifierImpl.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberIdentifierImpl.java
@@ -608,7 +608,7 @@ public class MemberIdentifierImpl implements MemberIdentifier, DataSerializableF
 
   @Override
   public int getDSFID() {
-    return DEFAULT_MEMBER_ID;
+    return MEMBER_IDENTIFIER;
   }
 
   @Override

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipLocatorBuilder.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipLocatorBuilder.java
@@ -24,8 +24,7 @@ import org.apache.geode.distributed.internal.membership.gms.MembershipLocatorBui
 import org.apache.geode.distributed.internal.tcpserver.ProtocolChecker;
 import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
-import org.apache.geode.internal.serialization.ObjectDeserializer;
-import org.apache.geode.internal.serialization.ObjectSerializer;
+import org.apache.geode.internal.serialization.DSFIDSerializer;
 
 public interface MembershipLocatorBuilder<ID extends MemberIdentifier> {
   MembershipLocatorBuilder<ID> setPort(int port);
@@ -47,11 +46,10 @@ public interface MembershipLocatorBuilder<ID extends MemberIdentifier> {
 
   static <ID extends MemberIdentifier> MembershipLocatorBuilder<ID> newLocatorBuilder(
       final TcpSocketCreator socketCreator,
-      final ObjectSerializer objectSerializer,
-      final ObjectDeserializer objectDeserializer,
+      final DSFIDSerializer serializer,
       final Path workingDirectory,
       final Supplier<ExecutorService> executorServiceSupplier) {
-    return new MembershipLocatorBuilderImpl<ID>(socketCreator, objectSerializer, objectDeserializer,
+    return new MembershipLocatorBuilderImpl<ID>(socketCreator, serializer,
         workingDirectory, executorServiceSupplier);
   }
 }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipLocatorBuilderImpl.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/MembershipLocatorBuilderImpl.java
@@ -30,11 +30,11 @@ import org.apache.geode.distributed.internal.membership.gms.locator.MembershipLo
 import org.apache.geode.distributed.internal.tcpserver.ProtocolChecker;
 import org.apache.geode.distributed.internal.tcpserver.TcpHandler;
 import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
-import org.apache.geode.internal.serialization.ObjectDeserializer;
-import org.apache.geode.internal.serialization.ObjectSerializer;
+import org.apache.geode.internal.serialization.DSFIDSerializer;
 
 public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> implements
     MembershipLocatorBuilder<ID> {
+  private final DSFIDSerializer serializer;
   private int port = 0;
   private InetAddress bindAddress = null;
   private ProtocolChecker protocolChecker = (socket, input, firstByte) -> false;
@@ -42,21 +42,17 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
   private MembershipLocatorStatistics locatorStats = new MembershipLocatorStatisticsNoOp();
   private boolean locatorsAreCoordinators = true;
   private final TcpSocketCreator socketCreator;
-  private final ObjectSerializer objectSerializer;
-  private final ObjectDeserializer objectDeserializer;
   private final Path workingDirectory;
   private MembershipConfig config = new MembershipConfig() {};
   private final Supplier<ExecutorService> executorServiceSupplier;
 
   public MembershipLocatorBuilderImpl(
       final TcpSocketCreator socketCreator,
-      final ObjectSerializer objectSerializer,
-      final ObjectDeserializer objectDeserializer,
+      final DSFIDSerializer serializer,
       final Path workingDirectory,
       final Supplier<ExecutorService> executorServiceSupplier) {
     this.socketCreator = socketCreator;
-    this.objectSerializer = objectSerializer;
-    this.objectDeserializer = objectDeserializer;
+    this.serializer = serializer;
     this.workingDirectory = workingDirectory;
     this.executorServiceSupplier = executorServiceSupplier;
   }
@@ -106,9 +102,11 @@ public final class MembershipLocatorBuilderImpl<ID extends MemberIdentifier> imp
   @Override
   public MembershipLocator<ID> create()
       throws UnknownHostException, MembershipConfigurationException {
+    Services.registerSerializables(serializer);
     return new MembershipLocatorImpl<ID>(port, bindAddress, protocolChecker,
         executorServiceSupplier,
-        socketCreator, objectSerializer, objectDeserializer, fallbackHandler,
+        socketCreator, serializer.getObjectSerializer(), serializer.getObjectDeserializer(),
+        fallbackHandler,
         locatorsAreCoordinators, locatorStats, workingDirectory, config);
   }
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.distributed.internal.membership.gms;
 
-import static org.apache.geode.internal.serialization.DataSerializableFixedID.DEFAULT_MEMBER_ID;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.FINAL_CHECK_PASSED_MESSAGE;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.FIND_COORDINATOR_REQ;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.FIND_COORDINATOR_RESP;
@@ -26,6 +25,7 @@ import static org.apache.geode.internal.serialization.DataSerializableFixedID.IN
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.JOIN_REQUEST;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.JOIN_RESPONSE;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.LEAVE_REQUEST_MESSAGE;
+import static org.apache.geode.internal.serialization.DataSerializableFixedID.MEMBER_IDENTIFIER;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.NETVIEW;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.NETWORK_PARTITION_MESSAGE;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.REMOVE_MEMBER_REQUEST;
@@ -175,7 +175,8 @@ public class Services<ID extends MemberIdentifier> {
     serializer.registerDSFID(FIND_COORDINATOR_RESP, FindCoordinatorResponse.class);
     serializer.registerDSFID(JOIN_RESPONSE, JoinResponseMessage.class);
     serializer.registerDSFID(JOIN_REQUEST, JoinRequestMessage.class);
-    serializer.registerDSFID(DEFAULT_MEMBER_ID, MemberIdentifierImpl.class);
+    serializer.registerDSFID(MEMBER_IDENTIFIER, MemberIdentifierImpl.class);
+
   }
 
   /**

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
@@ -70,7 +70,6 @@ public interface DataSerializableFixedID extends SerializationVersions, BasicSer
 
   short VIEW_ACK_MESSAGE = -151;
   short INSTALL_VIEW_MESSAGE = -150;
-  short DEFAULT_MEMBER_ID = -149; // membership module's default identifier
   short NETVIEW = -148;
   short GET_VIEW_REQ = -147;
   short GET_VIEW_RESP = -146;
@@ -673,6 +672,7 @@ public interface DataSerializableFixedID extends SerializationVersions, BasicSer
   short GATEWAY_SENDER_QUEUE_ENTRY_SYNCHRONIZATION_MESSAGE = 2181;
   short GATEWAY_SENDER_QUEUE_ENTRY_SYNCHRONIZATION_ENTRY = 2182;
   short ABORT_BACKUP_REQUEST = 2183;
+  short MEMBER_IDENTIFIER = 2184;
 
   // NOTE, codes > 65535 will take 4 bytes to serialize
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/StaticSerialization.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/StaticSerialization.java
@@ -403,6 +403,7 @@ public class StaticSerialization {
     byte typeCode = in.readByte();
     if (typeCode == DSCODE.CLASS.toByte()) {
       String className = readString(in);
+      className = processIncomingClassName(className);
       return Class.forName(className);
     } else {
       return StaticSerialization.decodePrimitiveClass(typeCode);


### PR DESCRIPTION
Removing some dependencies on geode-core from the MembershipOnlyTest and adding a test of two members.

As part of this PR, I ran into several problems with MembershipOnlyTest that needed product fixes. Please look at the individual commits in this PR for details.

* GEODE-7736: Adding a test of two members connecting to MembershipOnlyTest
* GEODE-7735: Giving a separate DSFID to MemberIdentifierImpl
* GEODE-7734: Registering DSFIDS inside MembershipLocatorBuilder.create
* GEODE-7733: Don't use geode-core serializer and IDM in MembershipOnlyTest