### PR TITLE
GEODE-7776 - Proposed changes to remove build cycle

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -263,10 +263,11 @@ dependencies {
   //Log4j is used everywhere
   implementation('org.apache.logging.log4j:log4j-api')
 
-  runtimeOnly(project(':geode-gfsh')) {
-    exclude module: 'geode-core'
-    ext.optional = true
-  }
+  // TODO: find a better way
+//  runtimeOnly(project(':geode-gfsh')) {
+//    exclude module: 'geode-core'
+//    ext.optional = true
+//  }
 
   runtimeOnly('io.swagger:swagger-annotations') {
     ext.optional = true

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -263,11 +263,6 @@ dependencies {
   //Log4j is used everywhere
   implementation('org.apache.logging.log4j:log4j-api')
 
-  // TODO: find a better way
-//  runtimeOnly(project(':geode-gfsh')) {
-//    exclude module: 'geode-core'
-//    ext.optional = true
-//  }
 
   runtimeOnly('io.swagger:swagger-annotations') {
     ext.optional = true

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -243,18 +243,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-gfsh</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>geode-core</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
There is a build / runtime cycle between geode-core and geode-gfsh, defined as a runtime-only dependency in Gradle. Can we break this optional, runtime-only declaration?