### PR TITLE
GEODE-7788: Alpine tools docker image creation fails due to internal

### DIFF
--- a/ci/images/alpine-tools/Dockerfile
+++ b/ci/images/alpine-tools/Dockerfile
@@ -36,10 +36,13 @@ RUN apk --no-cache add \
   && gcloud config set core/disable_usage_reporting true \
   && gcloud config set component_manager/disable_update_check true \
   && gcloud config set metrics/environment github_docker_image \
-  && git clone https://github.com/masterzen/winrm-cli \
-  && (cd winrm-cli; GOPATH=$PWD PATH=$PATH:$PWD/bin make) \
-  && cp winrm-cli/bin/winrm /usr/local/bin/ \
-  && rm -rf winrm-cli \
+  && mkdir -p gopath \
+  && cd gopath \
+  && export GOPATH=$(pwd) \
+  && go get github.com/masterzen/winrm-cli \
+  && cp ${GOPATH}/bin/winrm-cli /usr/local/bin/winrm \
+  && cd ${GOPATH}/.. \
+  && rm -rf ${GOPATH} \
   && gcloud components install -q beta \
   && printf "Host *\n  ServerAliveInterval 60 \n  ServerAliveCountMax 2\n" >> /etc/ssh/ssh_config \
   && pip2 install awscli \


### PR DESCRIPTION
winrm-cli changes.

Change the dockerfile to do go get instead of git clone which does
cloning, pulling dependencies and building as part of its process.
This eliminates the manual winrm-cli build process that was
being done before.

Signed-off-by: Bala Kaza Venkata <bkazavenkata@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
