### PR TITLE
GEODE-7820: Avoid Unnecessary toArray Invocations

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ProduceDateMessages.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ProduceDateMessages.java
@@ -36,7 +36,7 @@ public class ProduceDateMessages {
 
       // Make sure that message state was reset
       Assert.assertTrue(message.getDate() == null);
-      Assert.assertTrue(message.getRecipientsArray() == null);
+      Assert.assertTrue(message.getRecipients() == null);
       Assert.assertTrue(message.getSender() == null);
 
       message.setRecipient(DistributionMessage.ALL_RECIPIENTS);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverDistributedTest.java
@@ -390,7 +390,7 @@ public class ClientServerTransactionFailoverDistributedTest implements Serializa
             public void beforeSendMessage(ClusterDistributionManager dm,
                 DistributionMessage message) {
               if (message instanceof TXCommitMessage.CommitProcessForTXIdMessage) {
-                InternalDistributedMember m = message.getRecipientsArray()[0];
+                InternalDistributedMember m = message.getRecipients().get(0);
                 message.resetRecipients();
                 message.setRecipient(m);
               }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -20,7 +20,6 @@ import java.io.NotSerializableException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -1955,7 +1954,7 @@ public class ClusterDistributionManager implements DistributionManager {
     try {
       // m.resetTimestamp(); // nanotimers across systems don't match
       long startTime = DistributionStats.getStatTime();
-      sendViaMembershipManager(m.getRecipientsArray(), m, this, stats);
+      sendViaMembershipManager(m.getRecipients(), m, this, stats);
       stats.incSentMessages(1L);
       if (DistributionStats.enableClockStats) {
         stats.incSentMessagesTime(DistributionStats.getStatTime() - startTime);
@@ -1984,7 +1983,7 @@ public class ClusterDistributionManager implements DistributionManager {
     long startTime = DistributionStats.getStatTime();
 
     Set<InternalDistributedMember> result =
-        sendViaMembershipManager(message.getRecipientsArray(), message, this, stats);
+        sendViaMembershipManager(message.getRecipients(), message, this, stats);
     long endTime = 0L;
     if (DistributionStats.enableClockStats) {
       endTime = NanoTimer.getTime();
@@ -2036,7 +2035,7 @@ public class ClusterDistributionManager implements DistributionManager {
       if (message == null || message.forAll()) {
         return null;
       }
-      return new HashSet<>(Arrays.asList(message.getRecipientsArray()));
+      return new HashSet<>(message.getRecipients());
     }
   }
 
@@ -2046,17 +2045,16 @@ public class ClusterDistributionManager implements DistributionManager {
    * @throws NotSerializableException If content cannot be serialized
    */
   private Set<InternalDistributedMember> sendViaMembershipManager(
-      InternalDistributedMember[] destinations,
+      List<InternalDistributedMember> destinations,
       DistributionMessage content, ClusterDistributionManager dm, DistributionStats stats)
       throws NotSerializableException {
     if (distribution == null) {
       logger.warn("Attempting a send to a disconnected DistributionManager");
-      if (destinations.length == 1 && destinations[0] == Message.ALL_RECIPIENTS)
+      if (destinations.size() == 1 && destinations.get(0) == Message.ALL_RECIPIENTS)
         return null;
-      HashSet<InternalDistributedMember> result = new HashSet<>();
-      Collections.addAll(result, destinations);
-      return result;
+      return new HashSet<>(destinations);
     }
+
     return distribution.send(destinations, content);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/Distribution.java
@@ -15,6 +15,7 @@
 package org.apache.geode.distributed.internal;
 
 import java.io.NotSerializableException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
@@ -33,13 +34,11 @@ public interface Distribution {
 
   InternalDistributedMember getLocalMember();
 
-  Set<InternalDistributedMember> send(InternalDistributedMember[] destinations,
+  Set<InternalDistributedMember> send(List<InternalDistributedMember> destinations,
       DistributionMessage msg) throws NotSerializableException;
 
-  Set<InternalDistributedMember> directChannelSend(
-      InternalDistributedMember[] destinations,
-      DistributionMessage content)
-      throws NotSerializableException;
+  Set<InternalDistributedMember> directChannelSend(List<InternalDistributedMember> destinations,
+      DistributionMessage content) throws NotSerializableException;
 
   Map<String, Long> getMessageState(
       DistributedMember member, boolean includeMulticast);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -19,8 +19,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.NotSerializableException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -235,7 +233,7 @@ public class DistributionImpl implements Distribution {
   }
 
   @Override
-  public Set<InternalDistributedMember> send(InternalDistributedMember[] destinations,
+  public Set<InternalDistributedMember> send(List<InternalDistributedMember> destinations,
       DistributionMessage msg) throws NotSerializableException {
     Set<InternalDistributedMember> result;
     boolean allDestinations = msg.forAll();
@@ -246,18 +244,16 @@ public class DistributionImpl implements Distribution {
 
     if (membership.isJoining()) {
       // If we get here, we are starting up, so just report a failure.
-      if (allDestinations)
+      if (allDestinations) {
         return null;
-      else {
-        result = new HashSet<>();
-        Collections.addAll(result, destinations);
-        return result;
+      } else {
+        return new HashSet<>(destinations);
       }
     }
 
     if (msg instanceof AdminMessageType && shutdownInProgress()) {
       // no admin messages while shutting down - this can cause threads to hang
-      return new HashSet<>(Arrays.asList(msg.getRecipientsArray()));
+      return new HashSet<>(msg.getRecipients());
     }
 
     // Handle trivial cases
@@ -267,7 +263,7 @@ public class DistributionImpl implements Distribution {
             msg);
       return null; // trivially: all recipients received the message
     }
-    if (destinations.length == 0) {
+    if (destinations.isEmpty()) {
       if (logger.isTraceEnabled())
         logger.trace(
             "Membership: Message send: returning early because empty destination list passed in: '{}'",
@@ -288,7 +284,7 @@ public class DistributionImpl implements Distribution {
     boolean sendViaMessenger = isForceUDPCommunications() || (msg instanceof ShutdownMessage);
 
     if (useMcast || tcpDisabled || sendViaMessenger) {
-      result = membership.send(destinations, msg);
+      result = membership.send(destinations.toArray(EMPTY_MEMBER_ARRAY), msg);
     } else {
       result = directChannelSend(destinations, msg);
     }
@@ -328,7 +324,7 @@ public class DistributionImpl implements Distribution {
    */
   @Override
   public Set<InternalDistributedMember> directChannelSend(
-      InternalDistributedMember[] destinations,
+      List<InternalDistributedMember> destinations,
       DistributionMessage content)
       throws NotSerializableException {
     MembershipStatistics theStats = clusterDistributionManager.getStats();
@@ -339,7 +335,7 @@ public class DistributionImpl implements Distribution {
       keys = membership.getAllMembers(EMPTY_MEMBER_ARRAY);
     } else {
       allDestinations = false;
-      keys = destinations;
+      keys = destinations.toArray(EMPTY_MEMBER_ARRAY);
     }
 
     int sentBytes;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
@@ -17,6 +17,7 @@ package org.apache.geode.distributed.internal;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -108,7 +109,7 @@ public abstract class DistributionMessage
   protected transient InternalDistributedMember sender;
 
   /** A set of recipients for this message, not serialized */
-  private transient InternalDistributedMember[] recipients = null;
+  private transient List<InternalDistributedMember> recipients = null;
 
   /** A timestamp, in nanos, associated with this message. Not serialized. */
   private transient long timeStamp;
@@ -225,7 +226,8 @@ public abstract class DistributionMessage
       throw new IllegalStateException(
           "Recipients can only be set once");
     }
-    this.recipients = new InternalDistributedMember[] {recipient};
+
+    this.recipients = Collections.singletonList(recipient);
   }
 
   /**
@@ -261,8 +263,7 @@ public abstract class DistributionMessage
    */
   @Override
   public void setRecipients(Collection recipients) {
-    this.recipients = (InternalDistributedMember[]) recipients
-        .toArray(EMPTY_RECIPIENTS_ARRAY);
+    this.recipients = new ArrayList<>(recipients);
   }
 
   @Override
@@ -277,20 +278,18 @@ public abstract class DistributionMessage
 
   @Override
   public List<InternalDistributedMember> getRecipients() {
-    InternalDistributedMember[] recipients = getRecipientsArray();
     if (recipients == null
-        || recipients.length == 1 && recipients[0] == ALL_RECIPIENTS) {
+        || recipients.size() == 1 && recipients.get(0) == ALL_RECIPIENTS) {
       return ALL_RECIPIENTS_LIST;
     }
-    return Arrays.asList(recipients);
-  }
 
+    return recipients;
+  }
 
   public void resetRecipients() {
     this.recipients = null;
     this.multicast = false;
   }
-
 
   /**
    * Returns the intended recipient(s) of this message. If the message is intended to delivered to
@@ -301,7 +300,8 @@ public abstract class DistributionMessage
     if (this.multicast || this.recipients == null) {
       return ALL_RECIPIENTS_ARRAY;
     }
-    return this.recipients;
+
+    return this.recipients.toArray(EMPTY_RECIPIENTS_ARRAY);
   }
 
   /**
@@ -309,7 +309,7 @@ public abstract class DistributionMessage
    */
   public boolean forAll() {
     return (this.recipients == null) || (this.multicast)
-        || ((this.recipients.length > 0) && (this.recipients[0] == ALL_RECIPIENTS));
+        || ((!this.recipients.isEmpty()) && (this.recipients.get(0) == ALL_RECIPIENTS));
   }
 
   public String getRecipientsDescription() {
@@ -318,13 +318,14 @@ public abstract class DistributionMessage
     } else {
       StringBuffer sb = new StringBuffer(100);
       sb.append("recipients: <");
-      for (int i = 0; i < this.recipients.length; i++) {
+      for (int i = 0; i < this.recipients.size(); i++) {
         if (i != 0) {
           sb.append(", ");
         }
-        sb.append(this.recipients[i]);
+        sb.append(this.recipients.get(i));
       }
       sb.append(">");
+
       return sb.toString();
     }
   }
@@ -547,8 +548,9 @@ public abstract class DistributionMessage
       if (pid != 0) {
         procId = "processorId=" + pid;
       }
-      if (this.recipients != null && this.recipients.length <= 10) { // set a limit on recipients
-        Breadcrumbs.setSendSide(procId + " recipients=" + Arrays.toString(this.recipients));
+
+      if (this.recipients != null && this.recipients.size() <= 10) { // set a limit on recipients
+        Breadcrumbs.setSendSide(procId + " recipients=" + Arrays.toString(getRecipientsArray()));
       } else {
         if (procId.length() > 0) {
           Breadcrumbs.setSendSide(procId);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
@@ -18,7 +18,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -74,13 +73,6 @@ public abstract class DistributionMessage
 
   @Immutable
   protected static final InternalDistributedMember ALL_RECIPIENTS = null;
-
-  @Immutable
-  private static final InternalDistributedMember[] ALL_RECIPIENTS_ARRAY = {null};
-
-  @Immutable
-  private static final InternalDistributedMember[] EMPTY_RECIPIENTS_ARRAY =
-      new InternalDistributedMember[0];
 
   @Immutable
   private static final List<InternalDistributedMember> ALL_RECIPIENTS_LIST =
@@ -289,19 +281,6 @@ public abstract class DistributionMessage
   public void resetRecipients() {
     this.recipients = null;
     this.multicast = false;
-  }
-
-  /**
-   * Returns the intended recipient(s) of this message. If the message is intended to delivered to
-   * all distribution managers, then the array will contain ALL_RECIPIENTS. If the recipients have
-   * not been set null is returned.
-   */
-  public InternalDistributedMember[] getRecipientsArray() {
-    if (this.multicast || this.recipients == null) {
-      return ALL_RECIPIENTS_ARRAY;
-    }
-
-    return this.recipients.toArray(EMPTY_RECIPIENTS_ARRAY);
   }
 
   /**
@@ -550,7 +529,7 @@ public abstract class DistributionMessage
       }
 
       if (this.recipients != null && this.recipients.size() <= 10) { // set a limit on recipients
-        Breadcrumbs.setSendSide(procId + " recipients=" + Arrays.toString(getRecipientsArray()));
+        Breadcrumbs.setSendSide(procId + " recipients=" + getRecipients());
       } else {
         if (procId.length() > 0) {
           Breadcrumbs.setSendSide(procId);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminRequest.java
@@ -19,6 +19,7 @@ package org.apache.geode.internal.admin.remote;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 
@@ -128,7 +129,7 @@ public abstract class AdminRequest extends PooledDistributionMessage {
    */
   @Override
   protected void process(ClusterDistributionManager dm) {
-    AdminResponse response = null;
+    AdminResponse response;
     InspectionClasspathManager cpMgr = InspectionClasspathManager.getInstance();
     try {
       cpMgr.jumpToModifiedClassLoader(modifiedClasspath);
@@ -176,17 +177,15 @@ public abstract class AdminRequest extends PooledDistributionMessage {
   }
 
   public InternalDistributedMember getRecipient() {
-    InternalDistributedMember[] recipients = getRecipientsArray();
-    int size = recipients.length;
+    List<InternalDistributedMember> recipients = getRecipients();
+    int size = recipients.size();
     if (size == 0) {
       return null;
     } else if (size > 1) {
-      throw new IllegalStateException(
-          String.format("Could not return one recipient because this message has %s recipients",
-              Integer.valueOf(size)));
+      throw new IllegalStateException(String
+          .format("Could not return one recipient because this message has %s recipients", size));
     } else {
-      return recipients[0];
+      return recipients.get(0);
     }
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminResponse.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/AdminResponse.java
@@ -19,6 +19,7 @@ package org.apache.geode.internal.admin.remote;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.geode.distributed.internal.AdminMessageType;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
@@ -77,16 +78,15 @@ public abstract class AdminResponse extends HighPriorityDistributionMessage
   }
 
   public InternalDistributedMember getRecipient() {
-    InternalDistributedMember[] recipients = getRecipientsArray();
-    int size = recipients.length;
+    List<InternalDistributedMember> recipients = getRecipients();
+    int size = recipients.size();
     if (size == 0) {
       return null;
     } else if (size > 1) {
-      throw new IllegalStateException(
-          String.format("Could not return one recipient because this message has %s recipients",
-              Integer.valueOf(size)));
+      throw new IllegalStateException(String
+          .format("Could not return one recipient because this message has %s recipients", size));
     } else {
-      return recipients[0];
+      return recipients.get(0);
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.admin.remote;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,7 +39,6 @@ import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
-import org.apache.geode.internal.util.ArrayUtils;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -115,13 +115,13 @@ public class CompactRequest extends CliLegacyMessage {
 
   @Override
   public String toString() {
-    return "Compact request sent to " + ArrayUtils.toString((Object[]) this.getRecipientsArray())
+    return "Compact request sent to " + Arrays.toString(this.getRecipientsArray())
         + " from " + this.getSender();
   }
 
   private static class CompactReplyProcessor extends AdminMultipleReplyProcessor {
     Map<DistributedMember, Set<PersistentID>> results =
-        Collections.synchronizedMap(new HashMap<DistributedMember, Set<PersistentID>>());
+        Collections.synchronizedMap(new HashMap<>());
 
     CompactReplyProcessor(DistributionManager dm, Collection initMembers) {
       super(dm, initMembers);

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/CompactRequest.java
@@ -17,7 +17,6 @@ package org.apache.geode.internal.admin.remote;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -115,8 +114,8 @@ public class CompactRequest extends CliLegacyMessage {
 
   @Override
   public String toString() {
-    return "Compact request sent to " + Arrays.toString(this.getRecipientsArray())
-        + " from " + this.getSender();
+    return "Compact request sent to " + this.getRecipientsDescription() + " from "
+        + this.getSender();
   }
 
   private static class CompactReplyProcessor extends AdminMultipleReplyProcessor {

--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/ShutdownAllRequest.java
@@ -17,7 +17,6 @@ package org.apache.geode.internal.admin.remote;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -236,7 +235,7 @@ public class ShutdownAllRequest extends AdminRequest {
 
   @Override
   public String toString() {
-    return "ShutdownAllRequest sent to " + Arrays.toString(this.getRecipientsArray()) + " from "
+    return "ShutdownAllRequest sent to " + this.getRecipientsDescription() + " from "
         + this.getSender();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
@@ -721,7 +721,7 @@ public class StateFlushOperation {
         sb.append(" from ");
         sb.append(super.getSender());
       }
-      if (getRecipientsArray().length > 0) {
+      if (!getRecipients().isEmpty()) {
         String recip = getRecipientsDescription();
         sb.append(" to ");
         sb.append(recip);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionMessage.java
@@ -663,7 +663,7 @@ public abstract class PartitionMessage extends DistributionMessage
   }
 
   public InternalDistributedMember getRecipient() {
-    return getRecipientsArray()[0];
+    return getRecipients().get(0);
   }
 
   public void setOperation(Operation op) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutMessage.java
@@ -20,7 +20,6 @@ import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.EN
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
 
@@ -1076,7 +1075,7 @@ public class PutMessage extends PartitionMessageWithDirectReply implements NewVa
               putMsg.setSendDelta(false);
               if (logger.isDebugEnabled()) {
                 logger.debug("Sending full object({}) to {}", putMsg,
-                    Arrays.toString(putMsg.getRecipientsArray()));
+                    putMsg.getRecipientsDescription());
               }
               dm.putOutgoing(putMsg);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
@@ -18,6 +18,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 
@@ -417,18 +418,18 @@ public abstract class RemoteOperationMessage extends DistributionMessage
    */
   protected void appendFields(StringBuffer buff) {
     buff.append("; sender=").append(getSender()).append("; recipients=[");
-    InternalDistributedMember[] recips = getRecipientsArray();
-    for (int i = 0; i < recips.length - 1; i++) {
-      buff.append(recips[i]).append(',');
+    List<InternalDistributedMember> recipients = getRecipients();
+    for (int i = 0; i < recipients.size() - 1; i++) {
+      buff.append(recipients.get(i)).append(',');
     }
-    if (recips.length > 0) {
-      buff.append(recips[recips.length - 1]);
+    if (recipients.size() > 0) {
+      buff.append(recipients.get(recipients.size() - 1));
     }
     buff.append("]; processorId=").append(this.processorId);
   }
 
   public InternalDistributedMember getRecipient() {
-    return getRecipientsArray()[0];
+    return getRecipients().get(0);
   }
 
   public void setOperation(Operation op) {

--- a/geode-core/src/main/java/org/apache/geode/management/internal/messages/CompactRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/messages/CompactRequest.java
@@ -149,7 +149,7 @@ public class CompactRequest extends AdminRequest {
 
   private static class CompactReplyProcessor extends AdminMultipleReplyProcessor {
     Map<DistributedMember, PersistentID> results =
-        Collections.synchronizedMap(new HashMap<DistributedMember, PersistentID>());
+        Collections.synchronizedMap(new HashMap<>());
 
     public CompactReplyProcessor(DistributionManager dm, Collection<?> initMembers) {
       super(dm, initMembers);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/messages/CompactRequest.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/messages/CompactRequest.java
@@ -17,7 +17,6 @@ package org.apache.geode.management.internal.messages;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -143,7 +142,7 @@ public class CompactRequest extends AdminRequest {
 
   @Override
   public String toString() {
-    return "Compact request sent to " + Arrays.toString(this.getRecipientsArray()) + " from "
+    return "Compact request sent to " + this.getRecipientsDescription() + " from "
         + this.getSender() + " for " + this.diskStoreName;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -99,9 +101,8 @@ public class DistributionTest {
   @Test
   public void testDirectChannelSend() throws Exception {
     HighPriorityAckedMessage m = new HighPriorityAckedMessage();
-    InternalDistributedMember[] recipients =
-        new InternalDistributedMember[] {mockMembers[2], mockMembers[3]};
-    m.setRecipients(Arrays.asList(recipients));
+    List<InternalDistributedMember> recipients = Arrays.asList(mockMembers[2], mockMembers[3]);
+    m.setRecipients(recipients);
     Set<InternalDistributedMember> failures = distribution
         .directChannelSend(recipients, m);
     assertTrue(failures == null);
@@ -112,27 +113,25 @@ public class DistributionTest {
   @Test
   public void testDirectChannelSendFailureToOneRecipient() throws Exception {
     HighPriorityAckedMessage m = new HighPriorityAckedMessage();
-    InternalDistributedMember[] recipients =
-        new InternalDistributedMember[] {mockMembers[2], mockMembers[3]};
-    m.setRecipients(Arrays.asList(recipients));
+    List<InternalDistributedMember> recipients = Arrays.asList(mockMembers[2], mockMembers[3]);
+    m.setRecipients(recipients);
     Set<InternalDistributedMember> failures = distribution
         .directChannelSend(recipients, m);
     ConnectExceptions exception = new ConnectExceptions();
-    exception.addFailure(recipients[0], new Exception("testing"));
+    exception.addFailure(recipients.get(0), new Exception("testing"));
     when(dc.send(any(), any(mockMembers.getClass()),
         any(DistributionMessage.class), anyLong(), anyLong())).thenThrow(exception);
     failures = distribution.directChannelSend(recipients, m);
     assertTrue(failures != null);
     assertEquals(1, failures.size());
-    assertEquals(recipients[0], failures.iterator().next());
+    assertEquals(recipients.get(0), failures.iterator().next());
   }
 
   @Test
   public void testDirectChannelSendFailureToAll() throws Exception {
     HighPriorityAckedMessage m = new HighPriorityAckedMessage();
-    InternalDistributedMember[] recipients =
-        new InternalDistributedMember[] {mockMembers[2], mockMembers[3]};
-    m.setRecipients(Arrays.asList(recipients));
+    List<InternalDistributedMember> recipients = Arrays.asList(mockMembers[2], mockMembers[3]);
+    m.setRecipients(recipients);
     Set<InternalDistributedMember> failures = distribution
         .directChannelSend(recipients, m);
     when(dc.send(any(), any(mockMembers.getClass()),
@@ -163,14 +162,13 @@ public class DistributionTest {
   public void testDirectChannelSendFailureDueToForcedDisconnect() throws Exception {
     HighPriorityAckedMessage m = new HighPriorityAckedMessage();
     when(membership.shutdownInProgress()).thenReturn(true);
-    InternalDistributedMember[] recipients =
-        new InternalDistributedMember[] {mockMembers[2], mockMembers[3]};
-    m.setRecipients(Arrays.asList(recipients));
+    List<InternalDistributedMember> recipients = Arrays.asList(mockMembers[2], mockMembers[3]);
+    m.setRecipients(recipients);
     Set<InternalDistributedMember> failures = distribution
         .directChannelSend(recipients, m);
     distribution.setShutdown();
     ConnectExceptions exception = new ConnectExceptions();
-    exception.addFailure(recipients[0], new Exception("testing"));
+    exception.addFailure(recipients.get(0), new Exception("testing"));
     when(dc.send(any(), any(mockMembers.getClass()),
         any(DistributionMessage.class), anyLong(), anyLong())).thenThrow(exception);
     Assertions.assertThatThrownBy(() -> {
@@ -184,7 +182,7 @@ public class DistributionTest {
         Instant.now(), "thread", "", 1L, "", "");
     when(membership.shutdownInProgress()).thenReturn(true);
     Set<InternalDistributedMember> failures =
-        distribution.send(new InternalDistributedMember[] {mockMembers[0]}, m);
+        distribution.send(Collections.singletonList(mockMembers[0]), m);
     verify(membership, never()).send(any(), any());
     assertEquals(1, failures.size());
     assertEquals(mockMembers[0], failures.iterator().next());
@@ -200,7 +198,7 @@ public class DistributionTest {
 
   @Test
   public void testSendToEmptyListIsRejected() throws Exception {
-    InternalDistributedMember[] emptyList = new InternalDistributedMember[0];
+    List<InternalDistributedMember> emptyList = Collections.emptyList();
     HighPriorityAckedMessage m = new HighPriorityAckedMessage();
     m.setRecipient(mockMembers[0]);
     distribution.send(emptyList, m);


### PR DESCRIPTION
Avoid unnecessary invocations to the 'toArray' method and directly
use the java collection received instead.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
