### PR TITLE
GEODE-7768: remove redundant null checks

### DIFF
--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/util/BootstrappingFunction.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/util/BootstrappingFunction.java
@@ -191,10 +191,9 @@ public class BootstrappingFunction implements Function, MembershipListener, Data
       return true;
     }
 
-    if (obj == null || !(obj instanceof BootstrappingFunction)) {
+    if (!(obj instanceof BootstrappingFunction)) {
       return false;
     }
-
     return true;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteApplicationVM.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/RemoteApplicationVM.java
@@ -48,7 +48,7 @@ public class RemoteApplicationVM extends RemoteGemFireVM implements ApplicationV
 
   @Override
   public boolean equals(Object obj) {
-    if (obj == null || !(obj instanceof RemoteApplicationVM)) {
+    if (!(obj instanceof RemoteApplicationVM)) {
       return false;
     } else {
       RemoteApplicationVM vm = (RemoteApplicationVM) obj;

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/DummyStatisticInfoImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/DummyStatisticInfoImpl.java
@@ -103,7 +103,7 @@ public class DummyStatisticInfoImpl implements StatisticInfo {
   @Override
   public boolean equals(Object object) {
 
-    if (object == null || !(object instanceof DummyStatisticInfoImpl)) {
+    if (!(object instanceof DummyStatisticInfoImpl)) {
       return false;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/StatisticInfoImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/statalerts/StatisticInfoImpl.java
@@ -96,7 +96,7 @@ public class StatisticInfoImpl implements StatisticInfo {
   @Override
   public boolean equals(Object object) {
 
-    if (object == null || !(object instanceof StatisticInfoImpl)) {
+    if (!(object instanceof StatisticInfoImpl)) {
       return false;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
@@ -992,7 +992,7 @@ public class FilterProfile implements DataSerializableFixedID {
 
   private void sendProfileOperation(Long clientID, operationType opType, Object interest,
       boolean updatesAsInvalidates) {
-    if (this.region == null || !(this.region instanceof PartitionedRegion)) {
+    if (!(this.region instanceof PartitionedRegion)) {
       return;
     }
     OperationMessage msg = new OperationMessage();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionHelper.java
@@ -710,7 +710,7 @@ public class PartitionedRegionHelper {
     } finally {
       LocalRegion.setThreadInitLevelRequirement(oldLevel);
     }
-    if (region == null || !(region instanceof PartitionedRegion)) {
+    if (!(region instanceof PartitionedRegion)) {
       return null;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -1660,7 +1660,7 @@ public class TXCommitMessage extends PooledDistributionMessage
 
       @Override
       public boolean equals(Object o) {
-        if (o == null || !(o instanceof FarSideEntryOp)) {
+        if (!(o instanceof FarSideEntryOp)) {
           return false;
         }
         return compareTo(o) == 0;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
@@ -1970,7 +1970,7 @@ public class TXEntryState implements Releasable {
 
     @Override
     public boolean equals(Object o) {
-      if (o == null || !(o instanceof TxEntryEventImpl))
+      if (!(o instanceof TxEntryEventImpl))
         return false;
       return compareTo(o) == 0;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -1008,7 +1008,7 @@ public class TXState implements TXStateInterface {
 
     @Override
     public boolean equals(Object o) {
-      if (o == null || !(o instanceof TXEntryStateWithRegionAndKey))
+      if (!(o instanceof TXEntryStateWithRegionAndKey))
         return false;
       return compareTo(o) == 0;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HAEventWrapper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/HAEventWrapper.java
@@ -229,7 +229,7 @@ public class HAEventWrapper implements Conflatable, DataSerializableFixedID, Siz
    */
   @Override
   public boolean equals(Object other) {
-    if (other == null || !(other instanceof HAEventWrapper)) {
+    if (!(other instanceof HAEventWrapper)) {
       return false;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionHolder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionHolder.java
@@ -756,7 +756,7 @@ public class RegionVersionHolder<T> implements Cloneable, DataSerializable {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj == null || !(obj instanceof RegionVersionHolder)) {
+    if (!(obj instanceof RegionVersionHolder)) {
       return false;
     }
     return sameAs((RegionVersionHolder) obj);

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxField.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxField.java
@@ -203,7 +203,7 @@ public class PdxField implements DataSerializable, Comparable<PdxField> {
     if (other == this) {
       return true;
     }
-    if (other == null || !(other instanceof PdxField)) {
+    if (!(other instanceof PdxField)) {
       return false;
     }
     PdxField otherVFT = (PdxField) other;

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxType.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxType.java
@@ -177,7 +177,7 @@ public class PdxType implements DataSerializable {
     if (other == this) {
       return true;
     }
-    if (other == null || !(other instanceof PdxType)) {
+    if (!(other instanceof PdxType)) {
       return false;
     }
     // Note: do not compare type id in equals

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -83,14 +83,14 @@ public class ClusterStartupRule implements SerializableTestRule {
   }
 
   public static InternalLocator getLocator() {
-    if (memberStarter == null || !(memberStarter instanceof LocatorStarterRule)) {
+    if (!(memberStarter instanceof LocatorStarterRule)) {
       return null;
     }
     return ((LocatorStarterRule) memberStarter).getLocator();
   }
 
   public static CacheServer getServer() {
-    if (memberStarter == null || !(memberStarter instanceof ServerStarterRule)) {
+    if (!(memberStarter instanceof ServerStarterRule)) {
       return null;
     }
     return ((ServerStarterRule) memberStarter).getServer();

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeMemberCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeMemberCommand.java
@@ -56,7 +56,7 @@ public class DescribeMemberCommand extends GfshCommand {
     ArrayList<?> output = (ArrayList<?>) rc.getResult();
     Object obj = output.get(0);
 
-    if (obj == null || !(obj instanceof MemberInformation)) {
+    if (!(obj instanceof MemberInformation)) {
       return ResultModel.createInfo(String.format(
           CliStrings.DESCRIBE_MEMBER__MSG__INFO_FOR__0__COULD_NOT_BE_RETRIEVED, memberNameOrId));
     }

--- a/geode-junit/src/main/java/org/apache/geode/DeltaTestImpl.java
+++ b/geode-junit/src/main/java/org/apache/geode/DeltaTestImpl.java
@@ -244,7 +244,7 @@ public class DeltaTestImpl implements DataSerializable, Delta {
 
   @Override
   public boolean equals(Object other) {
-    if (other == null || !(other instanceof DeltaTestImpl)) {
+    if (!(other instanceof DeltaTestImpl)) {
       return false;
     }
     DeltaTestImpl delta = (DeltaTestImpl) other;

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioData.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/PortfolioData.java
@@ -112,7 +112,7 @@ public class PortfolioData implements Declarable, Serializable {
     if (this == p) {
       return true;
     }
-    if (p == null || !(p instanceof PortfolioData)) {
+    if (!(p instanceof PortfolioData)) {
       return false;
     }
     PortfolioData pd = (PortfolioData) p;

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
@@ -379,7 +379,7 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
   @Override
   public boolean equals(Object obj) {
     // GemStone fix for 29125
-    if ((obj == null) || !(obj instanceof GMSMemberData)) {
+    if (!(obj instanceof GMSMemberData)) {
       return false;
     }
     return compareTo((GMSMemberData) obj) == 0;


### PR DESCRIPTION

A null check is not needed before using instanceof.
The expression `x instanceof SomeClass` is **false** if _x_ is _null_.



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
