### PR TITLE
GEODE-7963: solution for faulty bucket metrics

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanDistributedTest.java
@@ -42,7 +42,11 @@ import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
 public class MemberMXBeanDistributedTest implements
     Serializable {
 
-  private static MemberVM locator, server1, server2, server3, server4;
+  private static MemberVM locator;
+  private static MemberVM server1;
+  private static MemberVM server2;
+  private static MemberVM server3;
+  private static MemberVM server4;
 
   @ClassRule
   public static ClusterStartupRule lsRule = new ClusterStartupRule();

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanDistributedTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management;
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+
+import java.io.Serializable;
+
+import javax.management.ObjectName;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.GfshTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@Category({GfshTest.class})
+public class MemberMXBeanDistributedTest implements
+    Serializable {
+
+  private static MemberVM locator, server1, server2, server3, server4;
+
+  @ClassRule
+  public static ClusterStartupRule lsRule = new ClusterStartupRule();
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Rule
+  public TestName testName = new SerializableTestName();
+
+  @BeforeClass
+  public static void before() throws Exception {
+    locator = lsRule.startLocatorVM(0);
+    server1 = lsRule.startServerVM(1, "", locator.getPort());
+    server2 = lsRule.startServerVM(2, "", locator.getPort());
+    server3 = lsRule.startServerVM(3, "", locator.getPort());
+    server4 = lsRule.startServerVM(4, "", locator.getPort());
+
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Test
+  public void testBucketCount() throws InterruptedException {
+    String regionName = "testCreateRegion";
+
+    gfsh.executeAndAssertThat("create region"
+        + " --name=" + regionName
+        + " --type=PARTITION_PERSISTENT"
+        + " --total-num-buckets=1000").statusIsSuccess();
+
+    gfsh.executeAndAssertThat("query --query=\"select * from /" + regionName + "\"")
+        .statusIsSuccess();
+
+    server1.invoke(() -> waitBucketsToInitialize(245));
+    server2.invoke(() -> waitBucketsToInitialize(245));
+    server3.invoke(() -> waitBucketsToInitialize(245));
+    server4.invoke(() -> waitBucketsToInitialize(245));
+
+    for (int i = 1; i < 4; i++) {
+      final String tempname = "/" + regionName + i;
+      gfsh.executeAndAssertThat("create region"
+          + " --name=" + regionName + i
+          + " --type=PARTITION_PERSISTENT"
+          + " --total-num-buckets=1000"
+          + " --colocated-with=" + regionName).statusIsSuccess();
+    }
+
+    server1.invoke(() -> waitBucketsToInitialize(990));
+    server2.invoke(() -> waitBucketsToInitialize(990));
+    server3.invoke(() -> waitBucketsToInitialize(990));
+    server4.invoke(() -> waitBucketsToInitialize(990));
+
+  }
+
+  private void waitBucketsToInitialize(int size) {
+    Cache cache = ClusterStartupRule.getCache();
+
+    DistributedMember member = cache.getDistributedSystem().getDistributedMember();
+    ManagementService mgmtService = ManagementService.getManagementService(cache);
+
+    ObjectName memberMBeanName = mgmtService.getMemberMBeanName(member);
+    MemberMXBean memberMXBean = mgmtService.getMBeanInstance(memberMBeanName, MemberMXBean.class);
+
+    await().until(() -> memberMXBean.getTotalBucketCount() >= size);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -3058,8 +3058,9 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
     invokeRegionAfter(region);
 
     // Putting the callback here to avoid creating RegionMBean in case of Exception
-    if (!region.isInternalRegion()) {
+    if (!region.isRegionCreateNotified() && !region.isInternalRegion()) {
       system.handleResourceEvent(ResourceEvent.REGION_CREATE, region);
+      region.setRegionCreateNotified(true);
     }
 
     return cast(region);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -459,4 +459,12 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
    * @return true if synchronization should be attempted
    */
   boolean shouldSyncForCrashedMember(InternalDistributedMember id);
+
+  default boolean isRegionCreateNotified() {
+    return false;
+  }
+
+  default void setRegionCreateNotified(boolean notified) {
+    // do nothing
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalRegion.java
@@ -460,11 +460,7 @@ public interface InternalRegion extends Region, HasCachePerfStats, RegionEntryCo
    */
   boolean shouldSyncForCrashedMember(InternalDistributedMember id);
 
-  default boolean isRegionCreateNotified() {
-    return false;
-  }
+  boolean isRegionCreateNotified();
 
-  default void setRegionCreateNotified(boolean notified) {
-    // do nothing
-  }
+  void setRegionCreateNotified(boolean notified);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -11047,6 +11047,16 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     KEYS, VALUES, ENTRIES
   }
 
+  @Override
+  public boolean isRegionCreateNotified() {
+    return false;
+  }
+
+  @Override
+  public void setRegionCreateNotified(boolean notified) {
+    // do nothing
+  }
+
   /**
    * Used by {@link #foreachRegionEntry}.
    *

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
@@ -1657,6 +1657,11 @@ public class PRHARedundancyProvider {
       for (ProxyBucketRegion proxyBucket : bucketsHostedLocally) {
         proxyBucket.waitForPrimaryPersistentRecovery();
       }
+
+      if (!partitionedRegion.isInternalRegion() && !bucketsNotHostedLocally.isEmpty()) {
+        partitionedRegion.notifyRegionCreated();
+      }
+
       for (ProxyBucketRegion proxyBucket : bucketsNotHostedLocally) {
         proxyBucket.recoverFromDiskRecursively();
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -154,6 +154,7 @@ import org.apache.geode.distributed.internal.OperationExecutors;
 import org.apache.geode.distributed.internal.ProfileListener;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.distributed.internal.ReplyProcessor21;
+import org.apache.geode.distributed.internal.ResourceEvent;
 import org.apache.geode.distributed.internal.locks.DLockRemoteToken;
 import org.apache.geode.distributed.internal.locks.DLockService;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -744,6 +745,8 @@ public class PartitionedRegion extends LocalRegion
 
   private final PartitionedRegionRedundancyTracker redundancyTracker;
 
+  private boolean regionCreationNotified;
+
   /**
    * Constructor for a PartitionedRegion. This has an accessor (Region API) functionality and
    * contains a datastore for actual storage. An accessor can act as a local cache by having a local
@@ -856,7 +859,7 @@ public class PartitionedRegion extends LocalRegion
       this.isShadowPR = true;
       this.parallelGatewaySender = internalRegionArgs.getParallelGatewaySender();
     }
-
+    this.regionCreationNotified = false;
 
     /*
      * Start persistent profile logging if we are a persistent region.
@@ -10187,5 +10190,22 @@ public class PartitionedRegion extends LocalRegion
   @VisibleForTesting
   public SenderIdMonitor getSenderIdMonitor() {
     return senderIdMonitor;
+  }
+
+  @Override
+  public boolean isRegionCreateNotified() {
+    return this.regionCreationNotified;
+  }
+
+  @Override
+  public void setRegionCreateNotified(boolean notified) {
+    this.regionCreationNotified = notified;
+  };
+
+  void notifyRegionCreated() {
+    if (regionCreationNotified)
+      return;
+    this.getSystem().handleResourceEvent(ResourceEvent.REGION_CREATE, this);
+    this.regionCreationNotified = true;
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -622,6 +622,30 @@ public class PartitionedRegionTest {
     assertThat(failures.contains(1)).isFalse();
   }
 
+  @Test
+  public void testGetRegionCreateNotification() {
+    partitionedRegion = new PartitionedRegion("region", attributesFactory.create(), null, cache,
+        mock(InternalRegionArguments.class), disabledClock(), ColocationLoggerFactory.create());
+
+    assertThat(partitionedRegion.isRegionCreateNotified()).isFalse();
+
+    partitionedRegion.setRegionCreateNotified(true);
+
+    assertThat(partitionedRegion.isRegionCreateNotified()).isTrue();
+  }
+
+  @Test
+  public void testNotifyRegionCreated() {
+    partitionedRegion = new PartitionedRegion("region", attributesFactory.create(), null, cache,
+        mock(InternalRegionArguments.class), disabledClock(), ColocationLoggerFactory.create());
+
+    assertThat(partitionedRegion.isRegionCreateNotified()).isFalse();
+
+    partitionedRegion.notifyRegionCreated();
+
+    assertThat(partitionedRegion.isRegionCreateNotified()).isTrue();
+  }
+
   private static <K> Set<K> asSet(K... values) {
     Set<K> set = new HashSet<>();
     Collections.addAll(set, values);


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In case we are creating persistent colocated region, and parent region is already initialized,
show metrics per server will show incorrect values for totalBucketCount and totalPrimaryCount.
This is the solution.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [*] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [*] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [*] Is your initial contribution a single, squashed commit?

- [*] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
