### PR TITLE
GEODE-7991: wait for test CqListener to see events

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNICQAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/client/sni/ClientSNICQAcceptanceTest.java
@@ -163,8 +163,7 @@ public class ClientSNICQAcceptanceTest {
     assertThat(region.get("key2")).isEqualTo(2);
     assertThat(region.get("key99")).isEqualTo(99);
 
-
-    assertThat(eventCreateCounter.get()).isEqualTo(62);
+    await().untilAsserted(() -> assertThat(eventCreateCounter.get()).isEqualTo(62));
 
     updateRegion(region);
     assertThat(region.get("key0")).isEqualTo(10);
@@ -172,7 +171,7 @@ public class ClientSNICQAcceptanceTest {
     assertThat(region.get("key2")).isEqualTo(12);
     assertThat(region.get("key99")).isEqualTo(109);
 
-    assertThat(eventUpdateCounter.get()).isEqualTo(62);
+    await().untilAsserted(() -> assertThat(eventUpdateCounter.get()).isEqualTo(62));
 
     // verify that the server cleans up when the client connection to the gateway is destroyed
     ((PoolImpl) cache.getDefaultPool()).killPrimaryEndpoint();


### PR DESCRIPTION
[GEODE-7991](https://issues.apache.org/jira/browse/GEODE-7991)

Test was flaky. Added awaitility calls to wait for test `CqListener` to see all events.

- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?