### PR TITLE
Feature/geode 7796: CI hang in LocatorDUnitTest.testCrashLocatorMultipleTimes

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -72,6 +72,7 @@ import java.util.Set;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -255,6 +256,7 @@ public class LocatorDUnitTest implements Serializable {
   }
 
   @Test
+  @Ignore("GEODE=7760 - test sometimes hangs due to product issue")
   public void testCrashLocatorMultipleTimes() throws Exception {
     port1 = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
     DistributedTestUtils.deleteLocatorStateFile(port1);

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -72,7 +72,6 @@ import java.util.Set;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -256,7 +255,6 @@ public class LocatorDUnitTest implements Serializable {
   }
 
   @Test
-  @Ignore("GEODE=7760 - test sometimes hangs due to product issue")
   public void testCrashLocatorMultipleTimes() throws Exception {
     port1 = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
     DistributedTestUtils.deleteLocatorStateFile(port1);
@@ -270,11 +268,14 @@ public class LocatorDUnitTest implements Serializable {
     properties.put(MAX_WAIT_TIME_RECONNECT, "" + (3 * memberTimeoutMS));
     // since we're restarting location services let's be a little forgiving about that service
     // starting up so that stress-tests can pass
-    properties.put(LOCATOR_WAIT_TIME, "" + (3 * memberTimeoutMS));
+    properties.put(LOCATOR_WAIT_TIME, "" + 3);
     addDSProps(properties);
     if (stateFile.exists()) {
       assertThat(stateFile.delete()).isTrue();
     }
+
+    IgnoredException
+        .addIgnoredException("Possible loss of quorum due to the loss of 1 cache processes");
 
     Locator locator = Locator.startLocatorAndDS(port1, logFile, properties);
     system = (InternalDistributedSystem) locator.getDistributedSystem();

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -919,7 +919,7 @@ public class DistributionImpl implements Distribution {
       // network-down testing
       InternalLocator loc = (InternalLocator) Locator.getLocator();
       if (loc != null) {
-        loc.stop(true, !distribution.disableAutoReconnect, false);
+        loc.stop(true, !distribution.disableAutoReconnect, true);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalDistributedSystem.java
@@ -962,13 +962,6 @@ public class InternalDistributedSystem extends DistributedSystem
   }
 
   /**
-   * record a locator as a dependent of this distributed system
-   */
-  void setDependentLocator(InternalLocator theLocator) {
-    startedLocator = theLocator;
-  }
-
-  /**
    * Used by DistributionManager to fix bug 33362
    */
   void setDM(DistributionManager dm) {
@@ -1624,8 +1617,8 @@ public class InternalDistributedSystem extends DistributedSystem
           dm.close();
           // we close the locator after the DM so that when split-brain detection
           // is enabled, loss of the locator doesn't cause the DM to croak
-          if (startedLocator != null && !isReconnectingDS) {
-            startedLocator.stop(forcedDisconnect, preparingForReconnect, false);
+          if (startedLocator != null) {
+            startedLocator.stop(forcedDisconnect, preparingForReconnect, true);
             startedLocator = null;
           }
         } finally { // timer canceled

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -1272,6 +1272,10 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
       services.setShutdownCause(e);
     }
 
+    if (cleanupTimer != null && !cleanupTimer.isShutdown()) {
+      cleanupTimer.shutdownNow();
+    }
+
     lifecycleListener.disconnect(e);
 
     // first shut down communication so we don't do any more harm to other
@@ -1914,7 +1918,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
         }
       }
 
-      if (cleanupTimer != null) {
+      if (cleanupTimer != null && !cleanupTimer.isShutdown()) {
         cleanupTimer.shutdown();
       }
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/MembershipLocatorImpl.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/locator/MembershipLocatorImpl.java
@@ -23,6 +23,7 @@ import java.net.SocketAddress;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.apache.logging.log4j.Logger;
@@ -181,10 +182,11 @@ public class MembershipLocatorImpl<ID extends MemberIdentifier> implements Membe
       }
 
       boolean interrupted = Thread.interrupted();
+      long waitTimeMillis = TcpServer.SHUTDOWN_WAIT_TIME * 2;
       try {
         // TcpServer up to SHUTDOWN_WAIT_TIME for its executor pool to shut down.
         // We wait 2 * SHUTDOWN_WAIT_TIME here to account for that shutdown, and then our own.
-        waitToShutdown(TcpServer.SHUTDOWN_WAIT_TIME * 2);
+        waitToShutdown(waitTimeMillis);
 
       } catch (InterruptedException ex) {
         interrupted = true;
@@ -198,7 +200,8 @@ public class MembershipLocatorImpl<ID extends MemberIdentifier> implements Membe
       }
 
       if (isAlive()) {
-        logger.fatal("Could not stop {} in 60 seconds", this);
+        logger.fatal("Could not stop {} in {} seconds", this,
+            TimeUnit.MILLISECONDS.toSeconds(waitTimeMillis));
       }
     }
   }

--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpServer.java
@@ -164,7 +164,9 @@ public class TcpServer {
   public void restarting() throws IOException {
     this.shuttingDown = false;
     startServerThread();
-    this.executor = executorServiceSupplier.get();
+    if (this.executor == null || this.executor.isShutdown()) {
+      this.executor = executorServiceSupplier.get();
+    }
     logger.info("TcpServer@" + System.identityHashCode(this)
         + " restarting: completed.  Server thread=" + this.serverThread + '@'
         + System.identityHashCode(this.serverThread) + ";alive=" + this.serverThread.isAlive());


### PR DESCRIPTION
This reinstates the test (removes Ignore annotation) and fixes the underlying problems...

    To fix the "hang" I reduced the locator-wait-time (seconds, not millis) in the test

    I also made several other changes to fix the underlying failure:
      1) add a synchronization to the services restart thread so only one
      thread is active at a time
      2) shut down membership cleanup executor and avoid creating multiple
      TcpServer executors on auto-reconnect
      3) remove setting the locator as a dependent of the
      InternalDistributedSystem.  This was causing locator.stop() to be
      invoked multiple times (as Dale noticed in his analysis)
      4) when stopping a locator for auto-reconnect wait for it to stop in
      order to avoid creating multiple restart threads when there are
      cascading failures.



Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
