### PR TITLE
GEODE-7981: Change the redis default region type to PARTITION_REDUNDANT

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -301,12 +301,13 @@ public class GeodeRedisServer {
 
   /**
    * Determine the {@link RegionShortcut} type from a String value. If the String value doesn't map
-   * to a RegionShortcut type then {@link RegionShortcut#PARTITION} will be used by default.
+   * to a RegionShortcut type then {@link RegionShortcut#PARTITION_REDUNDANT} will be used by
+   * default.
    *
    * @return {@link RegionShortcut}
    */
   private static RegionShortcut setRegionType() {
-    String regionType = System.getProperty(DEFAULT_REGION_SYS_PROP_NAME, "PARTITION");
+    String regionType = System.getProperty(DEFAULT_REGION_SYS_PROP_NAME, "PARTITION_REDUNDANT");
     RegionShortcut type;
     try {
       type = RegionShortcut.valueOf(regionType);


### PR DESCRIPTION
Change the redis API to have redundant regions by default.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
