### PR TITLE
GEODE-7819: Add debugging support to SerializableTemporaryFolder

### DIFF
--- a/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolderIntegrationTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolderIntegrationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.rules.serializable;
+
+import static org.apache.geode.test.junit.runners.TestRunner.runTestWithValidation;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+public class SerializableTemporaryFolderIntegrationTest {
+
+  private static final AtomicReference<File> ROOT = new AtomicReference<>();
+  private static final AtomicReference<File> DESTINATION = new AtomicReference<>();
+  private static final AtomicReference<String> TEST_NAME = new AtomicReference<>();
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void delete_false_doesNotDeleteTemporaryFolder() {
+    runTestWithValidation(DeleteFalse.class);
+
+    File root = ROOT.get();
+
+    assertThat(root).exists();
+  }
+
+  @Test
+  public void delete_false_deletesTemporaryFolder() {
+    runTestWithValidation(DeleteTrue.class);
+
+    File root = ROOT.get();
+
+    assertThat(root).doesNotExist();
+  }
+
+  @Test
+  public void copyTo_savesTemporaryFolderToDestination() {
+    DESTINATION.set(temporaryFolder.getRoot());
+
+    runTestWithValidation(CopyTo.class);
+
+    File destinationFolder = DESTINATION.get();
+    assertThat(destinationFolder).exists();
+
+    File testFolder = new File(destinationFolder, TEST_NAME.get());
+    assertThat(testFolder).exists();
+
+    File subFolder = new File(testFolder, CopyTo.FOLDER_NAME);
+    assertThat(subFolder).exists();
+
+    File file = new File(subFolder, CopyTo.FILE_NAME);
+    assertThat(file).exists();
+    assertThat(file).hasContent(CopyTo.DATA);
+  }
+
+  public static class DeleteFalse {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .delete(false);
+
+    @Test
+    public void captureRoot() {
+      ROOT.set(temporaryFolder.getRoot());
+    }
+  }
+
+  public static class DeleteTrue {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .delete(true);
+
+    @Test
+    public void captureRoot() {
+      ROOT.set(temporaryFolder.getRoot());
+    }
+  }
+
+  public static class CopyTo {
+
+    private static final String FOLDER_NAME = "myFolder";
+    private static final String FILE_NAME = "myFile.txt";
+    private static final String DATA = "data";
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .copyTo(DESTINATION.get());
+    @Rule
+    public TestName testName = new TestName();
+
+    @Before
+    public void preCondition() {
+      assertThat(DESTINATION.get()).exists();
+    }
+
+    @Test
+    public void writeToTemporaryFolder() throws Exception {
+      TEST_NAME.set(testName.getMethodName());
+      File folder = temporaryFolder.newFolder(FOLDER_NAME);
+      File file = new File(folder, FILE_NAME);
+      assertThat(file.createNewFile()).isTrue();
+      FileUtils.writeStringToFile(file, DATA, Charset.defaultCharset());
+    }
+  }
+}

--- a/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolderIntegrationTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolderIntegrationTest.java
@@ -14,12 +14,18 @@
  */
 package org.apache.geode.test.junit.rules.serializable;
 
+import static org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder.When.ALWAYS;
+import static org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder.When.FAILS;
+import static org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder.When.PASSES;
+import static org.apache.geode.test.junit.runners.TestRunner.runTestWithExpectedFailureTypes;
 import static org.apache.geode.test.junit.runners.TestRunner.runTestWithValidation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -29,6 +35,8 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
 public class SerializableTemporaryFolderIntegrationTest {
+
+  private static final Pattern DIGITS_REGEX = Pattern.compile("\\d+");
 
   private static final AtomicReference<File> ROOT = new AtomicReference<>();
   private static final AtomicReference<File> DESTINATION = new AtomicReference<>();
@@ -56,23 +64,115 @@ public class SerializableTemporaryFolderIntegrationTest {
   }
 
   @Test
-  public void copyTo_savesTemporaryFolderToDestination() {
+  public void copyTo_whenAlways_copiesFolderToDestination_ifTestPasses() {
     DESTINATION.set(temporaryFolder.getRoot());
 
-    runTestWithValidation(CopyTo.class);
+    runTestWithValidation(CopyTo_WhenAlways_Passes.class);
 
     File destinationFolder = DESTINATION.get();
     assertThat(destinationFolder).exists();
 
-    File testFolder = new File(destinationFolder, TEST_NAME.get());
+    File timestampFolder = Arrays.stream(destinationFolder.listFiles()).findFirst().get();
+    assertThat(timestampFolder.getName()).matches(DIGITS_REGEX);
+
+    File testFolder = new File(timestampFolder, TEST_NAME.get());
     assertThat(testFolder).exists();
 
-    File subFolder = new File(testFolder, CopyTo.FOLDER_NAME);
+    File subFolder = new File(testFolder, CopyTo_Passes.FOLDER_NAME);
     assertThat(subFolder).exists();
 
-    File file = new File(subFolder, CopyTo.FILE_NAME);
-    assertThat(file).exists();
-    assertThat(file).hasContent(CopyTo.DATA);
+    File file = new File(subFolder, CopyTo_Passes.FILE_NAME);
+    assertThat(file).exists().hasContent(CopyTo_Passes.DATA);
+  }
+
+  @Test
+  public void copyTo_whenAlways_copiesFolderToDestination_ifTestFails() {
+    DESTINATION.set(temporaryFolder.getRoot());
+
+    runTestWithExpectedFailureTypes(CopyTo_WhenAlways_Fails.class, ExpectedError.class);
+
+    File destinationFolder = DESTINATION.get();
+    assertThat(destinationFolder).exists();
+
+    File timestampFolder = Arrays.stream(destinationFolder.listFiles()).findFirst().get();
+    assertThat(timestampFolder.getName()).matches(DIGITS_REGEX);
+
+    File testFolder = new File(timestampFolder, TEST_NAME.get());
+    assertThat(testFolder).exists();
+
+    File subFolder = new File(testFolder, CopyTo_Passes.FOLDER_NAME);
+    assertThat(subFolder).exists();
+
+    File file = new File(subFolder, CopyTo_Passes.FILE_NAME);
+    assertThat(file).exists().hasContent(CopyTo_Passes.DATA);
+  }
+
+  @Test
+  public void copyTo_whenFails_doesNotCopyFolder_ifTestPasses() {
+    DESTINATION.set(temporaryFolder.getRoot());
+
+    runTestWithValidation(CopyTo_WhenFails_Passes.class);
+
+    File destinationFolder = DESTINATION.get();
+    assertThat(destinationFolder).exists();
+
+    assertThat(destinationFolder.listFiles()).isEmpty();
+  }
+
+  @Test
+  public void copyTo_whenFails_copiesFolderToDestination_ifTestFails() {
+    DESTINATION.set(temporaryFolder.getRoot());
+
+    runTestWithExpectedFailureTypes(CopyTo_WhenFails_Fails.class, ExpectedError.class);
+
+    File destinationFolder = DESTINATION.get();
+    assertThat(destinationFolder).exists();
+
+    File timestampFolder = Arrays.stream(destinationFolder.listFiles()).findFirst().get();
+    assertThat(timestampFolder.getName()).matches(DIGITS_REGEX);
+
+    File testFolder = new File(timestampFolder, TEST_NAME.get());
+    assertThat(testFolder).exists();
+
+    File subFolder = new File(testFolder, CopyTo_Passes.FOLDER_NAME);
+    assertThat(subFolder).exists();
+
+    File file = new File(subFolder, CopyTo_Passes.FILE_NAME);
+    assertThat(file).exists().hasContent(CopyTo_Passes.DATA);
+  }
+
+  @Test
+  public void copyTo_whenPasses_copiesFolderToDestination_ifTestPasses() {
+    DESTINATION.set(temporaryFolder.getRoot());
+
+    runTestWithValidation(CopyTo_WhenPasses_Passes.class);
+
+    File destinationFolder = DESTINATION.get();
+    assertThat(destinationFolder).exists();
+
+    File timestampFolder = Arrays.stream(destinationFolder.listFiles()).findFirst().get();
+    assertThat(timestampFolder.getName()).matches(DIGITS_REGEX);
+
+    File testFolder = new File(timestampFolder, TEST_NAME.get());
+    assertThat(testFolder).exists();
+
+    File subFolder = new File(testFolder, CopyTo_Passes.FOLDER_NAME);
+    assertThat(subFolder).exists();
+
+    File file = new File(subFolder, CopyTo_Passes.FILE_NAME);
+    assertThat(file).exists().hasContent(CopyTo_Passes.DATA);
+  }
+
+  @Test
+  public void copyTo_whenPasses_doesNotCopyFolder_ifTestFails() {
+    DESTINATION.set(temporaryFolder.getRoot());
+
+    runTestWithExpectedFailureTypes(CopyTo_WhenPasses_Fails.class, ExpectedError.class);
+
+    File destinationFolder = DESTINATION.get();
+    assertThat(destinationFolder).exists();
+
+    assertThat(destinationFolder.listFiles()).isEmpty();
   }
 
   public static class DeleteFalse {
@@ -99,15 +199,12 @@ public class SerializableTemporaryFolderIntegrationTest {
     }
   }
 
-  public static class CopyTo {
+  public abstract static class CopyTo_Passes {
 
     private static final String FOLDER_NAME = "myFolder";
     private static final String FILE_NAME = "myFile.txt";
     private static final String DATA = "data";
 
-    @Rule
-    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
-        .copyTo(DESTINATION.get());
     @Rule
     public TestName testName = new TestName();
 
@@ -116,13 +213,122 @@ public class SerializableTemporaryFolderIntegrationTest {
       assertThat(DESTINATION.get()).exists();
     }
 
+    protected abstract TemporaryFolder temporaryFolder();
+
     @Test
     public void writeToTemporaryFolder() throws Exception {
       TEST_NAME.set(testName.getMethodName());
-      File folder = temporaryFolder.newFolder(FOLDER_NAME);
+      File folder = temporaryFolder().newFolder(FOLDER_NAME);
       File file = new File(folder, FILE_NAME);
       assertThat(file.createNewFile()).isTrue();
       FileUtils.writeStringToFile(file, DATA, Charset.defaultCharset());
+    }
+  }
+
+  public abstract static class CopyTo_Fails {
+
+    private static final String FOLDER_NAME = "myFolder";
+    private static final String FILE_NAME = "myFile.txt";
+    private static final String DATA = "data";
+
+    @Rule
+    public TestName testName = new TestName();
+
+    @Before
+    public void preCondition() {
+      assertThat(DESTINATION.get()).exists();
+    }
+
+    protected abstract TemporaryFolder temporaryFolder();
+
+    @Test
+    public void writeToTemporaryFolder() throws Exception {
+      TEST_NAME.set(testName.getMethodName());
+      File folder = temporaryFolder().newFolder(FOLDER_NAME);
+      File file = new File(folder, FILE_NAME);
+      assertThat(file.createNewFile()).isTrue();
+      FileUtils.writeStringToFile(file, DATA, Charset.defaultCharset());
+      throw new ExpectedError(TEST_NAME.get() + " failed");
+    }
+  }
+
+  public static class CopyTo_WhenAlways_Passes extends CopyTo_Passes {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .copyTo(DESTINATION.get()).when(ALWAYS);
+
+    @Override
+    protected TemporaryFolder temporaryFolder() {
+      return temporaryFolder;
+    }
+  }
+
+  public static class CopyTo_WhenAlways_Fails extends CopyTo_Fails {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .copyTo(DESTINATION.get()).when(ALWAYS);
+
+    @Override
+    protected TemporaryFolder temporaryFolder() {
+      return temporaryFolder;
+    }
+  }
+
+  public static class CopyTo_WhenFails_Passes extends CopyTo_Passes {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .copyTo(DESTINATION.get()).when(FAILS);
+
+    @Override
+    protected TemporaryFolder temporaryFolder() {
+      return temporaryFolder;
+    }
+  }
+
+  public static class CopyTo_WhenFails_Fails extends CopyTo_Fails {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .copyTo(DESTINATION.get()).when(FAILS);
+
+    @Override
+    protected TemporaryFolder temporaryFolder() {
+      return temporaryFolder;
+    }
+  }
+
+  public static class CopyTo_WhenPasses_Passes extends CopyTo_Passes {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .copyTo(DESTINATION.get()).when(PASSES);
+
+    @Override
+    protected TemporaryFolder temporaryFolder() {
+      return temporaryFolder;
+    }
+  }
+
+  public static class CopyTo_WhenPasses_Fails extends CopyTo_Fails {
+
+    @Rule
+    public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder()
+        .copyTo(DESTINATION.get()).when(PASSES);
+
+    @Override
+    protected TemporaryFolder temporaryFolder() {
+      return temporaryFolder;
+    }
+  }
+
+  @SuppressWarnings("serial")
+  public static class ExpectedError extends AssertionError {
+
+    ExpectedError(Object detailMessage) {
+      super(detailMessage);
     }
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolder.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolder.java
@@ -20,50 +20,135 @@ import static org.apache.geode.test.junit.rules.serializable.FieldsOfTemporaryFo
 import static org.apache.geode.test.junit.rules.serializable.FieldsOfTemporaryFolder.FIELD_PARENT_FOLDER;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.Logger;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * Serializable subclass of {@link TemporaryFolder TemporaryFolder}. Instance
  * variables of TemporaryFolder are serialized by reflection.
  */
+@SuppressWarnings("WeakerAccess")
 public class SerializableTemporaryFolder extends TemporaryFolder implements SerializableTestRule {
+  private static final Logger logger = LogService.getLogger();
+
+  private final AtomicBoolean delete = new AtomicBoolean(true);
+  private final AtomicReference<File> copyTo = new AtomicReference<>();
+  private final AtomicReference<String> methodName = new AtomicReference<>();
 
   public SerializableTemporaryFolder() {
-    super();
+    // super
   }
 
   public SerializableTemporaryFolder(final File parentFolder) {
     super(parentFolder);
   }
 
+  /**
+   * Specifying false will prevent deletion of the temporary folder and its contents. Default is
+   * true.
+   */
+  public SerializableTemporaryFolder delete(boolean value) {
+    delete.set(value);
+    return this;
+  }
+
+  /**
+   * Specifies directory to copy artifacts to before deleting temporary folder. Default is null.
+   */
+  public SerializableTemporaryFolder copyTo(File directory) {
+    copyTo.set(directory);
+    return this;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return statement(base, description);
+  }
+
+  protected Statement statement(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        before(description);
+        try {
+          base.evaluate();
+        } finally {
+          after();
+        }
+      }
+    };
+  }
+
+  protected void before(Description description) throws Throwable {
+    methodName.set(description.getMethodName());
+    before();
+    logger.info("SerializableTemporaryFolder root: {}", getRoot().getAbsolutePath());
+  }
+
+  @Override
+  protected void after() {
+    File directory = copyTo.get();
+    if (directory != null) {
+      directory.mkdir();
+      File destination = new File(directory, methodName.get());
+      destination.mkdir();
+
+      copyTo(getRoot(), destination);
+    }
+    if (delete.get()) {
+      super.after();
+    }
+  }
+
+  private void copyTo(File source, File destination) {
+    if (destination == null) {
+      return;
+    }
+    try {
+      FileUtils.copyDirectory(source, destination, true);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
   private void readObject(final ObjectInputStream stream) throws InvalidObjectException {
     throw new InvalidObjectException("SerializationProxy required");
   }
 
-  private Object writeReplace() {
+  protected Object writeReplace() {
     return new SerializationProxy(this);
   }
 
   /**
    * Serialization proxy for {@code SerializableTemporaryFolder}.
    */
+  @SuppressWarnings("serial")
   private static class SerializationProxy implements Serializable {
 
     private final File parentFolder;
     private final File folder;
 
-    SerializationProxy(final SerializableTemporaryFolder instance) {
-      this.parentFolder = (File) readField(TemporaryFolder.class, instance, FIELD_PARENT_FOLDER);
-      this.folder = (File) readField(TemporaryFolder.class, instance, FIELD_FOLDER);
+    private SerializationProxy(final SerializableTemporaryFolder instance) {
+      parentFolder = (File) readField(TemporaryFolder.class, instance, FIELD_PARENT_FOLDER);
+      folder = (File) readField(TemporaryFolder.class, instance, FIELD_FOLDER);
     }
 
-    private Object readResolve() {
-      SerializableTemporaryFolder instance = new SerializableTemporaryFolder(this.parentFolder);
-      writeField(TemporaryFolder.class, instance, FIELD_FOLDER, this.folder);
+    protected Object readResolve() {
+      SerializableTemporaryFolder instance = new SerializableTemporaryFolder(parentFolder);
+      writeField(TemporaryFolder.class, instance, FIELD_FOLDER, folder);
       return instance;
     }
   }

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolder.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolder.java
@@ -29,12 +29,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * Serializable subclass of {@link TemporaryFolder TemporaryFolder}. Instance
@@ -42,7 +41,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  */
 @SuppressWarnings("WeakerAccess")
 public class SerializableTemporaryFolder extends TemporaryFolder implements SerializableTestRule {
-  private static final Logger logger = LogService.getLogger();
+  private static final Logger logger = LogManager.getLogger();
 
   private final AtomicBoolean delete = new AtomicBoolean(true);
   private final AtomicReference<File> copyTo = new AtomicReference<>();

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolderTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/serializable/SerializableTemporaryFolderTest.java
@@ -29,7 +29,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-
 /**
  * Unit tests for {@link SerializableTemporaryFolder}.
  */
@@ -39,7 +38,7 @@ public class SerializableTemporaryFolderTest {
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void hasTwoFields() throws Exception {
+  public void hasTwoFields() {
     Field[] fields = TemporaryFolder.class.getDeclaredFields();
     assertThat(fields.length).as("Fields: " + Arrays.asList(fields)).isEqualTo(2);
   }
@@ -58,7 +57,7 @@ public class SerializableTemporaryFolderTest {
 
   @Test
   public void fieldsCanBeRead() throws Exception {
-    File parentFolder = this.temporaryFolder.getRoot();
+    File parentFolder = temporaryFolder.getRoot();
 
     SerializableTemporaryFolder instance = new SerializableTemporaryFolder(parentFolder);
     instance.create();
@@ -70,19 +69,18 @@ public class SerializableTemporaryFolderTest {
   }
 
   @Test
-  public void isSerializable() throws Exception {
+  public void isSerializable() {
     assertThat(SerializableTemporaryFolder.class).isInstanceOf(Serializable.class);
   }
 
   @Test
   public void canBeSerialized() throws Exception {
-    File parentFolder = this.temporaryFolder.getRoot();
+    File parentFolder = temporaryFolder.getRoot();
 
     SerializableTemporaryFolder instance = new SerializableTemporaryFolder(parentFolder);
     instance.create();
 
-    SerializableTemporaryFolder cloned =
-        (SerializableTemporaryFolder) SerializationUtils.clone(instance);
+    SerializableTemporaryFolder cloned = SerializationUtils.clone(instance);
 
     assertThat(readField(TemporaryFolder.class, cloned, FIELD_PARENT_FOLDER))
         .isEqualTo(parentFolder);


### PR DESCRIPTION
When we are debugging a distributed test that uses 
SerializableTemporaryFolder for Server and Locator files, we need a 
way to save off the files.
```
GEODE-7819: Add debugging support to SerializableTemporaryFolder

Specifying delete(false) will prevent deletion of the temporary folder
tree during tear down.

Specifying copyTo(directory) with optional when(When) will result in
copying the contents of the temporary folder tree to the destination
directory during tear down.
```
I'm using this change on several branches to debug various dunit
tests. I think this is ready to merge to develop, and having it on 
develop will make it unnecessary to cherry-pick for debugging.