### PR TITLE
Decouple geode in sadd,srem,smembers

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -306,7 +306,7 @@ public class GeodeRedisServer {
    * @return {@link RegionShortcut}
    */
   private static RegionShortcut setRegionType() {
-    String regionType = System.getProperty(DEFAULT_REGION_SYS_PROP_NAME, "PARTITION");
+    String regionType = System.getProperty(DEFAULT_REGION_SYS_PROP_NAME, "REPLICATE");
     RegionShortcut type;
     try {
       type = RegionShortcut.valueOf(regionType);

--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -306,7 +306,7 @@ public class GeodeRedisServer {
    * @return {@link RegionShortcut}
    */
   private static RegionShortcut setRegionType() {
-    String regionType = System.getProperty(DEFAULT_REGION_SYS_PROP_NAME, "REPLICATE");
+    String regionType = System.getProperty(DEFAULT_REGION_SYS_PROP_NAME, "PARTITION");
     RegionShortcut type;
     try {
       type = RegionShortcut.valueOf(regionType);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Command.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Command.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal;
 
 import java.nio.channels.SocketChannel;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import io.netty.buffer.ByteBuf;
 
@@ -65,6 +66,15 @@ public class Command {
    */
   public List<byte[]> getProcessedCommand() {
     return this.commandElems;
+  }
+
+  /**
+   * Used to get the command element list
+   *
+   * @return List of command elements in form of {@link List}
+   */
+  public List<ByteArrayWrapper> getProcessedCommandWrappers() {
+    return this.commandElems.stream().map(ByteArrayWrapper::new).collect(Collectors.toList());
   }
 
   /**

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
@@ -15,8 +15,8 @@
 
 package org.apache.geode.redis.internal.executor.hash;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,7 +39,7 @@ class GeodeRedisHashSynchronized implements RedisHash {
 
   @Override
   public int hset(List<ByteArrayWrapper> fieldsToSet,
-                  boolean NX) {
+      boolean NX) {
     AtomicInteger fieldsAdded = new AtomicInteger();
 
     Map<ByteArrayWrapper, ByteArrayWrapper> computedHash =
@@ -94,12 +94,7 @@ class GeodeRedisHashSynchronized implements RedisHash {
 
   @Override
   public Collection<Map.Entry<ByteArrayWrapper, ByteArrayWrapper>> hgetall() {
-    Collection<Map.Entry<ByteArrayWrapper, ByteArrayWrapper>> entries = new ArrayList<>();
-    region().computeIfPresent(key, (_unused_, oldHash) -> {
-      entries.addAll(oldHash.entrySet());
-      return oldHash;
-    });
-    return entries;
+    return region().getOrDefault(key, Collections.emptyMap()).entrySet();
   }
 
   private Region<ByteArrayWrapper, Map<ByteArrayWrapper, ByteArrayWrapper>> region() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.hash;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.RedisDataType;
+
+class GeodeRedisHashSynchronized implements RedisHash {
+  private final ByteArrayWrapper key;
+  private final ExecutionHandlerContext context;
+
+  public GeodeRedisHashSynchronized(ByteArrayWrapper key, ExecutionHandlerContext context) {
+    this.key = key;
+    this.context = context;
+  }
+
+  @Override
+  public int hset(List<ByteArrayWrapper> fieldsToSet,
+      boolean NX) {
+    AtomicInteger fieldsAdded = new AtomicInteger();
+
+    Map<ByteArrayWrapper, ByteArrayWrapper> computedHash =
+        region().compute(key, (_unused_, oldHash) -> {
+
+          fieldsAdded.set(0);
+          HashMap<ByteArrayWrapper, ByteArrayWrapper> newHash;
+          if (oldHash == null) {
+            newHash = new HashMap<>();
+          } else {
+            newHash = new HashMap<>(oldHash);
+          }
+
+          for (int i = 0; i < fieldsToSet.size(); i += 2) {
+            ByteArrayWrapper field = fieldsToSet.get(i);
+            ByteArrayWrapper value = fieldsToSet.get(i + 1);
+
+            Object abc;
+            if (NX) {
+              abc = newHash.putIfAbsent(field, value);
+            } else {
+              abc = newHash.put(field, value);
+            }
+
+            if (abc == null) {
+              fieldsAdded.getAndIncrement();
+            }
+          }
+
+          return newHash;
+        });
+
+    if (computedHash != null) {
+      context.getKeyRegistrar().register(this.key, RedisDataType.REDIS_HASH);
+    }
+
+    return fieldsAdded.get();
+  }
+
+  @Override
+  public int hdel(List<ByteArrayWrapper> subList) {
+    AtomicLong numDeleted = new AtomicLong();
+    region().computeIfPresent(key, (_unused_, oldHash) -> {
+      HashMap<ByteArrayWrapper, ByteArrayWrapper> newHash = new HashMap<>(oldHash);
+      for (ByteArrayWrapper fieldToRemove : subList) {
+        Object oldValue = newHash.remove(fieldToRemove);
+        if (oldValue != null) {
+          numDeleted.incrementAndGet();
+        }
+      }
+      return newHash;
+    });
+    return numDeleted.intValue();
+  }
+
+  @Override
+  public Collection<Map.Entry<ByteArrayWrapper, ByteArrayWrapper>> hgetall() {
+    Collection<Map.Entry<ByteArrayWrapper, ByteArrayWrapper>> entries = new ArrayList<>();
+    region().computeIfPresent(key, (_unused_, oldHash) -> {
+      entries.addAll(oldHash.entrySet());
+      return oldHash;
+    });
+    return entries;
+  }
+
+  private Region<ByteArrayWrapper, Map<ByteArrayWrapper, ByteArrayWrapper>> region() {
+    return context.getRegionProvider().getHashRegion();
+  }
+
+
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
@@ -14,10 +14,8 @@
  */
 package org.apache.geode.redis.internal.executor.hash;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
@@ -58,23 +56,8 @@ public class HGetAllExecutor extends HashExecutor {
     Collection<Entry<ByteArrayWrapper, ByteArrayWrapper>> entries;
     ByteArrayWrapper key = command.getKey();
 
-    Map<ByteArrayWrapper, ByteArrayWrapper> results = getMap(context, key);
-
-    if (results == null || results.isEmpty()) {
-      command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
-      return;
-    }
-
-    entries = results.entrySet();
-
-    if (entries == null || entries.isEmpty()) {
-      command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
-      return;
-    }
-
-    // create a copy
-    entries = new ArrayList<>(entries);
-
+    RedisHash hash = new GeodeRedisHashSynchronized(key, context);
+    entries = hash.hgetall();
     command.setResponse(Coder.getKeyValArrayResponse(context.getByteBufAllocator(), entries));
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.hash;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+
+public interface RedisHash {
+  int hset(List<ByteArrayWrapper> fieldsToSet,
+      boolean NX);
+
+  int hdel(List<ByteArrayWrapper> subList);
+
+  Collection<Map.Entry<ByteArrayWrapper, ByteArrayWrapper>> hgetall();
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
@@ -22,8 +22,7 @@ import java.util.Map;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 
 public interface RedisHash {
-  int hset(List<ByteArrayWrapper> fieldsToSet,
-      boolean NX);
+  int hset(List<ByteArrayWrapper> fieldsToSet, boolean NX);
 
   int hdel(List<ByteArrayWrapper> subList);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.set;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
@@ -65,14 +66,7 @@ class GeodeRedisSetSynchronized implements RedisSet {
 
   @Override
   public Set<ByteArrayWrapper> members() {
-    HashSet<ByteArrayWrapper> members = new HashSet<>();
-    region().computeIfPresent(key,
-        (_unusedKey_, oldValue) -> {
-          members.clear();
-          members.addAll(oldValue);
-          return oldValue;
-        });
-    return members;
+    return region().getOrDefault(key, Collections.emptySet());
   }
 
   Region<ByteArrayWrapper, Set<ByteArrayWrapper>> region() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.set;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
+
+class GeodeRedisSetSynchronized implements RedisSet {
+
+  private ByteArrayWrapper key;
+  private ExecutionHandlerContext context;
+
+  public GeodeRedisSetSynchronized(ByteArrayWrapper key, ExecutionHandlerContext context) {
+    this.key = key;
+    this.context = context;
+  }
+
+  @Override
+  public long sadd(Collection<ByteArrayWrapper> membersToAdd) {
+    AtomicLong addedCount = new AtomicLong();
+    region().compute(key, (_unused_, oldValue) -> {
+      if (oldValue == null) {
+        addedCount.set(membersToAdd.size());
+        Set<ByteArrayWrapper> objects = createSet(membersToAdd);
+        return objects;
+      }
+
+      Set<ByteArrayWrapper> newValue = createSet(oldValue);
+      newValue.addAll(membersToAdd);
+      addedCount.set(newValue.size() - oldValue.size());
+      return newValue;
+    });
+    return addedCount.longValue();
+  }
+
+  @Override
+  public long srem(Collection<ByteArrayWrapper> membersToRemove) {
+    AtomicLong removedCount = new AtomicLong();
+    region().computeIfPresent(key, (_unused_, oldValue) -> {
+      Set<ByteArrayWrapper> newValue = createSet(oldValue);
+      newValue.removeAll(membersToRemove);
+      removedCount.set(oldValue.size() - newValue.size());
+      return newValue;
+    });
+    return removedCount.longValue();
+  }
+
+  @Override
+  public Set<ByteArrayWrapper> members() {
+    HashSet<ByteArrayWrapper> members = new HashSet<>();
+    region().computeIfPresent(key,
+        (_unused_, oldValue) -> {
+          members.clear();
+          members.addAll(oldValue);
+          return oldValue;
+        });
+    return members;
+  }
+
+  Region<ByteArrayWrapper, Set<ByteArrayWrapper>> region() {
+    return context.getRegionProvider().getSetRegion();
+  }
+
+  private Set<ByteArrayWrapper> createSet(Collection<ByteArrayWrapper> membersToAdd) {
+    return new HashSet<>(membersToAdd);
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.set;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+
+interface RedisSet {
+  long sadd(Collection<ByteArrayWrapper> membersToAdd);
+
+  long srem(Collection<ByteArrayWrapper> membersToAdd);
+
+  Set<ByteArrayWrapper> members();
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SAddExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SAddExecutor.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.executor.set;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
@@ -15,11 +15,7 @@
 package org.apache.geode.redis.internal.executor.set;
 
 import java.util.List;
-import java.util.Set;
 
-import org.apache.geode.cache.Region;
-import org.apache.geode.cache.TimeoutException;
-import org.apache.geode.redis.internal.AutoCloseableLock;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
@@ -28,12 +24,9 @@ import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class SRemExecutor extends SetExecutor {
-
-  private static final int NONE_REMOVED = 0;
-
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
-    List<byte[]> commandElems = command.getProcessedCommand();
+    List<ByteArrayWrapper> commandElems = command.getProcessedCommandWrappers();
 
     if (commandElems.size() < 3) {
       command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SREM));
@@ -42,36 +35,8 @@ public class SRemExecutor extends SetExecutor {
 
     ByteArrayWrapper key = command.getKey();
     checkDataType(key, RedisDataType.REDIS_SET, context);
-
-    Region<ByteArrayWrapper, Set<ByteArrayWrapper>> region = getRegion(context);
-
-    int numRemoved = 0;
-    try (AutoCloseableLock regionLock = withRegionLock(context, key)) {
-      Set<ByteArrayWrapper> set = region.get(key);
-
-      if (set == null || set.isEmpty()) {
-        command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), NONE_REMOVED));
-        return;
-      }
-
-      for (int i = 2; i < commandElems.size(); i++) {
-        if (set.remove(new ByteArrayWrapper(commandElems.get(i)))) {
-          numRemoved++;
-        }
-      }
-
-      region.put(key, set);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      command.setResponse(
-          Coder.getErrorResponse(context.getByteBufAllocator(), "Thread interrupted."));
-      return;
-    } catch (TimeoutException e) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(),
-          "Timeout acquiring lock. Please try again."));
-      return;
-    }
-
+    RedisSet set = new GeodeRedisSetSynchronized(key, context);
+    long numRemoved = set.srem(commandElems.subList(2, commandElems.size()));
     command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), numRemoved));
   }
 }


### PR DESCRIPTION
This commit builds a GeodeRedisSetSynchronized class that brings
together "set" methods.  These three are necessary for Spring-Session so
they are the only ones included.


Hey team,

The commit brings together two ideas in this PR:

1.  It synchronizes all calls to the set (at least sadd,srem,smembers) via compute.
2. It decouples all geode related code from the Executors.  We have discussed this a couple times, but I wanted to show it, and see if you all are on board.