### PR TITLE
GEODE-7926: GMSMemberData is doing unnecessary reverse-DNS lookups

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataJUnitTest.java
@@ -14,11 +14,7 @@
  */
 package org.apache.geode.distributed.internal.membership.gms;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.internal.serialization.BufferDataOutputStream;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 import org.apache.geode.internal.serialization.DSFIDSerializerFactory;
@@ -58,13 +55,13 @@ public class GMSMemberDataJUnitTest {
   @Test
   public void testEqualsNotSameType() {
     GMSMemberData member = new GMSMemberData();
-    assertFalse(member.equals("Not a GMSMemberData"));
+    assertThat(member).isNotEqualTo("Not a GMSMemberData");
   }
 
   @Test
   public void testEqualsIsSame() {
     GMSMemberData member = new GMSMemberData();
-    assertTrue(member.equals(member));
+    assertThat(member).isEqualTo(member);
   }
 
   @Test
@@ -72,7 +69,7 @@ public class GMSMemberDataJUnitTest {
     GMSMemberData member = new GMSMemberData();
     UUID uuid = new UUID(0, 0);
     member.setUUID(uuid);
-    assertEquals(0, member.compareTo(member));
+    assertThat(member.compareTo(member)).isZero();
   }
 
   private GMSMemberData createGMSMember(byte[] inetAddress, int viewId, long msb, long lsb) {
@@ -89,7 +86,7 @@ public class GMSMemberDataJUnitTest {
   public void testCompareToInetAddressIsLongerThan() {
     GMSMemberData member1 = createGMSMember(new byte[] {1, 1, 1, 1, 1}, 1, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1, 1, 1, 1}, 1, 1, 1);
-    assertEquals(1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isGreaterThan(0);
   }
 
   @Test
@@ -100,7 +97,7 @@ public class GMSMemberDataJUnitTest {
             member1.getVersionOrdinal(),
             member1.getUuidMostSignificantBits(), member1.getUuidLeastSignificantBits(),
             member1.getVmViewId());
-    assertEquals(0, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isZero();
   }
 
   @Test
@@ -109,70 +106,70 @@ public class GMSMemberDataJUnitTest {
     GMSMemberData member2 = new GMSMemberData(member1.getInetAddress(), member1.getMembershipPort(),
         member1.getVersionOrdinal(), member1.getUuidMostSignificantBits(),
         member1.getUuidLeastSignificantBits(), 100);
-    assertEquals(false, member1.equals(member2));
+    assertThat(member1).isNotEqualTo(member2);
   }
 
   @Test
   public void testCompareToInetAddressIsShorterThan() {
     GMSMemberData member1 = createGMSMember(new byte[] {1, 1, 1, 1}, 1, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1, 1, 1, 1, 1}, 1, 1, 1);
-    assertEquals(-1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isLessThan(0);
   }
 
   @Test
   public void testCompareToInetAddressIsGreater() {
     GMSMemberData member1 = createGMSMember(new byte[] {1, 2, 1, 1, 1}, 1, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1, 1, 1, 1, 1}, 1, 1, 1);
-    assertEquals(1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isGreaterThan(0);
   }
 
   @Test
   public void testCompareToInetAddressIsLessThan() {
     GMSMemberData member1 = createGMSMember(new byte[] {1, 1, 1, 1, 1}, 1, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1, 2, 1, 1, 1}, 1, 1, 1);
-    assertEquals(-1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isLessThan(0);
   }
 
   @Test
   public void testCompareToMyViewIdLarger() {
     GMSMemberData member1 = createGMSMember(new byte[] {1}, 2, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1}, 1, 1, 1);
-    assertEquals(1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isGreaterThan(0);
   }
 
   @Test
   public void testCompareToTheirViewIdLarger() {
     GMSMemberData member1 = createGMSMember(new byte[] {1}, 1, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1}, 2, 1, 1);
-    assertEquals(-1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isLessThan(0);
   }
 
   @Test
   public void testCompareToMyMSBLarger() {
     GMSMemberData member1 = createGMSMember(new byte[] {1}, 1, 2, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1}, 1, 1, 1);
-    assertEquals(1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isGreaterThan(0);
   }
 
   @Test
   public void testCompareToTheirMSBLarger() {
     GMSMemberData member1 = createGMSMember(new byte[] {1}, 1, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1}, 1, 2, 1);
-    assertEquals(-1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isLessThan(0);
   }
 
   @Test
   public void testCompareToMyLSBLarger() {
     GMSMemberData member1 = createGMSMember(new byte[] {1}, 1, 1, 2);
     GMSMemberData member2 = createGMSMember(new byte[] {1}, 1, 1, 1);
-    assertEquals(1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isGreaterThan(0);
   }
 
   @Test
   public void testCompareToTheirLSBLarger() {
     GMSMemberData member1 = createGMSMember(new byte[] {1}, 1, 1, 1);
     GMSMemberData member2 = createGMSMember(new byte[] {1}, 1, 1, 2);
-    assertEquals(-1, member1.compareTo(member2));
+    assertThat(member1.compareTo(member2)).isLessThan(0);
   }
 
   @Test
@@ -180,7 +177,7 @@ public class GMSMemberDataJUnitTest {
     GMSMemberData member = new GMSMemberData();
     UUID uuid = new UUID(0, 0);
     member.setUUID(uuid);
-    assertNull(member.getUUID());
+    assertThat(member.getUUID()).isNull();
   }
 
   @Test
@@ -188,7 +185,7 @@ public class GMSMemberDataJUnitTest {
     GMSMemberData member = new GMSMemberData();
     UUID uuid = new UUID(1, 1);
     member.setUUID(uuid);
-    assertNotNull(member.getUUID());
+    assertThat(member.getUUID()).isNotNull();
   }
 
   /**
@@ -204,6 +201,7 @@ public class GMSMemberDataJUnitTest {
   public void testGMSMemberBackwardCompatibility() throws Exception {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     GMSMemberData member = new GMSMemberData();
+    member.setInetAddr(LocalHostUtil.getLocalHost());
     DataOutput dataOutput = new DataOutputStream(baos);
     SerializationContext serializationContext = dsfidSerializer
         .createSerializationContext(dataOutput);
@@ -216,7 +214,10 @@ public class GMSMemberDataJUnitTest {
         .createDeserializationContext(dataInput);
     GMSMemberData newMember = new GMSMemberData();
     newMember.readEssentialData(dataInput, deserializationContext);
-    assertEquals(member.getVmKind(), newMember.getVmKind());
+    assertThat(newMember.getVmKind()).isEqualTo(member.getVmKind());
+    assertThat(newMember.getInetAddress()).isNotNull();
+    assertThat(newMember.getInetAddress().getHostAddress()).isEqualTo(newMember.getHostName());
+
 
     // vmKind should not be transmitted to a member with version GFE_90 or earlier
     dataOutput = new BufferDataOutputStream(Version.GFE_90);
@@ -227,7 +228,7 @@ public class GMSMemberDataJUnitTest {
     dataInput = new VersionedDataInputStream(stream, Version.GFE_90);
     newMember = new GMSMemberData();
     newMember.readEssentialData(dataInput, deserializationContext);
-    assertEquals(0, newMember.getVmKind());
+    assertThat(newMember.getVmKind()).isZero();
   }
 
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
@@ -589,7 +589,9 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
 
     this.inetAddr = StaticSerialization.readInetAddress(in);
     if (this.inetAddr != null) {
-      this.hostName = inetAddr.getHostName();
+      // use address as hostname at this level. getHostName() will do a reverse-dns lookup,
+      // which is very expensive
+      this.hostName = inetAddr.getHostAddress();
     }
     this.udpPort = in.readInt();
     this.vmViewId = in.readInt();


### PR DESCRIPTION
Removed hostname lookup from GMSMemberData a serialization method.
InternalDistributedMember does its own hostname lookup & there's no
reason for the lookup in GMSMemberData.  I found it was slowing down UDP
communications.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
