### PR TITLE
GEODE-7852: test ClientHealthMonitor functionality behind a SNI gateway

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNICQAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNICQAcceptanceTest.java
@@ -184,7 +184,6 @@ public class ClientSNICQAcceptanceTest {
           arguments("java", "-cp", "/geode/lib/geode-dependencies.jar",
               "org.apache.geode.internal.statistics.StatArchiveReader",
               "stat", "server-dolores/statArchive.gfs", "CqServiceStats.numCqsClosed"));
-      System.out.println("stats from server are :" + stats);
       // the stat should transition from zero to one at some point
       assertThat(stats).contains("0.0 1.0");
     });

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/geode-config/gemfire.properties
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/geode-config/gemfire.properties
@@ -15,4 +15,5 @@
 # limitations under the License.
 #
 
-#empty
+statistic-sampling-enabled=true
+statistic-archive-file=statArchive.gfs


### PR DESCRIPTION
This ensures that a server sitting behind an SNI gateway detects the
loss of a client and cleans up after it.  In this case the test detects
that the server has closed CQs created by the non-durable client.

Since test code is not accessible in the Docker container that's running
the server I've enhanced the StatArchiveReader to be able to report the
values of a statistic and have enabled statistics recording in the
server.  Much of this code came from the deprecated SystemAdmin class.

(cherry picked from commit 376df4cc7abc6db38b4b298f8af6f3c53baedf15)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
