### PR TITLE
GEODE-7912: cacheWriter should be triggered when PR.clear

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionClearDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionClearDUnitTest.java
@@ -113,7 +113,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     }
     factory.create(REGION_NAME);
     clearsByRegion = new HashMap<>();
-    destroyesByRegion = new HashMap<>();
+    destroysByRegion = new HashMap<>();
   }
 
   private void initAccessor(boolean withListener, boolean withWriter) {
@@ -143,7 +143,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     }
     factory.create(REGION_NAME);
     clearsByRegion = new HashMap<>();
-    destroyesByRegion = new HashMap<>();
+    destroysByRegion = new HashMap<>();
   }
 
   private void feed(boolean isClient) {
@@ -191,7 +191,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
 
   SerializableCallableIF<Integer> getWriterDestroys = () -> {
     int destroys =
-        destroyesByRegion.get(REGION_NAME) == null ? 0 : destroyesByRegion.get(REGION_NAME).get();
+        destroysByRegion.get(REGION_NAME) == null ? 0 : destroysByRegion.get(REGION_NAME).get();
     return destroys;
   };
 
@@ -221,7 +221,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     verifyServerRegionSize(NUM_ENTRIES);
     dataStore3.invoke(() -> getRegion(false).clear());
     verifyServerRegionSize(0);
-    // verifyCacheListenerTriggerCount(dataStore1);
+    verifyCacheListenerTriggerCount(dataStore3);
 
     assertThat(dataStore1.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore2.invoke(getWriterClears)).isEqualTo(0);
@@ -248,7 +248,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     verifyServerRegionSize(NUM_ENTRIES);
     dataStore1.invoke(() -> getRegion(false).clear());
     verifyServerRegionSize(0);
-    // verifyCacheListenerTriggerCount(dataStore1);
+    verifyCacheListenerTriggerCount(dataStore1);
 
     assertThat(dataStore1.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore2.invoke(getWriterClears)).isEqualTo(0);
@@ -275,7 +275,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     verifyServerRegionSize(NUM_ENTRIES);
     accessor.invoke(() -> getRegion(false).clear());
     verifyServerRegionSize(0);
-    // verifyCacheListenerTriggerCount(accessor);
+    verifyCacheListenerTriggerCount(accessor);
     assertThat(dataStore1.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore2.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore3.invoke(getWriterClears)).isEqualTo(0);
@@ -301,7 +301,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     verifyServerRegionSize(NUM_ENTRIES);
     accessor.invoke(() -> getRegion(false).clear());
     verifyServerRegionSize(0);
-    // verifyCacheListenerTriggerCount(accessor);
+    verifyCacheListenerTriggerCount(accessor);
     assertThat(dataStore1.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore2.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore3.invoke(getWriterClears)).isEqualTo(1);
@@ -330,7 +330,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     client1.invoke(() -> getRegion(true).clear());
     verifyServerRegionSize(0);
     verifyClientRegionSize(0);
-    // verifyCacheListenerTriggerCount(null);
+    verifyCacheListenerTriggerCount(null);
     assertThat(dataStore1.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore2.invoke(getWriterClears)).isEqualTo(0);
     assertThat(dataStore3.invoke(getWriterClears)).isEqualTo(1);
@@ -374,7 +374,7 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
   }
 
   public static HashMap<String, AtomicInteger> clearsByRegion = new HashMap<>();
-  public static HashMap<String, AtomicInteger> destroyesByRegion = new HashMap<>();
+  public static HashMap<String, AtomicInteger> destroysByRegion = new HashMap<>();
 
   private static class CountingCacheWriter extends CacheWriterAdapter {
     @Override
@@ -394,10 +394,10 @@ public class PartitionedRegionClearDUnitTest implements Serializable {
     @Override
     public void beforeRegionDestroy(RegionEvent event) throws CacheWriterException {
       Region region = event.getRegion();
-      AtomicInteger destroys = destroyesByRegion.get(region.getName());
+      AtomicInteger destroys = destroysByRegion.get(region.getName());
       if (destroys == null) {
         destroys = new AtomicInteger(1);
-        destroyesByRegion.put(region.getName(), destroys);
+        destroysByRegion.put(region.getName(), destroys);
       } else {
         destroys.incrementAndGet();
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -3002,7 +3002,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   /**
    * @since GemFire 5.7
    */
-  private void serverRegionClear(RegionEventImpl regionEvent) {
+  protected void serverRegionClear(RegionEventImpl regionEvent) {
     if (regionEvent.getOperation().isDistributed()) {
       ServerRegionProxy mySRP = getServerProxy();
       if (mySRP != null) {
@@ -3123,7 +3123,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     return result;
   }
 
-  private void cacheWriteBeforeRegionClear(RegionEventImpl event)
+  void cacheWriteBeforeRegionClear(RegionEventImpl event)
       throws CacheWriterException, TimeoutException {
     // copy into local var to prevent race condition
     CacheWriter writer = basicGetWriter();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -2161,6 +2161,9 @@ public class PartitionedRegion extends LocalRegion
           throw cache.getCacheClosedException("Cache is shutting down");
         }
 
+        // do cacheWrite
+        cacheWriteBeforeRegionClear(regionEvent);
+
         // create ClearPRMessage per bucket
         List<ClearPRMessage> clearMsgList = createClearPRMessages(regionEvent.getEventId());
         for (ClearPRMessage clearPRMessage : clearMsgList) {
@@ -4428,6 +4431,35 @@ public class PartitionedRegion extends LocalRegion
     return null;
   }
 
+  boolean triggerWriter(RegionEventImpl event) {
+    CacheWriter localWriter = basicGetWriter();
+    Set netWriteRecipients = localWriter == null ? this.distAdvisor.adviseNetWrite() : null;
+
+    if (localWriter == null && (netWriteRecipients == null || netWriteRecipients.isEmpty())) {
+      return false;
+    }
+
+    final long start = getCachePerfStats().startCacheWriterCall();
+    try {
+      SearchLoadAndWriteProcessor processor = SearchLoadAndWriteProcessor.getProcessor();
+      String theKey = "preDestroyRegion";
+      int paction = 0;
+      if (event.getOperation().isRegionDestroy()) {
+        theKey = "preDestroyRegion";
+        paction = SearchLoadAndWriteProcessor.BEFOREREGIONDESTROY;
+      } else if (event.getOperation().isClear()) {
+        theKey = "preClearRegion";
+        paction = SearchLoadAndWriteProcessor.BEFOREREGIONCLEAR;
+      }
+      processor.initialize(this, theKey, null);
+      processor.doNetWrite(event, netWriteRecipients, localWriter, paction);
+      processor.release();
+    } finally {
+      getCachePerfStats().endCacheWriterCall(start);
+    }
+    return true;
+  }
+
   /**
    * This invokes a cache writer before a destroy operation. Although it has the same method
    * signature as the method in LocalRegion, it is invoked in a different code path. LocalRegion
@@ -4437,29 +4469,20 @@ public class PartitionedRegion extends LocalRegion
   @Override
   boolean cacheWriteBeforeRegionDestroy(RegionEventImpl event)
       throws CacheWriterException, TimeoutException {
-
     if (event.getOperation().isDistributed()) {
       serverRegionDestroy(event);
-      CacheWriter localWriter = basicGetWriter();
-      Set netWriteRecipients = localWriter == null ? this.distAdvisor.adviseNetWrite() : null;
-
-      if (localWriter == null && (netWriteRecipients == null || netWriteRecipients.isEmpty())) {
-        return false;
-      }
-
-      final long start = getCachePerfStats().startCacheWriterCall();
-      try {
-        SearchLoadAndWriteProcessor processor = SearchLoadAndWriteProcessor.getProcessor();
-        processor.initialize(this, "preDestroyRegion", null);
-        processor.doNetWrite(event, netWriteRecipients, localWriter,
-            SearchLoadAndWriteProcessor.BEFOREREGIONDESTROY);
-        processor.release();
-      } finally {
-        getCachePerfStats().endCacheWriterCall(start);
-      }
-      return true;
+      return triggerWriter(event);
     }
     return false;
+  }
+
+  @Override
+  void cacheWriteBeforeRegionClear(RegionEventImpl event)
+      throws CacheWriterException, TimeoutException {
+    if (event.getOperation().isDistributed()) {
+      serverRegionClear(event);
+      triggerWriter(event);
+    }
   }
 
   /**


### PR DESCRIPTION
        Co-authored-by: Anil <agingade@pivotal.io>
        Co-authored-by: Xiaojian Zhou <gzhou@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
