### PR TITLE
GEODE-7969: bump netty version to latest

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -232,7 +232,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.45.Final</version>
+        <version>4.1.48.Final</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -116,7 +116,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'commons-validator', name: 'commons-validator', version: get('commons-validator.version'))
         api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.52')
         api(group: 'io.micrometer', name: 'micrometer-core', version: get('micrometer.version'))
-        api(group: 'io.netty', name: 'netty-all', version: '4.1.45.Final')
+        api(group: 'io.netty', name: 'netty-all', version: '4.1.48.Final')
         api(group: 'io.swagger', name: 'swagger-annotations', version: '1.5.23')
         api(group: 'it.unimi.dsi', name: 'fastutil', version: get('fastutil.version'))
         api(group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2')

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1047,7 +1047,7 @@ lib/micrometer-core-1.2.1.jar
 lib/mx4j-3.0.2.jar
 lib/mx4j-remote-3.0.2.jar
 lib/mx4j-tools-3.0.1.jar
-lib/netty-all-4.1.45.Final.jar
+lib/netty-all-4.1.48.Final.jar
 lib/protobuf-java-3.10.0.jar
 lib/ra.jar
 lib/rmiio-2.1.2.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -87,6 +87,6 @@ lucene-core-6.6.6.jar
 lucene-queries-6.6.6.jar
 protobuf-java-3.10.0.jar
 geo-0.7.1.jar
-netty-all-4.1.45.Final.jar
+netty-all-4.1.48.Final.jar
 grumpy-core-0.2.2.jar
 commons-math3-3.2.jar


### PR DESCRIPTION
go to netty 4.1.48 now ahead of #4867 which is not quite ready yet