### PR TITLE
GEODE-7918: Add assertion message to DNS resolution assertions.

### DIFF
--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
@@ -54,7 +54,9 @@ public class HostAndPortTest {
 
     InetSocketAddress actual = locator1.getSocketInetAddress();
 
-    assertThat(actual.isUnresolved()).isTrue();
+    assertThat(actual.isUnresolved())
+            .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
+            .isTrue();
   }
 
   /**
@@ -143,7 +145,9 @@ public class HostAndPortTest {
         .readObject(new ByteArrayDataInput(out.toByteArray()));
     assertThat(hostAndPort1).isEqualTo(hostAndPort2);
     assertThat(hostAndPort2).isEqualTo(hostAndPort1);
-    assertThat(hostAndPort1.getAddress()).isNull();
+    assertThat(hostAndPort1.getAddress())
+            .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
+            .isNull();
     assertThat(hostAndPort2.getAddress()).isNull();
     assertThat(hostAndPort2.getSocketInetAddress()).isNotNull();
     assertThat(hostAndPort1.getSocketInetAddress().isUnresolved()).isTrue();

--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
@@ -55,8 +55,8 @@ public class HostAndPortTest {
     InetSocketAddress actual = locator1.getSocketInetAddress();
 
     assertThat(actual.isUnresolved())
-            .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
-            .isTrue();
+        .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
+        .isTrue();
   }
 
   /**
@@ -146,8 +146,8 @@ public class HostAndPortTest {
     assertThat(hostAndPort1).isEqualTo(hostAndPort2);
     assertThat(hostAndPort2).isEqualTo(hostAndPort1);
     assertThat(hostAndPort1.getAddress())
-            .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
-            .isNull();
+        .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
+        .isNull();
     assertThat(hostAndPort2.getAddress()).isNull();
     assertThat(hostAndPort2.getSocketInetAddress()).isNotNull();
     assertThat(hostAndPort1.getSocketInetAddress().isUnresolved()).isTrue();

--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerJUnitTest.java
@@ -84,7 +84,9 @@ public class TcpServerJUnitTest {
     @SuppressWarnings("deprecation")
     InfoRequest testInfoRequest = new InfoRequest();
     assertThatThrownBy(() -> tcpClient.requestToServer(new HostAndPort("unknown host name", port),
-        testInfoRequest, TIMEOUT)).isInstanceOf(UnknownHostException.class);
+        testInfoRequest, TIMEOUT))
+            .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
+            .isInstanceOf(UnknownHostException.class);
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
In the case of DNS hijacking by an ISP, unresolvable hostnames may be
redirected to a search page. Log this breadcrumb in the test failures.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
