### PR TITLE
GEODE-7747: Refactor - extract class KeyRegistrar

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetCommandNegativeCaseTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetCommandNegativeCaseTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis;
+
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
+import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.redis.GeodeRedisServer.REDIS_META_DATA_REGION;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Random;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.test.junit.categories.RedisTest;
+
+@Category({RedisTest.class})
+public class SetCommandNegativeCaseTest {
+  private static Jedis jedis;
+  private static GeodeRedisServer server;
+  private static GemFireCache cache;
+  private static Random rand;
+  private static int port = 6379;
+
+  @BeforeClass
+  public static void setUp() {
+    rand = new Random();
+    CacheFactory cf = new CacheFactory();
+    cf.set(LOG_LEVEL, "error");
+    cf.set(MCAST_PORT, "0");
+    cf.set(LOCATORS, "");
+    cache = cf.create();
+    port = AvailablePortHelper.getRandomAvailableTCPPort();
+    server = new GeodeRedisServer("localhost", port);
+
+    server.start();
+    jedis = new Jedis("localhost", port, 10000000);
+  }
+
+
+  @After
+  public void flushAll() {
+    jedis.flushAll();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    jedis.close();
+    cache.close();
+    server.shutdown();
+  }
+
+  @Test
+  public void Should_Throw_RedisDataTypeMismatchException_Given_Key_Already_Exists_With_Different_RedisDataType() {
+    jedis.hset("key", "field", "value");
+
+    assertThatThrownBy(
+        () -> jedis.set("key", "something else")).isInstanceOf(JedisDataException.class)
+            .hasMessageContaining("WRONGTYPE");
+  }
+
+  @Test
+  public void Should_Throw_RedisDataTypeMismatchException_Given_RedisDataType_REDIS_PROTECTED() {
+    assertThatThrownBy(
+        () -> jedis.set(REDIS_META_DATA_REGION, "something else"))
+            .isInstanceOf(JedisDataException.class)
+            .hasMessageContaining("protected");
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
@@ -81,6 +81,12 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
 
   private boolean isAuthenticated;
 
+  public KeyRegistrar getKeyRegistrar() {
+    return keyRegistrar;
+  }
+
+  private KeyRegistrar keyRegistrar;
+
   /**
    * Default constructor for execution contexts.
    *
@@ -92,7 +98,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
    * @param pwd Authentication password for each context, can be null
    */
   public ExecutionHandlerContext(Channel ch, Cache cache, RegionProvider regionProvider,
-      GeodeRedisServer server, byte[] pwd) {
+      GeodeRedisServer server, byte[] pwd, KeyRegistrar keyRegistrar) {
+    this.keyRegistrar = keyRegistrar;
     if (ch == null || cache == null || regionProvider == null || server == null)
       throw new IllegalArgumentException("Only the authentication password may be null");
     this.cache = cache;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/KeyRegistrar.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/KeyRegistrar.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.geode.cache.Region;
+
+public class KeyRegistrar {
+  private Region<String, RedisDataType> redisMetaRegion;
+
+  public KeyRegistrar(Region<String, RedisDataType> redisMetaRegion) {
+    this.redisMetaRegion = redisMetaRegion;
+  }
+
+  /**
+   * Checks if the givenKey is associated with the passed data type. If an entry doesn't exist,
+   * store the key:datatype association in the metadataRegion
+   */
+  public void register(ByteArrayWrapper key, RedisDataType type) {
+    RedisDataType existingType = this.redisMetaRegion.putIfAbsent(key.toString(), type);
+    if (!isValidDataType(existingType, type)) {
+      throwDataTypeException(key, existingType);
+    }
+  }
+
+  public boolean unregister(ByteArrayWrapper key) {
+    return this.redisMetaRegion.remove(key.toString()) != null;
+  }
+
+  public boolean isRegistered(ByteArrayWrapper key) {
+    return this.redisMetaRegion.containsKey(key.toString());
+  }
+
+  public Set<String> keys() {
+    Set<String> keysWithProtected = this.redisMetaRegion.keySet();
+    return keysWithProtected;
+  }
+
+  public Set<Map.Entry<String, RedisDataType>> keyInfos() {
+    return this.redisMetaRegion.entrySet();
+  }
+
+  public int numKeys() {
+    return this.redisMetaRegion.size() - RedisConstants.NUM_DEFAULT_KEYS;
+  }
+
+  public RedisDataType getType(ByteArrayWrapper key) {
+    return this.redisMetaRegion.get(key.toString());
+  }
+
+  /**
+   * Checks if the given key is associated with the passed data type. If there is a mismatch, a
+   * {@link RuntimeException} is thrown
+   *
+   * @param key Key to check
+   * @param type Type to check to
+   */
+  public void validate(ByteArrayWrapper key, RedisDataType type) {
+    RedisDataType currentType = redisMetaRegion.get(key.toString());
+    if (!isValidDataType(currentType, type)) {
+      throwDataTypeException(key, currentType);
+    }
+  }
+
+  private boolean isValidDataType(RedisDataType actualDataType, RedisDataType expectedDataType) {
+    return isKeyUnused(actualDataType) || actualDataType == expectedDataType;
+  }
+
+  private boolean isKeyUnused(RedisDataType dataType) {
+    return dataType == null;
+  }
+
+  private void throwDataTypeException(ByteArrayWrapper key, RedisDataType dataType) {
+    if (dataType == RedisDataType.REDIS_PROTECTED)
+      throw new RedisDataTypeMismatchException("The key name \"" + key + "\" is protected");
+    else
+      throw new RedisDataTypeMismatchException(
+          "The key name \"" + key + "\" is already used by a " + dataType.toString());
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
@@ -29,7 +29,6 @@ import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.Executor;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.RedisDataType;
-import org.apache.geode.redis.internal.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.RegionProvider;
 
 /**
@@ -77,23 +76,17 @@ public abstract class AbstractExecutor implements Executor {
   }
 
   /**
-   * Checks if the given key is associated with the passed data type. If there is a mismatch, a
+   * Checks if the given key is associated with the passed expectedDataType. If there is a mismatch,
+   * a
    * {@link RuntimeException} is thrown
    *
    * @param key Key to check
-   * @param type Type to check to
+   * @param expectedDataType Type to check to
    * @param context context
    */
-  protected void checkDataType(ByteArrayWrapper key, RedisDataType type,
+  protected void checkDataType(ByteArrayWrapper key, RedisDataType expectedDataType,
       ExecutionHandlerContext context) {
-    RedisDataType currentType = context.getRegionProvider().getRedisDataType(key);
-    if (currentType == null)
-      return;
-    if (currentType == RedisDataType.REDIS_PROTECTED)
-      throw new RedisDataTypeMismatchException("The key name \"" + key + "\" is protected");
-    if (currentType != type)
-      throw new RedisDataTypeMismatchException(
-          "The key name \"" + key + "\" is already used by a " + currentType.toString());
+    context.getKeyRegistrar().validate(key, expectedDataType);
   }
 
   protected Query getQuery(ByteArrayWrapper key, Enum<?> type, ExecutionHandlerContext context) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/DBSizeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/DBSizeExecutor.java
@@ -22,7 +22,7 @@ public class DBSizeExecutor extends AbstractExecutor {
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
-    int size = context.getRegionProvider().getMetaSize();
+    int size = context.getKeyRegistrar().numKeys();
     command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), size));
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/DelExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/DelExecutor.java
@@ -42,7 +42,7 @@ public class DelExecutor extends AbstractExecutor {
     for (int i = 1; i < commandElems.size(); i++) {
       byte[] byteKey = commandElems.get(i);
       ByteArrayWrapper key = new ByteArrayWrapper(byteKey);
-      RedisDataType type = context.getRegionProvider().getRedisDataType(key);
+      RedisDataType type = context.getKeyRegistrar().getType(key);
       if (removeEntry(key, type, context))
         numRemoved++;
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExistsExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExistsExecutor.java
@@ -36,7 +36,7 @@ public class ExistsExecutor extends AbstractExecutor {
     }
 
     ByteArrayWrapper key = command.getKey();
-    boolean exists = context.getRegionProvider().existsKey(key);
+    boolean exists = context.getKeyRegistrar().isRegistered(key);
 
     if (exists)
       command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), EXISTS));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/FlushAllExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/FlushAllExecutor.java
@@ -30,7 +30,7 @@ public class FlushAllExecutor extends AbstractExecutor {
     if (context.hasTransaction())
       throw new UnsupportedOperationInTransactionException();
 
-    for (Entry<String, RedisDataType> e : context.getRegionProvider().metaEntrySet()) {
+    for (Entry<String, RedisDataType> e : context.getKeyRegistrar().keyInfos()) {
       try {
         String skey = e.getKey();
         RedisDataType type = e.getValue();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/KeysExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/KeysExecutor.java
@@ -39,7 +39,7 @@ public class KeysExecutor extends AbstractExecutor {
     }
 
     String glob = Coder.bytesToString(commandElems.get(1));
-    Set<String> allKeys = context.getRegionProvider().metaKeySet();
+    Set<String> allKeys = context.getKeyRegistrar().keys();
     List<String> matchingKeys = new ArrayList<String>();
 
     Pattern pattern;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
@@ -99,7 +99,7 @@ public class ScanExecutor extends AbstractScanExecutor {
     }
 
     @SuppressWarnings("unchecked")
-    List<String> returnList = (List<String>) getIteration(context.getRegionProvider().metaKeySet(),
+    List<String> returnList = (List<String>) getIteration(context.getKeyRegistrar().keys(),
         matchPattern, count, cursor);
 
     command.setResponse(Coder.getScanResponse(context.getByteBufAllocator(), returnList));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/TTLExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/TTLExecutor.java
@@ -43,7 +43,7 @@ public class TTLExecutor extends AbstractExecutor implements Extendable {
     ByteArrayWrapper key = command.getKey();
     RegionProvider rC = context.getRegionProvider();
     boolean exists = false;
-    RedisDataType val = rC.getRedisDataType(key);
+    RedisDataType val = context.getKeyRegistrar().getType(key);
     if (val != null)
       exists = true;
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/TypeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/TypeExecutor.java
@@ -35,7 +35,7 @@ public class TypeExecutor extends AbstractExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
-    RedisDataType type = context.getRegionProvider().getRedisDataType(key);
+    RedisDataType type = context.getKeyRegistrar().getType(key);
     if (type == null)
       respondBulkStrings(command, context, "none");
     else

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hll/HllExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hll/HllExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hll;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisDataType;
-import org.apache.geode.redis.internal.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 
 public abstract class HllExecutor extends AbstractExecutor {
@@ -27,11 +26,7 @@ public abstract class HllExecutor extends AbstractExecutor {
   public static final Integer DEFAULT_HLL_SPARSE = 32;
 
   protected void checkAndSetDataType(ByteArrayWrapper key, ExecutionHandlerContext context) {
-    Object oldVal = context.getRegionProvider().metaPutIfAbsent(key, RedisDataType.REDIS_HLL);
-    if (oldVal == RedisDataType.REDIS_PROTECTED)
-      throw new RedisDataTypeMismatchException("The key name \"" + key + "\" is protected");
-    if (oldVal != null && oldVal != RedisDataType.REDIS_HLL)
-      throw new RedisDataTypeMismatchException(
-          "The key name \"" + key + "\" is already used by a " + oldVal.toString());
+    context.getKeyRegistrar().register(key, RedisDataType.REDIS_HLL);
+
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/BitOpExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/BitOpExecutor.java
@@ -22,6 +22,7 @@ import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
+import org.apache.geode.redis.internal.RedisDataType;
 
 public class BitOpExecutor extends StringExecutor {
 
@@ -40,13 +41,13 @@ public class BitOpExecutor extends StringExecutor {
 
     String operation = command.getStringKey().toUpperCase();
     ByteArrayWrapper destKey = new ByteArrayWrapper(commandElems.get(2));
-    checkDataType(destKey, context);
+    checkDataType(destKey, RedisDataType.REDIS_STRING, context);
 
     byte[][] values = new byte[commandElems.size() - 3][];
     int maxLength = 0;
     for (int i = 3; i < commandElems.size(); i++) {
       ByteArrayWrapper key = new ByteArrayWrapper(commandElems.get(i));
-      checkDataType(key, context);
+      checkDataType(key, RedisDataType.REDIS_STRING, context);
       ByteArrayWrapper value = r.get(key);
       if (value == null) {
         values[i - 3] = null;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/DecrExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/DecrExecutor.java
@@ -22,7 +22,6 @@ import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.RegionProvider;
 
 public class DecrExecutor extends StringExecutor {
@@ -59,7 +58,6 @@ public class DecrExecutor extends StringExecutor {
     if (valueWrapper == null) {
       byte[] newValue = INIT_VALUE_BYTES;
       r.put(key, new ByteArrayWrapper(newValue));
-      rC.metaPut(key, RedisDataType.REDIS_STRING);
       command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), INIT_VALUE_INT));
       return;
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/MSetNXExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/MSetNXExecutor.java
@@ -24,6 +24,7 @@ import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
+import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.RedisDataTypeMismatchException;
 
 public class MSetNXExecutor extends StringExecutor {
@@ -50,7 +51,7 @@ public class MSetNXExecutor extends StringExecutor {
       byte[] keyArray = commandElems.get(i);
       ByteArrayWrapper key = new ByteArrayWrapper(keyArray);
       try {
-        checkDataType(key, context);
+        checkDataType(key, RedisDataType.REDIS_STRING, context);
       } catch (RedisDataTypeMismatchException e) {
         hasEntry = true;
         break;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetExecutor.java
@@ -22,6 +22,7 @@ import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
+import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 
 public class SetExecutor extends StringExecutor {
@@ -42,7 +43,7 @@ public class SetExecutor extends StringExecutor {
     }
 
     ByteArrayWrapper key = command.getKey();
-    checkDataType(key, context);
+    checkDataType(key, RedisDataType.REDIS_STRING, context);
     byte[] value = commandElems.get(VALUE_INDEX);
     ByteArrayWrapper valueWrapper = new ByteArrayWrapper(value);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/StringExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/string/StringExecutor.java
@@ -17,29 +17,11 @@ package org.apache.geode.redis.internal.executor.string;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisDataType;
-import org.apache.geode.redis.internal.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 
 public abstract class StringExecutor extends AbstractExecutor {
 
   protected void checkAndSetDataType(ByteArrayWrapper key, ExecutionHandlerContext context) {
-    Object oldVal = context.getRegionProvider().metaPutIfAbsent(key, RedisDataType.REDIS_STRING);
-    if (oldVal == RedisDataType.REDIS_PROTECTED)
-      throw new RedisDataTypeMismatchException("The key name \"" + key + "\" is protected");
-    if (oldVal != null && oldVal != RedisDataType.REDIS_STRING)
-      throw new RedisDataTypeMismatchException(
-          "The key name \"" + key + "\" is already used by a " + oldVal.toString());
+    context.getKeyRegistrar().register(key, RedisDataType.REDIS_STRING);
   }
-
-  protected void checkDataType(ByteArrayWrapper key, ExecutionHandlerContext context) {
-    RedisDataType currentType = context.getRegionProvider().getRedisDataType(key);
-    if (currentType == null)
-      return;
-    if (currentType == RedisDataType.REDIS_PROTECTED)
-      throw new RedisDataTypeMismatchException("The key name \"" + key + "\" is protected");
-    if (currentType != RedisDataType.REDIS_STRING)
-      throw new RedisDataTypeMismatchException(
-          "The key name \"" + key + "\" is already used by a " + currentType.toString());
-  }
-
 }


### PR DESCRIPTION
KeyRegistrar encapsulates info about keys that are inserted via the
Redis API. It uses a Geode Region to store a map from key -> RedisDataType

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
