### PR TITLE
GEODE-7863: Reduce ServerCQImpl Contention

### DIFF
--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/CqServiceImpl.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/CqServiceImpl.java
@@ -1347,15 +1347,14 @@ public class CqServiceImpl implements CqService {
           boolean error = false;
           {
             try {
-              synchronized (cQuery) {
-                // Apply query on new value.
-                if (!cqUnfilteredEventsSet_newValue.isEmpty()) {
-                  executionStartTime = this.stats.startCqQueryExecution();
-
+              // Apply query on new value.
+              if (!cqUnfilteredEventsSet_newValue.isEmpty()) {
+                executionStartTime = this.stats.startCqQueryExecution();
+                synchronized (cQuery) {
                   b_cqResults_newValue =
                       evaluateQuery(cQuery, new Object[] {cqUnfilteredEventsSet_newValue});
-                  this.stats.endCqQueryExecution(executionStartTime);
                 }
+                this.stats.endCqQueryExecution(executionStartTime);
               }
 
               // In case of Update, destroy and invalidate.
@@ -1390,19 +1389,19 @@ public class CqServiceImpl implements CqService {
                     }
                   }
 
-                  synchronized (cQuery) {
-                    // Apply query on old value.
-                    if (!cqUnfilteredEventsSet_oldValue.isEmpty()) {
-                      executionStartTime = this.stats.startCqQueryExecution();
+                  // Apply query on old value.
+                  if (!cqUnfilteredEventsSet_oldValue.isEmpty()) {
+                    executionStartTime = this.stats.startCqQueryExecution();
+                    synchronized (cQuery) {
                       b_cqResults_oldValue =
                           evaluateQuery(cQuery, new Object[] {cqUnfilteredEventsSet_oldValue});
-                      this.stats.endCqQueryExecution(executionStartTime);
-                    } else {
-                      if (isDebugEnabled) {
-                        logger.debug(
-                            "old value for event with key {} is null - query execution not performed",
-                            eventKey);
-                      }
+                    }
+                    this.stats.endCqQueryExecution(executionStartTime);
+                  } else {
+                    if (isDebugEnabled) {
+                      logger.debug(
+                          "old value for event with key {} is null - query execution not performed",
+                          eventKey);
                     }
                   }
                 } // Query oldValue

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/ServerCQImpl.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/ServerCQImpl.java
@@ -17,10 +17,9 @@ package org.apache.geode.cache.query.cq.internal;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.apache.logging.log4j.Logger;
 
@@ -35,7 +34,6 @@ import org.apache.geode.cache.query.CqException;
 import org.apache.geode.cache.query.CqExistsException;
 import org.apache.geode.cache.query.CqResults;
 import org.apache.geode.cache.query.Query;
-import org.apache.geode.cache.query.QueryException;
 import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.cache.query.internal.CompiledBindArgument;
 import org.apache.geode.cache.query.internal.CompiledIteratorDef;
@@ -45,6 +43,7 @@ import org.apache.geode.cache.query.internal.CqStateImpl;
 import org.apache.geode.cache.query.internal.DefaultQuery;
 import org.apache.geode.cache.query.internal.cq.CqServiceProvider;
 import org.apache.geode.cache.query.internal.cq.ServerCQ;
+import org.apache.geode.internal.CopyOnWriteHashSet;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.Token;
@@ -63,13 +62,13 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    * NOTE: In case of RR this map is populated and used as intended. In case of PR this map will not
    * be populated. If executeCQ happens after update operations this map will remain empty.
    */
-  private volatile HashMap<Object, Object> cqResultKeys;
+  private volatile ConcurrentMap<Object, Object> cqResultKeys;
 
   /**
    * This maintains the keys that are destroyed while the Results Cache is getting constructed. This
    * avoids any keys that are destroyed (after query execution) but is still part of the CQs result.
    */
-  private HashSet<Object> destroysWhileCqResultsInProgress;
+  private CopyOnWriteHashSet<Object> destroysWhileCqResultsInProgress;
 
   /**
    * To indicate if the CQ results key cache is initialized.
@@ -165,8 +164,8 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
     this.cqBaseRegion = (LocalRegion) cqService.getCache().getRegion(regionName);
     if (this.cqBaseRegion == null) {
       throw new RegionNotFoundException(
-          String.format("Region : %s specified with cq not found. CqName: %s",
-              new Object[] {regionName, this.cqName}));
+          String.format("Region : %s specified with cq not found. CqName: %s", regionName,
+              this.cqName));
     }
 
     // Make sure that the region is partitioned or
@@ -232,7 +231,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
 
     // Initialize CQ results (key) cache.
     if (CqServiceProvider.MAINTAIN_KEYS) {
-      this.cqResultKeys = new HashMap<>();
+      this.cqResultKeys = new ConcurrentHashMap<>();
       // Currently the CQ Result keys are not cached for the Partitioned
       // Regions. Supporting this with PR needs more work like forcing
       // query execution on primary buckets only; and handling the bucket
@@ -242,7 +241,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
       if (this.isPR) {
         this.setCqResultsCacheInitialized();
       } else {
-        this.destroysWhileCqResultsInProgress = new HashSet<>();
+        this.destroysWhileCqResultsInProgress = new CopyOnWriteHashSet<>();
       }
     }
 
@@ -251,8 +250,8 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
         cqService.addToCqMap(this);
       } catch (CqExistsException cqe) {
         // Should not happen.
-        throw new CqException(String.format("Unable to create cq %s Error : %s",
-            new Object[] {cqName, cqe.getMessage()}));
+        throw new CqException(
+            String.format("Unable to create cq %s Error : %s", cqName, cqe.getMessage()));
       }
       this.cqBaseRegion.getFilterProfile().registerCq(this);
     }
@@ -264,10 +263,8 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    * @return CQ Results Cache.
    */
   public Set<Object> getCqResultKeyCache() {
-    if (this.cqResultKeys != null) {
-      synchronized (this.cqResultKeys) {
-        return Collections.synchronizedSet(new HashSet<>(this.cqResultKeys.keySet()));
-      }
+    if (cqResultKeys != null) {
+      return cqResultKeys.keySet();
     } else {
       return null;
     }
@@ -280,7 +277,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    *
    * @return String modified query.
    */
-  Query constructServerSideQuery() throws QueryException {
+  Query constructServerSideQuery() {
     InternalCache cache = cqService.getInternalCache();
     DefaultQuery locQuery = (DefaultQuery) cache.getLocalQueryService().newQuery(this.queryString);
     CompiledSelect select = locQuery.getSimpleSelect();
@@ -304,23 +301,21 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
   public boolean isPartOfCqResult(Object key) {
     // Handle events that may have been deleted,
     // but added by result caching.
-    if (this.cqResultKeys == null) {
+    if (cqResultKeys == null) {
       logger.warn(
           "The CQ Result key cache is Null. This should not happen as the call to isPartOfCqResult() is based on the condition cqResultsCacheInitialized.");
       return false;
     }
 
-    synchronized (this.cqResultKeys) {
-      if (this.destroysWhileCqResultsInProgress != null) {
-        // this.logger.fine("Removing keys from Destroy Cache For CQ :" +
-        // this.cqName + " Keys :" + this.destroysWhileCqResultsInProgress);
-        for (Object k : this.destroysWhileCqResultsInProgress) {
-          this.cqResultKeys.remove(k);
-        }
-        this.destroysWhileCqResultsInProgress = null;
+    if (destroysWhileCqResultsInProgress != null) {
+      for (Object k : destroysWhileCqResultsInProgress) {
+        cqResultKeys.remove(k);
       }
-      return this.cqResultKeys.containsKey(key);
+
+      destroysWhileCqResultsInProgress = null;
     }
+
+    return cqResultKeys.containsKey(key);
   }
 
   @Override
@@ -329,15 +324,14 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
       return;
     }
 
-    if (this.cqResultKeys != null) {
-      synchronized (this.cqResultKeys) {
-        this.cqResultKeys.put(key, TOKEN);
-        if (!this.cqResultKeysInitialized) {
-          // This key could be coming after add, destroy.
-          // Remove this from destroy queue.
-          if (this.destroysWhileCqResultsInProgress != null) {
-            this.destroysWhileCqResultsInProgress.remove(key);
-          }
+    if (cqResultKeys != null) {
+      cqResultKeys.put(key, TOKEN);
+
+      if (!cqResultKeysInitialized) {
+        // This key could be coming after add, destroy.
+        // Remove this from destroy queue.
+        if (destroysWhileCqResultsInProgress != null) {
+          destroysWhileCqResultsInProgress.remove(key);
         }
       }
     }
@@ -348,16 +342,16 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
     if (!CqServiceProvider.MAINTAIN_KEYS) {
       return;
     }
-    if (this.cqResultKeys != null) {
-      synchronized (this.cqResultKeys) {
-        if (isTokenMode && this.cqResultKeys.get(key) != Token.DESTROYED) {
-          return;
-        }
-        this.cqResultKeys.remove(key);
-        if (!this.cqResultKeysInitialized) {
-          if (this.destroysWhileCqResultsInProgress != null) {
-            this.destroysWhileCqResultsInProgress.add(key);
-          }
+
+    if (cqResultKeys != null) {
+      if (isTokenMode && cqResultKeys.get(key) != Token.DESTROYED) {
+        return;
+      }
+
+      cqResultKeys.remove(key);
+      if (!cqResultKeysInitialized) {
+        if (destroysWhileCqResultsInProgress != null) {
+          destroysWhileCqResultsInProgress.add(key);
         }
       }
     }
@@ -369,11 +363,9 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
       return;
     }
 
-    if (this.cqResultKeys != null) {
-      synchronized (this.cqResultKeys) {
-        this.cqResultKeys.clear();
-        this.cqResultKeysInitialized = false;
-      }
+    if (cqResultKeys != null) {
+      cqResultKeys.clear();
+      cqResultKeysInitialized = false;
     }
   }
 
@@ -385,15 +377,11 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
       return;
     }
 
-    if (this.cqResultKeys != null) {
-      synchronized (this.cqResultKeys) {
-        this.cqResultKeys.put(key, Token.DESTROYED);
-        if (!this.cqResultKeysInitialized) {
-          // this.logger.fine("Adding key to Destroy Cache For CQ :" +
-          // this.cqName + " key :" + key);
-          if (this.destroysWhileCqResultsInProgress != null) {
-            this.destroysWhileCqResultsInProgress.add(key);
-          }
+    if (cqResultKeys != null) {
+      cqResultKeys.put(key, Token.DESTROYED);
+      if (!cqResultKeysInitialized) {
+        if (destroysWhileCqResultsInProgress != null) {
+          destroysWhileCqResultsInProgress.add(key);
         }
       }
     }
@@ -402,7 +390,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
   @Override
   public void setCqResultsCacheInitialized() {
     if (CqServiceProvider.MAINTAIN_KEYS) {
-      this.cqResultKeysInitialized = true;
+      cqResultKeysInitialized = true;
     }
   }
 
@@ -412,17 +400,16 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    * @return size of CQ Result key cache.
    */
   public int getCqResultKeysSize() {
-    if (this.cqResultKeys == null) {
+    if (cqResultKeys == null) {
       return 0;
     }
-    synchronized (this.cqResultKeys) {
-      return this.cqResultKeys.size();
-    }
+
+    return cqResultKeys.size();
   }
 
   @Override
   public boolean isOldValueRequiredForQueryProcessing(Object key) {
-    return !this.cqResultKeysInitialized || !this.isPartOfCqResult(key);
+    return !cqResultKeysInitialized || !isPartOfCqResult(key);
   }
 
   /**
@@ -454,7 +441,6 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
 
       int stateBeforeClosing = this.cqState.getState();
       this.cqState.setState(CqStateImpl.CLOSING);
-      boolean isClosed = false;
 
       // Cleanup the resource used by cq.
       this.removeFromCqMap();
@@ -468,9 +454,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
 
       // Clean-up the CQ Results Cache.
       if (this.cqResultKeys != null) {
-        synchronized (this.cqResultKeys) {
-          this.cqResultKeys.clear();
-        }
+        this.cqResultKeys.clear();
       }
 
       // Set the state to close, and update stats
@@ -503,7 +487,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    * Clears the resource used by CQ.
    */
   @Override
-  protected void cleanup() throws CqException {
+  protected void cleanup() {
     // CqBaseRegion
     try {
       if (this.cqBaseRegion != null && !this.cqBaseRegion.isDestroyed()) {
@@ -526,8 +510,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
    * Stop or pause executing the query.
    */
   @Override
-  public void stop() throws CqClosedException, CqException {
-    boolean isStopped = false;
+  public void stop() throws CqClosedException {
     synchronized (this.cqState) {
       if (this.isClosed()) {
         throw new CqClosedException(
@@ -551,7 +534,7 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
   }
 
   @Override
-  public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+  public void fromData(DataInput in) throws IOException {
     synchronized (cqState) {
       this.cqState.setState(DataSerializer.readInteger(in));
     }
@@ -585,13 +568,12 @@ public class ServerCQImpl extends CqQueryImpl implements DataSerializable, Serve
 
   @Override
   public <E> CqResults<E> executeWithInitialResults()
-      throws CqClosedException, RegionNotFoundException, CqException {
+      throws CqClosedException {
     throw new IllegalStateException("Execute cannot be called on a CQ on the server");
   }
 
   @Override
-  public void execute() throws CqClosedException, RegionNotFoundException, CqException {
+  public void execute() throws CqClosedException {
     throw new IllegalStateException("Execute cannot be called on a CQ on the server");
   }
-
 }


### PR DESCRIPTION
- Use ConcurrentMap and CopyOnWriteHashSet instead of locking the
entire map on every operation.
- Reduced time we hold the lock on the ServerCQImpl instance while
executing the query.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
