### PR TITLE
GEODE-7879: Add concurrent test for HGETALL, remove locking on HGETAL…

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisLockService.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisLockService.java
@@ -27,7 +27,7 @@ import org.apache.geode.cache.TimeoutException;
 /**
  * Locking mechanism to support Redis operations
  */
-public class RedisLockService {
+public class RedisLockService implements RedisLockServiceMBean {
 
   private static final int DEFAULT_TIMEOUT = 1000;
   private final int timeoutMS;
@@ -47,6 +47,11 @@ public class RedisLockService {
    */
   public RedisLockService(int timeoutMS) {
     this.timeoutMS = timeoutMS;
+  }
+
+  @Override
+  public int getLockCount() {
+    return map.size();
   }
 
   /**

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisLockServiceMBean.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisLockServiceMBean.java
@@ -1,0 +1,33 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package org.apache.geode.redis.internal;
+
+import org.apache.geode.management.internal.security.ResourceOperation;
+import org.apache.geode.security.ResourcePermission;
+
+/**
+ * MBean to expose number of locks in RedisLockService
+ */
+
+@ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,
+    operation = ResourcePermission.Operation.MANAGE)
+public interface RedisLockServiceMBean {
+  String OBJECTNAME__REDISLOCKSERVICE_MBEAN = "GemFire:service=RedisLockService,type=Member";
+
+  int getLockCount();
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.geode.cache.TimeoutException;
-import org.apache.geode.redis.internal.AutoCloseableLock;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
@@ -59,33 +57,23 @@ public class HGetAllExecutor extends HashExecutor {
     }
     Collection<Entry<ByteArrayWrapper, ByteArrayWrapper>> entries;
     ByteArrayWrapper key = command.getKey();
-    try (AutoCloseableLock regionLock = withRegionLock(context, key)) {
-      Map<ByteArrayWrapper, ByteArrayWrapper> results = getMap(context, key);
 
-      if (results == null || results.isEmpty()) {
-        command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
-        return;
-      }
+    Map<ByteArrayWrapper, ByteArrayWrapper> results = getMap(context, key);
 
-      entries = results.entrySet();
-
-      if (entries == null || entries.isEmpty()) {
-        command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
-        return;
-      }
-
-      // create a copy
-      entries = new ArrayList<>(entries);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      command.setResponse(
-          Coder.getErrorResponse(context.getByteBufAllocator(), "Thread interrupted."));
-      return;
-    } catch (TimeoutException e) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(),
-          "Timeout acquiring lock. Please try again."));
+    if (results == null || results.isEmpty()) {
+      command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
       return;
     }
+
+    entries = results.entrySet();
+
+    if (entries == null || entries.isEmpty()) {
+      command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
+      return;
+    }
+
+    // create a copy
+    entries = new ArrayList<>(entries);
 
     command.setResponse(Coder.getKeyValArrayResponse(context.getByteBufAllocator(), entries));
   }


### PR DESCRIPTION
…LExecutor, and add RedisLockServiceMBean to expose lock count

Currently the HGetAll method uses locking, but it really isn't necessary since there is no value mutation happening.

Co-authored-by: Jens Deppe <jdeppe@vmware.com>
