### PR TITLE
GEODE-7755: change Pulse to not keep locator alive

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseConnectivityTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.tools.pulse;
 
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_BIND_ADDRESS;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.InetAddress;
@@ -94,5 +95,10 @@ public class PulseConnectivityTest {
     Cluster cluster = pulse.getRepository().getCluster("admin", null);
     assertThat(cluster.isConnectedFlag()).isTrue();
     assertThat(cluster.getServerCount()).isEqualTo(0);
+    assertThat(cluster.isAlive()).isTrue();
+    assertThat(cluster.isDaemon()).isTrue();
+    locator.getLocator().stop();
+    assertThat(locator.getLocator().isStopped()).isTrue();
+    await().untilAsserted(() -> assertThat(cluster.isAlive()).isFalse());
   }
 }

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Cluster.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Cluster.java
@@ -2269,7 +2269,6 @@ public class Cluster extends Thread {
   public void run() {
     try {
       while (!this.stopUpdates && isConnectedFlag()) {
-        logger.info("in run loop");
         try {
           if (!this.updateData()) {
             this.stale++;

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdater.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/JMXDataUpdater.java
@@ -373,6 +373,8 @@ public class JMXDataUpdater implements IClusterUpdater, NotificationListener {
           logger.fatal(e1.getMessage(), e1);
         }
         this.conn = null;
+        cluster.setConnectedFlag(false);
+        cluster.setConnectionErrorMsg(ioe.getMessage());
       }
 
       return false;


### PR DESCRIPTION
Cluster now makes itself a daemon if embedded.
If the JMXDataUpdater loses its connection it now tells the Cluster it is no longer connected.
The Cluster run loop now checks that it is still connected.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
