### PR TITLE
GEODE-7957: query results toData will write to correct output stream 

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.cache.query.dunit;
 
 import static org.apache.geode.test.dunit.VM.getVM;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.stream.IntStream;
 
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,7 +63,7 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
   public ClientCacheRule clientCacheRule = new ClientCacheRule();
 
   private VM server1, server2, client;
-  private String regionName = "region";
+  private static String regionName = "region";
 
   @Before
   public void setup() {
@@ -74,12 +75,8 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
   @Test
   public void cumulativeResultsToDataShouldWriteToTheCorrectStreamNotCauseCorruption() {
     int numPuts = 10;
-    int port = server1.invoke(() -> {
-      return createServerAndRegion();
-    });
-    server2.invoke(() -> {
-      createServerAndRegion();
-    });
+    int port = server1.invoke(this::createServerAndRegion);
+    server2.invoke((SerializableRunnableIF) this::createServerAndRegion);
 
     String hostname = server1.getHost().getHostName();
     client.invoke(() -> {
@@ -93,22 +90,18 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
       ArrayList results = (ArrayList) FunctionService.onRegion(region)
           .execute(new QueryWithoutTurningIntoListFunction(regionName,
               "select distinct r.id, r.name from /" + regionName + " r, /" + regionName
-                  + " t where t.id = r.id order by r.id"))
+                  + " t where t.id = r.id"))
           .getResult();
       SelectResults rs = (SelectResults) results.get(0);
-      assertEquals(numPuts, rs.size());
+      assertThat(rs).size().equals(numPuts);
     });
   }
 
   @Test
   public void nwayMergeResultsToDataShouldWriteToTheCorrectStreamAndNotCauseCorruption() {
     int numPuts = 10;
-    int port = server1.invoke(() -> {
-      return createServerAndRegion();
-    });
-    server2.invoke(() -> {
-      createServerAndRegion();
-    });
+    int port = server1.invoke(this::createServerAndRegion);
+    server2.invoke((SerializableRunnableIF) this::createServerAndRegion);
 
     String hostname = server1.getHost().getHostName();
     client.invoke(() -> {
@@ -125,7 +118,7 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
                   + " t where t.id = r.id order by r.id"))
           .getResult();
       SelectResults rs = (SelectResults) results.get(0);
-      assertEquals(numPuts, rs.size());
+      assertThat(rs).size().equals(numPuts);
     });
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.dunit;
+
+import static org.apache.geode.test.dunit.VM.getVM;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Properties;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.execute.FunctionAdapter;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.FunctionException;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.cache.query.FunctionDomainException;
+import org.apache.geode.cache.query.NameResolutionException;
+import org.apache.geode.cache.query.Query;
+import org.apache.geode.cache.query.QueryInvocationTargetException;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.cache.query.TypeMismatchException;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.ClientCacheRule;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+
+public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable {
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+  @Rule
+  public CacheRule cacheRule = new CacheRule();
+  @Rule
+  public ClientCacheRule clientCacheRule = new ClientCacheRule();
+
+  private VM server1, server2, client;
+  private String regionName = "region";
+
+  @Before
+  public void setup() {
+    server1 = getVM(0);
+    server2 = getVM(1);
+    client = getVM(2);
+  }
+
+  @Test
+  public void cumulativeResultsToDataShouldWriteToTheCorrectStreamNotCauseCorruption() {
+    int numPuts = 10;
+    int port = server1.invoke(() -> {
+      return createServerAndRegion();
+    });
+    server2.invoke(() -> {
+      createServerAndRegion();
+    });
+
+    String hostname = server1.getHost().getHostName();
+    client.invoke(() -> {
+      ClientCacheFactory ccf = new ClientCacheFactory();
+      ccf.addPoolServer(hostname, port);
+      clientCacheRule.createClientCache(ccf);
+      ClientCache clientCache = clientCacheRule.getClientCache();
+      Region region =
+          clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY).create(regionName);
+      IntStream.range(0, numPuts).forEach(id -> region.put("key-" + id, new TestObject(id)));
+      ArrayList results = (ArrayList) FunctionService.onRegion(region)
+          .execute(new QueryWithoutTurningIntoListFunction(regionName,
+              "select distinct r.id, r.name from /" + regionName + " r, /" + regionName
+                  + " t where t.id = r.id order by r.id"))
+          .getResult();
+      SelectResults rs = (SelectResults) results.get(0);
+    });
+  }
+
+  @Test
+  public void nwayMergeResultsToDataShouldWriteToTheCorrectStreamAndNotCauseCorruption() {
+    int numPuts = 10;
+    int port = server1.invoke(() -> {
+      return createServerAndRegion();
+    });
+    server2.invoke(() -> {
+      createServerAndRegion();
+    });
+
+    String hostname = server1.getHost().getHostName();
+    client.invoke(() -> {
+      ClientCacheFactory ccf = new ClientCacheFactory();
+      ccf.addPoolServer(hostname, port);
+      clientCacheRule.createClientCache(ccf);
+      ClientCache clientCache = clientCacheRule.getClientCache();
+      Region region =
+          clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY).create(regionName);
+      IntStream.range(0, numPuts).forEach(id -> region.put("key-" + id, new TestObject(id)));
+      ArrayList results = (ArrayList) FunctionService.onRegion(region)
+          .execute(new QueryWithoutTurningIntoListFunction(regionName,
+              "select distinct r.id, r.name from /" + regionName + " r, /" + regionName
+                  + " t where t.id = r.id order by r.id"))
+          .getResult();
+      SelectResults rs = (SelectResults) results.get(0);
+      System.out.println("JASON results:" + rs);
+    });
+  }
+
+  private int createServerAndRegion() throws IOException {
+    Properties props = new Properties();
+    props.setProperty(DistributionConfig.VALIDATE_SERIALIZABLE_OBJECTS_NAME, "true");
+    props.setProperty(DistributionConfig.SERIALIZABLE_OBJECT_FILTER_NAME, "*");
+    cacheRule.createCache(new CacheFactory(props).setPdxReadSerialized(true));
+    Cache cache = cacheRule.getCache();
+    CacheServer cs = cache.addCacheServer();
+    cs.setPort(0);
+    cs.start();
+    cache.createRegionFactory(RegionShortcut.PARTITION).create(regionName);
+    return cs.getPort();
+  }
+
+  public static class TestObject implements Serializable {
+    public int id;
+    public String name;
+
+    public TestObject(int id) {
+      this.id = id;
+      this.name = "Name:" + id;
+    }
+  }
+
+  public static class QueryWithoutTurningIntoListFunction extends FunctionAdapter {
+
+    private String regionName;
+    private String queryString;
+
+    @Override
+    public boolean hasResult() {
+      return true;
+    }
+
+    @Override
+    public boolean isHA() {
+      return false;
+    }
+
+    public QueryWithoutTurningIntoListFunction(String regionName, String queryString) {
+      super();
+      this.regionName = regionName;
+      this.queryString = queryString;
+    }
+
+    @Override
+    public void execute(FunctionContext context) {
+      QueryService queryService = CacheFactory.getAnyInstance().getQueryService();
+      Query query = queryService.newQuery(queryString);
+      SelectResults results = null;
+      try {
+        results = (SelectResults) query.execute(context);
+      } catch (FunctionDomainException | TypeMismatchException | NameResolutionException
+          | QueryInvocationTargetException e) {
+        throw new FunctionException("Exception while executing function", e);
+      }
+      context.getResultSender().lastResult(results);
+
+    }
+
+    @Override
+    public String getId() {
+      return this.getClass().getName();
+    }
+  }
+
+}

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
@@ -93,7 +93,7 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
                   + " t where t.id = r.id"))
           .getResult();
       SelectResults rs = (SelectResults) results.get(0);
-      assertThat(rs).size().equals(numPuts);
+      assertThat(rs).size().isEqualTo(numPuts);
     });
   }
 
@@ -118,7 +118,7 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
                   + " t where t.id = r.id order by r.id"))
           .getResult();
       SelectResults rs = (SelectResults) results.get(0);
-      assertThat(rs).size().equals(numPuts);
+      assertThat(rs).size().isEqualTo(numPuts);
     });
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache.query.dunit;
 
 import static org.apache.geode.test.dunit.VM.getVM;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -95,6 +96,7 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
                   + " t where t.id = r.id order by r.id"))
           .getResult();
       SelectResults rs = (SelectResults) results.get(0);
+      assertEquals(numPuts, rs.size());
     });
   }
 
@@ -123,7 +125,7 @@ public class MultiServerPartitionedRegionQueryDUnitTest implements Serializable 
                   + " t where t.id = r.id order by r.id"))
           .getResult();
       SelectResults rs = (SelectResults) results.get(0);
-      System.out.println("JASON results:" + rs);
+      assertEquals(numPuts, rs.size());
     });
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/MultiServerPartitionedRegionQueryDUnitTest.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.stream.IntStream;
 
-import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,6 +47,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.ClientCacheRule;

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -72,7 +72,7 @@ toData,33
 
 org/apache/geode/cache/query/internal/CumulativeNonDistinctResults,2
 fromData,144
-toData,145
+toData,146
 
 org/apache/geode/cache/query/internal/LinkedResultSet,2
 fromData,58
@@ -84,7 +84,7 @@ toData,84
 
 org/apache/geode/cache/query/internal/NWayMergeResults,2
 fromData,152
-toData,153
+toData,154
 
 org/apache/geode/cache/query/internal/NullToken,2
 fromData,1

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CumulativeNonDistinctResults.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CumulativeNonDistinctResults.java
@@ -177,8 +177,6 @@ public class CumulativeNonDistinctResults<E> implements SelectResults<E>, DataSe
       this.results = results;
       this.limit = limit;
       this.collectionsMetdata = collectionsMetadata;
-      System.out.println("JASON");
-
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CumulativeNonDistinctResults.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CumulativeNonDistinctResults.java
@@ -177,6 +177,7 @@ public class CumulativeNonDistinctResults<E> implements SelectResults<E>, DataSe
       this.results = results;
       this.limit = limit;
       this.collectionsMetdata = collectionsMetadata;
+      System.out.println("JASON");
 
     }
 
@@ -322,7 +323,7 @@ public class CumulativeNonDistinctResults<E> implements SelectResults<E>, DataSe
       E data = iter.next();
       if (isStruct) {
         Object[] fields = ((Struct) data).getFieldValues();
-        DataSerializer.writeObjectArray(fields, out);
+        DataSerializer.writeObjectArray(fields, hdos);
       } else {
         context.getSerializer().writeObject(data, hdos);
       }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/NWayMergeResults.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/NWayMergeResults.java
@@ -481,7 +481,7 @@ public class NWayMergeResults<E> implements SelectResults<E>, Ordered, DataSeria
       E data = iter.next();
       if (isStruct) {
         Object[] fields = ((Struct) data).getFieldValues();
-        DataSerializer.writeObjectArray(fields, out);
+        DataSerializer.writeObjectArray(fields, hdos);
       } else {
         context.getSerializer().writeObject(data, hdos);
       }


### PR DESCRIPTION

  * Previously, when a query is executed in a function, the toData on specific results
    set types would write directly to the wrong output stream, causing deserialization issues

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
