### PR TITLE
GEODE-7710: Fix race condition in sending JMX notifications

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -478,8 +478,6 @@ public class FederatingManager extends Manager {
               return;
             }
             proxyFactory.createAllProxies(member, proxyMonitoringRegion);
-
-            notifListener.markReady();
           } catch (Exception e) {
             if (logger.isDebugEnabled()) {
               logger.debug("Error During GII Proxy creation", e);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/NotificationCacheListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/NotificationCacheListener.java
@@ -14,101 +14,35 @@
  */
 package org.apache.geode.management.internal;
 
-
 import javax.management.Notification;
 
-import org.apache.geode.cache.CacheListener;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.cache.RegionEvent;
+import org.apache.geode.cache.util.CacheListenerAdapter;
 
 /**
  * This listener will be attached to each notification region corresponding to a member
- *
  */
-public class NotificationCacheListener implements CacheListener<NotificationKey, Notification> {
+class NotificationCacheListener extends CacheListenerAdapter<NotificationKey, Notification> {
 
-  /**
-   * For the
-   */
-  private NotificationHubClient notifClient;
+  private final NotificationHubClient notificationHubClient;
 
-  private volatile boolean readyForEvents;
+  NotificationCacheListener(MBeanProxyFactory mBeanProxyFactory) {
+    this(new NotificationHubClient(mBeanProxyFactory));
+  }
 
-  public NotificationCacheListener(MBeanProxyFactory proxyHelper) {
-
-    notifClient = new NotificationHubClient(proxyHelper);
-    this.readyForEvents = false;
-
+  @VisibleForTesting
+  NotificationCacheListener(NotificationHubClient notificationHubClient) {
+    this.notificationHubClient = notificationHubClient;
   }
 
   @Override
   public void afterCreate(EntryEvent<NotificationKey, Notification> event) {
-    if (!readyForEvents) {
-      return;
-    }
-    notifClient.sendNotification(event);
-
-  }
-
-  @Override
-  public void afterDestroy(EntryEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterInvalidate(EntryEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionClear(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionCreate(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionDestroy(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionInvalidate(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionLive(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
+    notificationHubClient.sendNotification(event);
   }
 
   @Override
   public void afterUpdate(EntryEvent<NotificationKey, Notification> event) {
-    if (!readyForEvents) {
-      return;
-    }
-    notifClient.sendNotification(event);
-
+    notificationHubClient.sendNotification(event);
   }
-
-  @Override
-  public void close() {
-    // TODO Auto-generated method stub
-
-  }
-
-  public void markReady() {
-    readyForEvents = true;
-  }
-
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/NotificationCacheListenerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/NotificationCacheListenerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal;
+
+import static org.apache.geode.internal.cache.util.UncheckedUtils.cast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import javax.management.Notification;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+import org.apache.geode.cache.EntryEvent;
+
+/**
+ * Unit tests for {@link NotificationCacheListener} (ie the SUT). These are characterization tests
+ * that define behavior for an existing class. Test method names specify the SUT method and the
+ * result of invoking that method.
+ */
+public class NotificationCacheListenerTest {
+
+  private NotificationHubClient notificationHubClient;
+  private EntryEvent<NotificationKey, Notification> notificationEntryEvent;
+
+  @Rule
+  public MockitoRule mockitoRule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Before
+  public void setUp() {
+    notificationHubClient = mock(NotificationHubClient.class);
+    notificationEntryEvent = cast(mock(EntryEvent.class));
+  }
+
+  @Test
+  public void afterCreate_notifiesNotificationHubClient() {
+    NotificationCacheListener notificationCacheListener =
+        new NotificationCacheListener(notificationHubClient);
+
+    notificationCacheListener.afterCreate(notificationEntryEvent);
+
+    verify(notificationHubClient).sendNotification(notificationEntryEvent);
+  }
+
+  @Test
+  public void afterUpdate_notifiesNotificationHubClient() {
+    NotificationCacheListener notificationCacheListener =
+        new NotificationCacheListener(notificationHubClient);
+
+    notificationCacheListener.afterUpdate(notificationEntryEvent);
+
+    verify(notificationHubClient).sendNotification(notificationEntryEvent);
+  }
+}


### PR DESCRIPTION
JMX Manager may fail to broadcast one or more JMX notifications
during startup because of a race condition involving FederatingManager
and NotificationCacheListener.

Change NotificationCacheListener to be ready upon construction.

Since NotificationCacheListener is a test without unit test, I have created
NotificationCacheListenerTest which follows these unit testing standards:
* it uses Mockito for all dependencies
* follows Michael Feather's definition of a unit test
* uses terminology and patterns from http://xunitpatterns.com/
* uses TextDox inspired test method naming