### PR TITLE
GEODE-8036: Redis - Close Zombie TCP Client Connections

### DIFF
--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/MockSubscriber.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/MockSubscriber.java
@@ -41,7 +41,6 @@ public class MockSubscriber extends JedisPubSub {
 
   @Override
   public void onMessage(String channel, String message) {
-    // System.out.println("***************** GOT MESSAGE: " + message);
     receivedMessages.add(message);
   }
 }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/MockSubscriber.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/MockSubscriber.java
@@ -41,6 +41,7 @@ public class MockSubscriber extends JedisPubSub {
 
   @Override
   public void onMessage(String channel, String message) {
+    // System.out.println("***************** GOT MESSAGE: " + message);
     receivedMessages.add(message);
   }
 }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
@@ -16,6 +16,11 @@
 
 package org.apache.geode.redis;
 
+import static java.lang.String.valueOf;
+import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.LinkedList;
@@ -26,52 +31,223 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
 
 public class PubSubDUnitTest {
 
   public static final String CHANNEL_NAME = "salutations";
 
   @ClassRule
-  public static ClusterStartupRule cluster = new ClusterStartupRule();
+  public static ClusterStartupRule cluster = new ClusterStartupRule(5).withLogFile();
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
 
   @ClassRule
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
   private static int[] ports;
 
-  private static MemberVM server1, server2;
+  static final String LOCAL_HOST = "127.0.0.1";
+  static Jedis subscriber1;
+  static Jedis subscriber2;
+  static Jedis publisher1;
+  static Jedis publisher2;
+
+  static Properties locatorProperties;
+  static Properties serverProperties1;
+  static Properties serverProperties2;
+  static Properties serverProperties3;
+  static Properties serverProperties4;
+
+  static MemberVM locator;
+  static MemberVM server1;
+  static MemberVM server2;
+  static MemberVM server3;
+  static MemberVM server4;
 
   @BeforeClass
-  public static void beforeClass() {
-    ports = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-    Properties redisProps = new Properties();
-    redisProps.put(ConfigurationProperties.REDIS_BIND_ADDRESS, "localhost");
+  public static void beforeClass() throws Exception {
+    ports = AvailablePortHelper.getRandomAvailableTCPPorts(4);
 
-    MemberVM locator = cluster.startLocatorVM(0);
+    locatorProperties = new Properties();
+    serverProperties1 = new Properties();
+    serverProperties2 = new Properties();
+    serverProperties3 = new Properties();
+    serverProperties4 = new Properties();
 
-    redisProps.put(ConfigurationProperties.REDIS_PORT, Integer.toString(ports[0]));
-    server1 = cluster.startServerVM(1, redisProps, locator.getPort());
-    redisProps.put(ConfigurationProperties.REDIS_PORT, Integer.toString(ports[1]));
-    server2 = cluster.startServerVM(2, redisProps, locator.getPort());
+    locatorProperties.setProperty(MAX_WAIT_TIME_RECONNECT, "15000");
+
+    serverProperties1.setProperty(REDIS_PORT, valueOf(ports[0]));
+    serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    serverProperties2.setProperty(REDIS_PORT, valueOf(ports[1]));
+    serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    serverProperties3.setProperty(REDIS_PORT, valueOf(ports[2]));
+    serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    serverProperties4.setProperty(REDIS_PORT, valueOf(ports[3]));
+    serverProperties4.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    locator = cluster.startLocatorVM(0, locatorProperties);
+    server1 = cluster.startServerVM(1, serverProperties1, locator.getPort());
+    server2 = cluster.startServerVM(2, serverProperties2, locator.getPort());
+    server3 = cluster.startServerVM(3, serverProperties3, locator.getPort());
+    server4 = cluster.startServerVM(4, serverProperties4, locator.getPort());
+
+    subscriber1 = new Jedis(LOCAL_HOST, ports[0]);
+    subscriber2 = new Jedis(LOCAL_HOST, ports[1]);
+    publisher1 = new Jedis(LOCAL_HOST, ports[2]);
+    publisher2 = new Jedis(LOCAL_HOST, ports[3]);
+
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Before
+  public void testSetup() {
+    subscriber1.flushAll();
+    subscriber2.flushAll();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    subscriber1.disconnect();
+    subscriber2.disconnect();
+    publisher1.disconnect();
+    publisher2.disconnect();
+
+    server1.stop();
+    server2.stop();
+    server3.stop();
+    server4.stop();
+  }
+
+  @Test
+  public void shouldContinueToFunction_whenOneSubscriberShutsDownGracefully_givenTwoSubscribersOnePublisher()
+      throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
+
+    Future<Void> subscriber1Future = executor.submit(
+        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future = executor.submit(
+        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+
+    assertThat(latch.await(30, TimeUnit.SECONDS))
+        .as("channel subscription was not received")
+        .isTrue();
+
+    Long result = publisher1.publish(CHANNEL_NAME, "hello");
+    assertThat(result).isEqualTo(2);
+
+    server1.stop();
+    Long resultFromSecondMessage = publisher1.publish(CHANNEL_NAME, "hello again");
+    assertThat(resultFromSecondMessage).isEqualTo(1);
+
+    mockSubscriber2.unsubscribe(CHANNEL_NAME);
+    GeodeAwaitility.await().untilAsserted(subscriber2Future::get);
+
+    restartServerVM1();
+    reconnectSubscriber1();
+  }
+
+  @Test
+  public void shouldContinueToFunction_whenOneSubscriberShutsDownAbruptly_givenTwoSubscribersOnePublisher()
+      throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
+
+    Future<Void> subscriber1Future = executor.submit(
+        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future = executor.submit(
+        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+
+    assertThat(latch.await(30, TimeUnit.SECONDS))
+        .as("channel subscription was not received")
+        .isTrue();
+
+    Long result = publisher1.publish(CHANNEL_NAME, "hello");
+    assertThat(result).isEqualTo(2);
+
+    cluster.crashVM(1);
+    publisher1.publish(CHANNEL_NAME, "hello again");
+
+    mockSubscriber2.unsubscribe(CHANNEL_NAME);
+
+    GeodeAwaitility.await().untilAsserted(subscriber2Future::get);
+
+    restartServerVM1();
+    reconnectSubscriber1();
+  }
+
+  private void restartServerVM1() {
+    cluster.startServerVM(1, serverProperties1, locator.getPort());
+    await()
+        .untilAsserted(() -> gfsh.executeAndAssertThat("list members")
+            .statusIsSuccess()
+            .hasTableSection()
+            .hasColumn("Name")
+            .containsOnly("locator-0", "server-1", "server-2", "server-3", "server-4"));
+  }
+
+  private void reconnectSubscriber1() {
+    subscriber1 = new Jedis(LOCAL_HOST, ports[0]);
+  }
+
+  @Test
+  public void shouldContinueToFunction_whenOneSubscriberShutsDownGracefully_givenTwoSubscribersTwoPublishers()
+      throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
+
+    Future<Void> subscriber1Future = executor.submit(
+        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future = executor.submit(
+        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+
+    assertThat(latch.await(30, TimeUnit.SECONDS))
+        .as("channel subscription was not received")
+        .isTrue();
+
+    Long resultPublisher1 = publisher1.publish(CHANNEL_NAME, "hello");
+    Long resultPublisher2 = publisher2.publish(CHANNEL_NAME, "hello");
+    assertThat(resultPublisher1).isEqualTo(2);
+    assertThat(resultPublisher2).isEqualTo(2);
+
+    server1.stop();
+
+    publisher1.publish(CHANNEL_NAME, "hello again");
+    publisher2.publish(CHANNEL_NAME, "hello again");
+
+    mockSubscriber2.unsubscribe(CHANNEL_NAME);
+
+    GeodeAwaitility.await().untilAsserted(subscriber2Future::get);
+
+    restartServerVM1();
+    reconnectSubscriber1();
   }
 
   @Test
   public void testSubscribePublishUsingDifferentServers() throws Exception {
-    Jedis subscriber1 = new Jedis("localhost", ports[0]);
-    Jedis subscriber2 = new Jedis("localhost", ports[1]);
-    Jedis publisher = new Jedis("localhost", ports[1]);
-
     CountDownLatch latch = new CountDownLatch(2);
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
     MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
@@ -85,7 +261,7 @@ public class PubSubDUnitTest {
         .as("channel subscription was not received")
         .isTrue();
 
-    Long result = publisher.publish(CHANNEL_NAME, "hello");
+    Long result = publisher1.publish(CHANNEL_NAME, "hello");
     assertThat(result).isEqualTo(2);
 
     mockSubscriber1.unsubscribe(CHANNEL_NAME);
@@ -99,9 +275,6 @@ public class PubSubDUnitTest {
   public void testConcurrentPubSub() throws Exception {
     int CLIENT_COUNT = 10;
     int ITERATIONS = 1000;
-
-    Jedis subscriber1 = new Jedis("localhost", ports[0]);
-    Jedis subscriber2 = new Jedis("localhost", ports[1]);
 
     CountDownLatch latch = new CountDownLatch(2);
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
@@ -118,11 +291,11 @@ public class PubSubDUnitTest {
 
     List<Future<Void>> futures = new LinkedList<>();
     for (int i = 0; i < CLIENT_COUNT; i++) {
-      Jedis client = new Jedis("localhost", ports[i % 2]);
+      Jedis publisher = new Jedis("localhost", ports[i % 2]);
 
       Callable<Void> callable = () -> {
         for (int j = 0; j < ITERATIONS; j++) {
-          client.publish(CHANNEL_NAME, "hello");
+          publisher.publish(CHANNEL_NAME, "hello");
         }
         return null;
       };
@@ -143,5 +316,4 @@ public class PubSubDUnitTest {
     assertThat(mockSubscriber1.getReceivedMessages().size()).isEqualTo(CLIENT_COUNT * ITERATIONS);
     assertThat(mockSubscriber2.getReceivedMessages().size()).isEqualTo(CLIENT_COUNT * ITERATIONS);
   }
-
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/DummySubscription.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/DummySubscription.java
@@ -26,9 +26,8 @@ public class DummySubscription implements Subscription {
   }
 
   @Override
-  public PublishResult publishMessage(String channel, byte[] message) {
-    return null;
-  }
+  public void publishMessage(String channel, byte[] message,
+      PublishResultCollector publishResultCollector) {}
 
   @Override
   public boolean matchesClient(Client client) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -618,9 +618,7 @@ public class GeodeRedisServer {
         .childOption(EpollChannelOption.TCP_KEEPINTVL, 30)
         .childOption(EpollChannelOption.TCP_KEEPCNT, 3)
         .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, GeodeRedisServer.connectTimeoutMillis)
-        .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-
-    ;
+        .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
 
     // Bind and start to accept incoming connections.
     ChannelFuture f = b.bind(new InetSocketAddress(getBindAddress(), serverPort)).sync();

--- a/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/GeodeRedisServer.java
@@ -53,6 +53,7 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
@@ -610,10 +611,16 @@ public class GeodeRedisServer {
                 new ExecutionHandlerContext(ch, cache, regionCache, GeodeRedisServer.this, pwdB,
                     keyRegistrar, pubSub, hashLockService));
           }
-        }).option(ChannelOption.SO_REUSEADDR, true).option(ChannelOption.SO_RCVBUF, getBufferSize())
+        }).option(ChannelOption.SO_REUSEADDR, true)
+        .option(ChannelOption.SO_RCVBUF, getBufferSize())
         .childOption(ChannelOption.SO_KEEPALIVE, true)
+        .childOption(EpollChannelOption.TCP_KEEPIDLE, 1)
+        .childOption(EpollChannelOption.TCP_KEEPINTVL, 30)
+        .childOption(EpollChannelOption.TCP_KEEPCNT, 3)
         .childOption(ChannelOption.CONNECT_TIMEOUT_MILLIS, GeodeRedisServer.connectTimeoutMillis)
-        .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+        .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+
+    ;
 
     // Bind and start to accept incoming connections.
     ChannelFuture f = b.bind(new InetSocketAddress(getBindAddress(), serverPort)).sync();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
@@ -96,7 +96,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
    * @param cache The Geode cache instance of this vm
    * @param regionProvider The region provider of this context
    * @param server Instance of the server it is attached to, only used so that any execution
-   *        can initiate a shutdwon
+   *        can initiate a shutdown
    * @param password Authentication password for each context, can be null
    */
   public ExecutionHandlerContext(Channel channel, Cache cache, RegionProvider regionProvider,
@@ -176,6 +176,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
         && cause.getCause() instanceof RedisCommandParserException) {
       response =
           Coder.getErrorResponse(this.byteBufAllocator, RedisConstants.PARSING_EXCEPTION_MESSAGE);
+
     } else if (cause instanceof RegionCreationException) {
       this.logger.error(cause);
       response =

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResultCollector.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResultCollector.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class PublishResultCollector {
+  private final CountDownLatch countDownLatch;
+  private Subscriptions subscriptions;
+  private final AtomicLong successCount = new AtomicLong();
+
+  public PublishResultCollector(int resultsExpected, Subscriptions subscriptions) {
+    countDownLatch = new CountDownLatch(resultsExpected);
+    this.subscriptions = subscriptions;
+  }
+
+  public void success() {
+    successCount.incrementAndGet();
+    countDownLatch.countDown();
+  }
+
+  public void failure(Client result) {
+    pruneFailure(result);
+    countDownLatch.countDown();
+  }
+
+  public long getSuccessCount() {
+    waitForResults();
+    return successCount.get();
+  }
+
+  private void pruneFailure(Client c) {
+    if (c.isDead()) {
+      subscriptions.remove(c);
+    }
+  }
+
+  private void waitForResults() {
+    try {
+      countDownLatch.await();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscription.java
@@ -32,7 +32,8 @@ public interface Subscription {
   /**
    * Will publish a message to the designated channel.
    */
-  PublishResult publishMessage(String channel, byte[] message);
+  void publishMessage(String channel, byte[] message,
+      PublishResultCollector publishResultCollector);
 
   /**
    * Verifies that the subscription is established with the designated client.


### PR DESCRIPTION
Use KEEPALIVE settings to close TCP connections

Follow Netty's Asynchronous pattern to write to
the channel

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
