### PR TITLE
GEODE-7841 Add benchmarking scripts for Geode-Redis module

### DIFF
--- a/geode-redis/README.md
+++ b/geode-redis/README.md
@@ -1,0 +1,71 @@
+# Geode Redis Module
+
+## Contents
+1. [Overview](#overview)
+2. [Performance Test](#performance-test)
+
+## <a name="overview"></a>Overview
+
+The [Geode Redis Module](https://geode.apache.org/docs/guide/12/tools_modules/redis_adapter.html) allows 
+Geode to function as a drop-in replacement for a Redis data store, letting Redis applications 
+take advantage of Geode’s scaling capabilities without changing their client code. Redis clients 
+connect to a Geode server in the same way they connect to a Redis server, using an IP address and a 
+port number.
+
+## <a name="performance-test"></a>Performance Test
+
+To run the performance tests, use the `benchmark.sh` script located in the 
+`geode-redis/src/performanceTest` directory.  This script uses the `redis-benchmark` command to
+measure performance of various Redis commands in requests per second.
+
+Mandatory command line arguments for `benchmark.sh`:
+- either `-g` or `-r`
+
+`-g` will:
+- Start a local Geode Redis Server for you
+- Shut the server down once the benchmark finishes
+
+`-r` will:
+- Connect to a Redis server that is already running
+
+Optional command line arguments for `benchmark.sh`:
+- `-h` indicates the host to connect to (default: `localhost`)
+- `-p` indicates the port to connect to (default: `6379`)
+- `-t` indicates the number of times the `redis-benchmark` command will run (default: `10`)
+- `-c` indicates the number of times the individual commands will run (default: `100000`)
+
+The script will output a CSV file called `[current git short SHA]-aggregate.csv` which can be easily
+loaded into any spreadsheet program for analysis.
+
+Sample output:
+```csv
+Command, Average Requests Per Second
+SET, 78561.4
+GET, 86181.4
+INCR, 81021.9
+LPUSH, 32934.9
+RPUSH, 32095.3
+LPOP, 11715.8
+RPOP, 12054.4
+SADD, 74603.7
+SPOP, 2853.92
+```
+
+The `benchmark.sh` script calls the `aggregator.sh` script, which handles running the 
+`redis-benchmark` command and aggregating the results after `benchmark.sh` has validated the
+environment.  The aggregator script can be run on its own if you already have an environment set up.
+
+Optional command line arguments for `aggregator.sh`:
+- `-h` indicates the host to connect to (default: `localhost`)
+- `-p` indicates the port to connect to (default: `6379`)
+- `-t` indicates the number of times the `redis-benchmark` command will run (default: `10`)
+- `-c` indicates the number of times the individual commands will run (default: `100000`)
+- `-n` indicates the output file prefix you would like to use (default: current git short SHA)
+
+The `shacompare.sh` script takes in two different commit hashes, checks them out, and calls the 
+`benchmark.sh` script for each.  It generates two aggregate CSV files that can later be compared
+for performance changes.
+
+Mandatory command line arguments for `shacompare.sh`:
+- `-b` is the commit hash for the first commit you would like to compare
+- `-c` is the commit hash for the second commit you would like to compare

--- a/geode-redis/src/performanceTest/aggregator.sh
+++ b/geode-redis/src/performanceTest/aggregator.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+TEST_RUN_COUNT=10
+COMMAND_REPETITION_COUNT=100000
+REDIS_HOST=localhost
+REDIS_PORT=6379
+FILE_PREFIX=$(git rev-parse --short HEAD)
+
+while getopts ":t:c:h:p:n:" opt; do
+  case ${opt} in
+  t)
+    TEST_RUN_COUNT=${OPTARG}
+    ;;
+  c)
+    COMMAND_REPETITION_COUNT=${OPTARG}
+    ;;
+  n)
+    FILE_PREFIX=${OPTARG}
+    ;;
+  h)
+    REDIS_HOST=${OPTARG}
+    ;;
+  p)
+    REDIS_PORT=${OPTARG}
+    ;;
+  \?)
+    echo "Usage: ${0} [-h host] [-p port] [-t (test run count)] [-c (command repetition count)]"
+    ;;
+  :)
+    echo "Invalid option: $OPTARG requires an argument" 1>&2
+    exit 1
+    ;;
+  esac
+done
+
+
+redis_benchmark_commands=("SET" "GET" "INCR" "LPUSH" "RPUSH" "LPOP" "RPOP" "SADD" "SPOP")
+
+function aggregate() {
+  local command=$1
+
+  grep ${command} results.csv | cut -d"," -f 2 | cut -d"\"" -f 2 | awk '{ sum += $1 } END { if (NR > 0) print sum / NR }'
+}
+
+function join_by() {
+  local IFS="$1"
+  shift
+  echo "$*"
+}
+
+REDIS_COMMAND_STRING=$(join_by , "${redis_benchmark_commands[@]}")
+
+SCRIPT_DIR=$(
+  cd $(dirname $0)
+  pwd
+)
+
+cd ${SCRIPT_DIR}
+
+rm -f results.csv
+
+X=0
+while [[ ${X} -lt ${TEST_RUN_COUNT} ]]; do
+  echo "Run " ${X} " of " ${TEST_RUN_COUNT}
+  redis-benchmark -h ${REDIS_HOST} -p ${REDIS_PORT} -t ${REDIS_COMMAND_STRING} -q -n ${COMMAND_REPETITION_COUNT} -r 32767 --csv >>results.csv
+
+  ((X = X + 1))
+done
+
+AGGREGATE_FILE_NAME=${FILE_PREFIX}-aggregate.csv
+
+echo "Command", "Average Requests Per Second" >${AGGREGATE_FILE_NAME}
+for command in ${redis_benchmark_commands[@]}; do
+  SUM_AGGREGATE=$(aggregate ${command})
+  echo ${command}, ${SUM_AGGREGATE} >>${AGGREGATE_FILE_NAME}
+done
+
+echo "Results saved to " ${AGGREGATE_FILE_NAME}

--- a/geode-redis/src/performanceTest/aggregator.sh
+++ b/geode-redis/src/performanceTest/aggregator.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#agreements. See the NOTICE file distributed with this work for additional information regarding
+#copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+#"License"); you may not use this file except in compliance with the License. You may obtain a
+#copy of the License at
+#
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software distributed under the License
+#is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#or implied. See the License for the specific language governing permissions and limitations under
+#the License.
+
 TEST_RUN_COUNT=10
 COMMAND_REPETITION_COUNT=100000
 REDIS_HOST=localhost

--- a/geode-redis/src/performanceTest/benchmark.sh
+++ b/geode-redis/src/performanceTest/benchmark.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#agreements. See the NOTICE file distributed with this work for additional information regarding
+#copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+#"License"); you may not use this file except in compliance with the License. You may obtain a
+#copy of the License at
+#
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software distributed under the License
+#is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#or implied. See the License for the specific language governing permissions and limitations under
+#the License.
+
 SERVER_TYPE=""
 TEST_RUN_COUNT=10
 COMMAND_REPETITION_COUNT=100000

--- a/geode-redis/src/performanceTest/benchmark.sh
+++ b/geode-redis/src/performanceTest/benchmark.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+SERVER_TYPE=""
+TEST_RUN_COUNT=10
+COMMAND_REPETITION_COUNT=100000
+REDIS_HOST=localhost
+REDIS_PORT=6379
+
+while getopts ":rgt:c:h:p:" opt; do
+  case ${opt} in
+  r)
+    SERVER_TYPE='redis'
+    ;;
+  g)
+    SERVER_TYPE='geode'
+    ;;
+  t)
+    TEST_RUN_COUNT=${OPTARG}
+    ;;
+  c)
+    COMMAND_REPETITION_COUNT=${OPTARG}
+    ;;
+  h)
+    REDIS_HOST=${OPTARG}
+    ;;
+  p)
+    REDIS_PORT=${OPTARG}
+    ;;
+  \?)
+    echo "Usage: ${0} -r (Redis) | -g (Geode) [-h host] [-p port] [-t (test run count)] [-c (command repetition count)]"
+    exit 0
+    ;;
+  :)
+    echo "Invalid option: $OPTARG requires an argument" 1>&2
+    exit 1
+    ;;
+  esac
+done
+
+if [ -z ${SERVER_TYPE} ]; then
+  echo "Please specify native Redis (-r) or Geode Redis (-g)"
+  exit 1
+fi
+
+SCRIPT_DIR=$(
+  cd $(dirname $0)
+  pwd
+)
+
+function kill_geode() {
+  pkill -9 -f ServerLauncher || true
+  pkill -9 -f LocatorLauncher || true
+  rm -rf server1
+  rm -rf locator1
+}
+
+nc -zv ${REDIS_HOST} ${REDIS_PORT} 1>&2
+SERVER_NOT_FOUND=$?
+
+if [ ${SERVER_TYPE} == "geode" ]; then
+  if [ ${SERVER_NOT_FOUND} -eq 0 ]; then
+    echo "Redis server detected already running at port ${REDIS_PORT}}"
+    echo "Please stop sever before running this script"
+    exit 1
+  fi
+
+  GEODE_BASE=$(
+    cd $SCRIPT_DIR/../../..
+    pwd
+  )
+
+  cd $GEODE_BASE
+
+  kill_geode
+
+  ./gradlew devBuild installD
+
+  GFSH=$PWD/geode-assembly/build/install/apache-geode/bin/gfsh
+
+  $GFSH -e "start locator --name=locator1"
+
+  $GFSH -e "start server
+          --name=server1
+          --log-level=none
+          --locators=localhost[10334]
+          --server-port=0
+          --redis-port=6379
+          --redis-bind-address=127.0.0.1"
+else
+  if [ ${SERVER_NOT_FOUND} -eq 1 ]; then
+    echo "No Redis server detected on host '${REDIS_HOST}' at port '${REDIS_PORT}'"
+    exit 1
+  fi
+fi
+
+cd ${SCRIPT_DIR}
+
+./aggregator.sh -h ${REDIS_HOST} -p ${REDIS_PORT} -t "${TEST_RUN_COUNT}" -c "${COMMAND_REPETITION_COUNT}"
+
+if [ ${SERVER_TYPE} == "geode" ]; then
+  kill_geode
+  sleep 1 # Back to back runs need this delay or 'nc' doesn't detect shutdown correctly
+fi

--- a/geode-redis/src/performanceTest/shacompare.sh
+++ b/geode-redis/src/performanceTest/shacompare.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+#Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+#agreements. See the NOTICE file distributed with this work for additional information regarding
+#copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+#"License"); you may not use this file except in compliance with the License. You may obtain a
+#copy of the License at
+#
+#http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software distributed under the License
+#is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+#or implied. See the License for the specific language governing permissions and limitations under
+#the License.
+
 while getopts ":b:c:" opt; do
   case ${opt} in
   b)

--- a/geode-redis/src/performanceTest/shacompare.sh
+++ b/geode-redis/src/performanceTest/shacompare.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+while getopts ":b:c:" opt; do
+  case ${opt} in
+  b)
+    BASELINE_COMMIT=${OPTARG}
+    ;;
+  c)
+    COMPARISON_COMMIT=${OPTARG}
+    ;;
+  \?)
+    echo "Usage: ${0} -b BASELINE_COMMIT -c COMPARISON_COMMIT"
+    exit 0
+    ;;
+  :)
+    echo "Invalid option: $OPTARG requires an argument" 1>&2
+    exit 1
+    ;;
+  esac
+done
+
+if [ -z ${BASELINE_COMMIT} ] || [ -z ${COMPARISON_COMMIT} ]; then
+  echo "Must specify both BASELINE_COMMIT and COMPARISON_COMMIT. Shame on you."
+  exit 1
+fi
+
+echo "BASELINE_COMMIT: ${BASELINE_COMMIT}"
+echo "COMPARISON_COMMIT: ${COMPARISON_COMMIT}"
+
+ORIGINAL_BRANCH=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+echo " ORIGINAL_BRANCH: ${ORIGINAL_BRANCH}"
+
+git checkout ${BASELINE_COMMIT}
+RETURN_CODE=$?
+ if [[ ${RETURN_CODE} -ne 0 ]] ; then
+  echo "Please stash any uncommitted changes before using this script."
+  exit 1
+fi
+
+bash benchmark.sh -g
+
+git checkout ${COMPARISON_COMMIT}
+
+bash benchmark.sh -g
+
+git checkout ${ORIGINAL_BRANCH}


### PR DESCRIPTION
We have created some scripts to measure the performance of Geode-Redis versus native Redis. They use the standard 'redis-benchmark' tool to run various Redis commands against either Geode or native Redis.

The benchmark tools consist of three scripts:

- aggregator.sh runs the actual tests
- benchmark.sh handles validating the Redis server (e.g. starting and stopping Geode Redis if needed) then runs aggregator.sh
- shacompare.sh takes two git SHAs as arguments and runs benchmark.sh on each of them, generating separate output files for each.
