### PR TITLE
GEODE-7905: RedisDistDUnitTest failing intermittently in CI

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -1506,7 +1506,9 @@ public abstract class InternalDataSerializer extends DataSerializer {
       // error condition, so you also need to check to see if the JVM
       // is still usable:
       SystemFailure.checkFailure();
+      t.printStackTrace();
       throw new ToDataException("toData failed on dsfid=" + dsfid + " msg:" + t.getMessage(), t);
+
     }
   }
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
@@ -19,7 +19,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -34,14 +33,18 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
+import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})
@@ -54,7 +57,7 @@ public class SetsIntegrationTest {
   private static int port = 6379;
 
   @BeforeClass
-  public static void setUp() throws IOException {
+  public static void setUp() {
     CacheFactory cf = new CacheFactory();
     cf.set(LOG_LEVEL, "error");
     cf.set(MCAST_PORT, "0");
@@ -96,6 +99,42 @@ public class SetsIntegrationTest {
     assertThat(response2).isEqualTo(0L);
 
     assertThat(jedis.scard(key)).isEqualTo(strings.size());
+  }
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test
+  public void testSAdd_withExistingKey_ofWrongType_shouldReturnError() {
+    String key = "key";
+    String stringValue = "preexistingValue";
+    String[] setValue = new String[1];
+    setValue[0] = "set value that should never get added";
+
+    exceptionRule.expect(JedisDataException.class);
+    exceptionRule.expectMessage(RedisConstants.ERROR_WRONG_TYPE);
+
+    jedis.set(key, stringValue);
+    jedis.sadd(key, setValue);
+  }
+
+  @Test
+  public void testSAdd_withExistingKey_ofWrongType_shouldNotOverWriteExistingKey() {
+    String key = "key";
+    String stringValue = "preexistingValue";
+    String[] setValue = new String[1];
+    setValue[0] = "set value that should never get added";
+
+    jedis.set(key, stringValue);
+
+    try {
+      jedis.sadd(key, setValue);
+    } catch (Exception exception) {
+    }
+
+    String result = jedis.get(key);
+
+    assertThat(result).isEqualTo(stringValue);
   }
 
   @Test

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
@@ -146,6 +146,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       executeCommand(ctx, command);
     } catch (Exception e) {
       logger.error(e);
+      e.printStackTrace();
       throw e;
     }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/DeltaSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/DeltaSet.java
@@ -1,0 +1,142 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF licenses this file to You
+ * under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package org.apache.geode.redis.internal.executor.set;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.geode.DataSerializable;
+import org.apache.geode.DataSerializer;
+import org.apache.geode.Delta;
+import org.apache.geode.InvalidDeltaException;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+
+public class DeltaSet implements Delta, DataSerializable, Serializable, Set<ByteArrayWrapper> {
+  transient boolean hasDelta = false;
+  transient ByteArrayWrapper latestValue;
+
+  Set<ByteArrayWrapper> internalSet;
+
+  public DeltaSet(Set<ByteArrayWrapper> setToCopy) {
+    internalSet = new HashSet<>(setToCopy);
+  }
+
+  public DeltaSet() {
+    internalSet = new HashSet<>();
+  }
+
+
+  @Override
+  public int size() {
+    return internalSet.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return internalSet.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return internalSet.contains(o);
+  }
+
+  @Override
+  public Iterator<ByteArrayWrapper> iterator() {
+    return internalSet.iterator();
+  }
+
+  @Override
+  public Object[] toArray() {
+    return internalSet.toArray();
+  }
+
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return internalSet.toArray(a);
+  }
+
+  public synchronized boolean add(ByteArrayWrapper value) {
+    latestValue = value;
+    hasDelta = internalSet.add(value);
+    return hasDelta;
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    return internalSet.remove(o);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return internalSet.containsAll(c);
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends ByteArrayWrapper> c) {
+    return internalSet.addAll(c);
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    return internalSet.retainAll(c);
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    return internalSet.removeAll(c);
+  }
+
+  @Override
+  public void clear() {
+    internalSet.clear();
+  }
+
+  @Override
+  public boolean hasDelta() {
+    return hasDelta;
+  }
+
+  @Override
+  public synchronized void toDelta(DataOutput out) throws IOException {
+    out.writeUTF(new String(latestValue.toBytes()));
+    hasDelta = false;
+  }
+
+  @Override
+  public synchronized void fromDelta(DataInput in) throws IOException, InvalidDeltaException {
+    internalSet.add(new ByteArrayWrapper(in.readUTF().getBytes()));
+  }
+
+  @Override
+  public synchronized void toData(DataOutput out) throws IOException {
+    DataSerializer.writeHashSet((HashSet<ByteArrayWrapper>) this.internalSet, out);
+  }
+
+  @Override
+  public synchronized void fromData(DataInput in) throws IOException, ClassNotFoundException {
+    this.internalSet = DataSerializer.readHashSet(in);
+  }
+
+}

--- a/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
+++ b/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
@@ -199,3 +199,5 @@ org/apache/geode/redis/internal/executor/SortedSetQuery$9,false
 org/apache/geode/redis/internal/executor/list/ListExecutor$ListDirection,false
 org/apache/geode/redis/internal/executor/sortedset/GeoRadiusParameters$CommandType,false
 org/apache/geode/redis/internal/executor/sortedset/GeoRadiusParameters$SortOrder,false
+org/apache/geode/redis/internal/executor/set/DeltaSet,false
+org/apache/geode/redis/internal/ByteArrayWrapper,false


### PR DESCRIPTION
Fix RedisDistDUnitTest, which fails intermittently:
https://concourse.apachegeode-ci.info/builds/141130
 
```
org.apache.geode.redis.RedisDistDUnitTest > classMethod FAILED
 java.lang.AssertionError: Suspicious strings were written to the log during this run.
 Fix the strings or use IgnoredException.addIgnoredException to ignore.
 -----------------------------------------------------------------------
 Found suspect string in log4j at line 5030
[error 2020/03/23 19:26:51.559 GMT <GeodeRedisServer-WorkerThread-3> tid=99] org.apache.geode.ToDataException: toData failed on DataSerializer with id=0 for class class java.util.HashSet
6 tests completed, 1 failed
```

Updates SADD executor to use optimistic instead of pessimistic locking.