### PR TITLE
Revert "GEODE-7727: modify sender thread to detect release of connect…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/DistributedSystemMXBeanWithAlertsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/DistributedSystemMXBeanWithAlertsDistributedTest.java
@@ -137,7 +137,6 @@ public class DistributedSystemMXBeanWithAlertsDistributedTest implements Seriali
     memberVM3 = getVM(3);
 
     managerMember = managerVM.invoke(() -> createManager());
-    IgnoredException.addIgnoredException("Cannot form connection to alert listener");
 
     for (VM memberVM : toArray(memberVM1, memberVM2, memberVM3)) {
       memberVM.invoke(() -> {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.SystemFailure;
 import org.apache.geode.alerting.internal.spi.AlertingAction;
-import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
@@ -917,17 +916,6 @@ public class ConnectionTable {
       }
     }
   }
-
-  @VisibleForTesting
-  public static int getNumSenderSharedConnections() {
-    ConnectionTable ct = (ConnectionTable) lastInstance.get();
-    if (ct == null) {
-      return 0;
-    }
-    return (ct.getConduit().getStats().getSendersSU());
-  }
-
-
 
   /**
    * Clears lastInstance. Does not yet close underlying sockets, but probably not strictly


### PR DESCRIPTION
…ion (#4629)"

In internal tests, this commit was identified as causing deadlocks. Until the root cause can be discovered and addressed, we propose reverting the change.

This reverts commit 1a0d9769e482f49e0c725c0d6adc75d324f88958.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
