### PR TITLE
GEODE-7784: Region entry has wrong RVV version after removeAll retried

### DIFF
--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
@@ -217,7 +217,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests putAll to one server.
    */
-
+  @Test
   public void testOneServer() throws Exception {
     int serverPort = server1.invoke(() -> new ServerBuilder()
         .regionShortcut(REPLICATE)
@@ -373,7 +373,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests putAll afterUpdate event contained oldValue.
    */
-
+  @Test
   public void testOldValueInEvent() {
     // set notifyBySubscription=false to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -506,7 +506,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests putAll and removeAll to 2 servers. Use Case: 1) putAll from a single-threaded client to a
    * replicated region 2) putAll from a multi-threaded client to a replicated region 3)
    */
-
+  @Test
   public void test2Server() throws Exception {
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
         .regionShortcut(REPLICATE)
@@ -834,7 +834,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     });
   }
 
-
+  @Test
   @Parameters({"true", "false"})
   @TestCaseName("{method}(concurrencyChecksEnabled={0})")
   public void test2NormalServer(boolean concurrencyChecksEnabled) {
@@ -1027,7 +1027,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     });
   }
 
-
+  @Test
   @Parameters({"PARTITION,1", "PARTITION,0", "REPLICATE,0"})
   @TestCaseName("{method}(isPR={0}, redundantCopies={1})")
   public void testPRServerRVDuplicatedKeys(RegionShortcut regionShortcut, int redundantCopies) {
@@ -1192,7 +1192,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * 2) grep Object_82470 *.log and found the mismatched key is originated from 14640.
    * </pre>
    */
-
+  @Test
   @Parameters({"true", "false"})
   @TestCaseName("{method}(singleHop={0})")
   public void testBug51725(boolean singleHop) {
@@ -1293,7 +1293,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests putAll to 2 PR servers.
    */
-
+  @Test
   public void testPRServer() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1611,7 +1611,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Checks to see if a client does a destroy that throws an exception from CacheWriter
    * beforeDestroy that the size of the region is still correct. See bug 51583.
    */
-
+  @Test
   public void testClientDestroyOfUncreatedEntry() {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1659,7 +1659,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests partial key putAll and removeAll to 2 servers with local region
    */
-
+  @Test
   public void testPartialKeyInLocalRegion() {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1836,7 +1836,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests partial key putAll to 2 PR servers, because putting data at server side is different
    * between PR and LR. PR does it in postPutAll. It's not running in singleHop putAll
    */
-
+  @Test
   public void testPartialKeyInPR() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1988,7 +1988,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests partial key putAll to 2 PR servers, because putting data at server side is different
    * between PR and LR. PR does it in postPutAll. This is a singlehop putAll test.
    */
-
+  @Test
   public void testPartialKeyInPRSingleHop() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2147,7 +2147,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Set redundancy=1 to see if retry succeeded after PRE This is a singlehop putAll test.
    */
-
+  @Test
   public void testPartialKeyInPRSingleHopWithRedundancy() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2264,7 +2264,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests bug 41403: let 2 sub maps both failed with partial key applied. This is a singlehop
    * putAll test.
    */
-
+  @Test
   public void testEventIdMisorderInPRSingleHop() throws Exception {
     VM server3 = client2;
 
@@ -2370,7 +2370,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests while putAll to 2 distributed servers, one server failed over Add a listener to slow down
    * the processing of putAll
    */
-
+  @Test
   public void test2FailOverDistributedServer() throws Exception {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2452,7 +2452,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests while putAll timeout's exception
    */
-
+  @Test
   public void testClientTimeOut() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2497,7 +2497,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests while putAll timeout at endpoint1 and switch to endpoint2
    */
-
+  @Test
   public void testEndPointSwitch() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2558,7 +2558,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests while putAll to 2 distributed servers, one server failed over Add a listener to slow down
    * the processing of putAll
    */
-
+  @Test
   public void testHADRFailOver() throws Exception {
     addIgnoredException(DistributedSystemDisconnectedException.class);
 
@@ -2631,7 +2631,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     });
   }
 
-
+  @Test
   public void testVersionsOnClientsWithNotificationsOnly() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2716,7 +2716,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * basically same test as testVersionsOnClientsWithNotificationsOnly but also do a removeAll
    */
-
+  @Test
   public void testRAVersionsOnClientsWithNotificationsOnly() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2803,7 +2803,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     }
   }
 
-
+  @Test
   public void testVersionsOnServersWithNotificationsOnly() {
     VM server3 = client2;
 
@@ -2891,7 +2891,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Same test as testVersionsOnServersWithNotificationsOnly but also does a removeAll
    */
-
+  @Test
   public void testRAVersionsOnServersWithNotificationsOnly() {
     VM server3 = client2;
 
@@ -2980,7 +2980,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     }
   }
 
-
+  @Test
   public void testVersionsOnReplicasAfterPutAllAndRemoveAll() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -3182,7 +3182,6 @@ public class PutAllClientServerDistributedTest implements Serializable {
 
       Properties config = getDistributedSystemProperties();
       config.setProperty(LOCATORS, locators);
-      config.setProperty("log-level", "debug");
 
       createCache(new CacheFactory(config));
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
+import com.sun.tools.javac.resources.version;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
@@ -496,7 +497,10 @@ public class PutAllClientServerDistributedTest implements Serializable {
       return versionsToReturn;
     });
 
-    assertThat(versions.getVersionTags()).isEqualTo(versionsAfterRetry.getVersionTags());
+    List<VersionTag> versionTags = versions.getVersionTags();
+    List<VersionTag> versionTagsAfterRetry = versionsAfterRetry.getVersionTags();
+    assertThat(versionTags.size()).isEqualTo(versionTagsAfterRetry.size());
+    assertThat(versionTags).containsAll(versionTagsAfterRetry);
   }
 
   /**

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
@@ -57,7 +57,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import com.sun.tools.javac.resources.version;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
@@ -217,7 +217,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests putAll to one server.
    */
-  @Test
+
   public void testOneServer() throws Exception {
     int serverPort = server1.invoke(() -> new ServerBuilder()
         .regionShortcut(REPLICATE)
@@ -373,7 +373,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests putAll afterUpdate event contained oldValue.
    */
-  @Test
+
   public void testOldValueInEvent() {
     // set notifyBySubscription=false to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -503,7 +503,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests putAll and removeAll to 2 servers. Use Case: 1) putAll from a single-threaded client to a
    * replicated region 2) putAll from a multi-threaded client to a replicated region 3)
    */
-  @Test
+
   public void test2Server() throws Exception {
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
         .regionShortcut(REPLICATE)
@@ -831,7 +831,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     });
   }
 
-  @Test
+
   @Parameters({"true", "false"})
   @TestCaseName("{method}(concurrencyChecksEnabled={0})")
   public void test2NormalServer(boolean concurrencyChecksEnabled) {
@@ -1024,7 +1024,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     });
   }
 
-  @Test
+
   @Parameters({"PARTITION,1", "PARTITION,0", "REPLICATE,0"})
   @TestCaseName("{method}(isPR={0}, redundantCopies={1})")
   public void testPRServerRVDuplicatedKeys(RegionShortcut regionShortcut, int redundantCopies) {
@@ -1189,7 +1189,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * 2) grep Object_82470 *.log and found the mismatched key is originated from 14640.
    * </pre>
    */
-  @Test
+
   @Parameters({"true", "false"})
   @TestCaseName("{method}(singleHop={0})")
   public void testBug51725(boolean singleHop) {
@@ -1290,7 +1290,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests putAll to 2 PR servers.
    */
-  @Test
+
   public void testPRServer() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1608,7 +1608,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Checks to see if a client does a destroy that throws an exception from CacheWriter
    * beforeDestroy that the size of the region is still correct. See bug 51583.
    */
-  @Test
+
   public void testClientDestroyOfUncreatedEntry() {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1656,7 +1656,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests partial key putAll and removeAll to 2 servers with local region
    */
-  @Test
+
   public void testPartialKeyInLocalRegion() {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1833,7 +1833,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests partial key putAll to 2 PR servers, because putting data at server side is different
    * between PR and LR. PR does it in postPutAll. It's not running in singleHop putAll
    */
-  @Test
+
   public void testPartialKeyInPR() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -1985,7 +1985,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests partial key putAll to 2 PR servers, because putting data at server side is different
    * between PR and LR. PR does it in postPutAll. This is a singlehop putAll test.
    */
-  @Test
+
   public void testPartialKeyInPRSingleHop() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2144,7 +2144,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Set redundancy=1 to see if retry succeeded after PRE This is a singlehop putAll test.
    */
-  @Test
+
   public void testPartialKeyInPRSingleHopWithRedundancy() throws Exception {
     // set <true, false> means <PR=true, notifyBySubscription=false> to test local-invalidates
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2261,7 +2261,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests bug 41403: let 2 sub maps both failed with partial key applied. This is a singlehop
    * putAll test.
    */
-  @Test
+
   public void testEventIdMisorderInPRSingleHop() throws Exception {
     VM server3 = client2;
 
@@ -2367,7 +2367,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests while putAll to 2 distributed servers, one server failed over Add a listener to slow down
    * the processing of putAll
    */
-  @Test
+
   public void test2FailOverDistributedServer() throws Exception {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2449,7 +2449,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests while putAll timeout's exception
    */
-  @Test
+
   public void testClientTimeOut() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2494,7 +2494,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Tests while putAll timeout at endpoint1 and switch to endpoint2
    */
-  @Test
+
   public void testEndPointSwitch() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2555,7 +2555,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
    * Tests while putAll to 2 distributed servers, one server failed over Add a listener to slow down
    * the processing of putAll
    */
-  @Test
+
   public void testHADRFailOver() throws Exception {
     addIgnoredException(DistributedSystemDisconnectedException.class);
 
@@ -2628,7 +2628,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     });
   }
 
-  @Test
+
   public void testVersionsOnClientsWithNotificationsOnly() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2713,7 +2713,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * basically same test as testVersionsOnClientsWithNotificationsOnly but also do a removeAll
    */
-  @Test
+
   public void testRAVersionsOnClientsWithNotificationsOnly() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -2800,7 +2800,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     }
   }
 
-  @Test
+
   public void testVersionsOnServersWithNotificationsOnly() {
     VM server3 = client2;
 
@@ -2888,7 +2888,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
   /**
    * Same test as testVersionsOnServersWithNotificationsOnly but also does a removeAll
    */
-  @Test
+
   public void testRAVersionsOnServersWithNotificationsOnly() {
     VM server3 = client2;
 
@@ -2977,7 +2977,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
     }
   }
 
-  @Test
+
   public void testVersionsOnReplicasAfterPutAllAndRemoveAll() {
     // set notifyBySubscription=true to test register interest
     int serverPort1 = server1.invoke(() -> new ServerBuilder()
@@ -3179,6 +3179,7 @@ public class PutAllClientServerDistributedTest implements Serializable {
 
       Properties config = getDistributedSystemProperties();
       config.setProperty(LOCATORS, locators);
+      config.setProperty("log-level", "debug");
 
       createCache(new CacheFactory(config));
 


### PR DESCRIPTION
The two lists of VersionTag in the original test may contain the same elements, but in different order. This fixes the test to compare the elements of the lists regardless of order.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
