### PR TITLE
GEODE-7877: deal with the static Version map in TcpClient

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedRule.java
@@ -28,7 +28,6 @@ import org.apache.geode.cache30.ClientServerTestCase;
 import org.apache.geode.cache30.RegionTestCase;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
-import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.internal.admin.ClientStatsManager;
 import org.apache.geode.internal.cache.DiskStoreObserver;
 import org.apache.geode.internal.cache.InitialImageOperation;
@@ -243,7 +242,6 @@ public class DistributedRule extends AbstractDistributedRule {
       RegionTestCase.preSnapshotRegion = null;
       SocketCreator.resetHostNameCache();
       SocketCreator.resolve_dns = true;
-      TcpClient.clearStaticData();
 
       // clear system properties -- keep alphabetized
       System.clearProperty(GeodeGlossary.GEMFIRE_PREFIX + "log-level");

--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
@@ -290,17 +290,18 @@ public class TcpClient {
         // old locators will not recognize the version request and will close the connection
       }
     } finally {
-      try {
-        sock.setSoLinger(true, 0); // initiate an abort on close to shut down the server's socket
-      } catch (Exception e) {
-        logger.error("Error aborting socket ", e);
+      if (!sock.isClosed()) {
+        try {
+          sock.setSoLinger(true, 0); // initiate an abort on close to shut down the server's socket
+        } catch (Exception e) {
+          logger.error("Error aborting socket ", e);
+        }
+        try {
+          sock.close();
+        } catch (Exception e) {
+          logger.error("Error closing socket ", e);
+        }
       }
-      try {
-        sock.close();
-      } catch (Exception e) {
-        logger.error("Error closing socket ", e);
-      }
-
     }
     synchronized (serverVersions) {
       serverVersions.put(addr, Version.GFE_57.ordinal());

--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/TcpClient.java
@@ -32,7 +32,6 @@ import javax.net.ssl.SSLException;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.internal.serialization.ObjectDeserializer;
 import org.apache.geode.internal.serialization.ObjectSerializer;
 import org.apache.geode.internal.serialization.UnsupportedSerializationVersionException;
@@ -54,8 +53,7 @@ public class TcpClient {
 
   private static final int DEFAULT_REQUEST_TIMEOUT = 60 * 2 * 1000;
 
-  @MakeNotStatic
-  private static final Map<HostAndPort, Short> serverVersions =
+  private final Map<HostAndPort, Short> serverVersions =
       new HashMap<>();
 
   private final TcpSocketCreator socketCreator;
@@ -308,17 +306,5 @@ public class TcpClient {
       serverVersions.put(addr, Version.GFE_57.ordinal());
     }
     return Short.valueOf(Version.GFE_57.ordinal());
-  }
-
-
-  /**
-   * Clear static class information concerning Locators. This is used in unit tests. It will force
-   * TcpClient to send version-request messages to locators to reestablish knowledge of their
-   * communication protocols.
-   */
-  public static void clearStaticData() {
-    synchronized (serverVersions) {
-      serverVersions.clear();
-    }
   }
 }

--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.invocation.InvocationOnMock;
@@ -79,11 +78,6 @@ public class TcpServerJUnitTest {
     assertThat(server.isShuttingDown()).isFalse();
     assertThat(server.getSocketAddress()).isNotNull();
     assertThat(server.isAlive()).isTrue();
-  }
-
-  @Before
-  public void setup() {
-    TcpClient.clearStaticData();
   }
 
   @Test


### PR DESCRIPTION
The server-version map that tracks Locator versions is now an instance
variable instead of a static.

I looked into removing the map altogether but it's really needed for
rolling-upgrade purposes.  When one locator is rolled to a new version
of Geode but another locator is still running the old version it's
essential that the new locator know that it's communicating with an old
locator.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
