### PR TITLE
GEODE-7900: Only set the SNI hostname if it is not present

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -56,6 +56,7 @@ import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLProtocolException;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.StandardConstants;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509ExtendedKeyManager;
@@ -774,6 +775,14 @@ public class SocketCreator extends TcpSocketCreatorImpl {
     List<SNIServerName> oldNames = modifiedParams.getServerNames();
     oldNames = oldNames == null ? Collections.emptyList() : oldNames;
     final List<SNIServerName> serverNames = new ArrayList<>(oldNames);
+
+    if (serverNames.stream()
+        .mapToInt(SNIServerName::getType)
+        .anyMatch(type -> type == StandardConstants.SNI_HOST_NAME)) {
+      // we already have a SNI hostname set. Do nothing.
+      return;
+    }
+
     serverNames.add(new SNIHostName(addr.getHostName()));
     modifiedParams.setServerNames(serverNames);
   }


### PR DESCRIPTION
It turns out the JDK sometimes automatically sets the SNI hostname and
sometimes does not.  With openjdk 8, it only sets SNI hostname if there is a
dot in the hostname. See sun.security.ssl.Utilities#addToSNIServerNameList

For this reason, we need to only set the SNI hostname if the JDK did not.
Otherwise it will complain that there is a `Duplicated server name of type 0`

Note, this fixes the Windows distributed tests failures we are seeing - for example this run https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/WindowsGfshDistributedTestOpenJDK8/builds/1391. Those failures aren't really because of windows, its because our windows CI instances have fully qualified hostnames as opposed to the linux docker containers.
