### PR TITLE
GEODE-8060: Ignore flaky GemFireCacheImplCloseTest test

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplCloseTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplCloseTest.java
@@ -38,6 +38,7 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.junit.MockitoJUnit;
@@ -189,6 +190,7 @@ public class GemFireCacheImplCloseTest {
     verify(internalDistributedSystem).disconnect();
   }
 
+  @Ignore("GEODE-8060: wrong thread wins")
   @Test
   public void close_blocksUntilFirstCallToCloseCompletes() throws Exception {
     gemFireCacheImpl = gemFireCacheImpl(false);


### PR DESCRIPTION
GemFireCacheImplCloseTest.close_blocksUntilFirstCallToCloseCompletes
has failed for a couple other developers. I'm marking it with Ignore
while I try to reproduce and fix the problem.
