### PR TITLE
GEODE-7986: RedisLockServiceJUnitTest fails intermittently in CI on WindowsUnitTestOpenJDK8

### DIFF
--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/RedisLockServiceJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/RedisLockServiceJUnitTest.java
@@ -120,8 +120,8 @@ public class RedisLockServiceJUnitTest {
 
     latch.countDown();
 
-    assertThat(lockService1.lock(key)).isNotNull();
     t1.join();
+    assertThat(lockService1.lock(key)).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
Ensure thread that originally obtained the lock has released the lock and died prior to attempting to lock again.