### PR TITLE
GEODE-7852: Ignore ClientSNIAcceptanceTest on windows

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/ClientSNIAcceptanceTest.java
@@ -30,35 +30,34 @@ import java.net.URL;
 import java.util.Properties;
 
 import com.palantir.docker.compose.DockerComposeRule;
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.proxy.ProxySocketFactories;
+import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 public class ClientSNIAcceptanceTest {
 
   private static final URL DOCKER_COMPOSE_PATH =
       ClientSNIAcceptanceTest.class.getResource("docker-compose.yml");
 
-  @ClassRule
   public static DockerComposeRule docker = DockerComposeRule.builder()
       .file(DOCKER_COMPOSE_PATH.getPath())
       .build();
 
-  private String trustStorePath;
+  // Docker compose does not work on windows in CI. Ignore this test on windows
+  // Using a RuleChain to make sure we ignore the test before the rule comes into play
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(new IgnoreOnWindowsRule())
+      .around(docker);
 
-  @Before
-  public void ignoreOnWindows() {
-    // Docker compose does not work on windows in CI
-    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
-  }
+  private String trustStorePath;
 
   @Before
   public void before() throws IOException, InterruptedException {

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/ClientSNIAcceptanceTest.java
@@ -32,8 +32,9 @@ import java.util.Properties;
 import com.palantir.docker.compose.DockerComposeRule;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
@@ -47,15 +48,16 @@ public class ClientSNIAcceptanceTest {
   private static final URL DOCKER_COMPOSE_PATH =
       ClientSNIAcceptanceTest.class.getResource("docker-compose.yml");
 
-  public static DockerComposeRule docker = DockerComposeRule.builder()
-      .file(DOCKER_COMPOSE_PATH.getPath())
-      .build();
-
   // Docker compose does not work on windows in CI. Ignore this test on windows
   // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static RuleChain ruleChain = RuleChain.outerRule(new IgnoreOnWindowsRule())
-      .around(docker);
+  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+
+  @Rule
+  public DockerComposeRule docker = DockerComposeRule.builder()
+      .file(DOCKER_COMPOSE_PATH.getPath())
+      .build();
+
 
   private String trustStorePath;
 

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/IgnoreOnWindowsRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/IgnoreOnWindowsRule.java
@@ -1,0 +1,21 @@
+package org.apache.geode.test.junit.rules;
+
+import java.io.Serializable;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+
+/**
+ * A rule that causes a test to be ignored if it is run on windows.
+ *
+ * This is best used a as a ClassRule to make sure it runs first. If you have
+ * other class rules, us a {@link RuleChain} to make sure this runs first.
+ */
+public class IgnoreOnWindowsRule extends ExternalResource implements Serializable {
+  @Override
+  protected void before() throws Throwable {
+    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/IgnoreOnWindowsRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/IgnoreOnWindowsRule.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.test.junit.rules;
 
 import java.io.Serializable;


### PR DESCRIPTION
The rule to mark this test ignored has to run before the docker compose rule,
to prevent the test from failing first.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
