### PR TITLE
GEODE-8021: CI Failure: CloseConnectionTest. sharedSenderShouldRecove…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
@@ -106,7 +106,12 @@ public class CloseConnectionTest implements Serializable {
           .getOtherNormalDistributionManagerIds().iterator().next();
       Connection connection = conTable.getConduit().getConnection(otherMember, true, false,
           System.currentTimeMillis(), 15000, 0);
-      assertThat(connection.hasResidualReaderThread()).isTrue();
+      await().untilAsserted(() -> {
+        // grab the shared, ordered "sender" connection to vm0. It should have a residual
+        // reader thread that exists to detect that the socket has been closed.
+        ConnectionTable.threadWantsSharedResources();
+        assertThat(connection.hasResidualReaderThread()).isTrue();
+      });
     });
   }
 


### PR DESCRIPTION
…rFromClosedSocket

fixing a marginally flaky test
  - ensure no bleed-through from other tests in ConnectionTable's
    ThreadLocal, which would cause getConnection to return the wrong
    sort of Connection
  - since Connections are multi-threaded and the state we're looking for
    is set by a background thread, use GeodeAwaitility to wait for the
    condition to be set.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
