### PR TITLE
GEODE-7760: fixing LocatorUDPSecurityDUnitTest.testCrashLocatorMultip…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorUDPSecurityDUnitTest.java
@@ -36,6 +36,7 @@ public class LocatorUDPSecurityDUnitTest extends LocatorDUnitTest {
     p.setProperty(SECURITY_UDP_DHALGO, "AES:128");
   }
 
+
   @Test
   public void testLocatorWithUDPSecurityButServer() {
     String locators = hostName + "[" + port1 + "]";

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumCheckerJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumCheckerJUnitTest.java
@@ -76,7 +76,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -96,7 +96,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -111,7 +111,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -125,7 +125,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -152,7 +152,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -182,7 +182,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -215,7 +215,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -246,7 +246,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);
@@ -270,7 +270,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertTrue(quorum);
@@ -295,7 +295,7 @@ public class GMSQuorumCheckerJUnitTest {
     PingMessageAnswer answerer = new PingMessageAnswer(channel, pongResponders);
     Mockito.doAnswer(answerer).when(channel).send(any(Message.class));
 
-    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel);
+    GMSQuorumChecker qc = new GMSQuorumChecker(view, 51, channel, null);
     qc.initialize();
     boolean quorum = qc.checkForQuorum(500);
     assertFalse(quorum);

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessengerJUnitTest.java
@@ -883,7 +883,7 @@ public class JGroupsMessengerJUnitTest {
     initMocks(false, true);
     ((TestMembershipConfig) membershipConfig).oldMembershipInfo =
         new MembershipInformationImpl(messenger.myChannel,
-            new ConcurrentLinkedQueue<>());
+            new ConcurrentLinkedQueue<>(), null);
     JGroupsMessenger newMessenger = new JGroupsMessenger();
     newMessenger.init(services);
     newMessenger.start();

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
@@ -178,7 +178,7 @@ public final class GMSEncrypt<ID extends MemberIdentifier> {
   protected byte[] getPublicKey(ID member) {
     ID localMbr = services.getMessenger().getMemberID();
     try {
-      if (localMbr != null && localMbr.compareTo(member, true, false) == 0) {
+      if (localMbr != null && localMbr.compareTo(member, false, false) == 0) {
         return this.dhPublicKey.getEncoded();// local one
       }
       return lookupKeyByMember(member);

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
@@ -176,14 +176,15 @@ public final class GMSEncrypt<ID extends MemberIdentifier> {
   }
 
   protected byte[] getPublicKey(ID member) {
+    ID localMbr = services.getMessenger().getMemberID();
     try {
-      ID localMbr = services.getMessenger().getMemberID();
       if (localMbr != null && localMbr.compareTo(member, true, false) == 0) {
         return this.dhPublicKey.getEncoded();// local one
       }
       return lookupKeyByMember(member);
     } catch (Exception e) {
-      throw new RuntimeException("Not found public key for member " + member, e);
+      throw new RuntimeException(
+          "Not found public key for member " + member + "; my address is " + localMbr, e);
     }
   }
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSEncrypt.java
@@ -178,7 +178,7 @@ public final class GMSEncrypt<ID extends MemberIdentifier> {
   protected byte[] getPublicKey(ID member) {
     try {
       ID localMbr = services.getMessenger().getMemberID();
-      if (localMbr != null && localMbr.equals(member)) {
+      if (localMbr != null && localMbr.compareTo(member, true, false) == 0) {
         return this.dhPublicKey.getEncoded();// local one
       }
       return lookupKeyByMember(member);

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/GMSQuorumChecker.java
@@ -45,6 +45,8 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  */
 public class GMSQuorumChecker<ID extends MemberIdentifier> implements QuorumChecker {
   private static final Logger logger = LogService.getLogger();
+
+  private final GMSEncrypt encrypt;
   private boolean isInfoEnabled = false;
   private Map<SocketAddress, ID> addressConversionMap;
   private GMSPingPonger pingPonger;
@@ -60,10 +62,12 @@ public class GMSQuorumChecker<ID extends MemberIdentifier> implements QuorumChec
   private final long partitionThreshold;
   private ConcurrentLinkedQueue<Message> messageQueue = new ConcurrentLinkedQueue<>();
 
-  public GMSQuorumChecker(GMSMembershipView<ID> jgView, int partitionThreshold, JChannel channel) {
+  public GMSQuorumChecker(GMSMembershipView<ID> jgView, int partitionThreshold, JChannel channel,
+      GMSEncrypt encrypt) {
     this.lastView = jgView;
     this.partitionThreshold = partitionThreshold;
     this.channel = channel;
+    this.encrypt = encrypt;
   }
 
   public void initialize() {
@@ -119,7 +123,7 @@ public class GMSQuorumChecker<ID extends MemberIdentifier> implements QuorumChec
 
   @Override
   public MembershipInformation getMembershipInfo() {
-    return new MembershipInformationImpl(channel, messageQueue);
+    return new MembershipInformationImpl(channel, messageQueue, encrypt);
   }
 
   private boolean calculateQuorum() {

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -336,6 +336,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
         MembershipInformationImpl oldInfo = (MembershipInformationImpl) oldDSMembershipInfo;
         myChannel = oldInfo.getChannel();
         queuedMessagesFromReconnect = oldInfo.getQueuedMessages();
+        encrypt = oldInfo.getEncrypt();
 
         // scrub the old channel
         ViewId vid = new ViewId(new JGAddress(), 0);
@@ -1248,7 +1249,8 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
       }
     }
     GMSQuorumChecker<ID> qc =
-        new GMSQuorumChecker<>(view, services.getConfig().getLossThreshold(), this.myChannel);
+        new GMSQuorumChecker<>(view, services.getConfig().getLossThreshold(), this.myChannel,
+            encrypt);
     qc.initialize();
     return qc;
   }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -418,7 +418,7 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
 
   @Override
   public void started() throws MemberStartupException {
-    if (queuedMessagesFromReconnect != null && !services.getConfig().isUDPSecurityEnabled()) {
+    if (queuedMessagesFromReconnect != null) {
       logger.info("Delivering {} messages queued by quorum checker",
           queuedMessagesFromReconnect.size());
       for (org.jgroups.Message message : queuedMessagesFromReconnect) {

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/MembershipInformationImpl.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/MembershipInformationImpl.java
@@ -28,12 +28,20 @@ import org.apache.geode.distributed.internal.membership.api.MembershipInformatio
 public class MembershipInformationImpl implements MembershipInformation {
   private final JChannel channel;
   private final Queue<Message> queuedMessages;
+  private final GMSEncrypt encrypt;
 
   protected MembershipInformationImpl(JChannel channel,
-      Queue<Message> queuedMessages) {
+      Queue<Message> queuedMessages,
+      GMSEncrypt encrypt) {
 
     this.channel = channel;
     this.queuedMessages = queuedMessages;
+    this.encrypt = encrypt;
+  }
+
+
+  public GMSEncrypt getEncrypt() {
+    return encrypt;
   }
 
   public JChannel getChannel() {


### PR DESCRIPTION
…leTimes

This new test exposed a flaw in auto-reconnect where the quorum-checker
buffers messages from other members but the new Membership messenger is
unable to decrypt them when it starts up due to not having the old
encryption keys.

The encrypt/decrypt objects from the old Membership are now kept and
provided to the new Messenger during auto-reconnect.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
