### PR TITLE
GEODE-7864: Override the default implementation of write(byte[],int,int)

### DIFF
--- a/geode-common/src/main/java/org/apache/geode/util/internal/TeeOutputStream.java
+++ b/geode-common/src/main/java/org/apache/geode/util/internal/TeeOutputStream.java
@@ -62,6 +62,15 @@ public class TeeOutputStream extends FilterOutputStream {
   }
 
   @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    super.write(b, off, len);
+    OutputStream os = this.branch;
+    if (os != null) {
+      os.write(b, off, len);
+    }
+  }
+
+  @Override
   public void flush() throws IOException {
     super.flush();
     OutputStream os = this.branch;

--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -2163,6 +2163,11 @@ public abstract class InternalDataSerializer extends DataSerializer {
           public void write(int b) throws IOException {
             out2.write(b);
           }
+
+          @Override
+          public void write(byte[] b, int off, int len) throws IOException {
+            out2.write(b, off, len);
+          }
         };
       }
       boolean wasDoNotCopy = false;

--- a/geode-core/src/main/java/org/apache/geode/internal/io/CompositeOutputStream.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/io/CompositeOutputStream.java
@@ -125,6 +125,14 @@ public class CompositeOutputStream extends OutputStream implements Iterable<Outp
     }
   }
 
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    Set<OutputStream> outputStreams = this.streams;
+    for (OutputStream out : outputStreams) {
+      out.write(b, off, len);
+    }
+  }
+
   /**
    * Flushes this output stream and forces any buffered output bytes to be written out to the
    * stream.

--- a/geode-core/src/test/java/org/apache/geode/internal/io/CompositeOutputStreamJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/io/CompositeOutputStreamJUnitTest.java
@@ -77,11 +77,8 @@ public class CompositeOutputStreamJUnitTest {
     compositeOutputStream.close();
 
     InOrder inOrder = inOrder(mockStreamOne);
-    inOrder.verify(mockStreamOne, times(1)).write(2);
-    inOrder.verify(mockStreamOne, times(1)).write(3);
-    inOrder.verify(mockStreamOne, times(1)).write(4);
-    inOrder.verify(mockStreamOne, times(1)).write(0);
-    inOrder.verify(mockStreamOne, times(1)).write(1);
+    inOrder.verify(mockStreamOne, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2, 3);
+    inOrder.verify(mockStreamOne, times(1)).write(new byte[] {0, 1}, 0, 2);
     inOrder.verify(mockStreamOne, times(1)).write(9);
     inOrder.verify(mockStreamOne, times(2)).flush();
     inOrder.verify(mockStreamOne, times(1)).close();
@@ -101,11 +98,9 @@ public class CompositeOutputStreamJUnitTest {
     cos.close();
 
     InOrder inOrderStreams = inOrder(streamOne, streamTwo);
-    inOrderStreams.verify(streamOne, times(1)).write(2);
-    inOrderStreams.verify(streamOne, times(1)).write(3);
-    inOrderStreams.verify(streamOne, times(1)).write(4);
-    inOrderStreams.verify(streamOne, times(1)).write(0);
-    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2,
+        3);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1}, 0, 2);
     inOrderStreams.verify(streamOne, times(1)).write(9);
     inOrderStreams.verify(streamOne, times(2)).flush();
     inOrderStreams.verify(streamOne, times(1)).close();
@@ -128,11 +123,9 @@ public class CompositeOutputStreamJUnitTest {
     cos.close();
 
     InOrder inOrderStreams = inOrder(streamOne, streamTwo, streamThree);
-    inOrderStreams.verify(streamOne, times(1)).write(2);
-    inOrderStreams.verify(streamOne, times(1)).write(3);
-    inOrderStreams.verify(streamOne, times(1)).write(4);
-    inOrderStreams.verify(streamOne, times(1)).write(0);
-    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2,
+        3);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1}, 0, 2);
     inOrderStreams.verify(streamOne, times(1)).write(9);
     inOrderStreams.verify(streamOne, times(2)).flush();
     inOrderStreams.verify(streamOne, times(1)).close();
@@ -154,11 +147,9 @@ public class CompositeOutputStreamJUnitTest {
     cos.close();
 
     InOrder inOrderStreams = inOrder(streamOne, streamTwo);
-    inOrderStreams.verify(streamOne, times(1)).write(2);
-    inOrderStreams.verify(streamOne, times(1)).write(3);
-    inOrderStreams.verify(streamOne, times(1)).write(4);
-    inOrderStreams.verify(streamOne, times(1)).write(0);
-    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2,
+        3);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1}, 0, 2);
     inOrderStreams.verify(streamOne, times(1)).write(9);
     inOrderStreams.verify(streamOne, times(2)).flush();
     inOrderStreams.verify(streamOne, times(1)).close();
@@ -180,11 +171,9 @@ public class CompositeOutputStreamJUnitTest {
     cos.close();
 
     InOrder inOrderStreams = inOrder(streamOne);
-    inOrderStreams.verify(streamOne, times(1)).write(2);
-    inOrderStreams.verify(streamOne, times(1)).write(3);
-    inOrderStreams.verify(streamOne, times(1)).write(4);
-    inOrderStreams.verify(streamOne, times(1)).write(0);
-    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2,
+        3);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1}, 0, 2);
     inOrderStreams.verify(streamOne, times(1)).write(9);
     inOrderStreams.verify(streamOne, times(2)).flush();
     inOrderStreams.verify(streamOne, times(1)).close();
@@ -208,11 +197,9 @@ public class CompositeOutputStreamJUnitTest {
     cos.close();
 
     InOrder inOrderStreams = inOrder(streamOne, streamTwo);
-    inOrderStreams.verify(streamOne, times(1)).write(2);
-    inOrderStreams.verify(streamOne, times(1)).write(3);
-    inOrderStreams.verify(streamOne, times(1)).write(4);
-    inOrderStreams.verify(streamOne, times(1)).write(0);
-    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2,
+        3);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1}, 0, 2);
     inOrderStreams.verify(streamOne, times(1)).write(9);
     inOrderStreams.verify(streamOne, times(2)).flush();
     inOrderStreams.verify(streamOne, times(1)).close();
@@ -236,11 +223,9 @@ public class CompositeOutputStreamJUnitTest {
 
     verifyNoMoreInteractions(streamTwo);
     InOrder inOrderStreams = inOrder(streamOne);
-    inOrderStreams.verify(streamOne, times(1)).write(2);
-    inOrderStreams.verify(streamOne, times(1)).write(3);
-    inOrderStreams.verify(streamOne, times(1)).write(4);
-    inOrderStreams.verify(streamOne, times(1)).write(0);
-    inOrderStreams.verify(streamOne, times(1)).write(1);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, 2,
+        3);
+    inOrderStreams.verify(streamOne, times(1)).write(new byte[] {0, 1}, 0, 2);
     inOrderStreams.verify(streamOne, times(1)).write(9);
     inOrderStreams.verify(streamOne, times(2)).flush();
     inOrderStreams.verify(streamOne, times(1)).close();

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/http/converter/CustomMappingJackson2HttpMessageConverter.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/http/converter/CustomMappingJackson2HttpMessageConverter.java
@@ -148,6 +148,12 @@ public class CustomMappingJackson2HttpMessageConverter extends MappingJackson2Ht
       outputStream.write(byteData);
       byteCount.incrementAndGet();
     }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      outputStream.write(b, off, len);
+      byteCount.addAndGet(len);
+    }
   }
 
 }

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/converter/CustomMappingJackson2HttpMessageConverter.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/converter/CustomMappingJackson2HttpMessageConverter.java
@@ -144,6 +144,12 @@ public class CustomMappingJackson2HttpMessageConverter extends MappingJackson2Ht
       outputStream.write(byteData);
       byteCount.incrementAndGet();
     }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      outputStream.write(b, off, len);
+      byteCount.addAndGet(len);
+    }
   }
 
 }


### PR DESCRIPTION
	* Prevent overheads of writing one byte at a time.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
