### PR TITLE
GEODE-7947 Implement tests for EXPIRE-related functionality

### DIFF
--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireAtDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireAtDockerAcceptanceTest.java
@@ -27,11 +27,9 @@ import org.apache.geode.test.junit.categories.RedisTest;
 @Category({RedisTest.class})
 public class ExpireAtDockerAcceptanceTest extends ExpireAtIntegrationTest {
 
-  private static GenericContainer redisContainer;
-
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
   }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireAtDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireAtDockerAcceptanceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.redis.general.ExpireAtIntegrationTest;
+import org.apache.geode.test.junit.categories.RedisTest;
+
+@Category({RedisTest.class})
+public class ExpireAtDockerAcceptanceTest extends ExpireAtIntegrationTest {
+
+  private static GenericContainer redisContainer;
+
+  @BeforeClass
+  public static void setUp() {
+    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    redisContainer.start();
+    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @AfterClass
+  public static void classLevelTearDown() {
+    jedis.close();
+  }
+
+}

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireDockerAcceptanceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.redis.general.ExpireIntegrationTest;
+import org.apache.geode.test.junit.categories.RedisTest;
+
+@Category({RedisTest.class})
+public class ExpireDockerAcceptanceTest extends ExpireIntegrationTest {
+
+  private static GenericContainer redisContainer;
+
+  @BeforeClass
+  public static void setUp() {
+    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    redisContainer.start();
+    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @AfterClass
+  public static void classLevelTearDown() {
+    jedis.close();
+  }
+
+}

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ExpireDockerAcceptanceTest.java
@@ -31,7 +31,7 @@ public class ExpireDockerAcceptanceTest extends ExpireIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
   }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/GeoDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/GeoDockerAcceptanceTest.java
@@ -36,7 +36,7 @@ public class GeoDockerAcceptanceTest extends GeoIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
   }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/HashesDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/HashesDockerAcceptanceTest.java
@@ -37,7 +37,7 @@ public class HashesDockerAcceptanceTest extends HashesIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     rand = new Random();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ListsDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/ListsDockerAcceptanceTest.java
@@ -36,7 +36,7 @@ public class ListsDockerAcceptanceTest extends ListsIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
   }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/PexpireDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/PexpireDockerAcceptanceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.experimental.categories.Category;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.redis.general.PexpireIntegrationTest;
+import org.apache.geode.test.junit.categories.RedisTest;
+
+@Category({RedisTest.class})
+public class PexpireDockerAcceptanceTest extends PexpireIntegrationTest {
+
+  private static GenericContainer redisContainer;
+
+  @BeforeClass
+  public static void setUp() {
+    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    redisContainer.start();
+    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @AfterClass
+  public static void classLevelTearDown() {
+    jedis.close();
+  }
+
+}

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/PexpireDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/PexpireDockerAcceptanceTest.java
@@ -31,7 +31,7 @@ public class PexpireDockerAcceptanceTest extends PexpireIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
   }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/PubSubDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/PubSubDockerAcceptanceTest.java
@@ -40,7 +40,7 @@ public class PubSubDockerAcceptanceTest extends PubSubIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     subscriber = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
     publisher = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/RenameDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/RenameDockerAcceptanceTest.java
@@ -36,7 +36,7 @@ public class RenameDockerAcceptanceTest extends RenameIntegrationTest {
   @BeforeClass
   public static void setUp() {
     rand = new Random();
-    redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
   }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/SetsDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/SetsDockerAcceptanceTest.java
@@ -36,7 +36,7 @@ public class SetsDockerAcceptanceTest extends SetsIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
     jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/SortedSetsDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/SortedSetsDockerAcceptanceTest.java
@@ -35,7 +35,7 @@ public class SortedSetsDockerAcceptanceTest extends SortedSetsIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
   }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/StringsDockerAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/StringsDockerAcceptanceTest.java
@@ -38,7 +38,7 @@ public class StringsDockerAcceptanceTest extends StringsIntegrationTest {
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer("redis:5.0.6").withExposedPorts(6379);
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
     rand = new Random();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireAtIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireAtIntegrationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.general;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+
+public class ExpireAtIntegrationTest {
+
+  public static Jedis jedis;
+  public static int REDIS_CLIENT_TIMEOUT = 10000000;
+  private static GeodeRedisServer server;
+  private long unixTimeStampInTheFutureInSeconds;
+  private long unixTimeStampFromThePast = 0l;
+  String key = "key";
+  String value = "value";
+
+  @BeforeClass
+  public static void setUp() {
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
+
+    server = new GeodeRedisServer("localhost", port);
+    server.start();
+    jedis = new Jedis("localhost", port, REDIS_CLIENT_TIMEOUT);
+  }
+
+  @Before
+  public void testSetUp() {
+    unixTimeStampInTheFutureInSeconds = (System.currentTimeMillis() / 1000) + 60;
+  }
+
+
+  @After
+  public void testLevelTearDown() {
+    jedis.flushAll();
+  }
+
+  @AfterClass
+  public static void classLevelTearDown() {
+    jedis.close();
+    server.shutdown();
+  }
+
+  @Test
+  public void should_return_1_given_validKey_andTimeStampInThePast() {
+    jedis.set(key, value);
+
+    Long result = jedis.expireAt(key, unixTimeStampFromThePast);
+
+    assertThat(result).isEqualTo(1L);
+  }
+
+  @Test
+  public void should_delete_key_given_aTimeStampInThePast() {
+    jedis.set(key, value);
+
+    jedis.expireAt(key, unixTimeStampFromThePast);
+
+    assertThat(jedis.get(key)).isNull();
+  }
+
+  @Test
+  public void should_return_0_given_nonExistentKey_andTimeStampInFuture() {
+    String non_existent_key = "I don't exist";
+
+    long result = jedis.expireAt(
+        non_existent_key,
+        unixTimeStampInTheFutureInSeconds);
+
+    assertThat(result).isEqualTo(0);
+  }
+
+  @Test
+  public void should_return_0_given_nonExistentKey_andTimeStampInPast() {
+    String non_existent_key = "I don't exist";
+
+    long result = jedis.expireAt(
+        non_existent_key,
+        unixTimeStampFromThePast);
+
+    assertThat(result).isEqualTo(0);
+  }
+
+  @Test
+  public void should_return_1_given_validKey_andValidTimeStampInFuture() {
+
+    jedis.set(key, value);
+
+    long result = jedis.expireAt(
+        key,
+        unixTimeStampInTheFutureInSeconds);
+
+    assertThat(result).isEqualTo(1);
+  }
+
+  @Test
+  public void should_expireKeyAtTimeSpecified() {
+    long unixTimeStampInTheNearFuture = (System.currentTimeMillis() / 1000) + 5;
+    jedis.set(key, value);
+    jedis.expireAt(key, unixTimeStampInTheNearFuture);
+
+    GeodeAwaitility.await().until(
+        () -> jedis.get(key) == null);
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireAtIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireAtIntegrationTest.java
@@ -34,7 +34,7 @@ public class ExpireAtIntegrationTest {
   public static int REDIS_CLIENT_TIMEOUT = 10000000;
   private static GeodeRedisServer server;
   private long unixTimeStampInTheFutureInSeconds;
-  private long unixTimeStampFromThePast = 0l;
+  private long unixTimeStampFromThePast = 0L;
   String key = "key";
   String value = "value";
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
@@ -37,7 +37,8 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public class ExpireIntegrationTest {
 
-  private static Jedis jedis;
+  public static Jedis jedis;
+  public static int REDIS_CLIENT_TIMEOUT = 10000000;
   private static GeodeRedisServer server;
   private static GemFireCache cache;
   private static Random rand;
@@ -55,7 +56,7 @@ public class ExpireIntegrationTest {
     server = new GeodeRedisServer("localhost", port);
 
     server.start();
-    jedis = new Jedis("localhost", port, 10000000);
+    jedis = new Jedis("localhost", port, REDIS_CLIENT_TIMEOUT);
   }
 
   @After
@@ -64,7 +65,7 @@ public class ExpireIntegrationTest {
   }
 
   @AfterClass
-  public static void tearDown() {
+  public static void classLevelTearDown() {
     jedis.close();
     cache.close();
     server.shutdown();

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
@@ -20,8 +20,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Random;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
@@ -41,18 +41,15 @@ public class ExpireIntegrationTest {
   public static int REDIS_CLIENT_TIMEOUT = 10000000;
   private static GeodeRedisServer server;
   private static GemFireCache cache;
-  private static Random rand;
-  private static int port = 6379;
 
   @BeforeClass
   public static void setUp() {
-    rand = new Random();
     CacheFactory cf = new CacheFactory();
     cf.set(LOG_LEVEL, "error");
     cf.set(MCAST_PORT, "0");
     cf.set(LOCATORS, "");
     cache = cf.create();
-    port = AvailablePortHelper.getRandomAvailableTCPPort();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     server = new GeodeRedisServer("localhost", port);
 
     server.start();

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PexpireIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PexpireIntegrationTest.java
@@ -51,7 +51,7 @@ public class PexpireIntegrationTest {
 
     String key = "key";
     String value = "value";
-    long millisecondsToLive = 20000l;
+    long millisecondsToLive = 20000L;
 
     jedis.set(key, value);
     Long timeToLive = jedis.ttl(key);

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PexpireIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PexpireIntegrationTest.java
@@ -27,27 +27,27 @@ import org.apache.geode.redis.GeodeRedisServer;
 
 public class PexpireIntegrationTest {
 
-  private static Jedis jedis;
+  public static Jedis jedis;
+  public static int REDIS_CLIENT_TIMEOUT = 10000000;
   private static GeodeRedisServer server;
 
   @BeforeClass
   public static void setUp() {
     int port = AvailablePortHelper.getRandomAvailableTCPPort();
-    int TIMEOUT = 10000000;
 
     server = new GeodeRedisServer("localhost", port);
     server.start();
-    jedis = new Jedis("localhost", port, TIMEOUT);
+    jedis = new Jedis("localhost", port, REDIS_CLIENT_TIMEOUT);
   }
 
   @AfterClass
-  public static void tearDown() {
+  public static void classLevelTearDown() {
     jedis.close();
     server.shutdown();
   }
 
   @Test
-  public void Should_SetExpiration_givenKeyTo_StringValueInMilliSeconds() {
+  public void should_SetExpiration_givenKeyTo_StringValueInMilliSeconds() {
 
     String key = "key";
     String value = "value";

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireAtExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireAtExecutor.java
@@ -29,17 +29,12 @@ import org.apache.geode.redis.internal.RegionProvider;
 
 public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
 
-  private final String ERROR_TIMESTAMP_NOT_USABLE = "The timestamp specified must be numeric";
-
-  private final int TIMESTAMP_INDEX = 2;
-
-  private final int SET = 1;
-
-  private final int NOT_SET = 0;
-
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
+    int SET = 1;
+    int NOT_SET = 0;
+    int TIMESTAMP_INDEX = 2;
 
     if (commandElems.size() != 3) {
       command.setResponse(
@@ -85,7 +80,7 @@ public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
 
     long delayMillis = timestamp - currentTimeMillis;
 
-    boolean expirationSet = false;
+    boolean expirationSet;
 
     if (regionProvider.hasExpiration(wKey)) {
       expirationSet = regionProvider.modifyExpiration(wKey, delayMillis);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireAtExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireAtExecutor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.redis.internal.executor;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
@@ -22,6 +24,7 @@ import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.Extendable;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
+import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.RegionProvider;
 
 public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
@@ -38,11 +41,14 @@ public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
 
-    if (commandElems.size() < 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), getArgsError()));
+    if (commandElems.size() != 3) {
+      command.setResponse(
+          Coder.getErrorResponse(
+              context.getByteBufAllocator(),
+              getArgsError()));
       return;
     }
-    RegionProvider rC = context.getRegionProvider();
+    RegionProvider regionProvider = context.getRegionProvider();
     ByteArrayWrapper wKey = command.getKey();
 
     byte[] timestampByteArray = commandElems.get(TIMESTAMP_INDEX);
@@ -51,7 +57,7 @@ public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
       timestamp = Coder.bytesToLong(timestampByteArray);
     } catch (NumberFormatException e) {
       command.setResponse(
-          Coder.getErrorResponse(context.getByteBufAllocator(), ERROR_TIMESTAMP_NOT_USABLE));
+          Coder.getErrorResponse(context.getByteBufAllocator(), ERROR_NOT_INTEGER));
       return;
     }
 
@@ -62,7 +68,18 @@ public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
     long currentTimeMillis = System.currentTimeMillis();
 
     if (timestamp <= currentTimeMillis) {
-      command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), NOT_SET));
+      int result = NOT_SET;
+      RedisDataType redisDataType = context.getKeyRegistrar().getType(wKey);
+
+      if (redisDataType != null) {
+        regionProvider.getRegionForType(redisDataType).remove(wKey);
+        result = SET;
+      }
+
+      command.setResponse(
+          Coder.getIntegerResponse(
+              context.getByteBufAllocator(),
+              result));
       return;
     }
 
@@ -70,10 +87,10 @@ public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
 
     boolean expirationSet = false;
 
-    if (rC.hasExpiration(wKey)) {
-      expirationSet = rC.modifyExpiration(wKey, delayMillis);
+    if (regionProvider.hasExpiration(wKey)) {
+      expirationSet = regionProvider.modifyExpiration(wKey, delayMillis);
     } else {
-      expirationSet = rC.setExpiration(wKey, delayMillis);
+      expirationSet = regionProvider.setExpiration(wKey, delayMillis);
     }
 
     if (expirationSet) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireExecutor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.redis.internal.executor;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
@@ -26,8 +28,6 @@ import org.apache.geode.redis.internal.RegionProvider;
 
 public class ExpireExecutor extends AbstractExecutor implements Extendable {
 
-  private final String ERROR_SECONDS_NOT_USABLE = "The number of seconds specified must be numeric";
-
   private final int SECONDS_INDEX = 2;
 
   private final int SET = 1;
@@ -39,7 +39,9 @@ public class ExpireExecutor extends AbstractExecutor implements Extendable {
     List<byte[]> commandElems = command.getProcessedCommand();
 
     if (commandElems.size() != 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), getArgsError()));
+      command.setResponse(
+          Coder.getErrorResponse(
+              context.getByteBufAllocator(), getArgsError()));
       return;
     }
 
@@ -51,7 +53,7 @@ public class ExpireExecutor extends AbstractExecutor implements Extendable {
       delay = Coder.bytesToLong(delayByteArray);
     } catch (NumberFormatException e) {
       command.setResponse(
-          Coder.getErrorResponse(context.getByteBufAllocator(), ERROR_SECONDS_NOT_USABLE));
+          Coder.getErrorResponse(context.getByteBufAllocator(), ERROR_NOT_INTEGER));
       return;
     }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ExpireExecutor.java
@@ -28,15 +28,12 @@ import org.apache.geode.redis.internal.RegionProvider;
 
 public class ExpireExecutor extends AbstractExecutor implements Extendable {
 
-  private final int SECONDS_INDEX = 2;
-
-  private final int SET = 1;
-
-  private final int NOT_SET = 0;
-
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
+    int NOT_SET = 0;
+    int SET = 1;
+    int SECONDS_INDEX = 2;
 
     if (commandElems.size() != 3) {
       command.setResponse(
@@ -67,7 +64,7 @@ public class ExpireExecutor extends AbstractExecutor implements Extendable {
       delay = delay * millisInSecond;
     }
 
-    boolean expirationSucessfullySet = false;
+    boolean expirationSucessfullySet;
 
     if (regionProvider.hasExpiration(key)) {
       expirationSucessfullySet = regionProvider.modifyExpiration(key, delay);

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/general/PExpireAtExecutorJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/general/PExpireAtExecutorJUnitTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.general;
 
 import static java.nio.charset.Charset.defaultCharset;
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -27,6 +26,7 @@ import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -34,26 +34,27 @@ import org.mockito.ArgumentCaptor;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.Executor;
-import org.apache.geode.redis.internal.executor.ExpireExecutor;
+import org.apache.geode.redis.internal.executor.PExpireAtExecutor;
 
-public class ExpireExecutorJUnitTest {
+public class PExpireAtExecutorJUnitTest {
 
   private ExecutionHandlerContext context;
   private Command command;
   private UnpooledByteBufAllocator byteBuf;
+  Executor subject;
 
   @Before
   public void setUp() {
     context = mock(ExecutionHandlerContext.class);
     command = mock(Command.class);
     byteBuf = new UnpooledByteBufAllocator(false);
+    subject = new PExpireAtExecutor();
   }
 
   @Test
   public void calledWithTooFewCommandArguments_returnsError() {
-    Executor executor = new ExpireExecutor();
     List<byte[]> commandsAsBytesWithTooFewArguments = new ArrayList<>();
-    commandsAsBytesWithTooFewArguments.add("EXPIRE".getBytes());
+    commandsAsBytesWithTooFewArguments.add("PEXPIREAT".getBytes());
     commandsAsBytesWithTooFewArguments.add("key".getBytes());
 
     ArgumentCaptor<ByteBuf> argsErrorCaptor = ArgumentCaptor.forClass(ByteBuf.class);
@@ -61,54 +62,53 @@ public class ExpireExecutorJUnitTest {
     when(context.getByteBufAllocator()).thenReturn(byteBuf);
     when(command.getProcessedCommand()).thenReturn(commandsAsBytesWithTooFewArguments);
 
-    executor.executeCommand(command, context);
+    subject.executeCommand(command, context);
     verify(command, times(1)).setResponse(argsErrorCaptor.capture());
 
     List<ByteBuf> capturedErrors = argsErrorCaptor.getAllValues();
-    assertThat(capturedErrors.get(0).toString(defaultCharset()))
+    AssertionsForClassTypes.assertThat(capturedErrors.get(0).toString(defaultCharset()))
         .startsWith("-ERR The wrong number of arguments");
   }
 
   @Test
-  public void calledWithTooManyCommandArguments_returnsErrorMessage() {
-    Executor executor = new ExpireExecutor();
-    List<byte[]> commandsAsBytesWithTooManyArguments = new ArrayList<>();
-    commandsAsBytesWithTooManyArguments.add("EXPIRE".getBytes());
-    commandsAsBytesWithTooManyArguments.add("key".getBytes());
-    commandsAsBytesWithTooManyArguments.add("100".getBytes());
-    commandsAsBytesWithTooManyArguments.add("Bonus!".getBytes());
+  public void calledWithTooManyCommandArguments_returnsError() {
+    List<byte[]> commandsAsBytesWithTooFewArguments = new ArrayList<>();
+    commandsAsBytesWithTooFewArguments.add("PEXPIREAT".getBytes());
+    commandsAsBytesWithTooFewArguments.add("key".getBytes());
+    commandsAsBytesWithTooFewArguments.add("1".getBytes());
+    commandsAsBytesWithTooFewArguments.add("extra-argument".getBytes());
 
     ArgumentCaptor<ByteBuf> argsErrorCaptor = ArgumentCaptor.forClass(ByteBuf.class);
 
     when(context.getByteBufAllocator()).thenReturn(byteBuf);
-    when(command.getProcessedCommand()).thenReturn(commandsAsBytesWithTooManyArguments);
+    when(command.getProcessedCommand()).thenReturn(commandsAsBytesWithTooFewArguments);
 
-    executor.executeCommand(command, context);
+    subject.executeCommand(command, context);
     verify(command, times(1)).setResponse(argsErrorCaptor.capture());
 
     List<ByteBuf> capturedErrors = argsErrorCaptor.getAllValues();
-    assertThat(capturedErrors.get(0).toString(defaultCharset()))
+    AssertionsForClassTypes.assertThat(capturedErrors.get(0).toString(defaultCharset()))
         .startsWith("-ERR The wrong number of arguments");
   }
 
   @Test
-  public void calledWithInvalidCommandArguments_returnsErrorMessage() {
-    Executor executor = new ExpireExecutor();
-    List<byte[]> commandsAsBytesWithTooManyArguments = new ArrayList<>();
-    commandsAsBytesWithTooManyArguments.add("EXPIRE".getBytes());
-    commandsAsBytesWithTooManyArguments.add("key".getBytes());
-    commandsAsBytesWithTooManyArguments.add("not a number".getBytes());
+  public void calledWithInvalidTimeStamp_returnsError() {
+    List<byte[]> commandsAsBytesWithTooFewArguments = new ArrayList<>();
+    commandsAsBytesWithTooFewArguments.add("PEXPIREAT".getBytes());
+    commandsAsBytesWithTooFewArguments.add("key".getBytes());
+    commandsAsBytesWithTooFewArguments.add("not-a-timestamp".getBytes());
 
     ArgumentCaptor<ByteBuf> argsErrorCaptor = ArgumentCaptor.forClass(ByteBuf.class);
 
     when(context.getByteBufAllocator()).thenReturn(byteBuf);
-    when(command.getProcessedCommand()).thenReturn(commandsAsBytesWithTooManyArguments);
+    when(command.getProcessedCommand()).thenReturn(commandsAsBytesWithTooFewArguments);
 
-    executor.executeCommand(command, context);
+    subject.executeCommand(command, context);
     verify(command, times(1)).setResponse(argsErrorCaptor.capture());
 
     List<ByteBuf> capturedErrors = argsErrorCaptor.getAllValues();
-    assertThat(capturedErrors.get(0).toString(defaultCharset()))
+    AssertionsForClassTypes.assertThat(capturedErrors.get(0).toString(defaultCharset()))
         .startsWith("-ERR value is not an integer or out of range");
   }
+
 }


### PR DESCRIPTION
This does not cover concurrent tests. It ensures correctness of single-threaded functionality compared to native Redis. A few fixes to commands have been implemented when identified by the new tests.