### PR TITLE
GEODE-7938: added keys query param to GET, PUT, and DELETE /{region} endpoints

### DIFF
--- a/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
@@ -387,6 +387,29 @@ public class RestAccessControllerTest {
 
   @Test
   @WithMockUser
+  public void putAllWithQueryParam() throws Exception {
+    StringBuilder keysBuilder = new StringBuilder();
+    for (int i = 1; i < 60; i++) {
+      keysBuilder.append(i).append(',');
+    }
+    keysBuilder.append(60);
+    String keys = keysBuilder.toString();
+    mockMvc.perform(
+        put("/v1/customers?keys=" + keys)
+            .content(jsonResources.get(CUSTOMER_LIST_JSON))
+            .with(POST_PROCESSOR))
+        .andExpect(status().isOk())
+        .andExpect(header().string("Location", BASE_URL + "/customers/" + keys));
+    assertThat(customerRegion.size()).isEqualTo(60);
+    for (int i = 1; i <= 60; i++) {
+      PdxInstance customer = customerRegion.get(String.valueOf(i));
+      assertThat(customer.getField("customerId").toString())
+          .isEqualTo(Integer.valueOf(100 + i).toString());
+    }
+  }
+
+  @Test
+  @WithMockUser
   public void putAllWithSlashes() throws Exception {
     StringBuilder keysBuilder = new StringBuilder();
     for (int i = 1; i < 60; i++) {
@@ -692,6 +715,17 @@ public class RestAccessControllerTest {
 
   @Test
   @WithMockUser
+  public void getSpecificKeysUsingQueryParam() throws Exception {
+    putAll();
+    mockMvc.perform(get("/v1/customers?keys=1,2,3,4,5&ignoreMissingKey=false")
+        .with(POST_PROCESSOR))
+        .andExpect(status().isOk())
+        .andExpect(
+            jsonPath("$.customers[*].customerId", containsInAnyOrder(101, 102, 103, 104, 105)));
+  }
+
+  @Test
+  @WithMockUser
   public void getSpecificKeysWithSlashes() throws Exception {
     putAllWithSlashes();
     mockMvc.perform(get("/v1/customers/1" + SLASH + ",2" + SLASH + ",3" + SLASH
@@ -736,6 +770,25 @@ public class RestAccessControllerTest {
     mockMvc.perform(delete("/v1/customers/2,3,4,5")
         .with(POST_PROCESSOR))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  public void deleteMultipleKeysWithQueryParam() throws Exception {
+    putAll();
+    assertThat(customerRegion.size()).isEqualTo(60);
+    assertThat(customerRegion.containsKey("2")).isTrue();
+    assertThat(customerRegion.containsKey("3")).isTrue();
+    assertThat(customerRegion.containsKey("4")).isTrue();
+    assertThat(customerRegion.containsKey("5")).isTrue();
+    mockMvc.perform(delete("/v1/customers?keys=2,3,4,5")
+        .with(POST_PROCESSOR))
+        .andExpect(status().isOk());
+    assertThat(customerRegion.size()).isEqualTo(60 - 4);
+    assertThat(customerRegion.containsKey("2")).isFalse();
+    assertThat(customerRegion.containsKey("3")).isFalse();
+    assertThat(customerRegion.containsKey("4")).isFalse();
+    assertThat(customerRegion.containsKey("5")).isFalse();
   }
 
   @Test

--- a/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
@@ -16,11 +16,12 @@ package org.apache.geode.rest.internal.web.controllers;
 
 import static org.apache.geode.test.matchers.JsonEquivalence.jsonEquals;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.head;
@@ -44,7 +45,6 @@ import java.util.Properties;
 import java.util.stream.IntStream;
 
 import com.jayway.jsonpath.JsonPath;
-import org.hamcrest.core.StringStartsWith;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -722,7 +722,7 @@ public class RestAccessControllerTest {
         .with(POST_PROCESSOR))
         .andExpect(status().isOk())
         .andExpect(
-            header().string("Content-Location", new StringStartsWith(BASE_URL + "/customers/")))
+            header().string("Content-Location", startsWith(BASE_URL + "/customers/")))
         .andExpect(jsonPath("$.customers", jsonEquals(jsonResources.get(CUSTOMER_LIST_JSON))));
   }
 
@@ -745,7 +745,7 @@ public class RestAccessControllerTest {
         .with(POST_PROCESSOR))
         .andExpect(status().isOk())
         .andExpect(
-            header().string("Content-Location", new StringStartsWith(BASE_URL + "/customers/")))
+            header().string("Content-Location", startsWith(BASE_URL + "/customers/")))
         .andExpect(jsonPath("$.customers.length()", is(10)));
   }
 
@@ -757,7 +757,7 @@ public class RestAccessControllerTest {
         .with(POST_PROCESSOR))
         .andExpect(status().isOk())
         .andExpect(
-            header().string("Content-Location", new StringStartsWith(BASE_URL + "/customers/")))
+            header().string("Content-Location", startsWith(BASE_URL + "/customers/")))
         .andExpect(jsonPath("$.customers.length()", is(60)));
   }
 

--- a/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
@@ -405,7 +405,7 @@ public class RestAccessControllerTest {
             .with(POST_PROCESSOR))
         .andExpect(status().isOk())
         .andExpect(header().string("Location", BASE_URL + "/customers/" + keys));
-    assertThat(customerRegion.size()).isEqualTo(60);
+    assertThat(customerRegion).hasSize(60);
     for (int i = 1; i <= 60; i++) {
       PdxInstance customer = customerRegion.get(String.valueOf(i));
       assertThat(customer.getField("customerId").toString())
@@ -428,7 +428,7 @@ public class RestAccessControllerTest {
             .with(POST_PROCESSOR))
         .andExpect(status().isOk())
         .andExpect(header().string("Location", BASE_URL + "/customers?keys=" + keys));
-    assertThat(customerRegion.size()).isEqualTo(60);
+    assertThat(customerRegion).hasSize(60);
     for (int i = 1; i <= 60; i++) {
       PdxInstance customer = customerRegion.get(String.valueOf(i));
       assertThat(customer.getField("customerId").toString())
@@ -451,7 +451,7 @@ public class RestAccessControllerTest {
             .with(POST_PROCESSOR))
         .andExpect(status().isOk())
         .andExpect(header().string("Location", BASE_URL + "/customers?keys=" + keys));
-    assertThat(customerRegion.size()).isEqualTo(60);
+    assertThat(customerRegion).hasSize(60);
     for (int i = 1; i <= 60; i++) {
       PdxInstance customer = customerRegion.get(createKey(i));
       assertThat(customer.getField("customerId").toString())
@@ -472,7 +472,7 @@ public class RestAccessControllerTest {
         .andExpect(status().isOk())
         .andExpect(header().string("Location", BASE_URL + "/orders?keys=" + encodedKey));
 
-    assertThat(orderRegion.size()).isEqualTo(1);
+    assertThat(orderRegion).hasSize(1);
     PdxInstance customer = customerRegion.get(createKey(32));
     assertThat(orderRegion.containsKey(decodedKey)).isTrue();
     Order order = (Order) ((PdxInstance) orderRegion.get(decodedKey)).getObject();
@@ -968,15 +968,10 @@ public class RestAccessControllerTest {
   @WithMockUser
   public void deleteMultipleKeysWithQueryParam() throws Exception {
     putAll();
-    assertThat(customerRegion.size()).isEqualTo(60);
-    assertThat(customerRegion.containsKey("2")).isTrue();
-    assertThat(customerRegion.containsKey("3")).isTrue();
-    assertThat(customerRegion.containsKey("4")).isTrue();
-    assertThat(customerRegion.containsKey("5")).isTrue();
     mockMvc.perform(delete("/v1/customers?keys=2,3,4,5")
         .with(POST_PROCESSOR))
         .andExpect(status().isOk());
-    assertThat(customerRegion.size()).isEqualTo(60 - 4);
+    assertThat(customerRegion).hasSize(60 - 4);
     assertThat(customerRegion.containsKey("2")).isFalse();
     assertThat(customerRegion.containsKey("3")).isFalse();
     assertThat(customerRegion.containsKey("4")).isFalse();
@@ -1032,7 +1027,7 @@ public class RestAccessControllerTest {
     mockMvc.perform(delete("/v1/customers?keys=" + keys)
         .with(POST_PROCESSOR))
         .andExpect(status().isOk());
-    assertThat(customerRegion.size()).isEqualTo(60 - 4);
+    assertThat(customerRegion).hasSize(60 - 4);
     for (int i = 2; i <= 5; i++) {
       assertThat(customerRegion.containsKey(createKey(i))).isFalse();
     }

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
@@ -660,16 +660,6 @@ public abstract class AbstractBaseController implements InitializingBean {
     }
   }
 
-  List<String> checkForMultipleKeysExist(String region, String... keys) {
-    List<String> unknownKeys = new ArrayList<>();
-    for (String key : keys) {
-      if (!getRegion(region).containsKey(key)) {
-        unknownKeys.add(key);
-      }
-    }
-    return unknownKeys;
-  }
-
   protected Object[] getKeys(final String regionNamePath, Object[] keys) {
     return (!(keys == null || keys.length == 0) ? keys
         : getRegion(regionNamePath).keySet().toArray());

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
@@ -817,7 +817,6 @@ public abstract class AbstractBaseController implements InitializingBean {
       default:
         if (JSONTypes.JSON_ARRAY.equals(jsonType)) {
           putValue(region, key, convertJsonArrayIntoPdxCollection(json));
-          // putValue(region, key, convertJsonIntoPdxCollection(json));
         } else {
           putValue(region, key, convert(json));
         }

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/AbstractBaseController.java
@@ -604,7 +604,7 @@ public abstract class AbstractBaseController implements InitializingBean {
 
     if (StringUtils.hasText(existingKey)) {
       newKey = existingKey;
-      if (NumberUtils.isNumeric(newKey) && domainObjectId == null) {
+      if (domainObject != null && NumberUtils.isNumeric(newKey) && domainObjectId == null) {
         final Long newId = IdentifiableUtils.createId(NumberUtils.parseLong(newKey));
         if (newKey.equals(newId.toString())) {
           IdentifiableUtils.setId(domainObject, newId);

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
@@ -144,11 +144,12 @@ public abstract class CommonCrudController extends AbstractBaseController {
    * Delete all data in region or just the given keys
    *
    * @param region gemfire region
-   * @param keys optional comma separated list of keys
+   * @param encodedKeys optional comma separated list of keys
    * @return JSON document containing result
    */
   @RequestMapping(method = RequestMethod.DELETE, value = "/{region}")
-  @ApiOperation(value = "delete all data", notes = "Delete all data in the region")
+  @ApiOperation(value = "delete all data or the specified keys",
+      notes = "Delete all data in the region or just the specified keys.")
   @ApiResponses({@ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 401, message = "Invalid Username or Password."),
       @ApiResponse(code = 403, message = "Insufficient privileges for operation."),

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/CommonCrudController.java
@@ -19,8 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import javax.servlet.http.HttpServletRequest;
-
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
@@ -113,23 +111,23 @@ public abstract class CommonCrudController extends AbstractBaseController {
   }
 
   /**
-   * Delete data for single key or specific keys in region
+   * Delete data for one or more keys from a region
    *
    * @param region gemfire region
+   * @param keys comma separated list of keys
    * @return JSON document containing result
    */
-  @RequestMapping(method = RequestMethod.DELETE, value = "/{region}/**",
+  @RequestMapping(method = RequestMethod.DELETE, value = "/{region}/{keys}",
       produces = {APPLICATION_JSON_UTF8_VALUE})
   @ApiOperation(value = "delete data for key(s)",
-      notes = "Delete data for one or more keys in a region. The keys, ** in the endpoint, are a comma separated list.")
+      notes = "Delete data for one or more keys in a region. Deprecated in favor of /{region}?keys=.")
   @ApiResponses({@ApiResponse(code = 200, message = "OK"),
       @ApiResponse(code = 401, message = "Invalid Username or Password."),
       @ApiResponse(code = 403, message = "Insufficient privileges for operation."),
       @ApiResponse(code = 404, message = "Region or key(s) does not exist"),
       @ApiResponse(code = 500, message = "GemFire throws an error or exception")})
   public ResponseEntity<?> delete(@PathVariable("region") String region,
-      HttpServletRequest request) {
-    String[] keys = parseKeys(request, region);
+      @PathVariable("keys") String[] keys) {
     region = decode(region);
     return deleteRegionKeys(region, keys);
   }
@@ -156,13 +154,14 @@ public abstract class CommonCrudController extends AbstractBaseController {
       @ApiResponse(code = 403, message = "Insufficient privileges for operation."),
       @ApiResponse(code = 404, message = "Region does not exist"),
       @ApiResponse(code = 500, message = "if GemFire throws an error or exception")})
-  public ResponseEntity<?> delete(@PathVariable("region") String region,
-      @RequestParam(value = "keys", required = false) final String[] keys) {
+  public ResponseEntity<?> deleteAllOrGivenKeys(@PathVariable("region") String region,
+      @RequestParam(value = "keys", required = false) final String[] encodedKeys) {
     region = decode(region);
-    if (keys == null || keys.length == 0) {
+    if (encodedKeys == null || encodedKeys.length == 0) {
       return deleteAllRegionData(region);
     } else {
-      return deleteRegionKeys(region, keys);
+      String[] decodedKeys = decode(encodedKeys);
+      return deleteRegionKeys(region, decodedKeys);
     }
   }
 

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/PdxBasedCrudController.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/PdxBasedCrudController.java
@@ -127,15 +127,16 @@ public class PdxBasedCrudController extends CommonCrudController {
    *
    * @param region gemfire region name
    * @param limit total number of entries requested
-   * @param keys an optional comma separated list of encodeded keys to read
+   * @param encodedKeys an optional comma separated list of encoded keys to read
    * @param ignoreMissingKey if true and reading more than on ekey then if a key is missing ignore
    *        it
    * @return JSON document
    */
   @RequestMapping(method = RequestMethod.GET, value = "/{region}",
       produces = APPLICATION_JSON_UTF8_VALUE)
-  @ApiOperation(value = "read all data for region",
-      notes = "Read all data for region. Use limit param to get fixed or limited number of entries.")
+  @ApiOperation(value = "read all data for region or the specified keys",
+      notes = "If reading all data for region then the limit parameter can be used to give the maximum number of values to return."
+          + "If reading specific keys then the ignoreMissingKey parameter can be used to not fail if a key is missing.")
   @ApiResponses({@ApiResponse(code = 200, message = "OK."),
       @ApiResponse(code = 400, message = "Bad request."),
       @ApiResponse(code = 401, message = "Invalid Username or Password."),

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/support/UpdateOp.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/controllers/support/UpdateOp.java
@@ -16,7 +16,7 @@
 package org.apache.geode.rest.internal.web.controllers.support;
 
 /**
- * UpdateOp contains all posible update operation supported with REST APIs
+ * UpdateOp contains all possible update operation supported with REST APIs
  */
 
 @SuppressWarnings("unused")


### PR DESCRIPTION
The previous fix did not handle initial slashes (see GEODE-7938).
So now we have a new queryParam "?keys=" that can be used in place of the old {keys} pathVar. 
The new queryParam expects its keys to be encoded with UTF-8.

The previous fixes "/**" has been removed since it did harm to swagger.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
