### PR TITLE
GEODE-7953: Restore Redundancy Internal API

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -355,7 +355,12 @@ javadoc/org/apache/geode/cache/configuration/package-tree.html
 javadoc/org/apache/geode/cache/control/RebalanceFactory.html
 javadoc/org/apache/geode/cache/control/RebalanceOperation.html
 javadoc/org/apache/geode/cache/control/RebalanceResults.html
+javadoc/org/apache/geode/cache/control/RegionRedundancyStatus.RedundancyStatus.html
+javadoc/org/apache/geode/cache/control/RegionRedundancyStatus.html
 javadoc/org/apache/geode/cache/control/ResourceManager.html
+javadoc/org/apache/geode/cache/control/RestoreRedundancyOperation.html
+javadoc/org/apache/geode/cache/control/RestoreRedundancyResults.Status.html
+javadoc/org/apache/geode/cache/control/RestoreRedundancyResults.html
 javadoc/org/apache/geode/cache/control/package-frame.html
 javadoc/org/apache/geode/cache/control/package-summary.html
 javadoc/org/apache/geode/cache/control/package-tree.html

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationDUnitTest.java
@@ -1,0 +1,347 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static org.apache.geode.cache.PartitionAttributesFactory.GLOBAL_MAX_BUCKETS_DEFAULT;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.NOT_SATISFIED;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.NO_REDUNDANT_COPIES;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.SATISFIED;
+import static org.apache.geode.cache.control.RestoreRedundancyResults.Status.FAILURE;
+import static org.apache.geode.cache.control.RestoreRedundancyResults.Status.SUCCESS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.control.ResourceManager;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
+import org.apache.geode.internal.cache.PartitionAttributesImpl;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+
+@RunWith(JUnitParamsRunner.class)
+public class RestoreRedundancyOperationDUnitTest {
+  private List<MemberVM> servers;
+  private static final int SERVERS_TO_START = 3;
+  private static final String PARENT_REGION_NAME = "parentColocatedRegion";
+  private static final String CHILD_REGION_NAME = "childColocatedRegion";
+  private static final int DESIRED_REDUNDANCY_COPIES = 2;
+  private static final String LOW_REDUNDANCY_REGION_NAME = "lowRedundancyRegion";
+  private static final int LOW_REDUNDANCY_COPIES = 1;
+  private static final int ENTRIES = 5 * GLOBAL_MAX_BUCKETS_DEFAULT;
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Before
+  public void startUp() {
+    MemberVM locator = cluster.startLocatorVM(0);
+    int locatorPort = locator.getPort();
+    servers = new ArrayList<>();
+    IntStream.range(0, SERVERS_TO_START)
+        .forEach(i -> servers.add(cluster.startServerVM(i + 1, locatorPort)));
+
+    // Create the regions on server1 and populate with data
+    servers.get(0).invoke(() -> {
+      Collection<Region<Object, Object>> regions = createRegions();
+      regions.forEach(
+          region -> IntStream.range(0, ENTRIES).forEach(i -> region.put("key" + i, "value" + i)));
+    });
+
+    // Create regions on other servers but do not populate with data
+    servers.stream().skip(1).forEach(
+        s -> s.invoke((SerializableRunnableIF) RestoreRedundancyOperationDUnitTest::createRegions));
+
+    // Confirm that redundancy is impaired and primaries unbalanced for all regions on all members
+    servers.forEach(s -> s.invoke(() -> {
+      assertRedundancyStatus(PARENT_REGION_NAME, false);
+      assertRedundancyStatus(CHILD_REGION_NAME, false);
+      assertRedundancyStatus(LOW_REDUNDANCY_REGION_NAME, false);
+      assertPrimariesBalanced(PARENT_REGION_NAME, SERVERS_TO_START, false);
+      assertPrimariesBalanced(CHILD_REGION_NAME, SERVERS_TO_START, false);
+      assertPrimariesBalanced(LOW_REDUNDANCY_REGION_NAME, SERVERS_TO_START, false);
+    }));
+  }
+
+  @Test
+  public void statsAreUpdatedWhenRestoreRedundancyIsCalled() {
+    servers.get(0).invoke(() -> {
+      restoreRedundancyAndGetResults(null, null, true);
+
+      ResourceManagerStats stats = Objects.requireNonNull(ClusterStartupRule.getCache())
+          .getInternalResourceManager().getStats();
+
+      assertThat(stats.getRestoreRedundanciesInProgress(), equalTo(0L));
+      assertThat(stats.getRestoreRedundanciesCompleted(), equalTo(1L));
+      assertThat(stats.getRestoreRedundancyTime(), greaterThan(0L));
+    });
+  }
+
+  @Test
+  public void redundancyIsRecoveredAndPrimariesBalancedWhenRestoreRedundancyIsCalledWithNoIncludedOrExcludedRegions() {
+    servers.get(0).invoke(() -> {
+      RestoreRedundancyResults results = restoreRedundancyAndGetResults(null, null, true);
+      assertThat(results.getStatus(), is(SUCCESS));
+      assertThat(results.getTotalPrimaryTransfersCompleted() > 0, is(true));
+      assertThat(results.getTotalPrimaryTransferTime().toMillis() > 0, is(true));
+      assertThat(results.getRegionResult(PARENT_REGION_NAME).getStatus(), is(SATISFIED));
+      assertThat(results.getRegionResult(CHILD_REGION_NAME).getStatus(), is(SATISFIED));
+      assertThat(results.getRegionResult(LOW_REDUNDANCY_REGION_NAME).getStatus(), is(SATISFIED));
+    });
+
+    servers.forEach(s -> s.invoke(() -> {
+      assertRedundancyStatus(PARENT_REGION_NAME, true);
+      assertRedundancyStatus(CHILD_REGION_NAME, true);
+      assertRedundancyStatus(LOW_REDUNDANCY_REGION_NAME, true);
+      assertPrimariesBalanced(PARENT_REGION_NAME, SERVERS_TO_START, true);
+      assertPrimariesBalanced(CHILD_REGION_NAME, SERVERS_TO_START, true);
+      assertPrimariesBalanced(LOW_REDUNDANCY_REGION_NAME, SERVERS_TO_START, true);
+    }));
+  }
+
+  @Test
+  public void redundancyIsRecoveredAndPrimariesNotBalancedWhenRestoreRedundancyIsCalledWithReassignPrimariesFalse() {
+    servers.get(0).invoke(() -> {
+      RestoreRedundancyResults results = restoreRedundancyAndGetResults(null, null, false);
+
+      assertThat(results.getStatus(), is(SUCCESS));
+      assertThat(results.getTotalPrimaryTransfersCompleted(), is(0));
+      assertThat(results.getTotalPrimaryTransferTime().toMillis(), is(0L));
+      assertThat(results.getRegionResult(PARENT_REGION_NAME).getStatus(), is(SATISFIED));
+      assertThat(results.getRegionResult(CHILD_REGION_NAME).getStatus(), is(SATISFIED));
+      assertThat(results.getRegionResult(LOW_REDUNDANCY_REGION_NAME).getStatus(), is(SATISFIED));
+    });
+
+    servers.forEach(s -> s.invoke(() -> {
+      assertRedundancyStatus(PARENT_REGION_NAME, true);
+      assertRedundancyStatus(CHILD_REGION_NAME, true);
+      assertRedundancyStatus(LOW_REDUNDANCY_REGION_NAME, true);
+      assertPrimariesBalanced(PARENT_REGION_NAME, SERVERS_TO_START, false);
+      assertPrimariesBalanced(CHILD_REGION_NAME, SERVERS_TO_START, false);
+      assertPrimariesBalanced(LOW_REDUNDANCY_REGION_NAME, SERVERS_TO_START, false);
+    }));
+  }
+
+  @Test
+  public void redundancyIsNotRecoveredAndPrimariesNotBalancedForExcludedNonColocatedRegion() {
+    servers.get(0).invoke(() -> {
+      RestoreRedundancyResults results = restoreRedundancyAndGetResults(null,
+          Collections.singleton(LOW_REDUNDANCY_REGION_NAME), true);
+
+      assertThat(results.getStatus(), is(SUCCESS));
+      assertThat(results.getRegionResult(PARENT_REGION_NAME).getStatus(), is(SATISFIED));
+      assertThat(results.getRegionResult(CHILD_REGION_NAME).getStatus(), is(SATISFIED));
+      assertThat(results.getRegionResult(LOW_REDUNDANCY_REGION_NAME), nullValue());
+    });
+
+    servers.forEach(s -> s.invoke(() -> {
+      assertRedundancyStatus(PARENT_REGION_NAME, true);
+      assertRedundancyStatus(CHILD_REGION_NAME, true);
+      assertRedundancyStatus(LOW_REDUNDANCY_REGION_NAME, false);
+      assertPrimariesBalanced(PARENT_REGION_NAME, SERVERS_TO_START, true);
+      assertPrimariesBalanced(CHILD_REGION_NAME, SERVERS_TO_START, true);
+      assertPrimariesBalanced(LOW_REDUNDANCY_REGION_NAME, SERVERS_TO_START, false);
+    }));
+  }
+
+  @Test
+  @Parameters(method = "getIncludeAndExclude")
+  @TestCaseName("[{index}] {method}: Include={0}, Exclude={1}")
+  public void redundancyIsRecoveredAndPrimariesBalancedForAllColocatedRegionsWhenAtLeastOneIsIncluded(
+      String includeRegion, String excludeRegion) {
+    servers.get(0).invoke(() -> {
+      Set<String> includeSet = includeRegion == null ? null : Collections.singleton(includeRegion);
+      Set<String> excludeSet = excludeRegion == null ? null : Collections.singleton(excludeRegion);
+
+      RestoreRedundancyResults results =
+          restoreRedundancyAndGetResults(includeSet, excludeSet, true);
+
+      assertThat(results.getStatus(), is(SUCCESS));
+      assertThat(results.getRegionResult(PARENT_REGION_NAME).getStatus(), is(SATISFIED));
+      assertThat(results.getRegionResult(CHILD_REGION_NAME).getStatus(), is(SATISFIED));
+    });
+
+    servers.forEach(s -> s.invoke(() -> {
+      assertRedundancyStatus(PARENT_REGION_NAME, true);
+      assertRedundancyStatus(CHILD_REGION_NAME, true);
+      assertPrimariesBalanced(PARENT_REGION_NAME, SERVERS_TO_START, true);
+      assertPrimariesBalanced(CHILD_REGION_NAME, SERVERS_TO_START, true);
+    }));
+  }
+
+  @Test
+  public void restoringRedundancyWithoutEnoughServersToFullySatisfyRedundancyShouldReturnFailureStatusAndBalancePrimaries() {
+    servers.remove(servers.size() - 1).stop();
+    int activeServers = servers.size();
+
+    servers.get(0).invoke(() -> {
+      RestoreRedundancyResults results = restoreRedundancyAndGetResults(null, null, true);
+      assertThat(results.getStatus(), is(FAILURE));
+      assertThat(results.getRegionResult(PARENT_REGION_NAME).getStatus(), is(NOT_SATISFIED));
+      assertThat(results.getRegionResult(CHILD_REGION_NAME).getStatus(), is(NOT_SATISFIED));
+      assertThat(results.getRegionResult(LOW_REDUNDANCY_REGION_NAME).getStatus(), is(SATISFIED));
+    });
+
+    servers.forEach(s -> s.invoke(() -> {
+      assertRedundancyStatus(PARENT_REGION_NAME, false);
+      assertRedundancyStatus(CHILD_REGION_NAME, false);
+      assertRedundancyStatus(LOW_REDUNDANCY_REGION_NAME, true);
+      assertPrimariesBalanced(PARENT_REGION_NAME, activeServers, true);
+      assertPrimariesBalanced(CHILD_REGION_NAME, activeServers, true);
+      assertPrimariesBalanced(LOW_REDUNDANCY_REGION_NAME, activeServers, true);
+    }));
+  }
+
+  @Test
+  public void restoringRedundancyWithoutEnoughServersToCreateAnyRedundantCopyShouldReturnFailureStatus() {
+    // Stop the last two servers in the list and remove them from the list, leaving us with one
+    // server
+    servers.remove(servers.size() - 1).stop();
+    servers.remove(servers.size() - 1).stop();
+
+    assertThat(servers.size(), is(1));
+
+    servers.get(0).invoke(() -> {
+      RestoreRedundancyResults results = restoreRedundancyAndGetResults(null, null, true);
+      assertThat(results.getStatus(), is(FAILURE));
+      assertThat(results.getRegionResult(PARENT_REGION_NAME).getStatus(), is(NO_REDUNDANT_COPIES));
+      assertThat(results.getRegionResult(CHILD_REGION_NAME).getStatus(), is(NO_REDUNDANT_COPIES));
+      assertThat(results.getRegionResult(LOW_REDUNDANCY_REGION_NAME).getStatus(),
+          is(NO_REDUNDANT_COPIES));
+      assertRedundancyStatus(PARENT_REGION_NAME, false);
+      assertRedundancyStatus(CHILD_REGION_NAME, false);
+      assertRedundancyStatus(LOW_REDUNDANCY_REGION_NAME, false);
+    });
+  }
+
+  private static RestoreRedundancyResults restoreRedundancyAndGetResults(
+      Set<String> includeRegions, Set<String> excludeRegions, boolean shouldReassign)
+      throws InterruptedException, ExecutionException {
+    ResourceManager resourceManager =
+        Objects.requireNonNull(ClusterStartupRule.getCache()).getResourceManager();
+    CompletableFuture<RestoreRedundancyResults> redundancyOpFuture = resourceManager
+        .createRestoreRedundancyOperation()
+        .includeRegions(includeRegions)
+        .excludeRegions(excludeRegions)
+        .shouldReassignPrimaries(shouldReassign)
+        .start();
+    assertThat(resourceManager.getRestoreRedundancyFutures().size(), is(1));
+    assertThat(resourceManager.getRestoreRedundancyFutures().contains(redundancyOpFuture),
+        is(true));
+    return redundancyOpFuture.get();
+  }
+
+  private static Collection<Region<Object, Object>> createRegions() {
+    Collection<Region<Object, Object>> regions = new HashSet<>();
+    PartitionAttributesImpl attributes = getAttributesWithRedundancy(DESIRED_REDUNDANCY_COPIES);
+    regions.add(Objects.requireNonNull(ClusterStartupRule.getCache())
+        .createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(attributes)
+        .create(PARENT_REGION_NAME));
+
+    attributes.setColocatedWith(PARENT_REGION_NAME);
+    regions.add(Objects.requireNonNull(ClusterStartupRule.getCache())
+        .createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(attributes)
+        .create(CHILD_REGION_NAME));
+
+    PartitionAttributesImpl lowRedundancyAttributes =
+        getAttributesWithRedundancy(LOW_REDUNDANCY_COPIES);
+    regions.add(Objects.requireNonNull(ClusterStartupRule.getCache())
+        .createRegionFactory(RegionShortcut.PARTITION)
+        .setPartitionAttributes(lowRedundancyAttributes).create(LOW_REDUNDANCY_REGION_NAME));
+
+    return regions;
+  }
+
+  private static PartitionAttributesImpl getAttributesWithRedundancy(int desiredRedundancy) {
+    PartitionAttributesImpl attributes = new PartitionAttributesImpl();
+    attributes.setRedundantCopies(desiredRedundancy);
+    attributes.setRecoveryDelay(-1);
+    attributes.setStartupRecoveryDelay(-1);
+    attributes.setTotalNumBuckets(GLOBAL_MAX_BUCKETS_DEFAULT);
+    return attributes;
+  }
+
+  private static void assertRedundancyStatus(String regionName, boolean shouldBeSatisfied) {
+    Cache cache = Objects.requireNonNull(ClusterStartupRule.getCache());
+
+    PartitionedRegion region = (PartitionedRegion) cache.getRegion(regionName);
+
+    String message =
+        "Expecting redundancy to " + (shouldBeSatisfied ? "" : "not") + " be satisfied";
+    assertThat(message, region.getRedundancyProvider().isRedundancyImpaired(),
+        is(!shouldBeSatisfied));
+  }
+
+  private static void assertPrimariesBalanced(String regionName, int numberOfServers,
+      boolean shouldBeBalanced) {
+    Cache cache = Objects.requireNonNull(ClusterStartupRule.getCache());
+
+    PartitionedRegion region = (PartitionedRegion) cache.getRegion(regionName);
+    int primariesOnServer = region.getLocalPrimaryBucketsListTestOnly().size();
+    // Add one to account for integer rounding errors when dividing
+    int expectedPrimaries = 1 + GLOBAL_MAX_BUCKETS_DEFAULT / numberOfServers;
+    // Because of the way reassigning primaries works, it is sometimes only possible to get the
+    // difference between the most loaded member and the least loaded member to be 2, not 1 as would
+    // be the case for perfect balance
+    String message = "Primaries should be balanced, but expectedPrimaries:actualPrimaries = "
+        + expectedPrimaries + ":" + primariesOnServer;
+    if (shouldBeBalanced) {
+      assertThat(message, Math.abs(primariesOnServer - expectedPrimaries),
+          is(lessThanOrEqualTo(2)));
+    } else {
+      assertThat("Primaries should not be balanced",
+          Math.abs(primariesOnServer - expectedPrimaries), is(not(lessThanOrEqualTo(2))));
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private Object[] getIncludeAndExclude() {
+    return new Object[] {
+        new Object[] {PARENT_REGION_NAME, null},
+        new Object[] {CHILD_REGION_NAME, null},
+        new Object[] {CHILD_REGION_NAME, PARENT_REGION_NAME},
+        new Object[] {PARENT_REGION_NAME, CHILD_REGION_NAME},
+        new Object[] {null, PARENT_REGION_NAME},
+        new Object[] {null, CHILD_REGION_NAME}
+    };
+  }
+}

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1351,6 +1351,10 @@ toData,31
 org/apache/geode/internal/cache/control/MemoryThresholds$MemoryState,1
 toData,12
 
+org/apache/geode/internal/cache/control/RegionRedundancyStatusImpl,2
+fromData,42
+toData,37
+
 org/apache/geode/internal/cache/control/ResourceAdvisor$ResourceManagerProfile,2
 fromData,67
 toData,100
@@ -1358,6 +1362,10 @@ toData,100
 org/apache/geode/internal/cache/control/ResourceAdvisor$ResourceProfileMessage,2
 fromData,88
 toData,72
+
+org/apache/geode/internal/cache/control/RestoreRedundancyResultsImpl,2
+fromData,46
+toData,43
 
 org/apache/geode/internal/cache/event/EventSequenceNumberHolder,2
 fromData,22

--- a/geode-core/src/main/java/org/apache/geode/cache/control/RegionRedundancyStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/control/RegionRedundancyStatus.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.control;
+
+/**
+ * Used to calculate and store a snapshot of the redundancy status for a partitioned region.
+ */
+public interface RegionRedundancyStatus {
+
+  /**
+   * The redundancy status of the region used to create this object at time of creation.
+   * {@link #SATISFIED} if every bucket in the region has the configured number of redundant copies.
+   * {@link #NOT_SATISFIED} if at least one bucket in the region has less than the configured number
+   * of redundant copies.
+   * {@link #NO_REDUNDANT_COPIES} if at least one bucket in the region has zero redundant copies and
+   * the region is not configured for zero redundancy.
+   */
+  enum RedundancyStatus {
+    SATISFIED,
+    NOT_SATISFIED,
+    NO_REDUNDANT_COPIES
+  }
+
+  /**
+   * Returns the name of the region used to create this RegionRedundancyStatus.
+   *
+   * @return The name of the region used to create this RegionRedundancyStatus.
+   */
+  String getRegionName();
+
+  /**
+   * Returns the configured redundancy level for the region used to create this
+   * RegionRedundancyStatus.
+   *
+   * @return The configured redundancy level for the region used to create this
+   *         RegionRedundancyStatus.
+   */
+  int getConfiguredRedundancy();
+
+  /**
+   * Returns the number of redundant copies for all buckets in the region used to create this
+   * RegionRedundancyStatus, at the time of creation. If some buckets have fewer redundant copies
+   * than others, the lower number is returned.
+   *
+   * @return The number of redundant copies for all buckets in the region used to create this
+   *         RegionRedundancyStatus, at the time of creation.
+   */
+  int getActualRedundancy();
+
+  /**
+   * Returns the {@link RedundancyStatus} for the region used to create this RegionRedundancyStatus
+   * at the time of creation.
+   *
+   * @return The {@link RedundancyStatus} for the region used to create this RegionRedundancyStatus.
+   */
+  RedundancyStatus getStatus();
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/control/ResourceManager.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/control/ResourceManager.java
@@ -16,6 +16,7 @@
 package org.apache.geode.cache.control;
 
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.EvictionAttributes;
@@ -76,6 +77,27 @@ public interface ResourceManager {
    * @return a set of all active RebalanceOperations started locally
    */
   Set<RebalanceOperation> getRebalanceOperations();
+
+  /**
+   * Creates a {@link RestoreRedundancyOperation} class for defining and starting restore redundancy
+   * operations and for determining the redundancy status of regions. Similar to a rebalance
+   * operation, a restore redundancy operation will attempt to bring each included region to its
+   * configured redundancy level by creating redundant copies of buckets, and will also optionally
+   * reassign which members host the primary buckets for better load balancing. A restore redundancy
+   * operation differs from a rebalance operation in that it will not move buckets from one member
+   * to another.
+   *
+   * @return a class for defining and starting restore redundancy operations
+   */
+  RestoreRedundancyOperation createRestoreRedundancyOperation();
+
+  /**
+   * Returns a set of all active restore redundancy futures that were started locally on this
+   * member.
+   *
+   * @return a set of all active restore redundancy futures started locally.
+   */
+  Set<CompletableFuture<RestoreRedundancyResults>> getRestoreRedundancyFutures();
 
   /**
    * Set the percentage of heap at or above which the cache is considered in danger of becoming

--- a/geode-core/src/main/java/org/apache/geode/cache/control/RestoreRedundancyOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/control/RestoreRedundancyOperation.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.cache.control;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Class for defining and starting a {@link CompletableFuture} that returns
+ * {@link RestoreRedundancyResults}.
+ */
+public interface RestoreRedundancyOperation {
+  /**
+   * Specify which regions to include in the restore redundancy operation. The default,
+   * <code>null<code>, means all regions should be included. Includes take precedence over
+   * excludes.
+   *
+   * @param regions A set containing the names of regions to include.
+   */
+  RestoreRedundancyOperation includeRegions(Set<String> regions);
+
+  /**
+   * Exclude specific regions from the restore redundancy operation. The default,
+   * <code>null<code>, means don't exclude any regions.
+   *
+   * @param regions A set containing the names of regions to exclude.
+   */
+  RestoreRedundancyOperation excludeRegions(Set<String> regions);
+
+  /**
+   * Set whether the restore redundancy operation should reassign primary buckets. The default,
+   * <code>true</code>, will result in primary buckets being reassigned for better load balancing
+   * across members.
+   *
+   * @param shouldReassign A boolean indicating whether or not the operation created by this
+   *        class should reassign primary bucket hosts.
+   */
+  RestoreRedundancyOperation shouldReassignPrimaries(boolean shouldReassign);
+
+  /**
+   * Asynchronously starts a new restore redundancy operation. Only the cache resources used by this
+   * member will have redundancy restored. The operation may queue as needed for resources in
+   * contention by other active restore redundancy operations.
+   *
+   * @return a {@link CompletableFuture} which will return the results of the restore redundancy
+   *         operation started by this method.
+   */
+  CompletableFuture<RestoreRedundancyResults> start();
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/control/RestoreRedundancyResults.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/control/RestoreRedundancyResults.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.control;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * A class to collect the results of restore redundancy operations for one or more regions and
+ * determine the success of failure of the operation.
+ */
+public interface RestoreRedundancyResults {
+
+  /**
+   * {@link #SUCCESS} is defined as every included region having fully satisfied redundancy.
+   * {@link #FAILURE} is defined as at least one region that is configured to have redundant copies
+   * having fewer than its configured number of redundant copies.
+   * {@link #ERROR} is for cases when the restore redundancy operation was unable to begin or threw
+   * an exception.
+   */
+  enum Status {
+    SUCCESS,
+    FAILURE,
+    ERROR
+  }
+
+  /**
+   * Returns the {@link Status} of this restore redundancy operation. Possible statuses are
+   * {@link Status#SUCCESS}, {@link Status#FAILURE} and {@link Status#ERROR}.
+   *
+   * @return The {@link Status} of this restore redundancy operation.
+   */
+  Status getStatus();
+
+  /**
+   * Returns a message describing the results of this restore redundancy operation.
+   *
+   * @return A {@link String} describing the results of this restore redundancy operation.
+   */
+  String getMessage();
+
+  /**
+   * Returns the {@link RegionRedundancyStatus} for a specific region or null if that region
+   * is not present in this {@link RestoreRedundancyResults}.
+   *
+   * @param regionName The region to which the {@link RegionRedundancyStatus} to be returned
+   *        belongs.
+   * @return A {@link RegionRedundancyStatus} for the specified region or null if that region is not
+   *         present in this {@link RestoreRedundancyResults}.
+   */
+  RegionRedundancyStatus getRegionResult(String regionName);
+
+  /**
+   * Returns all the {@link RegionRedundancyStatus RegionRedundancyStatuses} for regions with
+   * configured redundancy but zero actual redundant copies.
+   *
+   * @return A {@link Map} of {@link String} region name to {@link RegionRedundancyStatus} for every
+   *         region contained in this {@link RestoreRedundancyResults} with configured redundancy
+   *         but zero actual redundant copies.
+   */
+  Map<String, RegionRedundancyStatus> getZeroRedundancyRegionResults();
+
+  /**
+   * Returns all the {@link RegionRedundancyStatus RegionRedundancyStatuses} for regions with with
+   * at least one redundant copy, but fewer than the configured number of redundant copies.
+   *
+   * @return A {@link Map} of {@link String} region name to {@link RegionRedundancyStatus} for every
+   *         region contained in this {@link RestoreRedundancyResults} with at least one redundant
+   *         copy, but fewer than the configured number of redundant copies.
+   */
+  Map<String, RegionRedundancyStatus> getUnderRedundancyRegionResults();
+
+  /**
+   * Returns all the {@link RegionRedundancyStatus RegionRedundancyStatuses} for regions with
+   * redundancy satisfied.
+   *
+   * @return A {@link Map} of {@link String} region name to {@link RegionRedundancyStatus} for every
+   *         region contained in this {@link RestoreRedundancyResults} with redundancy satisfied.
+   */
+  Map<String, RegionRedundancyStatus> getSatisfiedRedundancyRegionResults();
+
+  /**
+   * Returns all the {@link RegionRedundancyStatus RegionRedundancyStatuses} contained in this
+   * {@link RestoreRedundancyResults}. This method may return the actual backing map depending on
+   * implementation.
+   *
+   * @return A {@link Map} of {@link String} region name to {@link RegionRedundancyStatus} for every
+   *         region contained in this {@link RestoreRedundancyResults}.
+   */
+  Map<String, RegionRedundancyStatus> getRegionResults();
+
+  /**
+   * Returns the total number of primaries that were transferred as part of the restore redundancy
+   * operations.
+   *
+   * @return the total number of primaries that were transferred
+   */
+  int getTotalPrimaryTransfersCompleted();
+
+  /**
+   * Returns the total time spent transferring primaries as part of the restore redundancy
+   * operations.
+   *
+   * @return A {@link Duration} representing the total time spent transferring primaries
+   */
+  Duration getTotalPrimaryTransferTime();
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/DSFIDFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DSFIDFactory.java
@@ -267,8 +267,10 @@ import org.apache.geode.internal.cache.backup.FlushToDiskRequest;
 import org.apache.geode.internal.cache.backup.FlushToDiskResponse;
 import org.apache.geode.internal.cache.backup.PrepareBackupRequest;
 import org.apache.geode.internal.cache.compression.SnappyCompressedCachedDeserializable;
+import org.apache.geode.internal.cache.control.RegionRedundancyStatusImpl;
 import org.apache.geode.internal.cache.control.ResourceAdvisor.ResourceManagerProfile;
 import org.apache.geode.internal.cache.control.ResourceAdvisor.ResourceProfileMessage;
+import org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl;
 import org.apache.geode.internal.cache.ha.HARegionQueue.DispatchedAndCurrentEvents;
 import org.apache.geode.internal.cache.ha.QueueRemovalMessage;
 import org.apache.geode.internal.cache.locks.TXLockBatch;
@@ -453,6 +455,8 @@ public class DSFIDFactory implements DataSerializableFixedID {
   }
 
   private void registerDSFIDTypes(DSFIDSerializer serializer) {
+    serializer.registerDSFID(REGION_REDUNDANCY_STATUS, RegionRedundancyStatusImpl.class);
+    serializer.registerDSFID(RESTORE_REDUNDANCY_RESULTS, RestoreRedundancyResultsImpl.class);
     serializer.registerDSFID(FINAL_CHECK_PASSED_MESSAGE, FinalCheckPassedMessage.class);
     serializer.registerDSFID(NETWORK_PARTITION_MESSAGE, NetworkPartitionMessage.class);
     serializer.registerDSFID(REMOVE_MEMBER_REQUEST, RemoveMemberMessage.class);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/InternalResourceManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/InternalResourceManager.java
@@ -19,12 +19,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -42,6 +42,8 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.control.RebalanceFactory;
 import org.apache.geode.cache.control.RebalanceOperation;
 import org.apache.geode.cache.control.ResourceManager;
+import org.apache.geode.cache.control.RestoreRedundancyOperation;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionAdvisor.Profile;
 import org.apache.geode.distributed.internal.DistributionManager;
@@ -80,15 +82,20 @@ public class InternalResourceManager implements ResourceManager {
     }
   }
 
-  private Map<ResourceType, Set<ResourceListener>> listeners =
-      new HashMap<ResourceType, Set<ResourceListener>>();
+  private Map<ResourceType, Set<ResourceListener>> listeners = new HashMap<>();
 
   private final ScheduledExecutorService scheduledExecutor;
   private final ExecutorService notifyExecutor;
 
-  // The set of in progress rebalance operations.
-  private final Set<RebalanceOperation> inProgressOperations = new HashSet<RebalanceOperation>();
-  private final Object inProgressOperationsLock = new Object();
+  // A map of in progress rebalance operations. The value is Boolean because ConcurrentHashMap does
+  // not support null values.
+  private final Map<RebalanceOperation, Boolean> inProgressRebalanceOperations =
+      new ConcurrentHashMap<>();
+
+  // A map of in progress restore redundancy completable futures. The value is Boolean because
+  // ConcurrentHashMap does not support null values.
+  private final Map<CompletableFuture<RestoreRedundancyResults>, Boolean> inProgressRedundancyOperations =
+      new ConcurrentHashMap<>();
 
   final InternalCache cache;
 
@@ -288,21 +295,15 @@ public class InternalResourceManager implements ResourceManager {
 
   @Override
   public Set<RebalanceOperation> getRebalanceOperations() {
-    synchronized (this.inProgressOperationsLock) {
-      return new HashSet<RebalanceOperation>(this.inProgressOperations);
-    }
+    return Collections.unmodifiableSet(inProgressRebalanceOperations.keySet());
   }
 
   void addInProgressRebalance(RebalanceOperation op) {
-    synchronized (this.inProgressOperationsLock) {
-      this.inProgressOperations.add(op);
-    }
+    inProgressRebalanceOperations.put(op, Boolean.TRUE);
   }
 
   void removeInProgressRebalance(RebalanceOperation op) {
-    synchronized (this.inProgressOperationsLock) {
-      this.inProgressOperations.remove(op);
-    }
+    inProgressRebalanceOperations.remove(op);
   }
 
   class RebalanceFactoryImpl implements RebalanceFactory {
@@ -339,7 +340,26 @@ public class InternalResourceManager implements ResourceManager {
       this.includedRegions = regions;
       return this;
     }
+  }
 
+  @Override
+  public RestoreRedundancyOperation createRestoreRedundancyOperation() {
+    return new RestoreRedundancyOperationImpl(cache);
+  }
+
+  @Override
+  public Set<CompletableFuture<RestoreRedundancyResults>> getRestoreRedundancyFutures() {
+    return Collections.unmodifiableSet(inProgressRedundancyOperations.keySet());
+  }
+
+  void addInProgressRestoreRedundancy(
+      CompletableFuture<RestoreRedundancyResults> completableFuture) {
+    inProgressRedundancyOperations.put(completableFuture, Boolean.TRUE);
+  }
+
+  void removeInProgressRestoreRedundancy(
+      CompletableFuture<RestoreRedundancyResults> completableFuture) {
+    inProgressRedundancyOperations.remove(completableFuture);
   }
 
   void stopExecutor(ExecutorService executor) {
@@ -379,7 +399,6 @@ public class InternalResourceManager implements ResourceManager {
    * For testing only, an observer which is called when rebalancing is started and finished for a
    * particular region. This observer is called even the "rebalancing" is actually redundancy
    * recovery for a particular region.
-   *
    */
   public static void setResourceObserver(ResourceObserver observer) {
     if (observer == null) {
@@ -402,25 +421,21 @@ public class InternalResourceManager implements ResourceManager {
   public interface ResourceObserver {
     /**
      * Indicates that rebalancing has started on a given region.
-     *
      */
     void rebalancingStarted(Region region);
 
     /**
      * Indicates that rebalancing has finished on a given region.
-     *
      */
     void rebalancingFinished(Region region);
 
     /**
      * Indicates that recovery has started on a given region.
-     *
      */
     void recoveryStarted(Region region);
 
     /**
      * Indicates that recovery has finished on a given region.
-     *
      */
     void recoveryFinished(Region region);
 
@@ -428,7 +443,6 @@ public class InternalResourceManager implements ResourceManager {
      * Indicated that a membership event triggered a recovery operation, but the recovery operation
      * will not be executed because there is already an existing recovery operation waiting to
      * happen on this region.
-     *
      */
     void recoveryConflated(PartitionedRegion region);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/RegionRedundancyStatusImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/RegionRedundancyStatusImpl.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.geode.DataSerializer;
+import org.apache.geode.cache.control.RegionRedundancyStatus;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.serialization.DataSerializableFixedID;
+import org.apache.geode.internal.serialization.DeserializationContext;
+import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.internal.serialization.Version;
+
+public class RegionRedundancyStatusImpl implements DataSerializableFixedID, RegionRedundancyStatus {
+
+  public static final String OUTPUT_STRING =
+      "%s redundancy status: %s. Desired redundancy is %s and actual redundancy is %s.";
+
+  /**
+   * The name of the region used to create this object.
+   */
+  private String regionName;
+
+  /**
+   * The configured redundancy of the region used to create this object.
+   */
+  private int configuredRedundancy;
+
+  /**
+   * The actual redundancy of the region used to create this object at time of creation.
+   */
+  private int actualRedundancy;
+
+  /**
+   * The {@link RedundancyStatus} of the region used to create this object at time of creation.
+   */
+  private RedundancyStatus status;
+
+  /**
+   * Default constructor used for serialization
+   */
+  public RegionRedundancyStatusImpl() {}
+
+  public RegionRedundancyStatusImpl(PartitionedRegion region) {
+    regionName = region.getName();
+    configuredRedundancy = region.getRedundantCopies();
+    actualRedundancy = calculateLowestRedundancy(region);
+    status = determineStatus(configuredRedundancy, actualRedundancy);
+  }
+
+  @Override
+  public String getRegionName() {
+    return regionName;
+  }
+
+  @Override
+  public int getConfiguredRedundancy() {
+    return configuredRedundancy;
+  }
+
+  @Override
+  public int getActualRedundancy() {
+    return actualRedundancy;
+  }
+
+  @Override
+  public RedundancyStatus getStatus() {
+    return status;
+  }
+
+  /**
+   * Calculates the lowest redundancy for any bucket in the region.
+   *
+   * @param region The region for which the lowest redundancy should be calculated.
+   * @return The redundancy of the least redundant bucket in the region.
+   */
+  private int calculateLowestRedundancy(PartitionedRegion region) {
+    int numBuckets = region.getPartitionAttributes().getTotalNumBuckets();
+    int minRedundancy = Integer.MAX_VALUE;
+    for (int i = 0; i < numBuckets; i++) {
+      int bucketRedundancy = region.getRegionAdvisor().getBucketRedundancy(i);
+      if (bucketRedundancy < minRedundancy) {
+        minRedundancy = bucketRedundancy;
+      }
+    }
+    return minRedundancy;
+  }
+
+  /**
+   * Determines the {@link RedundancyStatus} for the region. If redundancy is not configured (i.e.
+   * configured redundancy = 0), this always returns {@link RedundancyStatus#SATISFIED}.
+   *
+   * @param desiredRedundancy The configured redundancy of the region.
+   * @param actualRedundancy The actual redundancy of the region.
+   * @return The {@link RedundancyStatus} for the region.
+   */
+  private RedundancyStatus determineStatus(int desiredRedundancy, int actualRedundancy) {
+    boolean zeroRedundancy = desiredRedundancy == 0;
+    if (actualRedundancy == 0) {
+      return zeroRedundancy ? RedundancyStatus.SATISFIED : RedundancyStatus.NO_REDUNDANT_COPIES;
+    }
+    return desiredRedundancy == actualRedundancy ? RedundancyStatus.SATISFIED
+        : RedundancyStatus.NOT_SATISFIED;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(OUTPUT_STRING, regionName, status.name(), configuredRedundancy,
+        actualRedundancy);
+  }
+
+  @Override
+  public int getDSFID() {
+    return REGION_REDUNDANCY_STATUS;
+  }
+
+  @Override
+  public void toData(DataOutput out, SerializationContext context) throws IOException {
+    DataSerializer.writeString(regionName, out);
+    DataSerializer.writeEnum(status, out);
+    out.writeInt(configuredRedundancy);
+    out.writeInt(actualRedundancy);
+  }
+
+  @Override
+  public void fromData(DataInput in, DeserializationContext context)
+      throws IOException, ClassNotFoundException {
+    this.regionName = DataSerializer.readString(in);
+    this.status = DataSerializer.readEnum(RedundancyStatus.class, in);
+    this.configuredRedundancy = in.readInt();
+    this.actualRedundancy = in.readInt();
+  }
+
+  @Override
+  public Version[] getSerializationVersions() {
+    return null;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/ResourceManagerStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/ResourceManagerStats.java
@@ -37,6 +37,9 @@ public class ResourceManagerStats {
   private static final int rebalancesCompletedId;
   private static final int autoRebalanceAttemptsId;
   private static final int rebalanceTimeId;
+  private static final int restoreRedundanciesInProgressId;
+  private static final int restoreRedundanciesCompletedId;
+  private static final int restoreRedundancyTimeId;
   private static final int rebalanceBucketCreatesInProgressId;
   private static final int rebalanceBucketCreatesCompletedId;
   private static final int rebalanceBucketCreatesFailedId;
@@ -91,6 +94,16 @@ public class ResourceManagerStats {
                 "Total number of cache auto-rebalance attempts.", "operations"),
             f.createLongCounter("rebalanceTime",
                 "Total time spent directing cache rebalance operations.", "nanoseconds", false),
+
+            f.createLongCounter("restoreRedundanciesInProgress",
+                "Current number of cache restore redundancy operations being directed by this process.",
+                "operations"),
+            f.createLongCounter("restoreRedundanciesCompleted",
+                "Total number of cache restore redundancy operations directed by this process.",
+                "operations"),
+            f.createLongCounter("restoreRedundancyTime",
+                "Total time spent directing cache restore redundancy operations.", "nanoseconds",
+                false),
 
             f.createIntGauge("rebalanceBucketCreatesInProgress",
                 "Current number of bucket create operations being directed for rebalancing.",
@@ -195,6 +208,9 @@ public class ResourceManagerStats {
     rebalancesCompletedId = type.nameToId("rebalancesCompleted");
     autoRebalanceAttemptsId = type.nameToId("autoRebalanceAttempts");
     rebalanceTimeId = type.nameToId("rebalanceTime");
+    restoreRedundanciesInProgressId = type.nameToId("restoreRedundanciesInProgress");
+    restoreRedundanciesCompletedId = type.nameToId("restoreRedundanciesCompleted");
+    restoreRedundancyTimeId = type.nameToId("restoreRedundancyTime");
     rebalanceBucketCreatesInProgressId = type.nameToId("rebalanceBucketCreatesInProgress");
     rebalanceBucketCreatesCompletedId = type.nameToId("rebalanceBucketCreatesCompleted");
     rebalanceBucketCreatesFailedId = type.nameToId("rebalanceBucketCreatesFailed");
@@ -258,6 +274,18 @@ public class ResourceManagerStats {
     this.stats.incInt(rebalancesInProgressId, -1);
     this.stats.incInt(rebalancesCompletedId, 1);
     this.stats.incLong(rebalanceTimeId, elapsed);
+  }
+
+  public long startRestoreRedundancy() {
+    this.stats.incLong(restoreRedundanciesInProgressId, 1);
+    return System.nanoTime();
+  }
+
+  public void endRestoreRedundancy(long start) {
+    long elapsed = System.nanoTime() - start;
+    this.stats.incLong(restoreRedundanciesInProgressId, -1);
+    this.stats.incLong(restoreRedundanciesCompletedId, 1);
+    this.stats.incLong(restoreRedundancyTimeId, elapsed);
   }
 
   public void startBucketCreate(int regions) {
@@ -341,6 +369,18 @@ public class ResourceManagerStats {
 
   public long getRebalanceTime() {
     return this.stats.getLong(rebalanceTimeId);
+  }
+
+  public long getRestoreRedundanciesInProgress() {
+    return this.stats.getLong(restoreRedundanciesInProgressId);
+  }
+
+  public long getRestoreRedundanciesCompleted() {
+    return this.stats.getLong(restoreRedundanciesCompletedId);
+  }
+
+  public long getRestoreRedundancyTime() {
+    return this.stats.getLong(restoreRedundancyTimeId);
   }
 
   public int getRebalanceBucketCreatesInProgress() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationImpl.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.cache.control.RegionRedundancyStatus;
+import org.apache.geode.cache.control.RestoreRedundancyOperation;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
+import org.apache.geode.cache.partition.PartitionRebalanceInfo;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.partitioned.PartitionedRegionRebalanceOp;
+import org.apache.geode.internal.cache.partitioned.rebalance.CompositeDirector;
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+class RestoreRedundancyOperationImpl implements RestoreRedundancyOperation {
+
+  private final InternalCache cache;
+  private final InternalResourceManager manager;
+  private Set<String> includedRegions;
+  private Set<String> excludedRegions;
+  private boolean shouldReassign = true;
+  private ScheduledExecutorService executor;
+
+  public RestoreRedundancyOperationImpl(InternalCache cache) {
+    this.cache = cache;
+    this.manager = cache.getInternalResourceManager();
+    this.executor = this.manager.getExecutor();
+  }
+
+  @Override
+  public RestoreRedundancyOperation includeRegions(Set<String> regions) {
+    this.includedRegions = regions;
+    return this;
+  }
+
+  @Override
+  public RestoreRedundancyOperation excludeRegions(Set<String> regions) {
+    this.excludedRegions = regions;
+    return this;
+  }
+
+  @Override
+  public RestoreRedundancyOperation shouldReassignPrimaries(boolean shouldReassign) {
+    this.shouldReassign = shouldReassign;
+    return this;
+  }
+
+  @Override
+  public CompletableFuture<RestoreRedundancyResults> start() {
+    RegionFilter filter = getRegionFilter();
+    long start = manager.getStats().startRestoreRedundancy();
+
+    // Create a list of completable futures for each restore redundancy operation
+    List<CompletableFuture<RestoreRedundancyResults>> regionFutures =
+        cache.getPartitionedRegions().stream()
+            .filter(filter::include)
+            .map(this::getRedundancyOpFuture)
+            .collect(Collectors.toList());
+
+    // Create a single completable future which completes when all of the restore redundancy
+    // futures return
+    CompletableFuture<Void> combinedFuture =
+        CompletableFuture.allOf(regionFutures.toArray(new CompletableFuture[0]));
+
+    // Once all restore redundancy futures have returned, combine the results from each into one
+    // results object
+    CompletableFuture<RestoreRedundancyResults> resultsFuture =
+        getResultsFuture(regionFutures, combinedFuture);
+
+    // Once results have been collected and combined, mark the operation as finished
+    resultsFuture.thenRun(() -> {
+      manager.removeInProgressRestoreRedundancy(resultsFuture);
+      manager.getStats().endRestoreRedundancy(start);
+    });
+
+    manager.addInProgressRestoreRedundancy(resultsFuture);
+    return resultsFuture;
+  }
+
+  RestoreRedundancyResults doRestoreRedundancy(PartitionedRegion region) {
+    try {
+      PartitionedRegionRebalanceOp op = getPartitionedRegionRebalanceOp(region);
+
+      cache.getCancelCriterion().checkCancelInProgress(null);
+
+      Set<PartitionRebalanceInfo> detailSet;
+      try {
+        detailSet = op.execute();
+
+        RestoreRedundancyResultsImpl results = getEmptyRestoreRedundancyResults();
+        // No work was done, either because redundancy was not impaired or because colocation
+        // was not complete
+        if (detailSet.isEmpty()) {
+          results.addRegionResult(getRegionResult(region));
+        } else {
+          for (PartitionRebalanceInfo details : detailSet) {
+            PartitionedRegion detailRegion =
+                (PartitionedRegion) cache.getRegion(details.getRegionPath());
+            results.addRegionResult(getRegionResult(detailRegion));
+            results.addPrimaryReassignmentDetails(details);
+          }
+        }
+        return results;
+      } catch (RuntimeException ex) {
+        LogService.getLogger().debug("Unexpected exception in restoring redundancy: {}",
+            ex.getMessage(), ex);
+        throw ex;
+      }
+    } catch (RegionDestroyedException ex) {
+      // We can ignore this and go on to the next region, so return an empty results object
+      return getEmptyRestoreRedundancyResults();
+    }
+  }
+
+  RestoreRedundancyResults getRestoreRedundancyResults(
+      List<CompletableFuture<RestoreRedundancyResults>> regionFutures) {
+    RestoreRedundancyResultsImpl finalResult = getEmptyRestoreRedundancyResults();
+    regionFutures.stream()
+        .map(CompletableFuture::join)
+        .forEach(finalResult::addRegionResults);
+    return finalResult;
+  }
+
+  // Extracted for testing
+  RegionFilter getRegionFilter() {
+    return new FilterByPath(this.includedRegions, this.excludedRegions);
+  }
+
+  // Extracted for testing
+  CompletableFuture<RestoreRedundancyResults> getRedundancyOpFuture(PartitionedRegion region) {
+    return CompletableFuture.supplyAsync(() -> doRestoreRedundancy(region), executor);
+  }
+
+  // Extracted for testing
+  PartitionedRegionRebalanceOp getPartitionedRegionRebalanceOp(PartitionedRegion region) {
+    CompositeDirector director = new CompositeDirector(true, true, false, shouldReassign);
+    director.setIsRestoreRedundancy(true);
+    return new PartitionedRegionRebalanceOp(region, false, director, true, false,
+        new AtomicBoolean(), manager.getStats());
+  }
+
+  // Extracted for testing
+  RestoreRedundancyResultsImpl getEmptyRestoreRedundancyResults() {
+    return new RestoreRedundancyResultsImpl();
+  }
+
+  // Extracted for testing
+  RegionRedundancyStatus getRegionResult(PartitionedRegion region) {
+    return new RegionRedundancyStatusImpl(region);
+  }
+
+  // Extracted for testing
+  CompletableFuture<RestoreRedundancyResults> getResultsFuture(
+      List<CompletableFuture<RestoreRedundancyResults>> regionFutures,
+      CompletableFuture<Void> combinedFuture) {
+    return combinedFuture.thenApplyAsync(voidd -> getRestoreRedundancyResults(regionFutures),
+        executor);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/RestoreRedundancyResultsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/RestoreRedundancyResultsImpl.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.geode.DataSerializer;
+import org.apache.geode.cache.control.RegionRedundancyStatus;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
+import org.apache.geode.cache.partition.PartitionRebalanceInfo;
+import org.apache.geode.internal.serialization.DataSerializableFixedID;
+import org.apache.geode.internal.serialization.DeserializationContext;
+import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.internal.serialization.Version;
+
+public class RestoreRedundancyResultsImpl
+    implements RestoreRedundancyResults, DataSerializableFixedID {
+  public static final String NO_REDUNDANT_COPIES_FOR_REGIONS =
+      "The following regions have redundancy configured but zero redundant copies: ";
+  public static final String REDUNDANCY_NOT_SATISFIED_FOR_REGIONS =
+      "Redundancy is partially satisfied for regions: ";
+  public static final String REDUNDANCY_SATISFIED_FOR_REGIONS =
+      "Redundancy is fully satisfied for regions: ";
+  public static final String PRIMARY_TRANSFERS_COMPLETED = "Total primary transfers completed = ";
+  public static final String PRIMARY_TRANSFER_TIME = "Total primary transfer time (ms) = ";
+
+  private Map<String, RegionRedundancyStatus> zeroRedundancyRegions = new HashMap<>();
+  private Map<String, RegionRedundancyStatus> underRedundancyRegions = new HashMap<>();
+  private Map<String, RegionRedundancyStatus> satisfiedRedundancyRegions = new HashMap<>();
+
+  private int totalPrimaryTransfersCompleted;
+  private Duration totalPrimaryTransferTime = Duration.ZERO;
+
+  public RestoreRedundancyResultsImpl() {}
+
+  public void addRegionResults(RestoreRedundancyResults results) {
+    this.satisfiedRedundancyRegions.putAll(results.getSatisfiedRedundancyRegionResults());
+    this.underRedundancyRegions.putAll(results.getUnderRedundancyRegionResults());
+    this.zeroRedundancyRegions.putAll(results.getZeroRedundancyRegionResults());
+    this.totalPrimaryTransfersCompleted += results.getTotalPrimaryTransfersCompleted();
+    this.totalPrimaryTransferTime =
+        this.totalPrimaryTransferTime.plus(results.getTotalPrimaryTransferTime());
+  }
+
+  public void addPrimaryReassignmentDetails(PartitionRebalanceInfo details) {
+    this.totalPrimaryTransfersCompleted += details.getPrimaryTransfersCompleted();
+    this.totalPrimaryTransferTime =
+        this.totalPrimaryTransferTime.plusMillis(details.getPrimaryTransferTime());
+  }
+
+  public void addRegionResult(RegionRedundancyStatus regionResult) {
+    addToFilteredMaps(regionResult);
+  }
+
+  // Adds to the region result to the appropriate map depending on redundancy status
+  private void addToFilteredMaps(RegionRedundancyStatus regionResult) {
+    switch (regionResult.getStatus()) {
+      case NO_REDUNDANT_COPIES:
+        zeroRedundancyRegions.put(regionResult.getRegionName(), regionResult);
+        break;
+      case NOT_SATISFIED:
+        underRedundancyRegions.put(regionResult.getRegionName(), regionResult);
+        break;
+      case SATISFIED:
+        satisfiedRedundancyRegions.put(regionResult.getRegionName(), regionResult);
+        break;
+    }
+  }
+
+  @Override
+  public RestoreRedundancyResults.Status getStatus() {
+    boolean fullySatisfied = zeroRedundancyRegions.isEmpty() && underRedundancyRegions.isEmpty();
+
+    return fullySatisfied ? Status.SUCCESS : Status.FAILURE;
+  }
+
+  @Override
+  public String getMessage() {
+    List<String> messages = new ArrayList<>();
+
+    // List regions with redundancy configured but no redundant copies first
+    if (zeroRedundancyRegions.size() != 0) {
+      messages.add(getResultsMessage(zeroRedundancyRegions, NO_REDUNDANT_COPIES_FOR_REGIONS));
+    }
+
+    // List failures
+    if (underRedundancyRegions.size() != 0) {
+      messages.add(getResultsMessage(underRedundancyRegions, REDUNDANCY_NOT_SATISFIED_FOR_REGIONS));
+    }
+
+    // List successes
+    if (satisfiedRedundancyRegions.size() != 0) {
+      messages.add(getResultsMessage(satisfiedRedundancyRegions, REDUNDANCY_SATISFIED_FOR_REGIONS));
+    }
+
+    // Add info about primaries
+    messages.add(PRIMARY_TRANSFERS_COMPLETED + totalPrimaryTransfersCompleted);
+    messages.add(PRIMARY_TRANSFER_TIME + totalPrimaryTransferTime.toMillis());
+
+    return String.join("\n", messages);
+  }
+
+  private String getResultsMessage(Map<String, RegionRedundancyStatus> regionResults,
+      String baseMessage) {
+    String message = baseMessage + "\n";
+    message += regionResults.values().stream().map(RegionRedundancyStatus::toString)
+        .collect(Collectors.joining(",\n"));
+    return message;
+  }
+
+  @Override
+  public RegionRedundancyStatus getRegionResult(String regionName) {
+    RegionRedundancyStatus result = satisfiedRedundancyRegions.get(regionName);
+    if (result == null) {
+      result = underRedundancyRegions.get(regionName);
+    }
+    if (result == null) {
+      result = zeroRedundancyRegions.get(regionName);
+    }
+    return result;
+  }
+
+  @Override
+  public Map<String, RegionRedundancyStatus> getZeroRedundancyRegionResults() {
+    return zeroRedundancyRegions;
+  }
+
+  @Override
+  public Map<String, RegionRedundancyStatus> getUnderRedundancyRegionResults() {
+    return underRedundancyRegions;
+  }
+
+  @Override
+  public Map<String, RegionRedundancyStatus> getSatisfiedRedundancyRegionResults() {
+    return satisfiedRedundancyRegions;
+  }
+
+  @Override
+  public Map<String, RegionRedundancyStatus> getRegionResults() {
+    Map<String, RegionRedundancyStatus> combinedResults =
+        new HashMap<>(satisfiedRedundancyRegions);
+    combinedResults.putAll(underRedundancyRegions);
+    combinedResults.putAll(zeroRedundancyRegions);
+
+    return combinedResults;
+  }
+
+  @Override
+  public int getTotalPrimaryTransfersCompleted() {
+    return this.totalPrimaryTransfersCompleted;
+  }
+
+  @Override
+  public Duration getTotalPrimaryTransferTime() {
+    return totalPrimaryTransferTime;
+  }
+
+  @Override
+  public int getDSFID() {
+    return RESTORE_REDUNDANCY_RESULTS;
+  }
+
+  @Override
+  public void toData(DataOutput out, SerializationContext context) throws IOException {
+    DataSerializer.writeHashMap(satisfiedRedundancyRegions, out);
+    DataSerializer.writeHashMap(underRedundancyRegions, out);
+    DataSerializer.writeHashMap(zeroRedundancyRegions, out);
+    out.writeInt(totalPrimaryTransfersCompleted);
+    DataSerializer.writeObject(totalPrimaryTransferTime, out);
+  }
+
+  @Override
+  public void fromData(DataInput in, DeserializationContext context)
+      throws IOException, ClassNotFoundException {
+    this.satisfiedRedundancyRegions = DataSerializer.readHashMap(in);
+    this.underRedundancyRegions = DataSerializer.readHashMap(in);
+    this.zeroRedundancyRegions = DataSerializer.readHashMap(in);
+    this.totalPrimaryTransfersCompleted = in.readInt();
+    this.totalPrimaryTransferTime = DataSerializer.readObject(in);
+  }
+
+  @Override
+  public Version[] getSerializationVersions() {
+    return null;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/CompositeDirector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/CompositeDirector.java
@@ -36,12 +36,12 @@ public class CompositeDirector extends RebalanceDirectorAdapter {
   private boolean moveBuckets;
   private boolean movePrimaries;
 
+  private boolean isRestoreRedundancy;
+
   private final RemoveOverRedundancy removeOverRedundancyDirector = new RemoveOverRedundancy();
   private final SatisfyRedundancy satisfyRedundancyDirector = new SatisfyRedundancy();
   private final MovePrimaries movePrimariesDirector = new MovePrimaries();
   private final MoveBuckets moveBucketsDirector = new MoveBuckets();
-
-  private PartitionedRegionLoadModel model;
 
   /**
    * @param removeOverRedundancy true to remove buckets that exceed redundancy levels
@@ -57,20 +57,20 @@ public class CompositeDirector extends RebalanceDirectorAdapter {
     this.initialMovePrimaries = movePrimaries;
   }
 
-
-
   @Override
   public boolean isRebalanceNecessary(boolean redundancyImpaired, boolean withPersistence) {
+    // Restoring redundancy does not require that persistence is enabled to consider the operation
+    // necessary
+    if (isRestoreRedundancy) {
+      return redundancyImpaired || initialMovePrimaries;
+    }
     // We can skip a rebalance is redundancy is not impaired and we
     // don't need to move primaries.
     return redundancyImpaired || (initialMovePrimaries && withPersistence);
   }
 
-
-
   @Override
   public void initialize(PartitionedRegionLoadModel model) {
-    this.model = model;
     this.removeOverRedundancy = initialRemoveOverRedundancy;
     this.satisfyRedundancy = initialSatisfyRedundancy;
     this.moveBuckets = initialMoveBuckets;
@@ -120,4 +120,11 @@ public class CompositeDirector extends RebalanceDirectorAdapter {
     return attemptedOperation;
   }
 
+  public boolean isRestoreRedundancy() {
+    return isRestoreRedundancy;
+  }
+
+  public void setIsRestoreRedundancy(boolean restoreRedundancy) {
+    isRestoreRedundancy = restoreRedundancy;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/SatisfyRedundancy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/SatisfyRedundancy.java
@@ -84,7 +84,4 @@ public class SatisfyRedundancy extends RebalanceDirectorAdapter {
 
     return true;
   }
-
-
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
@@ -362,6 +362,9 @@ public class PartitionedRegionLoadModel {
    * to create a bucket on that node. Because the bucket operator is asynchronous, the bucket may
    * not be created immediately, but the model will be updated regardless. Invoke
    * {@link #waitForOperations()} to wait for those operations to actually complete
+   *
+   * @param bucket the bucket for which a redundant copy should be made
+   * @param targetMember the member on which a redundant copy of a bucket should be made
    */
   public void createRedundantBucket(final BucketRollup bucket, final Member targetMember) {
     Map<String, Long> colocatedRegionSizes = getColocatedRegionSizes(bucket);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ResourceManagerCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/ResourceManagerCreation.java
@@ -15,10 +15,13 @@
 package org.apache.geode.internal.cache.xmlcache;
 
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.geode.cache.control.RebalanceFactory;
 import org.apache.geode.cache.control.RebalanceOperation;
 import org.apache.geode.cache.control.ResourceManager;
+import org.apache.geode.cache.control.RestoreRedundancyOperation;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
 import org.apache.geode.internal.cache.control.MemoryThresholds;
 
 /**
@@ -55,6 +58,26 @@ public class ResourceManagerCreation implements ResourceManager {
    */
   @Override
   public Set<RebalanceOperation> getRebalanceOperations() {
+    throw new IllegalArgumentException("Unused");
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.apache.geode.cache.control.ResourceManager#createRestoreRedundancyOperation()
+   */
+  @Override
+  public RestoreRedundancyOperation createRestoreRedundancyOperation() {
+    throw new IllegalArgumentException("Unused");
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see org.apache.geode.cache.control.ResourceManager#getRestoreRedundancyFutures()
+   */
+  @Override
+  public Set<CompletableFuture<RestoreRedundancyResults>> getRestoreRedundancyFutures() {
     throw new IllegalArgumentException("Unused");
   }
 

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -146,6 +146,8 @@ org/apache/geode/cache/configuration/RegionAttributesType$SubscriptionAttributes
 org/apache/geode/cache/configuration/RegionConfig,false,entries:java/util/List,indexes:java/util/List,name:java/lang/String,regionAttributes:org/apache/geode/cache/configuration/RegionAttributesType,regionElements:java/util/List,regions:java/util/List,type:java/lang/String
 org/apache/geode/cache/configuration/RegionConfig$Entry,false,key:org/apache/geode/cache/configuration/ObjectType,value:org/apache/geode/cache/configuration/ObjectType
 org/apache/geode/cache/configuration/RegionConfig$Index,false,expression:java/lang/String,fromClause:java/lang/String,imports:java/lang/String,keyIndex:java/lang/Boolean,name:java/lang/String,type:java/lang/String
+org/apache/geode/cache/control/RegionRedundancyStatus$RedundancyStatus,false
+org/apache/geode/cache/control/RestoreRedundancyResults$Status,false
 org/apache/geode/cache/execute/EmptyRegionFunctionException,true,1
 org/apache/geode/cache/execute/FunctionAdapter,true,-4891043890440825485
 org/apache/geode/cache/execute/FunctionException,true,4893171227542647452

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/RegionRedundancyStatusImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/RegionRedundancyStatusImplTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static org.apache.geode.cache.PartitionAttributesFactory.GLOBAL_MAX_BUCKETS_DEFAULT;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.NOT_SATISFIED;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.NO_REDUNDANT_COPIES;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.SATISFIED;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.control.RegionRedundancyStatus;
+import org.apache.geode.internal.cache.PartitionedRegion;
+
+@RunWith(JUnitParamsRunner.class)
+public class RegionRedundancyStatusImplTest {
+
+  private PartitionedRegion mockRegion;
+  private final int desiredRedundancy = 2;
+  private final int oneRedundantCopy = 1;
+  private final int zeroRedundancy = 0;
+
+  @Before
+  public void setUp() {
+    mockRegion = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
+    when(mockRegion.getRedundantCopies()).thenReturn(desiredRedundancy);
+    when(mockRegion.getPartitionAttributes().getTotalNumBuckets())
+        .thenReturn(GLOBAL_MAX_BUCKETS_DEFAULT);
+  }
+
+  @Test
+  @Parameters(method = "getActualRedundancyAndExpectedStatusAndMessage")
+  @TestCaseName("[{index}] {method} (Desired redundancy:" + desiredRedundancy
+      + "; Actual redundancy:{0}; Expected status:{1})")
+  public void constructorPopulatesValuesCorrectly(int actualRedundancy,
+      RegionRedundancyStatus.RedundancyStatus expectedStatus) {
+    when(mockRegion.getRegionAdvisor().getBucketRedundancy(anyInt())).thenReturn(actualRedundancy);
+
+    RegionRedundancyStatus result = new RegionRedundancyStatusImpl(mockRegion);
+
+    assertThat(result.getConfiguredRedundancy(), is(desiredRedundancy));
+    assertThat(result.getActualRedundancy(), is(actualRedundancy));
+    assertThat(result.getStatus(), is(expectedStatus));
+    assertThat(result.toString(), containsString(expectedStatus.name()));
+  }
+
+  @Test
+  public void constructorPopulatesValuesCorrectlyWhenNotAllBucketsReturnTheSameRedundancy() {
+    when(mockRegion.getRegionAdvisor().getBucketRedundancy(anyInt())).thenReturn(desiredRedundancy);
+    // Have only the bucket with ID = 1 report being under redundancy
+    when(mockRegion.getRegionAdvisor().getBucketRedundancy(1)).thenReturn(oneRedundantCopy);
+
+    RegionRedundancyStatus result = new RegionRedundancyStatusImpl(mockRegion);
+
+    assertThat(result.getConfiguredRedundancy(), is(desiredRedundancy));
+    assertThat(result.getActualRedundancy(), is(oneRedundantCopy));
+    assertThat(result.getStatus(), is(NOT_SATISFIED));
+    assertThat(result.toString(), containsString(NOT_SATISFIED.name()));
+  }
+
+  public Object[] getActualRedundancyAndExpectedStatusAndMessage() {
+    return new Object[] {
+        new Object[] {desiredRedundancy, SATISFIED},
+        new Object[] {oneRedundantCopy, NOT_SATISFIED},
+        new Object[] {zeroRedundancy, NO_REDUNDANT_COPIES}
+    };
+  }
+
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationImplTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.RegionDestroyedException;
+import org.apache.geode.cache.control.RegionRedundancyStatus;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
+import org.apache.geode.cache.partition.PartitionRebalanceInfo;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.partitioned.PartitionedRegionRebalanceOp;
+
+public class RestoreRedundancyOperationImplTest {
+  InternalCache cache;
+  InternalResourceManager manager;
+  ResourceManagerStats stats;
+  RestoreRedundancyOperationImpl operation;
+  RestoreRedundancyResultsImpl emptyResults;
+  long startTime = 5;
+
+  @Before
+  public void setUp() {
+    cache = mock(InternalCache.class, RETURNS_DEEP_STUBS);
+    manager = mock(InternalResourceManager.class);
+    stats = mock(ResourceManagerStats.class);
+    when(cache.getInternalResourceManager()).thenReturn(manager);
+    when(manager.getStats()).thenReturn(stats);
+    when(stats.startRestoreRedundancy()).thenReturn(startTime);
+
+    operation = spy(new RestoreRedundancyOperationImpl(cache));
+
+    emptyResults = mock(RestoreRedundancyResultsImpl.class);
+    doReturn(emptyResults).when(operation).getEmptyRestoreRedundancyResults();
+  }
+
+  @Test
+  public void doRestoreRedundancyReturnsEmptyResultsWhenRegionDestroyedExceptionIsThrown() {
+    PartitionedRegion region = mock(PartitionedRegion.class);
+    doThrow(new RegionDestroyedException("message", "/regionPath")).when(operation)
+        .getPartitionedRegionRebalanceOp(region);
+
+    assertThat(operation.doRestoreRedundancy(region), is(emptyResults));
+  }
+
+  @Test
+  public void doRestoreRedundancyAddsRegionResultForRegionIfDetailSetIsEmpty() {
+    PartitionedRegion region = mock(PartitionedRegion.class);
+
+    PartitionedRegionRebalanceOp op = mock(PartitionedRegionRebalanceOp.class);
+    doReturn(op).when(operation).getPartitionedRegionRebalanceOp(region);
+    when(op.execute()).thenReturn(new HashSet<>());
+
+    RegionRedundancyStatus regionResult = mock(RegionRedundancyStatusImpl.class);
+    doReturn(regionResult).when(operation).getRegionResult(region);
+
+    operation.doRestoreRedundancy(region);
+
+    verify(emptyResults, times(1)).addRegionResult(regionResult);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void doRestoreRedundancyAddsRegionResultAndPrimaryDetailsWhenDetailSetIsNotEmpty() {
+    PartitionedRegion region = mock(PartitionedRegion.class);
+
+    PartitionedRegionRebalanceOp op = mock(PartitionedRegionRebalanceOp.class);
+    doReturn(op).when(operation).getPartitionedRegionRebalanceOp(region);
+
+    PartitionRebalanceInfo details1 = mock(PartitionRebalanceInfo.class);
+    String regionPath1 = "/region1";
+    when(details1.getRegionPath()).thenReturn(regionPath1);
+    PartitionRebalanceInfo details2 = mock(PartitionRebalanceInfo.class);
+    String regionPath2 = "/region2";
+    when(details2.getRegionPath()).thenReturn(regionPath2);
+
+    Set<PartitionRebalanceInfo> detailSet = new HashSet<>();
+    detailSet.add(details1);
+    detailSet.add(details2);
+
+    when(op.execute()).thenReturn(detailSet);
+
+    PartitionedRegion detailRegion1 = mock(PartitionedRegion.class);
+    PartitionedRegion detailRegion2 = mock(PartitionedRegion.class);
+    when(cache.getRegion(regionPath1)).thenReturn(detailRegion1);
+    when(cache.getRegion(regionPath2)).thenReturn(detailRegion2);
+
+    RegionRedundancyStatus regionResult1 = mock(RegionRedundancyStatusImpl.class);
+    RegionRedundancyStatus regionResult2 = mock(RegionRedundancyStatusImpl.class);
+    doReturn(regionResult1).when(operation).getRegionResult(detailRegion1);
+    doReturn(regionResult2).when(operation).getRegionResult(detailRegion2);
+
+    operation.doRestoreRedundancy(region);
+
+    verify(emptyResults, times(1)).addRegionResult(regionResult1);
+    verify(emptyResults, times(1)).addRegionResult(regionResult2);
+    verify(emptyResults, times(1)).addPrimaryReassignmentDetails(details1);
+    verify(emptyResults, times(1)).addPrimaryReassignmentDetails(details2);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void getRestoreRedundancyResultsReturnsCombinedResultsFromAllFutures() {
+    CompletableFuture<RestoreRedundancyResults> future1 = mock(CompletableFuture.class);
+    RestoreRedundancyResults result1 = mock(RestoreRedundancyResults.class);
+    when(future1.join()).thenReturn(result1);
+    CompletableFuture<RestoreRedundancyResults> future2 = mock(CompletableFuture.class);
+    RestoreRedundancyResults result2 = mock(RestoreRedundancyResults.class);
+    when(future2.join()).thenReturn(result2);
+
+    List<CompletableFuture<RestoreRedundancyResults>> futures = new ArrayList<>();
+    futures.add(future1);
+    futures.add(future2);
+
+    operation.getRestoreRedundancyResults(futures);
+
+    verify(emptyResults, times(1)).addRegionResults(result1);
+    verify(emptyResults, times(1)).addRegionResults(result2);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void startCreatesRedundancyOpFutureForAllIncludedRegions() {
+    RegionFilter filter = mock(RegionFilter.class);
+    doReturn(filter).when(operation).getRegionFilter();
+
+    PartitionedRegion includeRegion = mock(PartitionedRegion.class);
+    PartitionedRegion excludeRegion = mock(PartitionedRegion.class);
+    Set<PartitionedRegion> regions = new HashSet<>();
+    regions.add(includeRegion);
+    regions.add(excludeRegion);
+    when(cache.getPartitionedRegions()).thenReturn(regions);
+
+    when(filter.include(includeRegion)).thenReturn(true);
+    when(filter.include(excludeRegion)).thenReturn(false);
+
+    CompletableFuture<RestoreRedundancyResults> redundancyOpFuture = mock(CompletableFuture.class);
+    doReturn(redundancyOpFuture).when(operation).getRedundancyOpFuture(any());
+
+    CompletableFuture<RestoreRedundancyResults> resultsFuture = mock(CompletableFuture.class);
+    doReturn(resultsFuture).when(operation).getResultsFuture(any(), any());
+
+    operation.start();
+
+    verify(operation, times(1)).getRedundancyOpFuture(includeRegion);
+    verify(operation, times(0)).getRedundancyOpFuture(excludeRegion);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void startAddsInProgressRestoreRedundancyAndRemovesInProgressRestoreRedundancyAndUpdatesStatsOnCompletion() {
+    RegionFilter filter = mock(RegionFilter.class);
+    doReturn(filter).when(operation).getRegionFilter();
+
+    PartitionedRegion includeRegion = mock(PartitionedRegion.class);
+    when(cache.getPartitionedRegions()).thenReturn(Collections.singleton(includeRegion));
+
+    when(filter.include(includeRegion)).thenReturn(true);
+
+    CompletableFuture<RestoreRedundancyResults> redundancyOpFuture = mock(CompletableFuture.class);
+    doReturn(redundancyOpFuture).when(operation).getRedundancyOpFuture(any());
+
+    CompletableFuture<RestoreRedundancyResults> resultsFuture =
+        CompletableFuture.completedFuture(null);
+    doReturn(resultsFuture).when(operation).getResultsFuture(any(), any());
+
+    operation.start().join();
+
+    verify(manager, times(1)).addInProgressRestoreRedundancy(resultsFuture);
+    verify(manager, times(1)).removeInProgressRestoreRedundancy(resultsFuture);
+    verify(stats, times(1)).endRestoreRedundancy(startTime);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/RestoreRedundancyResultsImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/RestoreRedundancyResultsImplTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.NOT_SATISFIED;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.NO_REDUNDANT_COPIES;
+import static org.apache.geode.cache.control.RegionRedundancyStatus.RedundancyStatus.SATISFIED;
+import static org.apache.geode.cache.control.RestoreRedundancyResults.Status.FAILURE;
+import static org.apache.geode.cache.control.RestoreRedundancyResults.Status.SUCCESS;
+import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.NO_REDUNDANT_COPIES_FOR_REGIONS;
+import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.PRIMARY_TRANSFERS_COMPLETED;
+import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.PRIMARY_TRANSFER_TIME;
+import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.REDUNDANCY_NOT_SATISFIED_FOR_REGIONS;
+import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.REDUNDANCY_SATISFIED_FOR_REGIONS;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.control.RegionRedundancyStatus;
+import org.apache.geode.cache.control.RestoreRedundancyResults;
+import org.apache.geode.cache.partition.PartitionRebalanceInfo;
+
+public class RestoreRedundancyResultsImplTest {
+  private final RegionRedundancyStatus successfulRegionResult =
+      mock(RegionRedundancyStatusImpl.class);
+  private final String successfulRegionName = "successfulRegion";
+  private final RegionRedundancyStatus underRedundancyRegionResult =
+      mock(RegionRedundancyStatusImpl.class);
+  private final String underRedundancyRegionName = "underRedundancyRegion";
+  private final RegionRedundancyStatus zeroRedundancyRegionResult =
+      mock(RegionRedundancyStatusImpl.class);
+  private final String zeroRedundancyRegionName = "zeroRedundancyRegion";
+  private PartitionRebalanceInfo details = mock(PartitionRebalanceInfo.class);
+  private int transfersCompleted = 5;
+  private long transferTime = 1234;
+  private RestoreRedundancyResultsImpl results;
+
+  @Before
+  public void setUp() {
+    when(successfulRegionResult.getStatus()).thenReturn(SATISFIED);
+    when(successfulRegionResult.getRegionName()).thenReturn(successfulRegionName);
+    when(underRedundancyRegionResult.getStatus()).thenReturn(NOT_SATISFIED);
+    when(underRedundancyRegionResult.getRegionName()).thenReturn(underRedundancyRegionName);
+    when(zeroRedundancyRegionResult.getStatus()).thenReturn(NO_REDUNDANT_COPIES);
+    when(zeroRedundancyRegionResult.getRegionName()).thenReturn(zeroRedundancyRegionName);
+    when(details.getPrimaryTransfersCompleted()).thenReturn(transfersCompleted);
+    when(details.getPrimaryTransferTime()).thenReturn(transferTime);
+    results = new RestoreRedundancyResultsImpl();
+  }
+
+  @Test
+  public void getStatusReturnsSuccessWhenAllRegionsHaveFullySatisfiedRedundancy() {
+    results.addRegionResult(successfulRegionResult);
+
+    assertThat(results.getStatus(), is(SUCCESS));
+  }
+
+  @Test
+  public void getStatusReturnsFailureNotAllRegionsHaveFullySatisfiedRedundancy() {
+    results.addRegionResult(successfulRegionResult);
+    results.addRegionResult(underRedundancyRegionResult);
+
+    assertThat(results.getStatus(), is(FAILURE));
+  }
+
+  @Test
+  public void getStatusReturnsFailureWhenAtLeastOneRegionHasNoRedundancy() {
+    results.addRegionResult(successfulRegionResult);
+    results.addRegionResult(zeroRedundancyRegionResult);
+
+    assertThat(results.getStatus(), is(FAILURE));
+  }
+
+  @Test
+  public void getMessageReturnsStatusForAllRegionsAndPrimaryInfo() {
+    results.addRegionResult(successfulRegionResult);
+    results.addRegionResult(underRedundancyRegionResult);
+    results.addRegionResult(zeroRedundancyRegionResult);
+
+    results.addPrimaryReassignmentDetails(details);
+
+    String message = results.getMessage();
+    List<String> messageLines = Arrays.asList(message.split("\n"));
+
+    assertThat(messageLines, contains(NO_REDUNDANT_COPIES_FOR_REGIONS,
+        zeroRedundancyRegionResult.toString(),
+        REDUNDANCY_NOT_SATISFIED_FOR_REGIONS,
+        underRedundancyRegionResult.toString(),
+        REDUNDANCY_SATISFIED_FOR_REGIONS,
+        successfulRegionResult.toString(),
+        PRIMARY_TRANSFERS_COMPLETED + transfersCompleted,
+        PRIMARY_TRANSFER_TIME + transferTime));
+  }
+
+  @Test
+  public void addRegionResultAddsToCorrectInternalMap() {
+    results.addRegionResult(zeroRedundancyRegionResult);
+    results.addRegionResult(underRedundancyRegionResult);
+    results.addRegionResult(successfulRegionResult);
+
+    Map<String, RegionRedundancyStatus> zeroRedundancyResults =
+        results.getZeroRedundancyRegionResults();
+    assertThat(zeroRedundancyResults.size(), is(1));
+    assertThat(zeroRedundancyResults.get(zeroRedundancyRegionName), is(zeroRedundancyRegionResult));
+
+    Map<String, RegionRedundancyStatus> underRedundancyResults =
+        results.getUnderRedundancyRegionResults();
+    assertThat(underRedundancyResults.size(), is(1));
+    assertThat(underRedundancyResults.get(underRedundancyRegionName),
+        is(underRedundancyRegionResult));
+
+    Map<String, RegionRedundancyStatus> successfulRegionResults =
+        results.getSatisfiedRedundancyRegionResults();
+    assertThat(successfulRegionResults.size(), is(1));
+    assertThat(successfulRegionResults.get(successfulRegionName), is(successfulRegionResult));
+  }
+
+  @Test
+  public void addRegionResultsAddsToCorrectInternalMapAndAddsPrimaryReassignmentDetails() {
+    RestoreRedundancyResults regionResults = mock(RestoreRedundancyResults.class);
+    when(regionResults.getZeroRedundancyRegionResults())
+        .thenReturn(Collections.singletonMap(zeroRedundancyRegionName, zeroRedundancyRegionResult));
+    when(regionResults.getUnderRedundancyRegionResults()).thenReturn(
+        Collections.singletonMap(underRedundancyRegionName, underRedundancyRegionResult));
+    when(regionResults.getSatisfiedRedundancyRegionResults())
+        .thenReturn(Collections.singletonMap(successfulRegionName, successfulRegionResult));
+    when(regionResults.getTotalPrimaryTransfersCompleted()).thenReturn(transfersCompleted);
+    when(regionResults.getTotalPrimaryTransferTime()).thenReturn(Duration.ofMillis(transferTime));
+
+    results.addRegionResults(regionResults);
+
+    Map<String, RegionRedundancyStatus> zeroRedundancyResults =
+        results.getZeroRedundancyRegionResults();
+    assertThat(zeroRedundancyResults.size(), is(1));
+    assertThat(zeroRedundancyResults.get(zeroRedundancyRegionName), is(zeroRedundancyRegionResult));
+
+    Map<String, RegionRedundancyStatus> underRedundancyResults =
+        results.getUnderRedundancyRegionResults();
+    assertThat(underRedundancyResults.size(), is(1));
+    assertThat(underRedundancyResults.get(underRedundancyRegionName),
+        is(underRedundancyRegionResult));
+
+    Map<String, RegionRedundancyStatus> successfulRegionResults =
+        results.getSatisfiedRedundancyRegionResults();
+    assertThat(successfulRegionResults.size(), is(1));
+    assertThat(successfulRegionResults.get(successfulRegionName), is(successfulRegionResult));
+
+    assertThat(results.getTotalPrimaryTransfersCompleted(), is(transfersCompleted));
+    assertThat(results.getTotalPrimaryTransferTime().toMillis(), is(transferTime));
+  }
+
+  @Test
+  public void addPrimaryDetailsUpdatesValue() {
+    assertThat(results.getTotalPrimaryTransfersCompleted(), is(0));
+    assertThat(results.getTotalPrimaryTransferTime().toMillis(), is(0L));
+    results.addPrimaryReassignmentDetails(details);
+    assertThat(results.getTotalPrimaryTransfersCompleted(), is(transfersCompleted));
+    assertThat(results.getTotalPrimaryTransferTime().toMillis(), is(transferTime));
+    results.addPrimaryReassignmentDetails(details);
+    assertThat(results.getTotalPrimaryTransfersCompleted(), is(transfersCompleted * 2));
+    assertThat(results.getTotalPrimaryTransferTime().toMillis(), is(transferTime * 2));
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/BucketOperatorImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/BucketOperatorImplTest.java
@@ -116,11 +116,8 @@ public class BucketOperatorImplTest {
 
   @Test
   public void createBucketShouldInvokeOnFailureIfCreateBucketFails() {
-    doReturn(false).when(rebalanceOp).createRedundantBucketForRegion(targetMember, bucketId); // return
-                                                                                              // false
-                                                                                              // for
-                                                                                              // create
-                                                                                              // fail
+    // return false for create fail
+    doReturn(false).when(rebalanceOp).createRedundantBucketForRegion(targetMember, bucketId);
 
     operator.createRedundantBucket(targetMember, bucketId, colocatedRegionBytes, completion);
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
@@ -57,6 +57,9 @@ public interface DataSerializableFixedID extends SerializationVersions, BasicSer
   // NOTE, codes < -65536 will take 4 bytes to serialize
   // NOTE, codes < -128 will take 2 bytes to serialize
 
+  short REGION_REDUNDANCY_STATUS = -161;
+  short RESTORE_REDUNDANCY_RESULTS = -160;
+
   short CREATE_REGION_MESSAGE_LUCENE = -159;
   short FINAL_CHECK_PASSED_MESSAGE = -158;
   short NETWORK_PARTITION_MESSAGE = -157;


### PR DESCRIPTION
- Add RestoreRedundancyOperation interface and Impl class
- Add RestoreRedundancyResults interface and Impl class
- Add RegionRedundancyStatus interface and Impl class
- Add accessor methods for RestoreRedundancyOperation to ResourceManager interface
- Replace manually-synchronized sets in InternalResourceManager with
ConcurrentHashMap
- Add stats for restore redundancy operations
- Add unit and DUnit tests for all the above

This commit undoes the previous revert of these changes.

Authored-by: Donal Evans <doevans@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
