### PR TITLE
GEODE-7851: Add slf4j implementation to Pulse

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseLoggingTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/tools/pulse/PulseLoggingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.tools.pulse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.PulseTest;
+import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.rules.LocatorStarterRule;
+
+@Category({SecurityTest.class, PulseTest.class})
+public class PulseLoggingTest {
+  @Rule
+  public LocatorStarterRule locator = new LocatorStarterRule()
+      .withHttpService()
+      .withJMXManager()
+      .withAutoStart();
+
+  @Test
+  public void pulseCreatesLogFileOnStartup() {
+    Path locatorDir = locator.getWorkingDir().toPath();
+    Path pulseLogFile = locatorDir.resolve("pulse.log");
+    assertThat(pulseLogFile).exists();
+  }
+}

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -92,11 +92,7 @@ dependencies {
 
   runtimeOnly('org.springframework:spring-expression')
 
-  // added only to ensure common version with other geode modules
-  runtimeOnly('org.slf4j:slf4j-api')
-  runtimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
-    exclude module: 'slf4j-api'
-  }
+  runtimeOnly('org.apache.logging.log4j:log4j-slf4j-impl')
 
   providedCompile('commons-logging:commons-logging')
 

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -50,7 +50,6 @@ dependencies {
   // Needed to fully use log4j instead of commons-logging.
   implementation('org.apache.logging.log4j:log4j-jcl')
   implementation('org.apache.logging.log4j:log4j-api')
-//  implementation('org.apache.logging.log4j:log4j-core')
 
   implementation('commons-beanutils:commons-beanutils')
   implementation('commons-collections:commons-collections')
@@ -95,6 +94,9 @@ dependencies {
 
   // added only to ensure common version with other geode modules
   runtimeOnly('org.slf4j:slf4j-api')
+  runtimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
+    exclude module: 'slf4j-api'
+  }
 
   providedCompile('commons-logging:commons-logging')
 
@@ -129,9 +131,6 @@ dependencies {
   integrationTestImplementation('org.springframework:spring-webmvc')
   integrationTestImplementation('org.springframework.security:spring-security-test')
 
-  integrationTestRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
-    exclude module: 'slf4j-api'
-  }
   integrationTestImplementation('junit:junit')
   integrationTestImplementation('org.hamcrest:hamcrest-core')
   integrationTestImplementation('org.hamcrest:hamcrest-library')


### PR DESCRIPTION
Pulse was not logging because its war file had no slf4j implementation.
This commit adds the log4j2 implementation to the war file.

Authored-by: Dale Emery <demery@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
