### PR TITLE
GEODE-7756: Do not use authorization cache for CQs

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryExecutionContext.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryExecutionContext.java
@@ -37,7 +37,7 @@ public class QueryExecutionContext extends ExecutionContext {
 
   private final Query query;
 
-  private boolean cqQueryContext = false;
+  private final boolean cqQueryContext;
 
   private List bucketList;
 
@@ -67,6 +67,14 @@ public class QueryExecutionContext extends ExecutionContext {
   public QueryExecutionContext(Object[] bindArguments, InternalCache cache) {
     super(bindArguments, cache);
     this.query = null;
+    this.cqQueryContext = false;
+  }
+
+  public QueryExecutionContext(Object[] bindArguments, InternalCache cache,
+      boolean cqQueryContext) {
+    super(bindArguments, cache);
+    this.query = null;
+    this.cqQueryContext = cqQueryContext;
   }
 
   public QueryExecutionContext(Object[] bindArguments, InternalCache cache, Query query) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/internal/CqSecurityExecutionContextTamperingDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/internal/CqSecurityExecutionContextTamperingDistributedTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
+import java.lang.reflect.Method;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,7 +50,7 @@ import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
 /**
- * Verifies that users can tamper the {@link ExecutionContext}.
+ * Verifies that users can not tamper the {@link ExecutionContext}.
  * It needs to be part of the {@link org.apache.geode.cache.query.cq.internal} package because the
  * method {@link CqQueryImpl#getQueryExecutionContext()} has package access.
  */
@@ -121,8 +122,9 @@ public class CqSecurityExecutionContextTamperingDistributedTest implements Seria
       assertThat(internalCache.getCqService().getAllCqs().size()).isEqualTo(1);
       CqQueryImpl cqQueryImpl =
           (CqQueryImpl) internalCache.getCqService().getAllCqs().iterator().next();
-      ExecutionContextTamperer.tamperContextCache(cqQueryImpl.getQueryExecutionContext(),
-          "org.apache.geode.security.query.data.QueryTestObject.getName", true);
+      Method method = QueryTestObject.class.getMethod("getName");
+      ExecutionContextTamperer.tamperContextCache(cqQueryImpl.getQueryExecutionContext(), method,
+          true);
 
       Region<String, QueryTestObject> region = ClusterStartupRule.getCache().getRegion(regionName);
       region.put("1", new QueryTestObject(1, "Beth"));

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/CqQueryImpl.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/CqQueryImpl.java
@@ -210,7 +210,7 @@ public abstract class CqQueryImpl implements InternalCqQuery {
 
     // Set Query ExecutionContext, that will be used in later execution.
     this.setQueryExecutionContext(
-        new QueryExecutionContext(null, (InternalCache) this.cqService.getCache()));
+        new QueryExecutionContext(null, (InternalCache) this.cqService.getCache(), true));
   }
 
   /**


### PR DESCRIPTION
CQs are executed on individual entries whenever an event is triggered
for them and the execution context is always cleared before the actual
evaluation, thus using an internal cache to keep already authorized
methods is useless (will always be a cache miss and the computation
required just adds overhead).

- Fixed the CQ creation to always set the 'cqQueryContext' flag.
- Modified the query engine to avoid using the internal cache for
  already authorized methods when the context belongs to a CQ.
- Avoid the creation and concatenation of unnecessary Strings, using
  the Method class directly instead.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
