### PR TITLE
GEODE-7852: Add bulk operation / large result tests for SNI gateway

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
@@ -54,8 +54,6 @@ public class ClientSNIAcceptanceTest {
   private final URL DOCKER_COMPOSE_PATH =
       ClientSNIAcceptanceTest.class.getResource("docker-compose.yml");
 
-  public final String TEST_KEY = "foo";
-
   // Docker compose does not work on windows in CI. Ignore this test on windows
   // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
@@ -134,8 +132,6 @@ public class ClientSNIAcceptanceTest {
     assertThat(region.get("hello")).isEqualTo("world");
     region.destroy("hello");
     assertThat(region.get("hello")).isNull();
-    // the geode-starter.gfsh script put an entry named "foo" into the region
-    assertThat(region.get(TEST_KEY)).isNotNull();
   }
 
   /**
@@ -192,7 +188,6 @@ public class ClientSNIAcceptanceTest {
     for (int i = 1; i < numberOfKeys; i++) {
       pairs.put("Object_" + i, "Value_" + i);
     }
-    pairs.put(TEST_KEY, "some value");
     return pairs;
   }
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
@@ -66,9 +66,9 @@ public class ClientSNIAcceptanceTest {
       .file(DOCKER_COMPOSE_PATH.getPath())
       .build();
 
-  private static ClientCache cache;
-  private static Region<String, String> region;
-  private static Map<String, String> bulkData;
+  private ClientCache cache;
+  private Region<String, String> region;
+  private Map<String, String> bulkData;
 
   @Before
   public void before() throws IOException, InterruptedException {

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
@@ -183,7 +183,7 @@ public class ClientSNIAcceptanceTest {
 
   protected Map<String, String> getBulkDataMap() {
     // create a putAll map with enough keys to force a lot of "chunking" of the results
-    int numberOfKeys = BaseCommand.MAXIMUM_CHUNK_SIZE * 10; // 10,000 keys
+    int numberOfKeys = BaseCommand.MAXIMUM_CHUNK_SIZE * 10; // 1,000 keys
     Map<String, String> pairs = new HashMap<>();
     for (int i = 1; i < numberOfKeys; i++) {
       pairs.put("Object_" + i, "Value_" + i);

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
@@ -27,12 +27,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import com.palantir.docker.compose.DockerComposeRule;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
@@ -41,65 +44,153 @@ import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.proxy.ProxySocketFactories;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.internal.cache.tier.sockets.BaseCommand;
 import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 public class ClientSNIAcceptanceTest {
 
   private static final URL DOCKER_COMPOSE_PATH =
-      ClientSNIAcceptanceTest.class.getResource("docker-compose.yml");
+      SingleServerSNIAcceptanceTest.class.getResource("docker-compose.yml");
+
+  public static final String TEST_KEY = "foo";
 
   // Docker compose does not work on windows in CI. Ignore this test on windows
   // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
   public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
 
-  @Rule
-  public DockerComposeRule docker = DockerComposeRule.builder()
+  @ClassRule
+  public static DockerComposeRule docker = DockerComposeRule.builder()
       .file(DOCKER_COMPOSE_PATH.getPath())
       .build();
 
+  private static Properties clientCacheProperties;
+  private static ClientCache cache;
+  private static Region<String, String> region;
+  private static Map<String, String> bulkData;
 
-  private String trustStorePath;
-
-  @Before
-  public void before() throws IOException, InterruptedException {
-    trustStorePath =
-        createTempFileFromResource(ClientSNIAcceptanceTest.class,
-            "geode-config/truststore.jks")
-                .getAbsolutePath();
+  @BeforeClass
+  public static void beforeClass() throws IOException, InterruptedException {
+    // start up server/locator processes and initialize the server cache
     docker.exec(options("-T"), "geode",
         arguments("gfsh", "run", "--file=/geode/scripts/geode-starter.gfsh"));
+
+    final String trustStorePath =
+        createTempFileFromResource(SingleServerSNIAcceptanceTest.class,
+            "geode-config/truststore.jks")
+                .getAbsolutePath();
+
+    // set up client cache properties so it can connect to the server
+    clientCacheProperties = new Properties();
+    clientCacheProperties.setProperty(SSL_ENABLED_COMPONENTS, "all");
+    clientCacheProperties.setProperty(SSL_KEYSTORE_TYPE, "jks");
+    clientCacheProperties.setProperty(SSL_REQUIRE_AUTHENTICATION, "false");
+
+    clientCacheProperties.setProperty(SSL_TRUSTSTORE, trustStorePath);
+    clientCacheProperties.setProperty(SSL_TRUSTSTORE_PASSWORD, "geode");
+    clientCacheProperties.setProperty(SSL_ENDPOINT_IDENTIFICATION_ENABLED, "true");
+    cache = getClientCache(clientCacheProperties);
+
+    // the gfsh startup script created a server-side region named "jellyfish"
+    region = cache.<String, String>createClientRegionFactory(ClientRegionShortcut.PROXY)
+        .create("jellyfish");
+    bulkData = getBulkDataMap();
+    region.putAll(bulkData);
   }
 
+  @AfterClass
+  public static void afterClass() throws Exception {
+    // preserve this commented code for debugging
+    // String logs = docker.exec(options("-T"), "geode",
+    // arguments("cat", "server-dolores/server-dolores.log"));
+    // System.out.println("server logs------------------------------------------");
+    // System.out.println(logs);
+
+    if (cache != null) {
+      cache.close();
+      cache = null;
+    }
+    bulkData = null;
+    region = null;
+  }
+
+  /**
+   * A basic connectivity test that does a
+   */
   @Test
   public void connectToSNIProxyDocker() {
-    Properties gemFireProps = new Properties();
-    gemFireProps.setProperty(SSL_ENABLED_COMPONENTS, "all");
-    gemFireProps.setProperty(SSL_KEYSTORE_TYPE, "jks");
-    gemFireProps.setProperty(SSL_REQUIRE_AUTHENTICATION, "false");
+    region.put("hello", "world");
+    assertThat(region.containsKey("hello")).isFalse(); // proxy regions don't store locally
+    assertThat(region.get("hello")).isEqualTo("world");
+    region.destroy("hello");
+    assertThat(region.get("hello")).isNull();
+    // the geode-starter.gfsh script put an entry named "foo" into the region
+    assertThat(region.get(TEST_KEY)).isNotNull();
+  }
 
-    gemFireProps.setProperty(SSL_TRUSTSTORE, trustStorePath);
-    gemFireProps.setProperty(SSL_TRUSTSTORE_PASSWORD, "geode");
-    gemFireProps.setProperty(SSL_ENDPOINT_IDENTIFICATION_ENABLED, "true");
+  /**
+   * A test of Region bulk put and query methods
+   */
+  @Test
+  public void query() throws Exception {
+    final SelectResults<String> results = region.query("SELECT * from /jellyfish");
+    assertThat(results).hasSize(bulkData.size());
+    for (String result : results) {
+      assertThat(bulkData.containsValue(result)).isTrue();
+    }
+  }
 
+  /**
+   * A test of Region bulk putAll/getAll methods
+   */
+  @Test
+  public void getAll() {
+    final Map<String, String> results = region.getAll(bulkData.keySet());
+    assertThat(results).hasSize(bulkData.size());
+    for (Map.Entry<String, String> entry : results.entrySet()) {
+      assertThat(region.containsKey(entry.getKey())).isFalse();
+      assertThat(bulkData.containsKey(entry.getKey())).isTrue();
+      assertThat(entry.getValue()).isEqualTo(bulkData.get(entry.getKey()));
+    }
+  }
+
+  /**
+   * A test of the Region API's methods that directly access the server cache
+   */
+  @Test
+  public void verifyServerAPIs() {
+    assertThat(region.sizeOnServer()).isEqualTo(bulkData.size());
+    Set<String> keysOnServer = region.keySetOnServer();
+    for (String entry : bulkData.keySet()) {
+      assertThat(region.containsKeyOnServer(entry)).isTrue();
+      assertThat(keysOnServer).contains(entry);
+    }
+  }
+
+
+  protected static Map<String, String> getBulkDataMap() {
+    // create a putAll map with enough keys to force a lot of "chunking" of the results
+    int numberOfKeys = BaseCommand.MAXIMUM_CHUNK_SIZE * 10; // 10,000 keys
+    Map<String, String> pairs = new HashMap<>();
+    for (int i = 1; i < numberOfKeys; i++) {
+      pairs.put("Object_" + i, "Value_" + i);
+    }
+    pairs.put(TEST_KEY, "some value");
+    return pairs;
+  }
+
+  protected static ClientCache getClientCache(Properties properties) {
     int proxyPort = docker.containers()
         .container("haproxy")
         .port(15443)
         .getExternalPort();
-    ClientCache cache = new ClientCacheFactory(gemFireProps)
-        .addPoolLocator("locator", 10334)
+    ClientCache result = new ClientCacheFactory(properties)
+        .addPoolLocator("locator-maeve", 10334)
         .setPoolSocketFactory(ProxySocketFactories.sni("localhost",
             proxyPort))
         .create();
-    // the geode-starter.gfsh script has created a Region named "jellyfish" on the
-    // server sitting behind the haproxy gateway. Show that an empty client cache can
-    // put something in that region and then retrieve it.
-    Region<String, String> region =
-        cache.<String, String>createClientRegionFactory(ClientRegionShortcut.PROXY)
-            .create("jellyfish");
-    region.destroy("hello");
-    region.put("hello", "world");
-    assertThat(region.get("hello")).isEqualTo("world");
-
+    return result;
   }
+
 }

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
@@ -122,10 +122,11 @@ public class ClientSNIAcceptanceTest {
     verifyServerAPIs();
     query();
     getAll();
+    removeAll();
   }
 
   /**
-   * A basic connectivity test that does a
+   * A basic connectivity test that performs a few simple operations
    */
   public void connectToSNIProxyDocker() {
     region.put("hello", "world");
@@ -138,7 +139,7 @@ public class ClientSNIAcceptanceTest {
   }
 
   /**
-   * A test of Region bulk put and query methods
+   * A test of Region query that returns a "big" result
    */
   public void query() throws Exception {
     final SelectResults<String> results = region.query("SELECT * from /jellyfish");
@@ -149,7 +150,7 @@ public class ClientSNIAcceptanceTest {
   }
 
   /**
-   * A test of Region bulk putAll/getAll methods
+   * A test of Region bulk getAll
    */
   public void getAll() {
     final Map<String, String> results = region.getAll(bulkData.keySet());
@@ -159,6 +160,16 @@ public class ClientSNIAcceptanceTest {
       assertThat(bulkData.containsKey(entry.getKey())).isTrue();
       assertThat(entry.getValue()).isEqualTo(bulkData.get(entry.getKey()));
     }
+  }
+
+  /**
+   * A test of Region bulk removeAll
+   */
+  public void removeAll() {
+    assertThat(region.sizeOnServer()).isEqualTo(bulkData.size());
+    region.removeAll(bulkData.keySet());
+    assertThat(region.sizeOnServer()).isZero();
+    region.putAll(bulkData);
   }
 
   /**

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
@@ -34,9 +34,7 @@ import java.util.Set;
 
 import com.palantir.docker.compose.DockerComposeRule;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,10 +51,10 @@ import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 public class ClientSNIAcceptanceTest {
 
-  private static final URL DOCKER_COMPOSE_PATH =
+  private final URL DOCKER_COMPOSE_PATH =
       ClientSNIAcceptanceTest.class.getResource("docker-compose.yml");
 
-  public static final String TEST_KEY = "foo";
+  public final String TEST_KEY = "foo";
 
   // Docker compose does not work on windows in CI. Ignore this test on windows
   // Using a RuleChain to make sure we ignore the test before the rule comes into play

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNIAcceptanceTest.java
@@ -51,7 +51,7 @@ import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 public class ClientSNIAcceptanceTest {
 
   private static final URL DOCKER_COMPOSE_PATH =
-      SingleServerSNIAcceptanceTest.class.getResource("docker-compose.yml");
+      ClientSNIAcceptanceTest.class.getResource("docker-compose.yml");
 
   public static final String TEST_KEY = "foo";
 
@@ -65,7 +65,6 @@ public class ClientSNIAcceptanceTest {
       .file(DOCKER_COMPOSE_PATH.getPath())
       .build();
 
-  private static Properties clientCacheProperties;
   private static ClientCache cache;
   private static Region<String, String> region;
   private static Map<String, String> bulkData;
@@ -77,12 +76,12 @@ public class ClientSNIAcceptanceTest {
         arguments("gfsh", "run", "--file=/geode/scripts/geode-starter.gfsh"));
 
     final String trustStorePath =
-        createTempFileFromResource(SingleServerSNIAcceptanceTest.class,
+        createTempFileFromResource(ClientSNIAcceptanceTest.class,
             "geode-config/truststore.jks")
                 .getAbsolutePath();
 
     // set up client cache properties so it can connect to the server
-    clientCacheProperties = new Properties();
+    Properties clientCacheProperties = new Properties();
     clientCacheProperties.setProperty(SSL_ENABLED_COMPONENTS, "all");
     clientCacheProperties.setProperty(SSL_KEYSTORE_TYPE, "jks");
     clientCacheProperties.setProperty(SSL_REQUIRE_AUTHENTICATION, "false");
@@ -100,7 +99,7 @@ public class ClientSNIAcceptanceTest {
   }
 
   @AfterClass
-  public static void afterClass() throws Exception {
+  public static void afterClass() {
     // preserve this commented code for debugging
     // String logs = docker.exec(options("-T"), "geode",
     // arguments("cat", "server-dolores/server-dolores.log"));
@@ -185,12 +184,11 @@ public class ClientSNIAcceptanceTest {
         .container("haproxy")
         .port(15443)
         .getExternalPort();
-    ClientCache result = new ClientCacheFactory(properties)
-        .addPoolLocator("locator-maeve", 10334)
+    return new ClientCacheFactory(properties)
+        .addPoolLocator("locator", 10334)
         .setPoolSocketFactory(ProxySocketFactories.sni("localhost",
             proxyPort))
         .create();
-    return result;
   }
 
 }

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/NotOnWindowsDockerRule.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/NotOnWindowsDockerRule.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.client.sni;
+
+import java.util.function.Supplier;
+
+import com.palantir.docker.compose.DockerComposeRule;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
+import org.junit.rules.ExternalResource;
+
+/**
+ * A rule that wraps {@link DockerComposeRule} in such a way that docker
+ * tests will be ignored on the windows platform.
+ *
+ * Provide the code to build a DockerComposeRule in the constructor to this rule,
+ * and access the rule later in your test with the {@link #get()} method.
+ */
+public class NotOnWindowsDockerRule extends ExternalResource {
+
+  private final Supplier<DockerComposeRule> dockerRuleSupplier;
+  private DockerComposeRule docker;
+
+  public NotOnWindowsDockerRule(Supplier<DockerComposeRule> dockerRuleSupplier) {
+    this.dockerRuleSupplier = dockerRuleSupplier;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+    this.docker = dockerRuleSupplier.get();
+    docker.before();
+  }
+
+  @Override
+  protected void after() {
+    if (docker != null) {
+      docker.after();
+    }
+  }
+
+  public DockerComposeRule get() {
+    return docker;
+  }
+}

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter.gfsh
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter.gfsh
@@ -15,8 +15,16 @@
 # limitations under the License.
 #
 
+<<<<<<< HEAD
 start locator --name=locator --hostname-for-clients=locator --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-keystore.jks
 start server --name=server --hostname-for-clients=server --locators=localhost[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-keystore.jks
+||||||| parent of e4820c0192... GEODE-7852: Add client side configuration option to support a SNI proxy
+start locator --name=locator-maeve --hostname-for-clients=locator-maeve --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-maeve-keystore.jks
+start server --name=server-dolores --hostname-for-clients=server-dolores --locators=localhost[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
+=======
+start locator --name=locator-maeve --hostname-for-clients=locator-maeve --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-maeve-keystore.jks
+start server --name=server-dolores --max-heap=256m --hostname-for-clients=server-dolores --locators=localhost[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
+>>>>>>> e4820c0192... GEODE-7852: Add client side configuration option to support a SNI proxy
 connect --locator=localhost[10334] --use-ssl=true --security-properties-file=/geode/config/gfsecurity.properties
 create region --name=jellyfish --type=REPLICATE
 

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter.gfsh
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter.gfsh
@@ -15,16 +15,8 @@
 # limitations under the License.
 #
 
-<<<<<<< HEAD
 start locator --name=locator --hostname-for-clients=locator --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-keystore.jks
-start server --name=server --hostname-for-clients=server --locators=localhost[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-keystore.jks
-||||||| parent of e4820c0192... GEODE-7852: Add client side configuration option to support a SNI proxy
-start locator --name=locator-maeve --hostname-for-clients=locator-maeve --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-maeve-keystore.jks
-start server --name=server-dolores --hostname-for-clients=server-dolores --locators=localhost[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
-=======
-start locator --name=locator-maeve --hostname-for-clients=locator-maeve --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-maeve-keystore.jks
-start server --name=server-dolores --max-heap=256m --hostname-for-clients=server-dolores --locators=localhost[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
->>>>>>> e4820c0192... GEODE-7852: Add client side configuration option to support a SNI proxy
+start server --name=server --max-heap=256m --hostname-for-clients=server --locators=localhost[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-keystore.jks
 connect --locator=localhost[10334] --use-ssl=true --security-properties-file=/geode/config/gfsecurity.properties
 create region --name=jellyfish --type=REPLICATE
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/proxy/SniSocketFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/proxy/SniSocketFactory.java
@@ -44,7 +44,6 @@ public class SniSocketFactory implements SocketFactory, Declarable {
 
   @Override // Declarable
   public void initialize(Cache cache, Properties properties) {
-    System.out.println("BRUCE: sni properties are " + properties);
     this.hostname = properties.getProperty("hostname");
     String portString =
         properties.getProperty("port", "" + DistributionLocator.DEFAULT_LOCATOR_PORT);
@@ -53,7 +52,6 @@ public class SniSocketFactory implements SocketFactory, Declarable {
 
   @Override
   public Socket createSocket() throws IOException {
-    System.out.println("BRUCE: creating a socket with " + hostname + ":" + port);
     return new SniProxySocket(new InetSocketAddress(hostname, port));
   }
 

--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/HostAndPort.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/HostAndPort.java
@@ -105,7 +105,7 @@ public class HostAndPort implements DataSerializableFixedID {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + " [socketInetAddress=" + socketInetAddress + "]";
+    return getClass().getSimpleName() + "[" + socketInetAddress + "]";
   }
 
   public InetAddress getAddress() {

--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
@@ -94,12 +94,6 @@ public class HostAndPortTest {
   }
 
   @Test
-  public void toString_LocatorAddress() {
-    HostAndPort locator1 = new HostAndPort("fakelocalhost", 8091);
-    assertThat(locator1.toString()).contains("socketInetAddress");
-  }
-
-  @Test
   public void constructorWithNoHostName() {
     HostAndPort hostAndPort = new HostAndPort(null, 8091);
     assertThat(hostAndPort.getAddress()).isNotNull();


### PR DESCRIPTION
Adding tests for query, putAll, getAll.  Ensuring that a client can
receive responses that are streamed through "chunking" from the server.

The test now creates the server cluster and client cache in a class rule
for faster execution.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
