### PR TITLE
GEODE-7946: Fix redis publish/subscribe leaking netty buffers

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/AbstractSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/AbstractSubscription.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal;
 
+import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.ExecutionException;
 
 import io.netty.buffer.ByteBuf;
@@ -81,7 +82,14 @@ public abstract class AbstractSubscription implements Subscription {
 
     try {
       channelFuture.get();
-    } catch (InterruptedException | ExecutionException e) {
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof ClosedChannelException) {
+        logger.warn("Unable to write to channel: {}", e.getMessage());
+      } else {
+        logger.warn("Unable to write to channel", e);
+      }
+      return false;
+    } catch (InterruptedException e) {
       logger.warn("Unable to write to channel", e);
       return false;
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
@@ -62,7 +62,10 @@ public class PsubscribeExecutor extends AbstractExecutor {
       } catch (CoderException e) {
         logger.warn("Error encoding subscribe response", e);
       }
-      aggregatedResponse.writeBytes(response);
+      if (response != null) {
+        aggregatedResponse.writeBytes(response);
+        response.release();
+      }
     });
     command.setResponse(aggregatedResponse);
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
@@ -59,7 +59,10 @@ public class SubscribeExecutor extends AbstractExecutor {
       } catch (CoderException e) {
         logger.warn("Error encoding subscribe response", e);
       }
-      aggregatedResponse.writeBytes(response);
+      if (response != null) {
+        aggregatedResponse.writeBytes(response);
+        response.release();
+      }
     });
     command.setResponse(aggregatedResponse);
   }


### PR DESCRIPTION
- Reduce logging verbosity of `ClosedChannelxception`s 

Authored-by: Jens Deppe <jdeppe@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
