### PR TITLE
GEODE-7833: WIP bump tomcat versions

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -51,9 +51,9 @@ class DependencyConstraints implements Plugin<Project> {
     // specifying @zip in a dependency, the manner in which we consume them in custom configurations.
     // This would possibly be corrected if they were proper source sets.
     deps.put("tomcat6.version", "6.0.37")
-    deps.put("tomcat7.version", "7.0.96")
-    deps.put("tomcat8.version", "8.5.46")
-    deps.put("tomcat9.version", "9.0.12")
+    deps.put("tomcat7.version", "7.0.100")
+    deps.put("tomcat8.version", "8.5.51")
+    deps.put("tomcat9.version", "9.0.31")
 
     // The jetty version is also hard-coded in geode-assembly:test
     // at o.a.g.sessions.tests.GenericAppServerInstall.java

--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionFacadeJUnitTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionFacadeJUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.modules.session.catalina;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -26,7 +27,8 @@ public class DeltaSessionFacadeJUnitTest {
 
   @Test
   public void DeltaSessionFacadeMakesProperCallsOnSessionWhenInvoked() {
-    DeltaSessionInterface session = spy(new DeltaSession());
+    DeltaSessionManager manager = mock(DeltaSessionManager.class);
+    DeltaSessionInterface session = spy(new DeltaSession(manager));
 
     DeltaSessionFacade facade = new DeltaSessionFacade(session);
 

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
@@ -41,9 +41,9 @@ public class TomcatInstall extends ContainerInstall {
    */
   public enum TomcatVersion {
     TOMCAT6(6, "tomcat-6.0.37.zip"),
-    TOMCAT7(7, "tomcat-7.0.96.zip"),
-    TOMCAT8(8, "tomcat-8.5.46.zip"),
-    TOMCAT9(9, "tomcat-9.0.12.zip");
+    TOMCAT7(7, "tomcat-7.0.100.zip"),
+    TOMCAT8(8, "tomcat-8.5.51.zip"),
+    TOMCAT9(9, "tomcat-9.0.31.zip");
 
     private final int version;
 


### PR DESCRIPTION
Although this may affect tests only, bump the tomcat versions as recommended in the ghostcat advisory.