### PR TITLE
Add 'attempts: 2' to all Git 'get' steps in CI.

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -98,7 +98,9 @@ jobs:
       - get: geode
         trigger: true
         version: every
+        attempts: 2
       - get: geode-ci
+        attempts: 2
       - get: {{ build_test.PLATFORM }}-builder-image-family
     - aggregate:
       - do:
@@ -254,7 +256,9 @@ jobs:
       - get: geode
         trigger: true
         version: every
+        attempts: 2
       - get: geode-ci
+        attempts: 2
       - get: {{ test.PLATFORM }}-builder-image-family
     - aggregate:
       - do:


### PR DESCRIPTION
Try to work around spurious DNS/HTTP issues

Co-authored-by: Steve Sienkowski <ssienkowski@pivotal.io>
Co-authored-by: Robert Houghton <rhoughton@pivotal.io>

