### PR TITLE
GEODE-7098: Tomcat8SessionsClientServerDUnitTest Tests were getting bind failures

### DIFF
--- a/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/TestSessionsTomcat8Base.java
+++ b/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/TestSessionsTomcat8Base.java
@@ -19,9 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.beans.PropertyChangeEvent;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.security.SecureRandom;
-import java.util.Random;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.servlet.http.HttpSession;
 
@@ -57,7 +54,7 @@ public abstract class TestSessionsTomcat8Base implements Serializable {
   DeltaSessionManager sessionManager;
 
   public void checkSanity() throws Exception {
-      testSanity();
+    testSanity();
   }
 
   /**

--- a/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/TestSessionsTomcat8Base.java
+++ b/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/TestSessionsTomcat8Base.java
@@ -53,14 +53,7 @@ public abstract class TestSessionsTomcat8Base implements Serializable {
   Region<String, HttpSession> region;
   DeltaSessionManager sessionManager;
 
-  public void checkSanity() throws Exception {
-    testSanity();
-  }
-
-  /**
-   * Check that the basics are working
-   */
-  public void testSanity() throws Exception {
+  public void basicConnectivityCheck() throws Exception {
     WebConversation wc = new WebConversation();
     assertThat(wc).describedAs("WebConversation was").isNotNull();
     logger.debug("Sending request to http://localhost:{}/test", port);
@@ -407,7 +400,7 @@ public abstract class TestSessionsTomcat8Base implements Serializable {
 
     WebResponse response = wc.getResponse(req);
     assertThat(response.getText()).isEqualTo("done");
-    assertThat(region.size()).as("The region should be empty").isEqualTo(1);
+    assertThat(region.size()).as("The region should contain one entry").isEqualTo(1);
   }
 
   /**

--- a/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
@@ -16,17 +16,20 @@ package org.apache.geode.modules.session;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.security.auth.message.config.AuthConfigFactory;
 
+import org.apache.catalina.LifecycleState;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.experimental.categories.Category;
-import org.springframework.util.SocketUtils;
 
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.modules.session.catalina.ClientServerCacheLifecycleListener;
 import org.apache.geode.modules.session.catalina.DeltaSessionManager;
 import org.apache.geode.modules.session.catalina.Tomcat8DeltaSessionManager;
@@ -34,50 +37,83 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.SessionTest;
 
+
+
 @Category(SessionTest.class)
 public class Tomcat8SessionsClientServerDUnitTest extends TestSessionsTomcat8Base {
+
   @Rule
   public ClusterStartupRule clusterStartupRule = new ClusterStartupRule(2);
 
   private ClientCache clientCache;
-  private MemberVM locatorVM;
-  private MemberVM serverVM;
 
   @Before
   public void setUp() throws Exception {
-    locatorVM = clusterStartupRule.startLocatorVM(0, 0);
-    Integer locatorPort = locatorVM.getPort();
-    serverVM = clusterStartupRule.startServerVM(1, locatorPort);
+    int locatorPortSuggestion = AvailablePortHelper.getRandomAvailableTCPPort();
+    MemberVM locatorVM = clusterStartupRule.startLocatorVM(0, locatorPortSuggestion);
+    assertThat(locatorVM).isNotNull();
 
-    port = SocketUtils.findAvailableTcpPort();
+    Integer locatorPort = locatorVM.getPort();
+    assertThat(locatorPort).isGreaterThan(0);
+
+    MemberVM serverVM = clusterStartupRule.startServerVM(1, locatorPort);
+    assertThat(serverVM).isNotNull();
+
+    port = AvailablePortHelper.getRandomAvailableTCPPort();
+    assertThat(port).isGreaterThan(0);
+
     server = new EmbeddedTomcat8(port, "JVM-1");
+    assertThat(server).isNotNull();
 
     ClientCacheFactory cacheFactory = new ClientCacheFactory();
+    assertThat(cacheFactory).isNotNull();
+
     cacheFactory.addPoolServer("localhost", serverVM.getPort()).setPoolSubscriptionEnabled(true);
     clientCache = cacheFactory.create();
+    assertThat(clientCache).isNotNull();
+
     DeltaSessionManager manager = new Tomcat8DeltaSessionManager();
+    assertThat(manager).isNotNull();
 
     ClientServerCacheLifecycleListener listener = new ClientServerCacheLifecycleListener();
+    assertThat(listener).isNotNull();
+
     listener.setProperty(MCAST_PORT, "0");
     listener.setProperty(LOG_LEVEL, "config");
     server.addLifecycleListener(listener);
+
     sessionManager = manager;
     sessionManager.setEnableCommitValve(true);
     server.getRootContext().setManager(sessionManager);
+
     AuthConfigFactory.setFactory(null);
 
     servlet = server.addServlet("/test/*", "default", CommandServlet.class.getName());
+    assertThat(servlet).isNotNull();
+
     server.startContainer();
-
-
     // Can only retrieve the region once the container has started up (& the cache has started too).
     region = sessionManager.getSessionCache().getSessionRegion();
+    assertThat(region).isNotNull();
+
     sessionManager.getTheContext().setSessionTimeout(30);
+    await().until(() -> sessionManager.getState() == LifecycleState.STARTED);
+
+    checkSanity();
   }
 
   @After
   public void tearDown() {
     clientCache.close();
+    clientCache = null;
+    port = -1;
+
     server.stopContainer();
+    server = null;
+    servlet = null;
+
+    sessionManager = null;
+    region = null;
+
   }
 }

--- a/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsClientServerDUnitTest.java
@@ -99,7 +99,7 @@ public class Tomcat8SessionsClientServerDUnitTest extends TestSessionsTomcat8Bas
     sessionManager.getTheContext().setSessionTimeout(30);
     await().until(() -> sessionManager.getState() == LifecycleState.STARTED);
 
-    checkSanity();
+    basicConnectivityCheck();
   }
 
   @After

--- a/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.springframework.util.SocketUtils;
 
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.modules.session.catalina.PeerToPeerCacheLifecycleListener;
 import org.apache.geode.modules.session.catalina.Tomcat8DeltaSessionManager;
 import org.apache.geode.test.junit.categories.SessionTest;
@@ -33,7 +34,7 @@ public class Tomcat8SessionsDUnitTest extends TestSessionsTomcat8Base {
 
   @Before
   public void setUp() throws Exception {
-    port = SocketUtils.findAvailableTcpPort();
+    port = AvailablePortHelper.getRandomAvailableTCPPort();
     server = new EmbeddedTomcat8(port, "JVM-1");
 
     PeerToPeerCacheLifecycleListener p2pListener = new PeerToPeerCacheLifecycleListener();
@@ -53,6 +54,7 @@ public class Tomcat8SessionsDUnitTest extends TestSessionsTomcat8Base {
 
     sessionManager.getTheContext().setSessionTimeout(30);
     region.clear();
+    checkSanity();
   }
 
   @After

--- a/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
@@ -53,7 +53,7 @@ public class Tomcat8SessionsDUnitTest extends TestSessionsTomcat8Base {
 
     sessionManager.getTheContext().setSessionTimeout(30);
     region.clear();
-    checkSanity();
+    basicConnectivityCheck();
   }
 
   @After

--- a/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
+++ b/extensions/geode-modules-tomcat8/src/distributedTest/java/org/apache/geode/modules/session/Tomcat8SessionsDUnitTest.java
@@ -22,7 +22,6 @@ import javax.security.auth.message.config.AuthConfigFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
-import org.springframework.util.SocketUtils;
 
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.modules.session.catalina.PeerToPeerCacheLifecycleListener;


### PR DESCRIPTION
 
- They were using SocketUtils.getAvailableTCPPort
- Moved tests to use AvailablePortHelper class
- Added Sanity check to setup

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
