### PR TITLE
GEODE-7728: Fix Assertion Failures in OQL

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
@@ -72,7 +72,7 @@ public class GroupJunctionIntegrationTest {
   @SuppressWarnings("unused")
   private Object[] regionTypeAndQuery() {
     return new Object[] {
-        // The order or the comparisons matters, so we test both combinations (see GEODE-7728).
+        // The comparison order matters, so we test both combinations (see GEODE-7728).
         new Object[] {"REPLICATE", "SELECT * FROM /" + REGION_NAME
             + " WHERE code=utilityCode AND functionalCode=managementCode"},
         new Object[] {"REPLICATE", "SELECT * FROM /" + REGION_NAME

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal;
+
+import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.query.Query;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.test.junit.categories.OQLQueryTest;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.util.internal.GeodeGlossary;
+
+@Category(OQLQueryTest.class)
+@RunWith(JUnitParamsRunner.class)
+public class GroupJunctionIntegrationTest {
+  private static final int ENTRIES = 1000;
+  private static final String REGION_NAME = "testRegion";
+  private QueryService queryService;
+
+  @Rule
+  public ServerStarterRule server = new ServerStarterRule()
+      .withProperty(SERIALIZABLE_OBJECT_FILTER,
+          "org.apache.geode.cache.query.internal.GroupJunctionIntegrationTest$TestObject")
+      .withAutoStart();
+
+  @ClassRule
+  public static RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @BeforeClass
+  public static void beforeClass() {
+    System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "Query.VERBOSE", "true");
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    queryService = server.getCache().getQueryService();
+  }
+
+  @SuppressWarnings("unused")
+  private Object[] regionTypeAndQuery() {
+    return new Object[] {
+        // The order or the comparisons matters, so we test both combinations (see GEODE-7728).
+        new Object[] {"REPLICATE", "SELECT * FROM /" + REGION_NAME
+            + " WHERE code=utilityCode AND functionalCode=managementCode"},
+        new Object[] {"REPLICATE", "SELECT * FROM /" + REGION_NAME
+            + " WHERE functionalCode=managementCode AND code=utilityCode"},
+        new Object[] {"REPLICATE", "SELECT * FROM /" + REGION_NAME
+            + " WHERE code=utilityCode OR functionalCode=managementCode"},
+        new Object[] {"REPLICATE", "SELECT * FROM /" + REGION_NAME
+            + " WHERE functionalCode=managementCode OR code=utilityCode"},
+
+        new Object[] {"PARTITION", "SELECT * FROM /" + REGION_NAME
+            + " WHERE code=utilityCode AND functionalCode=managementCode"},
+        new Object[] {"PARTITION", "SELECT * FROM /" + REGION_NAME
+            + " WHERE functionalCode=managementCode AND code=utilityCode"},
+        new Object[] {"PARTITION", "SELECT * FROM /" + REGION_NAME
+            + " WHERE code=utilityCode OR functionalCode=managementCode"},
+        new Object[] {"PARTITION", "SELECT * FROM /" + REGION_NAME
+            + " WHERE functionalCode=managementCode OR code=utilityCode"},
+    };
+  }
+
+  private void setUpRegionAndIndexes(RegionShortcut regionShortcut, List<String> indexedFields) {
+    Region<String, TestObject> region = server.getCache()
+        .<String, TestObject>createRegionFactory(regionShortcut).create(REGION_NAME);
+    indexedFields.forEach(fieldName -> {
+      try {
+        queryService.createIndex(fieldName + "Index", fieldName, "/" + REGION_NAME);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    IntStream.range(0, ENTRIES).forEach(value -> {
+      String stringValue = "string_" + value;
+      TestObject testObject = new TestObject(stringValue, stringValue, stringValue, stringValue);
+      region.put(String.valueOf(value), testObject);
+    });
+  }
+
+  @Test
+  @Parameters(method = "regionTypeAndQuery")
+  public void equiJoinWithBothFieldsRangeIndexedAndOtherFilterOnSingleRegionShouldReturnCorrectResults(
+      RegionShortcut regionShortcut, String queryString) throws Exception {
+    setUpRegionAndIndexes(regionShortcut, Arrays.asList("code", "utilityCode"));
+    Query queryObject = queryService.newQuery(queryString);
+
+    SelectResults<?> results = (SelectResults<?>) queryObject.execute();
+    assertThat(results).isNotNull();
+    assertThat(results.size()).isEqualTo(ENTRIES);
+  }
+
+  @Test
+  @Parameters(method = "regionTypeAndQuery")
+  public void multipleEquiJoinsWithAllFieldsRangedIndexedOnSingleRegionShouldReturnCorrectResults(
+      RegionShortcut regionShortcut, String queryString) throws Exception {
+    setUpRegionAndIndexes(regionShortcut,
+        Arrays.asList("code", "utilityCode", "functionalCode", "managementCode"));
+    Query queryObject = queryService.newQuery(queryString);
+
+    SelectResults<?> results = (SelectResults<?>) queryObject.execute();
+    assertThat(results).isNotNull();
+    assertThat(results.size()).isEqualTo(ENTRIES);
+  }
+
+  @SuppressWarnings("unused")
+  public static class TestObject implements Serializable {
+    private final String code;
+    private final String utilityCode;
+    private final String functionalCode;
+    private final String managementCode;
+
+    public String getCode() {
+      return code;
+    }
+
+    public String getUtilityCode() {
+      return utilityCode;
+    }
+
+    public String getFunctionalCode() {
+      return functionalCode;
+    }
+
+    public String getManagementCode() {
+      return managementCode;
+    }
+
+    public TestObject(String code, String utilityCode, String functionalCode,
+        String managementCode) {
+      this.code = code;
+      this.utilityCode = utilityCode;
+      this.functionalCode = functionalCode;
+      this.managementCode = managementCode;
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
@@ -310,9 +310,9 @@ public class CompiledComparison extends AbstractCompiledValue
     assert idxInfo.length == 1;
     Object key = idxInfo[0].evaluateIndexKey(context);
 
-    // Evaluate it second as we do with the independent condition if key was not found.
+    // Key not found (indexes have mapping for UNDEFINED), evaluation is fast so do it first.
     if (key != null && key.equals(QueryService.UNDEFINED)) {
-      return 1;
+      return 0;
     }
 
     if (context instanceof QueryExecutionContext) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
@@ -296,7 +296,7 @@ public class CompiledComparison extends AbstractCompiledValue
   public int getSizeEstimate(ExecutionContext context) throws FunctionDomainException,
       TypeMismatchException, NameResolutionException, QueryInvocationTargetException {
     IndexInfo[] idxInfo = getIndexInfo(context);
-    if (idxInfo == null) {
+    if ((idxInfo == null) || (idxInfo.length > 1)) {
       // Asif: This implies it is an independent condition. So evaluate it first
       // in filter operand
       return 0;

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/GroupJunction.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/GroupJunction.java
@@ -18,6 +18,7 @@
 package org.apache.geode.cache.query.internal;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.geode.cache.query.FunctionDomainException;
@@ -53,12 +54,12 @@ public class GroupJunction extends AbstractGroupOrRangeJunction {
   }
 
   private GroupJunction(AbstractGroupOrRangeJunction oldGJ, boolean completeExpansion,
-      RuntimeIterator indpnds[], CompiledValue iterOp) {
+      RuntimeIterator[] indpnds, CompiledValue iterOp) {
     super(oldGJ, completeExpansion, indpnds, iterOp);
   }
 
   @Override
-  AbstractGroupOrRangeJunction recreateFromOld(boolean completeExpansion, RuntimeIterator indpnds[],
+  AbstractGroupOrRangeJunction recreateFromOld(boolean completeExpansion, RuntimeIterator[] indpnds,
       CompiledValue iterOp) {
     return new GroupJunction(this, completeExpansion, indpnds, iterOp);
   }
@@ -75,19 +76,19 @@ public class GroupJunction extends AbstractGroupOrRangeJunction {
     // get the list of operands to evaluate,
     // and evaluate operands that can use indexes first
 
-    List evalOperands = new ArrayList(_operands.length);
+    List<Object> evalOperands = new ArrayList<>(_operands.length);
     int indexCount = 0;
     boolean foundPreferredCondition = false;
     if (this.getOperator() == LITERAL_and) {
       if (context instanceof QueryExecutionContext && ((QueryExecutionContext) context).hasHints()
           && ((QueryExecutionContext) context).hasMultiHints()) {
         // Hint was provided, so allow multi index usage
-        for (int i = 0; i < _operands.length; i++) {
-          if (_operands[i].getPlanInfo(context).evalAsFilter) {
+        for (CompiledValue operand : _operands) {
+          if (operand.getPlanInfo(context).evalAsFilter) {
             indexCount++;
-            evalOperands.add(0, _operands[i]);
+            evalOperands.add(0, operand);
           } else {
-            evalOperands.add(_operands[i]);
+            evalOperands.add(operand);
           }
         }
       } else {
@@ -107,7 +108,7 @@ public class GroupJunction extends AbstractGroupOrRangeJunction {
         int currentBestFilterSize = -1;
         indexCount = 1;
 
-        for (int i = 0; i < _operands.length; i++) {
+        for (CompiledValue operand : _operands) {
           // Asif : If we are inside this function this iteslf indicates
           // that there exists atleast on operand which can be evalauted
           // as an auxFilterEvaluate. If any operand even if its flag of
@@ -125,7 +126,7 @@ public class GroupJunction extends AbstractGroupOrRangeJunction {
           // We are here itself implies, that any independent operand can be
           // either tru or false for an AND junction but always false for an
           // OR Junction.
-          PlanInfo pi = _operands[i].getPlanInfo(context);
+          PlanInfo pi = operand.getPlanInfo(context);
           // we check for size == 1 now because of the join optimization can
           // leave an operand with two indexes, but the key element is not set
           // this will throw an npe
@@ -135,52 +136,61 @@ public class GroupJunction extends AbstractGroupOrRangeJunction {
                 evalOperands.add(currentBestFilter);
               }
               // new best
-              currentBestFilter = (Filter) _operands[i];
-              currentBestFilterSize = ((Filter) _operands[i]).getSizeEstimate(context);
+              currentBestFilter = (Filter) operand;
+              currentBestFilterSize = ((Filter) operand).getSizeEstimate(context);
               foundPreferredCondition = true;
               continue;
             }
             if (currentBestFilter == null) {
-              currentBestFilter = (Filter) _operands[i];
-              currentBestFilterSize = ((Filter) _operands[i]).getSizeEstimate(context);
-            } else if (foundPreferredCondition || currentBestFilter
-                .isBetterFilter((Filter) _operands[i], context, currentBestFilterSize)) {
-              evalOperands.add(_operands[i]);
+              currentBestFilter = (Filter) operand;
+              currentBestFilterSize = ((Filter) operand).getSizeEstimate(context);
+            } else if (foundPreferredCondition || currentBestFilter.isBetterFilter((Filter) operand,
+                context, currentBestFilterSize)) {
+              evalOperands.add(operand);
             } else {
               evalOperands.add(currentBestFilter);
-              currentBestFilter = (Filter) _operands[i];
+              currentBestFilter = (Filter) operand;
               // TODO:Asif: Avoid this call. Let the function which is doing the
               // comparison return some how the size of comparedTo operand.
-              currentBestFilterSize = ((Filter) _operands[i]).getSizeEstimate(context);
+              currentBestFilterSize = ((Filter) operand).getSizeEstimate(context);
 
             }
-          } else if (!_operands[i].isDependentOnCurrentScope(context)) {
+          } else if (!operand.isDependentOnCurrentScope(context)) {
             // TODO: Asif :Remove this Assert & else if condition after successful
             // testing of the build
             Support.assertionFailed(
                 "An independentoperand should not ever be present as operand inside a GroupJunction as it should always be present only in CompiledJunction");
           } else {
-            evalOperands.add(_operands[i]);
+            // Back off from the 1-index solution.
+            if (pi.indexes.size() > 1) {
+              // Add the filter evaluable operand at the beginning of the list.
+              evalOperands.add(0, operand);
+            } else {
+              // No indexes, just add the operand.
+              evalOperands.add(operand);
+            }
           }
         }
-        evalOperands.add(0, currentBestFilter);
+
+        // Don't add null to the list of operands.
+        if (currentBestFilter != null) {
+          evalOperands.add(0, currentBestFilter);
+        }
       }
     } else {
       indexCount = _operands.length;
-      for (int i = 0; i < indexCount; i++) {
-        evalOperands.add(_operands[i]);
-      }
+      evalOperands.addAll(Arrays.asList(_operands).subList(0, indexCount));
     }
 
     if (getIterOperands() != null) {
       evalOperands.add(getIterOperands());
     }
+
     return createOrganizedOperandsObject(indexCount, evalOperands);
   }
 
   @Override
-  public int getSizeEstimate(ExecutionContext context) throws FunctionDomainException,
-      TypeMismatchException, NameResolutionException, QueryInvocationTargetException {
+  public int getSizeEstimate(ExecutionContext context) {
     return 1;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledComparisonTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledComparisonTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.query.FunctionDomainException;
+import org.apache.geode.cache.query.NameResolutionException;
+import org.apache.geode.cache.query.QueryInvocationTargetException;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.TypeMismatchException;
+import org.apache.geode.cache.query.internal.index.IndexProtocol;
+import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
+
+public class CompiledComparisonTest {
+  private CompiledComparison compiledComparison;
+  private QueryExecutionContext queryExecutionContext;
+
+  @Before
+  public void setUp() {
+    CompiledValue aliasId = new CompiledID("Batman");
+    CompiledValue clarkLiteral = new CompiledLiteral("BruceWayne");
+    compiledComparison =
+        spy(new CompiledComparison(aliasId, clarkLiteral, OQLLexerTokenTypes.TOK_EQ));
+    queryExecutionContext = mock(QueryExecutionContext.class);
+  }
+
+  @Test
+  public void getSizeEstimateShouldReturnZeroWhenBothFieldsAreIndexed()
+      throws NameResolutionException, TypeMismatchException, FunctionDomainException,
+      QueryInvocationTargetException {
+    IndexInfo[] indexInfos = new IndexInfo[] {mock(IndexInfo.class), mock(IndexInfo.class)};
+    doReturn(indexInfos).when(compiledComparison).getIndexInfo(queryExecutionContext);
+
+    assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(0);
+  }
+
+  @Test
+  public void getSizeEstimateShouldReturnOneWhenThereAreNoIndexes() throws NameResolutionException,
+      TypeMismatchException, FunctionDomainException, QueryInvocationTargetException {
+    assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(1);
+  }
+
+  @Test
+  public void getSizeEstimateShouldReturnOneWhenTheIndexKeyIsUndefined()
+      throws NameResolutionException, TypeMismatchException, FunctionDomainException,
+      QueryInvocationTargetException {
+    IndexInfo indexInfo = mock(IndexInfo.class);
+    when(indexInfo.evaluateIndexKey(queryExecutionContext)).thenReturn(QueryService.UNDEFINED);
+    IndexInfo[] indexInfos = new IndexInfo[] {indexInfo};
+    doReturn(indexInfos).when(compiledComparison).getIndexInfo(queryExecutionContext);
+
+    assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(1);
+  }
+
+  @Test
+  public void getSizeEstimateShouldReturnHintSizeWhenTheIndexIsHinted()
+      throws NameResolutionException, TypeMismatchException, FunctionDomainException,
+      QueryInvocationTargetException {
+    String indexName = "MyIndex";
+    when(queryExecutionContext.isHinted(indexName)).thenReturn(true);
+    when(queryExecutionContext.getHintSize(indexName)).thenReturn(10);
+    IndexProtocol indexProtocol = mock(IndexProtocol.class);
+    when(indexProtocol.getName()).thenReturn(indexName);
+    IndexInfo indexInfo = spy(new IndexInfo(null, null, indexProtocol, 0, null, 0));
+    doReturn("Key1").when(indexInfo).evaluateIndexKey(queryExecutionContext);
+    IndexInfo[] indexInfos = new IndexInfo[] {indexInfo};
+    doReturn(indexInfos).when(compiledComparison).getIndexInfo(queryExecutionContext);
+
+    assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(10);
+  }
+
+  @Test
+  public void getSizeEstimateShouldReturnIndexSizeEstimate() throws NameResolutionException,
+      TypeMismatchException, FunctionDomainException, QueryInvocationTargetException {
+    String indexName = "MyIndex";
+    IndexProtocol indexProtocol = mock(IndexProtocol.class);
+    when(indexProtocol.getName()).thenReturn(indexName);
+    when(indexProtocol.getSizeEstimate(any(), anyInt(), anyInt())).thenReturn(15);
+    IndexInfo indexInfo = spy(new IndexInfo(null, null, indexProtocol, 0, null, 0));
+    doReturn("Key1").when(indexInfo).evaluateIndexKey(queryExecutionContext);
+    IndexInfo[] indexInfos = new IndexInfo[] {indexInfo};
+    doReturn(indexInfos).when(compiledComparison).getIndexInfo(queryExecutionContext);
+
+    assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(15);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledComparisonTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/CompiledComparisonTest.java
@@ -57,13 +57,7 @@ public class CompiledComparisonTest {
   }
 
   @Test
-  public void getSizeEstimateShouldReturnOneWhenThereAreNoIndexes() throws NameResolutionException,
-      TypeMismatchException, FunctionDomainException, QueryInvocationTargetException {
-    assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(1);
-  }
-
-  @Test
-  public void getSizeEstimateShouldReturnOneWhenTheIndexKeyIsUndefined()
+  public void getSizeEstimateShouldReturnZeroWhenTheIndexKeyIsUndefined()
       throws NameResolutionException, TypeMismatchException, FunctionDomainException,
       QueryInvocationTargetException {
     IndexInfo indexInfo = mock(IndexInfo.class);
@@ -71,6 +65,12 @@ public class CompiledComparisonTest {
     IndexInfo[] indexInfos = new IndexInfo[] {indexInfo};
     doReturn(indexInfos).when(compiledComparison).getIndexInfo(queryExecutionContext);
 
+    assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(0);
+  }
+
+  @Test
+  public void getSizeEstimateShouldReturnOneWhenThereAreNoIndexes() throws NameResolutionException,
+      TypeMismatchException, FunctionDomainException, QueryInvocationTargetException {
     assertThat(compiledComparison.getSizeEstimate(queryExecutionContext)).isEqualTo(1);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/GroupJunctionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/GroupJunctionTest.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.apache.geode.cache.query.FunctionDomainException;
+import org.apache.geode.cache.query.NameResolutionException;
+import org.apache.geode.cache.query.QueryInvocationTargetException;
+import org.apache.geode.cache.query.TypeMismatchException;
+import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
+
+public class GroupJunctionTest {
+  private GroupJunction groupJunction;
+  private CompiledValue nameIsClark;
+  private CompiledValue aliasNotBatman;
+  private CompiledValue aliasNotEqualsNameFilter;
+  private CompiledValue aliasNotEqualsNameFilterWithPreferredFlag;
+  private CompiledValue aliasNotEqualsNameFilterWithMultipleIndexes;
+
+  @Mock
+  private QueryExecutionContext queryExecutionContext;
+
+  @Captor
+  private ArgumentCaptor<Integer> indexCaptor;
+
+  @Captor
+  private ArgumentCaptor<List<Object>> evalOperandsCaptor;
+
+  @Before
+  public void setUp() throws NameResolutionException, TypeMismatchException,
+      QueryInvocationTargetException, FunctionDomainException {
+    MockitoAnnotations.initMocks(this);
+    nameIsClark = spy(new CompiledComparison(new CompiledID("name"), new CompiledLiteral("Clark"),
+        OQLLexerTokenTypes.TOK_EQ));
+    PlanInfo nameIsClarkPlanInfo = new PlanInfo();
+    nameIsClarkPlanInfo.indexes = Collections.emptyList();
+    doReturn(nameIsClarkPlanInfo).when(nameIsClark).getPlanInfo(any());
+    doReturn(true).when(nameIsClark).isDependentOnCurrentScope(any());
+
+    aliasNotBatman = spy(new CompiledComparison(new CompiledID("alias"),
+        new CompiledLiteral("Batman"), OQLLexerTokenTypes.TOK_NE));
+    PlanInfo aliasNotBatmanPlanInfo = new PlanInfo();
+    aliasNotBatmanPlanInfo.indexes = Collections.emptyList();
+    doReturn(aliasNotBatmanPlanInfo).when(aliasNotBatman).getPlanInfo(any());
+    doReturn(true).when(aliasNotBatman).isDependentOnCurrentScope(any());
+
+    aliasNotEqualsNameFilter = spy(new CompiledComparison(new CompiledID("alias"),
+        new CompiledID("name"), OQLLexerTokenTypes.TOK_NE));
+    PlanInfo aliasNotEqualsNamePlanInfo = new PlanInfo();
+    aliasNotEqualsNamePlanInfo.evalAsFilter = true;
+    aliasNotEqualsNamePlanInfo.indexes = Collections.singletonList("singleIndex");
+    doReturn(aliasNotEqualsNamePlanInfo).when(aliasNotEqualsNameFilter).getPlanInfo(any());
+    doReturn(true).when(aliasNotEqualsNameFilter).isDependentOnCurrentScope(any());
+
+    aliasNotEqualsNameFilterWithPreferredFlag = spy(new CompiledComparison(new CompiledID("alias"),
+        new CompiledID("name"), OQLLexerTokenTypes.TOK_NE));
+    PlanInfo aliasNotEqualsNameWithPreferredPlanInfo = new PlanInfo();
+    aliasNotEqualsNameWithPreferredPlanInfo.evalAsFilter = true;
+    aliasNotEqualsNameWithPreferredPlanInfo.indexes = Collections.singletonList("singleIndex");
+    aliasNotEqualsNameWithPreferredPlanInfo.isPreferred = true;
+    doReturn(aliasNotEqualsNameWithPreferredPlanInfo)
+        .when(aliasNotEqualsNameFilterWithPreferredFlag).getPlanInfo(any());
+    doReturn(true).when(aliasNotEqualsNameFilterWithPreferredFlag).isDependentOnCurrentScope(any());
+
+    aliasNotEqualsNameFilterWithMultipleIndexes =
+        spy(new CompiledComparison(new CompiledID("alias"), new CompiledID("name"),
+            OQLLexerTokenTypes.TOK_NE));
+    PlanInfo aliasNotEqualsNameFilterWithMultipleIndexesPlanInfo = new PlanInfo();
+    aliasNotEqualsNameFilterWithMultipleIndexesPlanInfo.evalAsFilter = true;
+    aliasNotEqualsNameFilterWithMultipleIndexesPlanInfo.indexes =
+        Arrays.asList("multipleIndex1", "multipleIndex2");
+    doReturn(aliasNotEqualsNameFilterWithMultipleIndexesPlanInfo)
+        .when(aliasNotEqualsNameFilterWithMultipleIndexes).getPlanInfo(any());
+    doReturn(true).when(aliasNotEqualsNameFilterWithMultipleIndexes)
+        .isDependentOnCurrentScope(any());
+  }
+
+  @Test
+  public void organizeOperandsForOROperationShouldUseAllOperands() throws NameResolutionException,
+      TypeMismatchException, QueryInvocationTargetException, FunctionDomainException {
+    groupJunction = spy(new GroupJunction(OQLLexerTokenTypes.LITERAL_or, new RuntimeIterator[] {},
+        true, new CompiledValue[] {nameIsClark, aliasNotBatman}));
+    OrganizedOperands organizedOperands = groupJunction.organizeOperands(queryExecutionContext);
+
+    assertThat(organizedOperands).isNotNull();
+    verify(groupJunction, times(1)).createOrganizedOperandsObject(indexCaptor.capture(),
+        evalOperandsCaptor.capture());
+    assertThat(indexCaptor.getValue()).isEqualTo(2);
+    assertThat(evalOperandsCaptor.getValue()).isEqualTo(Arrays.asList(nameIsClark, aliasNotBatman));
+  }
+
+  @Test
+  public void organizeOperandsForANDOperationShouldUseAllOperandsAndFiltersWhenHintsHaveBeenProvided()
+      throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException,
+      FunctionDomainException {
+    groupJunction = spy(new GroupJunction(OQLLexerTokenTypes.LITERAL_and, new RuntimeIterator[] {},
+        true, new CompiledValue[] {nameIsClark, aliasNotBatman, aliasNotEqualsNameFilter}));
+    when(queryExecutionContext.hasHints()).thenReturn(true);
+    when(queryExecutionContext.hasMultiHints()).thenReturn(true);
+    OrganizedOperands organizedOperands = groupJunction.organizeOperands(queryExecutionContext);
+
+    assertThat(organizedOperands).isNotNull();
+    verify(groupJunction, times(1)).createOrganizedOperandsObject(indexCaptor.capture(),
+        evalOperandsCaptor.capture());
+    assertThat(indexCaptor.getValue()).isEqualTo(1);
+    assertThat(evalOperandsCaptor.getValue())
+        .isEqualTo(Arrays.asList(aliasNotEqualsNameFilter, nameIsClark, aliasNotBatman));
+  }
+
+  @Test
+  public void organizeOperandsForANDOperationShouldUseSingleIndexOptimization()
+      throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException,
+      FunctionDomainException {
+    groupJunction = spy(new GroupJunction(OQLLexerTokenTypes.LITERAL_and, new RuntimeIterator[] {},
+        true, new CompiledValue[] {aliasNotBatman, aliasNotEqualsNameFilter}));
+    OrganizedOperands organizedOperands = groupJunction.organizeOperands(queryExecutionContext);
+
+    assertThat(organizedOperands).isNotNull();
+    verify(groupJunction, times(1)).createOrganizedOperandsObject(indexCaptor.capture(),
+        evalOperandsCaptor.capture());
+    assertThat(indexCaptor.getValue()).isEqualTo(1);
+    assertThat(evalOperandsCaptor.getValue())
+        .isEqualTo(Arrays.asList(aliasNotEqualsNameFilter, aliasNotBatman));
+  }
+
+  @Test
+  public void organizeOperandsForANDOperationShouldUseSingleIndexOptimizationAndOverrideBestFilterWithPreferredOne()
+      throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException,
+      FunctionDomainException {
+    groupJunction = spy(new GroupJunction(OQLLexerTokenTypes.LITERAL_and, new RuntimeIterator[] {},
+        true, new CompiledValue[] {aliasNotBatman, aliasNotEqualsNameFilter,
+            aliasNotEqualsNameFilterWithPreferredFlag}));
+    OrganizedOperands organizedOperands = groupJunction.organizeOperands(queryExecutionContext);
+
+    assertThat(organizedOperands).isNotNull();
+    verify(groupJunction, times(1)).createOrganizedOperandsObject(indexCaptor.capture(),
+        evalOperandsCaptor.capture());
+    assertThat(indexCaptor.getValue()).isEqualTo(1);
+    assertThat(evalOperandsCaptor.getValue()).isEqualTo(Arrays.asList(
+        aliasNotEqualsNameFilterWithPreferredFlag, aliasNotBatman, aliasNotEqualsNameFilter));
+  }
+
+  @Test
+  public void organizeOperandsForANDOperationShouldUseAllOperandsAndFiltersWhenHintsHaveNotBeenProvidedAndSingleIndexOptimizationCanNotBeApplied()
+      throws NameResolutionException, TypeMismatchException, QueryInvocationTargetException,
+      FunctionDomainException {
+    groupJunction = spy(new GroupJunction(OQLLexerTokenTypes.LITERAL_and, new RuntimeIterator[] {},
+        true, new CompiledValue[] {nameIsClark, aliasNotEqualsNameFilterWithMultipleIndexes}));
+    OrganizedOperands organizedOperands = groupJunction.organizeOperands(queryExecutionContext);
+
+    assertThat(organizedOperands).isNotNull();
+    verify(groupJunction, times(1)).createOrganizedOperandsObject(indexCaptor.capture(),
+        evalOperandsCaptor.capture());
+    assertThat(indexCaptor.getValue()).isEqualTo(1);
+    assertThat(evalOperandsCaptor.getValue())
+        .isEqualTo(Arrays.asList(aliasNotEqualsNameFilterWithMultipleIndexes, nameIsClark));
+  }
+}


### PR DESCRIPTION
- Added unit and integration tests.
- Back off from the single index optimisation during join queries if
  we can't find the (single) best filter, allowing the regular
  execution to continue and use multiple indexes.
- If there are multiple indexes, add the filter evaluable operand at
  the beginning of the internal list to evaluate it first in the chain.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
