### PR TITLE
GEODE-7869: Revert content type changes.

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestRegionAPIDUnitTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestRegionAPIDUnitTest.java
@@ -47,6 +47,9 @@ import org.apache.geode.test.junit.rules.RequiresGeodeHome;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 public class RestRegionAPIDUnitTest {
+  @SuppressWarnings("deprecation")
+  private static final String APPLICATION_JSON_UTF8_VALUE = MediaType.APPLICATION_JSON_UTF8_VALUE;
+
   @ClassRule
   public static ServerStarterRule server = new ServerStarterRule()
       .withRestService()
@@ -79,7 +82,7 @@ public class RestRegionAPIDUnitTest {
   public void getAllResources() {
     restClient.doGetAndAssert("")
         .hasStatusCode(HttpStatus.SC_OK)
-        .hasContentType(MediaType.APPLICATION_JSON.toString())
+        .hasContentType(APPLICATION_JSON_UTF8_VALUE)
         .hasResponseBody().isEqualToIgnoringWhitespace(
             "{\"regions\":[{\"name\":\"regionA\",\"type\":\"REPLICATE\",\"key-constraint\":null,\"value-constraint\":null}]}");
   }

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityIntegrationTest.java
@@ -41,6 +41,8 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 public class RestSecurityIntegrationTest {
 
   protected static final String REGION_NAME = "AuthRegion";
+  @SuppressWarnings("deprecation")
+  private static final String APPLICATION_JSON_UTF8_VALUE = MediaType.APPLICATION_JSON_UTF8_VALUE;
 
   @ClassRule
   public static ServerStarterRule serverStarter = new ServerStarterRule()
@@ -64,7 +66,7 @@ public class RestSecurityIntegrationTest {
     assertResponse(restClient.doGet("/functions", "user", "user")).hasStatusCode(403);
     assertResponse(restClient.doGet("/functions", "dataRead", "dataRead"))
         .hasStatusCode(200)
-        .hasContentType(MediaType.APPLICATION_JSON_VALUE);
+        .hasContentType(APPLICATION_JSON_UTF8_VALUE);
   }
 
   @Test
@@ -83,7 +85,7 @@ public class RestSecurityIntegrationTest {
         .hasStatusCode(403);
     restClient.doGetAndAssert("/queries", "dataRead", "dataRead")
         .hasStatusCode(200)
-        .hasContentType(MediaType.APPLICATION_JSON_VALUE);
+        .hasContentType(APPLICATION_JSON_UTF8_VALUE);
   }
 
   @Test
@@ -146,7 +148,7 @@ public class RestSecurityIntegrationTest {
         .hasStatusCode(403);
     assertResponse(restClient.doGet("/servers", "cluster", "cluster"))
         .hasStatusCode(200)
-        .hasContentType(MediaType.APPLICATION_JSON_VALUE);
+        .hasContentType(APPLICATION_JSON_UTF8_VALUE);
   }
 
   /**
@@ -172,7 +174,7 @@ public class RestSecurityIntegrationTest {
   @Test
   public void getRegions() throws IOException {
     JsonNode jsonObject = assertResponse(restClient.doGet("", "dataRead", "dataRead"))
-        .hasStatusCode(200).hasContentType(MediaType.APPLICATION_JSON_VALUE)
+        .hasStatusCode(200).hasContentType(APPLICATION_JSON_UTF8_VALUE)
         .getJsonObject();
 
     JsonNode regions = jsonObject.get("regions");
@@ -207,7 +209,7 @@ public class RestSecurityIntegrationTest {
 
     // Test an authorized user - 200
     assertResponse(restClient.doGet("/" + REGION_NAME, "data", "data"))
-        .hasStatusCode(200).hasContentType(MediaType.APPLICATION_JSON_VALUE);
+        .hasStatusCode(200).hasContentType(APPLICATION_JSON_UTF8_VALUE);
   }
 
   /**
@@ -249,7 +251,7 @@ public class RestSecurityIntegrationTest {
   public void getRegionKeys() {
     // Test an authorized user
     assertResponse(restClient.doGet("/" + REGION_NAME + "/keys", "data", "data"))
-        .hasStatusCode(200).hasContentType(MediaType.APPLICATION_JSON_VALUE);
+        .hasStatusCode(200).hasContentType(APPLICATION_JSON_UTF8_VALUE);
     // Test an unauthorized user
     assertResponse(restClient.doGet("/" + REGION_NAME + "/keys", "dataWrite", "dataWrite"))
         .hasStatusCode(403);
@@ -263,7 +265,7 @@ public class RestSecurityIntegrationTest {
     // Test an authorized user
     assertResponse(restClient.doGet("/" + REGION_NAME + "/key1", "dataReadAuthRegionKey1",
         "dataReadAuthRegionKey1"))
-            .hasStatusCode(200).hasContentType(MediaType.APPLICATION_JSON_VALUE);
+            .hasStatusCode(200).hasContentType(APPLICATION_JSON_UTF8_VALUE);
 
     // Test an unauthorized user
     assertResponse(restClient.doGet("/" + REGION_NAME + "/key1", "dataWrite", "dataWrite"))

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityPostProcessorTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityPostProcessorTest.java
@@ -43,6 +43,9 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 @Category({SecurityTest.class, RestAPITest.class})
 public class RestSecurityPostProcessorTest {
 
+  @SuppressWarnings("deprecation")
+  private static final String APPLICATION_JSON_UTF8_VALUE = MediaType.APPLICATION_JSON_UTF8_VALUE;
+
   @ClassRule
   public static ServerStarterRule serverStarter = new ServerStarterRule()
       .withProperty(TestSecurityManager.SECURITY_JSON,
@@ -76,7 +79,7 @@ public class RestSecurityPostProcessorTest {
     JsonNode jsonNode =
         assertResponse(restClient.doGet("/customers/1", "dataReader", "1234567"))
             .hasStatusCode(200)
-            .hasContentType(MediaType.APPLICATION_JSON_VALUE)
+            .hasContentType(APPLICATION_JSON_UTF8_VALUE)
             .getJsonObject();
 
     assertEquals("*********", jsonNode.get("ssn").asText());
@@ -86,7 +89,7 @@ public class RestSecurityPostProcessorTest {
     jsonNode =
         assertResponse(restClient.doGet("/customers/1", "super-user", "1234567"))
             .hasStatusCode(200)
-            .hasContentType(MediaType.APPLICATION_JSON_VALUE)
+            .hasContentType(APPLICATION_JSON_UTF8_VALUE)
             .getJsonObject();
     assertEquals("555555555", jsonNode.get("ssn").asText());
     assertEquals(1L, jsonNode.get("id").asLong());
@@ -98,7 +101,7 @@ public class RestSecurityPostProcessorTest {
     JsonNode jsonNode =
         assertResponse(restClient.doGet("/customers/1,3", "dataReader", "1234567"))
             .hasStatusCode(200)
-            .hasContentType(MediaType.APPLICATION_JSON_VALUE)
+            .hasContentType(APPLICATION_JSON_UTF8_VALUE)
             .getJsonObject();
 
     JsonNode customers = jsonNode.get("customers");
@@ -116,7 +119,7 @@ public class RestSecurityPostProcessorTest {
   public void getRegion() throws Exception {
     JsonNode jsonNode = assertResponse(restClient.doGet("/customers", "dataReader", "1234567"))
         .hasStatusCode(200)
-        .hasContentType(MediaType.APPLICATION_JSON_VALUE)
+        .hasContentType(APPLICATION_JSON_UTF8_VALUE)
         .getJsonObject();
 
     JsonNode customers = jsonNode.get("customers");
@@ -134,7 +137,7 @@ public class RestSecurityPostProcessorTest {
         + URLEncoder.encode("SELECT * FROM /customers order by customerId", "UTF-8");
     JsonNode jsonArray = assertResponse(restClient.doGet(query, "dataReader", "1234567"))
         .hasStatusCode(200)
-        .hasContentType(MediaType.APPLICATION_JSON_VALUE)
+        .hasContentType(APPLICATION_JSON_UTF8_VALUE)
         .getJsonObject();
 
     final int length = jsonArray.size();
@@ -160,7 +163,7 @@ public class RestSecurityPostProcessorTest {
     String query = "/queries";
     assertResponse(restClient.doGet(query, "dataReader", "1234567"))
         .hasStatusCode(200)
-        .hasContentType(MediaType.APPLICATION_JSON_VALUE);
+        .hasContentType(APPLICATION_JSON_UTF8_VALUE);
 
     // Execute the query
     JsonNode jsonArray =

--- a/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
@@ -968,10 +968,14 @@ public class RestAccessControllerTest {
   }
 
   private static class StandardRequestPostProcessor implements RequestPostProcessor {
+
+    @SuppressWarnings("deprecation")
+    private static final MediaType APPLICATION_JSON_UTF8 = MediaType.APPLICATION_JSON_UTF8;
+
     @Override
     public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
-      request.addHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON);
-      request.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+      request.addHeader(HttpHeaders.ACCEPT, APPLICATION_JSON_UTF8);
+      request.addHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON_UTF8);
       return request;
     }
   }

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -99,6 +100,11 @@ public abstract class AbstractBaseController implements InitializingBean {
   private static final String DEFAULT_ENCODING = UTF_8;
   private static final Logger logger = LogService.getLogger();
   private static final AtomicLong ID_SEQUENCE = new AtomicLong(0L);
+
+  @SuppressWarnings("deprecation")
+  protected static final String APPLICATION_JSON_UTF8_VALUE = MediaType.APPLICATION_JSON_UTF8_VALUE;
+  @SuppressWarnings("deprecation")
+  protected static final MediaType APPLICATION_JSON_UTF8 = MediaType.APPLICATION_JSON_UTF8;
 
   @Autowired
   protected RestSecurityService securityService;

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -62,7 +61,7 @@ public abstract class CommonCrudController extends AbstractBaseController {
    *
    * @return JSON document containing result
    */
-  @RequestMapping(method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
+  @RequestMapping(method = RequestMethod.GET, produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "list all resources (Regions)",
       notes = "List all available resources (Regions) in the Geode cluster")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),
@@ -89,7 +88,7 @@ public abstract class CommonCrudController extends AbstractBaseController {
    * @return JSON document containing result
    */
   @RequestMapping(method = RequestMethod.GET, value = "/{region}/keys",
-      produces = {MediaType.APPLICATION_JSON_VALUE})
+      produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "list all keys", notes = "List all keys in region")
   @ApiResponses({@ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 401, message = "Invalid Username or Password."),
@@ -118,7 +117,7 @@ public abstract class CommonCrudController extends AbstractBaseController {
    * @return JSON document containing result
    */
   @RequestMapping(method = RequestMethod.DELETE, value = "/{region}/{keys}",
-      produces = {MediaType.APPLICATION_JSON_VALUE})
+      produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "delete data for key(s)",
       notes = "Delete data for single key or specific keys in region")
   @ApiResponses({@ApiResponse(code = 200, message = "OK"),
@@ -174,7 +173,7 @@ public abstract class CommonCrudController extends AbstractBaseController {
   }
 
   @RequestMapping(method = {RequestMethod.GET}, value = "/servers",
-      produces = {MediaType.APPLICATION_JSON_VALUE})
+      produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "fetch all REST enabled servers in the DS",
       notes = "Find all gemfire node where developer REST service is up and running!")
   @ApiResponses({@ApiResponse(code = 200, message = "OK"),

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/FunctionAccessController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/FunctionAccessController.java
@@ -27,7 +27,6 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -84,7 +83,7 @@ public class FunctionAccessController extends AbstractBaseController {
    *
    * @return result as a JSON document.
    */
-  @RequestMapping(method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
+  @RequestMapping(method = RequestMethod.GET, produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "list all functions",
       notes = "list all functions available in the GemFire cluster")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),
@@ -121,7 +120,7 @@ public class FunctionAccessController extends AbstractBaseController {
    * @return result as a JSON document
    */
   @RequestMapping(method = RequestMethod.POST, value = "/{functionId:.+}",
-      produces = {MediaType.APPLICATION_JSON_VALUE})
+      produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "execute function",
       notes = "Execute function with arguments on regions, members, or group(s). By default function will be executed on all nodes if none of (onRegion, onMembers, onGroups) specified")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/PdxBasedCrudController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/PdxBasedCrudController.java
@@ -25,7 +25,6 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -76,7 +75,7 @@ public class PdxBasedCrudController extends CommonCrudController {
    * @return JSON document
    */
   @RequestMapping(method = RequestMethod.POST, value = "/{region}",
-      consumes = MediaType.APPLICATION_JSON_VALUE, produces = {MediaType.APPLICATION_JSON_VALUE})
+      consumes = APPLICATION_JSON_UTF8_VALUE, produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "create entry", notes = "Create (put-if-absent) data in region")
   @ApiResponses({@ApiResponse(code = 201, message = "Created."),
       @ApiResponse(code = 400,
@@ -112,7 +111,7 @@ public class PdxBasedCrudController extends CommonCrudController {
     if (existingPdxObj != null) {
       final RegionEntryData<Object> data = new RegionEntryData<>(region);
       data.add(existingPdxObj);
-      headers.setContentType(MediaType.APPLICATION_JSON);
+      headers.setContentType(APPLICATION_JSON_UTF8);
       return new ResponseEntity<RegionEntryData<?>>(data, headers, HttpStatus.CONFLICT);
     } else {
       return new ResponseEntity<String>(headers, HttpStatus.CREATED);
@@ -127,7 +126,7 @@ public class PdxBasedCrudController extends CommonCrudController {
    * @return JSON document
    */
   @RequestMapping(method = RequestMethod.GET, value = "/{region}",
-      produces = MediaType.APPLICATION_JSON_VALUE)
+      produces = APPLICATION_JSON_UTF8_VALUE)
   @ApiOperation(value = "read all data for region",
       notes = "Read all data for region. Use limit param to get fixed or limited number of entries.")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),
@@ -201,7 +200,7 @@ public class PdxBasedCrudController extends CommonCrudController {
    * @return JSON document
    */
   @RequestMapping(method = RequestMethod.GET, value = "/{region}/{keys}",
-      produces = MediaType.APPLICATION_JSON_VALUE)
+      produces = APPLICATION_JSON_UTF8_VALUE)
   @ApiOperation(value = "read data for specific keys",
       notes = "Read data for specific set of keys in region.")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),
@@ -279,7 +278,8 @@ public class PdxBasedCrudController extends CommonCrudController {
    * @return JSON document
    */
   @RequestMapping(method = RequestMethod.PUT, value = "/{region}/{keys}",
-      consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
+      consumes = {APPLICATION_JSON_UTF8_VALUE}, produces = {
+          APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "update data for key",
       notes = "Update or insert (put) data for key in region."
           + "op=REPLACE, update (replace) data with key if and only if the key exists in region"
@@ -312,7 +312,7 @@ public class PdxBasedCrudController extends CommonCrudController {
   }
 
   @RequestMapping(method = RequestMethod.HEAD, value = "/{region}",
-      produces = MediaType.APPLICATION_JSON_VALUE)
+      produces = APPLICATION_JSON_UTF8_VALUE)
   @ApiOperation(value = "Get total number of entries",
       notes = "Get total number of entries into the specified region")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/QueryAccessController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/QueryAccessController.java
@@ -23,7 +23,6 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.logging.log4j.Logger;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
@@ -58,7 +57,8 @@ import org.apache.geode.rest.internal.web.util.ValidationUtils;
  * @since GemFire 8.0
  */
 @Controller("queryController")
-@Api(value = "queries", produces = MediaType.APPLICATION_JSON_VALUE, tags = "queries")
+@Api(value = "queries", produces = AbstractBaseController.APPLICATION_JSON_UTF8_VALUE,
+    tags = "queries")
 @RequestMapping(QueryAccessController.REST_API_VERSION + "/queries")
 @SuppressWarnings("unused")
 public class QueryAccessController extends AbstractBaseController {
@@ -87,7 +87,7 @@ public class QueryAccessController extends AbstractBaseController {
    *
    * @return result as a JSON document.
    */
-  @RequestMapping(method = RequestMethod.GET, produces = {MediaType.APPLICATION_JSON_VALUE})
+  @RequestMapping(method = RequestMethod.GET, produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "list all parametrized queries",
       notes = "List all parametrized queries by id/name")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),
@@ -143,7 +143,7 @@ public class QueryAccessController extends AbstractBaseController {
     headers.setLocation(toUri("queries", queryId));
 
     if (existingOql != null) {
-      headers.setContentType(MediaType.APPLICATION_JSON);
+      headers.setContentType(APPLICATION_JSON_UTF8);
       return new ResponseEntity<>(JSONUtils.formulateJsonForExistingQuery(queryId, existingOql),
           headers, HttpStatus.CONFLICT);
     } else {
@@ -158,7 +158,7 @@ public class QueryAccessController extends AbstractBaseController {
    * @return query result as a JSON document
    */
   @RequestMapping(method = RequestMethod.GET, value = "/adhoc",
-      produces = {MediaType.APPLICATION_JSON_VALUE})
+      produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "run an adhoc query",
       notes = "Run an unnamed (unidentified), ad-hoc query passed as a URL parameter")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),
@@ -216,7 +216,7 @@ public class QueryAccessController extends AbstractBaseController {
    * @return query result as a JSON document
    */
   @RequestMapping(method = RequestMethod.POST, value = "/{query}",
-      produces = {MediaType.APPLICATION_JSON_VALUE})
+      produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "run parametrized query",
       notes = "run the specified named query passing in scalar values for query parameters in the GemFire cluster")
   @ApiResponses({@ApiResponse(code = 200, message = "Query successfully executed."),

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/security/RestSecurityConfiguration.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/security/RestSecurityConfiguration.java
@@ -112,13 +112,17 @@ public class RestSecurityConfiguration extends WebSecurityConfigurerAdapter {
   }
 
   private class AuthenticationFailedHandler implements AuthenticationEntryPoint {
+
+    @SuppressWarnings("deprecation")
+    private static final String CONTENT_TYPE = MediaType.APPLICATION_JSON_UTF8_VALUE;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
         AuthenticationException authException)
         throws IOException, ServletException {
       response.addHeader("WWW-Authenticate", "Basic realm=\"GEODE\"");
       response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+      response.setContentType(CONTENT_TYPE);
       ClusterManagementResult result =
           new ClusterManagementResult(ClusterManagementResult.StatusCode.UNAUTHENTICATED,
               authException.getMessage());


### PR DESCRIPTION
Older tests struggle with the deprecated symbols being replaced. Should be revisited later as a wider effort to cleanup deprecated usage. This ticket is focused on not making deprecated usage worse.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
