### PR TITLE
GEODE-7998: Do not block Netty threads when publishing

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ExecutorServiceRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ExecutorServiceRule.java
@@ -328,7 +328,7 @@ public class ExecutorServiceRule extends SerializableExternalResource {
    * a {@code Set<WeakReference<Thread>>} to track the {@code Thread}s in the factory's
    * {@code ThreadGroup} excluding subgroups.
    */
-  protected static class DedicatedThreadFactory implements ThreadFactory {
+  public static class DedicatedThreadFactory implements ThreadFactory {
 
     private static final AtomicInteger POOL_NUMBER = new AtomicInteger(1);
 
@@ -337,7 +337,7 @@ public class ExecutorServiceRule extends SerializableExternalResource {
     private final String namePrefix;
     private final Set<WeakReference<Thread>> directThreads = new HashSet<>();
 
-    protected DedicatedThreadFactory() {
+    public DedicatedThreadFactory() {
       group = new ThreadGroup(ExecutorServiceRule.class.getSimpleName() + "-ThreadGroup");
       namePrefix = "pool-" + POOL_NUMBER.getAndIncrement() + "-thread-";
     }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
@@ -16,62 +16,244 @@
 
 package org.apache.geode.redis;
 
+import static java.lang.String.valueOf;
+import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
 
 public class PubSubDUnitTest {
 
   public static final String CHANNEL_NAME = "salutations";
 
   @ClassRule
-  public static ClusterStartupRule cluster = new ClusterStartupRule();
+  public static ClusterStartupRule cluster = new ClusterStartupRule(5);
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
 
   @ClassRule
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
   private static int[] ports;
 
-  private static MemberVM server1, server2;
+  static final String LOCAL_HOST = "127.0.0.1";
+  static Jedis subscriber1;
+  static Jedis subscriber2;
+  static Jedis publisher1;
+  static Jedis publisher2;
+
+  static Properties locatorProperties;
+  static Properties serverProperties1;
+  static Properties serverProperties2;
+  static Properties serverProperties3;
+  static Properties serverProperties4;
+
+  static MemberVM locator;
+  static MemberVM server1;
+  static MemberVM server2;
+  static MemberVM server3;
+  static MemberVM server4;
 
   @BeforeClass
-  public static void beforeClass() {
-    ports = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-    Properties redisProps = new Properties();
-    redisProps.put(ConfigurationProperties.REDIS_BIND_ADDRESS, "localhost");
+  public static void beforeClass() throws Exception {
+    ports = AvailablePortHelper.getRandomAvailableTCPPorts(4);
 
-    MemberVM locator = cluster.startLocatorVM(0);
+    locatorProperties = new Properties();
+    serverProperties1 = new Properties();
+    serverProperties2 = new Properties();
+    serverProperties3 = new Properties();
+    serverProperties4 = new Properties();
 
-    redisProps.put(ConfigurationProperties.REDIS_PORT, Integer.toString(ports[0]));
-    server1 = cluster.startServerVM(1, redisProps, locator.getPort());
-    redisProps.put(ConfigurationProperties.REDIS_PORT, Integer.toString(ports[1]));
-    server2 = cluster.startServerVM(2, redisProps, locator.getPort());
+    locatorProperties.setProperty(MAX_WAIT_TIME_RECONNECT, "15000");
+
+    serverProperties1.setProperty(REDIS_PORT, valueOf(ports[0]));
+    serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    serverProperties2.setProperty(REDIS_PORT, valueOf(ports[1]));
+    serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    serverProperties3.setProperty(REDIS_PORT, valueOf(ports[2]));
+    serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    serverProperties4.setProperty(REDIS_PORT, valueOf(ports[3]));
+    serverProperties4.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+
+    locator = cluster.startLocatorVM(0, locatorProperties);
+    server1 = cluster.startServerVM(1, serverProperties1, locator.getPort());
+    server2 = cluster.startServerVM(2, serverProperties2, locator.getPort());
+    server3 = cluster.startServerVM(3, serverProperties3, locator.getPort());
+    server4 = cluster.startServerVM(4, serverProperties4, locator.getPort());
+    serverProperties1.setProperty("log-level", "error");
+    serverProperties2.setProperty("log-level", "error");
+    serverProperties3.setProperty("log-level", "error");
+    serverProperties4.setProperty("log-level", "error");
+
+    subscriber1 = new Jedis(LOCAL_HOST, ports[0]);
+    subscriber2 = new Jedis(LOCAL_HOST, ports[1]);
+    publisher1 = new Jedis(LOCAL_HOST, ports[2]);
+    publisher2 = new Jedis(LOCAL_HOST, ports[3]);
+
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Before
+  public void testSetup() {
+    subscriber1.flushAll();
+    subscriber2.flushAll();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    subscriber1.disconnect();
+    subscriber2.disconnect();
+    publisher1.disconnect();
+    publisher2.disconnect();
+
+    server1.stop();
+    server2.stop();
+    server3.stop();
+    server4.stop();
+  }
+
+  @Test
+  public void shouldContinueToFunction_whenOneSubscriberShutsDownGracefully_givenTwoSubscribersOnePublisher()
+      throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
+
+    Future<Void> subscriber1Future = executor.submit(
+        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future = executor.submit(
+        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+
+    assertThat(latch.await(30, TimeUnit.SECONDS))
+        .as("channel subscription was not received")
+        .isTrue();
+
+    Long result = publisher1.publish(CHANNEL_NAME, "hello");
+    assertThat(result).isEqualTo(2);
+
+    server1.stop();
+    Long resultFromSecondMessage = publisher1.publish(CHANNEL_NAME, "hello again");
+    assertThat(resultFromSecondMessage).isEqualTo(1);
+
+    mockSubscriber2.unsubscribe(CHANNEL_NAME);
+    GeodeAwaitility.await().untilAsserted(subscriber2Future::get);
+
+    restartServerVM1();
+    reconnectSubscriber1();
+  }
+
+  @Test
+  public void shouldContinueToFunction_whenOneSubscriberShutsDownAbruptly_givenTwoSubscribersOnePublisher()
+      throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
+
+    Future<Void> subscriber1Future = executor.submit(
+        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future = executor.submit(
+        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+
+    assertThat(latch.await(30, TimeUnit.SECONDS))
+        .as("channel subscription was not received")
+        .isTrue();
+
+    Long result = publisher1.publish(CHANNEL_NAME, "hello");
+    assertThat(result).isEqualTo(2);
+
+    cluster.crashVM(1);
+    publisher1.publish(CHANNEL_NAME, "hello again");
+
+    mockSubscriber2.unsubscribe(CHANNEL_NAME);
+
+    GeodeAwaitility.await().untilAsserted(subscriber2Future::get);
+
+    restartServerVM1();
+    reconnectSubscriber1();
+  }
+
+  private void restartServerVM1() {
+    cluster.startServerVM(1, serverProperties1, locator.getPort());
+    await()
+        .untilAsserted(() -> gfsh.executeAndAssertThat("list members")
+            .statusIsSuccess()
+            .hasTableSection()
+            .hasColumn("Name")
+            .containsOnly("locator-0", "server-1", "server-2", "server-3", "server-4"));
+  }
+
+  private void reconnectSubscriber1() {
+    subscriber1 = new Jedis(LOCAL_HOST, ports[0]);
+  }
+
+  @Test
+  public void shouldContinueToFunction_whenOneSubscriberShutsDownGracefully_givenTwoSubscribersTwoPublishers()
+      throws InterruptedException {
+    CountDownLatch latch = new CountDownLatch(2);
+
+    MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
+    MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
+
+    Future<Void> subscriber1Future = executor.submit(
+        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future = executor.submit(
+        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+
+    assertThat(latch.await(30, TimeUnit.SECONDS))
+        .as("channel subscription was not received")
+        .isTrue();
+
+    Long resultPublisher1 = publisher1.publish(CHANNEL_NAME, "hello");
+    Long resultPublisher2 = publisher2.publish(CHANNEL_NAME, "hello");
+    assertThat(resultPublisher1).isEqualTo(2);
+    assertThat(resultPublisher2).isEqualTo(2);
+
+    server1.stop();
+
+    publisher1.publish(CHANNEL_NAME, "hello again");
+    publisher2.publish(CHANNEL_NAME, "hello again");
+
+    mockSubscriber2.unsubscribe(CHANNEL_NAME);
+
+    GeodeAwaitility.await().untilAsserted(subscriber2Future::get);
+
+    restartServerVM1();
+    reconnectSubscriber1();
   }
 
   @Test
   public void testSubscribePublishUsingDifferentServers() throws Exception {
-    Jedis subscriber1 = new Jedis("localhost", ports[0]);
-    Jedis subscriber2 = new Jedis("localhost", ports[1]);
-    Jedis publisher = new Jedis("localhost", ports[1]);
-
     CountDownLatch latch = new CountDownLatch(2);
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
     MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
@@ -85,7 +267,7 @@ public class PubSubDUnitTest {
         .as("channel subscription was not received")
         .isTrue();
 
-    Long result = publisher.publish(CHANNEL_NAME, "hello");
+    Long result = publisher1.publish(CHANNEL_NAME, "hello");
     assertThat(result).isEqualTo(2);
 
     mockSubscriber1.unsubscribe(CHANNEL_NAME);
@@ -99,9 +281,6 @@ public class PubSubDUnitTest {
   public void testConcurrentPubSub() throws Exception {
     int CLIENT_COUNT = 10;
     int ITERATIONS = 1000;
-
-    Jedis subscriber1 = new Jedis("localhost", ports[0]);
-    Jedis subscriber2 = new Jedis("localhost", ports[1]);
 
     CountDownLatch latch = new CountDownLatch(2);
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
@@ -118,11 +297,11 @@ public class PubSubDUnitTest {
 
     List<Future<Void>> futures = new LinkedList<>();
     for (int i = 0; i < CLIENT_COUNT; i++) {
-      Jedis client = new Jedis("localhost", ports[i % 2]);
+      Jedis publisher = new Jedis("localhost", ports[i % 2]);
 
       Callable<Void> callable = () -> {
         for (int j = 0; j < ITERATIONS; j++) {
-          client.publish(CHANNEL_NAME, "hello");
+          publisher.publish(CHANNEL_NAME, "hello");
         }
         return null;
       };
@@ -144,4 +323,84 @@ public class PubSubDUnitTest {
     assertThat(mockSubscriber2.getReceivedMessages().size()).isEqualTo(CLIENT_COUNT * ITERATIONS);
   }
 
+  @Test
+  public void testPubSubWithMoreSubscribersThanNettyWorkerThreads() throws Exception {
+    int CLIENT_COUNT = 1000;
+    String CHANNEL_NAME = "best_channel_ever";
+
+    List<Jedis> clients = new ArrayList<>();
+
+    // Build up an initial set of subscribers
+    for (int i = 0; i < CLIENT_COUNT; i++) {
+      Jedis client = new Jedis("localhost", ports[0]);
+      clients.add(client);
+
+      CountDownLatch latch = new CountDownLatch(1);
+      MockSubscriber mockSubscriber = new MockSubscriber(latch);
+      executor.submit(() -> client.subscribe(mockSubscriber, CHANNEL_NAME));
+      latch.await();
+
+      clients.add(client);
+    }
+
+    Jedis publishingClient = new Jedis("localhost", ports[0]);
+    long result = 0;
+
+    for (int i = 0; i < 10; i++) {
+      result += publishingClient.publish(CHANNEL_NAME, "this is amazing");
+    }
+
+    assertThat(result).isEqualTo(CLIENT_COUNT * 10);
+
+    clients.forEach(Jedis::close);
+  }
+
+  @Test
+  public void testPubSubWithManyClientsDisconnecting() throws Exception {
+    int CLIENT_COUNT = 10;
+    int ITERATIONS = 400;
+
+    Random random = new Random();
+    List<Jedis> clients = new ArrayList<>();
+
+    // Build up an initial set of subscribers
+    for (int i = 0; i < CLIENT_COUNT; i++) {
+      Jedis client = new Jedis("localhost", ports[0]);
+      clients.add(client);
+
+      CountDownLatch latch = new CountDownLatch(1);
+      MockSubscriber mockSubscriber = new MockSubscriber(latch);
+      executor.submit(() -> client.subscribe(mockSubscriber, CHANNEL_NAME));
+      latch.await();
+    }
+
+    // Start actively publishing in the background
+    Jedis publishingClient = new Jedis("localhost", ports[0]);
+    Callable<Void> callable = () -> {
+      for (int j = 0; j < ITERATIONS; j++) {
+        publishingClient.publish(CHANNEL_NAME, "hello - " + j);
+      }
+      return null;
+    };
+
+    Future<Void> future = executor.submit(callable);
+
+    // Abnormally close and recreate new subscribers without unsubscribing
+    for (int i = 0; i < ITERATIONS; i++) {
+      int candy = random.nextInt(CLIENT_COUNT);
+      clients.get(candy).close();
+
+      Jedis client = new Jedis("localhost", ports[0]);
+      CountDownLatch latch = new CountDownLatch(1);
+      MockSubscriber mockSubscriber = new MockSubscriber(latch);
+      executor.submit(() -> client.subscribe(mockSubscriber, CHANNEL_NAME));
+      latch.await();
+
+      clients.set(candy, client);
+    }
+
+    GeodeAwaitility.await().untilAsserted(() -> future.get());
+
+    clients.forEach(Jedis::close);
+  }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Callable;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import redis.clients.jedis.Jedis;
@@ -38,6 +39,7 @@ import org.apache.geode.redis.mocks.MockBinarySubscriber;
 import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.junit.categories.RedisTest;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
 @Category({RedisTest.class})
 public class PubSubIntegrationTest {
@@ -47,6 +49,9 @@ public class PubSubIntegrationTest {
   private static GeodeRedisServer server;
   private static GemFireCache cache;
   private static int port = 6379;
+
+  @ClassRule
+  public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
   @BeforeClass
   public static void setUp() {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/DummySubscription.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/DummySubscription.java
@@ -26,9 +26,8 @@ public class DummySubscription implements Subscription {
   }
 
   @Override
-  public PublishResult publishMessage(String channel, byte[] message) {
-    return null;
-  }
+  public void publishMessage(String channel, byte[] message,
+      PublishResultCollector publishResultCollector) {}
 
   @Override
   public boolean matchesClient(Client client) {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriberWithLatch.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriberWithLatch.java
@@ -14,26 +14,20 @@
  *
  */
 
-package org.apache.geode.redis;
+package org.apache.geode.redis.mocks;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import org.apache.logging.log4j.Logger;
-import redis.clients.jedis.Client;
 import redis.clients.jedis.JedisPubSub;
 
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
-public class MockSubscriber extends JedisPubSub {
+public class MockSubscriberWithLatch extends JedisPubSub {
   private CountDownLatch latch;
   private List<String> receivedMessages = new ArrayList<String>();
-  private Client client;
 
-  private static final Logger logger = LogService.getLogger();
-
-  public MockSubscriber(CountDownLatch latch) {
+  public MockSubscriberWithLatch(CountDownLatch latch) {
     this.latch = latch;
   }
 
@@ -43,20 +37,11 @@ public class MockSubscriber extends JedisPubSub {
 
   @Override
   public void onSubscribe(String channel, int subscribedChannels) {
-    // logger.info("--->>> Received subscription for " + client.getSocket());
     latch.countDown();
   }
 
   @Override
   public void onMessage(String channel, String message) {
     receivedMessages.add(message);
-  }
-
-  @Override
-  public void proceed(Client client, String... channels) {
-    this.client = client;
-    // logger.info("--->>> Before for " + client.getSocket());
-    super.proceed(client, channels);
-    // logger.info("--->>> After for " + client.getSocket());
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/AbstractSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/AbstractSubscription.java
@@ -16,11 +16,8 @@
 
 package org.apache.geode.redis.internal;
 
-import java.nio.channels.ClosedChannelException;
-import java.util.concurrent.ExecutionException;
-
 import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -42,13 +39,10 @@ public abstract class AbstractSubscription implements Subscription {
   }
 
   @Override
-  public PublishResult publishMessage(String channel, byte[] message) {
+  public void publishMessage(String channel, byte[] message,
+      PublishResultCollector publishResultCollector) {
     ByteBuf messageByteBuffer = constructResponse(channel, message);
-    if (messageByteBuffer == null) {
-      return new PublishResult(client, false);
-    }
-
-    return new PublishResult(client, writeToChannelSynchronously(messageByteBuffer));
+    writeToChannel(messageByteBuffer, publishResultCollector);
   }
 
   Client getClient() {
@@ -77,23 +71,14 @@ public abstract class AbstractSubscription implements Subscription {
    * to the client, resulted in an error - for example if the client has disconnected and the write
    * fails. In such cases we need to be able to notify the caller.
    */
-  private boolean writeToChannelSynchronously(ByteBuf messageByteBuffer) {
-    ChannelFuture channelFuture = context.writeToChannel(messageByteBuffer);
-
-    try {
-      channelFuture.get();
-    } catch (ExecutionException e) {
-      if (e.getCause() instanceof ClosedChannelException) {
-        logger.warn("Unable to write to channel: {}", e.getMessage());
-      } else {
-        logger.warn("Unable to write to channel", e);
-      }
-      return false;
-    } catch (InterruptedException e) {
-      logger.warn("Unable to write to channel", e);
-      return false;
-    }
-
-    return channelFuture.cause() == null;
+  private void writeToChannel(ByteBuf messageByteBuffer, PublishResultCollector resultCollector) {
+    context.writeToChannel(messageByteBuffer)
+        .addListener((ChannelFutureListener) future -> {
+          if (future.cause() == null) {
+            resultCollector.success();
+          } else {
+            resultCollector.failure(client);
+          }
+        });
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Client.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Client.java
@@ -46,4 +46,8 @@ public class Client {
   public boolean isDead() {
     return !this.channel.isOpen();
   }
+
+  public String toString() {
+    return channel.toString();
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
@@ -147,9 +147,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       }
       executeCommand(ctx, command);
     } catch (Exception e) {
-      logger.error(
-          "Execution of  Redis command " + command + " failed",
-          e);
+      logger.warn("Execution of Redis command {} failed: {}", command, e);
       throw e;
     }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PubSubImpl.java
@@ -101,6 +101,12 @@ public class PubSubImpl implements PubSub {
         context.getResultSender().lastResult(subscriberCount);
       }
 
+      /**
+       * Since the publish process uses an onMembers function call, we don't want to re-publish
+       * to members if one fails.
+       * TODO: Revisit this in the event that we instead use an onMember call against individual
+       * members.
+       */
       @Override
       public boolean isHA() {
         return false;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PubSubImpl.java
@@ -17,8 +17,6 @@
 package org.apache.geode.redis.internal;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.execute.Function;
@@ -109,23 +107,21 @@ public class PubSubImpl implements PubSub {
   @VisibleForTesting
   long publishMessageToSubscribers(String channel, byte[] message) {
 
-    Map<Boolean, List<PublishResult>> results = subscriptions
-        .findSubscriptions(channel)
-        .stream()
-        .map(subscription -> subscription.publishMessage(channel, message))
-        .collect(Collectors.partitioningBy(PublishResult::isSuccessful));
+    List<Subscription> foundSubscriptions = subscriptions
+        .findSubscriptions(channel);
+    if (foundSubscriptions.isEmpty()) {
+      return 0;
+    }
 
-    prune(results.get(false));
+    PublishResultCollector publishResultCollector =
+        new PublishResultCollector(foundSubscriptions.size(), subscriptions);
 
-    return results.get(true).size();
+    foundSubscriptions.forEach(
+        subscription -> {
+          subscription.publishMessage(channel, message, publishResultCollector);
+        });
+
+    return publishResultCollector.getSuccessCount();
   }
 
-  private void prune(List<PublishResult> failedSubscriptions) {
-    failedSubscriptions.forEach(publishResult -> {
-      Client client = publishResult.getClient();
-      if (client.isDead()) {
-        subscriptions.remove(client);
-      }
-    });
-  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResultCollector.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResultCollector.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public class PublishResultCollector {
+  private final CountDownLatch countDownLatch;
+  private Subscriptions subscriptions;
+  private final AtomicLong successCount = new AtomicLong();
+
+  public PublishResultCollector(int resultsExpected, Subscriptions subscriptions) {
+    countDownLatch = new CountDownLatch(resultsExpected);
+    this.subscriptions = subscriptions;
+  }
+
+  public void success() {
+    successCount.incrementAndGet();
+    countDownLatch.countDown();
+  }
+
+  public void failure(Client result) {
+    pruneFailure(result);
+    countDownLatch.countDown();
+  }
+
+  public long getSuccessCount() {
+    waitForResults();
+    return successCount.get();
+  }
+
+  private void pruneFailure(Client c) {
+    if (c.isDead()) {
+      subscriptions.remove(c);
+    }
+  }
+
+  private void waitForResults() {
+    try {
+      countDownLatch.await();
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResultCollector.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/PublishResultCollector.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class PublishResultCollector {
   private final CountDownLatch countDownLatch;
-  private Subscriptions subscriptions;
+  private final Subscriptions subscriptions;
   private final AtomicLong successCount = new AtomicLong();
 
   public PublishResultCollector(int resultsExpected, Subscriptions subscriptions) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Subscription.java
@@ -32,7 +32,8 @@ public interface Subscription {
   /**
    * Will publish a message to the designated channel.
    */
-  PublishResult publishMessage(String channel, byte[] message);
+  void publishMessage(String channel, byte[] message,
+      PublishResultCollector publishResultCollector);
 
   /**
    * Verifies that the subscription is established with the designated client.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.logging.log4j.Logger;
@@ -32,7 +33,14 @@ public class UnsubscribeExecutor extends AbstractExecutor {
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
-    byte[] channelName = command.getProcessedCommand().get(1);
+    List<byte[]> commandElems = command.getProcessedCommand();
+    if (commandElems.size() < 2) {
+      command.setResponse(
+          Coder.getErrorResponse(context.getByteBufAllocator(), "not enough arguments"));
+      return;
+    }
+
+    byte[] channelName = commandElems.get(1);
     long subscriptionCount =
         context.getPubSub().unsubscribe(new String(channelName), context.getClient());
 

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/PubSubImplJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/PubSubImplJUnitTest.java
@@ -58,6 +58,7 @@ public class PubSubImplJUnitTest {
     assertThat(subscriptions.findSubscriptions(deadClient)).isEmpty();
   }
 
+  @SuppressWarnings("unchecked")
   static class FailingChannelFuture extends DefaultChannelPromise {
     private GenericFutureListener listener;
 


### PR DESCRIPTION
- Now delegate PUBLISH responses to a background executor in order to
  free up the Netty worker thread. This prevents possible deadlocks.

Co-authored-by: Murtuza Boxwala <mboxwala@vmware.com>
Co-authored-by: Ray Ingles <ringles@vmware.com>
Co-authored-by: Jens Deppe <jdeppe@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
