### PR TITLE
GEODE-7813: add Build-Java-Vendor to gfsh version --full

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -89,6 +89,7 @@ task createVersionPropertiesFile(dependsOn: ':writeBuildInfo') {
         "Build-Id"          : "${System.env.USER} ${buildId}".toString(),
         "Build-Date"        : new Date().format('yyyy-MM-dd HH:mm:ss Z'),
         "Build-Platform"    : "${System.properties['os.name']} ${System.properties['os.version']} ${System.properties['os.arch']}".toString(),
+        "Build-Java-Vendor" : System.properties['java.vendor'],
         "Build-Java-Version": System.properties['java.version']
     ] as Properties
     props.putAll(scmInfo)


### PR DESCRIPTION
The version info already includes the version of the compiler in `Build-Java-Version`. As there are now several java compiler vendors and a multitude of ways Geode may get compiled (various pipeline jobs, by a release manager, by users, etc) it makes sense to record the provider of that javac version as well. This is also helpful to audit that only open-source tools are being used to produce Geode artifacts.