### PR TITLE
GEODE-7982: Close the client first in rolling upgrade test

### DIFF
--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
@@ -123,8 +123,8 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
       // Execute a query on the client and verify the results
       client.invoke(() -> verifyLuceneQueryResults(regionName, numObjects));
     } finally {
-      invokeRunnableInVMs(true, invokeStopLocator(), locator);
       invokeRunnableInVMs(true, invokeCloseCache(), client, server2);
+      invokeRunnableInVMs(true, invokeStopLocator(), locator);
     }
   }
 }


### PR DESCRIPTION
To prevent suspect strings from a background thread in the client, close the
client before the locator in this test.