### PR TITLE
GEODE 8014: Sets and Hashes should be deleted once they are empty

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
@@ -154,6 +154,15 @@ public class HashesIntegrationTest {
   }
 
   @Test
+  public void testHDelErrorMessage_givenIncorrectDataType() {
+    jedis.set("farm", "chicken");
+    assertThatThrownBy(() -> {
+      jedis.hdel("farm", "chicken");
+    }).isInstanceOf(JedisDataException.class)
+        .hasMessageContaining("WRONGTYPE Operation against a key holding the wrong kind of value");
+  }
+
+  @Test
   public void testHDelDeletesKeyWhenHashIsEmpty() {
     jedis.hset("farm", "chicken", "little");
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
@@ -146,6 +146,15 @@ public class HashesIntegrationTest {
     assertTrue(jedis.hlen(key) == 0);
   }
 
+  @Test
+  public void testHDelDeletesKeyWhenHashIsEmpty() {
+    jedis.hset("farm", "chicken", "little");
+
+    jedis.hdel("farm", "chicken");
+
+    assertThat(jedis.exists("farm")).isFalse();
+  }
+
 
   @Test
   public void testHkeys() {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
@@ -213,6 +213,15 @@ public class SetsIntegrationTest {
   }
 
   @Test
+  public void testSRemDeletesKeyWhenSetIsEmpty() {
+    jedis.sadd("farm", "chicken");
+
+    jedis.srem("farm", "chicken");
+
+    assertThat(jedis.exists("farm")).isFalse();
+  }
+
+  @Test
   public void testSMembersSIsMember() {
     int elements = 10;
     Set<String> strings = new HashSet<String>();

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
@@ -18,6 +18,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.util.ArrayList;
@@ -213,6 +214,15 @@ public class SetsIntegrationTest {
       }
     }
     return successes;
+  }
+
+  @Test
+  public void testSRemErrorMessage_givenIncorrectDataType() {
+    jedis.set("farm", "chicken");
+    assertThatThrownBy(() -> {
+      jedis.srem("farm", "chicken");
+    }).isInstanceOf(JedisDataException.class)
+        .hasMessageContaining("WRONGTYPE Operation against a key holding the wrong kind of value");
   }
 
   @Test

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/SetsIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -34,6 +35,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -45,6 +47,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.junit.categories.RedisTest;
 
@@ -219,6 +222,61 @@ public class SetsIntegrationTest {
     jedis.srem("farm", "chicken");
 
     assertThat(jedis.exists("farm")).isFalse();
+  }
+
+  @Ignore("GEODE-7905")
+  @Test
+  public void testConcurrentSRemConsistentlyUpdatesMetaInformation()
+      throws ExecutionException, InterruptedException {
+    ByteArrayWrapper keyAsByteArray = new ByteArrayWrapper("set".getBytes());
+    AtomicLong errorCount = new AtomicLong();
+    CyclicBarrier startCyclicBarrier = new CyclicBarrier(2, () -> {
+      boolean keyIsRegistered = server.getKeyRegistrar().isRegistered(keyAsByteArray);
+      boolean containsKey = server.getRegionCache().getSetRegion().containsKey(keyAsByteArray);
+
+      if (keyIsRegistered != containsKey) {
+        errorCount.getAndIncrement();
+        jedis.sadd("set", "member");
+        jedis.del("set");
+      }
+    });
+
+    ExecutorService pool = Executors.newFixedThreadPool(2);
+
+    Callable<Long> callable1 = () -> {
+      Long removedCount = 0L;
+      for (int i = 0; i < 1000; i++) {
+        try {
+          Long result = jedis.srem("set", "member");
+          startCyclicBarrier.await();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return removedCount;
+    };
+
+    Callable<Long> callable2 = () -> {
+      Long addedCount = 0L;
+      for (int i = 0; i < 1000; i++) {
+        try {
+          addedCount += jedis2.sadd("set", "member");
+          startCyclicBarrier.await();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+      return addedCount;
+    };
+
+    Future<Long> future1 = pool.submit(callable1);
+    Future<Long> future2 = pool.submit(callable2);
+
+    future1.get();
+    future2.get();
+
+    assertThat(errorCount.get())
+        .as("Inconsistency between keyRegistrar and backing store detected.").isEqualTo(0L);
   }
 
   @Test

--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -294,10 +294,15 @@ public class GeodeRedisServer {
 
   private boolean shutdown;
   private boolean started;
+
   private KeyRegistrar keyRegistrar;
   private PubSub pubSub;
   private RedisLockService hashLockService;
 
+  @VisibleForTesting
+  protected KeyRegistrar getKeyRegistrar() {
+    return keyRegistrar;
+  }
 
   /**
    * Determine the {@link RegionShortcut} type from a String value. If the String value doesn't map
@@ -448,6 +453,11 @@ public class GeodeRedisServer {
     }
     this.cache = cache;
     logger = cache.getLogger();
+  }
+
+  @VisibleForTesting
+  protected RegionProvider getRegionCache() {
+    return regionCache;
   }
 
   private void initializeRedis() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -64,7 +64,7 @@ public class RedisConstants {
   public static final String ERROR_NOT_AUTH = "Must authenticate before sending any requests";
   public static final String ERROR_ZSET_MEMBER_NOT_FOUND = "could not decode requested zset member";
   public static final String ERROR_WRONG_TYPE =
-      "WRONGTYPE Operation against a key holding the wrong kind of value";
+      "Operation against a key holding the wrong kind of value";
   public static final String ERROR_NOT_INTEGER = "value is not an integer or out of range";
   public static final String ERROR_OVERFLOW = "increment or decrement would overflow";
   public static final String ERROR_NO_SUCH_KEY = "no such key";

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
@@ -90,7 +90,7 @@ class GeodeRedisHashSynchronized implements RedisHash {
       return newHash;
     });
 
-    if (hgetall().size() == 0) {
+    if (hgetall().isEmpty()) {
       RedisDataType type = context.getKeyRegistrar().getType(key);
       context.getRegionProvider().removeKey(key, type);
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
@@ -92,7 +92,9 @@ class GeodeRedisHashSynchronized implements RedisHash {
 
     if (hgetall().isEmpty()) {
       RedisDataType type = context.getKeyRegistrar().getType(key);
-      context.getRegionProvider().removeKey(key, type);
+      if (type == RedisDataType.REDIS_HASH) {
+        context.getRegionProvider().removeKey(key, type);
+      }
     }
     return numDeleted.intValue();
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/GeodeRedisHashSynchronized.java
@@ -89,6 +89,11 @@ class GeodeRedisHashSynchronized implements RedisHash {
       numDeleted.set(oldHash.size() - newHash.size());
       return newHash;
     });
+
+    if (hgetall().size() == 0) {
+      RedisDataType type = context.getKeyRegistrar().getType(key);
+      context.getRegionProvider().removeKey(key, type);
+    }
     return numDeleted.intValue();
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HDelExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HDelExecutor.java
@@ -21,6 +21,7 @@ import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
+import org.apache.geode.redis.internal.RedisDataType;
 
 /**
  * <pre>
@@ -55,6 +56,7 @@ public class HDelExecutor extends HashExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
+    checkDataType(key, RedisDataType.REDIS_HASH, context);
     RedisHash hash = new GeodeRedisHashSynchronized(key, context);
     int numDeleted = hash.hdel(commandElems.subList(2, commandElems.size()));
     command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), numDeleted));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
@@ -61,10 +61,14 @@ class GeodeRedisSetSynchronized implements RedisSet {
       newValue.removeAll(membersToRemove);
       removedCount.set(oldValue.size() - newValue.size());
 
+      // if(newValue.isEmpty()) {
+      // context.getRegionProvider().removeKey(key, context.getKeyRegistrar().getType(key));
+      // }
+
       return newValue;
     });
 
-    if (members().size() == 0) {
+    if (members().isEmpty()) {
       RedisDataType type = context.getKeyRegistrar().getType(key);
       context.getRegionProvider().removeKey(key, type);
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
@@ -66,7 +66,9 @@ class GeodeRedisSetSynchronized implements RedisSet {
 
     if (members().isEmpty()) {
       RedisDataType type = context.getKeyRegistrar().getType(key);
-      context.getRegionProvider().removeKey(key, type);
+      if (type == RedisDataType.REDIS_SET) {
+        context.getRegionProvider().removeKey(key, type);
+      }
     }
 
     return removedCount.longValue();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.RedisDataType;
 
 class GeodeRedisSetSynchronized implements RedisSet {
 
@@ -59,8 +60,15 @@ class GeodeRedisSetSynchronized implements RedisSet {
       Set<ByteArrayWrapper> newValue = createSet(oldValue);
       newValue.removeAll(membersToRemove);
       removedCount.set(oldValue.size() - newValue.size());
+
       return newValue;
     });
+
+    if (members().size() == 0) {
+      RedisDataType type = context.getKeyRegistrar().getType(key);
+      context.getRegionProvider().removeKey(key, type);
+    }
+
     return removedCount.longValue();
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/GeodeRedisSetSynchronized.java
@@ -61,10 +61,6 @@ class GeodeRedisSetSynchronized implements RedisSet {
       newValue.removeAll(membersToRemove);
       removedCount.set(oldValue.size() - newValue.size());
 
-      // if(newValue.isEmpty()) {
-      // context.getRegionProvider().removeKey(key, context.getKeyRegistrar().getType(key));
-      // }
-
       return newValue;
     });
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
@@ -37,6 +37,7 @@ public class SRemExecutor extends SetExecutor {
     checkDataType(key, RedisDataType.REDIS_SET, context);
     RedisSet set = new GeodeRedisSetSynchronized(key, context);
     long numRemoved = set.srem(commandElems.subList(2, commandElems.size()));
+
     command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), numRemoved));
   }
 }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/string/GetSetExecutorJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/string/GetSetExecutorJUnitTest.java
@@ -17,9 +17,7 @@
 package org.apache.geode.redis.internal.executor.string;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -39,7 +37,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.KeyRegistrar;
-import org.apache.geode.redis.internal.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.RedisLockService;
 import org.apache.geode.redis.internal.RegionProvider;
 
@@ -98,23 +95,5 @@ public class GetSetExecutorJUnitTest {
 
     assertThat(command.getResponse().toString(Charset.defaultCharset()))
         .startsWith("-ERR The wrong number of arguments or syntax was provided");
-  }
-
-  @Test
-  public void test_givenKeyHoldsWrongType_returnsError() {
-    List<byte[]> args = Arrays.asList(
-        "GETSET".getBytes(),
-        "key1".getBytes(),
-        "val1".getBytes());
-    Command command = new Command(args);
-
-    when(region.get(any())).thenReturn(new ByteArrayWrapper("non-null value".getBytes()));
-    doThrow(new RedisDataTypeMismatchException("this string doesn't matter")).when(executor)
-        .checkDataType(any(), any(), any());
-
-    executor.executeCommand(command, context);
-
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR WRONGTYPE Operation against a key holding the wrong kind of value");
   }
 }


### PR DESCRIPTION
Redis completely removes keys for sets and hashes once they are empty.  Currently the implementation leaves a key for an empty set/hash once the last element is removed.
