### PR TITLE
GEODE-7851: Pulse logout requests end of OAuth session

### DIFF
--- a/geode-docs/tools_modules/pulse/pulse-auth.html.md.erb
+++ b/geode-docs/tools_modules/pulse/pulse-auth.html.md.erb
@@ -156,7 +156,7 @@ After you set up the authentication provider properly, create a properties file 
 
 - **pulse.oauth.endSessionEndpoint**
 
-    The URI for your OAuth provider's endpoint to request that the End-User be logged out. See the `end_session_endpoint` parameter of the OpenID Provider Discovery Metadata standard proposal.
+    The URI for your OAuth provider's endpoint to request that the end user be logged out. See the `end_session_endpoint` parameter of the OpenID Provider Discovery Metadata standard proposal.
 
 - **pulse.oauth.userNameAttributeName**
 

--- a/geode-docs/tools_modules/pulse/pulse-auth.html.md.erb
+++ b/geode-docs/tools_modules/pulse/pulse-auth.html.md.erb
@@ -154,6 +154,10 @@ After you set up the authentication provider properly, create a properties file 
 
     The URI for your OAuth provider's JSON Web Key (JWK) Set endpoint.
 
+- **pulse.oauth.endSessionEndpoint**
+
+    The URI for your OAuth provider's endpoint to request that the End-User be logged out. See the `end_session_endpoint` parameter of the OpenID Provider Discovery Metadata standard proposal.
+
 - **pulse.oauth.userNameAttributeName**
 
     The attribute name used to access the user's name from your OAuth provider's user info response.
@@ -169,6 +173,7 @@ pulse.oauth.authorizationUri=http://example.com/uaa/oauth/authorize
 pulse.oauth.tokenUri=http://example.com/uaa/oauth/token
 pulse.oauth.userInfoUri=http://example.com/uaa/userinfo
 pulse.oauth.jwkSetUri=http://example.com/uaa/token_keys
+pulse.oauth.endSessionEndpoint=http://example.com/uaa/profile
 pulse.oauth.userNameAttributeName=user_name
 ```
 

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Repository.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/data/Repository.java
@@ -59,19 +59,18 @@ public class Repository {
   Locale locale =
       new Locale(PulseConstants.APPLICATION_LANGUAGE, PulseConstants.APPLICATION_COUNTRY);
 
-  private ResourceBundle resourceBundle =
+  private final ResourceBundle resourceBundle =
       ResourceBundle.getBundle(PulseConstants.LOG_MESSAGES_FILE, locale);
 
-  private PulseConfig pulseConfig = new PulseConfig();
+  private final PulseConfig pulseConfig = new PulseConfig();
 
+  @Autowired(required = false)
   public Repository() {
     this(null);
   }
 
-  // The authorizedClientService is required only when using OAuth2 security.
-  @Autowired
-  public Repository(
-      @Autowired(required = false) OAuth2AuthorizedClientService authorizedClientService) {
+  @Autowired(required = false)
+  public Repository(OAuth2AuthorizedClientService authorizedClientService) {
     this(authorizedClientService, Cluster::new);
   }
 

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/CustomSecurityConfig.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/CustomSecurityConfig.java
@@ -24,16 +24,26 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
-
+/**
+ * Configures Pulse to use the authentication manager defined by the
+ * {@code pulse-authentication-custom.xml} file, which <em>must</em> define an authentication
+ * manager. This configuration is applied when the {@code pulse.authentication.custom} profile is
+ * active.
+ */
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @Profile("pulse.authentication.custom")
 @ImportResource("classpath:pulse-authentication-custom.xml")
 public class CustomSecurityConfig extends DefaultSecurityConfig {
-  // the pulse-authentication-custom.xml should configure an <authentication-manager>
+  private final AuthenticationManager authenticationManager;
+
   @Autowired
-  private AuthenticationManager authenticationManager;
+  CustomSecurityConfig(AuthenticationManager authenticationManager,
+      RepositoryLogoutHandler repositoryLogoutHandler) {
+    super(repositoryLogoutHandler);
+    this.authenticationManager = authenticationManager;
+  }
 
   @Override
   protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/GemFireAuthentication.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/GemFireAuthentication.java
@@ -48,12 +48,9 @@ import org.apache.geode.tools.pulse.internal.data.PulseConstants;
  */
 public class GemFireAuthentication extends UsernamePasswordAuthenticationToken {
 
-  private JMXConnector jmxc = null;
-
   public GemFireAuthentication(Object principal, Object credentials,
-      Collection<GrantedAuthority> list, JMXConnector jmxc) {
+      Collection<GrantedAuthority> list) {
     super(principal, credentials, list);
-    this.jmxc = jmxc;
   }
 
   private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/GemFireAuthenticationProvider.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/GemFireAuthenticationProvider.java
@@ -20,12 +20,15 @@ import javax.management.remote.JMXConnector;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
 
 import org.apache.geode.tools.pulse.internal.data.Repository;
 
@@ -36,11 +39,13 @@ import org.apache.geode.tools.pulse.internal.data.Repository;
  *
  * @since GemFire version 9.0
  */
+@Component
+@Profile("pulse.authentication.gemfire")
 public class GemFireAuthenticationProvider implements AuthenticationProvider {
-
   private static final Logger logger = LogManager.getLogger();
   private final Repository repository;
 
+  @Autowired
   public GemFireAuthenticationProvider(Repository repository) {
     this.repository = repository;
   }
@@ -49,8 +54,9 @@ public class GemFireAuthenticationProvider implements AuthenticationProvider {
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {
     if (authentication instanceof GemFireAuthentication) {
       GemFireAuthentication gemAuth = (GemFireAuthentication) authentication;
-      if (gemAuth.isAuthenticated())
+      if (gemAuth.isAuthenticated()) {
         return gemAuth;
+      }
     }
 
     String name = authentication.getName();
@@ -65,7 +71,7 @@ public class GemFireAuthenticationProvider implements AuthenticationProvider {
 
     Collection<GrantedAuthority> list = GemFireAuthentication.populateAuthorities(jmxc);
     GemFireAuthentication auth = new GemFireAuthentication(authentication.getPrincipal(),
-        authentication.getCredentials(), list, jmxc);
+        authentication.getCredentials(), list);
     logger.debug("For user " + name + " authList=" + list);
     return auth;
   }

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/GemfireSecurityConfig.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/GemfireSecurityConfig.java
@@ -18,28 +18,27 @@ package org.apache.geode.tools.pulse.internal.security;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-
-import org.apache.geode.tools.pulse.internal.data.Repository;
 
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 @Profile("pulse.authentication.gemfire")
 public class GemfireSecurityConfig extends DefaultSecurityConfig {
-
-  private final Repository repository;
+  private final AuthenticationProvider authenticationProvider;
 
   @Autowired
-  public GemfireSecurityConfig(Repository repository) {
-    this.repository = repository;
+  public GemfireSecurityConfig(GemFireAuthenticationProvider gemFireAuthenticationProvider,
+      RepositoryLogoutHandler repositoryLogoutHandler) {
+    super(repositoryLogoutHandler);
+    authenticationProvider = gemFireAuthenticationProvider;
   }
 
   @Override
   protected void configure(AuthenticationManagerBuilder authenticationManagerBuilder) {
-    authenticationManagerBuilder
-        .authenticationProvider(new GemFireAuthenticationProvider(repository));
+    authenticationManagerBuilder.authenticationProvider(authenticationProvider);
   }
 }

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/OAuthClientConfig.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/OAuthClientConfig.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.tools.pulse.internal.security;
+
+import static java.util.Collections.singletonMap;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.oauth2.client.InMemoryOAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+/**
+ * Configures Pulse to use the OAuth 2 provider defined by properties in {@code pulse.properties}.
+ */
+@Configuration
+@Profile("pulse.authentication.oauth")
+@PropertySource("classpath:pulse.properties")
+public class OAuthClientConfig {
+  @Value("${pulse.oauth.providerId}")
+  private String providerId;
+  @Value("${pulse.oauth.providerName}")
+  private String providerName;
+  @Value("${pulse.oauth.clientId}")
+  private String clientId;
+  @Value("${pulse.oauth.clientSecret}")
+  private String clientSecret;
+  @Value("${pulse.oauth.authorizationUri}")
+  private String authorizationUri;
+  @Value("${pulse.oauth.tokenUri}")
+  private String tokenUri;
+  @Value("${pulse.oauth.userInfoUri}")
+  private String userInfoUri;
+  @Value("${pulse.oauth.jwkSetUri}")
+  private String jwkSetUri;
+  @Value("${pulse.oauth.endSessionEndpoint}")
+  private String endSessionEndpoint;
+  @Value("${pulse.oauth.userNameAttributeName}")
+  private String userNameAttributeName;
+
+  @Bean
+  ClientRegistration clientRegistration() {
+    return ClientRegistration.withRegistrationId(providerId)
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUriTemplate("{baseUrl}/login/oauth2/code/{registrationId}")
+        .clientId(clientId)
+        .clientSecret(clientSecret)
+        .scope("openid", "CLUSTER:READ", "CLUSTER:WRITE", "DATA:READ", "DATA:WRITE")
+        .authorizationUri(authorizationUri)
+        .tokenUri(tokenUri)
+        .userInfoUri(userInfoUri)
+        .jwkSetUri(jwkSetUri)
+        .providerConfigurationMetadata(
+            singletonMap("end_session_endpoint", endSessionEndpoint))
+        // When Spring shows the login page, it displays a link to the OAuth provider's
+        // authorization URI. Spring uses the value passed to clientName() as the text for that
+        // link. We pass the providerName property here, to let the user know which OAuth provider
+        // they will be redirected to.
+        .clientName(providerName)
+        .userNameAttributeName(userNameAttributeName)
+        .build();
+  }
+
+  @Bean
+  public ClientRegistrationRepository clientRegistrationRepository(
+      ClientRegistration clientRegistration) {
+    return new InMemoryClientRegistrationRepository(clientRegistration);
+  }
+
+  @Bean
+  public OAuth2AuthorizedClientService authorizedClientService(
+      ClientRegistrationRepository clientRegistrationRepository) {
+    return new InMemoryOAuth2AuthorizedClientService(clientRegistrationRepository);
+  }
+
+  @Bean
+  public OAuth2AuthorizedClientRepository authorizedClientRepository(
+      OAuth2AuthorizedClientService authorizedClientService) {
+    return new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(authorizedClientService);
+  }
+
+  @Bean
+  public OidcClientInitiatedLogoutSuccessHandler oidcLogoutHandler(
+      ClientRegistrationRepository clientRegistrationRepository) {
+    return new OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository);
+  }
+}

--- a/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/RepositoryLogoutHandler.java
+++ b/geode-pulse/src/main/java/org/apache/geode/tools/pulse/internal/security/RepositoryLogoutHandler.java
@@ -14,49 +14,35 @@
  */
 package org.apache.geode.tools.pulse.internal.security;
 
-import java.io.IOException;
-
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.BeansException;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ApplicationContextAware;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
 
 import org.apache.geode.tools.pulse.internal.data.Repository;
 
 /**
- * Handler is used to close jmx connection maintained at user-level
+ * Closes the user's JMX connection and releases the user's resources in the Repository.
  */
-public class LogoutHandler extends SimpleUrlLogoutSuccessHandler implements
-    ApplicationContextAware {
+@Component
+public class RepositoryLogoutHandler implements LogoutHandler {
   private static final Logger logger = LogManager.getLogger();
-  private ApplicationContext applicationContext;
+  private final Repository repository;
 
-  public LogoutHandler(String logoutTargetURL) {
-    setDefaultTargetUrl(logoutTargetURL);
+  RepositoryLogoutHandler(Repository repository) {
+    this.repository = repository;
   }
 
   @Override
-  public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
-      Authentication authentication) throws IOException, ServletException {
-
+  public void logout(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) {
     if (authentication != null) {
-      Repository repository = applicationContext.getBean("repository", Repository.class);
       repository.logoutUser(authentication.getName());
-      logger.info("#LogoutHandler: GemFireAuthentication JMX Connection Closed.");
+      logger.info("#RepositoryLogoutHandler: GemFireAuthentication JMX Connection Closed.");
     }
-
-    super.onLogoutSuccess(request, response, authentication);
-  }
-
-  @Override
-  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-    this.applicationContext = applicationContext;
   }
 }

--- a/geode-pulse/src/main/resources/pulse.properties
+++ b/geode-pulse/src/main/resources/pulse.properties
@@ -59,6 +59,6 @@ pulse.port=10334
 # provider's user info response
 #pulse.oauth.userNameAttributeName=user_name
 
-# The URI for your OAuth provider's endpoint to request that the End-User be logged out.
+# The URI for your OAuth provider's endpoint to request that the end user be logged out.
 # See the end_session_endpoint parameter of the OpenID Provider Discovery Metadata standard proposal.
 #pulse.oauth.endSessionEndpoint=http://example.com/uaa/profile

--- a/geode-pulse/src/main/resources/pulse.properties
+++ b/geode-pulse/src/main/resources/pulse.properties
@@ -58,3 +58,7 @@ pulse.port=10334
 # The attribute name used to access the user's name from your OAuth
 # provider's user info response
 #pulse.oauth.userNameAttributeName=user_name
+
+# The URI for your OAuth provider's endpoint to request that the End-User be logged out.
+# See the end_session_endpoint parameter of the OpenID Provider Discovery Metadata standard proposal.
+#pulse.oauth.endSessionEndpoint=http://example.com/uaa/profile

--- a/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/security/RepositoryLogoutHandlerTest.java
+++ b/geode-pulse/src/test/java/org/apache/geode/tools/pulse/internal/security/RepositoryLogoutHandlerTest.java
@@ -19,9 +19,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +26,6 @@ import org.junit.experimental.categories.Category;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.springframework.context.ApplicationContext;
 import org.springframework.security.core.Authentication;
 
 import org.apache.geode.test.junit.categories.LoggingTest;
@@ -38,57 +34,29 @@ import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.tools.pulse.internal.data.Repository;
 
 @Category({PulseTest.class, SecurityTest.class, LoggingTest.class})
-public class LogoutHandlerTest {
-  private static final String EXPECTED_REDIRECT_URL = "/defaultTargetUrl";
-
+public class RepositoryLogoutHandlerTest {
   @Rule
   public MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Mock
-  private HttpServletRequest request;
-  @Mock
-  private HttpServletResponse response;
-  @Mock
   private Repository repository;
-  @Mock
-  private ApplicationContext applicationContext;
 
-  private final LogoutHandler handler = new LogoutHandler(EXPECTED_REDIRECT_URL);
+  private RepositoryLogoutHandler handler;
 
   @Before
   public void setup() {
-    when(request.getContextPath()).thenReturn("");
-    when(response.encodeRedirectURL(EXPECTED_REDIRECT_URL)).thenReturn(EXPECTED_REDIRECT_URL);
-    handler.setApplicationContext(applicationContext);
+    handler = new RepositoryLogoutHandler(repository);
   }
 
   @Test
-  public void onLogoutSuccess_logsOutAuthenticatedUser() throws Exception {
+  public void logsOutAuthenticatedUser() {
     String authenticatedUser = "authenticated-user";
 
     Authentication authentication = mock(Authentication.class);
     when(authentication.getName()).thenReturn(authenticatedUser);
-    when(applicationContext.getBean("repository", Repository.class)).thenReturn(repository);
 
-    handler.onLogoutSuccess(request, response, authentication);
+    handler.logout(null, null, authentication);
 
     verify(repository, times(1)).logoutUser(authenticatedUser);
   }
-
-  @Test
-  public void onLogoutSuccess_redirectsToSpecifiedUrl() throws Exception {
-    when(applicationContext.getBean("repository", Repository.class)).thenReturn(repository);
-    handler.onLogoutSuccess(request, response, mock(Authentication.class));
-
-    verify(response).sendRedirect(EXPECTED_REDIRECT_URL);
-  }
-
-  @Test
-  public void onLogoutSuccess_redirectsToSpecifiedUrl_evenIfNoAuthenticationGiven()
-      throws Exception {
-    handler.onLogoutSuccess(request, response, null);
-
-    verify(response).sendRedirect(EXPECTED_REDIRECT_URL);
-  }
-
 }


### PR DESCRIPTION
When Pulse is configured to use OAuth, and a user logs out of Pulse,
Pulse redirects the browser to a page where the user can take action to
end their session. The available actions depend on the OAuth provider,
but may include revoking the token or logging out of the OAuth provider
entirely.

Main changes:

- Changed OAuthSecurityConfig to install two logout handlers: A
  RepositoryLogoutHandler (renamed from LogoutHandler) and an
  OidcClientInitiatedLogoutSuccessHandler.

- Added a pulse.security.oauth.endSessionEndpoint property to specify
  the URL to which the OidcClientInitiatedLogoutSuccessHandler should
  redirect the browser on logout.

- Configured the OAuthSecurityConfig to add the "end session endpoint"
  property value to the client configuration metadata.  On logout, the
  OidcClientInitiatedLogoutSuccessHandler redirects the browser to this
  endpoint, where the user can take action to end the session.

- In the OAuthClientConfig class (extracted from OAuthSecurityConfig),
  restored the code to explicitly list the scopes that Pulse is
  requesting, in particular to list "openid" in the scopes. Though
  authentication works just fine without that explicit list, the
  OidcClientInitiatedLogoutSuccessHandler does not. The
  OidcClientInitiatedLogoutSuccessHandler handles logout only if the the
  principal is an OidcUser. If "openid" is not explicitly listed in the
  client's scopes. Spring creates OAuth2User principals instead of
  OidcUser principals, and OidcClientInitiatedLogoutSuccessHandler
  return without redirecting the browser.

Also refactored to support the above changes:

- Moved the oauth client service configuration from OAuthSecurityConfig
  to a new OAuthClientConfig class. This breaks Respository's dependence
  on OAuthSecurityConfig, which in turn (through the LogoutHandler)
  depended on Repository. Repository now gets its
  OAuth2AuthorizedClientService from the OAuthClientConfig class, which
  does not in turn depend on Repository.

- Marked two Repository constructors as non-required. Spring will pick
  whichever one has the most dependencies it can satisfy. So if the
  profile specifies an OAuth2AuthorizedClientService, Spring will call
  the constructor that takes one of those. Otherwise Spring will call
  the no-args constructor.

- Renamed LogoutHandler to RepositoryLogoutHandler to better reflect its
  specific responsibilities.

- Changed RepositoryLogoutHandler to implement LogoutHandler instead of
  LogoutSuccessHandler. Now it does its work *during* logout instead of
  *after.*

- Changed DefaultSecurityConfig to specify the logout success URL
  directly instead of via a logout success handler. (OAuthSecurityConfig
  no longer needs a logout success URL, because the OIDC logout handler
  redirects to the OAuth provider instead.)

Co-authored-by: Dale Emery <demery@pivotal.io>
Co-authored-by: Joris Melchior <joris.melchior@gmail.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
