### PR TITLE
GEODE-7919-fix-flaky: shut down threads after tests

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.distributed.internal.membership.gms;
 
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class MembershipIntegrationTest {
 
   @Test
   public void oneMembershipCanStartWithALocator()
-      throws Throwable {
+      throws IOException, MemberStartupException {
 
     final MembershipLocator<MemberIdentifier> locator = createLocator(0);
     locator.start();
@@ -85,7 +86,7 @@ public class MembershipIntegrationTest {
 
   @Test
   public void twoMembershipsCanStartWithOneLocator()
-      throws Throwable {
+      throws IOException, MemberStartupException {
 
     final MembershipLocator<MemberIdentifier> locator = createLocator(0);
     locator.start();
@@ -98,8 +99,11 @@ public class MembershipIntegrationTest {
     final Membership<MemberIdentifier> membership2 = createMembership(null, locatorPort);
     start(membership2);
 
-    assertThat(membership1.getView().getMembers()).hasSize(2);
-    assertThat(membership2.getView().getMembers()).hasSize(2);
+    await().untilAsserted(
+        () -> assertThat(membership1.getView().getMembers()).hasSize(2));
+
+    await().untilAsserted(
+        () -> assertThat(membership2.getView().getMembers()).hasSize(2));
 
     stop(membership1, membership2);
     stop(locator);
@@ -107,7 +111,7 @@ public class MembershipIntegrationTest {
 
   @Test
   public void twoLocatorsCanStartSequentially()
-      throws Throwable {
+      throws IOException, MemberStartupException {
 
     final MembershipLocator<MemberIdentifier> locator1 = createLocator(0);
     locator1.start();
@@ -120,15 +124,16 @@ public class MembershipIntegrationTest {
     final MembershipLocator<MemberIdentifier> locator2 = createLocator(0, locatorPort1);
     locator2.start();
 
-    locator2.start();
     final int locatorPort2 = locator2.getPort();
 
     Membership<MemberIdentifier> membership2 =
         createMembership(locator2, locatorPort1, locatorPort2);
     start(membership2);
 
-    assertThat(membership1.getView().getMembers()).hasSize(2);
-    assertThat(membership2.getView().getMembers()).hasSize(2);
+    await().untilAsserted(
+        () -> assertThat(membership1.getView().getMembers()).hasSize(2));
+    await().untilAsserted(
+        () -> assertThat(membership2.getView().getMembers()).hasSize(2));
 
     stop(membership2, membership1);
     stop(locator2, locator1);
@@ -136,7 +141,7 @@ public class MembershipIntegrationTest {
 
   @Test
   public void secondMembershipCanJoinUsingTheSecondLocatorToStart()
-      throws Throwable {
+      throws IOException, MemberStartupException {
 
     final MembershipLocator<MemberIdentifier> locator1 = createLocator(0);
     locator1.start();
@@ -152,14 +157,16 @@ public class MembershipIntegrationTest {
     int locatorPort2 = locator2.getPort();
 
     // Force the next membership to use locator2 by stopping locator1
-    locator1.stop();
+    stop(locator1);
 
     Membership<MemberIdentifier> membership2 =
         createMembership(locator2, locatorPort1, locatorPort2);
     start(membership2);
 
-    assertThat(membership1.getView().getMembers()).hasSize(2);
-    assertThat(membership2.getView().getMembers()).hasSize(2);
+    await().untilAsserted(
+        () -> assertThat(membership1.getView().getMembers()).hasSize(2));
+    await().untilAsserted(
+        () -> assertThat(membership2.getView().getMembers()).hasSize(2));
 
     stop(membership2, membership1);
     stop(locator2, locator1);
@@ -238,11 +245,11 @@ public class MembershipIntegrationTest {
         .create();
   }
 
-  private void stop(final Membership<MemberIdentifier> ... memberships) {
-    Arrays.stream(memberships).forEach( membership -> membership.disconnect(false));
+  private void stop(final Membership<MemberIdentifier>... memberships) {
+    Arrays.stream(memberships).forEach(membership -> membership.disconnect(false));
   }
 
-  private void stop(final MembershipLocator<MemberIdentifier> ... locators) {
-    Arrays.stream(locators).forEach( locator -> locator.stop());
+  private void stop(final MembershipLocator<MemberIdentifier>... locators) {
+    Arrays.stream(locators).forEach(locator -> locator.stop());
   }
 }


### PR DESCRIPTION
CI failures yesterday: `MembershipIntegrationTest > secondMembershipCanJoinUsingTheSecondLocatorToStart`

It’s failing in both JDK8 and JDK11:

https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/IntegrationTestOpenJDK8/builds/4#A

```java
org.apache.geode.distributed.internal.membership.gms.MembershipIntegrationTest > secondMembershipCanJoinUsingTheSecondLocatorToStart FAILED

    java.lang.AssertionError: 

    Expected size:<2> but was:<1> in:

    <[172.17.0.26(1:locator)<ec><v0>:41002]>

        at org.apache.geode.distributed.internal.membership.gms.MembershipIntegrationTest.secondMembershipCanJoinUsingTheSecondLocatorToStart(MembershipIntegrationTest.java:144)
```

Looks like in a number of tests we expect to see two members in the view but see only one. I ran the test a couple hundred times in IntelliJ and was able to reproduce the failures. 

I added a couple methods to the test to shut down locators and memberships because that was a difference I saw introduced with GEODE-7919. But really I think that masks the problem. If you comment out the innards of those two new routines and give this test a couple hundred runs it'll repro the assertion failure.

I satisfied myself that the solution was to add `Awaitility` calls around the key assertions so that's what I did.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
