### PR TITLE
GEODE-7800: Add Redis PSUBSCRIBE and PUNSUBSCRIBE commands

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubTest.java
@@ -33,7 +33,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.exceptions.JedisConnectionException;
 
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
@@ -193,11 +192,7 @@ public class PubSubTest {
     MockSubscriber mockSubscriber = new MockSubscriber();
 
     Runnable runnable = () -> {
-      // this will throw an exception when the socket is closed later in this test
-      try {
-        deadSubscriber.subscribe(mockSubscriber, "salutations");
-      } catch (JedisConnectionException e) {
-      }
+      deadSubscriber.subscribe(mockSubscriber, "salutations");
     };
 
     Thread subscriberThread = new Thread(runnable);
@@ -296,6 +291,8 @@ public class PubSubTest {
   }
 
   private void waitFor(Callable<Boolean> booleanCallable) {
-    await().atMost(1, TimeUnit.SECONDS).until(booleanCallable);
+    await().atMost(1, TimeUnit.SECONDS)
+        .ignoreExceptions() // ignoring socket closed exceptions
+        .until(booleanCallable);
   }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubTest.java
@@ -205,9 +205,8 @@ public class PubSubTest {
 
     subscriber.close();
 
-    // waitFor flaky in this case, temporarily replaced with assert until we fully understand the
-    // issue
     assertThat(subscriber.isConnected()).isFalse();
+    waitFor(() -> !subscriber.isConnected());
     Long result = publisher.publish("salutations", "hello");
 
     assertThat(result).isEqualTo(0);
@@ -306,6 +305,6 @@ public class PubSubTest {
   }
 
   private void waitFor(Callable<Boolean> booleanCallable) {
-    await().atMost(10, TimeUnit.SECONDS).until(booleanCallable);
+    await().atMost(1, TimeUnit.SECONDS).until(booleanCallable);
   }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubTest.java
@@ -18,13 +18,14 @@ package org.apache.geode.redis;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.AfterClass;
@@ -70,13 +71,12 @@ public class PubSubTest {
   }
 
   @Test
-  public void testOneSubscriberOneChannel() throws InterruptedException {
+  public void testOneSubscriberOneChannel() {
     Jedis subscriber = new Jedis("localhost", port);
     Jedis publisher = new Jedis("localhost", port);
     List<String> expectedMessages = Arrays.asList("hello");
 
-    CountDownLatch latch = new CountDownLatch(1);
-    MockSubscriber mockSubscriber = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber = new MockSubscriber();
 
     Runnable runnable = () -> {
       subscriber.subscribe(mockSubscriber, "salutations");
@@ -84,41 +84,31 @@ public class PubSubTest {
 
     Thread subscriberThread = new Thread(runnable);
     subscriberThread.start();
-
-    assertThat(latch.await(2, TimeUnit.SECONDS))
-        .as("channel subscriptions were not received")
-        .isTrue();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
 
     Long result = publisher.publish("salutations", "hello");
     assertThat(result).isEqualTo(1);
 
     mockSubscriber.unsubscribe("salutations");
-
-    subscriberThread.join(2000);
-
-    assertThat(subscriberThread.isAlive())
-        .as("subscriber thread should not be alive")
-        .isFalse();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
 
     assertThat(mockSubscriber.getReceivedMessages()).isEqualTo(expectedMessages);
   }
 
   @Test
-  public void testOneSubscriberSubscribingToTwoChannels() throws Exception {
+  public void testOneSubscriberSubscribingToTwoChannels() {
     Jedis subscriber = new Jedis("localhost", port);
     Jedis publisher = new Jedis("localhost", port);
     List<String> expectedMessages = Arrays.asList("hello", "howdy");
-    CountDownLatch latch = new CountDownLatch(2);
-    MockSubscriber mockSubscriber = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber = new MockSubscriber();
 
     Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "salutations", "yuletide");
 
     Thread subscriberThread = new Thread(runnable);
     subscriberThread.start();
 
-    assertThat(latch.await(2, TimeUnit.SECONDS))
-        .as("channel subscriptions were not received")
-        .isTrue();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
 
     Long result = publisher.publish("salutations", "hello");
     assertThat(result).isEqualTo(1);
@@ -126,28 +116,24 @@ public class PubSubTest {
     result = publisher.publish("yuletide", "howdy");
     assertThat(result).isEqualTo(1);
     mockSubscriber.unsubscribe("salutations");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
     mockSubscriber.unsubscribe("yuletide");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
 
-    subscriberThread.join(2000);
-
-    assertThat(subscriberThread.isAlive())
-        .as("subscriber thread should not be alive")
-        .isFalse();
 
     assertThat(mockSubscriber.getReceivedMessages()).isEqualTo(expectedMessages);
   }
 
   @Test
-  public void testTwoSubscribersOneChannel() throws Exception {
+  public void testTwoSubscribersOneChannel() {
     Jedis subscriber1 = new Jedis("localhost", port);
     Jedis subscriber2 = new Jedis("localhost", port);
     Jedis publisher = new Jedis("localhost", port);
-    CountDownLatch latch = new CountDownLatch(2);
-    MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
-    MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber1 = new MockSubscriber();
+    MockSubscriber mockSubscriber2 = new MockSubscriber();
 
     Runnable runnable1 = () -> subscriber1.subscribe(mockSubscriber1, "salutations");
-
     Runnable runnable2 = () -> subscriber2.subscribe(mockSubscriber2, "salutations");
 
     Thread subscriber1Thread = new Thread(runnable1);
@@ -155,78 +141,62 @@ public class PubSubTest {
     Thread subscriber2Thread = new Thread(runnable2);
     subscriber2Thread.start();
 
-    assertThat(latch.await(2, TimeUnit.SECONDS))
-        .as("channel subscriptions were not received")
-        .isTrue();
+    waitFor(() -> mockSubscriber1.getSubscribedChannels() == 1);
+    waitFor(() -> mockSubscriber2.getSubscribedChannels() == 1);
+
 
     Long result = publisher.publish("salutations", "hello");
     assertThat(result).isEqualTo(2);
     mockSubscriber1.unsubscribe("salutations");
-
-    subscriber1Thread.join(2000);
-
-    assertThat(subscriber1Thread.isAlive())
-        .as("subscriber1 thread should not be alive")
-        .isFalse();
+    waitFor(() -> mockSubscriber1.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriber1Thread.isAlive());
 
     result = publisher.publish("salutations", "goodbye");
     assertThat(result).isEqualTo(1);
     mockSubscriber2.unsubscribe("salutations");
-
-    subscriber2Thread.join(2000);
-    assertThat(subscriber2Thread.isAlive())
-        .as("subscriber2 thread should not be alive")
-        .isFalse();
+    waitFor(() -> mockSubscriber2.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriber2Thread.isAlive());
 
     assertThat(mockSubscriber1.getReceivedMessages()).isEqualTo(Collections.singletonList("hello"));
     assertThat(mockSubscriber2.getReceivedMessages()).isEqualTo(Arrays.asList("hello", "goodbye"));
   }
 
   @Test
-  public void testPublishToNonexistentChannel() throws Exception {
+  public void testPublishToNonexistentChannel() {
     Jedis publisher = new Jedis("localhost", port);
     Long result = publisher.publish("thisChannelDoesn'tExist", "hello");
     assertThat(result).isEqualTo(0);
   }
 
   @Test
-  public void testOneSubscriberOneChannelTwoTimes() throws Exception {
+  public void testOneSubscriberOneChannelTwoTimes() {
     Jedis subscriber = new Jedis("localhost", port);
     Jedis publisher = new Jedis("localhost", port);
-    CountDownLatch latch = new CountDownLatch(2);
-    MockSubscriber mockSubscriber = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber = new MockSubscriber();
 
     Runnable runnable1 = () -> subscriber.subscribe(mockSubscriber, "salutations", "salutations");
 
     Thread subscriberThread = new Thread(runnable1);
     subscriberThread.start();
 
-    assertThat(latch.await(2, TimeUnit.SECONDS))
-        .as("channel subscriptions were not received")
-        .isTrue();
-    assertThat(mockSubscriber.getSubscribedChannels()).isEqualTo(1);
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
 
     Long result = publisher.publish("salutations", "hello");
     assertThat(result).isEqualTo(1);
 
     mockSubscriber.unsubscribe("salutations");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
 
-    subscriberThread.join(2000);
-
-    assertThat(subscriberThread.isAlive())
-        .as("subscriber1 thread should not be alive")
-        .isFalse();
-
+    waitFor(() -> !subscriberThread.isAlive());
     assertThat(mockSubscriber.getReceivedMessages()).isEqualTo(Collections.singletonList("hello"));
   }
 
   @Test
-  public void testDeadSubscriber() throws InterruptedException {
+  public void testDeadSubscriber() {
     Jedis subscriber = new Jedis("localhost", port);
     Jedis publisher = new Jedis("localhost", port);
 
-    CountDownLatch latch = new CountDownLatch(1);
-    MockSubscriber mockSubscriber = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber = new MockSubscriber();
 
     Runnable runnable = () -> {
       subscriber.subscribe(mockSubscriber, "salutations");
@@ -234,21 +204,109 @@ public class PubSubTest {
 
     Thread subscriberThread = new Thread(runnable);
     subscriberThread.start();
-
-    assertThat(latch.await(2, TimeUnit.SECONDS))
-        .as("channel subscriptions were not received")
-        .isTrue();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
 
     subscriber.close();
-    subscriberThread.join(2000);
-
-    assertThat(subscriberThread.isAlive())
-        .as("subscriber thread should not be alive")
-        .isFalse();
+    waitFor(() -> !subscriberThread.isAlive());
 
     Long result = publisher.publish("salutations", "hello");
     assertThat(result).isEqualTo(0);
 
     assertThat(mockSubscriber.getReceivedMessages()).isEmpty();
+  }
+
+  @Test
+  public void testPatternSubscribe() {
+    Jedis subscriber = new Jedis("localhost", port);
+    Jedis publisher = new Jedis("localhost", port);
+
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> {
+      subscriber.psubscribe(mockSubscriber, "sal*s");
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+    Long result = publisher.publish("salutations", "hello");
+    assertThat(result).isEqualTo(1);
+
+    assertThat(mockSubscriber.getReceivedMessages()).hasSize(1);
+    assertThat(mockSubscriber.getReceivedMessages()).contains("hello");
+
+    mockSubscriber.punsubscribe("sal*s");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
+  }
+
+  @Test
+  public void testPatternAndRegularSubscribe() {
+    Jedis subscriber = new Jedis("localhost", port);
+    Jedis publisher = new Jedis("localhost", port);
+
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> {
+      subscriber.subscribe(mockSubscriber, "salutations");
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+    mockSubscriber.psubscribe("sal*s");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+
+    Long result = publisher.publish("salutations", "hello");
+    assertThat(result).isEqualTo(2);
+
+    mockSubscriber.punsubscribe("sal*s");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+    mockSubscriber.unsubscribe("salutations");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+
+    waitFor(() -> !subscriberThread.isAlive());
+
+    assertThat(mockSubscriber.getReceivedMessages()).containsExactly("hello", "hello");
+  }
+
+  @Test
+  public void testPatternWithoutAGlob() {
+    Jedis subscriber = new Jedis("localhost", port);
+    Jedis publisher = new Jedis("localhost", port);
+
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> {
+      subscriber.subscribe(mockSubscriber, "salutations");
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+    mockSubscriber.psubscribe("salutations");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+
+    Long result = publisher.publish("salutations", "hello");
+    assertThat(result).isEqualTo(2);
+
+    mockSubscriber.punsubscribe("salutations");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+    mockSubscriber.unsubscribe("salutations");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+
+    waitFor(() -> !subscriberThread.isAlive());
+
+    assertThat(mockSubscriber.getReceivedMessages()).containsExactly("hello", "hello");
+  }
+
+  private void waitFor(Callable<Boolean> booleanCallable) {
+    await().atMost(1, TimeUnit.SECONDS).until(booleanCallable);
   }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -18,29 +18,23 @@ package org.apache.geode.redis.mocks;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 import redis.clients.jedis.JedisPubSub;
 
 public class MockSubscriber extends JedisPubSub {
-  private CountDownLatch latch;
-  private List<String> receivedMessages = new ArrayList<String>();
-
-  public MockSubscriber(CountDownLatch latch) {
-    this.latch = latch;
-  }
+  private List<String> receivedMessages = new ArrayList<>();
 
   public List<String> getReceivedMessages() {
     return receivedMessages;
   }
 
   @Override
-  public void onSubscribe(String channel, int subscribedChannels) {
-    latch.countDown();
+  public void onMessage(String channel, String message) {
+    receivedMessages.add(message);
   }
 
   @Override
-  public void onMessage(String channel, String message) {
+  public void onPMessage(String pattern, String channel, String message) {
     receivedMessages.add(message);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -75,6 +75,7 @@ import org.apache.geode.redis.internal.PubSub;
 import org.apache.geode.redis.internal.PubSubImpl;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.Subscriptions;
 
 /**
  * The GeodeRedisServer is a server that understands the Redis protocol. As commands are sent to the
@@ -450,7 +451,7 @@ public class GeodeRedisServer {
         throw assErr;
       }
       this.keyRegistrar = new KeyRegistrar(redisMetaData);
-      this.pubSub = new PubSubImpl();
+      this.pubSub = new PubSubImpl(new Subscriptions());
       this.regionCache = new RegionProvider(stringsRegion, hLLRegion, this.keyRegistrar,
           expirationFutures, expirationExecutor, this.DEFAULT_REGION_TYPE);
       redisMetaData.put(REDIS_META_DATA_REGION, RedisDataType.REDIS_PROTECTED);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ChannelSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ChannelSubscription.java
@@ -11,39 +11,35 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package org.apache.geode.redis.internal;
 
-import java.util.Objects;
+/**
+ * This class represents a single channel subscription as created by the SUBSCRIBE command
+ */
+class ChannelSubscription extends AbstractSubscription {
+  private String channel;
 
-import io.netty.channel.Channel;
+  public ChannelSubscription(Client client, String channel, ExecutionHandlerContext context) {
+    super(client, context);
 
-public class Client {
-  private Channel channel;
-
-  public Client(Channel remoteAddress) {
-    this.channel = remoteAddress;
+    if (channel == null) {
+      throw new IllegalArgumentException("channel cannot be null");
+    }
+    this.channel = channel;
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Client client = (Client) o;
-    return Objects.equals(channel, client.channel);
+  public boolean isEqualTo(Object channelOrPattern, Client client) {
+    return this.channel != null && this.channel.equals(channelOrPattern)
+        && this.getClient().equals(client);
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(channel);
+  public boolean matches(String channel) {
+    return this.channel.equals(channel);
   }
 
-  public boolean isDead() {
-    return !this.channel.isOpen();
-  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PatternSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PatternSubscription.java
@@ -11,39 +11,37 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package org.apache.geode.redis.internal;
 
-import java.util.Objects;
+import org.apache.geode.redis.internal.org.apache.hadoop.fs.GlobPattern;
 
-import io.netty.channel.Channel;
+/**
+ * This class represents a pattern subscription as created by the PSUBSCRIBE command
+ */
+class PatternSubscription extends AbstractSubscription {
+  final GlobPattern pattern;
 
-public class Client {
-  private Channel channel;
+  public PatternSubscription(Client client, GlobPattern pattern, ExecutionHandlerContext context) {
+    super(client, context);
 
-  public Client(Channel remoteAddress) {
-    this.channel = remoteAddress;
+    if (pattern == null) {
+      throw new IllegalArgumentException("pattern cannot be null");
+    }
+    this.pattern = pattern;
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Client client = (Client) o;
-    return Objects.equals(channel, client.channel);
+  public boolean isEqualTo(Object channelOrPattern, Client client) {
+    return this.pattern != null && this.pattern.equals(channelOrPattern)
+        && this.getClient().equals(client);
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(channel);
+  public boolean matches(String channel) {
+    return pattern.matches(channel);
   }
 
-  public boolean isDead() {
-    return !this.channel.isOpen();
-  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PubSub.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.redis.internal;
 
+import org.apache.geode.redis.internal.org.apache.hadoop.fs.GlobPattern;
+
 /**
  * Interface that represents the ability to Publish, Subscribe and Unsubscribe from channels.
  */
@@ -41,6 +43,16 @@ public interface PubSub {
   long subscribe(String channel, ExecutionHandlerContext context, Client client);
 
   /**
+   * Subscribe to a pattern
+   *
+   * @param pattern glob pattern to subscribe to
+   * @param context ExecutionHandlerContext which will handle the client response
+   * @param client a Client instance making the request
+   * @return the number of channels subscribed to
+   */
+  long psubscribe(GlobPattern pattern, ExecutionHandlerContext context, Client client);
+
+  /**
    * Unsubscribe a client from a channel
    *
    * @param channel the channel to unsubscribe from
@@ -48,4 +60,13 @@ public interface PubSub {
    * @return the number of channels still subscribed to by the client
    */
   long unsubscribe(String channel, Client client);
+
+  /**
+   * Unsubscribe from a previously subscribed pattern
+   *
+   * @param pattern the channel to unsubscribe from
+   * @param client the Client which is to be unsubscribed
+   * @return the number of channels still subscribed to by the client
+   */
+  long punsubscribe(GlobPattern pattern, Client client);
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResult.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResult.java
@@ -14,6 +14,7 @@
  */
 
 package org.apache.geode.redis.internal;
+
 /**
  * Represents the results of publishing a message to a subscription. Contains the client the message
  * was published to as well as whether or not the message was published successfully.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResult.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResult.java
@@ -1,5 +1,19 @@
-package org.apache.geode.redis.internal;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
+package org.apache.geode.redis.internal;
 /**
  * Represents the results of publishing a message to a subscription. Contains the client the message
  * was published to as well as whether or not the message was published successfully.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResult.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResult.java
@@ -1,0 +1,23 @@
+package org.apache.geode.redis.internal;
+
+/**
+ * Represents the results of publishing a message to a subscription. Contains the client the message
+ * was published to as well as whether or not the message was published successfully.
+ */
+public class PublishResult {
+  private final Client client;
+  private final boolean result;
+
+  public PublishResult(Client client, boolean result) {
+    this.client = client;
+    this.result = result;
+  }
+
+  public Client getClient() {
+    return client;
+  }
+
+  public boolean isSuccessful() {
+    return result;
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -66,7 +66,9 @@ import org.apache.geode.redis.internal.executor.list.LTrimExecutor;
 import org.apache.geode.redis.internal.executor.list.RPopExecutor;
 import org.apache.geode.redis.internal.executor.list.RPushExecutor;
 import org.apache.geode.redis.internal.executor.list.RPushXExecutor;
+import org.apache.geode.redis.internal.executor.pubsub.PsubscribeExecutor;
 import org.apache.geode.redis.internal.executor.pubsub.PublishExecutor;
+import org.apache.geode.redis.internal.executor.pubsub.PunsubscribeExecutor;
 import org.apache.geode.redis.internal.executor.pubsub.SubscribeExecutor;
 import org.apache.geode.redis.internal.executor.pubsub.UnsubscribeExecutor;
 import org.apache.geode.redis.internal.executor.set.SAddExecutor;
@@ -2624,6 +2626,10 @@ public enum RedisCommandType {
       return this.dataType;
     }
   },
+
+  /**
+   * PUBLISH channel message
+   */
   PUBLISH {
     private Executor executor;
 
@@ -2642,6 +2648,10 @@ public enum RedisCommandType {
       return this.dataType;
     }
   },
+
+  /**
+   * UNSUBSCRIBE channel...
+   */
   UNSUBSCRIBE {
     private Executor executor;
 
@@ -2649,6 +2659,52 @@ public enum RedisCommandType {
     public Executor getExecutor() {
       if (executor == null) {
         executor = new UnsubscribeExecutor();
+      }
+      return executor;
+    }
+
+    private final RedisDataType dataType = RedisDataType.REDIS_PUBSUB;
+
+    @Override
+    public RedisDataType getDataType() {
+      return this.dataType;
+    }
+  },
+
+  /**
+   * PSUBSCRIBE channel-pattern...
+   * <p>
+   * subscribe to channel
+   */
+  PSUBSCRIBE {
+    private Executor executor;
+
+    @Override
+    public Executor getExecutor() {
+      if (executor == null) {
+        executor = new PsubscribeExecutor();
+      }
+      return executor;
+    }
+
+    private final RedisDataType dataType = RedisDataType.REDIS_PUBSUB;
+
+    @Override
+    public RedisDataType getDataType() {
+      return this.dataType;
+    }
+  },
+
+  /**
+   * PUNSUBSCRIBE channel...
+   */
+  PUNSUBSCRIBE {
+    private Executor executor;
+
+    @Override
+    public Executor getExecutor() {
+      if (executor == null) {
+        executor = new PunsubscribeExecutor();
       }
       return executor;
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscription.java
@@ -11,39 +11,33 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 
 package org.apache.geode.redis.internal;
 
-import java.util.Objects;
+/**
+ * Interface that represents the relationship between a channel or pattern and client.
+ */
+public interface Subscription {
+  /**
+   * Equality of a subscription is represented by a combination of client and one of channel or
+   * pattern
+   */
+  boolean isEqualTo(Object channelOrPattern, Client client);
 
-import io.netty.channel.Channel;
+  /**
+   * Will publish a message to the designated channel.
+   */
+  PublishResult publishMessage(String channel, String message);
 
-public class Client {
-  private Channel channel;
+  /**
+   * Verifies that the subscription is established with the designated client.
+   */
+  boolean matchesClient(Client client);
 
-  public Client(Channel remoteAddress) {
-    this.channel = remoteAddress;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    Client client = (Client) o;
-    return Objects.equals(channel, client.channel);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(channel);
-  }
-
-  public boolean isDead() {
-    return !this.channel.isOpen();
-  }
+  /**
+   * Verifies that the subscription channel or pattern matches the designated channel.
+   */
+  boolean matches(String channel);
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscriptions.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscriptions.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Class that manages both channel and pattern subscriptions.
+ */
+public class Subscriptions {
+  private List<Subscription> subscriptions = new ArrayList<>();
+
+  /**
+   * Check whether a given client has already subscribed to a channel or pattern
+   *
+   * @param channelOrPattern channel or pattern
+   * @param client a client connection
+   */
+  public boolean exists(Object channelOrPattern, Client client) {
+    return subscriptions.stream()
+        .anyMatch(subscription -> subscription.isEqualTo(channelOrPattern, client));
+  }
+
+  /**
+   * Return all subscriptions for a given client
+   *
+   * @param client the subscribed client
+   * @return a list of subscriptions
+   */
+  public List<Subscription> findSubscriptions(Client client) {
+    return subscriptions.stream()
+        .filter(subscription -> subscription.matchesClient(client))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Return all subscriptions for a given channel or pattern
+   *
+   * @param channelOrPattern the channel or pattern
+   * @return a list of subscriptions
+   */
+  public List<Subscription> findSubscriptions(String channelOrPattern) {
+    return this.subscriptions.stream()
+        .filter(subscription -> subscription.matches(channelOrPattern))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Add a new subscription
+   */
+  public void add(Subscription subscription) {
+    this.subscriptions.add(subscription);
+  }
+
+  /**
+   * Remove all subscriptions for a given client
+   */
+  public void remove(Client client) {
+    this.subscriptions.removeIf(subscription -> subscription.matchesClient(client));
+  }
+
+  /**
+   * Remove a single subscription
+   */
+  public void remove(Object channel, Client client) {
+    this.subscriptions.removeIf(subscription -> subscription.isEqualTo(channel, client));
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal.executor.pubsub;
+
+import java.util.ArrayList;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.Coder;
+import org.apache.geode.redis.internal.CoderException;
+import org.apache.geode.redis.internal.Command;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.executor.AbstractExecutor;
+import org.apache.geode.redis.internal.org.apache.hadoop.fs.GlobPattern;
+
+public class PsubscribeExecutor extends AbstractExecutor {
+  private static final Logger logger = LogService.getLogger();
+
+  @Override
+  public void executeCommand(Command command, ExecutionHandlerContext context) {
+    ArrayList<ArrayList<Object>> items = new ArrayList<>();
+    for (int i = 1; i < command.getProcessedCommand().size(); i++) {
+      ArrayList<Object> item = new ArrayList<>();
+      byte[] pattern = command.getProcessedCommand().get(i);
+      long subscribedChannels =
+          context.getPubSub().psubscribe(
+              new GlobPattern(new String(pattern)), context, context.getClient());
+
+      item.add("psubscribe");
+      item.add(pattern);
+      item.add(subscribedChannels);
+
+      items.add(item);
+    }
+
+    writeResponse(command, context, items);
+  }
+
+  private void writeResponse(Command command, ExecutionHandlerContext context,
+      ArrayList<ArrayList<Object>> items) {
+    ByteBuf aggregatedResponse = context.getByteBufAllocator().buffer();
+    items.forEach(item -> {
+      ByteBuf response = null;
+      try {
+        response = Coder.getArrayResponse(context.getByteBufAllocator(), item);
+      } catch (CoderException e) {
+        logger.warn("Error encoding subscribe response", e);
+      }
+      aggregatedResponse.writeBytes(response);
+    });
+    command.setResponse(aggregatedResponse);
+  }
+
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/org/apache/hadoop/fs/GlobPattern.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/org/apache/hadoop/fs/GlobPattern.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.org.apache.hadoop.fs;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -157,6 +158,23 @@ public class GlobPattern {
    */
   public boolean hasWildcard() {
     return hasWildcard;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof GlobPattern)) {
+      return false;
+    }
+    GlobPattern that = (GlobPattern) o;
+    return this.compiled.pattern().equals(that.compiled.pattern());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(compiled, hasWildcard);
   }
 
   private static void error(String message, String pattern, int pos) {

--- a/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
+++ b/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
@@ -31,6 +31,8 @@ org/apache/geode/redis/internal/RedisCommandType$12,false,dataType:org/apache/ge
 org/apache/geode/redis/internal/RedisCommandType$120,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor
 org/apache/geode/redis/internal/RedisCommandType$121,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor
 org/apache/geode/redis/internal/RedisCommandType$122,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor
+org/apache/geode/redis/internal/RedisCommandType$123,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor
+org/apache/geode/redis/internal/RedisCommandType$124,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor
 org/apache/geode/redis/internal/RedisCommandType$13,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor
 org/apache/geode/redis/internal/RedisCommandType$14,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor
 org/apache/geode/redis/internal/RedisCommandType$15,false,dataType:org/apache/geode/redis/internal/RedisDataType,executor:org/apache/geode/redis/internal/Executor

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/PubSubImplJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/PubSubImplJUnitTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+
+public class PubSubImplJUnitTest {
+
+  @Test
+  public void testSubscriptionWithDeadClientIsPruned() {
+    Subscriptions subscriptions = new Subscriptions();
+    ExecutionHandlerContext mockExecutionHandlerContext = mock(ExecutionHandlerContext.class);
+
+    Client deadClient = mock(Client.class);
+    when(deadClient.isDead()).thenReturn(true);
+
+    ChannelSubscription subscription =
+        spy(new ChannelSubscription(deadClient,
+            "sally", mockExecutionHandlerContext));
+
+    doReturn(new PublishResult(deadClient, false)).when(subscription).publishMessage(any(), any());
+    subscriptions.add(subscription);
+
+    PubSubImpl subject = new PubSubImpl(subscriptions);
+
+    Long numberOfSubscriptions = subject.publishMessageToSubscribers("sally", "message");
+
+    assertThat(numberOfSubscriptions).isEqualTo(0);
+    assertThat(subscriptions.findSubscriptions(deadClient)).isEmpty();
+  }
+}

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/SubscriptionsTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/SubscriptionsTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.netty.channel.Channel;
+import org.junit.Test;
+
+import org.apache.geode.redis.internal.org.apache.hadoop.fs.GlobPattern;
+
+public class SubscriptionsTest {
+
+  @Test
+  public void correctlyIdentifiesChannelSubscriber() {
+    Subscriptions subscriptions = new Subscriptions();
+
+    Channel channel = mock(Channel.class);
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    Client client = new Client(channel);
+
+    subscriptions.add(new ChannelSubscription(client, "subscriptions", context));
+
+    assertThat(subscriptions.exists("subscriptions", client)).isTrue();
+    assertThat(subscriptions.exists("unknown", client)).isFalse();
+  }
+
+  @Test
+  public void correctlyIdentifiesPatternSubscriber() {
+    Subscriptions subscriptions = new Subscriptions();
+
+    Channel channel = mock(Channel.class);
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    Client client = new Client(channel);
+    GlobPattern pattern = new GlobPattern("sub*s");
+
+    subscriptions.add(new PatternSubscription(client, pattern, context));
+
+    assertThat(subscriptions.exists(pattern, client)).isTrue();
+  }
+
+  @Test
+  public void doesNotMisidentifyChannelAsPattern() {
+    Subscriptions subscriptions = new Subscriptions();
+
+    Channel channel = mock(Channel.class);
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    Client client = new Client(channel);
+    GlobPattern globPattern1 = new GlobPattern("sub*s");
+    GlobPattern globPattern2 = new GlobPattern("subscriptions");
+
+    subscriptions.add(new ChannelSubscription(client, "subscriptions", context));
+
+    assertThat(subscriptions.exists(globPattern1, client)).isFalse();
+    assertThat(subscriptions.exists(globPattern2, client)).isFalse();
+  }
+
+  @Test
+  public void doesNotMisidentifyWhenBothTypesArePresent() {
+    Subscriptions subscriptions = new Subscriptions();
+
+    Channel channel = mock(Channel.class);
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    Client client = new Client(channel);
+    GlobPattern globby = new GlobPattern("sub*s");
+
+    subscriptions.add(new ChannelSubscription(client, "subscriptions", context));
+    subscriptions.add(new PatternSubscription(client, globby, context));
+
+    assertThat(subscriptions.exists(globby, client)).isTrue();
+    assertThat(subscriptions.exists("subscriptions", client)).isTrue();
+  }
+
+
+  @Test
+  public void verifyDifferentMockChannelsNotEqual() {
+    Channel mockChannelOne = mock(Channel.class);
+    Channel mockChannelTwo = mock(Channel.class);
+
+    assertThat(mockChannelOne).isNotEqualTo(mockChannelTwo);
+    assertThat(mockChannelOne.equals(mockChannelTwo)).isFalse();
+  }
+
+  @Test
+  public void findSubscribers() {
+    Subscriptions subscriptions = new Subscriptions();
+
+    Channel mockChannelOne = mock(Channel.class);
+    Channel mockChannelTwo = mock(Channel.class);
+
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    Client clientOne = new Client(mockChannelOne);
+    Client clientTwo = new Client(mockChannelTwo);
+
+    ChannelSubscription subscriptionOne =
+        new ChannelSubscription(clientOne, "subscriptions", context);
+    ChannelSubscription subscriptionTwo = new ChannelSubscription(clientTwo, "monkeys", context);
+
+    subscriptions.add(subscriptionOne);
+    subscriptions.add(subscriptionTwo);
+
+    assertThat(subscriptions.findSubscriptions(clientOne)).containsExactly(subscriptionOne);
+  }
+
+  @Test
+  public void removeByClient() {
+    Subscriptions subscriptions = new Subscriptions();
+    Channel mockChannelOne = mock(Channel.class);
+    Channel mockChannelTwo = mock(Channel.class);
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    Client clientOne = new Client(mockChannelOne);
+    Client clientTwo = new Client(mockChannelTwo);
+
+    ChannelSubscription subscriptionOne =
+        new ChannelSubscription(clientOne, "subscriptions", context);
+    ChannelSubscription subscriptionTwo = new ChannelSubscription(clientTwo, "monkeys", context);
+
+    subscriptions.add(subscriptionOne);
+    subscriptions.add(subscriptionTwo);
+
+    subscriptions.remove(clientOne);
+
+    assertThat(subscriptions.findSubscriptions(clientOne)).isEmpty();
+    assertThat(subscriptions.findSubscriptions(clientTwo)).containsExactly(subscriptionTwo);
+  }
+
+  @Test
+  public void removeByClientAndPattern() {
+
+    Subscriptions subscriptions = new Subscriptions();
+    Channel mockChannelOne = mock(Channel.class);
+
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    Client client = new Client(mockChannelOne);
+
+    ChannelSubscription channelSubscriberOne =
+        new ChannelSubscription(client, "subscriptions", context);
+    GlobPattern pattern = new GlobPattern("monkeys");
+    PatternSubscription patternSubscriber = new PatternSubscription(client,
+        pattern, context);
+    ChannelSubscription channelSubscriberTwo = new ChannelSubscription(client, "monkeys", context);
+
+    subscriptions.add(channelSubscriberOne);
+    subscriptions.add(patternSubscriber);
+    subscriptions.add(channelSubscriberTwo);
+
+    subscriptions.remove(pattern, client);
+
+    assertThat(subscriptions
+        .findSubscriptions(client))
+            .containsExactlyInAnyOrder(
+                channelSubscriberOne,
+                channelSubscriberTwo);
+  }
+}


### PR DESCRIPTION
Similar to `SUBSCRIBE` and `UNSUBSCRIBE`, `PSUBSCRIBE` allows a client
to subscribe to a pattern. For example: `PSUBSCRIBE sal*s`

The subscription pattern is in the form of a glob supporting `*`, `?`
and ranges. https://redis.io/commands/psubscribe

Pattern subscriptions must be unsubscribed verbatim. i.e., the above
subscription would not be unsubscribed using the pattern `s*`, but must
be unsubscribed using the complete subscribed pattern, namely `sal*s`.

When clients subscribe to overlapping patterns (or channels) they will
receive a message for every matched subscription. Matches for a single
client are not conflated.

Co-authored-by: Sarah Abbey <sabbey@pivotal.io>
Co-authored-by: John Hutchison <jhutchison@pivotal.io>
Co-authored-by: Jens Deppe <jdeppe@pivotal.io>
Co-authored-by: Murtuza Boxwala <mboxwala@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
