### PR TITLE
GEODE-7937: fix Tomcat test to get product version correctly

### DIFF
--- a/dev-tools/release/set_versions.sh
+++ b/dev-tools/release/set_versions.sh
@@ -107,12 +107,7 @@ sed -e 's/^SEMVER_PRERELEASE_TOKEN=.*/SEMVER_PRERELEASE_TOKEN=""/' -i.bak ci/pip
 #  initial_version: 1.12.0
 sed -e "s/^  initial_version:.*/  initial_version: ${VERSION}/" -i.bak ./ci/pipelines/shared/jinja.variables.yml
 
-#"/lib/geode-modules-" + currentVersion + "-SNAPSHOT.jar",
-#"/lib/geode-modules-tomcat8-" + currentVersion + "-SNAPSHOT.jar",
-TCTEST=geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
-sed -e "s/-SNAPSHOT//" -i.bak $TCTEST
-
-rm gradle.properties.bak ci/pipelines/meta/meta.properties.bak ci/pipelines/shared/jinja.variables.yml.bak $TCTEST.bak
+rm gradle.properties.bak ci/pipelines/meta/meta.properties.bak ci/pipelines/shared/jinja.variables.yml.bak
 set -x
 git add .
 git diff --staged

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
@@ -35,8 +35,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.UniquePortSupplier;
-import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;
@@ -324,11 +324,11 @@ public class Tomcat8ClientServerRollingUpgradeTest {
    * @return Paths to required jars
    */
   private String getClassPathTomcat8AndCurrentModules() {
-    String currentVersion = Version.CURRENT.getName();
+    String currentVersion = GemFireVersion.getGemFireVersion();
 
     final String[] requiredClasspathJars = {
-        "/lib/geode-modules-" + currentVersion + "-SNAPSHOT.jar",
-        "/lib/geode-modules-tomcat8-" + currentVersion + "-SNAPSHOT.jar",
+        "/lib/geode-modules-" + currentVersion + ".jar",
+        "/lib/geode-modules-tomcat8-" + currentVersion + ".jar",
         "/lib/servlet-api.jar",
         "/lib/catalina.jar",
         "/lib/tomcat-util.jar",


### PR DESCRIPTION
fix Tomcat8ClientServerRollingUpgradeTest to use product version instead of serialization version for building test classpath

with this fix, the test should work correctly regardless of whether the current release ends in -SNAPSHOT or not or .0 or not.