### PR TITLE
GEODE-7889: Fix CloseConnectionTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
@@ -14,24 +14,56 @@
  */
 package org.apache.geode.internal.tcp;
 
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
+import static org.apache.geode.test.dunit.VM.getController;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.VM.toArray;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.Serializable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.cache.CacheTestCase;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.DistributedRule;
 
-public class CloseConnectionTest extends CacheTestCase {
+public class CloseConnectionTest implements Serializable {
+  private VM vm0;
+  private VM vm1;
 
-  @Test(timeout = 60_000)
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+
+  @Rule
+  public CacheRule cacheRule = new CacheRule();
+
+  @Before
+  public void setUp() {
+    vm0 = getVM(0);
+    vm1 = getVM(1);
+  }
+
+  @After
+  public void tearDown() {
+    for (VM vm : toArray(getController(), vm0, vm1)) {
+      vm.invoke(() -> cacheRule.closeAndNullCache());
+    }
+
+    disconnectAllFromDS();
+  }
+
+  @Test
   public void sharedSenderShouldRecoverFromClosedSocket() {
-    VM vm0 = VM.getVM(0);
-    VM vm1 = VM.getVM(1);
-
     // Create a region in each member. VM0 has a proxy region, so state must be in VM1
     vm0.invoke(() -> {
       getCache().createRegionFactory(RegionShortcut.REPLICATE_PROXY).create("region");
@@ -46,7 +78,7 @@ public class CloseConnectionTest extends CacheTestCase {
       ConnectionTable conTable = getConnectionTable();
       assertThat(conTable.getNumberOfReceivers()).isEqualTo(2);
       conTable.closeReceivers(false);
-      assertThat(conTable.getNumberOfReceivers()).isEqualTo(0);
+      await().untilAsserted(() -> assertThat(conTable.getNumberOfReceivers()).isEqualTo(0));
     });
 
     // See if VM0 noticed the closed connections. Try to do a couple of region
@@ -61,16 +93,18 @@ public class CloseConnectionTest extends CacheTestCase {
     // Make sure connections were reestablished
     vm1.invoke(() -> {
       ConnectionTable conTable = getConnectionTable();
-      assertThat(conTable.getNumberOfReceivers()).isEqualTo(2);
+      await().untilAsserted(() -> assertThat(conTable.getNumberOfReceivers()).isEqualTo(2));
     });
   }
 
   private ConnectionTable getConnectionTable() {
     ClusterDistributionManager cdm =
-        (ClusterDistributionManager) getSystem().getDistributionManager();
+        (ClusterDistributionManager) getCache().getDistributionManager();
     DistributionImpl distribution = (DistributionImpl) cdm.getDistribution();
     return distribution.getDirectChannel().getConduit().getConTable();
   }
 
-
+  private InternalCache getCache() {
+    return cacheRule.getOrCreateCache();
+  }
 }


### PR DESCRIPTION
- Use await().untilAsserted() to allow connections to settle
- Use setup and tear down methods
- Do not extend CacheTestCase as it is an empty abstract with a deprecated super

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
