### PR TITLE
Adding a new rule that ignores docker tests on windows

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/NotOnWindowsDockerRule.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/NotOnWindowsDockerRule.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.client.sni;
 
 import java.util.function.Supplier;
@@ -7,6 +21,13 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assume;
 import org.junit.rules.ExternalResource;
 
+/**
+ * A rule that wraps {@link DockerComposeRule} in such a way that docker
+ * tests will be ignored on the windows platform.
+ *
+ * Provide the code to build a DockerComposeRule in the constructor to this rule,
+ * and access the rule later in your test with the {@link #get()} method.
+ */
 public class NotOnWindowsDockerRule extends ExternalResource {
 
   private final Supplier<DockerComposeRule> dockerRuleSupplier;

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/NotOnWindowsDockerRule.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/NotOnWindowsDockerRule.java
@@ -1,0 +1,36 @@
+package org.apache.geode.client.sni;
+
+import java.util.function.Supplier;
+
+import com.palantir.docker.compose.DockerComposeRule;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
+import org.junit.rules.ExternalResource;
+
+public class NotOnWindowsDockerRule extends ExternalResource {
+
+  private final Supplier<DockerComposeRule> dockerRuleSupplier;
+  private DockerComposeRule docker;
+
+  public NotOnWindowsDockerRule(Supplier<DockerComposeRule> dockerRuleSupplier) {
+    this.dockerRuleSupplier = dockerRuleSupplier;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+    this.docker = dockerRuleSupplier.get();
+    docker.before();
+  }
+
+  @Override
+  protected void after() {
+    if (docker != null) {
+      docker.after();
+    }
+  }
+
+  public DockerComposeRule get() {
+    return docker;
+  }
+}


### PR DESCRIPTION
In order to be able to use DockerComposeRule from within a class rule, wrapping
it in a new rule that ignores the tests on windows before the docker compose
rule is loaded.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
