### PR TITLE
Geode prefers not to use merge-commits, so do not test against them.

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -102,6 +102,8 @@ jobs:
         trigger: true
         version: every
         attempts: 2
+        params:
+          integration_tool: rebase
       - get: geode-ci
         attempts: 2
       - get: {{ build_test.PLATFORM }}-builder-image-family
@@ -260,6 +262,8 @@ jobs:
         trigger: true
         version: every
         attempts: 2
+        params:
+          integration_tool: rebase
       - get: geode-ci
         attempts: 2
       - get: {{ test.PLATFORM }}-builder-image-family


### PR DESCRIPTION
The PR resource supports rebase instead of merging against the latest
base-branch. Do that instead of merging.

Co-authored-by: Robert Houghton <rhoughton@pivotal.io>
Co-authored-by: Owen Nichols <onichols@pivotal.io>
