### PR TITLE
GEODE-7810: Change alert listener connection warning from fatal

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -2,6 +2,7 @@ org/apache/geode/GemFireCacheException
 org/apache/geode/admin/AlertLevel
 org/apache/geode/alerting/internal/AlertingSession$State
 org/apache/geode/alerting/internal/spi/AlertLevel
+org/apache/geode/alerting/internal/spi/AlertingIOException
 org/apache/geode/cache/operations/internal/UpdateOnlyMap
 org/apache/geode/cache/query/internal/index/CompactRangeIndex$1
 org/apache/geode/cache/query/internal/DefaultQuery$TestHook$SPOTS

--- a/geode-core/src/main/java/org/apache/geode/alerting/internal/spi/AlertingIOException.java
+++ b/geode-core/src/main/java/org/apache/geode/alerting/internal/spi/AlertingIOException.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.alerting.internal.spi;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * Wraps an {@link IOException} that is thrown while attempting to notify an alert listener.
+ */
+public class AlertingIOException extends UncheckedIOException {
+
+  private static final long serialVersionUID = 3702403276743962841L;
+
+  public AlertingIOException(IOException cause) {
+    super(cause);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
@@ -91,7 +91,8 @@ public class TCPConduitTest {
         tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
       });
 
-      assertThat(thrown).isInstanceOf(AlertingIOException.class);
+      assertThat(thrown)
+          .isInstanceOf(AlertingIOException.class);
     });
   }
 
@@ -116,7 +117,8 @@ public class TCPConduitTest {
 
     Connection value = tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
 
-    assertThat(value).isSameAs(connection);
+    assertThat(value)
+        .isSameAs(connection);
   }
 
   @Test
@@ -135,7 +137,9 @@ public class TCPConduitTest {
       tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
     });
 
-    assertThat(thrown).isNotInstanceOf(AlertingIOException.class);
+    assertThat(thrown)
+        .isInstanceOf(IOException.class)
+        .isNotInstanceOf(AlertingIOException.class);
   }
 
   @Test
@@ -184,8 +188,7 @@ public class TCPConduitTest {
 
     assertThat(thrown)
         .isInstanceOf(DistributedSystemDisconnectedException.class)
-        .hasMessage("Abandoned because shutdown is in progress")
-        .isNotInstanceOf(AlertingIOException.class);
+        .hasMessage("Abandoned because shutdown is in progress");
   }
 
   @Test
@@ -211,7 +214,6 @@ public class TCPConduitTest {
 
     assertThat(thrown)
         .isInstanceOf(DistributedSystemDisconnectedException.class)
-        .hasMessage("Abandoned because shutdown is in progress")
-        .isNotInstanceOf(AlertingIOException.class);
+        .hasMessage("Abandoned because shutdown is in progress");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
@@ -76,8 +76,7 @@ public class TCPConduitTest {
       throws Exception {
     TCPConduit tcpConduit =
         new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
-            TCPConduit -> connectionTable, socketCreator, () -> {
-            }, false);
+            TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
         .when(connectionTable).get(eq(member), anyBoolean(), anyLong(), anyLong(), anyLong());
@@ -100,8 +99,7 @@ public class TCPConduitTest {
   public void getConnectionRethrows_ifCaughtIOException_whileNotAlerting() throws Exception {
     TCPConduit tcpConduit =
         new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
-            TCPConduit -> connectionTable, socketCreator, () -> {
-            }, false);
+            TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     Connection connection = mock(Connection.class);
     when(connection.getRemoteAddress())
@@ -125,8 +123,7 @@ public class TCPConduitTest {
   public void getConnectionRethrows_ifCaughtIOException_whenMemberDoesNotExist() throws Exception {
     TCPConduit tcpConduit =
         new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
-            TCPConduit -> connectionTable, socketCreator, () -> {
-            }, false);
+            TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
         .when(connectionTable).get(eq(member), anyBoolean(), anyLong(), anyLong(), anyLong());
@@ -146,8 +143,7 @@ public class TCPConduitTest {
   public void getConnectionRethrows_ifCaughtIOException_whenMemberIsShunned() throws Exception {
     TCPConduit tcpConduit =
         new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
-            TCPConduit -> connectionTable, socketCreator, () -> {
-            }, false);
+            TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
         .when(connectionTable).get(same(member), anyBoolean(), anyLong(), anyLong(), anyLong());
@@ -170,8 +166,7 @@ public class TCPConduitTest {
       throws Exception {
     TCPConduit tcpConduit =
         new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
-            TCPConduit -> connectionTable, socketCreator, () -> {
-            }, false);
+            TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
         .when(connectionTable).get(same(member), anyBoolean(), anyLong(), anyLong(), anyLong());
@@ -196,8 +191,7 @@ public class TCPConduitTest {
       throws Exception {
     TCPConduit tcpConduit =
         new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
-            TCPConduit -> connectionTable, socketCreator, () -> {
-            }, false);
+            TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
         .when(connectionTable).get(same(member), anyBoolean(), anyLong(), anyLong(), anyLong());
@@ -215,5 +209,11 @@ public class TCPConduitTest {
     assertThat(thrown)
         .isInstanceOf(DistributedSystemDisconnectedException.class)
         .hasMessage("Abandoned because shutdown is in progress");
+  }
+
+  private Runnable doNothing() {
+    return () -> {
+      // nothing
+    };
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.internal.tcp;
+
+import static org.apache.geode.internal.cache.util.UncheckedUtils.cast;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.same;
+import static org.mockito.Mockito.when;
+import static org.mockito.quality.Strictness.STRICT_STUBS;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import org.apache.geode.alerting.internal.spi.AlertingAction;
+import org.apache.geode.alerting.internal.spi.AlertingIOException;
+import org.apache.geode.distributed.DistributedSystemDisconnectedException;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.direct.DirectChannel;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.distributed.internal.membership.api.Membership;
+import org.apache.geode.internal.inet.LocalHostUtil;
+import org.apache.geode.internal.net.SocketCreator;
+
+public class TCPConduitTest {
+
+  private Membership<InternalDistributedMember> membership;
+  private DirectChannel directChannel;
+  private InetAddress localHost;
+  private ConnectionTable connectionTable;
+  private SocketCreator socketCreator;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(STRICT_STUBS);
+
+  @Before
+  public void setUp() throws Exception {
+    membership = cast(mock(Membership.class));
+    directChannel = mock(DirectChannel.class);
+    connectionTable = mock(ConnectionTable.class);
+    socketCreator = mock(SocketCreator.class);
+    localHost = LocalHostUtil.getLocalHost();
+
+    when(directChannel.getDM())
+        .thenReturn(mock(DistributionManager.class));
+  }
+
+  @Test
+  public void getConnectionThrowsAlertingIOException_ifCaughtIOException_whileAlerting()
+      throws Exception {
+    TCPConduit tcpConduit =
+        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+            TCPConduit -> connectionTable, socketCreator, () -> {
+            }, false);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    doThrow(new IOException("Cannot form connection to alert listener"))
+        .when(connectionTable).get(eq(member), anyBoolean(), anyLong(), anyLong(), anyLong());
+    when(membership.memberExists(eq(member)))
+        .thenReturn(true);
+    when(membership.isShunned(same(member)))
+        .thenReturn(false);
+
+    AlertingAction.execute(() -> {
+      Throwable thrown = catchThrowable(() -> {
+        tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
+      });
+
+      assertThat(thrown).isInstanceOf(AlertingIOException.class);
+    });
+  }
+
+  @Test
+  public void getConnectionRethrows_ifCaughtIOException_whileNotAlerting() throws Exception {
+    TCPConduit tcpConduit =
+        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+            TCPConduit -> connectionTable, socketCreator, () -> {
+            }, false);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    Connection connection = mock(Connection.class);
+    when(connection.getRemoteAddress())
+        .thenReturn(member);
+    doThrow(new IOException("Cannot form connection to alert listener"))
+        // getConnection will loop indefinitely until connectionTable returns connection
+        .doReturn(connection)
+        .when(connectionTable).get(eq(member), anyBoolean(), anyLong(), anyLong(), anyLong());
+    when(membership.memberExists(eq(member)))
+        .thenReturn(true);
+    when(membership.isShunned(same(member)))
+        .thenReturn(false);
+
+    Connection value = tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
+
+    assertThat(value).isSameAs(connection);
+  }
+
+  @Test
+  public void getConnectionRethrows_ifCaughtIOException_whenMemberDoesNotExist() throws Exception {
+    TCPConduit tcpConduit =
+        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+            TCPConduit -> connectionTable, socketCreator, () -> {
+            }, false);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    doThrow(new IOException("Cannot form connection to alert listener"))
+        .when(connectionTable).get(eq(member), anyBoolean(), anyLong(), anyLong(), anyLong());
+    when(membership.memberExists(eq(member)))
+        .thenReturn(false);
+
+    Throwable thrown = catchThrowable(() -> {
+      tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
+    });
+
+    assertThat(thrown).isNotInstanceOf(AlertingIOException.class);
+  }
+
+  @Test
+  public void getConnectionRethrows_ifCaughtIOException_whenMemberIsShunned() throws Exception {
+    TCPConduit tcpConduit =
+        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+            TCPConduit -> connectionTable, socketCreator, () -> {
+            }, false);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    doThrow(new IOException("Cannot form connection to alert listener"))
+        .when(connectionTable).get(same(member), anyBoolean(), anyLong(), anyLong(), anyLong());
+    when(membership.memberExists(same(member)))
+        .thenReturn(true);
+    when(membership.isShunned(same(member)))
+        .thenReturn(true);
+
+    Throwable thrown = catchThrowable(() -> {
+      tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
+    });
+
+    assertThat(thrown)
+        .isInstanceOf(IOException.class)
+        .isNotInstanceOf(AlertingIOException.class);
+  }
+
+  @Test
+  public void getConnectionThrowsDistributedSystemDisconnectedException_ifCaughtIOException_whenShutdownIsInProgress()
+      throws Exception {
+    TCPConduit tcpConduit =
+        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+            TCPConduit -> connectionTable, socketCreator, () -> {
+            }, false);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    doThrow(new IOException("Cannot form connection to alert listener"))
+        .when(connectionTable).get(same(member), anyBoolean(), anyLong(), anyLong(), anyLong());
+    when(membership.memberExists(same(member)))
+        .thenReturn(true);
+    when(membership.isShunned(same(member)))
+        .thenReturn(false);
+    when(membership.shutdownInProgress())
+        .thenReturn(true);
+
+    Throwable thrown = catchThrowable(() -> {
+      tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
+    });
+
+    assertThat(thrown)
+        .isInstanceOf(DistributedSystemDisconnectedException.class)
+        .hasMessage("Abandoned because shutdown is in progress")
+        .isNotInstanceOf(AlertingIOException.class);
+  }
+
+  @Test
+  public void getConnectionThrowsDistributedSystemDisconnectedException_ifCaughtIOException_whenShutdownIsInProgress_andCancelIsInProgress()
+      throws Exception {
+    TCPConduit tcpConduit =
+        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+            TCPConduit -> connectionTable, socketCreator, () -> {
+            }, false);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    doThrow(new IOException("Cannot form connection to alert listener"))
+        .when(connectionTable).get(same(member), anyBoolean(), anyLong(), anyLong(), anyLong());
+    when(membership.memberExists(same(member)))
+        .thenReturn(true);
+    when(membership.isShunned(same(member)))
+        .thenReturn(false);
+    when(membership.shutdownInProgress())
+        .thenReturn(true);
+
+    Throwable thrown = catchThrowable(() -> {
+      tcpConduit.getConnection(member, false, false, 0L, 0L, 0L);
+    });
+
+    assertThat(thrown)
+        .isInstanceOf(DistributedSystemDisconnectedException.class)
+        .hasMessage("Abandoned because shutdown is in progress")
+        .isNotInstanceOf(AlertingIOException.class);
+  }
+}


### PR DESCRIPTION
Change from FATAL log level to WARNING log level for log statement with stack trace when unable to create a connection to an alert listener.

Note to reviewers: let me know if you think this should be ERROR log level instead of warning. I picked WARNING because I think that FATAL is too high. This doesn't prevent any operations or represent data corruption or the inability to continue to run as a data server. It just means that we couldn't create a new connection for a remote alert listener (probably because the member left or is about to depart the view).