### PR TITLE
Revert "GEODE-6536: Added retry in borrowConnection/single hop (#4719)"

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImplTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImplTest.java
@@ -94,7 +94,7 @@ public class ConnectionManagerImplTest {
     ServerLocation serverLocation = mock(ServerLocation.class);
 
     connectionManager = createDefaultConnectionManager();
-    assertThatThrownBy(() -> connectionManager.borrowConnection(serverLocation, timeout, true))
+    assertThatThrownBy(() -> connectionManager.borrowConnection(serverLocation, true))
         .isInstanceOf(AllConnectionsInUseException.class);
 
     connectionManager.close(false);
@@ -110,7 +110,7 @@ public class ConnectionManagerImplTest {
     connectionManager = createDefaultConnectionManager();
     connectionManager.start(backgroundProcessor);
 
-    assertThat(connectionManager.borrowConnection(serverLocation, timeout, false))
+    assertThat(connectionManager.borrowConnection(serverLocation, false))
         .isInstanceOf(PooledConnection.class);
     assertThat(connectionManager.getConnectionCount()).isEqualTo(1);
 
@@ -266,9 +266,9 @@ public class ConnectionManagerImplTest {
         cancelCriterion, poolStats);
     connectionManager.start(backgroundProcessor);
 
-    connectionManager.borrowConnection(serverLocation1, timeout, false);
-    connectionManager.borrowConnection(serverLocation2, timeout, false);
-    connectionManager.borrowConnection(serverLocation3, timeout, false);
+    connectionManager.borrowConnection(serverLocation1, false);
+    connectionManager.borrowConnection(serverLocation2, false);
+    connectionManager.borrowConnection(serverLocation3, false);
 
     assertThat(connectionManager.getConnectionCount()).isGreaterThan(maxConnections);
 
@@ -295,9 +295,9 @@ public class ConnectionManagerImplTest {
     connectionManager = createDefaultConnectionManager();
     connectionManager.start(backgroundProcessor);
     Connection heldConnection1 =
-        connectionManager.borrowConnection(serverLocation1, timeout, false);
+        connectionManager.borrowConnection(serverLocation1, false);
     Connection heldConnection2 =
-        connectionManager.borrowConnection(serverLocation2, timeout, false);
+        connectionManager.borrowConnection(serverLocation2, false);
     assertThat(connectionManager.getConnectionCount()).isEqualTo(2);
 
     connectionManager.returnConnection(heldConnection1, true);
@@ -352,11 +352,11 @@ public class ConnectionManagerImplTest {
     connectionManager.start(backgroundProcessor);
 
     Connection heldConnection1 =
-        connectionManager.borrowConnection(serverLocation1, timeout, false);
+        connectionManager.borrowConnection(serverLocation1, false);
     Connection heldConnection2 =
-        connectionManager.borrowConnection(serverLocation2, timeout, false);
+        connectionManager.borrowConnection(serverLocation2, false);
     Connection heldConnection3 =
-        connectionManager.borrowConnection(serverLocation3, timeout, false);
+        connectionManager.borrowConnection(serverLocation3, false);
 
     assertThat(connectionManager.getConnectionCount()).isGreaterThan(maxConnections);
 
@@ -391,7 +391,7 @@ public class ConnectionManagerImplTest {
     connectionManager = createDefaultConnectionManager();
     connectionManager.start(backgroundProcessor);
 
-    Connection heldConnection = connectionManager.borrowConnection(serverLocation1, timeout, false);
+    Connection heldConnection = connectionManager.borrowConnection(serverLocation1, false);
     heldConnection = connectionManager.exchangeConnection(heldConnection, excluded);
 
     assertThat(heldConnection.getServer()).isEqualTo(connection2.getServer());
@@ -435,9 +435,9 @@ public class ConnectionManagerImplTest {
         cancelCriterion, poolStats);
     connectionManager.start(backgroundProcessor);
 
-    Connection heldConnection = connectionManager.borrowConnection(serverLocation1, timeout, false);
-    connectionManager.borrowConnection(serverLocation2, timeout, false);
-    connectionManager.borrowConnection(serverLocation3, timeout, false);
+    Connection heldConnection = connectionManager.borrowConnection(serverLocation1, false);
+    connectionManager.borrowConnection(serverLocation2, false);
+    connectionManager.borrowConnection(serverLocation3, false);
     assertThat(connectionManager.getConnectionCount()).isGreaterThan(maxConnections);
 
     heldConnection = connectionManager.exchangeConnection(heldConnection, excluded);
@@ -470,9 +470,9 @@ public class ConnectionManagerImplTest {
     connectionManager.start(backgroundProcessor);
 
     Connection heldConnection1 =
-        connectionManager.borrowConnection(serverLocation1, timeout, false);
+        connectionManager.borrowConnection(serverLocation1, false);
     Connection heldConnection2 =
-        connectionManager.borrowConnection(serverLocation2, timeout, false);
+        connectionManager.borrowConnection(serverLocation2, false);
 
     connectionManager.returnConnection(heldConnection2);
     heldConnection2 = connectionManager.exchangeConnection(heldConnection1, excluded);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerJUnitTest.java
@@ -341,9 +341,9 @@ public class ConnectionManagerJUnitTest {
 
     // Ok, now get some connections that fill our queue
     Connection ping1 =
-        manager.borrowConnection(new ServerLocation("localhost", 5), BORROW_TIMEOUT_MILLIS, false);
+        manager.borrowConnection(new ServerLocation("localhost", 5), false);
     Connection ping2 =
-        manager.borrowConnection(new ServerLocation("localhost", 5), BORROW_TIMEOUT_MILLIS, false);
+        manager.borrowConnection(new ServerLocation("localhost", 5), false);
     manager.returnConnection(ping1);
     manager.returnConnection(ping2);
 
@@ -692,7 +692,7 @@ public class ConnectionManagerJUnitTest {
       // do nothing
     }
 
-    Connection conn3 = manager.borrowConnection(new ServerLocation("localhost", -2), 10, false);
+    Connection conn3 = manager.borrowConnection(new ServerLocation("localhost", -2), false);
     Assert.assertEquals(2, factory.creates);
     Assert.assertEquals(0, factory.destroys);
     Assert.assertEquals(0, factory.closes);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/OpExecutorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/OpExecutorImpl.java
@@ -323,7 +323,7 @@ public class OpExecutorImpl implements ExecutablePool {
       }
     }
     if (conn == null) {
-      conn = connectionManager.borrowConnection(p_server, serverTimeout, onlyUseExistingCnx);
+      conn = connectionManager.borrowConnection(p_server, onlyUseExistingCnx);
     }
     try {
       return executeWithPossibleReAuthentication(conn, op);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -918,14 +918,10 @@ public class PoolImpl implements InternalPool {
   }
 
   /**
-   * Borrows a connection to a specific server from the pool.. Used by gateway and tests. Any
-   * connection
-   * that is acquired using this method must be returned using returnConnection, even if it is
-   * destroyed.
-   *
+   * Test hook that acquires and returns a connection from the pool with a given ServerLocation.
    */
   public Connection acquireConnection(ServerLocation loc) {
-    return manager.borrowConnection(loc, 15000L, false);
+    return manager.borrowConnection(loc, false);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManager.java
@@ -56,18 +56,17 @@ public interface ConnectionManager {
    * no connection is available.
    *
    * @param server The server the connection needs to be to.
-   * @param aquireTimeout The amount of time to wait for a connection to become available, if
-   *        onlyUseExistingCnx is set to true.
    * @param onlyUseExistingCnx if true, will not create a new connection if none are available.
    * @return A connection to use.
    * @throws AllConnectionsInUseException If there is no available connection on the desired server,
    *         and onlyUseExistingCnx is set.
+   * @throws ServerOperationException If there is an issue creating the connection due to security
    * @throws NoAvailableServersException If we can't connect to any server
    * @throws ServerConnectivityException If finding a connection and creating a connection both fail
    *         to return a connection
    *
    */
-  Connection borrowConnection(ServerLocation server, long aquireTimeout, boolean onlyUseExistingCnx)
+  Connection borrowConnection(ServerLocation server, boolean onlyUseExistingCnx)
       throws AllConnectionsInUseException, NoAvailableServersException;
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/pooling/ConnectionManagerImpl.java
@@ -301,51 +301,31 @@ public class ConnectionManagerImpl implements ConnectionManager {
     throw new AllConnectionsInUseException();
   }
 
+  /**
+   * Borrow a connection to a specific server. This task currently allows us to break the connection
+   * limit, because it is used by tasks from the background thread that shouldn't be constrained by
+   * the limit. They will only violate the limit by 1 connection, and that connection will be
+   * destroyed when returned to the pool.
+   */
   @Override
-  public PooledConnection borrowConnection(ServerLocation server, long acquireTimeout,
-      boolean onlyUseExistingCnx)
-      throws AllConnectionsInUseException, NoAvailableServersException,
-      ServerConnectivityException {
-
+  public PooledConnection borrowConnection(ServerLocation server,
+      boolean onlyUseExistingCnx) throws AllConnectionsInUseException, NoAvailableServersException {
     PooledConnection connection =
         availableConnectionManager.useFirst((c) -> c.getServer().equals(server));
     if (null != connection) {
       return connection;
     }
 
-    if (!onlyUseExistingCnx) {
-      connection = forceCreateConnection(server);
-      if (null != connection) {
-        return connection;
-      }
-      throw new ServerConnectivityException(BORROW_CONN_ERROR_MSG + server);
+    if (onlyUseExistingCnx) {
+      throw new AllConnectionsInUseException();
     }
 
-    long waitStart = NOT_WAITING;
-    try {
-      long timeout = System.nanoTime() + MILLISECONDS.toNanos(acquireTimeout);
-      while (true) {
-        connection =
-            availableConnectionManager.useFirst((c) -> c.getServer().equals(server));
-        if (null != connection) {
-          return connection;
-        }
-
-        if (checkShutdownInterruptedOrTimeout(timeout)) {
-          break;
-        }
-
-        waitStart = beginConnectionWaitStatIfNotStarted(waitStart);
-
-        Thread.yield();
-      }
-    } finally {
-      endConnectionWaitStatIfStarted(waitStart);
+    connection = forceCreateConnection(server);
+    if (null != connection) {
+      return connection;
     }
 
-    cancelCriterion.checkCancelInProgress(null);
-
-    throw new AllConnectionsInUseException();
+    throw new ServerConnectivityException(BORROW_CONN_ERROR_MSG + server);
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplJUnitTest.java
@@ -453,7 +453,7 @@ public class OpExecutorImplJUnitTest {
     }
 
     @Override
-    public Connection borrowConnection(ServerLocation server, long aquireTimeout,
+    public Connection borrowConnection(ServerLocation server,
         boolean onlyUseExistingCnx) {
       borrows++;
       return new DummyConnection(server);


### PR DESCRIPTION
This reverts commit 9da2cd49e2e04564b446eaad579b51e986bc2179.

Hangs were observed in internal tests and this commit was determined to be responsible. As of yet, no local reproduction of the issue is available, but work is ongoing to provide a test that can be used to debug the issue.

In addition to the hangs caused by this commit, it should be noted that no additional tests were checked in to validate the change, as required in the "For all changes" checklist that accompanies every PR. This alone could be seen as a reason to revert, as changes without associated tests to go with them should not really be merged in the first place.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
