### PR TITLE
GEODE-7156: add docs for security-auth-token-enabled-components

### DIFF
--- a/geode-docs/configuring/running/cluster-management-service.html.md.erb
+++ b/geode-docs/configuring/running/cluster-management-service.html.md.erb
@@ -76,15 +76,16 @@ See the [Cluster Management Service Java Client topic on the Geode Wiki](https:/
 
 ## <a id='cms-security'>Authentication and Authorization</a>
 
-The cluster management service REST API is secured by the <code class="ph codeph">security-manager</code> of your cluster. If a security-manager is specified, by default, you will
-need to pass in a username/password pair in order to invoke the rest api.
+The cluster management service REST API is secured by the <code class="ph codeph">security-manager</code> of your cluster. If a security-manager is specified, you must provide authorization in order to invoke the REST api.
+
+By default, the security manager accepts authorization for REST API access in the form of a username/password pair:
 
 ```
 curl --user username:password http://example.com/management/regions
 ```
 
-When <code class="ph codeph">security-auth-token-enabled-components</code> is set to "all" or "management", you will
-need to pass in a valid bearer token in your request header in order to invoke the rest api.
+When <code class="ph codeph">security-auth-token-enabled-components</code> is set to "all" or "management", 
+you must provide REST API authorization in the form of a valid bearer token (instead of username/password):
 
 ```
 curl -H "Authorization: Bearer YWhhbWlsdG9uQGFwaWdlZS5jb206bXlwYXNzdzByZAo" http://example.com/management/regions

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -525,10 +525,10 @@ Any security-related (properties that begin with <code class="ph codeph">securit
 </tr>
 <tr>
 <td>security-auth-token-enabled-components</td>
-<td>A comma delimited list of component names which works in conjunction with the <code class="ph codeph">security-manager</code> property. if security manager is enabled, this property will determine what components will use token based authentication instead of basic (username/password) authentication.
+<td>A comma-delimited list of component names which works in conjunction with the <code class="ph codeph">security-manager</code> property. If <code class="ph codeph">security-manager</code> is enabled, this property determines which components will use token-based authentication instead of basic (username/password) authentication.
 <p>Valid values are: "all", "management", "pulse"</p>
 <p>"all": shorthand for all the security components that support token authentication.</p>
-<p>"management": the management rest service.</p>
+<p>"management": the management REST service.</p>
 <p>"pulse": the Pulse web app</p>
 </td>
 <td>L</td>


### PR DESCRIPTION
Edit for style - clarify default (username/password) vs token-based auth. Uppercase REST.