### PR TITLE
GEODE-6819: Fix PartitionedRegionSingleHopDUnitTest BindExceptions

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/InternalClientCache.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/InternalClientCache.java
@@ -48,4 +48,6 @@ public interface InternalClientCache extends ClientCache {
   CachePerfStats getCachePerfStats();
 
   MeterRegistry getMeterRegistry();
+
+  ClientMetadataService getClientMetadataService();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/util/UncheckedUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/util/UncheckedUtils.java
@@ -14,10 +14,16 @@
  */
 package org.apache.geode.internal.cache.util;
 
+import org.apache.geode.cache.execute.Execution;
+
 @SuppressWarnings({"unchecked", "unused"})
 public class UncheckedUtils {
 
   public static <T> T cast(Object object) {
     return (T) object;
+  }
+
+  public static <IN, OUT, AGG> Execution<IN, OUT, AGG> cast(Execution execution) {
+    return execution;
   }
 }


### PR DESCRIPTION
Intermittent failures were caused by trying to stop and then restart
server(s) with the previously used ports which are no longer free on
the host machine.

This PR overhauls all of PartitionedRegionSingleHopDUnitTest while 
also fixing flaky failures caused by underlying BindExceptions in both:
* testMetadataIsSameOnAllServersAndClients
* testSingleHopWithHAWithLocator

I've added comments below that point to the actual BindException
fixes to aid in reviewing.