### PR TITLE
GEODE-5595: Fix DeltaPropagationDUnitTest flakiness

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplJUnitTest.java
@@ -436,6 +436,11 @@ public class AutoConnectionSourceImplJUnitTest {
     }
 
     @Override
+    public int getPrimaryPort() {
+      return 0;
+    }
+
+    @Override
     public EndpointManager getEndpointManager() {
       return null;
     }

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/QueueManagerJUnitTest.java
@@ -312,6 +312,11 @@ public class QueueManagerJUnitTest {
     }
 
     @Override
+    public int getPrimaryPort() {
+      return 0;
+    }
+
+    @Override
     public Object execute(Op op, int retryAttempts) {
       return null;
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/ClientRegionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/ClientRegionFactory.java
@@ -216,7 +216,7 @@ public interface ClientRegionFactory<K, V> {
    * @since GemFire 7.0
    * @param concurrencyChecksEnabled whether to perform concurrency checks on operations
    */
-  void setConcurrencyChecksEnabled(boolean concurrencyChecksEnabled);
+  ClientRegionFactory<K, V> setConcurrencyChecksEnabled(boolean concurrencyChecksEnabled);
 
   /**
    * Sets the DiskStore name attribute. This causes the region to belong to the DiskStore.

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientRegionFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientRegionFactoryImpl.java
@@ -186,8 +186,9 @@ public class ClientRegionFactoryImpl<K, V> implements ClientRegionFactory<K, V> 
   }
 
   @Override
-  public void setConcurrencyChecksEnabled(boolean concurrencyChecksEnabled) {
+  public ClientRegionFactory<K, V> setConcurrencyChecksEnabled(boolean concurrencyChecksEnabled) {
     this.attrsFactory.setConcurrencyChecksEnabled(concurrencyChecksEnabled);
+    return this;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/InternalPool.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/InternalPool.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.internal.cache.PoolStats;
 
@@ -26,9 +27,9 @@ import org.apache.geode.internal.cache.PoolStats;
  * connection source to access the cache and update the list of endpoints on the connection pool.
  *
  * @since GemFire 5.7
- *
  */
 public interface InternalPool extends Pool, ExecutablePool {
+
   PoolStats getStats();
 
   Map getEndpointMap();
@@ -46,4 +47,10 @@ public interface InternalPool extends Pool, ExecutablePool {
   String getPoolOrCacheCancelInProgress();
 
   boolean getKeepAlive();
+
+  /**
+   * Test hook that returns the port of the primary server. -1 is returned if we have no primary.
+   */
+  @VisibleForTesting
+  int getPrimaryPort();
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -35,6 +35,7 @@ import org.apache.geode.CancelCriterion;
 import org.apache.geode.CancelException;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.SystemFailure;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.cache.NoSubscriptionServersAvailableException;
@@ -1019,10 +1020,8 @@ public class PoolImpl implements InternalPool {
     return result;
   }
 
-  /**
-   * Test hook that returns an int which the port of the primary server. -1 is returned if we have
-   * no primary.
-   */
+  @Override
+  @VisibleForTesting
   public int getPrimaryPort() {
     int result = -1;
     ServerLocation sl = getPrimary();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -44,7 +44,7 @@ import static org.apache.geode.internal.cache.PartitionedRegion.PRIMARY_BUCKETS_
 import static org.apache.geode.internal.cache.PartitionedRegionHelper.PARTITION_LOCK_SERVICE_NAME;
 import static org.apache.geode.internal.cache.control.InternalResourceManager.ResourceType.HEAP_MEMORY;
 import static org.apache.geode.internal.cache.control.InternalResourceManager.ResourceType.OFFHEAP_MEMORY;
-import static org.apache.geode.internal.cache.util.UncheckedUtils.uncheckedRegion;
+import static org.apache.geode.internal.cache.util.UncheckedUtils.cast;
 import static org.apache.geode.internal.logging.CoreLoggingExecutors.newThreadPoolWithFixedFeed;
 import static org.apache.geode.internal.tcp.ConnectionTable.threadWantsSharedResources;
 import static org.apache.geode.logging.internal.executors.LoggingExecutors.newFixedThreadPool;
@@ -3022,7 +3022,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       system.handleResourceEvent(ResourceEvent.REGION_CREATE, region);
     }
 
-    return uncheckedRegion(region);
+    return cast(region);
   }
 
   @Override
@@ -3146,7 +3146,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
 
   @Override
   public <K, V> Region<K, V> getRegionByPath(String path) {
-    return uncheckedRegion(getInternalRegionByPath(path));
+    return cast(getInternalRegionByPath(path));
   }
 
   @Override
@@ -3203,7 +3203,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
         stopper.checkCancelInProgress(null);
         return null;
       }
-      return uncheckedRegion(result);
+      return cast(result);
     }
 
     String[] pathParts = parsePath(path);
@@ -3227,7 +3227,7 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       logger.debug("GemFireCache.getRegion, calling getSubregion on rootRegion({}): {}",
           pathParts[0], pathParts[1]);
     }
-    return uncheckedRegion(rootRegion.getSubregion(pathParts[1], returnDestroyedRegion));
+    return cast(rootRegion.getSubregion(pathParts[1], returnDestroyedRegion));
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -16,7 +16,7 @@
  */
 package org.apache.geode.internal.cache;
 
-import static org.apache.geode.internal.cache.util.UncheckedUtils.uncheckedRegion;
+import static org.apache.geode.internal.cache.util.UncheckedUtils.cast;
 
 import java.io.File;
 import java.io.IOException;
@@ -162,7 +162,7 @@ public class InternalCacheForClientAccess implements InternalCache {
   public <K, V> Region<K, V> getRegion(String path, boolean returnDestroyedRegion) {
     Region result = delegate.getRegion(path, returnDestroyedRegion);
     checkForInternalRegion(result);
-    return uncheckedRegion(result);
+    return cast(result);
   }
 
   @Override
@@ -176,7 +176,7 @@ public class InternalCacheForClientAccess implements InternalCache {
   public <K, V> Region<K, V> getRegionByPath(String path) {
     InternalRegion result = delegate.getInternalRegionByPath(path);
     checkForInternalRegion(result);
-    return uncheckedRegion(result);
+    return cast(result);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalPoolFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalPoolFactory.java
@@ -12,12 +12,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.internal.cache.util;
+package org.apache.geode.internal.cache;
 
-@SuppressWarnings({"unchecked", "unused"})
-public class UncheckedUtils {
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.client.PoolFactory;
+import org.apache.geode.internal.cache.PoolFactoryImpl.PoolAttributes;
 
-  public static <T> T cast(Object object) {
-    return (T) object;
-  }
+public interface InternalPoolFactory extends PoolFactory {
+
+  /**
+   * Initializes the state of this factory for the given pool's state.
+   */
+  void init(Pool cp);
+
+  /**
+   * Needed by test framework.
+   */
+  @VisibleForTesting
+  PoolAttributes getPoolAttributes();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PoolFactoryImpl.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.client.PoolFactory;
@@ -49,7 +50,7 @@ import org.apache.geode.pdx.internal.TypeRegistry;
  *
  * @since GemFire 5.7
  */
-public class PoolFactoryImpl implements PoolFactory {
+public class PoolFactoryImpl implements InternalPoolFactory {
   private static final Logger logger = LogService.getLogger();
 
   /**
@@ -310,10 +311,7 @@ public class PoolFactoryImpl implements PoolFactory {
     return this;
   }
 
-
-  /**
-   * Initializes the state of this factory for the given pool's state.
-   */
+  @Override
   public void init(Pool cp) {
     setSocketConnectTimeout(cp.getSocketConnectTimeout());
     setFreeConnectionTimeout(cp.getFreeConnectionTimeout());
@@ -380,9 +378,8 @@ public class PoolFactoryImpl implements PoolFactory {
     return GemFireCacheImpl.getInstance();
   }
 
-  /**
-   * Needed by test framework.
-   */
+  @Override
+  @VisibleForTesting
   public PoolAttributes getPoolAttributes() {
     return attributes;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -18,8 +18,6 @@ import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,29 +28,23 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.regex.Pattern;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadState;
 
 import org.apache.geode.CancelException;
-import org.apache.geode.DataSerializer;
 import org.apache.geode.StatisticsFactory;
+import org.apache.geode.annotations.Immutable;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.ClientSession;
 import org.apache.geode.cache.DynamicRegionFactory;
-import org.apache.geode.cache.InterestRegistrationEvent;
 import org.apache.geode.cache.InterestResultPolicy;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
-import org.apache.geode.cache.RegionExistsException;
 import org.apache.geode.cache.client.internal.RegisterInterestTracker;
 import org.apache.geode.cache.operations.DestroyOperationContext;
 import org.apache.geode.cache.operations.InvalidateOperationContext;
@@ -65,28 +57,20 @@ import org.apache.geode.cache.query.CqException;
 import org.apache.geode.cache.query.internal.cq.CqService;
 import org.apache.geode.cache.query.internal.cq.InternalCqQuery;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.OperationExecutors;
 import org.apache.geode.internal.SystemTimer;
 import org.apache.geode.internal.SystemTimer.SystemTimerTask;
 import org.apache.geode.internal.cache.CacheDistributionAdvisee;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor.InitialImageAdvice;
-import org.apache.geode.internal.cache.ClientServerObserver;
-import org.apache.geode.internal.cache.ClientServerObserverHolder;
 import org.apache.geode.internal.cache.Conflatable;
 import org.apache.geode.internal.cache.DistributedRegion;
 import org.apache.geode.internal.cache.EnumListenerEvent;
 import org.apache.geode.internal.cache.EventID;
-import org.apache.geode.internal.cache.FilterProfile;
-import org.apache.geode.internal.cache.InterestRegistrationEventImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.StateFlushOperation;
-import org.apache.geode.internal.cache.ha.HAContainerWrapper;
 import org.apache.geode.internal.cache.ha.HARegionQueue;
-import org.apache.geode.internal.cache.ha.HARegionQueueAttributes;
-import org.apache.geode.internal.cache.ha.HARegionQueueStats;
 import org.apache.geode.internal.cache.tier.InterestType;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl.CqNameToOp;
 import org.apache.geode.internal.cache.tier.sockets.command.Get70;
@@ -95,10 +79,8 @@ import org.apache.geode.internal.logging.LogWriterImpl;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.security.AuthorizeRequestPP;
 import org.apache.geode.internal.security.SecurityService;
-import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.internal.statistics.StatisticsClock;
-import org.apache.geode.logging.internal.executors.LoggingThread;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.security.AccessControl;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -113,6 +95,16 @@ import org.apache.geode.util.internal.GeodeGlossary;
 @SuppressWarnings("synthetic-access")
 public class CacheClientProxy implements ClientSession {
   private static final Logger logger = LogService.getLogger();
+
+  @Immutable
+  @VisibleForTesting
+  protected static final CacheClientProxyStatsFactory DEFAULT_CACHECLIENTPROXYSTATSFACTORY =
+      (statisticsFactory, proxyId, remoteHostAddress) -> new CacheClientProxyStats(
+          statisticsFactory,
+          "id_" + proxyId.getDistributedMember().getId() + "_at_" + remoteHostAddress);
+  @Immutable
+  private static final MessageDispatcherFactory DEFAULT_MESSAGEDISPATCHERFACTORY =
+      MessageDispatcher::new;
 
   /**
    * The socket between the server and the client
@@ -227,16 +219,6 @@ public class CacheClientProxy implements ClientSession {
   @MutableForTesting
   public static boolean isSlowStartForTesting = false;
 
-  /**
-   * Default value for slow starting time of dispatcher
-   */
-  private static final long DEFAULT_SLOW_STARTING_TIME = 5000;
-
-  /**
-   * Key in the system property from which the slow starting time value will be retrieved
-   */
-  private static final String KEY_SLOW_START_TIME_FOR_TESTING = "slowStartTimeForTesting";
-
   private boolean isPrimary;
 
   /** @since GemFire 5.7 */
@@ -318,6 +300,8 @@ public class CacheClientProxy implements ClientSession {
   private final SecurityService securityService;
   private final StatisticsClock statisticsClock;
 
+  private final MessageDispatcherFactory messageDispatcherFactory;
+
   /**
    * Constructor.
    *
@@ -332,20 +316,33 @@ public class CacheClientProxy implements ClientSession {
       Version clientVersion, long acceptorId, boolean notifyBySubscription,
       SecurityService securityService, Subject subject, StatisticsClock statisticsClock)
       throws CacheException {
+    this(ccn.getCache(), ccn, socket, proxyID, isPrimary, clientConflation, clientVersion,
+        acceptorId, notifyBySubscription, securityService, subject, statisticsClock,
+        ccn.getCache().getInternalDistributedSystem().getStatisticsManager(),
+        DEFAULT_CACHECLIENTPROXYSTATSFACTORY,
+        DEFAULT_MESSAGEDISPATCHERFACTORY);
+  }
 
+  @VisibleForTesting
+  protected CacheClientProxy(InternalCache cache, CacheClientNotifier ccn, Socket socket,
+      ClientProxyMembershipID proxyID, boolean isPrimary, byte clientConflation,
+      Version clientVersion, long acceptorId, boolean notifyBySubscription,
+      SecurityService securityService, Subject subject, StatisticsClock statisticsClock,
+      StatisticsFactory statisticsFactory,
+      CacheClientProxyStatsFactory cacheClientProxyStatsFactory,
+      MessageDispatcherFactory messageDispatcherFactory)
+      throws CacheException {
     initializeTransientFields(socket, proxyID, isPrimary, clientConflation, clientVersion);
     this._cacheClientNotifier = ccn;
-    this._cache = ccn.getCache();
+    this._cache = cache;
     this.securityService = securityService;
     this._maximumMessageCount = ccn.getMaximumMessageCount();
     this._messageTimeToLive = ccn.getMessageTimeToLive();
     this._acceptorId = acceptorId;
     this.notifyBySubscription = notifyBySubscription;
-    StatisticsFactory factory = this._cache.getInternalDistributedSystem().getStatisticsManager();
     this.statisticsClock = statisticsClock;
     this._statistics =
-        new CacheClientProxyStats(factory, "id_" + this.proxyID.getDistributedMember().getId()
-            + "_at_" + this._remoteHostAddress);
+        cacheClientProxyStatsFactory.create(statisticsFactory, proxyID, _remoteHostAddress);
     this.subject = subject;
 
     // Create the interest list
@@ -357,7 +354,12 @@ public class CacheClientProxy implements ClientSession {
     this.postAuthzCallback = null;
     this._cacheClientNotifier.getAcceptorStats().incCurrentQueueConnections();
     this.creationDate = new Date();
+    this.messageDispatcherFactory = messageDispatcherFactory;
     initializeClientAuths();
+  }
+
+  Version getClientVersion() {
+    return clientVersion;
   }
 
   private void initializeClientAuths() {
@@ -1708,7 +1710,7 @@ public class CacheClientProxy implements ClientSession {
   }
 
   MessageDispatcher createMessageDispatcher(String name) {
-    return new MessageDispatcher(this, name, statisticsClock);
+    return messageDispatcherFactory.create(this, name, statisticsClock);
   }
 
   protected void startOrResumeMessageDispatcher(boolean processedMarker) {
@@ -1937,944 +1939,6 @@ public class CacheClientProxy implements ClientSession {
     }
   }
 
-  /**
-   * Class <code>ClientInterestList</code> provides a convenient interface for manipulating client
-   * interest information.
-   */
-  protected static class ClientInterestList {
-
-    final CacheClientProxy ccp;
-
-    final Object id;
-
-    /**
-     * An object used for synchronizing the interest lists
-     */
-    private final Object interestListLock = new Object();
-
-    /**
-     * Regions that this client is interested in
-     */
-    protected final Set<String> regions = new HashSet<String>();
-
-    /**
-     * Constructor.
-     */
-    protected ClientInterestList(CacheClientProxy ccp, Object interestID) {
-      this.ccp = ccp;
-      this.id = interestID;
-      // this.id = getNextId();
-    }
-
-    /**
-     * Registers interest in the input region name and key
-     */
-    protected void registerClientInterest(String regionName, Object keyOfInterest, int interestType,
-        boolean sendUpdatesAsInvalidates) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("{}: registerClientInterest region={} key={}", ccp, regionName, keyOfInterest);
-      }
-      Set keysRegistered = null;
-      synchronized (this.interestListLock) {
-        LocalRegion r = (LocalRegion) this.ccp._cache.getRegion(regionName, true);
-        if (r == null) {
-          throw new RegionDestroyedException("Region could not be found for interest registration",
-              regionName);
-        }
-        if (!(r instanceof CacheDistributionAdvisee)) {
-          throw new IllegalArgumentException("region " + regionName
-              + " is not distributed and does not support interest registration");
-        }
-        FilterProfile p = r.getFilterProfile();
-        keysRegistered =
-            p.registerClientInterest(id, keyOfInterest, interestType, sendUpdatesAsInvalidates);
-        regions.add(regionName);
-      }
-      // Perform actions if any keys were registered
-      if ((keysRegistered != null) && containsInterestRegistrationListeners()
-          && !keysRegistered.isEmpty()) {
-        handleInterestEvent(regionName, keysRegistered, interestType, true);
-      }
-    }
-
-
-    protected FilterProfile getProfile(String regionName) {
-      try {
-        return this.ccp._cache.getFilterProfile(regionName);
-      } catch (CancelException e) {
-        return null;
-      }
-    }
-
-    /**
-     * Unregisters interest in the input region name and key
-     *
-     * @param regionName The fully-qualified name of the region in which to unregister interest
-     * @param keyOfInterest The key in which to unregister interest
-     */
-    protected void unregisterClientInterest(String regionName, Object keyOfInterest,
-        int interestType) {
-      if (logger.isDebugEnabled()) {
-        logger.debug("{}: unregisterClientInterest region={} key={}", ccp, regionName,
-            keyOfInterest);
-      }
-      FilterProfile p = getProfile(regionName);
-      Set keysUnregistered = null;
-      synchronized (this.interestListLock) {
-        if (p != null) {
-          keysUnregistered = p.unregisterClientInterest(id, keyOfInterest, interestType);
-          if (!p.hasInterestFor(id)) {
-            this.regions.remove(regionName);
-          }
-        } else {
-          this.regions.remove(regionName);
-        }
-      }
-      if (keysUnregistered != null && !keysUnregistered.isEmpty()) {
-        handleInterestEvent(regionName, keysUnregistered, interestType, false);
-      }
-    }
-
-    /**
-     * Registers interest in the input region name and list of keys
-     *
-     * @param regionName The fully-qualified name of the region in which to register interest
-     * @param keysOfInterest The list of keys in which to register interest
-     */
-    protected void registerClientInterestList(String regionName, List keysOfInterest,
-        boolean sendUpdatesAsInvalidates) {
-      FilterProfile p = getProfile(regionName);
-      if (p == null) {
-        throw new RegionDestroyedException("Region not found during client interest registration",
-            regionName);
-      }
-      Set keysRegistered = null;
-      synchronized (this.interestListLock) {
-        keysRegistered = p.registerClientInterestList(id, keysOfInterest, sendUpdatesAsInvalidates);
-        regions.add(regionName);
-      }
-      // Perform actions if any keys were registered
-      if (containsInterestRegistrationListeners() && !keysRegistered.isEmpty()) {
-        handleInterestEvent(regionName, keysRegistered, InterestType.KEY, true);
-      }
-    }
-
-    /**
-     * Unregisters interest in the input region name and list of keys
-     *
-     * @param regionName The fully-qualified name of the region in which to unregister interest
-     * @param keysOfInterest The list of keys in which to unregister interest
-     */
-    protected void unregisterClientInterestList(String regionName, List keysOfInterest) {
-      FilterProfile p = getProfile(regionName);
-      Set keysUnregistered = null;
-      synchronized (this.interestListLock) {
-        if (p != null) {
-          keysUnregistered = p.unregisterClientInterestList(id, keysOfInterest);
-          if (!p.hasInterestFor(id)) {
-            regions.remove(regionName);
-          }
-        } else {
-          regions.remove(regionName);
-        }
-      }
-      // Perform actions if any keys were unregistered
-      if (!keysUnregistered.isEmpty()) {
-        handleInterestEvent(regionName, keysUnregistered, InterestType.KEY, false);
-      }
-    }
-
-    /*
-     * Returns whether this interest list has any keys, patterns or filters of interest. It answers
-     * the question: Are any clients being notified because of this interest list? @return whether
-     * this interest list has any keys, patterns or filters of interest
-     */
-    protected boolean hasInterest() {
-      return regions.size() > 0;
-    }
-
-    protected void clearClientInterestList() {
-      boolean isClosed = ccp.getCache().isClosed();
-
-      synchronized (this.interestListLock) {
-        for (String regionName : regions) {
-          FilterProfile p = getProfile(regionName);
-          if (p == null) {
-            continue;
-          }
-          if (!isClosed) {
-            if (p.hasAllKeysInterestFor(id)) {
-              Set allKeys = new HashSet();
-              allKeys.add(".*");
-              allKeys = Collections.unmodifiableSet(allKeys);
-              handleInterestEvent(regionName, allKeys, InterestType.REGULAR_EXPRESSION, false);
-            }
-            Set keysOfInterest = p.getKeysOfInterestFor(id);
-            if (keysOfInterest != null && keysOfInterest.size() > 0) {
-              handleInterestEvent(regionName, keysOfInterest, InterestType.KEY, false);
-            }
-            Map<String, Pattern> patternsOfInterest = p.getPatternsOfInterestFor(id);
-            if (patternsOfInterest != null && patternsOfInterest.size() > 0) {
-              handleInterestEvent(regionName, patternsOfInterest.keySet(),
-                  InterestType.REGULAR_EXPRESSION, false);
-            }
-          }
-          p.clearInterestFor(id);
-        }
-        regions.clear();
-      }
-    }
-
-
-    private void handleInterestEvent(String regionName, Set keysOfInterest, int interestType,
-        boolean isRegister) {
-      // Notify the region about this register interest event if:
-      // - the application has requested it
-      // - this is a primary CacheClientProxy (otherwise multiple notifications
-      // may occur)
-      // - it is a key interest type (regex is currently not supported)
-      InterestRegistrationEvent event = null;
-      if (NOTIFY_REGION_ON_INTEREST && this.ccp.isPrimary() && interestType == InterestType.KEY) {
-        event = new InterestRegistrationEventImpl(this.ccp, regionName, keysOfInterest,
-            interestType, isRegister);
-        try {
-          notifyRegionOfInterest(event);
-        } catch (Exception e) {
-          logger.warn("Region notification of interest failed", e);
-        }
-      }
-      // Invoke interest registration listeners
-      if (containsInterestRegistrationListeners()) {
-        if (event == null) {
-          event = new InterestRegistrationEventImpl(this.ccp, regionName, keysOfInterest,
-              interestType, isRegister);
-        }
-        notifyInterestRegistrationListeners(event);
-      }
-    }
-
-    private void notifyRegionOfInterest(InterestRegistrationEvent event) {
-      this.ccp.getCacheClientNotifier().handleInterestEvent(event);
-    }
-
-    private void notifyInterestRegistrationListeners(InterestRegistrationEvent event) {
-      this.ccp.getCacheClientNotifier().notifyInterestRegistrationListeners(event);
-    }
-
-    private boolean containsInterestRegistrationListeners() {
-      return this.ccp.getCacheClientNotifier().containsInterestRegistrationListeners();
-    }
-  }
-
-
-  /**
-   * Class <code>MessageDispatcher</code> is a <code>Thread</code> that processes messages bound for
-   * the client by taking messsages from the message queue and sending them to the client over the
-   * socket.
-   */
-  static class MessageDispatcher extends LoggingThread {
-
-    /**
-     * The queue of messages to be sent to the client
-     */
-    protected final HARegionQueue _messageQueue;
-
-    // /**
-    // * An int used to keep track of the number of messages dropped for logging
-    // * purposes. If greater than zero then a warning has been logged about
-    // * messages being dropped.
-    // */
-    // private int _numberOfMessagesDropped = 0;
-
-    /**
-     * The proxy for which this dispatcher is processing messages
-     */
-    private final CacheClientProxy _proxy;
-
-    // /**
-    // * The conflator faciliates message conflation
-    // */
-    // protected BridgeEventConflator _eventConflator;
-
-    /**
-     * Whether the dispatcher is stopped
-     */
-    private volatile boolean _isStopped = true;
-
-    /**
-     * guarded.By _pausedLock
-     */
-    // boolean _isPausedDispatcher = false;
-
-    /**
-     * A lock object used to control pausing this dispatcher
-     */
-    protected final Object _pausedLock = new Object();
-
-    /**
-     * An object used to protect when dispatching is being stopped.
-     */
-    private final Object _stopDispatchingLock = new Object();
-
-    private final ReadWriteLock socketLock = new ReentrantReadWriteLock();
-
-    private final Lock socketWriteLock = socketLock.writeLock();
-    // /**
-    // * A boolean verifying whether a warning has already been issued if the
-    // * message queue has reached its capacity.
-    // */
-    // private boolean _messageQueueCapacityReachedWarning = false;
-
-    /**
-     * Constructor.
-     *
-     * @param proxy The <code>CacheClientProxy</code> for which this dispatcher is processing
-     *        messages
-     * @param name thread name for this dispatcher
-     */
-    protected MessageDispatcher(CacheClientProxy proxy, String name,
-        StatisticsClock statisticsClock) throws CacheException {
-      super(name);
-
-      this._proxy = proxy;
-
-      // Create the event conflator
-      // this._eventConflator = new BridgeEventConflator
-
-      // Create the message queue
-      try {
-        HARegionQueueAttributes harq = new HARegionQueueAttributes();
-        harq.setBlockingQueueCapacity(proxy._maximumMessageCount);
-        harq.setExpiryTime(proxy._messageTimeToLive);
-        ((HAContainerWrapper) proxy._cacheClientNotifier.getHaContainer())
-            .putProxy(HARegionQueue.createRegionName(getProxy().getHARegionName()), getProxy());
-        boolean createDurableQueue = proxy.proxyID.isDurable();
-        boolean canHandleDelta = (proxy.clientVersion.compareTo(Version.GFE_61) >= 0)
-            && InternalDistributedSystem.getAnyInstance().getConfig().getDeltaPropagation()
-            && !(this._proxy.clientConflation == Handshake.CONFLATION_ON);
-        if ((createDurableQueue || canHandleDelta) && logger.isDebugEnabled()) {
-          logger.debug("Creating a {} subscription queue for {}",
-              createDurableQueue ? "durable" : "non-durable",
-              proxy.getProxyID());
-        }
-        this._messageQueue = HARegionQueue.getHARegionQueueInstance(getProxy().getHARegionName(),
-            getCache(), harq, HARegionQueue.BLOCKING_HA_QUEUE, createDurableQueue,
-            proxy._cacheClientNotifier.getHaContainer(), proxy.getProxyID(),
-            this._proxy.clientConflation, this._proxy.isPrimary(), canHandleDelta, statisticsClock);
-        // Check if interests were registered during HARegion GII.
-        if (this._proxy.hasRegisteredInterested()) {
-          this._messageQueue.setHasRegisteredInterest(true);
-        }
-      } catch (CancelException e) {
-        throw e;
-      } catch (RegionExistsException ree) {
-        throw ree;
-      } catch (Exception e) {
-        getCache().getCancelCriterion().checkCancelInProgress(e);
-        throw new CacheException(
-            "Exception occurred while trying to create a message queue.",
-            e) {
-          private static final long serialVersionUID = 0L;
-        };
-      }
-    }
-
-    private CacheClientProxy getProxy() {
-      return this._proxy;
-    }
-
-    private InternalCache getCache() {
-      return getProxy().getCache();
-    }
-
-    private Socket getSocket() {
-      return getProxy().getSocket();
-    }
-
-    private ByteBuffer getCommBuffer() {
-      return getProxy().getCommBuffer();
-    }
-
-    private CacheClientProxyStats getStatistics() {
-      return getProxy().getStatistics();
-    }
-
-    private void basicStopDispatching() {
-      if (logger.isDebugEnabled()) {
-        logger.debug("{}: notified dispatcher to stop", this);
-      }
-      this._isStopped = true;
-      // this.interrupt(); // don't interrupt here. Let close(boolean) do this.
-    }
-
-    @Override
-    public String toString() {
-      return getProxy().toString();
-    }
-
-    /**
-     * Notifies the dispatcher to stop dispatching.
-     *
-     * @param checkQueue Whether to check the message queue for any unprocessed messages and process
-     *        them for MAXIMUM_SHUTDOWN_PEEKS.
-     *
-     * @see CacheClientProxy#MAXIMUM_SHUTDOWN_PEEKS
-     */
-    protected synchronized void stopDispatching(boolean checkQueue) {
-      if (isStopped()) {
-        return;
-      }
-
-      if (logger.isDebugEnabled()) {
-        logger.debug("{}: Stopping dispatching", this);
-      }
-      if (!checkQueue) {
-        basicStopDispatching();
-        return;
-      }
-
-      // Stay alive until the queue is empty or a number of peeks is reached.
-      List events = null;
-      try {
-        for (int numberOfPeeks = 0; numberOfPeeks < MAXIMUM_SHUTDOWN_PEEKS; ++numberOfPeeks) {
-          boolean interrupted = Thread.interrupted();
-          try {
-            events = this._messageQueue.peek(1, -1);
-            if (events == null || events.size() == 0) {
-              break;
-            }
-            if (logger.isDebugEnabled()) {
-              logger.debug("Waiting for client to drain queue: {}", _proxy.proxyID);
-            }
-            Thread.sleep(500);
-          } catch (InterruptedException e) {
-            interrupted = true;
-          } catch (CancelException e) {
-            break;
-          } catch (CacheException e) {
-            if (logger.isDebugEnabled()) {
-              logger.debug("{}: Exception occurred while trying to stop dispatching", this, e);
-            }
-          } finally {
-            if (interrupted)
-              Thread.currentThread().interrupt();
-          }
-        } // for
-      } finally {
-        basicStopDispatching();
-      }
-    }
-
-    /**
-     * Returns whether the dispatcher is stopped
-     *
-     * @return whether the dispatcher is stopped
-     */
-    protected boolean isStopped() {
-      return this._isStopped;
-    }
-
-    /**
-     * Returns the size of the queue for heuristic purposes. This size may be changing concurrently
-     * if puts / gets are occurring at the same time.
-     *
-     * @return the size of the queue
-     */
-    protected int getQueueSize() {
-      return this._messageQueue == null ? 0 : this._messageQueue.size();
-    }
-
-    /**
-     * Returns the size of the queue calculated through stats This includes events that have
-     * dispatched but have yet been removed
-     *
-     * @return the size of the queue
-     */
-    protected int getQueueSizeStat() {
-      if (this._messageQueue != null) {
-        HARegionQueueStats stats = this._messageQueue.getStatistics();
-        return ((int) (stats.getEventsEnqued() - stats.getEventsRemoved()
-            - stats.getEventsConflated() - stats.getMarkerEventsConflated()
-            - stats.getEventsExpired() - stats.getEventsRemovedByQrm() - stats.getEventsTaken()
-            - stats.getNumVoidRemovals()));
-      }
-      return 0;
-    }
-
-    protected void drainClientCqEvents(ClientProxyMembershipID clientId,
-        InternalCqQuery cqToClose) {
-      this._messageQueue.closeClientCq(clientId, cqToClose);
-    }
-
-    /**
-     * Runs the dispatcher by taking a message from the queue and sending it to the client attached
-     * to this proxy.
-     */
-    @Override
-    public void run() {
-      boolean exceptionOccurred = false;
-      this._isStopped = false;
-
-      if (logger.isDebugEnabled()) {
-        logger.debug("{}: Beginning to process events", this);
-      }
-      // for testing purposes
-      if (isSlowStartForTesting) {
-        long slowStartTimeForTesting =
-            Long.getLong(KEY_SLOW_START_TIME_FOR_TESTING, DEFAULT_SLOW_STARTING_TIME).longValue();
-        long elapsedTime = 0;
-        long startTime = System.currentTimeMillis();
-        while ((slowStartTimeForTesting > elapsedTime) && isSlowStartForTesting) {
-          try {
-            Thread.sleep(500);
-          } catch (InterruptedException ignore) {
-            if (logger.isDebugEnabled()) {
-              logger.debug("Slow start for testing interrupted");
-            }
-            break;
-          }
-          elapsedTime = System.currentTimeMillis() - startTime;
-        }
-        if (slowStartTimeForTesting < elapsedTime) {
-          isSlowStartForTesting = false;
-        }
-      }
-
-      ClientMessage clientMessage = null;
-      while (!isStopped()) {
-        // SystemFailure.checkFailure(); DM's stopper does this
-        if (this._proxy._cache.getCancelCriterion().isCancelInProgress()) {
-          break;
-        }
-        try {
-          // If paused, wait to be told to resume (or interrupted if stopped)
-          if (getProxy().isPaused()) {
-            // ARB: Before waiting for resumption, process acks from client.
-            // This will reduce the number of duplicates that a client receives after
-            // reconnecting.
-            synchronized (_pausedLock) {
-              try {
-                logger.info("available ids = " + this._messageQueue.size() + " , isEmptyAckList ="
-                    + this._messageQueue.isEmptyAckList() + ", peekInitialized = "
-                    + this._messageQueue.isPeekInitialized());
-                while (!this._messageQueue.isEmptyAckList()
-                    && this._messageQueue.isPeekInitialized()) {
-                  this._messageQueue.remove();
-                }
-              } catch (InterruptedException ex) {
-                logger.warn("{}: sleep interrupted.", this);
-              }
-            }
-            waitForResumption();
-          }
-          try {
-            clientMessage = (ClientMessage) this._messageQueue.peek();
-          } catch (RegionDestroyedException skipped) {
-            break;
-          }
-          getStatistics().setQueueSize(this._messageQueue.size());
-          if (isStopped()) {
-            break;
-          }
-          if (clientMessage != null) {
-            // Process the message
-            long start = getStatistics().startTime();
-            //// BUGFIX for BUG#38206 and BUG#37791
-            boolean isDispatched = dispatchMessage(clientMessage);
-            getStatistics().endMessage(start);
-            if (isDispatched) {
-              this._messageQueue.remove();
-              if (clientMessage instanceof ClientMarkerMessageImpl) {
-                getProxy().markerEnqueued = false;
-              }
-            }
-          } else {
-            this._messageQueue.remove();
-          }
-          clientMessage = null;
-        } catch (MessageTooLargeException e) {
-          logger.warn("Message too large to send to client: {}, {}", clientMessage, e.getMessage());
-        } catch (IOException e) {
-          // Added the synchronization below to ensure that exception handling
-          // does not occur while stopping the dispatcher and vice versa.
-          synchronized (this._stopDispatchingLock) {
-            // An IOException occurred while sending a message to the
-            // client. If the processor is not already stopped, assume
-            // the client is dead and stop processing.
-            if (!isStopped() && !getProxy().isPaused()) {
-              if ("Broken pipe".equals(e.getMessage())) {
-                logger.warn("{}: Proxy closing due to unexpected broken pipe on socket connection.",
-                    this);
-              } else if ("Connection reset".equals(e.getMessage())) {
-                logger.warn("{}: Proxy closing due to unexpected reset on socket connection.",
-                    this);
-              } else if ("Connection reset by peer".equals(e.getMessage())) {
-                logger.warn(
-                    "{}: Proxy closing due to unexpected reset by peer on socket connection.",
-                    this);
-              } else if ("Socket is closed".equals(e.getMessage())
-                  || "Socket Closed".equals(e.getMessage())) {
-                logger.info("{}: Proxy closing due to socket being closed locally.",
-                    this);
-              } else {
-                logger.warn(String.format(
-                    "%s: An unexpected IOException occurred so the proxy will be closed.",
-                    this),
-                    e);
-              }
-              // Let the CacheClientNotifier discover the proxy is not alive.
-              // See isAlive().
-              // getProxy().close(false);
-
-              pauseOrUnregisterProxy(e);
-            } // _isStopped
-          } // synchronized
-          exceptionOccurred = true;
-        } // IOException
-        catch (InterruptedException e) {
-          // If the thread is paused, ignore the InterruptedException and
-          // continue. The proxy is null if stopDispatching has been called.
-          if (getProxy().isPaused()) {
-            if (logger.isDebugEnabled()) {
-              logger.debug(
-                  "{}: interrupted because it is being paused. It will continue and wait for resumption.",
-                  this);
-            }
-            Thread.interrupted();
-            continue;
-          }
-
-          // no need to reset the bit; we're exiting
-          if (logger.isDebugEnabled()) {
-            logger.debug("{}: interrupted", this);
-          }
-          break;
-        } catch (CancelException e) {
-          if (logger.isDebugEnabled()) {
-            logger.debug("{}: shutting down due to cancellation", this);
-          }
-          exceptionOccurred = true; // message queue is defunct, don't try to read it.
-          break;
-        } catch (RegionDestroyedException e) {
-          if (logger.isDebugEnabled()) {
-            logger.debug("{}: shutting down due to loss of message queue", this);
-          }
-          exceptionOccurred = true; // message queue is defunct, don't try to read it.
-          break;
-        } catch (Exception e) {
-          // An exception occurred while processing a message. Since it
-          // is not an IOException, the client may still be alive, so
-          // continue processing.
-          if (!isStopped()) {
-            logger.fatal(String.format("%s : An unexpected Exception occurred", this),
-                e);
-          }
-        }
-      }
-
-      // Processing gets here if isStopped=true. What is this code below doing?
-      List list = null;
-      if (!exceptionOccurred) {
-        try {
-          // Clear the interrupt status if any,
-          Thread.interrupted();
-          int size = this._messageQueue.size();
-          list = this._messageQueue.peek(size);
-          if (logger.isDebugEnabled()) {
-            logger.debug(
-                "{}: After flagging the dispatcher to stop , the residual List of messages to be dispatched={} size={}",
-                this, list, list.size());
-          }
-          if (list.size() > 0) {
-            long start = getStatistics().startTime();
-            Iterator itr = list.iterator();
-            while (itr.hasNext()) {
-              dispatchMessage((ClientMessage) itr.next());
-              getStatistics().endMessage(start);
-              // @todo asif: shouldn't we call itr.remove() since the current msg
-              // has been sent? That way list will be more accurate
-              // if we have an exception.
-            }
-            this._messageQueue.remove();
-          }
-        } catch (CancelException e) {
-          if (logger.isDebugEnabled()) {
-            logger.debug("CacheClientNotifier stopped due to cancellation");
-          }
-        } catch (Exception ignore) {
-          // if (logger.isInfoEnabled()) {
-          String extraMsg = null;
-
-          if ("Broken pipe".equals(ignore.getMessage())) {
-            extraMsg = "Problem caused by broken pipe on socket.";
-          } else if (ignore instanceof RegionDestroyedException) {
-            extraMsg =
-                "Problem caused by message queue being closed.";
-          }
-          final Object[] msgArgs = new Object[] {((!isStopped()) ? this.toString() + ": " : ""),
-              ((list == null) ? 0 : list.size())};
-          if (extraMsg != null) {
-            // Dont print exception details, but add on extraMsg
-            logger.info(
-                String.format(
-                    "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
-                    msgArgs));
-            logger.info(extraMsg);
-          } else {
-            // Print full stacktrace
-            logger.info(String.format(
-                "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
-                msgArgs),
-                ignore);
-          }
-        }
-
-        if (list != null && logger.isTraceEnabled()) {
-          logger.trace("Messages remaining in the list are: {}", list);
-        }
-
-        // }
-      }
-      if (logger.isTraceEnabled()) {
-        logger.trace("{}: Dispatcher thread is ending", this);
-      }
-
-    }
-
-    private void pauseOrUnregisterProxy(Throwable t) {
-      if (getProxy().isDurable()) {
-        try {
-          getProxy().pauseDispatching();
-        } catch (Exception ex) {
-          // see bug 40611; we catch Exception here because
-          // we once say an InterruptedException here.
-          // log a warning saying we couldn't pause?
-          if (logger.isDebugEnabled()) {
-            logger.debug("{}: {}", this, ex);
-          }
-        }
-      } else {
-        this._isStopped = true;
-      }
-
-      // Stop the ServerConnections. This will force the client to
-      // server communication to close.
-      ClientHealthMonitor chm = ClientHealthMonitor.getInstance();
-
-      // Note now that _proxy is final the following comment is no
-      // longer true. the _isStopped check should be sufficient.
-      // Added the test for this._proxy != null to prevent bug 35801.
-      // The proxy could have been stopped after this IOException has
-      // been caught and here, so the _proxy will be null.
-      if (chm != null) {
-        ClientProxyMembershipID proxyID = getProxy().proxyID;
-        chm.removeAllConnectionsAndUnregisterClient(proxyID, t);
-        if (!getProxy().isDurable()) {
-          getProxy().getCacheClientNotifier().unregisterClient(proxyID, false);
-        }
-      }
-    }
-
-    /**
-     * Sends a message to the client attached to this proxy
-     *
-     * @param clientMessage The <code>ClientMessage</code> to send to the client
-     *
-     */
-    protected boolean dispatchMessage(ClientMessage clientMessage) throws IOException {
-      boolean isDispatched = false;
-      if (logger.isTraceEnabled(LogMarker.BRIDGE_SERVER_VERBOSE)) {
-        logger.trace(LogMarker.BRIDGE_SERVER_VERBOSE, "Dispatching {}", clientMessage);
-      }
-      Message message;
-
-
-      if (clientMessage instanceof ClientUpdateMessage) {
-        byte[] latestValue = (byte[]) ((ClientUpdateMessage) clientMessage).getValue();
-        if (logger.isTraceEnabled()) {
-          StringBuilder msg = new StringBuilder(100);
-          msg.append(this).append(": Using latest value: ").append(Arrays.toString(latestValue));
-          if (((ClientUpdateMessage) clientMessage).valueIsObject()) {
-            if (latestValue != null) {
-              msg.append(" (").append(deserialize(latestValue)).append(")");
-            }
-            msg.append(" for ").append(clientMessage);
-          }
-          logger.trace(msg.toString());
-        }
-
-        message = ((ClientUpdateMessageImpl) clientMessage).getMessage(getProxy(), latestValue);
-
-        if (AFTER_MESSAGE_CREATION_FLAG) {
-          ClientServerObserver bo = ClientServerObserverHolder.getInstance();
-          bo.afterMessageCreation(message);
-        }
-      } else {
-        message = clientMessage.getMessage(getProxy(), true /* notify */);
-      }
-
-      if (!this._proxy.isPaused()) {
-        sendMessage(message);
-
-        if (logger.isTraceEnabled()) {
-          logger.trace("{}: Dispatched {}", this, clientMessage);
-        }
-        isDispatched = true;
-      } else {
-        if (logger.isDebugEnabled()) {
-          logger.debug("Message Dispatcher of a Paused CCProxy is trying to dispatch message");
-        }
-      }
-      if (isDispatched) {
-        this._messageQueue.getStatistics().incEventsDispatched();
-      }
-      return isDispatched;
-    }
-
-    private void sendMessage(Message message) throws IOException {
-      if (message == null) {
-        return;
-      }
-      this.socketWriteLock.lock();
-      try {
-        message.setComms(getSocket(), getCommBuffer(), getStatistics());
-        message.send();
-        getProxy().resetPingCounter();
-      } finally {
-        this.socketWriteLock.unlock();
-      }
-      if (logger.isTraceEnabled()) {
-        logger.trace("{}: Sent {}", this, message);
-      }
-    }
-
-    /**
-     * Add the input client message to the message queue
-     *
-     * @param clientMessage The <code>Conflatable</code> to add to the queue
-     */
-    protected void enqueueMessage(Conflatable clientMessage) {
-      try {
-        this._messageQueue.put(clientMessage);
-        if (this._proxy.isPaused() && this._proxy.isDurable()) {
-          this._proxy._cacheClientNotifier.statistics.incEventEnqueuedWhileClientAwayCount();
-          if (logger.isDebugEnabled()) {
-            logger.debug("{}: Queued message while Durable Client is away {}", this, clientMessage);
-          }
-        }
-      } catch (CancelException e) {
-        throw e;
-      } catch (Exception e) {
-        if (!isStopped()) {
-          this._proxy._statistics.incMessagesFailedQueued();
-          logger.fatal(
-              String.format("%s: Exception occurred while attempting to add message to queue",
-                  this),
-              e);
-        }
-      }
-    }
-
-
-    protected void enqueueMarker(ClientMessage message) {
-      try {
-        if (logger.isDebugEnabled()) {
-          logger.debug("{}: Queueing marker message. <{}>. The queue contains {} entries.", this,
-              message, getQueueSize());
-        }
-        this._messageQueue.put(message);
-        if (logger.isDebugEnabled()) {
-          logger.debug("{}: Queued marker message. The queue contains {} entries.", this,
-              getQueueSize());
-        }
-      } catch (CancelException e) {
-        throw e;
-      } catch (Exception e) {
-        if (!isStopped()) {
-          logger.fatal(
-              String.format("%s : Exception occurred while attempting to add message to queue",
-                  this),
-              e);
-        }
-      }
-    }
-
-    private void sendMessageDirectly(ClientMessage clientMessage) {
-      Message message;
-      try {
-        if (logger.isDebugEnabled()) {
-          logger.debug("{}: Dispatching directly: {}", this, clientMessage);
-        }
-        message = clientMessage.getMessage(getProxy(), true);
-        sendMessage(message);
-        if (logger.isDebugEnabled()) {
-          logger.debug("{}: Dispatched directly: {}", this, clientMessage);
-        }
-        // The exception handling code was modeled after the MessageDispatcher
-        // run method
-      } catch (MessageTooLargeException e) {
-        logger.warn("Message too large to send to client: {}, {}", clientMessage, e.getMessage());
-
-      } catch (IOException e) {
-        synchronized (this._stopDispatchingLock) {
-          // Pause or unregister proxy
-          if (!isStopped() && !getProxy().isPaused()) {
-            logger.fatal(String.format("%s : An unexpected Exception occurred", this),
-                e);
-            pauseOrUnregisterProxy(e);
-          }
-        }
-      } catch (Exception e) {
-        if (!isStopped()) {
-          logger.fatal(String.format("%s : An unexpected Exception occurred", this), e);
-        }
-      }
-    }
-
-    protected void waitForResumption() throws InterruptedException {
-      synchronized (this._pausedLock) {
-        logger.info("{} : Pausing processing", this);
-        if (!getProxy().isPaused()) {
-          return;
-        }
-        while (getProxy().isPaused()) {
-          this._pausedLock.wait();
-        }
-        // Fix for #48571
-        _messageQueue.clearPeekedIDs();
-      }
-    }
-
-    protected void resumeDispatching() {
-      logger.info("{} : Resuming processing", this);
-
-      // Notify thread to resume
-      this._pausedLock.notifyAll();
-    }
-
-    protected Object deserialize(byte[] serializedBytes) {
-      Object deserializedObject = serializedBytes;
-      // This is a debugging method so ignore all exceptions like
-      // ClassNotFoundException
-      try {
-        ByteArrayDataInput dis = new ByteArrayDataInput(serializedBytes);
-        deserializedObject = DataSerializer.readObject(dis);
-      } catch (Exception e) {
-      }
-      return deserializedObject;
-    }
-
-    protected void initializeTransients() {
-      while (!this._messageQueue.isEmptyAckList() && this._messageQueue.isPeekInitialized()) {
-        try {
-          this._messageQueue.remove();
-        } catch (InterruptedException e) {
-          e.printStackTrace();
-        }
-      }
-      this._messageQueue.initializeTransients();
-    }
-  }
 
   /**
    * Returns the current number of CQS the client installed.
@@ -2962,4 +2026,19 @@ public class CacheClientProxy implements ClientSession {
 
   @MutableForTesting
   public static TestHook testHook;
+
+  @FunctionalInterface
+  @VisibleForTesting
+  interface CacheClientProxyStatsFactory {
+
+    CacheClientProxyStats create(StatisticsFactory statisticsFactory,
+        ClientProxyMembershipID proxyID, String remoteHostAddress);
+  }
+
+  @FunctionalInterface
+  @VisibleForTesting
+  public interface MessageDispatcherFactory {
+
+    MessageDispatcher create(CacheClientProxy proxy, String name, StatisticsClock statisticsClock);
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.apache.geode.internal.cache.util.UncheckedUtils.cast;
+
+import java.lang.reflect.InvocationTargetException;
+import java.net.Socket;
+
+import org.apache.shiro.subject.Subject;
+
+import org.apache.geode.annotations.Immutable;
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.CacheException;
+import org.apache.geode.internal.ClassPathLoader;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.statistics.StatisticsClock;
+
+/**
+ * Creates instances of CacheClientProxy.
+ *
+ * <p>
+ * CacheClientProxyFactory delegates to InternalCacheClientProxyFactory which can be specified by
+ * System Property {@code gemfire.CacheClientProxyFactory.INTERNAL_FACTORY}. This allows tests to
+ * customize CacheClientProxy and/or MessageDispatcher using Property-Injection. See
+ * DeltaPropagationDUnitTest for an example.
+ */
+public class CacheClientProxyFactory {
+
+  @Immutable
+  private static final InternalCacheClientProxyFactory DEFAULT = CacheClientProxy::new;
+
+  @Immutable
+  @VisibleForTesting
+  public static final String INTERNAL_FACTORY_PROPERTY =
+      "gemfire.CacheClientProxyFactory.INTERNAL_FACTORY";
+
+  private static InternalCacheClientProxyFactory factory() {
+    String proxyClassName = System.getProperty(INTERNAL_FACTORY_PROPERTY);
+    if (proxyClassName == null || proxyClassName.isEmpty()) {
+      return DEFAULT;
+    }
+    try {
+      Class<InternalCacheClientProxyFactory> proxyClass =
+          cast(ClassPathLoader.getLatest().forName(proxyClassName));
+      return proxyClass.getConstructor().newInstance();
+    } catch (ClassNotFoundException | NoSuchMethodException | InstantiationException
+        | IllegalAccessException | InvocationTargetException e) {
+      return DEFAULT;
+    }
+  }
+
+  private final InternalCacheClientProxyFactory internalFactory;
+
+  CacheClientProxyFactory() {
+    this(factory());
+  }
+
+  private CacheClientProxyFactory(InternalCacheClientProxyFactory internalFactory) {
+    this.internalFactory = internalFactory;
+  }
+
+  public CacheClientProxy create(CacheClientNotifier notifier, Socket socket,
+      ClientProxyMembershipID proxyId, boolean isPrimary, byte clientConflation,
+      Version clientVersion, long acceptorId, boolean notifyBySubscription,
+      SecurityService securityService, Subject subject, StatisticsClock statisticsClock)
+      throws CacheException {
+    return internalFactory.create(notifier, socket, proxyId, isPrimary, clientConflation,
+        clientVersion, acceptorId, notifyBySubscription, securityService, subject, statisticsClock);
+  }
+
+  @FunctionalInterface
+  @VisibleForTesting
+  public interface InternalCacheClientProxyFactory {
+    CacheClientProxy create(CacheClientNotifier notifier, Socket socket,
+        ClientProxyMembershipID proxyId, boolean isPrimary, byte clientConflation,
+        Version clientVersion, long acceptorId, boolean notifyBySubscription,
+        SecurityService securityService, Subject subject, StatisticsClock statisticsClock)
+        throws CacheException;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientInterestList.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientInterestList.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.CancelException;
+import org.apache.geode.cache.InterestRegistrationEvent;
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.internal.cache.CacheDistributionAdvisee;
+import org.apache.geode.internal.cache.FilterProfile;
+import org.apache.geode.internal.cache.InterestRegistrationEventImpl;
+import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.cache.tier.InterestType;
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+/**
+ * Class <code>ClientInterestList</code> provides a convenient interface for manipulating client
+ * interest information.
+ */
+class ClientInterestList {
+  private static final Logger logger = LogService.getLogger();
+
+  final CacheClientProxy ccp;
+
+  final Object id;
+
+  /**
+   * An object used for synchronizing the interest lists
+   */
+  private final Object interestListLock = new Object();
+
+  /**
+   * Regions that this client is interested in
+   */
+  protected final Set<String> regions = new HashSet<String>();
+
+  /**
+   * Constructor.
+   */
+  protected ClientInterestList(CacheClientProxy ccp, Object interestID) {
+    this.ccp = ccp;
+    this.id = interestID;
+    // this.id = getNextId();
+  }
+
+  /**
+   * Registers interest in the input region name and key
+   */
+  protected void registerClientInterest(String regionName, Object keyOfInterest, int interestType,
+      boolean sendUpdatesAsInvalidates) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("{}: registerClientInterest region={} key={}", ccp, regionName, keyOfInterest);
+    }
+    Set keysRegistered = null;
+    synchronized (this.interestListLock) {
+      LocalRegion r = (LocalRegion) this.ccp._cache.getRegion(regionName, true);
+      if (r == null) {
+        throw new RegionDestroyedException("Region could not be found for interest registration",
+            regionName);
+      }
+      if (!(r instanceof CacheDistributionAdvisee)) {
+        throw new IllegalArgumentException("region " + regionName
+            + " is not distributed and does not support interest registration");
+      }
+      FilterProfile p = r.getFilterProfile();
+      keysRegistered =
+          p.registerClientInterest(id, keyOfInterest, interestType, sendUpdatesAsInvalidates);
+      regions.add(regionName);
+    }
+    // Perform actions if any keys were registered
+    if ((keysRegistered != null) && containsInterestRegistrationListeners()
+        && !keysRegistered.isEmpty()) {
+      handleInterestEvent(regionName, keysRegistered, interestType, true);
+    }
+  }
+
+
+  protected FilterProfile getProfile(String regionName) {
+    try {
+      return this.ccp._cache.getFilterProfile(regionName);
+    } catch (CancelException e) {
+      return null;
+    }
+  }
+
+  /**
+   * Unregisters interest in the input region name and key
+   *
+   * @param regionName The fully-qualified name of the region in which to unregister interest
+   * @param keyOfInterest The key in which to unregister interest
+   */
+  protected void unregisterClientInterest(String regionName, Object keyOfInterest,
+      int interestType) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("{}: unregisterClientInterest region={} key={}", ccp, regionName,
+          keyOfInterest);
+    }
+    FilterProfile p = getProfile(regionName);
+    Set keysUnregistered = null;
+    synchronized (this.interestListLock) {
+      if (p != null) {
+        keysUnregistered = p.unregisterClientInterest(id, keyOfInterest, interestType);
+        if (!p.hasInterestFor(id)) {
+          this.regions.remove(regionName);
+        }
+      } else {
+        this.regions.remove(regionName);
+      }
+    }
+    if (keysUnregistered != null && !keysUnregistered.isEmpty()) {
+      handleInterestEvent(regionName, keysUnregistered, interestType, false);
+    }
+  }
+
+  /**
+   * Registers interest in the input region name and list of keys
+   *
+   * @param regionName The fully-qualified name of the region in which to register interest
+   * @param keysOfInterest The list of keys in which to register interest
+   */
+  protected void registerClientInterestList(String regionName, List keysOfInterest,
+      boolean sendUpdatesAsInvalidates) {
+    FilterProfile p = getProfile(regionName);
+    if (p == null) {
+      throw new RegionDestroyedException("Region not found during client interest registration",
+          regionName);
+    }
+    Set keysRegistered = null;
+    synchronized (this.interestListLock) {
+      keysRegistered = p.registerClientInterestList(id, keysOfInterest, sendUpdatesAsInvalidates);
+      regions.add(regionName);
+    }
+    // Perform actions if any keys were registered
+    if (containsInterestRegistrationListeners() && !keysRegistered.isEmpty()) {
+      handleInterestEvent(regionName, keysRegistered, InterestType.KEY, true);
+    }
+  }
+
+  /**
+   * Unregisters interest in the input region name and list of keys
+   *
+   * @param regionName The fully-qualified name of the region in which to unregister interest
+   * @param keysOfInterest The list of keys in which to unregister interest
+   */
+  protected void unregisterClientInterestList(String regionName, List keysOfInterest) {
+    FilterProfile p = getProfile(regionName);
+    Set keysUnregistered = null;
+    synchronized (this.interestListLock) {
+      if (p != null) {
+        keysUnregistered = p.unregisterClientInterestList(id, keysOfInterest);
+        if (!p.hasInterestFor(id)) {
+          regions.remove(regionName);
+        }
+      } else {
+        regions.remove(regionName);
+      }
+    }
+    // Perform actions if any keys were unregistered
+    if (!keysUnregistered.isEmpty()) {
+      handleInterestEvent(regionName, keysUnregistered, InterestType.KEY, false);
+    }
+  }
+
+  /*
+   * Returns whether this interest list has any keys, patterns or filters of interest. It answers
+   * the question: Are any clients being notified because of this interest list? @return whether
+   * this interest list has any keys, patterns or filters of interest
+   */
+  protected boolean hasInterest() {
+    return regions.size() > 0;
+  }
+
+  protected void clearClientInterestList() {
+    boolean isClosed = ccp.getCache().isClosed();
+
+    synchronized (this.interestListLock) {
+      for (String regionName : regions) {
+        FilterProfile p = getProfile(regionName);
+        if (p == null) {
+          continue;
+        }
+        if (!isClosed) {
+          if (p.hasAllKeysInterestFor(id)) {
+            Set allKeys = new HashSet();
+            allKeys.add(".*");
+            allKeys = Collections.unmodifiableSet(allKeys);
+            handleInterestEvent(regionName, allKeys, InterestType.REGULAR_EXPRESSION, false);
+          }
+          Set keysOfInterest = p.getKeysOfInterestFor(id);
+          if (keysOfInterest != null && keysOfInterest.size() > 0) {
+            handleInterestEvent(regionName, keysOfInterest, InterestType.KEY, false);
+          }
+          Map<String, Pattern> patternsOfInterest = p.getPatternsOfInterestFor(id);
+          if (patternsOfInterest != null && patternsOfInterest.size() > 0) {
+            handleInterestEvent(regionName, patternsOfInterest.keySet(),
+                InterestType.REGULAR_EXPRESSION, false);
+          }
+        }
+        p.clearInterestFor(id);
+      }
+      regions.clear();
+    }
+  }
+
+
+  private void handleInterestEvent(String regionName, Set keysOfInterest, int interestType,
+      boolean isRegister) {
+    // Notify the region about this register interest event if:
+    // - the application has requested it
+    // - this is a primary CacheClientProxy (otherwise multiple notifications
+    // may occur)
+    // - it is a key interest type (regex is currently not supported)
+    InterestRegistrationEvent event = null;
+    if (CacheClientProxy.NOTIFY_REGION_ON_INTEREST && this.ccp.isPrimary()
+        && interestType == InterestType.KEY) {
+      event = new InterestRegistrationEventImpl(this.ccp, regionName, keysOfInterest,
+          interestType, isRegister);
+      try {
+        notifyRegionOfInterest(event);
+      } catch (Exception e) {
+        logger.warn("Region notification of interest failed", e);
+      }
+    }
+    // Invoke interest registration listeners
+    if (containsInterestRegistrationListeners()) {
+      if (event == null) {
+        event = new InterestRegistrationEventImpl(this.ccp, regionName, keysOfInterest,
+            interestType, isRegister);
+      }
+      notifyInterestRegistrationListeners(event);
+    }
+  }
+
+  private void notifyRegionOfInterest(InterestRegistrationEvent event) {
+    this.ccp.getCacheClientNotifier().handleInterestEvent(event);
+  }
+
+  private void notifyInterestRegistrationListeners(InterestRegistrationEvent event) {
+    this.ccp.getCacheClientNotifier().notifyInterestRegistrationListeners(event);
+  }
+
+  private boolean containsInterestRegistrationListeners() {
+    return this.ccp.getCacheClientNotifier().containsInterestRegistrationListeners();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -1,0 +1,778 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.CancelException;
+import org.apache.geode.DataSerializer;
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.CacheException;
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.cache.RegionExistsException;
+import org.apache.geode.cache.query.internal.cq.InternalCqQuery;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.ClientServerObserver;
+import org.apache.geode.internal.cache.ClientServerObserverHolder;
+import org.apache.geode.internal.cache.Conflatable;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.ha.HAContainerWrapper;
+import org.apache.geode.internal.cache.ha.HARegionQueue;
+import org.apache.geode.internal.cache.ha.HARegionQueueAttributes;
+import org.apache.geode.internal.cache.ha.HARegionQueueStats;
+import org.apache.geode.internal.logging.log4j.LogMarker;
+import org.apache.geode.internal.serialization.ByteArrayDataInput;
+import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.logging.internal.executors.LoggingThread;
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+/**
+ * Class <code>MessageDispatcher</code> is a <code>Thread</code> that processes messages bound for
+ * the client by taking messsages from the message queue and sending them to the client over the
+ * socket.
+ */
+public class MessageDispatcher extends LoggingThread {
+  private static final Logger logger = LogService.getLogger();
+
+  /**
+   * Default value for slow starting time of dispatcher
+   */
+  private static final long DEFAULT_SLOW_STARTING_TIME = 5000;
+
+  /**
+   * Key in the system property from which the slow starting time value will be retrieved
+   */
+  private static final String KEY_SLOW_START_TIME_FOR_TESTING = "slowStartTimeForTesting";
+
+  /**
+   * The queue of messages to be sent to the client
+   */
+  protected final HARegionQueue _messageQueue;
+
+  // /**
+  // * An int used to keep track of the number of messages dropped for logging
+  // * purposes. If greater than zero then a warning has been logged about
+  // * messages being dropped.
+  // */
+  // private int _numberOfMessagesDropped = 0;
+
+  /**
+   * The proxy for which this dispatcher is processing messages
+   */
+  private final CacheClientProxy _proxy;
+
+  // /**
+  // * The conflator faciliates message conflation
+  // */
+  // protected BridgeEventConflator _eventConflator;
+
+  /**
+   * Whether the dispatcher is stopped
+   */
+  private volatile boolean _isStopped = true;
+
+  /**
+   * guarded.By _pausedLock
+   */
+  // boolean _isPausedDispatcher = false;
+
+  /**
+   * A lock object used to control pausing this dispatcher
+   */
+  protected final Object _pausedLock = new Object();
+
+  /**
+   * An object used to protect when dispatching is being stopped.
+   */
+  private final Object _stopDispatchingLock = new Object();
+
+  private final ReadWriteLock socketLock = new ReentrantReadWriteLock();
+
+  private final Lock socketWriteLock = socketLock.writeLock();
+  // /**
+  // * A boolean verifying whether a warning has already been issued if the
+  // * message queue has reached its capacity.
+  // */
+  // private boolean _messageQueueCapacityReachedWarning = false;
+
+  /**
+   * Constructor.
+   *
+   * @param proxy The <code>CacheClientProxy</code> for which this dispatcher is processing
+   *        messages
+   * @param name thread name for this dispatcher
+   */
+  protected MessageDispatcher(CacheClientProxy proxy, String name,
+      StatisticsClock statisticsClock) throws CacheException {
+    super(name);
+
+    this._proxy = proxy;
+
+    // Create the event conflator
+    // this._eventConflator = new BridgeEventConflator
+
+    // Create the message queue
+    try {
+      HARegionQueueAttributes harq = new HARegionQueueAttributes();
+      harq.setBlockingQueueCapacity(proxy._maximumMessageCount);
+      harq.setExpiryTime(proxy._messageTimeToLive);
+      ((HAContainerWrapper) proxy._cacheClientNotifier.getHaContainer())
+          .putProxy(HARegionQueue.createRegionName(getProxy().getHARegionName()), getProxy());
+      boolean createDurableQueue = proxy.proxyID.isDurable();
+      boolean canHandleDelta = (proxy.getClientVersion().compareTo(Version.GFE_61) >= 0)
+          && InternalDistributedSystem.getAnyInstance().getConfig().getDeltaPropagation()
+          && !(this._proxy.clientConflation == Handshake.CONFLATION_ON);
+      if ((createDurableQueue || canHandleDelta) && logger.isDebugEnabled()) {
+        logger.debug("Creating a {} subscription queue for {}",
+            createDurableQueue ? "durable" : "non-durable",
+            proxy.getProxyID());
+      }
+      this._messageQueue = HARegionQueue.getHARegionQueueInstance(getProxy().getHARegionName(),
+          getCache(), harq, HARegionQueue.BLOCKING_HA_QUEUE, createDurableQueue,
+          proxy._cacheClientNotifier.getHaContainer(), proxy.getProxyID(),
+          this._proxy.clientConflation, this._proxy.isPrimary(), canHandleDelta, statisticsClock);
+      // Check if interests were registered during HARegion GII.
+      if (this._proxy.hasRegisteredInterested()) {
+        this._messageQueue.setHasRegisteredInterest(true);
+      }
+    } catch (CancelException e) {
+      throw e;
+    } catch (RegionExistsException ree) {
+      throw ree;
+    } catch (Exception e) {
+      getCache().getCancelCriterion().checkCancelInProgress(e);
+      throw new CacheException(
+          "Exception occurred while trying to create a message queue.",
+          e) {
+        private static final long serialVersionUID = 0L;
+      };
+    }
+  }
+
+  private CacheClientProxy getProxy() {
+    return this._proxy;
+  }
+
+  private InternalCache getCache() {
+    return getProxy().getCache();
+  }
+
+  private Socket getSocket() {
+    return getProxy().getSocket();
+  }
+
+  private ByteBuffer getCommBuffer() {
+    return getProxy().getCommBuffer();
+  }
+
+  private CacheClientProxyStats getStatistics() {
+    return getProxy().getStatistics();
+  }
+
+  private void basicStopDispatching() {
+    if (logger.isDebugEnabled()) {
+      logger.debug("{}: notified dispatcher to stop", this);
+    }
+    this._isStopped = true;
+    // this.interrupt(); // don't interrupt here. Let close(boolean) do this.
+  }
+
+  @Override
+  public String toString() {
+    return getProxy().toString();
+  }
+
+  /**
+   * Notifies the dispatcher to stop dispatching.
+   *
+   * @param checkQueue Whether to check the message queue for any unprocessed messages and process
+   *        them for MAXIMUM_SHUTDOWN_PEEKS.
+   *
+   * @see CacheClientProxy#MAXIMUM_SHUTDOWN_PEEKS
+   */
+  protected synchronized void stopDispatching(boolean checkQueue) {
+    if (isStopped()) {
+      return;
+    }
+
+    if (logger.isDebugEnabled()) {
+      logger.debug("{}: Stopping dispatching", this);
+    }
+    if (!checkQueue) {
+      basicStopDispatching();
+      return;
+    }
+
+    // Stay alive until the queue is empty or a number of peeks is reached.
+    List events = null;
+    try {
+      for (int numberOfPeeks =
+          0; numberOfPeeks < CacheClientProxy.MAXIMUM_SHUTDOWN_PEEKS; ++numberOfPeeks) {
+        boolean interrupted = Thread.interrupted();
+        try {
+          events = this._messageQueue.peek(1, -1);
+          if (events == null || events.size() == 0) {
+            break;
+          }
+          if (logger.isDebugEnabled()) {
+            logger.debug("Waiting for client to drain queue: {}", _proxy.proxyID);
+          }
+          Thread.sleep(500);
+        } catch (InterruptedException e) {
+          interrupted = true;
+        } catch (CancelException e) {
+          break;
+        } catch (CacheException e) {
+          if (logger.isDebugEnabled()) {
+            logger.debug("{}: Exception occurred while trying to stop dispatching", this, e);
+          }
+        } finally {
+          if (interrupted)
+            Thread.currentThread().interrupt();
+        }
+      } // for
+    } finally {
+      basicStopDispatching();
+    }
+  }
+
+  /**
+   * Returns whether the dispatcher is stopped
+   *
+   * @return whether the dispatcher is stopped
+   */
+  protected boolean isStopped() {
+    return this._isStopped;
+  }
+
+  /**
+   * Returns the size of the queue for heuristic purposes. This size may be changing concurrently
+   * if puts / gets are occurring at the same time.
+   *
+   * @return the size of the queue
+   */
+  protected int getQueueSize() {
+    return this._messageQueue == null ? 0 : this._messageQueue.size();
+  }
+
+  /**
+   * Returns the size of the queue calculated through stats This includes events that have
+   * dispatched but have yet been removed
+   *
+   * @return the size of the queue
+   */
+  protected int getQueueSizeStat() {
+    if (this._messageQueue != null) {
+      HARegionQueueStats stats = this._messageQueue.getStatistics();
+      return ((int) (stats.getEventsEnqued() - stats.getEventsRemoved()
+          - stats.getEventsConflated() - stats.getMarkerEventsConflated()
+          - stats.getEventsExpired() - stats.getEventsRemovedByQrm() - stats.getEventsTaken()
+          - stats.getNumVoidRemovals()));
+    }
+    return 0;
+  }
+
+  protected void drainClientCqEvents(ClientProxyMembershipID clientId,
+      InternalCqQuery cqToClose) {
+    this._messageQueue.closeClientCq(clientId, cqToClose);
+  }
+
+  @Override
+  public void run() {
+    // for testing purposes
+    if (CacheClientProxy.isSlowStartForTesting) {
+      long slowStartTimeForTesting =
+          Long.getLong(KEY_SLOW_START_TIME_FOR_TESTING, DEFAULT_SLOW_STARTING_TIME);
+      long elapsedTime = 0;
+      long startTime = System.currentTimeMillis();
+      while ((slowStartTimeForTesting > elapsedTime) && CacheClientProxy.isSlowStartForTesting) {
+        try {
+          Thread.sleep(500);
+        } catch (InterruptedException ignore) {
+          if (logger.isDebugEnabled()) {
+            logger.debug("Slow start for testing interrupted");
+          }
+          break;
+        }
+        elapsedTime = System.currentTimeMillis() - startTime;
+      }
+      if (slowStartTimeForTesting < elapsedTime) {
+        CacheClientProxy.isSlowStartForTesting = false;
+      }
+    }
+
+    runDispatcher();
+  }
+
+  /**
+   * Runs the dispatcher by taking a message from the queue and sending it to the client attached
+   * to this proxy.
+   */
+  @VisibleForTesting
+  protected void runDispatcher() {
+    boolean exceptionOccurred = false;
+    this._isStopped = false;
+
+    if (logger.isDebugEnabled()) {
+      logger.debug("{}: Beginning to process events", this);
+    }
+
+    ClientMessage clientMessage = null;
+    while (!isStopped()) {
+      // SystemFailure.checkFailure(); DM's stopper does this
+      if (this._proxy._cache.getCancelCriterion().isCancelInProgress()) {
+        break;
+      }
+      try {
+        // If paused, wait to be told to resume (or interrupted if stopped)
+        if (getProxy().isPaused()) {
+          // ARB: Before waiting for resumption, process acks from client.
+          // This will reduce the number of duplicates that a client receives after
+          // reconnecting.
+          synchronized (_pausedLock) {
+            try {
+              logger.info("available ids = " + this._messageQueue.size() + " , isEmptyAckList ="
+                  + this._messageQueue.isEmptyAckList() + ", peekInitialized = "
+                  + this._messageQueue.isPeekInitialized());
+              while (!this._messageQueue.isEmptyAckList()
+                  && this._messageQueue.isPeekInitialized()) {
+                this._messageQueue.remove();
+              }
+            } catch (InterruptedException ex) {
+              logger.warn("{}: sleep interrupted.", this);
+            }
+          }
+          waitForResumption();
+        }
+        try {
+          clientMessage = (ClientMessage) this._messageQueue.peek();
+        } catch (RegionDestroyedException skipped) {
+          break;
+        }
+        getStatistics().setQueueSize(this._messageQueue.size());
+        if (isStopped()) {
+          break;
+        }
+        if (clientMessage != null) {
+          // Process the message
+          long start = getStatistics().startTime();
+          //// BUGFIX for BUG#38206 and BUG#37791
+          boolean isDispatched = dispatchMessage(clientMessage);
+          getStatistics().endMessage(start);
+          if (isDispatched) {
+            this._messageQueue.remove();
+            if (clientMessage instanceof ClientMarkerMessageImpl) {
+              getProxy().setMarkerEnqueued(false);
+            }
+          }
+        } else {
+          this._messageQueue.remove();
+        }
+        clientMessage = null;
+      } catch (MessageTooLargeException e) {
+        logger.warn("Message too large to send to client: {}, {}", clientMessage, e.getMessage());
+      } catch (IOException e) {
+        // Added the synchronization below to ensure that exception handling
+        // does not occur while stopping the dispatcher and vice versa.
+        synchronized (this._stopDispatchingLock) {
+          // An IOException occurred while sending a message to the
+          // client. If the processor is not already stopped, assume
+          // the client is dead and stop processing.
+          if (!isStopped() && !getProxy().isPaused()) {
+            if ("Broken pipe".equals(e.getMessage())) {
+              logger.warn("{}: Proxy closing due to unexpected broken pipe on socket connection.",
+                  this);
+            } else if ("Connection reset".equals(e.getMessage())) {
+              logger.warn("{}: Proxy closing due to unexpected reset on socket connection.",
+                  this);
+            } else if ("Connection reset by peer".equals(e.getMessage())) {
+              logger.warn(
+                  "{}: Proxy closing due to unexpected reset by peer on socket connection.",
+                  this);
+            } else if ("Socket is closed".equals(e.getMessage())
+                || "Socket Closed".equals(e.getMessage())) {
+              logger.info("{}: Proxy closing due to socket being closed locally.",
+                  this);
+            } else {
+              logger.warn(String.format(
+                  "%s: An unexpected IOException occurred so the proxy will be closed.",
+                  this),
+                  e);
+            }
+            // Let the CacheClientNotifier discover the proxy is not alive.
+            // See isAlive().
+            // getProxy().close(false);
+
+            pauseOrUnregisterProxy(e);
+          } // _isStopped
+        } // synchronized
+        exceptionOccurred = true;
+      } // IOException
+      catch (InterruptedException e) {
+        // If the thread is paused, ignore the InterruptedException and
+        // continue. The proxy is null if stopDispatching has been called.
+        if (getProxy().isPaused()) {
+          if (logger.isDebugEnabled()) {
+            logger.debug(
+                "{}: interrupted because it is being paused. It will continue and wait for resumption.",
+                this);
+          }
+          Thread.interrupted();
+          continue;
+        }
+
+        // no need to reset the bit; we're exiting
+        if (logger.isDebugEnabled()) {
+          logger.debug("{}: interrupted", this);
+        }
+        break;
+      } catch (CancelException e) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("{}: shutting down due to cancellation", this);
+        }
+        exceptionOccurred = true; // message queue is defunct, don't try to read it.
+        break;
+      } catch (RegionDestroyedException e) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("{}: shutting down due to loss of message queue", this);
+        }
+        exceptionOccurred = true; // message queue is defunct, don't try to read it.
+        break;
+      } catch (Exception e) {
+        // An exception occurred while processing a message. Since it
+        // is not an IOException, the client may still be alive, so
+        // continue processing.
+        if (!isStopped()) {
+          logger.fatal(String.format("%s : An unexpected Exception occurred", this),
+              e);
+        }
+      }
+    }
+
+    // Processing gets here if isStopped=true. What is this code below doing?
+    List list = null;
+    if (!exceptionOccurred) {
+      try {
+        // Clear the interrupt status if any,
+        Thread.interrupted();
+        int size = this._messageQueue.size();
+        list = this._messageQueue.peek(size);
+        if (logger.isDebugEnabled()) {
+          logger.debug(
+              "{}: After flagging the dispatcher to stop , the residual List of messages to be dispatched={} size={}",
+              this, list, list.size());
+        }
+        if (list.size() > 0) {
+          long start = getStatistics().startTime();
+          Iterator itr = list.iterator();
+          while (itr.hasNext()) {
+            dispatchMessage((ClientMessage) itr.next());
+            getStatistics().endMessage(start);
+            // @todo asif: shouldn't we call itr.remove() since the current msg
+            // has been sent? That way list will be more accurate
+            // if we have an exception.
+          }
+          this._messageQueue.remove();
+        }
+      } catch (CancelException e) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("CacheClientNotifier stopped due to cancellation");
+        }
+      } catch (Exception ignore) {
+        // if (logger.isInfoEnabled()) {
+        String extraMsg = null;
+
+        if ("Broken pipe".equals(ignore.getMessage())) {
+          extraMsg = "Problem caused by broken pipe on socket.";
+        } else if (ignore instanceof RegionDestroyedException) {
+          extraMsg =
+              "Problem caused by message queue being closed.";
+        }
+        final Object[] msgArgs = new Object[] {((!isStopped()) ? this.toString() + ": " : ""),
+            ((list == null) ? 0 : list.size())};
+        if (extraMsg != null) {
+          // Dont print exception details, but add on extraMsg
+          logger.info(
+              String.format(
+                  "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
+                  msgArgs));
+          logger.info(extraMsg);
+        } else {
+          // Print full stacktrace
+          logger.info(String.format(
+              "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
+              msgArgs),
+              ignore);
+        }
+      }
+
+      if (list != null && logger.isTraceEnabled()) {
+        logger.trace("Messages remaining in the list are: {}", list);
+      }
+
+      // }
+    }
+    if (logger.isTraceEnabled()) {
+      logger.trace("{}: Dispatcher thread is ending", this);
+    }
+  }
+
+  private void pauseOrUnregisterProxy(Throwable t) {
+    if (getProxy().isDurable()) {
+      try {
+        getProxy().pauseDispatching();
+      } catch (Exception ex) {
+        // see bug 40611; we catch Exception here because
+        // we once say an InterruptedException here.
+        // log a warning saying we couldn't pause?
+        if (logger.isDebugEnabled()) {
+          logger.debug("{}: {}", this, ex);
+        }
+      }
+    } else {
+      this._isStopped = true;
+    }
+
+    // Stop the ServerConnections. This will force the client to
+    // server communication to close.
+    ClientHealthMonitor chm = ClientHealthMonitor.getInstance();
+
+    // Note now that _proxy is final the following comment is no
+    // longer true. the _isStopped check should be sufficient.
+    // Added the test for this._proxy != null to prevent bug 35801.
+    // The proxy could have been stopped after this IOException has
+    // been caught and here, so the _proxy will be null.
+    if (chm != null) {
+      ClientProxyMembershipID proxyID = getProxy().proxyID;
+      chm.removeAllConnectionsAndUnregisterClient(proxyID, t);
+      if (!getProxy().isDurable()) {
+        getProxy().getCacheClientNotifier().unregisterClient(proxyID, false);
+      }
+    }
+  }
+
+  /**
+   * Sends a message to the client attached to this proxy
+   *
+   * @param clientMessage The <code>ClientMessage</code> to send to the client
+   *
+   */
+  protected boolean dispatchMessage(ClientMessage clientMessage) throws IOException {
+    boolean isDispatched = false;
+    if (logger.isTraceEnabled(LogMarker.BRIDGE_SERVER_VERBOSE)) {
+      logger.trace(LogMarker.BRIDGE_SERVER_VERBOSE, "Dispatching {}", clientMessage);
+    }
+    Message message = null;
+
+    // byte[] latestValue =
+    // this._eventConflator.getLatestValue(clientMessage);
+
+    if (clientMessage instanceof ClientUpdateMessage) {
+      byte[] latestValue = (byte[]) ((ClientUpdateMessage) clientMessage).getValue();
+      if (logger.isTraceEnabled()) {
+        StringBuilder msg = new StringBuilder(100);
+        msg.append(this).append(": Using latest value: ").append(Arrays.toString(latestValue));
+        if (((ClientUpdateMessage) clientMessage).valueIsObject()) {
+          if (latestValue != null) {
+            msg.append(" (").append(deserialize(latestValue)).append(")");
+          }
+          msg.append(" for ").append(clientMessage);
+        }
+        logger.trace(msg.toString());
+      }
+
+      message = ((ClientUpdateMessageImpl) clientMessage).getMessage(getProxy(), latestValue);
+
+      if (CacheClientProxy.AFTER_MESSAGE_CREATION_FLAG) {
+        ClientServerObserver bo = ClientServerObserverHolder.getInstance();
+        bo.afterMessageCreation(message);
+      }
+    } else {
+      message = clientMessage.getMessage(getProxy(), true /* notify */);
+    }
+
+    if (!this._proxy.isPaused()) {
+      sendMessage(message);
+
+      if (logger.isTraceEnabled()) {
+        logger.trace("{}: Dispatched {}", this, clientMessage);
+      }
+      isDispatched = true;
+    } else {
+      if (logger.isDebugEnabled()) {
+        logger.debug("Message Dispatcher of a Paused CCProxy is trying to dispatch message");
+      }
+    }
+    if (isDispatched) {
+      this._messageQueue.getStatistics().incEventsDispatched();
+    }
+    return isDispatched;
+  }
+
+  private void sendMessage(Message message) throws IOException {
+    if (message == null) {
+      return;
+    }
+    this.socketWriteLock.lock();
+    try {
+      message.setComms(getSocket(), getCommBuffer(), getStatistics());
+      message.send();
+      getProxy().resetPingCounter();
+    } finally {
+      this.socketWriteLock.unlock();
+    }
+    if (logger.isTraceEnabled()) {
+      logger.trace("{}: Sent {}", this, message);
+    }
+  }
+
+  /**
+   * Add the input client message to the message queue
+   *
+   * @param clientMessage The <code>Conflatable</code> to add to the queue
+   */
+  protected void enqueueMessage(Conflatable clientMessage) {
+    try {
+      this._messageQueue.put(clientMessage);
+      if (this._proxy.isPaused() && this._proxy.isDurable()) {
+        this._proxy._cacheClientNotifier.statistics.incEventEnqueuedWhileClientAwayCount();
+        if (logger.isDebugEnabled()) {
+          logger.debug("{}: Queued message while Durable Client is away {}", this, clientMessage);
+        }
+      }
+    } catch (CancelException e) {
+      throw e;
+    } catch (Exception e) {
+      if (!isStopped()) {
+        this._proxy._statistics.incMessagesFailedQueued();
+        logger.fatal(
+            String.format("%s: Exception occurred while attempting to add message to queue",
+                this),
+            e);
+      }
+    }
+  }
+
+
+  protected void enqueueMarker(ClientMessage message) {
+    try {
+      if (logger.isDebugEnabled()) {
+        logger.debug("{}: Queueing marker message. <{}>. The queue contains {} entries.", this,
+            message, getQueueSize());
+      }
+      this._messageQueue.put(message);
+      if (logger.isDebugEnabled()) {
+        logger.debug("{}: Queued marker message. The queue contains {} entries.", this,
+            getQueueSize());
+      }
+    } catch (CancelException e) {
+      throw e;
+    } catch (Exception e) {
+      if (!isStopped()) {
+        logger.fatal(
+            String.format("%s : Exception occurred while attempting to add message to queue",
+                this),
+            e);
+      }
+    }
+  }
+
+  void sendMessageDirectly(ClientMessage clientMessage) {
+    Message message;
+    try {
+      if (logger.isDebugEnabled()) {
+        logger.debug("{}: Dispatching directly: {}", this, clientMessage);
+      }
+      message = clientMessage.getMessage(getProxy(), true);
+      sendMessage(message);
+      if (logger.isDebugEnabled()) {
+        logger.debug("{}: Dispatched directly: {}", this, clientMessage);
+      }
+      // The exception handling code was modeled after the MessageDispatcher
+      // run method
+    } catch (MessageTooLargeException e) {
+      logger.warn("Message too large to send to client: {}, {}", clientMessage, e.getMessage());
+
+    } catch (IOException e) {
+      synchronized (this._stopDispatchingLock) {
+        // Pause or unregister proxy
+        if (!isStopped() && !getProxy().isPaused()) {
+          logger.fatal(String.format("%s : An unexpected Exception occurred", this),
+              e);
+          pauseOrUnregisterProxy(e);
+        }
+      }
+    } catch (Exception e) {
+      if (!isStopped()) {
+        logger.fatal(String.format("%s : An unexpected Exception occurred", this), e);
+      }
+    }
+  }
+
+  protected void waitForResumption() throws InterruptedException {
+    synchronized (this._pausedLock) {
+      logger.info("{} : Pausing processing", this);
+      if (!getProxy().isPaused()) {
+        return;
+      }
+      while (getProxy().isPaused()) {
+        this._pausedLock.wait();
+      }
+      // Fix for #48571
+      _messageQueue.clearPeekedIDs();
+    }
+  }
+
+  protected void resumeDispatching() {
+    logger.info("{} : Resuming processing", this);
+
+    // Notify thread to resume
+    this._pausedLock.notifyAll();
+  }
+
+  protected Object deserialize(byte[] serializedBytes) {
+    Object deserializedObject = serializedBytes;
+    // This is a debugging method so ignore all exceptions like
+    // ClassNotFoundException
+    try {
+      ByteArrayDataInput dis = new ByteArrayDataInput(serializedBytes);
+      deserializedObject = DataSerializer.readObject(dis);
+    } catch (Exception e) {
+    }
+    return deserializedObject;
+  }
+
+  protected void initializeTransients() {
+    while (!this._messageQueue.isEmptyAckList() && this._messageQueue.isPeekInitialized()) {
+      try {
+        this._messageQueue.remove();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+    this._messageQueue.initializeTransients();
+  }
+}

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -353,8 +353,8 @@ org/apache/geode/internal/cache/snapshot/SnapshotOptionsImpl,true,1,filter:org/a
 org/apache/geode/internal/cache/snapshot/WindowedExporter$WindowedArgs,true,1,exporter:org/apache/geode/distributed/DistributedMember,options:org/apache/geode/cache/snapshot/SnapshotOptions
 org/apache/geode/internal/cache/snapshot/WindowedExporter$WindowedExportFunction,true,1
 org/apache/geode/internal/cache/tier/BatchException,true,-6707074107791305564,_index:int
-org/apache/geode/internal/cache/tier/sockets/CacheClientProxy$MessageDispatcher$1,true,0,this$0:org/apache/geode/internal/cache/tier/sockets/CacheClientProxy$MessageDispatcher
 org/apache/geode/internal/cache/tier/sockets/ClientTombstoneMessage$TOperation,false
+org/apache/geode/internal/cache/tier/sockets/MessageDispatcher$1,true,0,this$0:org/apache/geode/internal/cache/tier/sockets/MessageDispatcher
 org/apache/geode/internal/cache/tier/sockets/MessageTooLargeException,true,-8970585803331525833
 org/apache/geode/internal/cache/tier/sockets/UnregisterAllInterest,true,5026160621257178459
 org/apache/geode/internal/cache/tx/TransactionalOperation$ServerRegionOperation,false

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyFactoryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyFactoryTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.apache.geode.internal.cache.tier.sockets.Handshake.CONFLATION_DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.Socket;
+
+import org.apache.shiro.subject.Subject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import org.apache.geode.cache.CacheException;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.tier.sockets.CacheClientProxyFactory.InternalCacheClientProxyFactory;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.internal.statistics.StatisticsManager;
+
+public class CacheClientProxyFactoryTest {
+
+  private CacheClientNotifier notifier;
+  private Socket socket;
+  private ClientProxyMembershipID proxyId;
+  private Version clientVersion;
+  private SecurityService securityService;
+  private Subject subject;
+  private StatisticsClock statisticsClock;
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Before
+  public void setUp() throws Exception {
+    notifier = mock(CacheClientNotifier.class);
+    socket = mock(Socket.class);
+    proxyId = mock(ClientProxyMembershipID.class);
+    clientVersion = mock(Version.class);
+    securityService = mock(SecurityService.class);
+    subject = mock(Subject.class);
+    statisticsClock = mock(StatisticsClock.class);
+
+    InetAddress inetAddress = mock(InetAddress.class);
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    InternalDistributedSystem system = mock(InternalDistributedSystem.class);
+
+    when(cache.getInternalDistributedSystem()).thenReturn(system);
+    when(inetAddress.getHostAddress()).thenReturn("localhost");
+    when(member.getId()).thenReturn("memberId");
+    when(notifier.getCache()).thenReturn(cache);
+    when(notifier.getAcceptorStats()).thenReturn(mock(CacheServerStats.class));
+    when(proxyId.getDistributedMember()).thenReturn(member);
+    when(socket.getInetAddress()).thenReturn(inetAddress);
+    when(socket.getPort()).thenReturn(33333);
+    when(system.getStatisticsManager()).thenReturn(mock(StatisticsManager.class));
+  }
+
+  @Test
+  public void createsCacheClientProxyByDefault() {
+    CacheClientProxyFactory factory = new CacheClientProxyFactory();
+
+    CacheClientProxy proxy = factory.create(notifier, socket, proxyId, false, CONFLATION_DEFAULT,
+        clientVersion, 0, false, securityService, subject, statisticsClock);
+
+    assertThat(proxy).isExactlyInstanceOf(CacheClientProxy.class);
+  }
+
+  @Test
+  public void usesCustomInternalFactorySpecifiedByProperty() {
+    System.setProperty(CacheClientProxyFactory.INTERNAL_FACTORY_PROPERTY,
+        SubCacheClientProxyFactory.class.getName());
+    CacheClientProxyFactory factory = new CacheClientProxyFactory();
+
+    CacheClientProxy proxy = factory.create(notifier, socket, proxyId, false, CONFLATION_DEFAULT,
+        clientVersion, 0, false, securityService, subject, statisticsClock);
+
+    assertThat(proxy).isExactlyInstanceOf(SubCacheClientProxy.class);
+
+  }
+
+  public static class SubCacheClientProxyFactory implements InternalCacheClientProxyFactory {
+
+    @Override
+    public CacheClientProxy create(CacheClientNotifier notifier, Socket socket,
+        ClientProxyMembershipID proxyId, boolean isPrimary, byte clientConflation,
+        Version clientVersion, long acceptorId, boolean notifyBySubscription,
+        SecurityService securityService, Subject subject, StatisticsClock statisticsClock)
+        throws CacheException {
+      return new SubCacheClientProxy(notifier, socket, proxyId, isPrimary, clientConflation,
+          clientVersion, acceptorId, notifyBySubscription, securityService, subject,
+          statisticsClock);
+    }
+  }
+
+  private static class SubCacheClientProxy extends CacheClientProxy {
+
+    SubCacheClientProxy(CacheClientNotifier notifier, Socket socket,
+        ClientProxyMembershipID proxyId, boolean isPrimary, byte clientConflation,
+        Version clientVersion, long acceptorId, boolean notifyBySubscription,
+        SecurityService securityService, Subject subject, StatisticsClock statisticsClock)
+        throws CacheException {
+      super(notifier, socket, proxyId, isPrimary, clientConflation, clientVersion, acceptorId,
+          notifyBySubscription, securityService, subject, statisticsClock);
+    }
+  }
+}


### PR DESCRIPTION
Improve testability of CacheClientProxy
* Extract inner classes
* Introduce CacheClientProxyFactory with support for property injection
* Pull getPrimaryPort up to InternalPool interface
* Define InternalPoolFactory and pull up init and getPoolAttributes

Replace flaky sleep-based test-hook in product code with custom
MessageDispatcher injected by property in CacheClientProxyFactory
which uses CountDownLatch.