### PR TITLE
GEODE-7789: Cache DurableClienAttributes

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -275,9 +275,9 @@ fromData,17
 toData,17
 
 org/apache/geode/distributed/internal/membership/InternalDistributedMember,6
-fromData,12
-fromDataPre_GFE_7_1_0_0,12
-fromDataPre_GFE_9_0_0_0,12
+fromData,17
+fromDataPre_GFE_7_1_0_0,17
+fromDataPre_GFE_9_0_0_0,17
 toData,12
 toDataPre_GFE_7_1_0_0,12
 toDataPre_GFE_9_0_0_0,12

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/InternalDistributedMemberTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/membership/InternalDistributedMemberTest.java
@@ -231,6 +231,27 @@ public class InternalDistributedMemberTest {
   }
 
   @Test
+  public void getDurableClientAttributesShouldReturnCachedInstanceWhenBackingMemberIdentifierAttributesHaveNotChanged()
+      throws UnknownHostException {
+    InetAddress host1 = InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+    MemberData memberData = mock(MemberData.class);
+    when(memberData.getInetAddress()).thenReturn(host1);
+    when(memberData.getDurableId()).thenReturn("durableId");
+    when(memberData.getDurableTimeout()).thenReturn(Integer.MAX_VALUE);
+    InternalDistributedMember internalDistributedMember = new InternalDistributedMember(memberData);
+    assertThat(internalDistributedMember.durableClientAttributes).isNull();
+
+    // Get Attributes first time - should be instantiated and cached.
+    DurableClientAttributes attributes = internalDistributedMember.getDurableClientAttributes();
+    assertThat(attributes).isNotNull();
+    assertThat(attributes.getId()).isEqualTo("durableId");
+    assertThat(attributes.getTimeout()).isEqualTo(Integer.MAX_VALUE);
+
+    // Get Attributes again without changing backing store - should return cached instance .
+    assertThat(internalDistributedMember.getDurableClientAttributes()).isSameAs(attributes);
+  }
+
+  @Test
   public void setDurableTimeOutShouldNullifyCachedDurableClientAttributes() {
     InternalDistributedMember member = new InternalDistributedMember("", 34567, "name", "uniqueId",
         MemberIdentifier.NORMAL_DM_TYPE, new String[] {}, new DurableClientAttributes("", 500));


### PR DESCRIPTION
Keep the last known 'DurableClienAttributes' cached within the
'InternalDistributedMember' class to avoid the overhead of creating a
new instance every time.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
