### PR TITLE
GEODE-7754: show gatewaysender's running state instead of connected s…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemBridgeIntegrationTest.java
@@ -138,18 +138,18 @@ public class DistributedSystemBridgeIntegrationTest {
   }
 
   @Test
-  public void viewClusterStatusShouldBeTrueIfAllParallelSendersAreConnected() {
+  public void viewClusterStatusShouldBeTrueIfAllParallelSendersAreRunning() {
     // parallel senders for dsid = 2
     doReturn(true).when(bean1).isParallel();
-    doReturn(true).when(bean1).isConnected();
+    doReturn(true).when(bean1).isRunning();
     doReturn(true).when(bean2).isParallel();
-    doReturn(true).when(bean2).isConnected();
+    doReturn(true).when(bean2).isRunning();
 
     // parallel senders for dsid = 3
     doReturn(true).when(bean3).isParallel();
-    doReturn(true).when(bean3).isConnected();
+    doReturn(true).when(bean3).isRunning();
     doReturn(true).when(bean4).isParallel();
-    doReturn(true).when(bean4).isConnected();
+    doReturn(true).when(bean4).isRunning();
 
     Map<String, Boolean> status = bridge.viewRemoteClusterStatus();
     assertThat(status.keySet()).hasSize(2);
@@ -158,18 +158,18 @@ public class DistributedSystemBridgeIntegrationTest {
   }
 
   @Test
-  public void viewClusterStatusShouldBeFalseIfAnyParallelSendersIsNotConnected() {
+  public void viewClusterStatusShouldBeFalseIfAnyParallelSendersIsNotRunning() {
     // parallel senders for dsid = 2
     doReturn(true).when(bean1).isParallel();
-    doReturn(true).when(bean1).isConnected();
+    doReturn(true).when(bean1).isRunning();
     doReturn(true).when(bean2).isParallel();
-    doReturn(true).when(bean2).isConnected();
+    doReturn(true).when(bean2).isRunning();
 
     // parallel senders for dsid = 3
     doReturn(true).when(bean3).isParallel();
-    doReturn(true).when(bean3).isConnected();
+    doReturn(true).when(bean3).isRunning();
     doReturn(true).when(bean4).isParallel();
-    doReturn(false).when(bean4).isConnected();
+    doReturn(false).when(bean4).isRunning();
 
     Map<String, Boolean> status = bridge.viewRemoteClusterStatus();
     assertThat(status.keySet()).hasSize(2);
@@ -178,26 +178,26 @@ public class DistributedSystemBridgeIntegrationTest {
   }
 
   @Test
-  public void viewClusterStatusShouldBeTrueIfASerialPrimaryIsConnected() {
+  public void viewClusterStatusShouldBeTrueIfASerialPrimaryIsRunning() {
     // serial primary for dsid = 2
     doReturn(false).when(bean1).isParallel();
     doReturn(true).when(bean1).isPrimary();
-    doReturn(true).when(bean1).isConnected();
+    doReturn(true).when(bean1).isRunning();
 
     // serial secondary for dsid = 2
     doReturn(false).when(bean2).isParallel();
     doReturn(false).when(bean2).isPrimary();
-    doReturn(false).when(bean2).isConnected();
+    doReturn(false).when(bean2).isRunning();
 
     // serial primary for dsid = 3
     doReturn(false).when(bean3).isParallel();
     doReturn(true).when(bean3).isPrimary();
-    doReturn(true).when(bean3).isConnected();
+    doReturn(true).when(bean3).isRunning();
 
     // serial secondary for dsid = 3
     doReturn(false).when(bean4).isParallel();
     doReturn(false).when(bean4).isPrimary();
-    doReturn(false).when(bean4).isConnected();
+    doReturn(false).when(bean4).isRunning();
 
     Map<String, Boolean> status = bridge.viewRemoteClusterStatus();
     assertThat(status.keySet()).hasSize(2);
@@ -206,26 +206,26 @@ public class DistributedSystemBridgeIntegrationTest {
   }
 
   @Test
-  public void viewClusterStatusShouldBeFalseIfASerialPrimaryIsNotConnected() {
+  public void viewClusterStatusShouldBeFalseIfASerialPrimaryIsNotRunning() {
     // serial primary for dsid = 2
     doReturn(false).when(bean1).isParallel();
     doReturn(true).when(bean1).isPrimary();
-    doReturn(true).when(bean1).isConnected();
+    doReturn(true).when(bean1).isRunning();
 
     // serial secondary for dsid = 2
     doReturn(false).when(bean2).isParallel();
     doReturn(false).when(bean2).isPrimary();
-    doReturn(false).when(bean2).isConnected();
+    doReturn(false).when(bean2).isRunning();
 
     // serial primary for dsid = 3
     doReturn(false).when(bean3).isParallel();
     doReturn(true).when(bean3).isPrimary();
-    doReturn(false).when(bean3).isConnected();
+    doReturn(false).when(bean3).isRunning();
 
     // serial secondary for dsid = 3
     doReturn(false).when(bean4).isParallel();
     doReturn(false).when(bean4).isPrimary();
-    doReturn(true).when(bean4).isConnected();
+    doReturn(true).when(bean4).isRunning();
 
     Map<String, Boolean> status = bridge.viewRemoteClusterStatus();
     assertThat(status.keySet()).hasSize(2);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/DistributedSystemBridge.java
@@ -1410,10 +1410,10 @@ public class DistributedSystemBridge {
           continue;
         }
         if (bean.isParallel()) {
-          senderMap.merge(String.valueOf(dsId), bean.isConnected(), Boolean::logicalAnd);
+          senderMap.merge(String.valueOf(dsId), bean.isRunning(), Boolean::logicalAnd);
         } else {
           if (bean.isPrimary()) {
-            senderMap.put(String.valueOf(dsId), bean.isConnected());
+            senderMap.put(String.valueOf(dsId), bean.isRunning());
           }
         }
       }


### PR DESCRIPTION
…tate

* viewRemoteClusterStatus is only used by Pluse to gather gatewaysender status, so changing that to show the running state in Pulse.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
