### PR TITLE
GEODE-7870: Fix PubSubIntegrationTest flakiness

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
@@ -257,7 +257,7 @@ public class PubSubIntegrationTest {
     assertThat(result).isEqualTo(1);
 
     assertThat(mockSubscriber.getReceivedMessages()).isEmpty();
-    GeodeAwaitility.await().until(() -> mockSubscriber.getReceivedPMessages().size() != 0);
+    GeodeAwaitility.await().until(() -> mockSubscriber.getReceivedPMessages().isEmpty());
     assertThat(mockSubscriber.getReceivedPMessages()).containsExactly(message);
 
     mockSubscriber.punsubscribe("sal*s");

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
@@ -41,7 +41,6 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})
-@Ignore("GEODE-7870")
 public class PubSubIntegrationTest {
   static Jedis publisher;
   static Jedis subscriber;
@@ -53,7 +52,7 @@ public class PubSubIntegrationTest {
   @BeforeClass
   public static void setUp() {
     CacheFactory cf = new CacheFactory();
-    cf.set(LOG_LEVEL, "warn");
+    cf.set(LOG_LEVEL, "info");
     cf.set(MCAST_PORT, "0");
     cf.set(LOCATORS, "");
     cache = cf.create();
@@ -253,11 +252,14 @@ public class PubSubIntegrationTest {
 
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
 
-    Long result = publisher.publish("salutations", "hello");
+    String message = "hello-" + System.currentTimeMillis();
+
+    Long result = publisher.publish("salutations", message);
     assertThat(result).isEqualTo(1);
 
     assertThat(mockSubscriber.getReceivedMessages()).isEmpty();
-    assertThat(mockSubscriber.getReceivedPMessages()).containsExactly("hello");
+    GeodeAwaitility.await().until(() -> mockSubscriber.getReceivedPMessages().size() != 0);
+    assertThat(mockSubscriber.getReceivedPMessages()).containsExactly(message);
 
     mockSubscriber.punsubscribe("sal*s");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Callable;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import redis.clients.jedis.Jedis;

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
@@ -257,7 +257,7 @@ public class PubSubIntegrationTest {
     assertThat(result).isEqualTo(1);
 
     assertThat(mockSubscriber.getReceivedMessages()).isEmpty();
-    GeodeAwaitility.await().until(() -> mockSubscriber.getReceivedPMessages().isEmpty());
+    GeodeAwaitility.await().until(() -> !mockSubscriber.getReceivedPMessages().isEmpty());
     assertThat(mockSubscriber.getReceivedPMessages()).containsExactly(message);
 
     mockSubscriber.punsubscribe("sal*s");

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -17,20 +17,21 @@
 package org.apache.geode.redis.mocks;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import redis.clients.jedis.JedisPubSub;
 
 public class MockSubscriber extends JedisPubSub {
-  private List<String> receivedMessages = new ArrayList<>();
-  private List<String> receivedPMessages = new ArrayList<>();
+  private final List<String> receivedMessages = Collections.synchronizedList(new ArrayList<>());
+  private final List<String> receivedPMessages = Collections.synchronizedList(new ArrayList<>());
 
   public List<String> getReceivedMessages() {
-    return receivedMessages;
+    return new ArrayList<>(receivedMessages);
   }
 
   public List<String> getReceivedPMessages() {
-    return receivedPMessages;
+    return new ArrayList<>(receivedPMessages);
   }
 
   @Override


### PR DESCRIPTION
The complete fix also builds on the following prior fixes

- GEODE-7943 add synchronization to Subscriptions class
- GEODE-7946: Fix redis publish/subscribe leaking netty buffers

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
