### PR TITLE
GEODE-7901: Redis testGetSet_shouldBeAtomic and testGetRange_rangePastEndOfValue_returnsEmptyString tests failing

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.After;
@@ -48,6 +47,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.redis.internal.RedisConstants;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})
@@ -281,11 +281,8 @@ public class StringsIntegrationTest {
 
     latch.countDown();
 
-    Integer getSetSum = future2.get(60, TimeUnit.SECONDS);
-    Integer incrSum = future1.get();
-
-    assertThat(getSetSum).isEqualTo(incrSum);
-    assertThat(incrSum + getSetSum).isEqualTo(2 * ITERATION_COUNT);
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(future2.get()).isEqualTo(future1.get()));
+    assertThat(future1.get() + future2.get()).isEqualTo(2 * ITERATION_COUNT);
   }
 
   private Integer doABunchOfIncrs(Jedis jedis, CountDownLatch latch) throws InterruptedException {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
@@ -281,7 +281,7 @@ public class StringsIntegrationTest {
 
     latch.countDown();
 
-    Integer getSetSum = future2.get(5, TimeUnit.SECONDS);
+    Integer getSetSum = future2.get(60, TimeUnit.SECONDS);
     Integer incrSum = future1.get();
 
     assertThat(getSetSum).isEqualTo(incrSum);


### PR DESCRIPTION
One test for atomicity had too small a timeout to run reliably in CI. This has been increased to a safe value. (The timeout sometimes caused the subsequent test to fail as well.)