### PR TITLE
GEODE-7915: rc pipeline fixes and improvements

### DIFF
--- a/dev-tools/release/finalize_release.sh
+++ b/dev-tools/release/finalize_release.sh
@@ -174,8 +174,8 @@ echo "============================================================"
 set -x
 cd $SVN_RELEASE_DIR
 svn update --set-depth immediates
-#identify the latest patch release for the latest 2 major.minor releases, remove anything else from mirrors (all releases remain available on non-mirrored archive site)
-RELEASES_TO_KEEP=2
+#identify the latest patch release for "N-2" (the latest 3 major.minor releases), remove anything else from mirrors (all releases remain available on non-mirrored archive site)
+RELEASES_TO_KEEP=3
 set +x
 ls | awk -F. '/KEYS/{next}{print 1000000*$1+1000*$2+$3,$1"."$2"."$3}'| sort -n | awk '{mm=$2;sub(/\.[^.]*$/,"",mm);V[mm]=$2}END{for(v in V){print V[v]}}'|tail -$RELEASES_TO_KEEP > ../keep
 echo Keeping releases: $(cat ../keep)


### PR DESCRIPTION
.zip is no longer produced (as per GEODE-7719) so `run-geode-examples-from-src-zip` is no longer needed

also adds `verify-no-binaries`

also fixes `verify-keys` to check that no unexpected files are present