### PR TITLE
GEODE-7832: Remove Connection Semaphores

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterOperationExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterOperationExecutors.java
@@ -38,7 +38,6 @@ import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
 import org.apache.geode.internal.monitoring.ThreadsMonitoringImpl;
 import org.apache.geode.internal.monitoring.ThreadsMonitoringImplDummy;
-import org.apache.geode.internal.tcp.Connection;
 import org.apache.geode.internal.tcp.ConnectionTable;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -375,7 +374,6 @@ public class ClusterOperationExecutors implements OperationExecutors {
     FunctionExecutionPooledExecutor.setIsFunctionExecutionThread(Boolean.TRUE);
     try {
       ConnectionTable.threadWantsSharedResources();
-      Connection.makeReaderThread();
       runUntilShutdown(command);
     } finally {
       ConnectionTable.releaseThreadsSockets();
@@ -388,7 +386,6 @@ public class ClusterOperationExecutors implements OperationExecutors {
     stats.incNumProcessingThreads(1);
     try {
       ConnectionTable.threadWantsSharedResources();
-      Connection.makeReaderThread();
       runUntilShutdown(command);
     } finally {
       ConnectionTable.releaseThreadsSockets();
@@ -400,7 +397,6 @@ public class ClusterOperationExecutors implements OperationExecutors {
     stats.incHighPriorityThreads(1);
     try {
       ConnectionTable.threadWantsSharedResources();
-      Connection.makeReaderThread();
       runUntilShutdown(command);
     } finally {
       ConnectionTable.releaseThreadsSockets();
@@ -412,7 +408,6 @@ public class ClusterOperationExecutors implements OperationExecutors {
     stats.incWaitingThreads(1);
     try {
       ConnectionTable.threadWantsSharedResources();
-      Connection.makeReaderThread();
       runUntilShutdown(command);
     } finally {
       ConnectionTable.releaseThreadsSockets();
@@ -424,7 +419,6 @@ public class ClusterOperationExecutors implements OperationExecutors {
     stats.incPartitionedRegionThreads(1);
     try {
       ConnectionTable.threadWantsSharedResources();
-      Connection.makeReaderThread();
       runUntilShutdown(command);
     } finally {
       ConnectionTable.releaseThreadsSockets();
@@ -436,7 +430,6 @@ public class ClusterOperationExecutors implements OperationExecutors {
     stats.incNumSerialThreads(1);
     try {
       ConnectionTable.threadWantsSharedResources();
-      Connection.makeReaderThread();
       runUntilShutdown(command);
     } finally {
       ConnectionTable.releaseThreadsSockets();
@@ -816,7 +809,6 @@ public class ClusterOperationExecutors implements OperationExecutors {
 
     private void doSerialPooledThread(Runnable command) {
       ConnectionTable.threadWantsSharedResources();
-      Connection.makeReaderThread();
       try {
         command.run();
       } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
@@ -2657,23 +2657,6 @@ TBA
 </dd>
 
 <!-- -------------------------------------------------------  -->
-<dt><strong>p2p.defaultConcurrencyLevel</strong></dt>
-<dd>
-<em>Public:</em> false
-<p>
-<em>Integer</em> (default is the number of processors on current machine,
-but no less than 2)
-<p>
-See <code>org.apache.geode.distributed.internal.direct.DirectChannel#DEFAULT_CONCURRENCY_LEVEL</code>.
-<p>
-<pre>
-   Return how many concurrent operations should be allowed by default.
-</pre>
-<p>
-TBA
-</dd>
-
-<!-- -------------------------------------------------------  -->
 <dt><strong>p2p.defaultLogLevel</strong></dt>
 <dd>
 <em>Public:</em> false
@@ -2781,23 +2764,6 @@ See <code>org.apache.geode.internal.tcp.TCPConduit#LISTENER_CLOSE_TIMEOUT</code>
 <p>
 <pre>
   max amount of time (ms) to wait for listener threads to stop
-</pre>
-<p>
-TBA
-</dd>
-
-<!-- -------------------------------------------------------  -->
-<dt><strong>p2p.maxConnectionSenders</strong></dt>
-<dd>
-<em>Public:</em> false
-<p>
-<em>Integer</em> (default is p2p.defaultConcurrencyLevel)
-<p>
-See <code>org.apache.geode.internal.tcp.Connection#MAX_SENDERS</code>.
-<p>
-<pre>
-  The maximum number of concurrent senders sending a message to a single
-  recipient.
 </pre>
 <p>
 TBA


### PR DESCRIPTION
Removed the semaphores and related methods from DirectChannel and
Connection classes. They were used to constrain messaging when some
undocumented system properties were set.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
