### PR TITLE
GEODE-7664: calling RegionConfigRealizer.exists methods doesn't need …

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizer.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizer.java
@@ -308,6 +308,22 @@ public class RegionConfigRealizer
     return info;
   }
 
+  /**
+   * the default implementation will have the extra work of getting the runtime info which is
+   * unnecessary. It will also have some concurrency issue if the region is being destroyed.
+   */
+  @Override
+  public boolean exists(Region config, InternalCache cache) {
+    org.apache.geode.cache.Region<Object, Object> region = cache.getRegion("/" + config.getName());
+    if (region == null) {
+      return false;
+    }
+
+    if (region.isDestroyed()) {
+      return false;
+    }
+    return true;
+  }
 
   @Override
   public RealizationResult update(Region config, InternalCache cache) {
@@ -325,7 +341,7 @@ public class RegionConfigRealizer
     try {
       region.destroyRegion();
     } catch (RegionDestroyedException dex) {
-      // Probably happened as a distirbuted op but it still reflects our current desired action
+      // Probably happened as a distributed op but it still reflects our current desired action
       // which is why it can be ignored here.
       return new RealizationResult().setMessage("Region does not exist.");
     }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -118,21 +117,27 @@ public class RegionConfigRealizerTest {
   }
 
   @Test
-  public void exists() {
+  public void regionDoesNotExistIfNotInCache() {
     config.setName("test");
     when(cache.getRegion("/test")).thenReturn(null);
     assertThat(realizer.exists(config, cache)).isFalse();
+  }
 
+
+  @Test
+  public void regionDoesNotExistIfDestroyed() {
+    when(cache.getRegion("/test")).thenReturn(region);
     when(region.isDestroyed()).thenReturn(true);
     assertThat(realizer.exists(config, cache)).isFalse();
   }
 
   @Test
-  public void existsDoesNotGetRuntimeInfo() {
+  public void regionExistsDoesNotGetRuntimeInfo() {
     config.setName("test");
     when(cache.getRegion("/test")).thenReturn(region);
+    when(region.isDestroyed()).thenReturn(false);
     boolean exists = realizer.exists(config, cache);
     assertThat(exists).isTrue();
-    verify(region, times(0)).size();
+    verify(region, never()).size();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -42,6 +43,7 @@ public class RegionConfigRealizerTest {
   RegionConfigRealizer realizer;
   RegionConfigValidator validator;
   Region config;
+  org.apache.geode.cache.Region region;
 
   @Before
   public void setup() {
@@ -52,6 +54,7 @@ public class RegionConfigRealizerTest {
     realizer = new RegionConfigRealizer();
     config = new Region();
     config.setName("test");
+    region = mock(org.apache.geode.cache.Region.class);
   }
 
   @Test
@@ -112,5 +115,24 @@ public class RegionConfigRealizerTest {
     verify(regionFactory, never()).setValueConstraint(any());
     verify(regionFactory, never()).setDiskStoreName(any());
     verify(regionFactory).setDataPolicy(DataPolicy.REPLICATE);
+  }
+
+  @Test
+  public void exists() {
+    config.setName("test");
+    when(cache.getRegion("/test")).thenReturn(null);
+    assertThat(realizer.exists(config, cache)).isFalse();
+
+    when(region.isDestroyed()).thenReturn(true);
+    assertThat(realizer.exists(config, cache)).isFalse();
+  }
+
+  @Test
+  public void existsDoesNotGetRuntimeInfo() {
+    config.setName("test");
+    when(cache.getRegion("/test")).thenReturn(region);
+    boolean exists = realizer.exists(config, cache);
+    assertThat(exists).isTrue();
+    verify(region, times(0)).size();
   }
 }


### PR DESCRIPTION
…to get the runtime info of the region to avoid concurrency issues.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
