### PR TITLE
GEODE-7950: Force TLS1.2 for installing PackageProvider=NuGet

### DIFF
--- a/ci/images/google-windows-geode-builder/build_image.sh
+++ b/ci/images/google-windows-geode-builder/build_image.sh
@@ -18,7 +18,7 @@
 
 PACKER=${PACKER:-packer}
 PACKER_ARGS="${*}"
-INTERNAL=${INTERNAL:-true}
+INTERNAL=${INTERNAL:-false}
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
@@ -46,6 +46,7 @@ if [[ -n "${MY_NAME}" ]]; then
   GCP_NETWORK=${GCP_NETWORK##*/}
   GCP_SUBNETWORK=$(echo ${NETWORK_INTERFACE_INFO} | jq -r '.networkInterfaces[0].subnetwork')
   GCP_SUBNETWORK=${GCP_SUBNETWORK##*/}
+  INTERNAL=true
 fi
 
 if [[ -z "${GCP_PROJECT}" ]]; then

--- a/ci/images/google-windows-geode-builder/windows-packer.json
+++ b/ci/images/google-windows-geode-builder/windows-packer.json
@@ -53,6 +53,7 @@
       "inline": [
         "$ErrorActionPreference = \"Stop\"",
         "Set-ExecutionPolicy Bypass -Scope Process -Force",
+        "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12",
         "Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force",
         "Install-Module DockerMsftProvider -Force",
         "Install-Package Docker -ProviderName DockerMsftProvider -Force",


### PR DESCRIPTION
Would be nice to set the default TLS for all PowerShell sessions, but
that seems to be unsupported.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
