### PR TITLE
GEODE-7981: Redis default should be PARTITION_REDUNDANT

### DIFF
--- a/geode-docs/tools_modules/redis_adapter.html.md.erb
+++ b/geode-docs/tools_modules/redis_adapter.html.md.erb
@@ -47,7 +47,7 @@ To implement a <%=vars.product_name%> instance using the Redis Adapter:
 2.  Use gfsh to start a <%=vars.product_name%> server, specifying the three configuration options described above:
     -   Use `--redis-port` to specify the port. This parameter is required -- the <%=vars.product_name%> server will listen on this port for Redis commands.
     -   Use `--redis-bind-address` to specify the IP address of the server host. This parameter is optional. If not specified, the default is determined from the /etc/hosts file.
-    -   Use `--J=-Dgemfireredis.regiontype` to specify the region type. This parameter is optional. If not specified, regiontype is set to PARTITION.
+    -   Use `--J=-Dgemfireredis.regiontype` to specify the region type. This parameter is optional. If not specified, regiontype is set to PARTITION_REDUNDANT.
 
 For example:
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -312,7 +312,7 @@ public class GeodeRedisServer {
     try {
       type = RegionShortcut.valueOf(regionType);
     } catch (Exception e) {
-      type = RegionShortcut.PARTITION;
+      type = RegionShortcut.PARTITION_REDUNDANT;
     }
     return type;
   }


### PR DESCRIPTION
Fixed docs to describe the new default.
Also if the system property it set to an unknown shortcut
then it now defaults to PARTITION_REDUNDANT instead of PARTITION.
The test now validates this case and now uses assertThat instead of assert.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
