### PR TITLE
GEODE-7885: Improve RedisLockService - fix synchronization and memory leak

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -158,6 +158,12 @@
         <scope>compile</scope>
       </dependency>
       <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.14</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
         <version>3.2.2</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -104,6 +104,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'com.tngtech.archunit', name:'archunit-junit4', version: '0.12.0')
         api(group: 'com.zaxxer', name: 'HikariCP', version: '3.4.1')
         api(group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4')
+        api(group: 'commons-codec', name: 'commons-codec', version: '1.14')
         api(group: 'commons-collections', name: 'commons-collections', version: '3.2.2')
         api(group: 'commons-configuration', name: 'commons-configuration', version: '1.10')
         api(group: 'commons-digester', name: 'commons-digester', version: '2.1')

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -963,7 +963,7 @@ lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
 lib/classgraph-4.8.52.jar
 lib/commons-beanutils-1.9.4.jar
-lib/commons-codec-1.11.jar
+lib/commons-codec-1.14.jar
 lib/commons-collections-3.2.2.jar
 lib/commons-digester-2.1.jar
 lib/commons-io-2.6.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -72,7 +72,7 @@ HdrHistogram-2.1.11.jar
 LatencyUtils-2.0.3.jar
 javax.transaction-api-1.3.jar
 spring-jcl-5.2.1.RELEASE.jar
-commons-codec-1.11.jar
+commons-codec-1.14.jar
 jetty-xml-9.4.21.v20190926.jar
 jetty-http-9.4.21.v20190926.jar
 jetty-io-9.4.21.v20190926.jar

--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   implementation('com.github.davidmoten:geo')
   implementation('io.netty:netty-all')
   implementation('org.apache.logging.log4j:log4j-api')
+  implementation('commons-codec:commons-codec')
 
   testImplementation(project(':geode-junit'))
   testImplementation('org.mockito:mockito-core')

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
@@ -21,12 +21,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis;
+
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
+import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.GemFireCache;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+
+public class RedisLockServiceIntegrationTest {
+
+  private static final int REDIS_CLIENT_TIMEOUT = 100000;
+  private static GeodeRedisServer server;
+  private static GemFireCache cache;
+  private static Jedis jedis;
+  private static int port = 6379;
+
+  @BeforeClass
+  public static void setUp() {
+    CacheFactory cf = new CacheFactory();
+    cf.set(LOG_LEVEL, "warn");
+    cf.set(MCAST_PORT, "0");
+    cf.set(LOCATORS, "");
+    cache = cf.create();
+
+    port = AvailablePortHelper.getRandomAvailableTCPPort();
+    server = new GeodeRedisServer("localhost", port);
+    server.start();
+
+    jedis = new Jedis("localhost", port, REDIS_CLIENT_TIMEOUT);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    jedis.close();
+    cache.close();
+    server.shutdown();
+  }
+
+  @Test
+  public void onceLocksAreFreed_thenTheyAreAutomaticallyCleanedUp() {
+    for (int i = 0; i < 1000; i++) {
+      jedis.sadd("key-" + i, "value-" + i);
+    }
+
+    System.gc();
+    System.runFinalization();
+
+    GeodeAwaitility.await().until(() -> server.getLockService().getLockCount() == 0);
+    assertThat(server.getLockService().getLockCount()).isEqualTo(0);
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
@@ -21,6 +21,12 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -47,6 +53,7 @@ public class RedisLockServiceIntegrationTest {
     cf.set(LOCATORS, "");
     cache = cf.create();
 
+    System.setProperty(GeodeRedisServer.DEFAULT_REGION_SYS_PROP_NAME, "REPLICATE");
     port = AvailablePortHelper.getRandomAvailableTCPPort();
     server = new GeodeRedisServer("localhost", port);
     server.start();

--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -65,6 +65,7 @@ import io.netty.util.concurrent.Future;
 import org.apache.geode.GemFireConfigException;
 import org.apache.geode.LogWriter;
 import org.apache.geode.annotations.Experimental;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -84,6 +85,8 @@ import org.apache.geode.internal.hll.HyperLogLogPlus;
 import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
+import org.apache.geode.management.ManagementService;
+import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.ByteToCommandDecoder;
 import org.apache.geode.redis.internal.Coder;
@@ -507,9 +510,17 @@ public class GeodeRedisServer {
     registerLockServiceMBean();
   }
 
+  @VisibleForTesting
+  public RedisLockService getLockService() {
+    return hashLockService;
+  }
+
   private void registerLockServiceMBean() {
+    ManagementService sms = SystemManagementService.getManagementService(cache);
+
     try {
       ObjectName mbeanON = new ObjectName(OBJECTNAME__REDISLOCKSERVICE_MBEAN);
+      sms.registerMBean(hashLockService, mbeanON);
       MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
 
       Set<ObjectName> names = platformMBeanServer.queryNames(mbeanON, null);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ByteArrayWrapper.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ByteArrayWrapper.java
@@ -36,7 +36,7 @@ public class ByteArrayWrapper implements DataSerializable, Comparable<ByteArrayW
   /**
    * The data portion of ValueWrapper
    */
-  private byte[] value;
+  protected byte[] value;
 
   /**
    * Hash of {@link #value}, this value is cached for performance
@@ -128,7 +128,6 @@ public class ByteArrayWrapper implements DataSerializable, Comparable<ByteArrayW
   @Override
   public int compareTo(ByteArrayWrapper other) {
     return arrayCmp(value, other.value);
-
   }
 
   /**

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/KeyHashIdentifier.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/KeyHashIdentifier.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal;
+
+import org.apache.commons.codec.digest.MurmurHash3;
+
+/**
+ * Key object specifically for use by the RedisLockService. This object has various unique
+ * properties:
+ * <ul>
+ * <li>
+ * The hashcode is calculated using the low 64 bits of a 128 bit Murmur3 hash
+ * </li>
+ * <li>
+ * Equality between keys is determined exclusively using the hashcode. This is done in order
+ * to speed up equality checks.
+ * </li>
+ * </ul>
+ * <p/>
+ * This implies that keys may exhibit equality even when their values are actually different.
+ * However, since these keys are only used to identify a lock, the worst that may happen is that
+ * a request for a lock will identify an already existing lock and have to wait on that lock to
+ * become free.
+ */
+public class KeyHashIdentifier {
+
+  private final long hashCode;
+
+  /**
+   * Since the key is used by the RedisLockService in a WeakHashMap, keep a reference to it so that
+   * it is not removed prematurely (before the lock is actually released).
+   */
+  private final byte[] key;
+
+  public KeyHashIdentifier(byte[] key) {
+    this.key = key;
+    long[] murmur = MurmurHash3.hash128(key);
+    this.hashCode = murmur[0];
+  }
+
+  @Override
+  public int hashCode() {
+    return (int) hashCode;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof KeyHashIdentifier)) {
+      return false;
+    }
+
+    KeyHashIdentifier otherKey = (KeyHashIdentifier) other;
+    return this.hashCode == otherKey.hashCode;
+  }
+
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisLockService.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisLockService.java
@@ -74,9 +74,8 @@ public class RedisLockService implements RedisLockServiceMBean {
     KeyHashIdentifier lockKey = new KeyHashIdentifier(key.toBytes());
     KeyHashIdentifier referencedKey = lockKey;
 
-    Lock lock;
+    Lock lock = new ReentrantLock();
     do {
-      lock = new ReentrantLock();
       Lock oldLock = weakReferencesTolocks.putIfAbsent(lockKey, lock);
 
       if (oldLock != null) {

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/KeyHashIdentifierTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/KeyHashIdentifierTest.java
@@ -13,24 +13,32 @@
  * the License.
  *
  */
+
 package org.apache.geode.redis.internal;
 
-import java.util.concurrent.locks.Lock;
+import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Created by gosullivan on 3/10/17.
- */
-public class AutoCloseableLock implements AutoCloseable {
-  private final Lock lock;
-  private final KeyHashIdentifier key;
+import org.junit.Test;
 
-  public AutoCloseableLock(KeyHashIdentifier key, Lock lock) {
-    this.key = key;
-    this.lock = lock;
+public class KeyHashIdentifierTest {
+
+  @Test
+  public void equals_shouldReturnTrue_givenDistinctObjectsWithSameValue() {
+    KeyHashIdentifier key1 = new KeyHashIdentifier(new byte[] {0, 1, 2, 3});
+    KeyHashIdentifier key2 = new KeyHashIdentifier(new byte[] {0, 1, 2, 3});
+
+    assertThat(key1.equals(key2))
+        .as("equals() method should return true")
+        .isTrue();
   }
 
-  @Override
-  public void close() {
-    lock.unlock();
+  @Test
+  public void equals_shouldReturnFalse_givenDistinctObjectsWithDifferentValues() {
+    KeyHashIdentifier key1 = new KeyHashIdentifier(new byte[] {0, 1, 2, 3});
+    KeyHashIdentifier key2 = new KeyHashIdentifier(new byte[] {0, 1, 2, 4});
+
+    assertThat(key1.equals(key2))
+        .as("equals() method should return false")
+        .isFalse();
   }
 }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/RedisLockServiceJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/RedisLockServiceJUnitTest.java
@@ -174,26 +174,27 @@ public class RedisLockServiceJUnitTest {
   public void lockingDoesNotCauseConcurrentModificationExceptions()
       throws ExecutionException, InterruptedException {
 
+    int ITERATIONS = 10000;
     RedisLockService lockService = new RedisLockService();
 
     ExecutorService pool = Executors.newFixedThreadPool(5);
     Callable<Void> callable = () -> {
       ByteArrayWrapper key = new ByteArrayWrapper("key".getBytes());
-      for (int i = 0; i < 10000; i++) {
+      for (int i = 0; i < ITERATIONS; i++) {
         lockService.lock(key).close();
       }
       return null;
     };
 
     Callable<Void> lockMaker = () -> {
-      for (int i = 0; i < 10000; i++) {
+      for (int i = 0; i < ITERATIONS; i++) {
         lockService.lock(new ByteArrayWrapper(("key-" + i++).getBytes())).close();
       }
       return null;
     };
 
     Callable<Void> garbageCollection = () -> {
-      for (int i = 0; i < 100; i++) {
+      for (int i = 0; i < ITERATIONS / 100; i++) {
         System.gc();
         System.runFinalization();
       }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/RedisLockServiceJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/RedisLockServiceJUnitTest.java
@@ -60,7 +60,7 @@ public class RedisLockServiceJUnitTest {
 
     // start thread with locking
     t1.start();
-    await().until(() -> lockService.getMapSize() == 1);
+    await().until(() -> lockService.getLockCount() == 1);
 
     // test current thread cannot lock the same key
     assertThatExceptionOfType(TimeoutException.class).isThrownBy(() -> lockService.lock(key1));
@@ -76,7 +76,7 @@ public class RedisLockServiceJUnitTest {
     assertThat(lockService.lock(key1)).isNotNull();
     assertThat(lockService.lock(key2)).isNotNull();
 
-    assertThat(lockService.getMapSize()).isEqualTo(1);
+    assertThat(lockService.getLockCount()).isEqualTo(1);
   }
 
   /**
@@ -103,7 +103,7 @@ public class RedisLockServiceJUnitTest {
 
     // start thread with locking
     t1.start();
-    await().until(() -> lockService1.getMapSize() == 1);
+    await().until(() -> lockService1.getLockCount() == 1);
 
     assertThatExceptionOfType(TimeoutException.class).isThrownBy(() -> lockService1.lock(key));
 
@@ -126,7 +126,7 @@ public class RedisLockServiceJUnitTest {
     ByteArrayWrapper obj = new ByteArrayWrapper(new byte[] {1});
 
     AutoCloseableLock autoLock = lockService.lock(obj);
-    assertThat(lockService.getMapSize()).isEqualTo(1);
+    assertThat(lockService.getLockCount()).isEqualTo(1);
 
     autoLock.close();
     autoLock = null;
@@ -136,8 +136,8 @@ public class RedisLockServiceJUnitTest {
     System.runFinalization();
 
     // check lock removed
-    await().until(() -> lockService.getMapSize() == 0);
-    assertThat(lockService.getMapSize()).isEqualTo(0);
+    await().until(() -> lockService.getLockCount() == 0);
+    assertThat(lockService.getLockCount()).isEqualTo(0);
   }
 
   @Test
@@ -147,12 +147,12 @@ public class RedisLockServiceJUnitTest {
     ByteArrayWrapper obj1 = new ByteArrayWrapper(new byte[] {77});
     AutoCloseableLock lock1 = lockService.lock(obj1);
 
-    assertThat(lockService.getMapSize()).isEqualTo(1);
+    assertThat(lockService.getLockCount()).isEqualTo(1);
 
     ByteArrayWrapper obj2 = new ByteArrayWrapper(new byte[] {77});
     AutoCloseableLock lock2 = lockService.lock(obj2);
 
-    assertThat(lockService.getMapSize()).isEqualTo(1);
+    assertThat(lockService.getLockCount()).isEqualTo(1);
 
     obj1 = null;
     lock1 = null;
@@ -161,8 +161,8 @@ public class RedisLockServiceJUnitTest {
     System.runFinalization();
 
     // check lock removed
-    await().until(() -> lockService.getMapSize() == 1);
-    assertThat(lockService.getMapSize()).isEqualTo(1);
+    await().until(() -> lockService.getLockCount() == 1);
+    assertThat(lockService.getLockCount()).isEqualTo(1);
   }
 
 }

--- a/geode-redis/src/test/resources/expected-pom.xml
+++ b/geode-redis/src/test/resources/expected-pom.xml
@@ -81,5 +81,10 @@
       <artifactId>log4j-api</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
- RedisLockService was not able to automatically free keys/locks after
  unlocking since keys were also beging referenced in regions.
- Fix synchronization while iterating over keySet to avoid
  ConcurrentModifiactionExceptions.

Co-Authored-By: Sarah Abbey <sabbey@pivotal.io>
Co-Authored-By: Ray Ingles <ringles@pivotal.io>
Co-Authored-By: John Hutchison <jhutchison@pivotal.io>
