### PR TITLE
GEODE-8031: Close lingering SocketCreatorFactory instances

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorFactoryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorFactoryJUnitTest.java
@@ -80,6 +80,7 @@ import java.io.IOException;
 import java.util.Properties;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -89,6 +90,12 @@ import org.apache.geode.test.junit.categories.MembershipTest;
 
 @Category({MembershipTest.class})
 public class SocketCreatorFactoryJUnitTest {
+
+  @Before
+  public void setUp() {
+    // Ensure that no lingering SocketCreatorFactory instances are open from previous tests
+    SocketCreatorFactory.close();
+  }
 
   @After
   public void tearDown() throws Exception {


### PR DESCRIPTION
- Ensure that any existing SocketCreatorFactory instances created by
previously-run tests are closed before each test execution in
SocketFactoryCreatorJUnitTest

Authored-by: Donal Evans <doevans@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
