### PR TITLE
GEODE-8060: Fix flakiness in GemFireCacheImplCloseTest

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -2063,13 +2063,20 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   @Override
   public void close(String reason, Throwable systemFailureCause, boolean keepAlive,
       boolean keepDS, boolean skipAwait) {
+    doClose(reason, systemFailureCause, keepAlive, keepDS, skipAwait);
+  }
+
+  /**
+   * Returns true if the caller performed the actual closing of the cache. Returns false if the
+   * caller simply waited for another thread to perform the close.
+   */
+  @VisibleForTesting
+  boolean doClose(String reason, Throwable systemFailureCause, boolean keepAlive,
+      boolean keepDS, boolean skipAwait) {
     securityService.close();
 
-    if (isClosed()) {
-      if (!skipAwait && !Thread.currentThread().equals(CLOSING_THREAD.get())) {
-        waitUntilClosed();
-      }
-      return;
+    if (waitIfClosing(skipAwait)) {
+      return false;
     }
 
     if (!keepDS && systemFailureCause == null
@@ -2082,17 +2089,14 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       if (system.getReconnectedSystem() != null) {
         system.getReconnectedSystem().disconnect();
       }
-      return;
+      return false;
     }
 
     synchronized (GemFireCacheImpl.class) {
       // ALL CODE FOR CLOSE SHOULD NOW BE UNDER STATIC SYNCHRONIZATION OF GemFireCacheImpl.class
       // static synchronization is necessary due to static resources
-      if (isClosed()) {
-        if (!skipAwait && !Thread.currentThread().equals(CLOSING_THREAD.get())) {
-          waitUntilClosed();
-        }
-        return;
+      if (waitIfClosing(skipAwait)) {
+        return false;
       }
 
       CLOSING_THREAD.set(Thread.currentThread());
@@ -2377,15 +2381,23 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
       } finally {
         CLOSING_THREAD.remove();
       }
+      return true;
     }
   }
 
-  private void waitUntilClosed() {
-    try {
-      isClosedLatch.await();
-    } catch (InterruptedException ignore) {
-      // ignored
+  /**
+   * Returns true if caller waited on the {@code isClosedLatch}.
+   */
+  private boolean waitIfClosing(boolean skipAwait) {
+    if (isClosing && !skipAwait && !Thread.currentThread().equals(CLOSING_THREAD.get())) {
+      try {
+        isClosedLatch.await();
+      } catch (InterruptedException ignore) {
+        // ignored
+      }
+      return true;
     }
+    return false;
   }
 
   private void stopServices() {


### PR DESCRIPTION
I hate creating a special package-private method just for the test BUT I can't think of an effective test without getting some sort of state from GemFireCacheImpl that identifies which call or which thread actually performed the close.

Without identifying which call or thread performed the close, the test devolves to just asserting that two threads can call close but it can't really assert which call did the actual work of closing GemFireCacheImpl. From a really high level, we don't really care. But at a low level, we don't want the 2nd callers to return before the 1st caller has finished the close (doesn't matter if the 1st caller returns from close() after 2nd callers though which is what causes the flakiness).