### PR TITLE
GEODE-7920: Geode UDP INT thread found processing cache operations

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterOperationExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterOperationExecutors.java
@@ -737,7 +737,7 @@ public class ClusterOperationExecutors implements OperationExecutors {
       // UDP readers are throttled in the FC protocol, which queries
       // the queue to see if it should throttle
       if (stats.getInternalSerialQueueBytes() > TOTAL_SERIAL_QUEUE_THROTTLE
-          && !DistributionMessage.isPreciousThread()) {
+          && !DistributionMessage.isMembershipMessengerThread()) {
         do {
           boolean interrupted = Thread.interrupted();
           try {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionMessage.java
@@ -412,7 +412,8 @@ public abstract class DistributionMessage
    */
   protected void schedule(final ClusterDistributionManager dm) {
     boolean inlineProcess = INLINE_PROCESS
-        && getProcessorType() == OperationExecutors.SERIAL_EXECUTOR && !isPreciousThread();
+        && getProcessorType() == OperationExecutors.SERIAL_EXECUTOR
+        && !isMembershipMessengerThread();
 
     boolean forceInline = this.acker != null || getInlineProcess() || Connection.isDominoThread();
 
@@ -476,13 +477,19 @@ public abstract class DistributionMessage
   }
 
   /**
-   * returns true if the current thread should not be used for inline processing. i.e., it is a
-   * "precious" resource
+   * returns true if the current thread should not be used for inline processing because it
+   * is responsible for reading geode-membership messages. Blocking such a thread can cause
+   * a server to be kicked out
    */
-  public static boolean isPreciousThread() {
+  public static boolean isMembershipMessengerThread() {
     String thrname = Thread.currentThread().getName();
-    // return thrname.startsWith("Geode UDP");
-    return thrname.startsWith("unicast receiver") || thrname.startsWith("multicast receiver");
+
+    return isMembershipMessengerThreadName(thrname);
+  }
+
+  public static boolean isMembershipMessengerThreadName(String thrname) {
+    return thrname.startsWith("unicast receiver") || thrname.startsWith("multicast receiver")
+        || thrname.startsWith("Geode UDP");
   }
 
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ShutdownMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ShutdownMessage.java
@@ -79,7 +79,7 @@ public class ShutdownMessage extends HighPriorityDistributionMessage
     // reply.setRecipient(getSender());
     // can't send a response in a UDP receiver thread or we might miss
     // the other side going away due to blocking receipt of views
-    // if (DistributionMessage.isPreciousThread()) {
+    // if (DistributionMessage.isMembershipMessengerThread()) {
     // dm.getWaitingThreadPool().execute(new Runnable() {
     // public void run() {
     // dm.putOutgoing(reply);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ShutdownMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ShutdownMessage.java
@@ -71,27 +71,8 @@ public class ShutdownMessage extends HighPriorityDistributionMessage
   @Override
   protected void process(final ClusterDistributionManager dm) {
     Assert.assertTrue(this.id != null);
-    // The peer goes deaf after sending us this message, so do not
-    // attempt a reply.
-
-    // final ReplyMessage reply = new ReplyMessage();
-    // reply.setProcessorId(processorId);
-    // reply.setRecipient(getSender());
-    // can't send a response in a UDP receiver thread or we might miss
-    // the other side going away due to blocking receipt of views
-    // if (DistributionMessage.isMembershipMessengerThread()) {
-    // dm.getWaitingThreadPool().execute(new Runnable() {
-    // public void run() {
-    // dm.putOutgoing(reply);
-    // dm.handleManagerDeparture(ShutdownMessage.this.id, false, "shutdown message received");
-    // }
-    // });
-    // }
-    // else {
-    // dm.putOutgoing(reply);
     dm.shutdownMessageReceived(id,
         "shutdown message received");
-    // }
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ThrottlingMemLinkedQueueWithDMStats.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ThrottlingMemLinkedQueueWithDMStats.java
@@ -102,7 +102,7 @@ public class ThrottlingMemLinkedQueueWithDMStats<E> extends OverflowQueueWithDMS
       throw new InterruptedException();
     // only block threads reading from tcp stream sockets. blocking udp
     // will cause retransmission storms
-    if (!DistributionMessage.isPreciousThread()) {
+    if (!DistributionMessage.isMembershipMessengerThread()) {
       long startTime = DistributionStats.getStatTime();
       do {
         try {

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionMessageTest.java
@@ -14,9 +14,13 @@
  */
 package org.apache.geode.distributed.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,5 +38,13 @@ public class DistributionMessageTest {
     mockDistributionMessage.setReplySender(mockReplySender);
 
     verify(mockDistributionMessage, times(1)).setReplySender(mockReplySender);
+  }
+
+  @Test
+  public void membershipMessengerThreadsAreRecognized() {
+    List<String> threadNames = Arrays.asList("unicast receiver", "multicast receiver", "Geode UDP");
+    for (String threadName : threadNames) {
+      assertThat(DistributionMessage.isMembershipMessengerThreadName(threadName)).isTrue();
+    }
   }
 }


### PR DESCRIPTION
Modified DistributionMessage to look for JGroups "internal" executor
threads.  We thought we'd turned off all JGroups thread pools but this
one is still around.  We don't want to process DistributionMessages in
these threads unless absolutely necessary since they're needed when
processing incoming messages.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
