### PR TITLE
GEODE-7779: Concourse BumpXYZ does not include {prerelease}

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -186,7 +186,7 @@ resources:
     driver: gcs
     initial_version: {{ metadata.initial_version }}
     json_key: ((!concourse-gcp-key))
-    key: semvers/((pipeline-prefix))((geode-build-branch))/version
+    key: semvers/((pipeline-prefix))((geode-build-branch))/number
 - name: geode-passing-tokens
   type: gcs-resource
   source:
@@ -238,7 +238,9 @@ jobs:
   serial: true
   plan:
   - get: geode-build-version
-    params: { bump: {{ semverPiece }} }
+    params: { bump: {{ semverPiece }},
+              pre: ((semver-prerelease-token)),
+              pre_without_version: true }
   - put: geode-build-version
     params:
       file: geode-build-version/number

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -66,7 +66,7 @@ java_test_versions:
   version: 11
 
 metadata:
-  initial_version: 1.13.0
+  initial_version: 1.13.0-((semver-prerelease-token))
 
 publish_artifacts:
   CPUS: '8'


### PR DESCRIPTION
Update the bump jobs to increment and add the semver release token which
clears the wrong semver picking happening in past few days.

Signed-off-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
