### PR TITLE
GEODE-7937: [support/1.12] fix Tomcat test to get product version correctly

### DIFF
--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/session/tests/Tomcat8ClientServerRollingUpgradeTest.java
@@ -35,8 +35,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.internal.UniquePortSupplier;
-import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;
@@ -324,7 +324,7 @@ public class Tomcat8ClientServerRollingUpgradeTest {
    * @return Paths to required jars
    */
   private String getClassPathTomcat8AndCurrentModules() {
-    String currentVersion = Version.CURRENT.getName();
+    String currentVersion = GemFireVersion.getGemFireVersion();
 
     final String[] requiredClasspathJars = {
         "/lib/geode-modules-" + currentVersion + ".jar",


### PR DESCRIPTION
fix Tomcat8ClientServerRollingUpgradeTest to use product version instead of serialization version for building test classpath

with this fix, the test should work correctly regardless of whether the current release ends in `-SNAPSHOT` or not or `.0` or not.

PLEASE NOTE that this PR targets **support/1.12**, not develop.  It was cherry-picked from develop (#4889).  