### PR TITLE
GEODE-7741 - Instance labels and TTL on packer GCE instances

### DIFF
--- a/ci/images/google-geode-builder/build_image.sh
+++ b/ci/images/google-geode-builder/build_image.sh
@@ -59,4 +59,5 @@ PACKER_LOG=1 packer build \
   --var "gcp_network=${GCP_NETWORK}" \
   --var "gcp_subnetwork=${GCP_SUBNETWORK}" \
   --var "use_internal_ip=true" \
+  --var "packer_ttl=$(($(date +%s) + 60 * 60 * 12))" \
   packer.json

--- a/ci/images/google-geode-builder/packer.json
+++ b/ci/images/google-geode-builder/packer.json
@@ -4,8 +4,25 @@
     "hashed_pipeline_prefix": "0b7ad56c-671b-5244-9f36-01f92928abf8",
     "geode_docker_image": "unset",
     "gcp_project": "unset",
-    "java_build_version": "8"
+    "java_build_version": "8",
+    "packer_ttl": ""
   },
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "{{user `gcp_project`}}",
+      "source_image_family": "{{ user `base_family`}}",
+      "ssh_username": "packer",
+      "zone": "us-central1-f",
+      "image_family": "{{user `pipeline_prefix`}}linux-geode-builder",
+      "image_name": "{{user `hashed_pipeline_prefix`}}gb-{{timestamp}}",
+      "tags": ["packer"],
+      "labels": {
+        "time-to-live": "{{user `packer_ttl`}}",
+        "instance_type": "packer"
+      }
+    }
+  ],
   "provisioners": [
     {
       "type": "shell",
@@ -28,16 +45,4 @@
       "script": "scripts/cache_dependencies.sh"
     }
   ],
-  "builders": [
-    {
-      "type": "googlecompute",
-      "project_id": "{{user `gcp_project`}}",
-      "source_image_family": "{{ user `base_family`}}",
-      "ssh_username": "packer",
-      "zone": "us-central1-f",
-      "image_family": "{{user `pipeline_prefix`}}linux-geode-builder",
-      "image_name": "{{user `hashed_pipeline_prefix`}}gb-{{timestamp}}",
-      "tags": ["packer"]
-    }
-  ]
 }

--- a/ci/images/google-windows-geode-builder/build_image.sh
+++ b/ci/images/google-windows-geode-builder/build_image.sh
@@ -66,4 +66,5 @@ PACKER_LOG=1 ${PACKER} build ${PACKER_ARGS} \
   --var "gcp_network=${GCP_NETWORK}" \
   --var "gcp_subnetwork=${GCP_SUBNETWORK}" \
   --var "use_internal_ip=${INTERNAL}" \
+  --var "packer_ttl=$(($(date +%s) + 60 * 60 * 12))" \
   windows-packer.json

--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -7,7 +7,8 @@
     "gcp_network": "default",
     "gcp_subnetwork": "default",
     "use_internal_ip": "false",
-    "java_build_version": "8"
+    "java_build_version": "8",
+    "packer_ttl": ""
   },
   "builders": [
     {
@@ -31,7 +32,11 @@
       "zone": "us-central1-a",
       "tags": ["packer"],
       "omit_external_ip": false,
-      "use_internal_ip": "{{user `use_internal_ip`}}"
+      "use_internal_ip": "{{user `use_internal_ip`}}",
+      "labels": {
+        "time-to-live": "{{user `packer_ttl`}}",
+        "instance_type": "packer"
+      }
     }
   ],
   "provisioners": [


### PR DESCRIPTION
The Geode instance reaper job looks for 'label:time-to-live' to exist on
instances, as the criterion for stopping and deleting old instances.
Make sure we put that onto the Packer instances we use to build Google
Compute Images

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
