### PR TITLE
GEODE-7864: Replace uses of hardcoded "/" with Region.SEPARATOR

### DIFF
--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCacheJUnitTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/ClientServerSessionCacheJUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.modules.session.catalina;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
@@ -272,7 +273,7 @@ public class ClientServerSessionCacheJUnitTest extends AbstractSessionCacheJUnit
 
     Set<String> sessionIds = new HashSet<>();
 
-    when(sessionRegion.getFullPath()).thenReturn("/" + sessionRegionName);
+    when(sessionRegion.getFullPath()).thenReturn(SEPARATOR + sessionRegionName);
     when(sessionManager.getRegionAttributesId()).thenReturn(RegionShortcut.REPLICATE.toString());
 
     sessionCache.touchSessions(sessionIds);
@@ -289,7 +290,7 @@ public class ClientServerSessionCacheJUnitTest extends AbstractSessionCacheJUnit
     FunctionException exception = new FunctionException();
     ResultCollector exceptionCollector = mock(ResultCollector.class);
 
-    when(sessionRegion.getFullPath()).thenReturn("/" + sessionRegionName);
+    when(sessionRegion.getFullPath()).thenReturn(SEPARATOR + sessionRegionName);
     when(sessionManager.getRegionAttributesId()).thenReturn(RegionShortcut.REPLICATE.toString());
     when(emptyExecution.execute(TouchReplicatedRegionEntriesFunction.ID))
         .thenReturn(exceptionCollector);

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.modules.session.catalina;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.BufferedInputStream;
@@ -682,10 +684,10 @@ public abstract class DeltaSessionManager extends ManagerBase
     }
 
     String regionName;
-    if (getRegionName().startsWith("/")) {
+    if (getRegionName().startsWith(SEPARATOR)) {
       regionName = getRegionName();
     } else {
-      regionName = "/" + getRegionName();
+      regionName = SEPARATOR + getRegionName();
     }
 
     Query query = querySvc.newQuery("select s.id from " + regionName

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListRegionManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListRegionManagementDunitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.rest;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.lang.Identifiable.find;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,7 +76,7 @@ public class ListRegionManagementDunitTest {
     regionConfig.setGroup("group1");
     regionConfig.setType(RegionType.PARTITION);
     client.create(regionConfig);
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REGION_IN_SINGLE_GROUP, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REGION_IN_SINGLE_GROUP, 1);
 
     // create a region that has different type on different group
     regionConfig = new Region();
@@ -89,13 +90,14 @@ public class ListRegionManagementDunitTest {
     regionConfig.setGroup("group2");
     regionConfig.setType(RegionType.PARTITION);
     client.create(regionConfig);
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REGION_WITH_MULTIPLE_TYPES, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REGION_WITH_MULTIPLE_TYPES,
+        2);
 
     regionConfig = new Region();
     regionConfig.setName(REGION_IN_CLUSTER);
     regionConfig.setType(RegionType.PARTITION);
     client.create(regionConfig);
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REGION_IN_CLUSTER, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REGION_IN_CLUSTER, 2);
 
     // create a region that belongs to multiple groups
     regionConfig = new Region();
@@ -105,7 +107,8 @@ public class ListRegionManagementDunitTest {
     client.create(regionConfig);
     regionConfig.setGroup("group2");
     client.create(regionConfig);
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REGION_IN_MULTIPLE_GROUPS, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REGION_IN_MULTIPLE_GROUPS,
+        2);
   }
 
   @Before
@@ -171,7 +174,7 @@ public class ListRegionManagementDunitTest {
   public void testEntryCount() {
     server1.invoke(() -> {
       org.apache.geode.cache.Region<String, String> region =
-          ClusterStartupRule.getCache().getRegion("/" + REGION_IN_CLUSTER);
+          ClusterStartupRule.getCache().getRegion(SEPARATOR + REGION_IN_CLUSTER);
       region.put("k1", "v1");
       region.put("k2", "v2");
     });
@@ -179,8 +182,9 @@ public class ListRegionManagementDunitTest {
     // wait till entry size are correctly gathered by the mbean
     locator.invoke(() -> {
       await().untilAsserted(
-          () -> assertThat(ClusterStartupRule.memberStarter.getRegionMBean("/" + REGION_IN_CLUSTER)
-              .getSystemRegionEntryCount()).isEqualTo(2));
+          () -> assertThat(
+              ClusterStartupRule.memberStarter.getRegionMBean(SEPARATOR + REGION_IN_CLUSTER)
+                  .getSystemRegionEntryCount()).isEqualTo(2));
     });
 
     filter.setName(REGION_IN_CLUSTER);

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.DescribeMappingCommand.DESCRIBE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.MappingConstants.DATA_SOURCE_NAME;
@@ -248,7 +249,7 @@ public class CreateMappingCommandDUnitTest {
   }
 
   private static String convertRegionPathToName(String regionPath) {
-    if (regionPath.startsWith("/")) {
+    if (regionPath.startsWith(SEPARATOR)) {
       return regionPath.substring(1);
     }
     return regionPath;
@@ -401,7 +402,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingReplicatedUpdatesServiceAndClusterConfigForMultiServerGroup() {
-    String regionName = "/" + GROUP1_GROUP2_REGION;
+    String regionName = SEPARATOR + GROUP1_GROUP2_REGION;
     setupGroupReplicate(regionName, TEST_GROUP1 + "," + TEST_GROUP2);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -437,7 +438,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingPartitionedUpdatesServiceAndClusterConfigForMultiServerGroup() {
-    String regionName = "/" + GROUP1_GROUP2_REGION;
+    String regionName = SEPARATOR + GROUP1_GROUP2_REGION;
     setupGroupPartition(regionName, TEST_GROUP1 + "," + TEST_GROUP2);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -759,7 +760,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingUpdatesServiceAndClusterConfig() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupReplicate(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -786,7 +787,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingWithDomainClassUpdatesServiceAndClusterConfig() {
-    String regionName = "/" + EMPLOYEE_REGION;
+    String regionName = SEPARATOR + EMPLOYEE_REGION;
     setupReplicate(regionName);
     server1.invoke(() -> {
       ClusterStartupRule.getCache().registerPdxMetaData(new Employee());
@@ -952,7 +953,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createSynchronousMappingUpdatesServiceAndClusterConfig() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupReplicate(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -980,7 +981,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingWithPartitionUpdatesServiceAndClusterConfig() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupPartition(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -1015,7 +1016,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingWithNoTable() {
-    String regionName = "/" + "myTable";
+    String regionName = SEPARATOR + "myTable";
     setupReplicate(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -1048,7 +1049,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createExistingRegionMappingFails() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupReplicate(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -1086,7 +1087,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingWithoutPdxNameFails() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupReplicate(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -1100,7 +1101,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingWithNonExistentRegionFails() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupReplicate(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, "bogusRegion");
@@ -1113,7 +1114,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingWithRegionThatHasALoaderFails() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupReplicate(regionName, true);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);
     csb.addOption(REGION_NAME, regionName);
@@ -1127,7 +1128,7 @@ public class CreateMappingCommandDUnitTest {
 
   @Test
   public void createMappingWithExistingQueueFails() {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     setupReplicate(regionName);
     setupAsyncEventQueue(regionName);
     CommandStringBuilder csb = new CommandStringBuilder(CREATE_MAPPING);

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandForProxyRegionDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandForProxyRegionDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.DescribeMappingCommand.DESCRIBE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.DestroyMappingCommand.DESTROY_MAPPING;
@@ -203,7 +204,7 @@ public class CreateMappingCommandForProxyRegionDUnitTest {
   }
 
   private static String convertRegionPathToName(String regionPath) {
-    if (regionPath.startsWith("/")) {
+    if (regionPath.startsWith(SEPARATOR)) {
       return regionPath.substring(1);
     }
     return regionPath;
@@ -253,7 +254,7 @@ public class CreateMappingCommandForProxyRegionDUnitTest {
   @Test
   @Parameters(method = "parametersToTestPRDR")
   public void createMappingTogetherForMultiServerGroupWithEmptyRegion(boolean isPR) {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     if (isPR) {
       setupGroupPartition(regionName, TEST_GROUP1, false);
       setupGroupPartition(regionName, TEST_GROUP2, true);
@@ -322,7 +323,7 @@ public class CreateMappingCommandForProxyRegionDUnitTest {
   @Test
   @Parameters(method = "parametersToTestPRDR")
   public void createMappingSeparatelyForMultiServerGroupWithEmptyRegion(boolean isPR) {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     if (isPR) {
       setupGroupPartition(regionName, TEST_GROUP1, false);
       setupGroupPartition(regionName, TEST_GROUP2, true);
@@ -419,7 +420,7 @@ public class CreateMappingCommandForProxyRegionDUnitTest {
   @Test
   @Parameters(method = "parametersToTestPRDR")
   public void createEmptyRegionAfterCreateMapping(boolean isPR) {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     if (isPR) {
       setupGroupPartition(regionName, TEST_GROUP1, false);
     } else {

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommandDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.DescribeMappingCommand.DESCRIBE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.MappingConstants.DATA_SOURCE_NAME;
@@ -68,7 +69,7 @@ public class DescribeMappingCommandDUnitTest implements Serializable {
   private MemberVM server2;
 
   private static String convertRegionPathToName(String regionPath) {
-    if (regionPath.startsWith("/")) {
+    if (regionPath.startsWith(SEPARATOR)) {
       return regionPath.substring(1);
     }
     return regionPath;
@@ -185,7 +186,7 @@ public class DescribeMappingCommandDUnitTest implements Serializable {
   @SuppressWarnings("deprecation")
   @Test
   public void describesExistingSynchronousMapping() throws Exception {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     locator = startupRule.startLocatorVM(0);
     server = startupRule.startServerVM(1, locator.getPort());
 
@@ -266,7 +267,7 @@ public class DescribeMappingCommandDUnitTest implements Serializable {
   @SuppressWarnings("deprecation")
   @Test
   public void describesExistingAsyncMapping() throws Exception {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     locator = startupRule.startLocatorVM(0);
     server = startupRule.startServerVM(1, locator.getPort());
 
@@ -353,7 +354,7 @@ public class DescribeMappingCommandDUnitTest implements Serializable {
   @Test
   public void describesExistingAsyncMappingsWithSameRegionOnDifferentGroups()
       throws Exception {
-    String regionName = "/" + TEST_REGION;
+    String regionName = SEPARATOR + TEST_REGION;
     String groupName1 = "group1";
     String groupName2 = "group2";
     locator = startupRule.startLocatorVM(0);

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandDunitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandDunitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.connectors.jdbc.internal.cli.CreateMappingCommand.CREATE_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.DestroyMappingCommand.DESTROY_MAPPING;
 import static org.apache.geode.connectors.jdbc.internal.cli.MappingConstants.DATA_SOURCE_NAME;
@@ -257,7 +258,7 @@ public class DestroyMappingCommandDunitTest implements Serializable {
   public void destroysAsyncMappingWithRegionPath() {
     setupAsyncMapping();
     CommandStringBuilder csb = new CommandStringBuilder(DESTROY_MAPPING);
-    csb.addOption(REGION_NAME, "/" + TEST_REGION);
+    csb.addOption(REGION_NAME, SEPARATOR + TEST_REGION);
 
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
 
@@ -376,7 +377,7 @@ public class DestroyMappingCommandDunitTest implements Serializable {
   public void destroysSynchronousMappingWithRegionPath() throws Exception {
     setupSynchronousMapping();
     CommandStringBuilder csb = new CommandStringBuilder(DESTROY_MAPPING);
-    csb.addOption(REGION_NAME, "/" + TEST_REGION);
+    csb.addOption(REGION_NAME, SEPARATOR + TEST_REGION);
 
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess();
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -15,6 +15,8 @@
 package org.apache.geode.connectors.jdbc.internal.cli;
 
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -131,7 +133,7 @@ public class CreateMappingCommand extends SingleGfshCommand {
           optionContext = ConverterHint.MEMBERGROUP,
           help = CREATE_MAPPING__GROUPS_NAME__HELP) String[] groups)
       throws IOException {
-    if (regionName.startsWith("/")) {
+    if (regionName.startsWith(SEPARATOR)) {
       regionName = regionName.substring(1);
     }
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DescribeMappingCommand.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.connectors.jdbc.internal.cli.MappingConstants.CATALOG_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.MappingConstants.DATA_SOURCE_NAME;
 import static org.apache.geode.connectors.jdbc.internal.cli.MappingConstants.ID_NAME;
@@ -71,7 +72,7 @@ public class DescribeMappingCommand extends GfshCommand {
       @CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS},
           optionContext = ConverterHint.MEMBERGROUP,
           help = DESCRIBE_MAPPING__GROUPS_NAME__HELP) String[] groups) {
-    if (regionName.startsWith("/")) {
+    if (regionName.startsWith(SEPARATOR)) {
       regionName = regionName.substring(1);
     }
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommand.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.connectors.jdbc.internal.cli.MappingConstants.REGION_NAME;
 
 import java.util.ArrayList;
@@ -67,7 +68,7 @@ public class DestroyMappingCommand extends SingleGfshCommand {
       @CliOption(key = {CliStrings.GROUP, CliStrings.GROUPS},
           optionContext = ConverterHint.MEMBERGROUP,
           help = DESTROY_MAPPING__GROUPS_NAME__HELP) String[] groups) {
-    if (regionName.startsWith("/")) {
+    if (regionName.startsWith(SEPARATOR)) {
       regionName = regionName.substring(1);
     }
 

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtils.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtils.java
@@ -15,6 +15,9 @@
 
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.cache.Region.SEPARATOR_CHAR;
+
 import java.util.ArrayList;
 
 import org.apache.geode.cache.configuration.CacheConfig;
@@ -98,10 +101,10 @@ public class MappingCommandUtils {
   }
 
   public static String createAsyncEventQueueName(String regionPath) {
-    if (regionPath.startsWith("/")) {
+    if (regionPath.startsWith(SEPARATOR)) {
       regionPath = regionPath.substring(1);
     }
-    return "JDBC#" + regionPath.replace('/', '_');
+    return "JDBC#" + regionPath.replace(SEPARATOR_CHAR, '_');
   }
 
 }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -331,8 +332,9 @@ public class CreateMappingCommandTest {
     setupRequiredPreconditions();
     results.add(successFunctionResult);
 
-    ResultModel result = createRegionMappingCommand.createMapping("/" + regionName, dataSourceName,
-        tableName, pdxClass, pdxClassFile, false, null, null, null, false, null);
+    ResultModel result =
+        createRegionMappingCommand.createMapping(SEPARATOR + regionName, dataSourceName,
+            tableName, pdxClass, pdxClassFile, false, null, null, null, false, null);
 
     assertThat(result.getStatus()).isSameAs(Result.Status.OK);
     Object[] results = (Object[]) result.getConfigObject();

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/DestroyMappingCommandTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.connectors.jdbc.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -151,7 +152,7 @@ public class DestroyMappingCommandTest {
     when(cacheConfig.getRegions()).thenReturn(list);
     results.add(successFunctionResult);
 
-    ResultModel result = destroyRegionMappingCommand.destroyMapping("/" + regionName, null);
+    ResultModel result = destroyRegionMappingCommand.destroyMapping(SEPARATOR + regionName, null);
 
     verify(destroyRegionMappingCommand, times(1)).executeAndGetFunctionResult(any(), eq(regionName),
         any());

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/CompiledInDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/CompiledInDUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -54,7 +56,7 @@ public class CompiledInDUnitTest extends JUnit4CacheTestCase {
 
   final String rootRegionName = "root";
   final String regionName = "PdxTest";
-  final String regName = "/" + rootRegionName + "/" + regionName;
+  final String regName = SEPARATOR + rootRegionName + SEPARATOR + regionName;
   private Host host;
   private VM vm0;
   private VM vm1;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/CorruptedIndexIntegrationTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/CorruptedIndexIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -54,9 +55,9 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
         cache.createRegionFactory().setDataPolicy(DataPolicy.PARTITION).create(regionName);
 
     QueryService queryService = cache.getQueryService();
-    Index idIndex = queryService.createIndex("idIndex", "ID", "/" + regionName);
+    Index idIndex = queryService.createIndex("idIndex", "ID", SEPARATOR + regionName);
     Index exceptionIndex =
-        queryService.createIndex("exceptionIndex", "throwExceptionMethod", "/" + regionName);
+        queryService.createIndex("exceptionIndex", "throwExceptionMethod", SEPARATOR + regionName);
 
     IntStream.rangeClosed(1, 3).forEach(i -> region.put(i, new Portfolio(i)));
 
@@ -84,9 +85,9 @@ public class CorruptedIndexIntegrationTest extends JUnit4CacheTestCase {
 
     IntStream.rangeClosed(1, 3).forEach(i -> region.put(i, new Portfolio(i)));
 
-    Index idIndex = queryService.createIndex("idIndex", "ID", "/" + regionName);
+    Index idIndex = queryService.createIndex("idIndex", "ID", SEPARATOR + regionName);
     try {
-      queryService.createIndex("exceptionIndex", "throwExceptionMethod", "/" + regionName);
+      queryService.createIndex("exceptionIndex", "throwExceptionMethod", SEPARATOR + regionName);
       fail();
     } catch (Exception exception) {
       System.out.println("Exception expected!");

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PDXQueryTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PDXQueryTestBase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.dunit.Assert.assertFalse;
 import static org.apache.geode.test.dunit.Assert.fail;
 
@@ -63,8 +64,8 @@ public abstract class PDXQueryTestBase extends JUnit4CacheTestCase {
   protected final String rootRegionName = "root";
   protected final String regionName = "PdxTest";
   protected final String regionName2 = "PdxTest2";
-  protected final String regName = "/" + rootRegionName + "/" + regionName;
-  protected final String regName2 = "/" + rootRegionName + "/" + regionName2;
+  protected final String regName = SEPARATOR + rootRegionName + SEPARATOR + regionName;
+  protected final String regName2 = SEPARATOR + rootRegionName + SEPARATOR + regionName2;
   protected final String[] queryString = new String[] {"SELECT DISTINCT id FROM " + regName, // 0
       "SELECT * FROM " + regName, // 1
       "SELECT ticker FROM " + regName, // 2

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertTrue;
 import static org.apache.geode.test.dunit.Assert.fail;
@@ -61,7 +62,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
     final VM server2 = host.getVM(1);
 
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
 
     final String[] queries = {"select * from " + name + " where status = 'inactive'",
         "select p from " + name + " p where p.status = 'inactive'",
@@ -125,7 +126,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
     final VM server2 = host.getVM(1);
 
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
 
     final String[] queries = {"select * from " + name + " where position1 = $1",
         "select * from " + name + " where aDay = $1",
@@ -238,8 +239,8 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
     final VM client = host.getVM(2);
 
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
-    final String name2 = "/" + regionName2;
+    final String name = SEPARATOR + regionName;
+    final String name2 = SEPARATOR + regionName2;
     final String[] queries = {"select * from " + name + " where position1 = $1",
         "select * from " + name + " where aDay = $1",
         "select distinct * from " + name + " p where p.status = 'inactive'", // numberOfEntries
@@ -593,7 +594,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
     final VM client = host.getVM(2);
 
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String[] queries = {"select * from " + name + " where position1 = $1",
         "select * from " + name + " where aDay = $1",
         "select distinct * from " + name + " p where p.status = 'inactive'", // numberOfEntries

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryVersionedClassDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryVersionedClassDUnitTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -56,7 +58,7 @@ public class PdxLocalQueryVersionedClassDUnitTest extends PDXQueryTestBase {
     final VM client = host.getVM(1);
 
     final int numberOfEntries = 1000;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
 
     final String query =
         "select distinct * from " + name + " where id > $1 and id < $2 and status = 'active'";

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.Assert.fail;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -2607,7 +2608,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         }
         // Create Index on empty region
         try {
-          cache.getQueryService().createIndex("myFuncIndex", "intId", "/" + name);
+          cache.getQueryService().createIndex("myFuncIndex", "intId", SEPARATOR + name);
         } catch (Exception e) {
           Assert.fail("index creation failed", e);
         }
@@ -2709,7 +2710,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String[] qs = {"select * from " + name + " where pdxStatus = 'active'",
         "select pdxStatus from " + name + " where id > 4"};
 
@@ -2815,7 +2816,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String[] qs = {"select * from " + name + " where status = 'active'",
         "select status from " + name + " where id >= 5"};
 
@@ -2961,7 +2962,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String[] qs = {"select pdxStatus from " + name + " where pdxStatus = 'active'",
         "select pdxStatus from " + name + " where id > 8 and id < 14"};
 
@@ -3198,7 +3199,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
     final VM vm2 = host.getVM(2);
     final VM vm3 = host.getVM(3);
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String[] qs = {"select pdxStatus from " + name + " where pdxStatus = 'active'",
         "select status from " + name + " where id > 8 and id < 14"};
 
@@ -3334,7 +3335,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
     final VM vm0 = host.getVM(0);
     final VM vm3 = host.getVM(3);
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String[] qs = {"select * from " + name + " where pdxStatus = 'active'",
         "select pdxStatus from " + name + " where id > 4"};
 
@@ -3423,7 +3424,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
     final VM vm0 = host.getVM(0);
     final VM vm1 = host.getVM(1);
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String query =
         "select stringField, booleanField, charField, shortField, intField, longField, floatField, doubleField from "
             + name;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxStringQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxStringQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -78,7 +79,7 @@ import org.apache.geode.test.junit.categories.OQLQueryTest;
 public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
   final String rootRegionName = "root";
   final String regionName = "PdxTest";
-  final String regName = "/" + rootRegionName + "/" + regionName;
+  final String regName = SEPARATOR + rootRegionName + SEPARATOR + regionName;
   private static int bridgeServerPort;
 
   private static final int orderByQueryIndex = 11;
@@ -2000,7 +2001,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
     final VM vm0 = host.getVM(0);
     final VM vm1 = host.getVM(1);
     final VM vm2 = host.getVM(2);
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
     final String[] qs =
         {"select distinct pkid from " + name, "select distinct pkid, status from " + name};
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PersistentRegionCompactRangeIndexDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PersistentRegionCompactRangeIndexDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
@@ -501,14 +502,14 @@ public class PersistentRegionCompactRangeIndexDUnitTest implements Serializable 
   }
 
   private void populateRegion(String regionName, Map<String, Portfolio> entries) {
-    Region r = ClusterStartupRule.getCache().getRegion("/" + regionName);
+    Region r = ClusterStartupRule.getCache().getRegion(SEPARATOR + regionName);
     entries.entrySet().forEach(e -> {
       r.put(e.getKey(), e.getValue());
     });
   }
 
   private void destroyFromRegion(String regionName, Collection keys) {
-    Region r = ClusterStartupRule.getCache().getRegion("/" + regionName);
+    Region r = ClusterStartupRule.getCache().getRegion(SEPARATOR + regionName);
     keys.forEach(i -> r.remove(i));
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryDataInconsistencyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryDataInconsistencyDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.fail;
@@ -99,7 +100,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
 
       QueryService queryService = cache.getQueryService();
       try {
-        Index index = queryService.createIndex("idIndex", "ID", "/" + repRegionName);
+        Index index = queryService.createIndex("idIndex", "ID", SEPARATOR + repRegionName);
         assertEquals(10, index.getStatistics().getNumberOfKeys());
       } catch (Exception e) {
         logger.error(e);
@@ -183,7 +184,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
       QueryService queryService = cache.getQueryService();
       try {
         Index index = queryService.createIndex("posIndex", "pos.secId",
-            "/" + repRegionName + " p, p.positions.values pos");
+            SEPARATOR + repRegionName + " p, p.positions.values pos");
         assertEquals(12, index.getStatistics().getNumberOfKeys());
       } catch (Exception e) {
         logger.error(e);
@@ -265,7 +266,8 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
       QueryService queryService = cache.getQueryService();
       try {
         Index index = queryService.createIndex("posIndex", "pos.secId",
-            "/" + repRegionName + " p, p.collectionHolderMap.values coll, p.positions.values pos");
+            SEPARATOR + repRegionName
+                + " p, p.collectionHolderMap.values coll, p.positions.values pos");
         assertEquals(12, index.getStatistics().getNumberOfKeys());
       } catch (Exception e) {
         logger.error(e);
@@ -344,7 +346,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
       QueryService queryService = cache.getQueryService();
       try {
         Index index = queryService.createIndex("posIndex", "pos.secId",
-            "/" + repRegionName + " p, p.positions.values pos");
+            SEPARATOR + repRegionName + " p, p.positions.values pos");
         assertEquals(12, index.getStatistics().getNumberOfKeys());
       } catch (Exception e) {
         logger.error(e);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -333,14 +334,15 @@ public class QueryIndexDUnitTest extends JUnit4CacheTestCase {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i1 = qs.createIndex(indexName, "pf.ID", "/" + regionNames[i] + " pf");
+                Index i1 = qs.createIndex(indexName, "pf.ID", SEPARATOR + regionNames[i] + " pf");
               }
               indexName = "keyIdIndex" + regionNames[i];
               if (qs.getIndex(region, indexName) == null) {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i2 = qs.createIndex(indexName, "key.ID", "/" + regionNames[i] + ".keys key");
+                Index i2 =
+                    qs.createIndex(indexName, "key.ID", SEPARATOR + regionNames[i] + ".keys key");
               }
             } catch (IndexNameConflictException ice) {
               // Ignore. The pr may have created the index through
@@ -502,21 +504,23 @@ public class QueryIndexDUnitTest extends JUnit4CacheTestCase {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i1 = qs.createIndex(indexName, "pf", "/" + regionNames[i] + " pf");
+                Index i1 = qs.createIndex(indexName, "pf", SEPARATOR + regionNames[i] + " pf");
               }
               indexName = "valueIndex" + regionNames[i];
               if (qs.getIndex(region, indexName) == null) {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i1 = qs.createIndex(indexName, "pf", "/" + regionNames[i] + ".values pf");
+                Index i1 =
+                    qs.createIndex(indexName, "pf", SEPARATOR + regionNames[i] + ".values pf");
               }
               indexName = "keyIdIndex" + regionNames[i];
               if (qs.getIndex(region, indexName) == null) {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i2 = qs.createIndex(indexName, "key.ID", "/" + regionNames[i] + ".keys key");
+                Index i2 =
+                    qs.createIndex(indexName, "key.ID", SEPARATOR + regionNames[i] + ".keys key");
               }
               indexName = "keyIdIndex2" + regionNames[i];
 
@@ -669,14 +673,15 @@ public class QueryIndexDUnitTest extends JUnit4CacheTestCase {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i1 = qs.createIndex(indexName, "pf.ID", "/" + regionNames[i] + " pf");
+                Index i1 = qs.createIndex(indexName, "pf.ID", SEPARATOR + regionNames[i] + " pf");
               }
               indexName = "keyIdIndex" + regionNames[i];
               if (qs.getIndex(region, indexName) == null) {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i2 = qs.createIndex(indexName, "key.ID", "/" + regionNames[i] + ".keys key");
+                Index i2 =
+                    qs.createIndex(indexName, "key.ID", SEPARATOR + regionNames[i] + ".keys key");
               }
             } catch (IndexNameConflictException ice) {
               // Ignore. The pr may have created the index through
@@ -831,21 +836,23 @@ public class QueryIndexDUnitTest extends JUnit4CacheTestCase {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i1 = qs.createIndex(indexName, "pf", "/" + regionNames[i] + " pf");
+                Index i1 = qs.createIndex(indexName, "pf", SEPARATOR + regionNames[i] + " pf");
               }
               indexName = "valueIndex" + regionNames[i];
               if (qs.getIndex(region, indexName) == null) {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i1 = qs.createIndex(indexName, "pf", "/" + regionNames[i] + ".values pf");
+                Index i1 =
+                    qs.createIndex(indexName, "pf", SEPARATOR + regionNames[i] + ".values pf");
               }
               indexName = "keyIdIndex" + regionNames[i];
               if (qs.getIndex(region, indexName) == null) {
                 cache.getLogger()
                     .fine("createIndexOnOverFlowRegions() Index doesn't exist, creating index: "
                         + indexName);
-                Index i2 = qs.createIndex(indexName, "key.ID", "/" + regionNames[i] + ".keys key");
+                Index i2 =
+                    qs.createIndex(indexName, "key.ID", SEPARATOR + regionNames[i] + ".keys key");
               }
             } catch (IndexNameConflictException ice) {
               // Ignore. The pr may have created the index through
@@ -1106,35 +1113,36 @@ public class QueryIndexDUnitTest extends JUnit4CacheTestCase {
           cache.getLogger().fine(
               "createIndexOnOverFlowRegions() Index doesn't exist, creating index: " + indexName);
           Index i1 = qs.createIndex(indexName, IndexType.FUNCTIONAL, "pf.ID",
-              "/" + regionNames[i] + " pf");
+              SEPARATOR + regionNames[i] + " pf");
         }
         indexName = "keyIdIndex" + regionNames[i];
         if (qs.getIndex(region, indexName) == null) {
           cache.getLogger().fine(
               "createIndexOnOverFlowRegions() Index doesn't exist, creating index: " + indexName);
           Index i2 = qs.createIndex(indexName, IndexType.FUNCTIONAL, "key.ID",
-              "/" + regionNames[i] + ".keys key");
+              SEPARATOR + regionNames[i] + ".keys key");
         }
         indexName = "entryIdIndex" + regionNames[i];
         if (qs.getIndex(region, indexName) == null) {
           cache.getLogger().fine(
               "createIndexOnOverFlowRegions() Index doesn't exist, creating index: " + indexName);
           Index i2 = qs.createIndex(indexName, IndexType.FUNCTIONAL, "entry.value.ID",
-              "/" + regionNames[i] + ".entries entry");
+              SEPARATOR + regionNames[i] + ".entries entry");
         }
         indexName = "entryMethodIndex" + regionNames[i];
         if (qs.getIndex(region, indexName) == null) {
           cache.getLogger().fine(
               "createIndexOnOverFlowRegions() Index doesn't exist, creating index: " + indexName);
           Index i2 = qs.createIndex(indexName, IndexType.FUNCTIONAL, "entry.getValue().getID()",
-              "/" + regionNames[i] + ".entries entry");
+              SEPARATOR + regionNames[i] + ".entries entry");
         }
         indexName = "entryMethodWithArgIndex" + regionNames[i];
         if (qs.getIndex(region, indexName) == null) {
           cache.getLogger().fine(
               "createIndexOnOverFlowRegions() Index doesn't exist, creating index: " + indexName);
           Index i2 = qs.createIndex(indexName, IndexType.FUNCTIONAL,
-              "entry.getValue().boolFunction('active')", "/" + regionNames[i] + ".entries entry");
+              "entry.getValue().boolFunction('active')",
+              SEPARATOR + regionNames[i] + ".entries entry");
         }
       } catch (IndexNameConflictException ice) {
         // Ignore. The pr may have created the index through

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingFunctionContextDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1025,9 +1026,9 @@ public class QueryUsingFunctionContextDUnitTest extends JUnit4CacheTestCase {
   public void createIndex() {
     QueryService qs = CacheFactory.getAnyInstance().getQueryService();
     try {
-      qs.createIndex("ID1", "ID", "/" + PartitionedRegionName1);
-      qs.createIndex("ID2", "ID", "/" + PartitionedRegionName2);
-      qs.createIndex("ID3", "ID", "/" + PartitionedRegionName3);
+      qs.createIndex("ID1", "ID", SEPARATOR + PartitionedRegionName1);
+      qs.createIndex("ID2", "ID", SEPARATOR + PartitionedRegionName2);
+      qs.createIndex("ID3", "ID", SEPARATOR + PartitionedRegionName3);
     } catch (Exception e) {
       fail("Index creation failed " + e);
     }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingPoolDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryUsingPoolDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -91,7 +92,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
   public final void postSetUp() throws Exception {
     this.rootRegionName = "root";
     this.regionName = this.getName();
-    this.regName = "/" + this.rootRegionName + "/" + this.regionName;
+    this.regName = SEPARATOR + this.rootRegionName + SEPARATOR + this.regionName;
 
     this.queryString =
         new String[] {"SELECT itr.value FROM " + this.regName + ".entries itr where itr.key = $1", // 0
@@ -177,7 +178,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
     final int port =
         vm0.invoke("GetCacheServerPort", () -> QueryUsingPoolDUnitTest.getCacheServerPort());
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
-    final String regionName = "/" + rootRegionName + "/" + name;
+    final String regionName = SEPARATOR + rootRegionName + SEPARATOR + name;
 
     // Create client pool.
     final String poolName = "testRemoteImportQueries";
@@ -297,7 +298,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
 
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
 
-    final String regionName = "/" + rootRegionName + "/" + name;
+    final String regionName = SEPARATOR + rootRegionName + SEPARATOR + name;
 
     // Create client pool.
     final String poolName = "testRemoteStructQueries";
@@ -445,7 +446,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
     final int port = vm0.invoke(() -> QueryUsingPoolDUnitTest.getCacheServerPort());
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
 
-    final String regionName = "/" + rootRegionName + "/" + name;
+    final String regionName = SEPARATOR + rootRegionName + SEPARATOR + name;
 
     // Create client pool.
     final String poolName = "testRemoteFullRegionQueries";
@@ -1228,8 +1229,8 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
     final int port =
         vm0.invoke("getCacheServerPort", () -> QueryUsingPoolDUnitTest.getCacheServerPort());
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
-    final String regionName1 = "/" + rootRegionName + "/" + name + "1";
-    final String regionName2 = "/" + rootRegionName + "/" + name + "2";
+    final String regionName1 = SEPARATOR + rootRegionName + SEPARATOR + name + "1";
+    final String regionName2 = SEPARATOR + rootRegionName + SEPARATOR + name + "2";
 
     // Create client pool.
     final String poolName = "testRemoteJoinRegionQueries";
@@ -1310,7 +1311,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
     final int port = vm0.invoke("getCacheServerPort", () -> getCacheServerPort());
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
 
-    final String regionName = "/" + rootRegionName + "/" + name;
+    final String regionName = SEPARATOR + rootRegionName + SEPARATOR + name;
 
     // Create client pool.
     final String poolName1 = "testRemoteBridgeClientQueries1";
@@ -1412,8 +1413,8 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
         vm0.invoke("getCachedServerPort", () -> QueryUsingPoolDUnitTest.getCacheServerPort());
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
 
-    final String regionName1 = "/" + rootRegionName + "/" + name;
-    final String regionName2 = "/" + rootRegionName + "/" + name + "_2";
+    final String regionName1 = SEPARATOR + rootRegionName + SEPARATOR + name;
+    final String regionName2 = SEPARATOR + rootRegionName + SEPARATOR + name + "_2";
 
     // Create client pool.
     final String poolName = "testBug36969";
@@ -1484,7 +1485,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
         vm0.invoke("getCacheServerPort", () -> QueryUsingPoolDUnitTest.getCacheServerPort());
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
 
-    final String regionName = "/" + rootRegionName + "/" + name;
+    final String regionName = SEPARATOR + rootRegionName + SEPARATOR + name;
 
     // Create client pool.
     final String poolName = "testRemoteFullRegionQueries";
@@ -1611,7 +1612,7 @@ public class QueryUsingPoolDUnitTest extends JUnit4CacheTestCase {
         vm0.invoke("getCacheServerPort", () -> QueryUsingPoolDUnitTest.getCacheServerPort());
     final String host0 = NetworkUtils.getServerHostName(vm0.getHost());
 
-    final String regionName1 = "/" + rootRegionName + "/" + name;
+    final String regionName1 = SEPARATOR + rootRegionName + SEPARATOR + name;
 
     // Create client pool.
     final String poolName = "testUnSupportedOps";

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache.query.dunit;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.cache.control.MemoryThresholds.MemoryState.EVICTION_DISABLED;
@@ -565,9 +566,9 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
           qs = getCache().getQueryService();
           Index index = null;
           if (indexType.equals("compact")) {
-            index = qs.createIndex("newIndex", "ID", "/" + "portfolios");
+            index = qs.createIndex("newIndex", "ID", SEPARATOR + "portfolios");
           } else if (indexType.equals("hash")) {
-            index = qs.createIndex("newIndex", "ID", "/" + "portfolios");
+            index = qs.createIndex("newIndex", "ID", SEPARATOR + "portfolios");
           }
           assertThat(index).isNotNull();
           assertThat(((CancelDuringGatherHook) DefaultQuery.testHook).triggeredOOME).isTrue();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/SelectStarQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/SelectStarQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertFalse;
 import static org.apache.geode.test.dunit.Assert.assertTrue;
@@ -955,7 +956,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
         QueryService qs = null;
         try {
           qs = getCache().getQueryService();
-          qs.createIndex("status", "status", "/" + regName);
+          qs.createIndex("status", "status", SEPARATOR + regName);
         } catch (Exception e) {
           fail("Exception getting query service ", e);
         }
@@ -1025,7 +1026,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
         QueryService qs = null;
         try {
           qs = getCache().getQueryService();
-          qs.createIndex("status", "status", "/" + regName2);
+          qs.createIndex("status", "status", SEPARATOR + regName2);
         } catch (Exception e) {
           fail("Exception getting query service ", e);
         }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -337,7 +338,7 @@ public class QueryConfigurationServiceConstraintsDistributedTest implements Seri
       // Index is valid.
       QueryService queryService = internalCache.getQueryService();
       queryService.createIndex(NAME_INDEX_IDENTIFIER, "e." + QueryObject.GET_NAME_METHOD,
-          "/" + regionName + " e");
+          SEPARATOR + regionName + " e");
       Index index =
           queryService.getIndex(internalCache.getRegion(regionName), NAME_INDEX_IDENTIFIER);
       assertThat(index.isValid()).isTrue();
@@ -391,7 +392,7 @@ public class QueryConfigurationServiceConstraintsDistributedTest implements Seri
       // Index is valid.
       QueryService queryService = internalCache.getQueryService();
       queryService.createIndex(NAME_INDEX_IDENTIFIER, "e." + QueryObject.GET_NAME_METHOD,
-          "/" + regionName + " e");
+          SEPARATOR + regionName + " e");
       Index index =
           queryService.getIndex(internalCache.getRegion(regionName), NAME_INDEX_IDENTIFIER);
       assertThat(index.isValid()).isTrue();
@@ -440,7 +441,7 @@ public class QueryConfigurationServiceConstraintsDistributedTest implements Seri
       // Index is valid.
       QueryService queryService = internalCache.getQueryService();
       queryService.createIndex(ID_INDEX_IDENTIFIER, "e." + QueryObject.GET_ID_METHOD,
-          "/" + regionName + " e");
+          SEPARATOR + regionName + " e");
       Index index = queryService.getIndex(internalCache.getRegion(regionName), ID_INDEX_IDENTIFIER);
       assertThat(index.isValid()).isTrue();
 
@@ -493,7 +494,7 @@ public class QueryConfigurationServiceConstraintsDistributedTest implements Seri
       // Index is valid.
       QueryService queryService = internalCache.getQueryService();
       queryService.createIndex(ID_INDEX_IDENTIFIER, "e." + QueryObject.GET_ID_METHOD,
-          "/" + regionName + " e");
+          SEPARATOR + regionName + " e");
       Index index = queryService.getIndex(internalCache.getRegion(regionName), ID_INDEX_IDENTIFIER);
       assertThat(index.isValid()).isTrue();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/aggregate/AggregateFunctionsQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/aggregate/AggregateFunctionsQueryDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.internal.aggregate.AbstractAggregator.downCast;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,7 +89,7 @@ public class AggregateFunctionsQueryDUnitTest implements Serializable {
   private void createRegion(String regionType) {
     gfsh.executeAndAssertThat("create region --name=" + regionName + " --type=" + regionType)
         .statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 4);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 4);
   }
 
   private void createIndexes() {
@@ -102,7 +103,8 @@ public class AggregateFunctionsQueryDUnitTest implements Serializable {
         "define index --name=idIndex --expression=ID --type=key --region=" + regionName)
         .statusIsSuccess();
     gfsh.executeAndAssertThat(
-        "define index --name=secIdIndex --expression=\"pos.secId\" --region=\"/" + regionName
+        "define index --name=secIdIndex --expression=\"pos.secId\" --region=\"" + SEPARATOR
+            + regionName
             + " p, p.positions.values pos\"")
         .statusIsSuccess();
     gfsh.executeAndAssertThat("create defined indexes").statusIsSuccess();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexInitOnOverflowRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexInitOnOverflowRegionDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -126,7 +127,8 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.status", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.status",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -175,7 +177,7 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
             // Create and hence initialize Index
             try {
               Index index =
-                  cache.getQueryService().createIndex("idIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("idIndex", "p.ID", SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -242,7 +244,7 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("idIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("idIndex", "p.ID", SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -313,7 +315,8 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.status", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.status",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -361,9 +364,9 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
         QueryService qService = cache.getQueryService();
 
         try {
-          qService.createIndex("idIndex", "ID", "/" + regionName);
+          qService.createIndex("idIndex", "ID", SEPARATOR + regionName);
           qService.createIndex("secIdIndex", "pos.secId",
-              "/" + regionName + " p, p.positions.values pos");
+              SEPARATOR + regionName + " p, p.positions.values pos");
         } catch (Exception e) {
           fail("Index creation failed." + e);
         }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexOperationsOnOverflowRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexOperationsOnOverflowRegionDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -118,7 +119,8 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.ID",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -222,7 +224,8 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.ID",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -326,7 +329,8 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.ID",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -427,7 +431,8 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.ID",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -519,7 +524,8 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.ID",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();
@@ -614,7 +620,8 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
             // Create Indexes
             try {
               Index index =
-                  cache.getQueryService().createIndex("statusIndex", "p.ID", "/" + name + " p");
+                  cache.getQueryService().createIndex("statusIndex", "p.ID",
+                      SEPARATOR + name + " p");
               assertNotNull(index);
             } catch (Exception e1) {
               e1.printStackTrace();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -75,12 +76,12 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
   // CompactRangeIndex
   private String indexName = "idIndex";
   private String indexedExpression = "ID";
-  private String fromClause = "/" + regionName;
+  private String fromClause = SEPARATOR + regionName;
   private String alias = "p";
 
   private String rindexName = "secidIndex";
   private String rindexedExpression = "pos.secId";
-  private String rfromClause = "/" + regionName + " p, p.positions.values pos";
+  private String rfromClause = SEPARATOR + regionName + " p, p.positions.values pos";
   private String ralias = "pos";
 
   int stepSize = 10;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithoutWLDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithoutWLDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -71,12 +72,12 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
   // CompactRangeIndex
   private String indexName = "idIndex";
   private String indexedExpression = "ID";
-  private String fromClause = "/" + regionName;
+  private String fromClause = SEPARATOR + regionName;
   private String alias = "p";
 
   private String rindexName = "secidIndex";
   private String rindexedExpression = "pos.secId";
-  private String rfromClause = "/" + regionName + " p, p.positions.values pos";
+  private String rfromClause = SEPARATOR + regionName + " p, p.positions.values pos";
   private String ralias = "pos";
 
   int stepSize = 10;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/InitializeIndexEntryDestroyQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/InitializeIndexEntryDestroyQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createPortfolioData;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
@@ -129,9 +130,9 @@ public class InitializeIndexEntryDestroyQueryDUnitTest extends JUnit4CacheTestCa
       vm0.invoke(() -> createRegionInVM(name, null));
       final PortfolioData[] portfolio = createPortfolioData(cnt, cntDest);
       vm0.invoke(PRQHelp.getCacheSerializableRunnableForPRPuts(name, portfolio, cnt, cntDest));
-      vm0.invoke(() -> createIndex(name, "statusIndex", "p.status", "/" + name + " p"));
-      vm0.invoke(() -> createIndex(name, "idIndex", "p.ID", "/" + name + " p"));
-      vm0.invoke(() -> createIndex(name, "pkidIndex", "p.pk", "/" + name + " p"));
+      vm0.invoke(() -> createIndex(name, "statusIndex", "p.status", SEPARATOR + name + " p"));
+      vm0.invoke(() -> createIndex(name, "idIndex", "p.ID", SEPARATOR + name + " p"));
+      vm0.invoke(() -> createIndex(name, "pkidIndex", "p.pk", SEPARATOR + name + " p"));
       vm0.invoke(() -> executeAndValidateQueryResults(query));
     } finally {
       vm0.invoke(() -> clearIndexesAndDestroyRegion(name));
@@ -183,7 +184,8 @@ public class InitializeIndexEntryDestroyQueryDUnitTest extends JUnit4CacheTestCa
       Index index = null;
       try {
         index =
-            cache.getQueryService().createIndex("statusIndex", "p.status", "/" + regionName + " p");
+            cache.getQueryService().createIndex("statusIndex", "p.status",
+                SEPARATOR + regionName + " p");
       } catch (Exception e1) {
         logger.error("Index creation failed", e1);
         fail();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/MultiIndexCreationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/MultiIndexCreationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -62,7 +63,7 @@ public class MultiIndexCreationDUnitTest extends JUnit4CacheTestCase {
     final VM server1 = host.getVM(1);
 
     final int numberOfEntries = 10;
-    final String name = "/" + regionName;
+    final String name = SEPARATOR + regionName;
 
     // Start server1
     AsyncInvocation a1 = server1.invokeAsync(new SerializableCallable("Create Server1") {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/PutAllWithIndexPerfDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/PutAllWithIndexPerfDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.fail;
@@ -91,7 +92,7 @@ public class PutAllWithIndexPerfDUnitTest extends JUnit4CacheTestCase {
         }
         // Create Index on empty region
         try {
-          cache.getQueryService().createIndex("idIndex", "ID", "/" + name);
+          cache.getQueryService().createIndex("idIndex", "ID", SEPARATOR + name);
         } catch (Exception e) {
           Assert.fail("index creation failed", e);
         }
@@ -152,7 +153,7 @@ public class PutAllWithIndexPerfDUnitTest extends JUnit4CacheTestCase {
           Cache cache = CacheFactory.getAnyInstance();
           cache.getQueryService().removeIndexes();
           cache.getRegion(name).clear();
-          cache.getQueryService().createIndex("idIndex", "p.ID", "/" + name + " p");
+          cache.getQueryService().createIndex("idIndex", "p.ID", SEPARATOR + name + " p");
         } catch (Exception e) {
           Assert.fail("index creation failed", e);
         }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicIndexCreationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicIndexCreationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.partitioned;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createPortfolioData;
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
@@ -202,7 +203,7 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
         assertNotNull(idIndex);
         assertEquals("PrIndexOnID", idIndex.getName());
         assertEquals("p.ID", idIndex.getIndexedExpression());
-        assertEquals("/" + PARTITIONED_REGION_NAME + " p", idIndex.getFromClause());
+        assertEquals(SEPARATOR + PARTITIONED_REGION_NAME + " p", idIndex.getFromClause());
         assertNotNull(idIndex.getStatistics());
 
         // Check for status index
@@ -211,7 +212,7 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
         assertNotNull(statusIndex);
         assertEquals("PrIndexOnStatus", statusIndex.getName());
         assertEquals("p.status", statusIndex.getIndexedExpression());
-        assertEquals("/" + PARTITIONED_REGION_NAME + " p", statusIndex.getFromClause());
+        assertEquals(SEPARATOR + PARTITIONED_REGION_NAME + " p", statusIndex.getFromClause());
         assertNotNull(statusIndex.getStatistics());
 
         // Check for all Indexes on the region.
@@ -535,10 +536,11 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
         portfolio, cnt, cntDest));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(
-        PARTITIONED_REGION_NAME, "index8", "k", "/" + PARTITIONED_REGION_NAME + ".keys k", ""));
+        PARTITIONED_REGION_NAME, "index8", "k", SEPARATOR + PARTITIONED_REGION_NAME + ".keys k",
+        ""));
     vm1.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(
         PARTITIONED_REGION_NAME, "index7", "nvl(k.status.toString(),'nopes')",
-        "/" + PARTITIONED_REGION_NAME + ".values k", ""));
+        SEPARATOR + PARTITIONED_REGION_NAME + ".values k", ""));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRPuts(PARTITIONED_REGION_NAME,
         portfolio, cnt, cntDest));
@@ -678,7 +680,7 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
 
     vm1.invoke(
         prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(PARTITIONED_REGION_NAME,
-            "PrIndexOnKeyID", "key.ID", "/" + PARTITIONED_REGION_NAME + ".keys key", null));
+            "PrIndexOnKeyID", "key.ID", SEPARATOR + PARTITIONED_REGION_NAME + ".keys key", null));
 
     // querying the VM for data
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPROrderByQueryAndCompareResults(
@@ -749,7 +751,7 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
 
     vm1.invoke(
         prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(PARTITIONED_REGION_NAME,
-            "PrIndexOnKeyID", "key.ID", "/" + PARTITIONED_REGION_NAME + ".keys key", null));
+            "PrIndexOnKeyID", "key.ID", SEPARATOR + PARTITIONED_REGION_NAME + ".keys key", null));
 
     // querying the VM for data
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPROrderByQueryAndVerifyOrder(
@@ -812,15 +814,17 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
 
     vm1.invoke(
         prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(PARTITIONED_REGION_NAME,
-            "PrIndexOnKeyID", "key.ID", "/" + PARTITIONED_REGION_NAME + ".keys key", null));
+            "PrIndexOnKeyID", "key.ID", SEPARATOR + PARTITIONED_REGION_NAME + ".keys key", null));
 
     vm1.invoke(
         prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(PARTITIONED_REGION_NAME,
-            "PrIndexOnKeyStatus", "key.status", "/" + PARTITIONED_REGION_NAME + ".keys key", null));
+            "PrIndexOnKeyStatus", "key.status", SEPARATOR + PARTITIONED_REGION_NAME + ".keys key",
+            null));
 
     vm1.invoke(
         prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(PARTITIONED_REGION_NAME,
-            "PrIndexOnsecID", "p.position1.secId", "/" + PARTITIONED_REGION_NAME + " p", null));
+            "PrIndexOnsecID", "p.position1.secId", SEPARATOR + PARTITIONED_REGION_NAME + " p",
+            null));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForRRIndexCreate(LOCAL_REGION_NAME,
         "rrIndexOnStatus", "p.status", null, "p"));
@@ -829,13 +833,13 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
         "rrIndexOnID", "p.ID", null, "p"));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForRRIndexCreate(LOCAL_REGION_NAME,
-        "rrIndexOnKeyID", "key.ID", "/" + LOCAL_REGION_NAME + ".keys key", null));
+        "rrIndexOnKeyID", "key.ID", SEPARATOR + LOCAL_REGION_NAME + ".keys key", null));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForRRIndexCreate(LOCAL_REGION_NAME,
-        "rrIndexOnsecID", "p.position1.secId", "/" + LOCAL_REGION_NAME + " p", null));
+        "rrIndexOnsecID", "p.position1.secId", SEPARATOR + LOCAL_REGION_NAME + " p", null));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForRRIndexCreate(LOCAL_REGION_NAME,
-        "rrIndexOnKeyStatus", "key.status", "/" + LOCAL_REGION_NAME + ".keys key", null));
+        "rrIndexOnKeyStatus", "key.status", SEPARATOR + LOCAL_REGION_NAME + ".keys key", null));
 
     // querying the VM for data
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPROrderByQueryWithLimit(

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicMultiIndexCreationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicMultiIndexCreationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.partitioned;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createPortfolioData;
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
@@ -163,7 +164,7 @@ public class PRBasicMultiIndexCreationDUnitTest extends CacheTestCase {
         assertNotNull(idIndex);
         assertEquals("PrIndexOnID", idIndex.getName());
         assertEquals("ID", idIndex.getIndexedExpression());
-        assertEquals("/" + name, idIndex.getFromClause());
+        assertEquals(SEPARATOR + name, idIndex.getFromClause());
         assertNotNull(idIndex.getStatistics());
 
         // Check for status index
@@ -172,7 +173,7 @@ public class PRBasicMultiIndexCreationDUnitTest extends CacheTestCase {
         assertNotNull(statusIndex);
         assertEquals("PrIndexOnStatus", statusIndex.getName());
         assertEquals("status", statusIndex.getIndexedExpression());
-        assertEquals("/" + name, statusIndex.getFromClause());
+        assertEquals(SEPARATOR + name, statusIndex.getFromClause());
         assertNotNull(statusIndex.getStatistics());
 
         // Check for all Indexes on the region.
@@ -786,11 +787,11 @@ public class PRBasicMultiIndexCreationDUnitTest extends CacheTestCase {
     exps.add("position1.secId");
 
     ArrayList<String> fromClause = new ArrayList<>();
-    fromClause.add("/" + name);
-    fromClause.add("/" + name);
-    fromClause.add("/" + name + ".keys key");
-    fromClause.add("/" + name + ".keys key");
-    fromClause.add("/" + name);
+    fromClause.add(SEPARATOR + name);
+    fromClause.add(SEPARATOR + name);
+    fromClause.add(SEPARATOR + name + ".keys key");
+    fromClause.add(SEPARATOR + name + ".keys key");
+    fromClause.add(SEPARATOR + name);
 
     vm1.invoke(PRQHelp.getCacheSerializableRunnableForDefineIndex(name, names, exps, fromClause));
 
@@ -809,11 +810,11 @@ public class PRBasicMultiIndexCreationDUnitTest extends CacheTestCase {
     exps2.add("position1.secId");
 
     ArrayList<String> fromClause2 = new ArrayList<>();
-    fromClause2.add("/" + localName);
-    fromClause2.add("/" + localName);
-    fromClause2.add("/" + localName + ".keys key");
-    fromClause2.add("/" + localName + ".keys key");
-    fromClause2.add("/" + localName);
+    fromClause2.add(SEPARATOR + localName);
+    fromClause2.add(SEPARATOR + localName);
+    fromClause2.add(SEPARATOR + localName + ".keys key");
+    fromClause2.add(SEPARATOR + localName + ".keys key");
+    fromClause2.add(SEPARATOR + localName);
 
     vm0.invoke(
         PRQHelp.getCacheSerializableRunnableForDefineIndex(localName, names2, exps2, fromClause2));

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.partitioned;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createPortfolioData;
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
@@ -379,7 +380,7 @@ public class PRBasicQueryDUnitTest extends CacheTestCase {
 
     vm1.invoke(() -> {
       QueryService qs = getCache().getQueryService();
-      qs.createIndex("index", IndexType.FUNCTIONAL, "ID", "/" + name);
+      qs.createIndex("index", IndexType.FUNCTIONAL, "ID", SEPARATOR + name);
       for (int i = 0; i < 100; i++) {
         Query query = qs.newQuery(
             "SELECT DISTINCT * FROM /" + name + " WHERE ID >= " + i + " ORDER BY ID asc LIMIT 1");

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRColocatedEquiJoinDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.partitioned;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createNewPortfoliosAndPositions;
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
@@ -267,13 +268,13 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(name, redundancy,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRColocatedCreate(coloName,
         redundancy, name));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(coloName, "IdIndex2",
-        "r2.id", "/" + coloName + " r2", null));
+        "r2.id", SEPARATOR + coloName + " r2", null));
 
     // Creating local region on vm0 to compare the results of query.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(localName,
@@ -323,9 +324,9 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(name, redundancy,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex11",
-        "r1.status", "/" + name + " r1", null));
+        "r1.status", SEPARATOR + name + " r1", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRColocatedCreate(coloName,
@@ -433,14 +434,14 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(name, redundancy,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(coloName,
         NewPortfolio.class));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(coloName, "IdIndex2",
-        "r2.id", "/" + coloName + " r2", null));
+        "r2.id", SEPARATOR + coloName + " r2", null));
 
     // Creating local region on vm0 to compare the results of query.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(localName,
@@ -492,9 +493,9 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(name, redundancy,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex11",
-        "r1.status", "/" + name + " r1", null));
+        "r1.status", SEPARATOR + name + " r1", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(coloName,
@@ -600,14 +601,14 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(coloName, redundancy,
         NewPortfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(coloName, "IdIndex1",
-        "r2.id", "/" + coloName + " r2", null));
+        "r2.id", SEPARATOR + coloName + " r2", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(name,
         Portfolio.class));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex2",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
 
     // Creating local region on vm0 to compare the results of query.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(localName,
@@ -661,7 +662,7 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(name,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
 
     // Creating local region on vm0 to compare the results of query.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(localName,
@@ -791,14 +792,14 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(name, redundancy,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(coloName,
         NewPortfolio.class));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(coloName, "IdIndex2",
-        "r2.id", "/" + coloName + " r2, r2.positions.values pos2", null));
+        "r2.id", SEPARATOR + coloName + " r2, r2.positions.values pos2", null));
 
     // Creating local region on vm0 to compare the results of query.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(localName,
@@ -838,14 +839,14 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(name, redundancy,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(coloName,
         Portfolio.class));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(coloName, "IdIndex2",
-        "pos2.id", "/" + coloName + " r2, r2.positions.values pos2", null));
+        "pos2.id", SEPARATOR + coloName + " r2, r2.positions.values pos2", null));
 
     // Creating local region on vm0 to compare the results of query.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(localName,
@@ -886,27 +887,27 @@ public class PRColocatedEquiJoinDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(name, redundancy,
         Portfolio.class));
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex1",
-        "r1.ID", "/" + name + " r1", null));
+        "r1.ID", SEPARATOR + name + " r1", null));
 
     // Creating Colocated Region DataStore node on the VM0.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionWithAsyncIndexCreation(
         coloName, NewPortfolio.class));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(coloName, "IdIndex2",
-        "r2.id", "/" + coloName + " r2", null));
+        "r2.id", SEPARATOR + coloName + " r2", null));
 
     // Creating local region on vm0 to compare the results of query.
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(localName,
         Portfolio.class));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(name, "IdIndex3",
-        "r1.ID", "/" + localName + " r1", null));
+        "r1.ID", SEPARATOR + localName + " r1", null));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForLocalRegionCreation(coloLocalName,
         NewPortfolio.class));
 
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(coloName, "IdIndex4",
-        "r2.id", "/" + coloLocalName + " r2", null));
+        "r2.id", SEPARATOR + coloLocalName + " r2", null));
 
     // Generating portfolio object array to be populated across the PR's & Local Regions
     Portfolio[] portfolio = createPortfoliosAndPositions(cntDest);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/CacheXmlGeode10DUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/CacheXmlGeode10DUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache30;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.OFF_HEAP_MEMORY_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -103,7 +104,7 @@ public class CacheXmlGeode10DUnitTest extends CacheXml81DUnitTest {
     IgnoredException.addIgnoredException(
         String.format(
             "The region %s was configured to use off heap memory but no off heap memory was configured",
-            "/" + regionName));
+            SEPARATOR + regionName));
 
     try {
       testXml(cache);
@@ -113,7 +114,7 @@ public class CacheXmlGeode10DUnitTest extends CacheXml81DUnitTest {
       String msg =
           String.format(
               "The region %s was configured to use off heap memory but no off heap memory was configured",
-              "/" + regionName);
+              SEPARATOR + regionName);
       assertEquals(msg, e.getMessage());
     }
   }
@@ -144,7 +145,7 @@ public class CacheXmlGeode10DUnitTest extends CacheXml81DUnitTest {
     IgnoredException.addIgnoredException(
         String.format(
             "The region %s was configured to use off heap memory but no off heap memory was configured",
-            "/" + rootRegionName + "/" + subRegionName));
+            SEPARATOR + rootRegionName + SEPARATOR + subRegionName));
 
     try {
       testXml(cache);
@@ -154,7 +155,7 @@ public class CacheXmlGeode10DUnitTest extends CacheXml81DUnitTest {
       final String msg =
           String.format(
               "The region %s was configured to use off heap memory but no off heap memory was configured",
-              "/" + rootRegionName + "/" + subRegionName);
+              SEPARATOR + rootRegionName + SEPARATOR + subRegionName);
       assertEquals(msg, e.getMessage());
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.cache30;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.CONSERVE_SOCKETS;
 import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.BEFORE_INITIAL_IMAGE;
@@ -171,7 +172,7 @@ public class DistributedAckRegionCCEDUnitTest extends DistributedAckRegionDUnitT
               InitialImageOperation.VMOTION_DURING_GII = false;
               final InitializationLevel oldLevel =
                   LocalRegion.setThreadInitLevelRequirement(BEFORE_INITIAL_IMAGE);
-              LocalRegion ccregion = (LocalRegion) cache.getInternalRegionByPath("/" + name);
+              LocalRegion ccregion = (LocalRegion) cache.getInternalRegionByPath(SEPARATOR + name);
               try {
                 // wait for the update op (sent below from vm1) to arrive, then allow the GII to
                 // happen

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/FixedPRSinglehopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/FixedPRSinglehopDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache;
 
 import static java.lang.System.out;
 import static java.util.Map.Entry;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
@@ -343,7 +344,7 @@ public class FixedPRSinglehopDUnitTest extends JUnit4CacheTestCase {
       updateIntoSinglePR(false);
 
       ClientMetadataService cms = ((GemFireCacheImpl) cache).getClientMetadataService();
-      ClientPartitionAdvisor advisor = cms.getClientPartitionAdvisor("/" + PR_NAME);
+      ClientPartitionAdvisor advisor = cms.getClientPartitionAdvisor(SEPARATOR + PR_NAME);
       int[] expected = new int[] {port1, port1, port1, port4, port4, port4, port2, port2, port2,
           port4, port4, port4};
       for (int i = 0; i < expected.length; i++) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/FailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/FailoverDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.client.PoolManager.find;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
@@ -193,7 +194,7 @@ public class FailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void registerInterestList() {
     try {
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       r.registerInterest("key-1");
       r.registerInterest("key-2");
@@ -208,7 +209,7 @@ public class FailoverDUnitTest extends JUnit4DistributedTestCase {
   public static void createEntries() {
     try {
 
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
 
       r.create("key-1", "key-1");
@@ -235,7 +236,7 @@ public class FailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void put() {
     try {
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
 
       r.put("key-1", "value-1");
@@ -248,7 +249,7 @@ public class FailoverDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public void verifyEntries() {
-    final Region r = cache.getRegion("/" + regionName);
+    final Region r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     WaitCriterion ev = new WaitCriterion() {
       @Override
@@ -281,7 +282,7 @@ public class FailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void putDuringFailover() {
     try {
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       r.put("key-4", "value-4");
       r.put("key-5", "value-5");
@@ -292,7 +293,7 @@ public class FailoverDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public void verifyEntriesAfterFailover() {
-    final Region r = cache.getRegion("/" + regionName);
+    final Region r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     WaitCriterion ev = new WaitCriterion() {
       @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAGIIDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAGIIDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
@@ -183,7 +184,7 @@ public class HAGIIDUnitTest extends JUnit4DistributedTestCase {
 
   public static void registerInterestList() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.registerInterest("key-1", InterestResultPolicy.KEYS_VALUES);
       r.registerInterest("key-2", InterestResultPolicy.KEYS_VALUES);
@@ -195,7 +196,7 @@ public class HAGIIDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntries() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.create("key-1", "key-1");
       r.create("key-2", "key-2");
@@ -220,7 +221,7 @@ public class HAGIIDUnitTest extends JUnit4DistributedTestCase {
 
   public static void put() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
 
       r.put("key-1", "value-1");
@@ -234,7 +235,7 @@ public class HAGIIDUnitTest extends JUnit4DistributedTestCase {
 
   /** queue a tombstone GC message for the client. See bug #46832 */
   public static void tombstonegc() throws Exception {
-    LocalRegion r = (LocalRegion) cache.getRegion("/" + REGION_NAME);
+    LocalRegion r = (LocalRegion) cache.getRegion(SEPARATOR + REGION_NAME);
     assertNotNull(r);
 
     DistributedMember id = r.getCache().getDistributedSystem().getDistributedMember();
@@ -253,7 +254,7 @@ public class HAGIIDUnitTest extends JUnit4DistributedTestCase {
 
   public static void verifyEntries() {
     try {
-      final Region r = cache.getRegion("/" + REGION_NAME);
+      final Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       // wait until we
       // have a dead
@@ -355,7 +356,7 @@ public class HAGIIDUnitTest extends JUnit4DistributedTestCase {
 
   public static void verifyEntriesAfterGII() {
     try {
-      final Region r = cache.getRegion("/" + REGION_NAME);
+      final Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       // wait until
       // we have a

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
@@ -257,7 +257,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   private static void registerInterestListAll() {
     try {
-      Region<Object, Object> region = cache.getRegion("/" + regionName);
+      Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
       assertThat(region).isNotNull();
       region.registerInterest("ALL_KEYS");
     } catch (GemFireException ex) {
@@ -267,7 +267,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   private static void registerInterestList() {
     try {
-      Region<Object, Object> region = cache.getRegion("/" + regionName);
+      Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
       assertThat(region).isNotNull();
       region.registerInterest("k1");
       region.registerInterest("k3");
@@ -280,7 +280,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
   private static void putEntries() {
     try {
 
-      Region<Object, Object> region = cache.getRegion("/" + regionName);
+      Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
       assertThat(region).isNotNull();
 
       region.put("k1", "pv1");
@@ -295,7 +295,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntries() {
     try {
-      Region<Object, Object> region = cache.getRegion("/" + regionName);
+      Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
       assertThat(region).isNotNull();
 
       region.create("k1", "v1");
@@ -310,7 +310,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntries(Long num) {
     try {
-      Region<Object, Object> region = cache.getRegion("/" + regionName);
+      Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
       assertThat(region).isNotNull();
       for (long i = 0; i < num; i++) {
         region.create("k" + i, "v" + i);
@@ -323,7 +323,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
   private static void putHeavyEntries(Integer num) {
     try {
       byte[] val;
-      Region<Object, Object> region = cache.getRegion("/" + regionName);
+      Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
       assertThat(region).isNotNull();
       for (long i = 0; i < num; i++) {
         val = new byte[1024 * 1024 * 5]; // 5 MB
@@ -412,7 +412,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   private void ValidateRegionSizes(int port) {
     await().untilAsserted(() -> {
-      Region region = cache.getRegion("/" + regionName);
+      Region region = cache.getRegion(SEPARATOR + regionName);
       Region<Object, Object> msgsRegion =
           cache.getRegion(CacheServerImpl.generateNameForClientMsgsRegion(port));
       int clientMsgRegionSize = msgsRegion.size();
@@ -847,7 +847,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   private static void verifyNullCUMReference(Integer port) {
     Region<Object, Object> region =
-        cache.getRegion("/" + CacheServerImpl.generateNameForClientMsgsRegion(port));
+        cache.getRegion(SEPARATOR + CacheServerImpl.generateNameForClientMsgsRegion(port));
     assertThat(region).isNotNull();
 
     Object[] arr = region.keySet().toArray();
@@ -858,7 +858,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
   }
 
   private static void verifyHaContainerDestroyed(Boolean isRegion, Integer port) {
-    Map region = cache.getRegion("/" + CacheServerImpl.generateNameForClientMsgsRegion(port));
+    Map region = cache.getRegion(SEPARATOR + CacheServerImpl.generateNameForClientMsgsRegion(port));
 
     if (isRegion) {
       if (region != null) {
@@ -997,7 +997,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
     // Get the clientMessagesRegion and check the size.
     Region<Object, Object> msgsRegion =
         cache.getRegion(CacheServerImpl.generateNameForClientMsgsRegion(port));
-    Region region = cache.getRegion("/" + regionName);
+    Region region = cache.getRegion(SEPARATOR + regionName);
     logger.debug(
         "size<serverRegion, clientMsgsRegion>: " + region.size() + ", " + msgsRegion.size());
     assertThat(region.size()).isEqualTo(((Integer) 5).intValue());
@@ -1019,7 +1019,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
   private static void verifyRegionSize(final Integer regionSize, final Integer msgsRegionSize) {
     GeodeAwaitility.await().until(() -> {
       // Get the clientMessagesRegion and check the size.
-      Region<Object, Object> region = cache.getRegion("/" + regionName);
+      Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
       int sz = region.size();
       if (regionSize != sz) {
         return false;
@@ -1042,7 +1042,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
     GeodeAwaitility.await().until(() -> {
       try {
         // Get the clientMessagesRegion and check the size.
-        Region<Object, Object> region = cache.getRegion("/" + regionName);
+        Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
         int sz = region.size();
         if (sz != 1) {
           return false;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HASlowReceiverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HASlowReceiverDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.REMOVE_UNRESPONSIVE_CLIENT;
@@ -191,7 +192,7 @@ public class HASlowReceiverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void registerInterest() {
     try {
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       r.registerInterest("ALL_KEYS");
     } catch (Exception ex) {
@@ -202,7 +203,7 @@ public class HASlowReceiverDUnitTest extends JUnit4DistributedTestCase {
   public static void putEntries() {
     try {
 
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       for (long i = 0; i < 300; i++) {
         r.put("k" + (i % 10), "v" + i);
@@ -215,7 +216,7 @@ public class HASlowReceiverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntries(Long num) {
     try {
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       for (long i = 0; i < num.longValue(); i++) {
         r.create("k" + i, "v" + i);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionDistributedTest.java
@@ -209,7 +209,7 @@ public class PersistentPartitionedRegionDistributedTest implements Serializable 
         .isInstanceOf(IllegalStateException.class).hasMessageContaining(
             String.format(
                 "For partition region %s,total-num-buckets %s should not be changed. Previous configured number is %s.",
-                "/" + partitionedRegionName, 2, 5));
+                SEPARATOR + partitionedRegionName, 2, 5));
 
     getCache().close();
 
@@ -217,7 +217,7 @@ public class PersistentPartitionedRegionDistributedTest implements Serializable 
         .isInstanceOf(IllegalStateException.class).hasMessageContaining(
             String.format(
                 "For partition region %s,total-num-buckets %s should not be changed. Previous configured number is %s.",
-                "/" + partitionedRegionName, 10, 5));
+                SEPARATOR + partitionedRegionName, 10, 5));
   }
 
   @Test

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/BackwardCompatibilityHigherVersionClientDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/BackwardCompatibilityHigherVersionClientDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertNotNull;
@@ -225,7 +226,7 @@ public class BackwardCompatibilityHigherVersionClientDUnitTest extends JUnit4Dis
 
   public static void destroyRegion() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.destroyRegion();
     } catch (Exception ex) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/EventIDVerificationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/EventIDVerificationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
@@ -354,7 +355,7 @@ public class EventIDVerificationDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntry() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
 
       if (!r.containsKey("key-1")) {
@@ -369,7 +370,7 @@ public class EventIDVerificationDUnitTest extends JUnit4DistributedTestCase {
 
   public static void put() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
 
       r.put("key-1", "vm2-key-1");
@@ -383,7 +384,7 @@ public class EventIDVerificationDUnitTest extends JUnit4DistributedTestCase {
 
   public static void destroy() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.destroy("key-1");
     } catch (Exception ex) {
@@ -394,7 +395,7 @@ public class EventIDVerificationDUnitTest extends JUnit4DistributedTestCase {
 
   public static void remove() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.remove("key-1");
     } catch (Exception ex) {
@@ -405,7 +406,7 @@ public class EventIDVerificationDUnitTest extends JUnit4DistributedTestCase {
 
   public static void destroyRegion() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.destroyRegion();
     } catch (Exception ex) {
@@ -415,7 +416,7 @@ public class EventIDVerificationDUnitTest extends JUnit4DistributedTestCase {
 
   public static void clearRegion() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.clear();
     } catch (Exception ex) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/EventIDVerificationInP2PDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/EventIDVerificationInP2PDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -198,7 +199,7 @@ public class EventIDVerificationInP2PDUnitTest extends JUnit4DistributedTestCase
 
   public static void createEntry() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
 
       if (!r.containsKey("key-1")) {
@@ -213,7 +214,7 @@ public class EventIDVerificationInP2PDUnitTest extends JUnit4DistributedTestCase
 
   public static void put() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
 
       r.put("key-1", "vm0-key-1");
@@ -227,7 +228,7 @@ public class EventIDVerificationInP2PDUnitTest extends JUnit4DistributedTestCase
 
   public static void destroy() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.destroy("key-1");
     } catch (Exception ex) {
@@ -237,7 +238,7 @@ public class EventIDVerificationInP2PDUnitTest extends JUnit4DistributedTestCase
 
   public static void destroyRegion() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.destroyRegion();
     } catch (Exception ex) {
@@ -247,7 +248,7 @@ public class EventIDVerificationInP2PDUnitTest extends JUnit4DistributedTestCase
 
   public static void invalidateRegion() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.invalidateRegion();
     } catch (Exception ex) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/HAStartupAndFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/HAStartupAndFailoverDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.cache.CacheFactory.getAnyInstance;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -316,7 +317,7 @@ public class HAStartupAndFailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void put() {
     try {
-      Region r1 = cache.getRegion("/" + REGION_NAME);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME);
       r1.put("key-1", "server-value-1");
       r1.put("key-2", "server-value-2");
       r1.put("key-3", "server-value-3");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListEndpointDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListEndpointDUnitTest.java
@@ -285,7 +285,6 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
       Iterator iter_prox = bs.getAcceptor().getCacheClientNotifier().getClientProxies().iterator();
       if (iter_prox.hasNext()) {
         CacheClientProxy proxy = (CacheClientProxy) iter_prox.next();
-        // if (proxy._interestList._keysOfInterest.get(SEPARATOR+REGION_NAME) != null) {
         if (proxy.isPrimary()) {
           Iterator iter = cache.getCacheServers().iterator();
           if (iter.hasNext()) {
@@ -399,7 +398,6 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
       // only one server thats why if and not while
       if (iter.hasNext()) {
         CacheClientProxy proxy = (CacheClientProxy) iter.next();
-        // if (proxy._interestList._keysOfInterest.get(SEPARATOR+ REGION_NAME) == null) {
         if (!proxy.isPrimary()) {
           Region r = cache.getRegion(SEPARATOR + REGION_NAME);
           r.put(k1, server_k1);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListEndpointDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListEndpointDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.cache.Region.Entry;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.client.PoolManager.find;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
@@ -179,7 +180,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
     client1.invoke(new CacheSerializableRunnable("Ensure that the failover from ILEP occurs") {
       @Override
       public void run2() throws CacheException {
-        Region r = cache.getRegion("/" + REGION_NAME);
+        Region r = cache.getRegion(SEPARATOR + REGION_NAME);
 
         String poolName = r.getAttributes().getPoolName();
         assertNotNull(poolName);
@@ -225,7 +226,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
   }
 
   public static int getPrimaryPort() throws Exception {
-    Region r1 = cache.getRegion("/" + REGION_NAME);
+    Region r1 = cache.getRegion(SEPARATOR + REGION_NAME);
     String poolName = r1.getAttributes().getPoolName();
     assertNotNull(poolName);
     pool = (PoolImpl) PoolManager.find(poolName);
@@ -244,7 +245,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
 
   public static void acquirePoolConnection() {
     try {
-      Region r1 = cache.getRegion("/" + REGION_NAME);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r1);
       String poolName = r1.getAttributes().getPoolName();
       assertNotNull(poolName);
@@ -284,7 +285,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
       Iterator iter_prox = bs.getAcceptor().getCacheClientNotifier().getClientProxies().iterator();
       if (iter_prox.hasNext()) {
         CacheClientProxy proxy = (CacheClientProxy) iter_prox.next();
-        // if (proxy._interestList._keysOfInterest.get("/"+REGION_NAME) != null) {
+        // if (proxy._interestList._keysOfInterest.get(SEPARATOR+REGION_NAME) != null) {
         if (proxy.isPrimary()) {
           Iterator iter = cache.getCacheServers().iterator();
           if (iter.hasNext()) {
@@ -301,7 +302,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntriesK1andK2() {
     try {
-      Region r1 = cache.getRegion("/" + REGION_NAME);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r1);
       if (!r1.containsKey(k1)) {
         r1.create(k1, client_k1);
@@ -377,7 +378,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
 
   public static void put() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.put(k1, server_k1);
       r.put(k2, server_k2);
@@ -398,9 +399,9 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
       // only one server thats why if and not while
       if (iter.hasNext()) {
         CacheClientProxy proxy = (CacheClientProxy) iter.next();
-        // if (proxy._interestList._keysOfInterest.get("/"+ REGION_NAME) == null) {
+        // if (proxy._interestList._keysOfInterest.get(SEPARATOR+ REGION_NAME) == null) {
         if (!proxy.isPrimary()) {
-          Region r = cache.getRegion("/" + REGION_NAME);
+          Region r = cache.getRegion(SEPARATOR + REGION_NAME);
           r.put(k1, server_k1);
           r.put(k2, server_k2);
         }
@@ -413,7 +414,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
 
   public static void registerKey1() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.registerInterest(k1, InterestResultPolicy.KEYS);
     } catch (Exception ex) {
@@ -423,7 +424,7 @@ public class InterestListEndpointDUnitTest extends JUnit4DistributedTestCase {
 
   public static void verifyPut() {
     try {
-      final Region r = cache.getRegion("/" + REGION_NAME);
+      final Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       WaitCriterion ev = new WaitCriterion() {
         @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListFailoverDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.getCache;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -141,7 +142,7 @@ public class InterestListFailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntries() {
     try {
-      Region r = CacheServerTestUtil.getCache().getRegion("/" + REGION_NAME);
+      Region r = CacheServerTestUtil.getCache().getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
 
       if (!r.containsKey("key-1")) {
@@ -160,7 +161,7 @@ public class InterestListFailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void verifyEntries() {
     try {
-      Region r = CacheServerTestUtil.getCache().getRegion("/" + REGION_NAME);
+      Region r = CacheServerTestUtil.getCache().getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       if (r.getEntry("key-1") != null) {
         assertEquals(r.getEntry("key-1").getValue(), "key-1");
@@ -175,7 +176,7 @@ public class InterestListFailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static Integer registerInterestList() {
     try {
-      Region r = CacheServerTestUtil.getCache().getRegion("/" + REGION_NAME);
+      Region r = CacheServerTestUtil.getCache().getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.registerInterest("key-1");
       r.registerInterest("key-2");
@@ -216,7 +217,7 @@ public class InterestListFailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void _put(String v) {
     try {
-      Region r = CacheServerTestUtil.getCache().getRegion("/" + REGION_NAME);
+      Region r = CacheServerTestUtil.getCache().getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.put("key-1", "vm2-key-1" + v);
       r.put("key-6", "vm2-key-6" + v);
@@ -246,7 +247,7 @@ public class InterestListFailoverDUnitTest extends JUnit4DistributedTestCase {
 
   public static void _validateEntries(final String v) {
     try {
-      final Region r = getCache().getRegion("/" + REGION_NAME);
+      final Region r = getCache().getRegion(SEPARATOR + REGION_NAME);
       final String key1 = "key-1";
       assertNotNull(r);
       // Verify that 'key-1' was updated

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/InterestListRecoveryDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.SystemFailure.initiateFailure;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
@@ -176,7 +177,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
      */
     // check whether the primary endpoint is connected to server1 or server2
     try {
-      Region<?, ?> r1 = cache.getRegion("/" + REGION_NAME);
+      Region<?, ?> r1 = cache.getRegion(SEPARATOR + REGION_NAME);
       String poolName = r1.getAttributes().getPoolName();
       assertNotNull(poolName);
       pool = (PoolImpl) PoolManager.find(poolName);
@@ -240,7 +241,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createEntries() {
     try {
-      LocalRegion r1 = (LocalRegion) cache.getRegion("/" + REGION_NAME);
+      LocalRegion r1 = (LocalRegion) cache.getRegion(SEPARATOR + REGION_NAME);
       for (int i = 1; i < 6; i++) {
         if (!r1.containsKey("key-" + i)) {
           r1.create("key-" + i, "key-" + i);
@@ -254,7 +255,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
 
   public static void registerK1toK5() {
     try {
-      LocalRegion r = (LocalRegion) cache.getRegion("/" + REGION_NAME);
+      LocalRegion r = (LocalRegion) cache.getRegion(SEPARATOR + REGION_NAME);
       for (int i = 1; i < 6; i++) {
         r.registerInterest("key-" + i, InterestResultPolicy.KEYS);
       }
@@ -265,7 +266,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
 
   public static void unregisterK1toK3() {
     try {
-      LocalRegion r = (LocalRegion) cache.getRegion("/" + REGION_NAME);
+      LocalRegion r = (LocalRegion) cache.getRegion(SEPARATOR + REGION_NAME);
       for (int i = 1; i < 4; i++) {
         r.unregisterInterest("key-" + i);
       }
@@ -295,7 +296,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
 
   public static void killCurrentEndpoint() {
     try {
-      Region r1 = cache.getRegion("/" + REGION_NAME);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME);
       String poolName = r1.getAttributes().getPoolName();
       assertNotNull(poolName);
       pool = (PoolImpl) PoolManager.find(poolName);
@@ -308,7 +309,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
 
   public static void put(String key) {
     try {
-      Region r1 = cache.getRegion("/" + REGION_NAME);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME);
       r1.put(key, "server-" + key);
     } catch (Exception ex) {
       Assert.fail("failed while r.put()", ex);
@@ -343,7 +344,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
   public static void verifyRegionToProxyMapForFullRegistration() {
     Iterator iter = getCacheClientProxies().iterator();
     if (iter.hasNext()) {
-      Set keys = getKeysOfInterestMap((CacheClientProxy) iter.next(), "/" + REGION_NAME);
+      Set keys = getKeysOfInterestMap((CacheClientProxy) iter.next(), SEPARATOR + REGION_NAME);
       assertNotNull(keys);
 
       assertTrue(keys.contains("key-1"));
@@ -382,7 +383,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
   public static void verifyRegisterK4toK5() {
     Iterator iter = getCacheClientProxies().iterator();
     if (iter.hasNext()) {
-      Set keysMap = getKeysOfInterestMap((CacheClientProxy) iter.next(), "/" + REGION_NAME);
+      Set keysMap = getKeysOfInterestMap((CacheClientProxy) iter.next(), SEPARATOR + REGION_NAME);
       assertNotNull(keysMap);
 
       assertFalse(keysMap.contains("key-1"));
@@ -421,7 +422,7 @@ public class InterestListRecoveryDUnitTest extends JUnit4DistributedTestCase {
   public static void verifyRegionToProxyMapForNoRegistration() {
     Iterator iter = getCacheClientProxies().iterator();
     if (iter.hasNext()) {
-      Set keysMap = getKeysOfInterestMap((CacheClientProxy) iter.next(), "/" + REGION_NAME);
+      Set keysMap = getKeysOfInterestMap((CacheClientProxy) iter.next(), SEPARATOR + REGION_NAME);
       if (keysMap != null) { // its ok not to have an empty map, just means there is no registration
         assertFalse(keysMap.contains("key-1"));
         assertFalse(keysMap.contains("key-2"));

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RegionCloseDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RegionCloseDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.cache.CacheFactory.getAnyInstance;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
@@ -170,7 +171,7 @@ public class RegionCloseDUnitTest extends JUnit4DistributedTestCase {
 
   public static void closeRegion() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       String poolName = r.getAttributes().getPoolName();
       assertNotNull(poolName);
@@ -202,7 +203,7 @@ public class RegionCloseDUnitTest extends JUnit4DistributedTestCase {
     ev = new WaitCriterion() {
       @Override
       public boolean done() {
-        return c.getRegion("/" + clientMembershipId) == null;
+        return c.getRegion(SEPARATOR + clientMembershipId) == null;
       }
 
       @Override
@@ -224,7 +225,7 @@ public class RegionCloseDUnitTest extends JUnit4DistributedTestCase {
       }
     };
     GeodeAwaitility.await().untilAsserted(ev);
-    // assertNull(c.getRegion("/"+clientMembershipId));
+    // assertNull(c.getRegion(SEPARATOR+clientMembershipId));
     assertEquals(0, bs.getAcceptor().getCacheClientNotifier().getClientProxies().size());
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RegionCloseDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RegionCloseDUnitTest.java
@@ -225,7 +225,6 @@ public class RegionCloseDUnitTest extends JUnit4DistributedTestCase {
       }
     };
     GeodeAwaitility.await().untilAsserted(ev);
-    // assertNull(c.getRegion(SEPARATOR+clientMembershipId));
     assertEquals(0, bs.getAcceptor().getCacheClientNotifier().getClientProxies().size());
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/VerifyEventIDGenerationInP2PDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/VerifyEventIDGenerationInP2PDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -126,7 +127,7 @@ public class VerifyEventIDGenerationInP2PDUnitTest extends JUnit4DistributedTest
 
   public static void createEntry() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
 
       if (!r.containsKey("key-1")) {
@@ -141,7 +142,7 @@ public class VerifyEventIDGenerationInP2PDUnitTest extends JUnit4DistributedTest
 
   public static void get() {
     try {
-      Region r = cache.getRegion("/" + REGION_NAME);
+      Region r = cache.getRegion(SEPARATOR + REGION_NAME);
       assertNotNull(r);
       r.get("key-1");
     } catch (Exception ex) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/OffHeapManagementDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/OffHeapManagementDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.management;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_START;
@@ -80,7 +81,7 @@ public class OffHeapManagementDUnitTest extends CacheTestCase {
   /**
    * Path of off-heap test region.
    */
-  private static final String OFF_HEAP_REGION_PATH = "/" + OFF_HEAP_REGION_NAME;
+  private static final String OFF_HEAP_REGION_PATH = SEPARATOR + OFF_HEAP_REGION_NAME;
 
   /**
    * Expected total off-heap reserved memory (1 megabyte).

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/QueryDataDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/QueryDataDUnitTest.java
@@ -18,6 +18,7 @@ import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.isJson;
 import static com.jayway.jsonpath.matchers.JsonPathMatchers.withJsonPath;
 import static org.apache.geode.cache.FixedPartitionAttributes.createFixedPartition;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
 import static org.apache.geode.management.internal.ManagementConstants.DEFAULT_QUERY_LIMIT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -300,7 +301,7 @@ public class QueryDataDUnitTest implements Serializable {
           distributedSystemMXBean.queryData(regionsNotFoundQuery, null, 2);
       assertThat(regionsNotFoundResult, isJson(withJsonPath("$.message",
           equalTo(String.format("Cannot find regions %s in any of the members",
-              "/" + nonexistentRegionName)))));
+              SEPARATOR + nonexistentRegionName)))));
 
       String regionName = testName.getMethodName() + "_REGION";
       String regionsNotFoundOnMembersQuery = "SELECT * FROM /" + regionName;
@@ -313,7 +314,8 @@ public class QueryDataDUnitTest implements Serializable {
           distributedSystemMXBean.queryData(regionsNotFoundOnMembersQuery, member1.getId(), 2);
       assertThat(regionsNotFoundOnMembersResult, isJson(withJsonPath("$.message",
           equalTo(
-              String.format("Cannot find regions %s in specified members", "/" + regionName)))));
+              String.format("Cannot find regions %s in specified members",
+                  SEPARATOR + regionName)))));
 
       String joinMissingMembersQuery = QUERIES[1];
       String joinMissingMembersResult =
@@ -343,7 +345,7 @@ public class QueryDataDUnitTest implements Serializable {
       regionFactory.create(normalRegionName1);
       regionFactory.create(normalRegionName2);
 
-      Region region = cache.getRegion("/" + normalRegionName1);
+      Region region = cache.getRegion(SEPARATOR + normalRegionName1);
       assertThat(region.getAttributes().getDataPolicy()).isEqualTo(DataPolicy.NORMAL);
 
       RegionFactory regionFactory1 = cache.createRegionFactory(RegionShortcut.REPLICATE);
@@ -439,7 +441,7 @@ public class QueryDataDUnitTest implements Serializable {
       DistributedSystemMXBean distributedSystemMXBean =
           managementTestRule.getSystemManagementService().getDistributedSystemMXBean();
       DistributedRegionMXBean distributedRegionMXBean =
-          awaitDistributedRegionMXBean("/" + partitionedRegionName, 3);
+          awaitDistributedRegionMXBean(SEPARATOR + partitionedRegionName, 3);
 
       String alias = "Waiting for all entries to get reflected at managing node";
       int expectedEntryCount = values1.length + values2.length;
@@ -635,15 +637,15 @@ public class QueryDataDUnitTest implements Serializable {
     memberVMs[2].invoke(this::createColocatedPR);
 
     managerVM.invoke("Wait for all Region Proxies to get replicated", () -> {
-      awaitDistributedRegionMXBean("/" + PARTITIONED_REGION_NAME1, 3);
-      awaitDistributedRegionMXBean("/" + PARTITIONED_REGION_NAME2, 3);
-      awaitDistributedRegionMXBean("/" + PARTITIONED_REGION_NAME3, 3);
-      awaitDistributedRegionMXBean("/" + PARTITIONED_REGION_NAME4, 3);
-      awaitDistributedRegionMXBean("/" + PARTITIONED_REGION_NAME5, 3);
-      awaitDistributedRegionMXBean("/" + REPLICATE_REGION_NAME1, 3);
-      awaitDistributedRegionMXBean("/" + REPLICATE_REGION_NAME2, 1);
-      awaitDistributedRegionMXBean("/" + REPLICATE_REGION_NAME3, 1);
-      awaitDistributedRegionMXBean("/" + REPLICATE_REGION_NAME4, 1);
+      awaitDistributedRegionMXBean(SEPARATOR + PARTITIONED_REGION_NAME1, 3);
+      awaitDistributedRegionMXBean(SEPARATOR + PARTITIONED_REGION_NAME2, 3);
+      awaitDistributedRegionMXBean(SEPARATOR + PARTITIONED_REGION_NAME3, 3);
+      awaitDistributedRegionMXBean(SEPARATOR + PARTITIONED_REGION_NAME4, 3);
+      awaitDistributedRegionMXBean(SEPARATOR + PARTITIONED_REGION_NAME5, 3);
+      awaitDistributedRegionMXBean(SEPARATOR + REPLICATE_REGION_NAME1, 3);
+      awaitDistributedRegionMXBean(SEPARATOR + REPLICATE_REGION_NAME2, 1);
+      awaitDistributedRegionMXBean(SEPARATOR + REPLICATE_REGION_NAME3, 1);
+      awaitDistributedRegionMXBean(SEPARATOR + REPLICATE_REGION_NAME4, 1);
     });
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/api/RegionAPIDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/api/RegionAPIDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.api;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.lang.Identifiable.find;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,7 +73,7 @@ public class RegionAPIDUnitTest {
 
     server.invoke(() -> verifyRegionCreated(regionName, "PARTITION"));
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 1);
 
     gfsh.executeAndAssertThat("put --key='foo' --value='125' --region=" + regionName)
         .statusIsSuccess();

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/DeltaClientPostAuthorizationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/DeltaClientPostAuthorizationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.security;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.security.SecurityTestUtils.NOTAUTHZ_EXCEPTION;
 import static org.apache.geode.security.SecurityTestUtils.NO_EXCEPTION;
 import static org.apache.geode.security.SecurityTestUtils.OTHER_EXCEPTION;
@@ -166,9 +167,9 @@ public class DeltaClientPostAuthorizationDUnitTest extends ClientAuthorizationTe
       if ((opFlags & OpFlags.USE_OLDCONN) == 0) {
         Properties opCredentials;
         int newRnd = random.nextInt(100) + 1;
-        String currentRegionName = '/' + regionName;
+        String currentRegionName = SEPARATOR + regionName;
         if ((opFlags & OpFlags.USE_SUBREGION) > 0) {
-          currentRegionName += ('/' + SUBREGION_NAME);
+          currentRegionName += (SEPARATOR + SUBREGION_NAME);
         }
 
         String credentialsTypeStr;

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/PDXGfshPostProcessorOnRemoteServerTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/PDXGfshPostProcessorOnRemoteServerTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.security;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_POST_PROCESSOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -89,7 +90,7 @@ public class PDXGfshPostProcessorOnRemoteServerTest {
           .until(() -> {
             Cache cache = CacheFactory.getAnyInstance();
             Object bean = ManagementService.getManagementService(cache)
-                .getDistributedRegionMXBean("/" + REGION_NAME);
+                .getDistributedRegionMXBean(SEPARATOR + REGION_NAME);
             return bean != null;
           });
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/query/IndexSecurityDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/query/IndexSecurityDistributedTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.security.query;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.RegionShortcut.PARTITION;
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,7 +72,7 @@ public class IndexSecurityDistributedTest extends AbstractQuerySecurityDistribut
     server.invoke(() -> {
       assertThat(ClusterStartupRule.getCache()).isNotNull();
       QueryService queryService = ClusterStartupRule.getCache().getQueryService();
-      queryService.createIndex("IdIndex", "id", "/" + regionName);
+      queryService.createIndex("IdIndex", "id", SEPARATOR + regionName);
     });
 
     putIntoRegion(specificUserClient, keys, values, regionName);
@@ -82,7 +83,7 @@ public class IndexSecurityDistributedTest extends AbstractQuerySecurityDistribut
     server.invoke(() -> {
       assertThat(ClusterStartupRule.getCache()).isNotNull();
       QueryService queryService = ClusterStartupRule.getCache().getQueryService();
-      queryService.createIndex("IdIndex", "e.id", "/" + regionName + ".entries e");
+      queryService.createIndex("IdIndex", "e.id", SEPARATOR + regionName + ".entries e");
     });
 
     putIntoRegion(specificUserClient, keys, values, regionName);
@@ -96,7 +97,7 @@ public class IndexSecurityDistributedTest extends AbstractQuerySecurityDistribut
       assertThat(ClusterStartupRule.getCache()).isNotNull();
       QueryService queryService = ClusterStartupRule.getCache().getQueryService();
       assertThatThrownBy(
-          () -> queryService.createIndex("IdIndex", "e.getName()", "/" + regionName + " e"))
+          () -> queryService.createIndex("IdIndex", "e.getName()", SEPARATOR + regionName + " e"))
               .isInstanceOf(IndexInvalidException.class)
               .hasMessageContaining("Unauthorized access to method: getName");
     });
@@ -107,7 +108,7 @@ public class IndexSecurityDistributedTest extends AbstractQuerySecurityDistribut
     server.invoke(() -> {
       assertThat(ClusterStartupRule.getCache()).isNotNull();
       QueryService queryService = ClusterStartupRule.getCache().getQueryService();
-      queryService.createIndex("IdIndex", "e.getName()", "/" + regionName + " e");
+      queryService.createIndex("IdIndex", "e.getName()", SEPARATOR + regionName + " e");
     });
 
     putIntoRegion(superUserClient, keys, values, regionName);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/DistinctResultsWithDupValuesInRegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/DistinctResultsWithDupValuesInRegionJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -300,7 +301,7 @@ public class DistinctResultsWithDupValuesInRegionJUnitTest {
     QueryService queryService = cache.getQueryService();
     Query query1 = null;
     try {
-      queryService.createIndex("idIndex", "p.ID", "/" + regionName + " p");
+      queryService.createIndex("idIndex", "p.ID", SEPARATOR + regionName + " p");
       for (String queryStr : queries) {
         query1 = queryService.newQuery(queryStr);
 
@@ -331,7 +332,7 @@ public class DistinctResultsWithDupValuesInRegionJUnitTest {
     QueryService queryService = cache.getQueryService();
     Query query1 = null;
     try {
-      queryService.createIndex("idIndex", "p.ID", "/" + regionName + " p");
+      queryService.createIndex("idIndex", "p.ID", SEPARATOR + regionName + " p");
       for (String queryStr : queries) {
         query1 = queryService.newQuery(queryStr);
 
@@ -363,7 +364,7 @@ public class DistinctResultsWithDupValuesInRegionJUnitTest {
     QueryService queryService = cache.getQueryService();
     Query query1 = null;
     try {
-      queryService.createIndex("idIndex", "p.ID", "/" + regionName + " p");
+      queryService.createIndex("idIndex", "p.ID", SEPARATOR + regionName + " p");
       for (String queryStr : queries) {
         query1 = queryService.newQuery(queryStr);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexOnEntrySetJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexOnEntrySetJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -104,14 +105,14 @@ public class IndexOnEntrySetJUnitTest {
   @Test
   public void testQueriesOnReplicatedRegion() throws Exception {
     testRegion = createReplicatedRegion(testRegionName);
-    String regionPath = "/" + testRegionName + ".entrySet entry";
+    String regionPath = SEPARATOR + testRegionName + ".entrySet entry";
     executeQueryTest(getQueriesOnRegion(testRegionName), "entry.key.Index", regionPath, 200);
   }
 
   @Test
   public void testEntryDestroyedRaceWithSizeEstimateReplicatedRegion() throws Exception {
     testRegion = createReplicatedRegion(testRegionName);
-    String regionPath = "/" + testRegionName + ".entrySet entry";
+    String regionPath = SEPARATOR + testRegionName + ".entrySet entry";
     executeQueryTestDestroyDuringSizeEstimation(getQueriesOnRegion(testRegionName),
         "entry.key.Index", regionPath, 201);
   }
@@ -123,7 +124,7 @@ public class IndexOnEntrySetJUnitTest {
   @Test
   public void testQueriesOnPartitionedRegion() throws Exception {
     testRegion = createPartitionedRegion(testRegionName);
-    String regionPath = "/" + testRegionName + ".entrySet entry";
+    String regionPath = SEPARATOR + testRegionName + ".entrySet entry";
     executeQueryTest(getQueriesOnRegion(testRegionName), "entry.key.Index", regionPath, 200);
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/LikePredicateJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/LikePredicateJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -1853,7 +1854,7 @@ public class LikePredicateJUnitTest {
     }
 
     QueryService qs = cache.getQueryService();
-    String name = "/" + regionName;
+    String name = SEPARATOR + regionName;
     qs.createIndex("status", "status", name);
     assertEquals(cache.getQueryService().getIndexes().size(), 1);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/NumericQueryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/NumericQueryJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -162,7 +163,7 @@ public class NumericQueryJUnitTest {
     populateRegion(testRegion);
     assertNotNull(cache.getRegion(testRegionName));
     assertEquals(numElem * 2, cache.getRegion(testRegionName).size());
-    String regionPath = "/" + testRegionName + " r";
+    String regionPath = SEPARATOR + testRegionName + " r";
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", EQ), "r.max1", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", LT), "r.max1", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", GT), "r.max1", regionPath);
@@ -180,7 +181,7 @@ public class NumericQueryJUnitTest {
     populateRegion(testRegion);
     assertNotNull(cache.getRegion(testRegionName));
     assertEquals(numElem * 2, cache.getRegion(testRegionName).size());
-    String regionPath = "/" + testRegionName + " r";
+    String regionPath = SEPARATOR + testRegionName + " r";
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", EQ), "r.max1", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", LT), "r.max1", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", GT), "r.max1", regionPath);
@@ -198,7 +199,7 @@ public class NumericQueryJUnitTest {
     populateRegion(testRegion);
     assertNotNull(cache.getRegion(testRegionName));
     assertEquals(numElem * 2, cache.getRegion(testRegionName).size());
-    String regionPath = "/" + testRegionName + " r";
+    String regionPath = SEPARATOR + testRegionName + " r";
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", EQ), "r.max1", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", LT), "r.max1", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.max1", GT), "r.max1", regionPath);
@@ -217,7 +218,7 @@ public class NumericQueryJUnitTest {
     populateRegion(testRegion);
     assertNotNull(cache.getRegion(testRegionName));
     assertEquals(numElem * 2, cache.getRegion(testRegionName).size());
-    String regionPath = "/" + testRegionName + " r";
+    String regionPath = SEPARATOR + testRegionName + " r";
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", EQ), "r.id", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", LT), "r.id", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", GT), "r.id", regionPath);
@@ -235,7 +236,7 @@ public class NumericQueryJUnitTest {
     populateRegion(testRegion);
     assertNotNull(cache.getRegion(testRegionName));
     assertEquals(numElem * 2, cache.getRegion(testRegionName).size());
-    String regionPath = "/" + testRegionName + " r";
+    String regionPath = SEPARATOR + testRegionName + " r";
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", EQ), "r.id", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", LT), "r.id", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", GT), "r.id", regionPath);
@@ -253,7 +254,7 @@ public class NumericQueryJUnitTest {
     populateRegion(testRegion);
     assertNotNull(cache.getRegion(testRegionName));
     assertEquals(numElem * 2, cache.getRegion(testRegionName).size());
-    String regionPath = "/" + testRegionName + " r";
+    String regionPath = SEPARATOR + testRegionName + " r";
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", EQ), "r.id", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", LT), "r.id", regionPath);
     executeQueryTest(getQueriesOnRegion(testRegionName, "r.id", GT), "r.id", regionPath);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/PdxOrderByJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/PdxOrderByJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.fail;
 
 import java.util.Iterator;
@@ -52,7 +53,7 @@ import org.apache.geode.test.junit.categories.OQLQueryTest;
 public class PdxOrderByJUnitTest {
   private final String rootRegionName = "root";
   private final String regionName = "PdxTest";
-  private final String regName = "/" + rootRegionName + "/" + regionName;
+  private final String regName = SEPARATOR + rootRegionName + SEPARATOR + regionName;
 
   private final String[] queryString = new String[] {
       "SELECT pos.secId FROM " + regName + " p, p.positions.values pos WHERE pos.secId LIKE '%L'", // 0

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/QueryREUpdateInProgressJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/QueryREUpdateInProgressJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.Utils.createPortfoliosAndPositions;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -158,19 +159,21 @@ public class QueryREUpdateInProgressJUnitTest {
     }
 
     try {
-      qs.createIndex("idIndex", "p.ID", "/" + regionName + " p");
-      qs.createIndex("statusIndex", "p.status", "/" + regionName + " p");
-      qs.createIndex("secIdIndex", "pos.secId", "/" + regionName + " p, p.positions.values pos");
-      qs.createIndex("pentryKeyIndex", "p_ent.key", "/" + regionName + ".entries p_ent");
+      qs.createIndex("idIndex", "p.ID", SEPARATOR + regionName + " p");
+      qs.createIndex("statusIndex", "p.status", SEPARATOR + regionName + " p");
+      qs.createIndex("secIdIndex", "pos.secId",
+          SEPARATOR + regionName + " p, p.positions.values pos");
+      qs.createIndex("pentryKeyIndex", "p_ent.key", SEPARATOR + regionName + ".entries p_ent");
       qs.createIndex("pentryValueIndex", "ppos.secId",
-          "/" + regionName + ".entries p_ent, p_ent.value.positions.values ppos");
+          SEPARATOR + regionName + ".entries p_ent, p_ent.value.positions.values ppos");
 
-      qs.createIndex("eidIndex", "e.ID", "/" + exampleRegionName + " e");
-      qs.createIndex("estatusIndex", "e.status", "/" + exampleRegionName + " e");
-      qs.createIndex("eentryKeyIndex", "e_ent.key", "/" + exampleRegionName + ".entries e_ent");
+      qs.createIndex("eidIndex", "e.ID", SEPARATOR + exampleRegionName + " e");
+      qs.createIndex("estatusIndex", "e.status", SEPARATOR + exampleRegionName + " e");
+      qs.createIndex("eentryKeyIndex", "e_ent.key",
+          SEPARATOR + exampleRegionName + ".entries e_ent");
       qs.createIndex("eentryValueIndex", "epos.secId",
-          "/" + exampleRegionName + ".entries e_ent, e_ent.value.positions.values epos");
-      qs.createIndex("keyIndex", "toString", "/" + regionForAsyncIndex + ".keys");
+          SEPARATOR + exampleRegionName + ".entries e_ent, e_ent.value.positions.values epos");
+      qs.createIndex("keyIndex", "toString", SEPARATOR + regionForAsyncIndex + ".keys");
     } catch (Exception e) {
       throw new RuntimeException("Index creation failed!", e);
     }
@@ -217,7 +220,7 @@ public class QueryREUpdateInProgressJUnitTest {
       }
     }
 
-    qs.createIndex("idIndex", "p.ID", "/" + regionName + " p");
+    qs.createIndex("idIndex", "p.ID", SEPARATOR + regionName + " p");
 
 
     // Run all queries with Indexes.
@@ -263,7 +266,7 @@ public class QueryREUpdateInProgressJUnitTest {
       }
     }
 
-    qs.createIndex("secIdindex", "z.position1.secId", "/" + regionName + " z ");
+    qs.createIndex("secIdindex", "z.position1.secId", SEPARATOR + regionName + " z ");
 
 
     // Run all queries with Indexes.
@@ -309,7 +312,7 @@ public class QueryREUpdateInProgressJUnitTest {
     }
 
 
-    qs.createIndex("mapIndex", "pf.positions['IBM','YHOO','SUN']", "/" + regionName + " pf");
+    qs.createIndex("mapIndex", "pf.positions['IBM','YHOO','SUN']", SEPARATOR + regionName + " pf");
 
 
     // Run all queries with Indexes.
@@ -354,18 +357,19 @@ public class QueryREUpdateInProgressJUnitTest {
       }
     }
 
-    qs.createIndex("idIndex", "p.ID", "/" + regionName + " p");
-    qs.createIndex("statusIndex", "p.status", "/" + regionName + " p");
-    qs.createIndex("secIdIndex", "pos.secId", "/" + regionName + " p, p.positions.values pos");
-    qs.createIndex("pentryKeyIndex", "p_ent.key", "/" + regionName + ".entries p_ent");
+    qs.createIndex("idIndex", "p.ID", SEPARATOR + regionName + " p");
+    qs.createIndex("statusIndex", "p.status", SEPARATOR + regionName + " p");
+    qs.createIndex("secIdIndex", "pos.secId",
+        SEPARATOR + regionName + " p, p.positions.values pos");
+    qs.createIndex("pentryKeyIndex", "p_ent.key", SEPARATOR + regionName + ".entries p_ent");
     qs.createIndex("pentryValueIndex", "ppos.secId",
-        "/" + regionName + ".entries p_ent, p_ent.value.positions.values ppos");
+        SEPARATOR + regionName + ".entries p_ent, p_ent.value.positions.values ppos");
 
-    qs.createIndex("eidIndex", "e.ID", "/" + exampleRegionName + " e");
-    qs.createIndex("estatusIndex", "e.status", "/" + exampleRegionName + " e");
-    qs.createIndex("eentryKeyIndex", "e_ent.key", "/" + exampleRegionName + ".entries e_ent");
+    qs.createIndex("eidIndex", "e.ID", SEPARATOR + exampleRegionName + " e");
+    qs.createIndex("estatusIndex", "e.status", SEPARATOR + exampleRegionName + " e");
+    qs.createIndex("eentryKeyIndex", "e_ent.key", SEPARATOR + exampleRegionName + ".entries e_ent");
     qs.createIndex("eentryValueIndex", "epos.secId",
-        "/" + exampleRegionName + ".entries e_ent, e_ent.value.positions.values epos");
+        SEPARATOR + exampleRegionName + ".entries e_ent, e_ent.value.positions.values epos");
 
 
     // Run all queries with Indexes.

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/CopyOnReadQueryJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/CopyOnReadQueryJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
@@ -125,7 +126,7 @@ public class CopyOnReadQueryJUnitTest {
     for (int i = 0; i < queries.length; i++) {
       Portfolio.instanceCount.set(0);
       utils.createPartitionRegion(regionName, null);
-      Region region = utils.getCache().getRegion("/" + regionName);
+      Region region = utils.getCache().getRegion(SEPARATOR + regionName);
       createData(region, numObjects, objectsAndResultsMultiplier);
       helpTestCopyOnReadFalse(queries[i], expectedResults[i], numObjects,
           objectsAndResultsMultiplier, false, true, containsInnerQuery[i]);
@@ -137,7 +138,7 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithHashIndexWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -146,7 +147,7 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithHashIndexWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -155,7 +156,7 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithHashIndexWithPartitionedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createPartitionRegion(regionName, null);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, true);
   }
@@ -164,7 +165,7 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithCompactRangeIndexWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -173,7 +174,7 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithCompactRangeIndexWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -182,7 +183,7 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithCompactRangeIndexWithPartitionedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, true);
   }
@@ -191,7 +192,8 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -200,7 +202,8 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -209,7 +212,8 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexWithPartitionedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, true);
   }
@@ -218,7 +222,7 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexTupleWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -227,14 +231,14 @@ public class CopyOnReadQueryJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexTupleWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
 
   private void helpExecuteQueriesCopyOnRead(String[] queries, int[] expectedResults, int numObjects,
       int objectsAndResultsMultiplier, boolean hasIndex, boolean isPR) throws Exception {
-    Region region = utils.getCache().getRegion("/" + regionName);
+    Region region = utils.getCache().getRegion(SEPARATOR + regionName);
     createData(region, numObjects, objectsAndResultsMultiplier);
     for (int i = 0; i < queries.length; i++) {
       Portfolio.instanceCount.set(numObjects * objectsAndResultsMultiplier);
@@ -249,7 +253,7 @@ public class CopyOnReadQueryJUnitTest {
   private void helpExecuteQueriesCopyOnReadFalse(String[] queries, int[] expectedResults,
       int numObjects, int objectsAndResultsMultiplier, boolean hasIndex, boolean isPR)
       throws Exception {
-    Region region = utils.getCache().getRegion("/" + regionName);
+    Region region = utils.getCache().getRegion(SEPARATOR + regionName);
     createData(region, numObjects, objectsAndResultsMultiplier);
     for (int i = 0; i < queries.length; i++) {
       Portfolio.instanceCount.set(numObjects * objectsAndResultsMultiplier);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,7 +99,7 @@ public class GroupJunctionIntegrationTest {
         .<String, TestObject>createRegionFactory(regionShortcut).create(REGION_NAME);
     indexedFields.forEach(fieldName -> {
       try {
-        queryService.createIndex(fieldName + "Index", fieldName, "/" + REGION_NAME);
+        queryService.createIndex(fieldName + "Index", fieldName, SEPARATOR + REGION_NAME);
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/AvgIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/AvgIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.internal.aggregate.AbstractAggregator.downCast;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -294,10 +295,10 @@ public class AvgIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     parameterizedSetUp(usePdx);
     createRegion(firstRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
     queryService.createIndex("sampleIndex-3", "pos.secId",
-        "/" + firstRegionName + " p, p.positions.values pos");
+        SEPARATOR + firstRegionName + " p, p.positions.values pos");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(3));
     populateRegion(firstRegionName, regionOneLocalCopy);
 
@@ -342,10 +343,10 @@ public class AvgIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     createRegion(firstRegionName, regionShortcut);
     createRegion(secondRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-3", "e.ID", "/" + secondRegionName + " e");
-    queryService.createIndex("sampleIndex-4", "e.status", "/" + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-3", "e.ID", SEPARATOR + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-4", "e.status", SEPARATOR + secondRegionName + " e");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(4));
     populateRegion(firstRegionName, regionOneLocalCopy);
     populateRegion(secondRegionName, regionTwoLocalCopy);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/CountIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/CountIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -297,10 +298,10 @@ public class CountIntegrationTest extends AggregateFunctionQueryBaseIntegrationT
     parameterizedSetUp(usePdx);
     createRegion(firstRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
     queryService.createIndex("sampleIndex-3", "pos.secId",
-        "/" + firstRegionName + " p, p.positions.values pos");
+        SEPARATOR + firstRegionName + " p, p.positions.values pos");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(3));
     populateRegion(firstRegionName, regionOneLocalCopy);
 
@@ -345,10 +346,10 @@ public class CountIntegrationTest extends AggregateFunctionQueryBaseIntegrationT
     createRegion(firstRegionName, regionShortcut);
     createRegion(secondRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-3", "e.ID", "/" + secondRegionName + " e");
-    queryService.createIndex("sampleIndex-4", "e.status", "/" + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-3", "e.ID", SEPARATOR + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-4", "e.status", SEPARATOR + secondRegionName + " e");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(4));
     populateRegion(firstRegionName, regionOneLocalCopy);
     populateRegion(secondRegionName, regionTwoLocalCopy);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/MaxIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/MaxIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -291,10 +292,10 @@ public class MaxIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     parameterizedSetUp(usePdx);
     createRegion(firstRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
     queryService.createIndex("sampleIndex-3", "pos.secId",
-        "/" + firstRegionName + " p, p.positions.values pos");
+        SEPARATOR + firstRegionName + " p, p.positions.values pos");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(3));
     populateRegion(firstRegionName, regionOneLocalCopy);
 
@@ -339,10 +340,10 @@ public class MaxIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     createRegion(firstRegionName, regionShortcut);
     createRegion(secondRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-3", "e.ID", "/" + secondRegionName + " e");
-    queryService.createIndex("sampleIndex-4", "e.status", "/" + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-3", "e.ID", SEPARATOR + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-4", "e.status", SEPARATOR + secondRegionName + " e");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(4));
     populateRegion(firstRegionName, regionOneLocalCopy);
     populateRegion(secondRegionName, regionTwoLocalCopy);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/MinIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/MinIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -292,10 +293,10 @@ public class MinIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     parameterizedSetUp(usePdx);
     createRegion(firstRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
     queryService.createIndex("sampleIndex-3", "pos.secId",
-        "/" + firstRegionName + " p, p.positions.values pos");
+        SEPARATOR + firstRegionName + " p, p.positions.values pos");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(3));
     populateRegion(firstRegionName, regionOneLocalCopy);
 
@@ -340,10 +341,10 @@ public class MinIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     createRegion(firstRegionName, regionShortcut);
     createRegion(secondRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-3", "e.ID", "/" + secondRegionName + " e");
-    queryService.createIndex("sampleIndex-4", "e.status", "/" + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-3", "e.ID", SEPARATOR + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-4", "e.status", SEPARATOR + secondRegionName + " e");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(4));
     populateRegion(firstRegionName, regionOneLocalCopy);
     populateRegion(secondRegionName, regionTwoLocalCopy);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/SumIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/SumIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.aggregate;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.internal.aggregate.AbstractAggregator.downCast;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -285,10 +286,10 @@ public class SumIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     parameterizedSetUp(usePdx);
     createRegion(firstRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
     queryService.createIndex("sampleIndex-3", "pos.secId",
-        "/" + firstRegionName + " p, p.positions.values pos");
+        SEPARATOR + firstRegionName + " p, p.positions.values pos");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(3));
     populateRegion(firstRegionName, regionOneLocalCopy);
 
@@ -333,10 +334,10 @@ public class SumIntegrationTest extends AggregateFunctionQueryBaseIntegrationTes
     createRegion(firstRegionName, regionShortcut);
     createRegion(secondRegionName, regionShortcut);
     QueryService queryService = server.getCache().getQueryService();
-    queryService.createIndex("sampleIndex-1", "p.ID", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-2", "p.status", "/" + firstRegionName + " p");
-    queryService.createIndex("sampleIndex-3", "e.ID", "/" + secondRegionName + " e");
-    queryService.createIndex("sampleIndex-4", "e.status", "/" + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-1", "p.ID", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-2", "p.status", SEPARATOR + firstRegionName + " p");
+    queryService.createIndex("sampleIndex-3", "e.ID", SEPARATOR + secondRegionName + " e");
+    queryService.createIndex("sampleIndex-4", "e.status", SEPARATOR + secondRegionName + " e");
     await().untilAsserted(() -> assertThat(queryService.getIndexes().size()).isEqualTo(4));
     populateRegion(firstRegionName, regionOneLocalCopy);
     populateRegion(secondRegionName, regionTwoLocalCopy);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/AsyncIndexUpdaterThreadShutdownJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/AsyncIndexUpdaterThreadShutdownJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -61,7 +62,7 @@ public class AsyncIndexUpdaterThreadShutdownJUnitTest {
     assertNotNull("Region ref null", localRegion);
 
     try {
-      cache.getQueryService().createIndex("idIndex", "ID", "/" + name);
+      cache.getQueryService().createIndex("idIndex", "ID", SEPARATOR + name);
     } catch (Exception e) {
       cache.close();
       e.printStackTrace();
@@ -93,7 +94,7 @@ public class AsyncIndexUpdaterThreadShutdownJUnitTest {
     assertNotNull("Region ref null", localRegion);
 
     try {
-      cache.getQueryService().createIndex("idIndex", "ID", "/" + name);
+      cache.getQueryService().createIndex("idIndex", "ID", SEPARATOR + name);
     } catch (Exception e) {
       cache.close();
       e.printStackTrace();

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CopyOnReadIndexJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CopyOnReadIndexJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertEquals;
 
@@ -42,19 +43,18 @@ public class CopyOnReadIndexJUnitTest {
   QueryTestUtils utils;
   static String regionName = "portfolios";
   static final String indexName = "testIndex";
-  String[] queries = {"select * from /" + regionName + " p where p.indexKey = 1",
-      "select distinct * from /" + regionName + " p where p.indexKey = 1 order by p.indexKey",
-      "select * from /" + regionName + " p, p.positions.values pv where pv.secId = '1'",
-      "select * from /" + regionName + " p where p in (select * from /" + regionName
-          + " pi where pi.indexKey = 1)",
+  String[] queries = {"select * from " + SEPARATOR + regionName + " p where p.indexKey = 1",
+      "select distinct * from " + SEPARATOR + regionName
+          + " p where p.indexKey = 1 order by p.indexKey",
+      "select * from " + SEPARATOR + regionName + " p, p.positions.values pv where pv.secId = '1'",
+      "select * from " + SEPARATOR + regionName + " p where p in (select * from " + SEPARATOR
+          + regionName + " pi where pi.indexKey = 1)",
 
-      // "select * from /" + regionName + " p where p.ID = ELEMENT(select pi.ID from /" + regionName
-      // + " pi where pi.ID = 1)"
+      // "select * from " + SEPARATOR + regionName + " p where p.ID = ELEMENT(select pi.ID from " +
+      // SEPARATOR + regionName pi where pi.ID = 1)"
   };
 
-  int[] expectedResults = {1, 1, 1, 1// ,
-                                     // 1
-  };
+  int[] expectedResults = {1, 1, 1, 1/* , 1 */};
 
   boolean[] containsInnerQuery = {false, false, false, true
 
@@ -98,7 +98,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithHashIndexWithLocalRegion() throws Exception {
     utils.createLocalRegion(regionName);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -106,7 +106,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithHashIndexWithReplicatedRegion() throws Exception {
     utils.createReplicateRegion(regionName);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -114,7 +114,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithHashIndexWithPartitionedRegion() throws Exception {
     utils.createPartitionRegion(regionName, null);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, true);
   }
@@ -122,7 +122,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithCompactRangeIndexWithLocalRegion() throws Exception {
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -130,7 +130,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithCompactRangeIndexWithReplicatedRegion() throws Exception {
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -138,7 +138,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithCompactRangeIndexWithPartitionedRegion() throws Exception {
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, true);
   }
@@ -146,7 +146,8 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithRangeIndexWithLocalRegion() throws Exception {
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -154,7 +155,8 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithRangeIndexWithReplicatedRegion() throws Exception {
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -162,7 +164,8 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithRangeIndexWithPartitionedRegion() throws Exception {
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, true);
   }
@@ -170,7 +173,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithRangeIndexTupleWithLocalRegion() throws Exception {
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -178,7 +181,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithRangeIndexTupleWithReplicatedRegion() throws Exception {
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, false);
   }
@@ -186,7 +189,7 @@ public class CopyOnReadIndexJUnitTest {
   @Test
   public void testCopyOnReadWithRangeIndexTupleWithPartitionedRegion() throws Exception {
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnRead(queries, expectedResults, numObjects, objectsAndResultsMultiplier,
         true, true);
   }
@@ -196,7 +199,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithHashIndexWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -205,7 +208,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithHashIndexWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -214,7 +217,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithHashIndexWithPartitionedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createPartitionRegion(regionName, null);
-    utils.createHashIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createHashIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, true);
   }
@@ -223,7 +226,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithCompactRangeIndexWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -232,7 +235,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithCompactRangeIndexWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -241,7 +244,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithCompactRangeIndexWithPartitionedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p");
+    utils.createIndex(indexName, "p.indexKey", SEPARATOR + regionName + " p");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, true);
   }
@@ -250,7 +253,8 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -259,7 +263,8 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -268,7 +273,8 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexWithPartitionedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "p.indexKey", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "p.indexKey",
+        SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, true);
   }
@@ -277,7 +283,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexTupleWithLocalRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createLocalRegion(regionName);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -286,7 +292,7 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexTupleWithReplicatedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createReplicateRegion(regionName);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, false);
   }
@@ -295,14 +301,14 @@ public class CopyOnReadIndexJUnitTest {
   public void testCopyOnReadFalseWithRangeIndexTupleWithPartitionedRegion() throws Exception {
     utils.getCache().setCopyOnRead(false);
     utils.createPartitionRegion(regionName, null);
-    utils.createIndex(indexName, "pv.secId", "/" + regionName + " p, p.positions.values pv");
+    utils.createIndex(indexName, "pv.secId", SEPARATOR + regionName + " p, p.positions.values pv");
     helpExecuteQueriesCopyOnReadFalse(queries, expectedResults, numObjects,
         objectsAndResultsMultiplier, true, true);
   }
 
   private void helpExecuteQueriesCopyOnRead(String[] queries, int[] expectedResults, int numObjects,
       int objectsAndResultsMultiplier, boolean hasIndex, boolean isPR) throws Exception {
-    Region region = utils.getCache().getRegion("/" + regionName);
+    Region region = utils.getCache().getRegion(SEPARATOR + regionName);
     createData(region, numObjects, objectsAndResultsMultiplier);
     for (int i = 0; i < queries.length; i++) {
       Portfolio.instanceCount.set(numObjects * objectsAndResultsMultiplier);
@@ -317,7 +323,7 @@ public class CopyOnReadIndexJUnitTest {
   private void helpExecuteQueriesCopyOnReadFalse(String[] queries, int[] expectedResults,
       int numObjects, int objectsAndResultsMultiplier, boolean hasIndex, boolean isPR)
       throws Exception {
-    Region region = utils.getCache().getRegion("/" + regionName);
+    Region region = utils.getCache().getRegion(SEPARATOR + regionName);
     createData(region, numObjects, objectsAndResultsMultiplier);
     for (int i = 0; i < queries.length; i++) {
       Portfolio.instanceCount.set(numObjects * objectsAndResultsMultiplier);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/EquiJoinIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/EquiJoinIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
@@ -452,7 +453,7 @@ public class EquiJoinIntegrationTest {
 
     private Index createCompactRangeIndex(String regionName, String fieldName)
         throws RegionNotFoundException, IndexExistsException, IndexNameConflictException {
-      String fromClause = "/" + regionName + " r";
+      String fromClause = SEPARATOR + regionName + " r";
       String indexedExpression = "r." + fieldName;
       return qs.createIndex("Compact " + fromClause + ":" + indexedExpression, indexedExpression,
           fromClause);
@@ -460,7 +461,7 @@ public class EquiJoinIntegrationTest {
 
     private Index createHashIndex(String regionName, String fieldName)
         throws RegionNotFoundException, IndexExistsException, IndexNameConflictException {
-      String fromClause = "/" + regionName + " r";
+      String fromClause = SEPARATOR + regionName + " r";
       String indexedExpression = "r." + fieldName;
       return qs.createHashIndex("Hash " + fromClause + ":" + indexedExpression, indexedExpression,
           fromClause);
@@ -468,7 +469,7 @@ public class EquiJoinIntegrationTest {
 
     private Index createPrimaryKeyIndex(String regionName, String fieldName)
         throws RegionNotFoundException, IndexExistsException, IndexNameConflictException {
-      String fromClause = "/" + regionName + " r";
+      String fromClause = SEPARATOR + regionName + " r";
       String indexedExpression = "r." + fieldName;
       return qs.createKeyIndex("PrimaryKey " + fromClause + ":" + indexedExpression,
           indexedExpression, fromClause);
@@ -476,7 +477,7 @@ public class EquiJoinIntegrationTest {
 
     private Index createRangeIndexOnFirstIterator(String regionName, String fieldName)
         throws RegionNotFoundException, IndexExistsException, IndexNameConflictException {
-      String fromClause = "/" + regionName + " r, r.nested.values v";
+      String fromClause = SEPARATOR + regionName + " r, r.nested.values v";
       String indexedExpression = "r." + fieldName;
       return qs.createIndex("Range " + fromClause + ":" + indexedExpression, indexedExpression,
           fromClause);
@@ -484,7 +485,7 @@ public class EquiJoinIntegrationTest {
 
     private Index createRangeIndexOnSecondIterator(String regionName, String fieldName)
         throws RegionNotFoundException, IndexExistsException, IndexNameConflictException {
-      String fromClause = "/" + regionName + " r, r.nested.values v";
+      String fromClause = SEPARATOR + regionName + " r, r.nested.values v";
       String indexedExpression = "v." + fieldName;
       return qs.createIndex("Range " + fromClause + ":" + indexedExpression, indexedExpression,
           fromClause);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexManagerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexManagerIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.RegionShortcut.PARTITION;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -106,7 +107,7 @@ public class IndexManagerIntegrationTest {
         .create(regionName);
 
     QueryService queryService = internalCache.getQueryService();
-    queryService.createIndex(indexName, "id", "/" + regionName);
+    queryService.createIndex(indexName, "id", SEPARATOR + regionName);
     IntStream.range(1, entries + 1).forEach(i -> region.put(i, new TestQueryObject(i)));
     waitForIndexUpdaterTask(synchronousMaintenance, region);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -715,7 +716,7 @@ public class IndexStatisticsJUnitTest {
     String regionName = "testCompactRegionIndexNumKeysStats_region";
     Region region = CacheUtils.createRegion(regionName, Numbers.class);
 
-    Index index = qs.createIndex("idIndexName", "r.max1", "/" + regionName + " r");
+    Index index = qs.createIndex("idIndexName", "r.max1", SEPARATOR + regionName + " r");
     IndexStatistics stats = index.getStatistics();
 
     // Add an object and check stats
@@ -784,7 +785,7 @@ public class IndexStatisticsJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(observer);
 
     String regionName = "exampleRegion";
-    String name = "/" + regionName;
+    String name = SEPARATOR + regionName;
 
     final Cache cache = CacheUtils.getCache();
     Region r1 = null;
@@ -820,7 +821,7 @@ public class IndexStatisticsJUnitTest {
     QueryObserver old = QueryObserverHolder.setInstance(observer);
 
     String regionName = "exampleRegion";
-    String name = "/" + regionName;
+    String name = SEPARATOR + regionName;
 
     final Cache cache = CacheUtils.getCache();
     Region r1 = cache.getRegion(regionName);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexUseJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexUseJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -1349,7 +1350,7 @@ public class IndexUseJUnitTest {
     r.put("A0", map0);
     r.put("A1", map1);
     r.put("A2", map2);
-    qs.createIndex("pkIndex", IndexType.PRIMARY_KEY, "p.pk", "/" + regionName + " p");
+    qs.createIndex("pkIndex", IndexType.PRIMARY_KEY, "p.pk", SEPARATOR + regionName + " p");
     QueryObserverImpl observer = new QueryObserverImpl();
     QueryObserverHolder.setInstance(observer);
     SelectResults sr = (SelectResults) qs

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/jta/functional/CacheJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/jta/functional/CacheJUnitTest.java
@@ -19,6 +19,7 @@
  */
 package org.apache.geode.internal.jta.functional;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -245,7 +246,8 @@ public class CacheJUnitTest {
       jtaObj.getRegionFromCache("region1");
 
       String current_fullpath = jtaObj.currRegion.getFullPath();
-      assertEquals("failed retrieving current region fullpath", "/" + DEFAULT_RGN + "/region1",
+      assertEquals("failed retrieving current region fullpath",
+          SEPARATOR + DEFAULT_RGN + "/region1",
           current_fullpath);
 
       jtaObj.put("key1", "value1");
@@ -255,7 +257,8 @@ public class CacheJUnitTest {
       assertEquals("get failed for corresponding put", "\"value1\"", tok);
 
       current_fullpath = jtaObj.currRegion.getFullPath();
-      assertEquals("failed retrieving current region fullpath", "/" + DEFAULT_RGN + "/region1",
+      assertEquals("failed retrieving current region fullpath",
+          SEPARATOR + DEFAULT_RGN + "/region1",
           current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
@@ -276,7 +279,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath after txn commit",
-          "/" + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
 
       int ifAnyRows = jtaObj.getRows(this.tblName);
       assertEquals("rows retrieved is:" + ifAnyRows, 1, ifAnyRows);
@@ -341,7 +344,7 @@ public class CacheJUnitTest {
       String current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals(
           "failed retrieving current region fullpath after doing getRegionFromCache(region1)",
-          "/" + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
 
       jtaObj.put("key1", "test");
       ta.begin();
@@ -352,7 +355,8 @@ public class CacheJUnitTest {
       assertEquals("get value do not match with the put", "\"value1\"", tok);
 
       current_fullpath = jtaObj.currRegion.getFullPath();
-      assertEquals("failed retrieving current region fullpath", "/" + DEFAULT_RGN + "/region1",
+      assertEquals("failed retrieving current region fullpath",
+          SEPARATOR + DEFAULT_RGN + "/region1",
           current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
@@ -372,7 +376,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retirieving current region fullpath after txn rollback",
-          "/" + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
 
       int ifAnyRows = jtaObj.getRows(this.tblName);
       assertEquals("rows retrieved is: " + ifAnyRows, 0, ifAnyRows);
@@ -440,7 +444,7 @@ public class CacheJUnitTest {
       // now current region should point to region1, as done from within
       // getRegionFromCache method...
       String current_fullpath = jtaObj.currRegion.getFullPath();
-      assertEquals("failed retirieving current fullpath", "/" + DEFAULT_RGN + "/region1",
+      assertEquals("failed retirieving current fullpath", SEPARATOR + DEFAULT_RGN + "/region1",
           current_fullpath);
 
       jtaObj.put("key1", "test");
@@ -454,7 +458,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current fullpath, current fullpath: " + current_fullpath,
-          "/" + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
 
@@ -505,7 +509,7 @@ public class CacheJUnitTest {
         String current_fullpath = jtaObj.currRegion.getFullPath();
         assertEquals(
             "failed retrieving current fullpath after rollback, fullpath is: " + current_fullpath,
-            "/" + DEFAULT_RGN + "/region1", current_fullpath);
+            SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
 
         // after jdbc rollback, cache value in region1 for key1 must vanish...
         String str1 = null;
@@ -566,7 +570,8 @@ public class CacheJUnitTest {
       // now current region should point to region1, as done from within
       // getRegionFromCache method...
       String current_fullpath = jtaObj.currRegion.getFullPath();
-      assertEquals("failed retrieving the current region fullpath", "/" + DEFAULT_RGN + "/region1",
+      assertEquals("failed retrieving the current region fullpath",
+          SEPARATOR + DEFAULT_RGN + "/region1",
           current_fullpath);
 
       jtaObj.put("key1", "value1");
@@ -577,7 +582,8 @@ public class CacheJUnitTest {
       assertEquals("get value mismatch with put", "\"value1\"", tok);
 
       current_fullpath = jtaObj.currRegion.getFullPath();
-      assertEquals("failed retrieving current region fullpath", "/" + DEFAULT_RGN + "/region1",
+      assertEquals("failed retrieving current region fullpath",
+          SEPARATOR + DEFAULT_RGN + "/region1",
           current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
@@ -590,7 +596,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath after txn commit, fullpath is: "
-          + current_region, "/" + DEFAULT_RGN + "/region1", current_fullpath);
+          + current_region, SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
 
       str = jtaObj.get("key1");
       tok = jtaObj.parseGetValue(str);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/jta/functional/CacheJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/jta/functional/CacheJUnitTest.java
@@ -247,7 +247,7 @@ public class CacheJUnitTest {
 
       String current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath",
-          SEPARATOR + DEFAULT_RGN + "/region1",
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1",
           current_fullpath);
 
       jtaObj.put("key1", "value1");
@@ -258,7 +258,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath",
-          SEPARATOR + DEFAULT_RGN + "/region1",
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1",
           current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
@@ -279,7 +279,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath after txn commit",
-          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1", current_fullpath);
 
       int ifAnyRows = jtaObj.getRows(this.tblName);
       assertEquals("rows retrieved is:" + ifAnyRows, 1, ifAnyRows);
@@ -344,7 +344,7 @@ public class CacheJUnitTest {
       String current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals(
           "failed retrieving current region fullpath after doing getRegionFromCache(region1)",
-          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1", current_fullpath);
 
       jtaObj.put("key1", "test");
       ta.begin();
@@ -356,7 +356,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath",
-          SEPARATOR + DEFAULT_RGN + "/region1",
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1",
           current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
@@ -376,7 +376,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retirieving current region fullpath after txn rollback",
-          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1", current_fullpath);
 
       int ifAnyRows = jtaObj.getRows(this.tblName);
       assertEquals("rows retrieved is: " + ifAnyRows, 0, ifAnyRows);
@@ -444,7 +444,8 @@ public class CacheJUnitTest {
       // now current region should point to region1, as done from within
       // getRegionFromCache method...
       String current_fullpath = jtaObj.currRegion.getFullPath();
-      assertEquals("failed retirieving current fullpath", SEPARATOR + DEFAULT_RGN + "/region1",
+      assertEquals("failed retirieving current fullpath",
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1",
           current_fullpath);
 
       jtaObj.put("key1", "test");
@@ -458,7 +459,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current fullpath, current fullpath: " + current_fullpath,
-          SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1", current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
 
@@ -509,7 +510,7 @@ public class CacheJUnitTest {
         String current_fullpath = jtaObj.currRegion.getFullPath();
         assertEquals(
             "failed retrieving current fullpath after rollback, fullpath is: " + current_fullpath,
-            SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
+            SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1", current_fullpath);
 
         // after jdbc rollback, cache value in region1 for key1 must vanish...
         String str1 = null;
@@ -571,7 +572,7 @@ public class CacheJUnitTest {
       // getRegionFromCache method...
       String current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving the current region fullpath",
-          SEPARATOR + DEFAULT_RGN + "/region1",
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1",
           current_fullpath);
 
       jtaObj.put("key1", "value1");
@@ -583,7 +584,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath",
-          SEPARATOR + DEFAULT_RGN + "/region1",
+          SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1",
           current_fullpath);
 
       DataSource da = (DataSource) ctx.lookup("java:/XAPooledDataSource");
@@ -596,7 +597,7 @@ public class CacheJUnitTest {
 
       current_fullpath = jtaObj.currRegion.getFullPath();
       assertEquals("failed retrieving current region fullpath after txn commit, fullpath is: "
-          + current_region, SEPARATOR + DEFAULT_RGN + "/region1", current_fullpath);
+          + current_region, SEPARATOR + DEFAULT_RGN + SEPARATOR + "region1", current_fullpath);
 
       str = jtaObj.get("key1");
       tok = jtaObj.parseGetValue(str);

--- a/geode-core/src/main/java/org/apache/geode/admin/RegionSubRegionSnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/RegionSubRegionSnapshot.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.admin;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -141,7 +143,7 @@ public class RegionSubRegionSnapshot implements DataSerializable {
    * @return full path of region
    */
   public String getFullPath() {
-    return (getParent() == null ? "/" : getParent().getFullPath()) + getName() + "/";
+    return (getParent() == null ? SEPARATOR : getParent().getFullPath()) + getName() + SEPARATOR;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/cache/DynamicRegionFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/DynamicRegionFactory.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -222,7 +224,7 @@ public abstract class DynamicRegionFactory {
   }
 
   public static boolean regionIsDynamicRegionList(String regionPath) {
-    return regionPath != null && regionPath.equals('/' + DYNAMIC_REGION_LIST_NAME);
+    return regionPath != null && regionPath.equals(SEPARATOR + DYNAMIC_REGION_LIST_NAME);
   }
 
   /**
@@ -328,7 +330,7 @@ public abstract class DynamicRegionFactory {
     while (iterator.hasNext()) {
       Region.Entry e = (Region.Entry) iterator.next();
       DynamicRegionAttributes dda = (DynamicRegionAttributes) e.getValue();
-      sorted.put(dda.rootRegionName + '/' + dda.name, dda);
+      sorted.put(dda.rootRegionName + SEPARATOR + dda.name, dda);
     }
     iterator = sorted.values().iterator();
 

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
@@ -34,6 +34,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.w3c.dom.Element;
 
 import org.apache.geode.annotations.Experimental;
+import org.apache.geode.cache.Region;
 import org.apache.geode.internal.config.VersionAdapter;
 import org.apache.geode.lang.Identifiable;
 
@@ -328,7 +329,7 @@ public class CacheConfig {
   @XmlJavaTypeAdapter(VersionAdapter.class)
   protected String version;
 
-  public static final String SEPARATOR = "/";
+  public static final String SEPARATOR = Region.SEPARATOR;
 
   public CacheConfig() {}
 

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/CacheConfig.java
@@ -329,6 +329,10 @@ public class CacheConfig {
   @XmlJavaTypeAdapter(VersionAdapter.class)
   protected String version;
 
+  /**
+   * @deprecated Please use {@link Region#SEPARATOR}
+   */
+  @Deprecated
   public static final String SEPARATOR = Region.SEPARATOR;
 
   public CacheConfig() {}
@@ -1028,12 +1032,12 @@ public class CacheConfig {
 
   // this supports looking for sub regions
   public RegionConfig findRegionConfiguration(String regionPath) {
-    if (regionPath.startsWith(SEPARATOR)) {
+    if (regionPath.startsWith(Region.SEPARATOR)) {
       regionPath = regionPath.substring(1);
     }
     List<RegionConfig> regions = getRegions();
     RegionConfig found = null;
-    for (String regionToken : regionPath.split(SEPARATOR)) {
+    for (String regionToken : regionPath.split(Region.SEPARATOR)) {
       found = Identifiable.find(regions, regionToken);
       // couldn't find one of the sub regions, break out of the loop
       if (found == null) {

--- a/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/configuration/RegionConfig.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.cache.configuration;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -277,7 +279,7 @@ public class RegionConfig implements Identifiable<String>, Serializable {
       return;
     }
 
-    this.name = value.startsWith("/") ? value.substring(1) : value;
+    this.name = value.startsWith(SEPARATOR) ? value.substring(1) : value;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.ANY_INIT;
 
 import java.io.Serializable;
@@ -146,7 +147,7 @@ public class ColocationHelper {
         }
         if (prConf.getColocatedWith() != null) {
           if (prConf.getColocatedWith().equals(tempToBeColocatedWith.getFullPath())
-              || (Region.SEPARATOR + prConf.getColocatedWith())
+              || (SEPARATOR + prConf.getColocatedWith())
                   .equals(tempToBeColocatedWith.getFullPath())) {
             colocatedRegions.add(prConf);
             tempcolocatedRegions.add(prConf);
@@ -409,7 +410,8 @@ public class ColocationHelper {
         if (prRegion != null) {
           if (prRegion.getColocatedWith() != null) {
             if (prRegion.getColocatedWith().equals(partitionedRegion.getFullPath())
-                || ("/" + prRegion.getColocatedWith()).equals(partitionedRegion.getFullPath())) {
+                || (SEPARATOR + prRegion.getColocatedWith())
+                    .equals(partitionedRegion.getFullPath())) {
               // only regions directly colocatedWith partitionedRegion are
               // added to the list...
               prRegion.waitOnBucketMetadataInitialization();
@@ -470,10 +472,10 @@ public class ColocationHelper {
   }
 
   private static String getRegionIdentifier(String regionName) {
-    if (regionName.startsWith("/")) {
-      return regionName.replace("/", "#");
+    if (regionName.startsWith(SEPARATOR)) {
+      return regionName.replace(SEPARATOR, "#");
     } else {
-      return "#" + regionName.replace("/", "#");
+      return "#" + regionName.replace(SEPARATOR, "#");
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.cache.Region.SEPARATOR_CHAR;
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
@@ -3903,7 +3904,7 @@ public class DiskStoreImpl implements DiskStore {
         String regionName = (drv.isBucket() ? ph.getPrName() : drv.getName());
         SnapshotWriter writer = regions.get(regionName);
         if (writer == null) {
-          String fname = regionName.substring(1).replace('/', '-');
+          String fname = regionName.substring(1).replace(SEPARATOR_CHAR, '-');
           File f = new File(out, "snapshot-" + name + "-" + fname + ".gfd");
           writer = GFSnapshot.create(f, regionName, cache);
           regions.put(regionName, writer);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -7500,7 +7500,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       }
 
       DiskStoreFactoryImpl diskStoreFactoryImpl = (DiskStoreFactoryImpl) diskStoreFactory;
-      return diskStoreFactoryImpl.createOwnedByRegion(getFullPath().replace('/', '_'),
+      return diskStoreFactoryImpl.createOwnedByRegion(getFullPath().replace(SEPARATOR_CHAR, '_'),
           this instanceof PartitionedRegion, internalRegionArgs);
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -764,7 +764,7 @@ public class PartitionedRegion extends LocalRegion
     this.node = initializeNode();
     this.prStats = new PartitionedRegionStats(cache.getDistributedSystem(), getFullPath(),
         statisticsClock);
-    this.regionIdentifier = getFullPath().replace('/', '#');
+    this.regionIdentifier = getFullPath().replace(SEPARATOR_CHAR, '#');
 
     if (logger.isDebugEnabled()) {
       logger.debug("Constructing Partitioned Region {}", regionName);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/FilterByPath.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/FilterByPath.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.control;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,7 +31,8 @@ public class FilterByPath implements RegionFilter {
     if (included != null) {
       this.included = new HashSet<String>();
       for (String regionName : included) {
-        this.included.add((!regionName.startsWith("/")) ? ("/" + regionName) : regionName);
+        this.included
+            .add((!regionName.startsWith(SEPARATOR)) ? (SEPARATOR + regionName) : regionName);
       }
     } else {
       this.included = null;
@@ -37,7 +40,8 @@ public class FilterByPath implements RegionFilter {
     if (excluded != null) {
       this.excluded = new HashSet<String>();
       for (String regionName : excluded) {
-        this.excluded.add((!regionName.startsWith("/")) ? ("/" + regionName) : regionName);
+        this.excluded
+            .add((!regionName.startsWith(SEPARATOR)) ? (SEPARATOR + regionName) : regionName);
       }
     } else {
       this.excluded = null;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.cache.Region.SEPARATOR_CHAR;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.THREAD_ID_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductIntegerProperty;
@@ -325,7 +326,7 @@ public class HARegionQueue implements RegionQueue {
    * @return legal region name
    */
   public static String createRegionName(String regionName) {
-    return regionName.replace('/', '#');
+    return regionName.replace(SEPARATOR_CHAR, '#');
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/CacheSnapshotServiceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/CacheSnapshotServiceImpl.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.snapshot;
 
+import static org.apache.geode.cache.Region.SEPARATOR_CHAR;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -128,7 +130,7 @@ public class CacheSnapshotServiceImpl implements CacheSnapshotService {
   private void saveRegion(Region<?, ?> region, File dir, SnapshotFormat format,
       SnapshotOptions options) throws IOException {
     RegionSnapshotService<?, ?> regionSnapshotService = region.getSnapshotService();
-    String name = "snapshot" + region.getFullPath().replace('/', '-')
+    String name = "snapshot" + region.getFullPath().replace(SEPARATOR_CHAR, '-')
         + RegionSnapshotService.SNAPSHOT_FILE_EXTENSION;
     File f = new File(dir, name);
     regionSnapshotService.save(f, format, options);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegion.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tier.sockets.command;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.IOException;
 
 import org.apache.geode.annotations.Immutable;
@@ -106,7 +108,7 @@ public class CreateRegion extends BaseCommand {
     AuthorizeRequest authzRequest = serverConnection.getAuthzRequest();
     if (authzRequest != null) {
       try {
-        authzRequest.createRegionAuthorize(parentRegionName + '/' + regionName);
+        authzRequest.createRegionAuthorize(parentRegionName + SEPARATOR + regionName);
       } catch (NotAuthorizedException ex) {
         writeException(clientMessage, ex, false, serverConnection);
         serverConnection.setAsTrue(RESPONDED);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.xmlcache;
 
 import static java.lang.String.format;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.logging.LogWriterFactory.toSecurityLogWriter;
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.logging.internal.spi.LogWriterLevel.ALL;
@@ -1161,7 +1162,7 @@ public class CacheCreation implements InternalCache {
 
   @Override
   public Region getRegion(String path) {
-    if (path.contains("/")) {
+    if (path.contains(SEPARATOR)) {
       throw new UnsupportedOperationException("Region path '" + path + "' contains '/'");
     }
     return roots.get(path);

--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.security;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.logging.internal.spi.LoggingProvider.SECURITY_LOGGER_NAME;
 
 import java.io.IOException;
@@ -309,7 +310,7 @@ public class IntegratedSecurityService implements SecurityService {
       principal = getSubject().getPrincipal();
     }
 
-    String regionName = StringUtils.stripStart(regionPath, "/");
+    String regionName = StringUtils.stripStart(regionPath, SEPARATOR);
     Object newValue;
 
     // if the data is a byte array, but the data itself is supposed to be an object, we need to

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/realizers/IndexRealizer.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/realizers/IndexRealizer.java
@@ -16,6 +16,8 @@
 package org.apache.geode.management.internal.configuration.realizers;
 
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.Immutable;
@@ -75,7 +77,7 @@ public class IndexRealizer implements ConfigurationRealizer<Index, IndexInfo> {
     if (regionName == null || indexName == null) {
       return null;
     }
-    Region<Object, Object> region = cache.getRegion("/" + regionName);
+    Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
     if (region == null) {
       return null;
     }
@@ -97,7 +99,7 @@ public class IndexRealizer implements ConfigurationRealizer<Index, IndexInfo> {
   public RealizationResult delete(Index config, InternalCache cache) {
     QueryService queryService = cache.getQueryService();
     RealizationResult realizationResult = new RealizationResult();
-    Region<Object, Object> region = cache.getRegion("/" + config.getRegionName());
+    Region<Object, Object> region = cache.getRegion(SEPARATOR + config.getRegionName());
     if (region == null) {
       realizationResult.setSuccess(false);
       realizationResult.setMessage("Region for index not found: " + config.getRegionName());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizer.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizer.java
@@ -17,6 +17,8 @@
 
 package org.apache.geode.management.internal.configuration.realizers;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -298,7 +300,8 @@ public class RegionConfigRealizer
 
   @Override
   public RuntimeRegionInfo get(Region config, InternalCache cache) {
-    org.apache.geode.cache.Region<Object, Object> region = cache.getRegion("/" + config.getName());
+    org.apache.geode.cache.Region<Object, Object> region =
+        cache.getRegion(SEPARATOR + config.getName());
     if (region == null) {
       return null;
     }
@@ -314,7 +317,8 @@ public class RegionConfigRealizer
    */
   @Override
   public boolean exists(Region config, InternalCache cache) {
-    org.apache.geode.cache.Region<Object, Object> region = cache.getRegion("/" + config.getName());
+    org.apache.geode.cache.Region<Object, Object> region =
+        cache.getRegion(SEPARATOR + config.getName());
     if (region == null) {
       return false;
     }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal.operation;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -102,7 +104,7 @@ public class RebalanceOperationPerformer {
       boolean simulate)
       throws InterruptedException {
     // To be removed after region Name specification with "/" is fixed
-    regionName = regionName.startsWith("/") ? regionName : ("/" + regionName);
+    regionName = regionName.startsWith(SEPARATOR) ? regionName : (SEPARATOR + regionName);
     Region region = cache.getRegion(regionName);
 
     if (region == null) {
@@ -158,7 +160,7 @@ public class RebalanceOperationPerformer {
 
       // translate to the return type we want
       RebalanceRegionResultImpl result = new RebalanceRegionResultImpl();
-      result.setRegionName(regionName.replace("/", ""));
+      result.setRegionName(regionName.replace(SEPARATOR, ""));
       result.setBucketCreateBytes(results.getTotalBucketCreateBytes());
       result.setBucketCreateTimeInMilliseconds(results.getTotalBucketCreateTime());
       result.setBucketCreatesCompleted(results.getTotalBucketCreatesCompleted());
@@ -220,14 +222,14 @@ public class RebalanceOperationPerformer {
         // this is needed since region name may start with / or without it
         // also
         String excludedRegion = aListExcludedRegion.trim();
-        if (regionName.startsWith("/")) {
-          if (!excludedRegion.startsWith("/")) {
-            excludedRegion = "/" + excludedRegion;
+        if (regionName.startsWith(SEPARATOR)) {
+          if (!excludedRegion.startsWith(SEPARATOR)) {
+            excludedRegion = SEPARATOR + excludedRegion;
           }
         }
-        if (excludedRegion.startsWith("/")) {
-          if (!regionName.startsWith("/")) {
-            regionName = "/" + regionName;
+        if (excludedRegion.startsWith(SEPARATOR)) {
+          if (!regionName.startsWith(SEPARATOR)) {
+            regionName = SEPARATOR + regionName;
           }
         }
 
@@ -242,8 +244,8 @@ public class RebalanceOperationPerformer {
         continue;
       }
 
-      if (!regionName.startsWith("/")) {
-        regionName = Region.SEPARATOR + regionName;
+      if (!regionName.startsWith(SEPARATOR)) {
+        regionName = SEPARATOR + regionName;
       }
       // remove this prefix /
       DistributedRegionMXBean bean = managementService.getDistributedRegionMXBean(regionName);
@@ -457,7 +459,7 @@ public class RebalanceOperationPerformer {
     result.setPrimaryTransfersCompleted(Integer.parseInt(rstList.get(7)));
     result.setTimeInMilliseconds(Long.parseLong(rstList.get(8)));
     result.setNumOfMembers(Integer.parseInt(rstList.get(9)));
-    result.setRegionName(rstList.get(10).replace("/", ""));
+    result.setRegionName(rstList.get(10).replace(SEPARATOR, ""));
 
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PeerTypeRegistration.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.pdx.internal;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +68,7 @@ public class PeerTypeRegistration implements TypeRegistration {
   private static final String LOCK_NAME = "PDX_LOCK";
 
   public static final String REGION_NAME = "PdxTypes";
-  public static final String REGION_FULL_PATH = "/" + REGION_NAME;
+  public static final String REGION_FULL_PATH = SEPARATOR + REGION_NAME;
 
   @VisibleForTesting
   public static final int PLACE_HOLDER_FOR_TYPE_ID = 0xFFFFFF;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionHelperJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionHelperJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -25,13 +26,13 @@ public class PartitionedRegionHelperJUnitTest {
   public void testEscapeUnescape() {
     {
       String bucketName = PartitionedRegionHelper.getBucketName("/root/region", 5);
-      assertEquals("Name = " + bucketName, -1, bucketName.indexOf('/'));
+      assertEquals("Name = " + bucketName, -1, bucketName.indexOf(SEPARATOR));
       assertEquals("/root/region", PartitionedRegionHelper.getPRPath(bucketName));
     }
 
     {
       String bucketName = PartitionedRegionHelper.getBucketName("/root/region_one", 5);
-      assertEquals("Name = " + bucketName, -1, bucketName.indexOf('/'));
+      assertEquals("Name = " + bucketName, -1, bucketName.indexOf(SEPARATOR));
       assertEquals("/root/region_one", PartitionedRegionHelper.getPRPath(bucketName));
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/FilterByPathJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/FilterByPathJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.control;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -84,7 +85,7 @@ public class FilterByPathJUnitTest {
     private String name;
 
     public RegionHandler(String name) {
-      this.name = "/" + name;
+      this.name = SEPARATOR + name;
     }
 
     @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegionTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets.command;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -142,7 +143,8 @@ public class CreateRegionTest {
 
     this.createRegion.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
 
-    verify(this.authzRequest).createRegionAuthorize(eq(PARENT_REGION_NAME + '/' + REGION_NAME));
+    verify(this.authzRequest)
+        .createRegionAuthorize(eq(PARENT_REGION_NAME + SEPARATOR + REGION_NAME));
     verify(this.responseMessage).send(this.serverConnection);
   }
 
@@ -151,11 +153,12 @@ public class CreateRegionTest {
     when(this.securityService.isClientSecurityRequired()).thenReturn(true);
     when(this.securityService.isIntegratedSecurity()).thenReturn(false);
     doThrow(new NotAuthorizedException("")).when(this.authzRequest)
-        .createRegionAuthorize(eq(PARENT_REGION_NAME + '/' + REGION_NAME));
+        .createRegionAuthorize(eq(PARENT_REGION_NAME + SEPARATOR + REGION_NAME));
 
     this.createRegion.cmdExecute(this.message, this.serverConnection, this.securityService, 0);
 
-    verify(this.authzRequest).createRegionAuthorize(eq(PARENT_REGION_NAME + '/' + REGION_NAME));
+    verify(this.authzRequest)
+        .createRegionAuthorize(eq(PARENT_REGION_NAME + SEPARATOR + REGION_NAME));
     verify(this.errorResponseMessage).send(eq(this.serverConnection));
   }
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTestBase.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgrade2DUnitTestBase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.rollingupgrade;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertFalse;
@@ -410,9 +411,9 @@ public abstract class RollingUpgrade2DUnitTestBase extends JUnit4DistributedTest
       putDataSerializableAndVerify(currentServer1, regionName, 0, 100, currentServer2, oldServer,
           oldServerAndLocator);
       if (createMultiIndexes) {
-        doCreateIndexes("/" + regionName, currentServer1);
+        doCreateIndexes(SEPARATOR + regionName, currentServer1);
       } else {
-        doCreateIndex("/" + regionName, oldServer);
+        doCreateIndex(SEPARATOR + regionName, oldServer);
       }
     } finally {
       invokeRunnableInVMs(invokeCloseCache(), currentServer1, currentServer2, oldServer,

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeNonHAFunction.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeNonHAFunction.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.rollingupgrade;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Assert.fail;
 import static org.junit.Assert.assertNotNull;
@@ -96,7 +97,7 @@ public class RollingUpgradeNonHAFunction extends RollingUpgrade2DUnitTestBase {
 
       putDataSerializableAndVerify(currentServer1, regionName, 0, 100, currentServer2, oldServer,
           oldServerAndLocator);
-      runFunction("/" + regionName, currentServer1,
+      runFunction(SEPARATOR + regionName, currentServer1,
           currentServer2, oldServer, oldServerAndLocator);
 
     } finally {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.cq.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -2607,7 +2608,7 @@ public class CqQueryDUnitTest extends JUnit4CacheTestCase {
     createCQ(client, "testQuery_3", "select * from /" + regions[0]);
     String expectedError =
         String.format("CQ is not supported for replicated region: %s with eviction action: %s",
-            "/" + regions[0], EvictionAction.LOCAL_DESTROY);
+            SEPARATOR + regions[0], EvictionAction.LOCAL_DESTROY);
     try {
       executeCQ(client, "testQuery_3", false, expectedError);
     } catch (Exception e) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionCqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionCqQueryDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.cq.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertFalse;
@@ -1042,7 +1043,7 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
 
       @Override
       public void run2() throws CacheException {
-        Region region = getCache().getRegion("/" + regions[0]);
+        Region region = getCache().getRegion(SEPARATOR + regions[0]);
         for (int i = 1; i <= numObjects; i++) {
           getCache().getLogger().fine("### DOING PUT with key: " + ("KEY-" + i));
           Portfolio p = new Portfolio(i);
@@ -1056,7 +1057,7 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
       @Override
       public void run2() throws CacheException {
         // Check for region destroyed event from server.
-        Region localRegion = getCache().getRegion("/" + regions[0]);
+        Region localRegion = getCache().getRegion(SEPARATOR + regions[0]);
         assertNotNull(localRegion);
 
         CqQueryTestListener cqListener = (CqQueryTestListener) getCache().getQueryService()
@@ -1072,7 +1073,7 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
       @Override
       public void run2() throws CacheException {
         // Check for region destroyed event from server.
-        Region localRegion = getCache().getRegion("/" + regions[0]);
+        Region localRegion = getCache().getRegion(SEPARATOR + regions[0]);
         assertNotNull(localRegion);
 
         localRegion.destroyRegion();
@@ -1084,7 +1085,7 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
       @Override
       public void run2() throws CacheException {
         // Check for region destroyed event from server.
-        Region localRegion = getCache().getRegion("/" + regions[0]);
+        Region localRegion = getCache().getRegion(SEPARATOR + regions[0]);
         // IF NULL - GOOD
         // ELSE - get listener and wait for destroyed.
         if (localRegion != null) {
@@ -1100,7 +1101,7 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
           assertNull(
               "Region is still available on client1 even after performing destroyRegion from client2 on server."
                   + "Client1 must have received destroyRegion message from server with CQ parts in it.",
-              getCache().getRegion("/" + regions[0]));
+              getCache().getRegion(SEPARATOR + regions[0]));
         }
       }
     });

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxQueryCQTestBase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxQueryCQTestBase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertFalse;
@@ -66,8 +67,8 @@ public abstract class PdxQueryCQTestBase extends JUnit4CacheTestCase {
   protected final String rootRegionName = "root";
   protected final String regionName = "PdxTest";
   protected final String regionName2 = "PdxTest2";
-  protected final String regName = "/" + rootRegionName + "/" + regionName;
-  protected final String regName2 = "/" + rootRegionName + "/" + regionName2;
+  protected final String regName = SEPARATOR + rootRegionName + SEPARATOR + regionName;
+  protected final String regName2 = SEPARATOR + rootRegionName + SEPARATOR + regionName2;
   protected final String[] queryString = new String[] {"SELECT DISTINCT id FROM " + regName, // 0
       "SELECT * FROM " + regName, // 1
       "SELECT ticker FROM " + regName, // 2

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/ha/CQListGIIDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
@@ -498,7 +499,7 @@ public class CQListGIIDUnitTest extends JUnit4DistributedTestCase {
 
   public static void registerInterestListAll() {
     try {
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       r.registerInterest("ALL_KEYS");
     } catch (Exception ex) {
@@ -508,7 +509,7 @@ public class CQListGIIDUnitTest extends JUnit4DistributedTestCase {
 
   public static void registerInterestList() {
     try {
-      Region r = cache.getRegion("/" + regionName);
+      Region r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       r.registerInterest("k1");
       r.registerInterest("k3");
@@ -681,7 +682,7 @@ public class CQListGIIDUnitTest extends JUnit4DistributedTestCase {
       boolean dispatched = false;
       Map haContainer = null;
       haContainer = cache.getRegion(
-          Region.SEPARATOR + CacheServerImpl.generateNameForClientMsgsRegion(port.intValue()));
+          SEPARATOR + CacheServerImpl.generateNameForClientMsgsRegion(port.intValue()));
       if (haContainer == null) {
         Object[] servers = cache.getCacheServers().toArray();
         for (int i = 0; i < servers.length; i++) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandDistributedTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.internal.QueryConfigurationServiceImpl.CONTINUOUS_QUERIES_RUNNING_MESSAGE;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.AUTHORIZER_NAME;
 import static org.apache.geode.management.internal.cli.commands.AlterQueryServiceCommand.COMMAND_NAME;
@@ -77,9 +78,9 @@ public class AlterQueryServiceCommandDistributedTest {
         .statusIsSuccess();
     locator.invoke(() -> {
       ClusterStartupRule.memberStarter
-          .waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REPLICATE_REGION_NAME, 1);
+          .waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REPLICATE_REGION_NAME, 1);
       ClusterStartupRule.memberStarter
-          .waitUntilRegionIsReadyOnExactlyThisManyServers("/" + PARTITION_REGION_NAME, 1);
+          .waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + PARTITION_REGION_NAME, 1);
     });
 
     client = cluster.startClientVM(2, ccf -> ccf.withCredential("data", "data")

--- a/geode-dunit/src/main/java/org/apache/geode/cache/query/QueryTestUtils.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache/query/QueryTestUtils.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 
 import java.io.File;
@@ -1813,7 +1814,7 @@ public class QueryTestUtils implements Serializable {
   }
 
   public void populateRegion(String regionName, Map<?, ?> entries) {
-    Region r = cache.getRegion("/" + regionName);
+    Region r = cache.getRegion(SEPARATOR + regionName);
     entries.entrySet().forEach(e -> {
       r.put(e.getKey(), e.getValue());
     });

--- a/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/HelperTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/HelperTestCase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertFalse;
@@ -124,7 +125,7 @@ public abstract class HelperTestCase extends JUnit4CacheTestCase {
     vm.invoke(new SerializableCallable() {
       @Override
       public Object call() throws CqException, RegionNotFoundException, CqExistsException {
-        getCache().getRegion("/" + regionName).registerInterestRegex(".*");
+        getCache().getRegion(SEPARATOR + regionName).registerInterestRegex(".*");
         return true;
       }
     });
@@ -147,7 +148,7 @@ public abstract class HelperTestCase extends JUnit4CacheTestCase {
       @Override
       public Object call() throws RegionNotFoundException, CqExistsException, IndexExistsException,
           IndexNameConflictException {
-        Region region = getCache().getRegion("/" + regionName);
+        Region region = getCache().getRegion(SEPARATOR + regionName);
         CompactRangeIndex index =
             (CompactRangeIndex) getCache().getQueryService().getIndex(region, indexName);
         System.out.println(index.dump());
@@ -161,7 +162,7 @@ public abstract class HelperTestCase extends JUnit4CacheTestCase {
       @Override
       public Object call() throws RegionNotFoundException, CqExistsException, IndexExistsException,
           IndexNameConflictException {
-        getCache().getRegion("/" + regionName).put(key, value);
+        getCache().getRegion(SEPARATOR + regionName).put(key, value);
         return true;
       }
     });

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
@@ -180,11 +181,11 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
     host.getVM(testVersion, 1).invoke(() -> createClientCacheV(serverName, port2));
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a distributed region");
-    concurrentMapTest(host.getVM(testVersion, 0), "/" + REGION_NAME1);
+    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + REGION_NAME1);
     // TODO add verification in vm1
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a partitioned region");
-    concurrentMapTest(host.getVM(testVersion, 0), "/" + PR_REGION_NAME);
+    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + PR_REGION_NAME);
     // TODO add verification in vm1
   }
 
@@ -244,11 +245,11 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
     host.getVM(testVersion, 1).invoke(() -> createClientCacheV(serverName, port2));
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a distributed region");
-    concurrentMapTest(host.getVM(testVersion, 0), "/" + REGION_NAME1);
+    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + REGION_NAME1);
     // TODO add verification in vm1
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a partitioned region");
-    concurrentMapTest(host.getVM(testVersion, 0), "/" + PR_REGION_NAME);
+    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + PR_REGION_NAME);
     // TODO add verification in vm1
   }
 
@@ -988,7 +989,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
   public static void registerInterest() {
     Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-    Region r = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+    Region r = cache.getRegion(SEPARATOR + REGION_NAME2);
     assertNotNull(r);
     r.registerInterest("ALL_KEYS");
     r.getAttributesMutator().addCacheListener(new MemberIDVerifier());
@@ -997,9 +998,9 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void registerInterestForInvalidatesInBothTheRegions() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
       assertNotNull(r1);
-      Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+      Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
       assertNotNull(r2);
       r1.registerInterestForAllKeys(InterestResultPolicy.KEYS, false, false);
       r2.registerInterestForAllKeys(InterestResultPolicy.KEYS, false, false);
@@ -1012,9 +1013,9 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void registerInterestInBothTheRegions() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
       assertNotNull(r1);
-      Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+      Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
       assertNotNull(r2);
       r1.registerInterestForAllKeys();
       r2.registerInterestForAllKeys();
@@ -1027,7 +1028,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void closeRegion1() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      Region<String, String> r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
+      Region<String, String> r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
       assertNotNull(r1);
       r1.close();
     } catch (Exception e) {
@@ -1039,9 +1040,9 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void closeBothRegions() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
-      Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
-      Region pr = cache.getRegion(Region.SEPARATOR + PR_REGION_NAME);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
+      Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
+      Region pr = cache.getRegion(SEPARATOR + PR_REGION_NAME);
       assertNotNull(r1);
       assertNotNull(r2);
       assertNotNull(pr);
@@ -1057,7 +1058,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void destroyRegion1() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
+      Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
       assertNotNull(r1);
       r1.destroyRegion();
     } catch (Exception e) {
@@ -1069,7 +1070,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void destroyRegion2() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+      Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
       assertNotNull(r2);
       r2.destroyRegion();
     } catch (Exception e) {
@@ -1081,7 +1082,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void destroyPRRegion() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      Region r2 = cache.getRegion(Region.SEPARATOR + PR_REGION_NAME);
+      Region r2 = cache.getRegion(SEPARATOR + PR_REGION_NAME);
       assertNotNull(r2);
       r2.destroyRegion();
     } catch (Exception e) {
@@ -1102,9 +1103,9 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
         // CCP should not contain region1
         Set<String> akr = ccp.cils[RegisterInterestTracker.interestListIndex].regions;
         assertNotNull(akr);
-        assertTrue(!akr.contains(Region.SEPARATOR + REGION_NAME1));
+        assertTrue(!akr.contains(SEPARATOR + REGION_NAME1));
         // CCP should contain region2
-        assertTrue(akr.contains(Region.SEPARATOR + REGION_NAME2));
+        assertTrue(akr.contains(SEPARATOR + REGION_NAME2));
         assertEquals(1, akr.size());
       }
     } catch (Exception ex) {
@@ -1135,7 +1136,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void verifyCacheClientProxyOnServer(String regionName) {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      assertNull(cache.getRegion(Region.SEPARATOR + regionName));
+      assertNull(cache.getRegion(SEPARATOR + regionName));
       verifyCacheClientProxyOnServer();
 
       // assertIndexDetailsEquals(1,
@@ -1162,8 +1163,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
   public static void populateCache() {
     Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-    Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
-    Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+    Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
+    Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
     assertNotNull(r1);
     assertNotNull(r2);
 
@@ -1184,8 +1185,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
   public static void put() {
     Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-    Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
-    Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+    Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
+    Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
     assertNotNull(r1);
     assertNotNull(r2);
 
@@ -1203,7 +1204,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
   static void putForClient() {
     Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-    Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+    Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
     if (r2 == null) {
       r2 = cache.createRegionFactory(RegionShortcut.REPLICATE).create(REGION_NAME2);
     }
@@ -1214,8 +1215,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
 
   private static void verifyUpdates() {
     Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-    final Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
-    final Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+    final Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
+    final Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
     assertNotNull(r1);
     assertNotNull(r2);
 
@@ -1254,8 +1255,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void verifyInvalidatesOnBothRegions() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      final Region r1 = cache.getRegion(Region.SEPARATOR + REGION_NAME1);
-      final Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+      final Region r1 = cache.getRegion(SEPARATOR + REGION_NAME1);
+      final Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
       assertNotNull(r1);
       assertNotNull(r2);
 
@@ -1279,7 +1280,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private static void verifyUpdatesOnRegion2() {
     try {
       Cache cache = new ClientServerMiscDUnitTestBase().getCache();
-      final Region r2 = cache.getRegion(Region.SEPARATOR + REGION_NAME2);
+      final Region r2 = cache.getRegion(SEPARATOR + REGION_NAME2);
       assertNotNull(r2);
 
       await()
@@ -1336,8 +1337,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
       // add another server for HA scenario
       initServerCache(true, host.getVM(VersionManager.CURRENT_VERSION, 1), true);
     }
-    String rName = "/" + REGION_NAME1;
-    String prName = "/" + PR_REGION_NAME;
+    String rName = SEPARATOR + REGION_NAME1;
+    String prName = SEPARATOR + PR_REGION_NAME;
 
     verifyIsEmptyOnServer(rName, true);
     verifyIsEmptyOnServer(prName, true);

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommandsIntegrationTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommandsIntegrationTestBase.java
@@ -101,7 +101,7 @@ public class IndexCommandsIntegrationTestBase {
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__NAME, "indexA");
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "\"h.low\"");
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__REGION,
-        SEPARATOR + regionName + " s, s.history h\"");
+        "\"" + SEPARATOR + regionName + " s, s.history h\"");
 
     gfsh.executeAndAssertThat(createStringBuilder.toString()).statusIsSuccess();
     assertThat(gfsh.getGfshOutput()).contains("Index successfully created");
@@ -116,7 +116,9 @@ public class IndexCommandsIntegrationTestBase {
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__NAME, indexName);
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "\"h.low\"");
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__REGION,
-        SEPARATOR + regionName + " s, s.history h\"");
+        "\"" + SEPARATOR + regionName + " s, s.history h\"");
+
+    System.out.println("DONAL: " + createStringBuilder.toString());
 
     gfsh.executeAndAssertThat(createStringBuilder.toString()).statusIsSuccess();
     assertThat(gfsh.getGfshOutput()).contains("Index successfully created");

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommandsIntegrationTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommandsIntegrationTestBase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -100,7 +101,7 @@ public class IndexCommandsIntegrationTestBase {
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__NAME, "indexA");
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "\"h.low\"");
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__REGION,
-        "\"/" + regionName + " s, s.history h\"");
+        SEPARATOR + regionName + " s, s.history h\"");
 
     gfsh.executeAndAssertThat(createStringBuilder.toString()).statusIsSuccess();
     assertThat(gfsh.getGfshOutput()).contains("Index successfully created");
@@ -115,7 +116,7 @@ public class IndexCommandsIntegrationTestBase {
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__NAME, indexName);
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "\"h.low\"");
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__REGION,
-        "\"/" + regionName + " s, s.history h\"");
+        SEPARATOR + regionName + " s, s.history h\"");
 
     gfsh.executeAndAssertThat(createStringBuilder.toString()).statusIsSuccess();
     assertThat(gfsh.getGfshOutput()).contains("Index successfully created");
@@ -132,7 +133,7 @@ public class IndexCommandsIntegrationTestBase {
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_INDEX);
     csb.addOption(CliStrings.CREATE_INDEX__NAME, indexName);
     csb.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "key");
-    csb.addOption(CliStrings.CREATE_INDEX__REGION, "/" + regionName);
+    csb.addOption(CliStrings.CREATE_INDEX__REGION, SEPARATOR + regionName);
     csb.addOption(CliStrings.CREATE_INDEX__TYPE, "hash");
 
     gfsh.executeAndAssertThat(csb.toString()).statusIsError();
@@ -178,7 +179,7 @@ public class IndexCommandsIntegrationTestBase {
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_INDEX);
     csb.addOption(CliStrings.CREATE_INDEX__NAME, indexName);
     csb.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "InvalidExpressionOption");
-    csb.addOption(CliStrings.CREATE_INDEX__REGION, "/" + regionName);
+    csb.addOption(CliStrings.CREATE_INDEX__REGION, SEPARATOR + regionName);
     csb.addOption(CliStrings.CREATE_INDEX__TYPE, "hash");
 
     gfsh.executeAndAssertThat(csb.toString()).statusIsError();
@@ -286,7 +287,7 @@ public class IndexCommandsIntegrationTestBase {
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.CREATE_INDEX);
     csb.addOption(CliStrings.CREATE_INDEX__NAME, indexName);
     csb.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "key");
-    csb.addOption(CliStrings.CREATE_INDEX__REGION, "/" + regionName);
+    csb.addOption(CliStrings.CREATE_INDEX__REGION, SEPARATOR + regionName);
     gfsh.executeAndAssertThat(csb.toString()).statusIsSuccess()
         .containsOutput("Index successfully created");
   }

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommandDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommandDUnitTestBase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
@@ -57,13 +58,13 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 @SuppressWarnings("serial")
 public class QueryCommandDUnitTestBase {
   private static final String DATA_REGION_NAME = "GemfireDataCommandsTestRegion";
-  private static final String DATA_REGION_NAME_PATH = "/" + DATA_REGION_NAME;
+  private static final String DATA_REGION_NAME_PATH = SEPARATOR + DATA_REGION_NAME;
   private static final String DATA_REGION_WITH_EVICTION_NAME =
       "GemfireDataCommandsTestRegionWithEviction";
   private static final String DATA_REGION_WITH_EVICTION_NAME_PATH =
-      "/" + DATA_REGION_WITH_EVICTION_NAME;
+      SEPARATOR + DATA_REGION_WITH_EVICTION_NAME;
   private static final String DATA_PAR_REGION_NAME = "GemfireDataCommandsTestParRegion";
-  private static final String DATA_PAR_REGION_NAME_PATH = "/" + DATA_PAR_REGION_NAME;
+  private static final String DATA_PAR_REGION_NAME_PATH = SEPARATOR + DATA_PAR_REGION_NAME;
 
   private static final String SERIALIZATION_FILTER =
       "org.apache.geode.management.internal.cli.dto.**";

--- a/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.security;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_ACCESSOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_ACCESSOR_PP;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTHENTICATOR;
@@ -251,7 +252,7 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
   }
 
   protected static Region getSubregion() {
-    return getCache().getRegion(regionName + '/' + SUBREGION_NAME);
+    return getCache().getRegion(regionName + SEPARATOR + SUBREGION_NAME);
   }
 
   private static Region createSubregion(final Region region) {
@@ -692,7 +693,8 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
           // Assume it has been already initialized
           DynamicRegionFactory drf = DynamicRegionFactory.get();
           Region subregion = drf.createDynamicRegion(regionName, SUBREGION_NAME);
-          assertEquals('/' + regionName + '/' + SUBREGION_NAME, subregion.getFullPath());
+          assertEquals(SEPARATOR + regionName + SEPARATOR + SUBREGION_NAME,
+              subregion.getFullPath());
 
         } else if (op.isRegionDestroy()) {
           breakLoop = true;
@@ -782,9 +784,9 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
       if ((opFlags & OpFlags.USE_OLDCONN) == 0) {
         Properties opCredentials;
         int newRnd = random.nextInt(100) + 1;
-        String currentRegionName = '/' + regionName;
+        String currentRegionName = SEPARATOR + regionName;
         if ((opFlags & OpFlags.USE_SUBREGION) > 0) {
-          currentRegionName += ('/' + SUBREGION_NAME);
+          currentRegionName += (SEPARATOR + SUBREGION_NAME);
         }
 
         String credentialsTypeStr;

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateDefinedIndexesCommandDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.management.internal.cli.result.model.ResultModel.MEMBER_STATUS_SECTION;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -116,14 +117,16 @@ public class CreateDefinedIndexesCommandDUnitTest {
     String index2Name = "index_" + region2Name;
 
     gfsh.executeAndAssertThat("create region --name=" + region1Name + " --type=REPLICATE")
-        .statusIsSuccess().containsOutput("Region \"/" + region1Name + "\" created on \"server-1\"")
-        .containsOutput("Region \"/" + region1Name + "\" created on \"server-2\"")
-        .containsOutput("Region \"/" + region1Name + "\" created on \"server-3\"");
+        .statusIsSuccess()
+        .containsOutput("Region \"" + SEPARATOR + region1Name + "\" created on \"server-1\"")
+        .containsOutput("Region \"" + SEPARATOR + region1Name + "\" created on \"server-2\"")
+        .containsOutput("Region \"" + SEPARATOR + region1Name + "\" created on \"server-3\"");
 
     gfsh.executeAndAssertThat("create region --name=" + region2Name + " --type=REPLICATE")
-        .statusIsSuccess().containsOutput("Region \"/" + region2Name + "\" created on \"server-1\"")
-        .containsOutput("Region \"/" + region2Name + "\" created on \"server-2\"")
-        .containsOutput("Region \"/" + region2Name + "\" created on \"server-3\"");
+        .statusIsSuccess()
+        .containsOutput("Region \"" + SEPARATOR + region2Name + "\" created on \"server-1\"")
+        .containsOutput("Region \"" + SEPARATOR + region2Name + "\" created on \"server-2\"")
+        .containsOutput("Region \"" + SEPARATOR + region2Name + "\" created on \"server-3\"");
 
     VMProvider.invokeInEveryMember(() -> {
       Cache cache = ClusterStartupRule.getCache();

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.lang.Identifiable.find;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -198,14 +199,14 @@ public class CreateRegionCommandDUnitTest {
     gfsh.executeAndAssertThat("create region --name=" + regionName + " --type=REPLICATE")
         .statusIsSuccess();
     String subRegionName = "subregion";
-    String subRegionPath = regionName + "/" + subRegionName;
+    String subRegionPath = regionName + SEPARATOR + subRegionName;
 
     gfsh.executeAndAssertThat("create region --name=" + subRegionPath +
         " --type=REPLICATE")
         .statusIsSuccess();
 
     String subSubRegionName = "subregion2";
-    String subSubRegionPath = regionName + "/" + subRegionName + "/" + subSubRegionName;
+    String subSubRegionPath = regionName + SEPARATOR + subRegionName + SEPARATOR + subSubRegionName;
     gfsh.executeAndAssertThat("create region --name=" + subSubRegionPath +
         " --type=REPLICATE")
         .statusIsSuccess();
@@ -525,7 +526,7 @@ public class CreateRegionCommandDUnitTest {
         "create region --type=REPLICATE_PROXY --group=group2 --name=" + regionName)
         .statusIsSuccess().tableHasRowWithValues("Member", "server-2");
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 2);
 
     gfsh.executeAndAssertThat(
         "create region --type=PARTITION_PROXY --group=group2 --name=" + regionName).statusIsError()
@@ -542,7 +543,7 @@ public class CreateRegionCommandDUnitTest {
     gfsh.executeAndAssertThat("create region --type=REPLICATE --group=group2 --name=" + regionName)
         .statusIsSuccess().tableHasRowWithValues("Member", "server-2");
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 2);
     // the following two should fail with name check on locator, not on server
     gfsh.executeAndAssertThat("create region --type=PARTITION --group=group2 --name=" + regionName)
         .statusIsError().containsOutput("Region /" + regionName + " already exists on the cluster");
@@ -663,7 +664,7 @@ public class CreateRegionCommandDUnitTest {
     gfsh.executeAndAssertThat("create region --type=PARTITION --group=group2 --name=" + regionName)
         .statusIsSuccess().tableHasRowWithValues("Member", "server-2");
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 2);
     gfsh.executeAndAssertThat("create region --type=PARTITION --group=group2 --name=" + regionName)
         .statusIsError().containsOutput("Region /" + regionName + " already exists on the cluster");
     gfsh.executeAndAssertThat(

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandPersistsConfigurationDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandPersistsConfigurationDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.management.internal.cli.commands;
 import static java.lang.management.ManagementFactory.getPlatformMBeanServer;
 import static java.util.Arrays.asList;
 import static javax.management.ObjectName.getInstance;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.lang.Identifiable.find;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -471,14 +472,14 @@ public class CreateRegionCommandPersistsConfigurationDUnitTest {
       RegionConfig colocatedConfig = find(regions, colocatedRegionName);
       assertThat(
           colocatedConfig.getRegionAttributes().getPartitionAttributes().getColocatedWith())
-              .isEqualTo("/" + regionName);
+              .isEqualTo(SEPARATOR + regionName);
 
       RegionConfig colocatedConfigFromTemplate = find(regions,
           colocatedRegionFromTemplateName);
       assertThat(
           colocatedConfigFromTemplate.getRegionAttributes().getPartitionAttributes()
               .getColocatedWith())
-                  .isEqualTo("/" + regionName);
+                  .isEqualTo(SEPARATOR + regionName);
     });
   }
 

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandWithNoClusterConfigDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandWithNoClusterConfigDUnitTest.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -65,7 +67,7 @@ public class CreateRegionCommandWithNoClusterConfigDUnitTest {
         "create region --name=" + regionName + " --type=REPLICATE_PROXY --group=group2")
         .statusIsSuccess();
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 2);
 
     gfsh.executeAndAssertThat("create region --name=failed --template-region=" + regionName)
         .statusIsError()
@@ -79,7 +81,7 @@ public class CreateRegionCommandWithNoClusterConfigDUnitTest {
     gfsh.executeAndAssertThat("create region --name=" + regionName + " --type=REPLICATE")
         .statusIsSuccess();
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 2);
     gfsh.executeAndAssertThat("create region --name=success --template-region=" + regionName)
         .statusIsSuccess();
   }

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.lang.SystemUtils.CURRENT_DIRECTORY;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -206,7 +207,7 @@ public class DiskStoreCommandsDUnitTest implements Serializable {
     gfsh.executeAndAssertThat("revoke missing-disk-store --id=" + diskstoreIDs.get(0))
         .statusIsSuccess().containsOutput("Missing disk store successfully revoked");
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REGION_1, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REGION_1, 1);
 
     server1.invoke(() -> {
       Cache cache = ClusterStartupRule.getCache();

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/IndexCommandsShareConfigurationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -79,7 +80,8 @@ public class IndexCommandsShareConfigurationDUnitTest {
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__NAME, indexName);
     createStringBuilder.addOption(CliStrings.CREATE_INDEX__EXPRESSION, "key");
     createStringBuilder.addOption(CliStrings.GROUP, groupName);
-    createStringBuilder.addOption(CliStrings.CREATE_INDEX__REGION, "/" + partitionedRegionName);
+    createStringBuilder.addOption(CliStrings.CREATE_INDEX__REGION,
+        SEPARATOR + partitionedRegionName);
     gfsh.executeAndAssertThat(createStringBuilder.toString()).statusIsSuccess();
 
     gfsh.executeAndAssertThat(CliStrings.LIST_INDEX).statusIsSuccess().containsOutput(indexName);
@@ -94,7 +96,8 @@ public class IndexCommandsShareConfigurationDUnitTest {
     createStringBuilder = new CommandStringBuilder(CliStrings.DESTROY_INDEX);
     createStringBuilder.addOption(CliStrings.DESTROY_INDEX__NAME, indexName);
     createStringBuilder.addOption(CliStrings.GROUP, groupName);
-    createStringBuilder.addOption(CliStrings.DESTROY_INDEX__REGION, "/" + partitionedRegionName);
+    createStringBuilder.addOption(CliStrings.DESTROY_INDEX__REGION,
+        SEPARATOR + partitionedRegionName);
     gfsh.executeAndAssertThat(createStringBuilder.toString()).statusIsSuccess();
 
     locator.invoke(() -> {

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceCommandDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static java.lang.Math.abs;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -114,8 +115,8 @@ public class RebalanceCommandDUnitTest {
 
   @Test
   public void testRegionNameInResultStartsWithSlash() {
-    final String REGION_NAME_WITH_SLASH = "/" + SHARED_REGION_NAME;
-    String command = "rebalance --include-region=" + "/" + SHARED_REGION_NAME;
+    final String REGION_NAME_WITH_SLASH = SEPARATOR + SHARED_REGION_NAME;
+    String command = "rebalance --include-region=" + SEPARATOR + SHARED_REGION_NAME;
     gfsh.executeAndAssertThat(command).statusIsSuccess();
 
     ResultModel result = gfsh.getCommandResult().getResultData();
@@ -134,14 +135,14 @@ public class RebalanceCommandDUnitTest {
 
   @Test
   public void testWithTimeOutAndRegion() {
-    String command = "rebalance --time-out=1 --include-region=" + "/" + SHARED_REGION_NAME;
+    String command = "rebalance --time-out=1 --include-region=" + SEPARATOR + SHARED_REGION_NAME;
     gfsh.executeAndAssertThat(command).statusIsSuccess();
     assertRegionBalanced(SHARED_REGION_NAME);
   }
 
   @Test
   public void testWithSimulateAndRegion() {
-    String command = "rebalance --simulate=true --include-region=" + "/" + SHARED_REGION_NAME;
+    String command = "rebalance --simulate=true --include-region=" + SEPARATOR + SHARED_REGION_NAME;
     gfsh.executeAndAssertThat(command).statusIsSuccess();
 
     assertAllRegionsUnchanged();
@@ -158,7 +159,8 @@ public class RebalanceCommandDUnitTest {
   @Test
   public void testWithTwoRegions() {
     String command =
-        "rebalance --include-region=" + "/" + SHARED_REGION_NAME + ",/" + REGION2_NAME;
+        "rebalance --include-region=" + SEPARATOR + SHARED_REGION_NAME + "," + SEPARATOR
+            + REGION2_NAME;
     gfsh.executeAndAssertThat(command).statusIsSuccess();
 
     assertRegionBalanced(SHARED_REGION_NAME);
@@ -179,7 +181,8 @@ public class RebalanceCommandDUnitTest {
     });
 
     String command =
-        "rebalance --include-region=" + "/" + SHARED_REGION_NAME + ",/" + REGION2_NAME;
+        "rebalance --include-region=" + SEPARATOR + SHARED_REGION_NAME + "," + SEPARATOR
+            + REGION2_NAME;
     gfsh.executeAndAssertThat(command).statusIsSuccess();
 
     assertRegionBalanced(SHARED_REGION_NAME);
@@ -191,7 +194,8 @@ public class RebalanceCommandDUnitTest {
   @Test
   public void testWithBadRegionNames() {
     String command =
-        "rebalance --include-region=" + "/" + "randomGarbageString" + ",/" + "otherRandomGarbage";
+        "rebalance --include-region=" + SEPARATOR + "randomGarbageString" + "," + SEPARATOR
+            + "otherRandomGarbage";
     gfsh.executeAndAssertThat(command).statusIsError();
     assertAllRegionsUnchanged();
   }
@@ -199,7 +203,8 @@ public class RebalanceCommandDUnitTest {
   @Test
   public void testWithOneGoodAndOneBadRegionName() {
     String command =
-        "rebalance --include-region=" + "/" + SHARED_REGION_NAME + ",/" + "otherRandomGarbage";
+        "rebalance --include-region=" + SEPARATOR + SHARED_REGION_NAME + "," + SEPARATOR
+            + "otherRandomGarbage";
     gfsh.executeAndAssertThat(command).statusIsSuccess();
     assertRegionBalanced(SHARED_REGION_NAME);
     assertThat(server1.invoke(() -> getLocalDataSizeForRegion(REGION1_NAME)))
@@ -210,7 +215,8 @@ public class RebalanceCommandDUnitTest {
 
   @Test
   public void testWithNonSharedRegions() {
-    String command = "rebalance --include-region=" + "/" + REGION1_NAME + ",/" + REGION2_NAME;
+    String command =
+        "rebalance --include-region=" + SEPARATOR + REGION1_NAME + "," + SEPARATOR + REGION2_NAME;
     gfsh.executeAndAssertThat(command).statusIsError();
 
     assertAllRegionsUnchanged();
@@ -236,7 +242,7 @@ public class RebalanceCommandDUnitTest {
 
   @Test
   public void testWithExcludedRegion() {
-    String command = "rebalance --exclude-region=" + "/" + REGION2_NAME;
+    String command = "rebalance --exclude-region=" + SEPARATOR + REGION2_NAME;
     gfsh.executeAndAssertThat(command).statusIsSuccess();
     assertRegionBalanced(SHARED_REGION_NAME);
     assertThat(server1.invoke(() -> getLocalDataSizeForRegion(REGION1_NAME)))
@@ -247,7 +253,7 @@ public class RebalanceCommandDUnitTest {
 
   @Test
   public void testWithExcludedSharedRegion() {
-    String command = "rebalance --exclude-region=" + "/" + SHARED_REGION_NAME;
+    String command = "rebalance --exclude-region=" + SEPARATOR + SHARED_REGION_NAME;
     gfsh.executeAndAssertThat(command).statusIsSuccess();
     assertAllRegionsUnchanged();
   }
@@ -284,7 +290,7 @@ public class RebalanceCommandDUnitTest {
 
   private static Integer getLocalDataSizeForRegion(String regionName) {
     InternalCache cache = ClusterStartupRule.getCache();
-    Region<?, ?> region = cache.getInternalRegionByPath("/" + regionName);
+    Region<?, ?> region = cache.getInternalRegionByPath(SEPARATOR + regionName);
     return PartitionRegionHelper.getLocalData(region).size();
   }
 
@@ -293,7 +299,7 @@ public class RebalanceCommandDUnitTest {
       final ManagementService service =
           ManagementService.getManagementService(ClusterStartupRule.getCache());
       final DistributedRegionMXBean bean =
-          service.getDistributedRegionMXBean("/" + SHARED_REGION_NAME);
+          service.getDistributedRegionMXBean(SEPARATOR + SHARED_REGION_NAME);
 
 
       return bean != null && bean.getMembers() != null && bean.getMembers().length > 1

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceMembersColocationTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceMembersColocationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -84,8 +85,8 @@ public class RebalanceMembersColocationTest {
           .create(CHILD_REGION_NAME);
     });
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + PARENT_REGION_NAME, 2);
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + CHILD_REGION_NAME, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + PARENT_REGION_NAME, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + CHILD_REGION_NAME, 2);
 
     gfsh.connectAndVerify(locator);
 

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RegionChangesPersistThroughClusterConfigurationDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RegionChangesPersistThroughClusterConfigurationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
@@ -55,7 +56,7 @@ public class RegionChangesPersistThroughClusterConfigurationDUnitTest {
   private MemberVM server2;
 
   private static final String REGION_NAME = "testRegionSharedConfigRegion";
-  private static final String REGION_PATH = "/" + REGION_NAME;
+  private static final String REGION_PATH = SEPARATOR + REGION_NAME;
   private static final String GROUP_NAME = "cluster";
 
   @Before

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RemoveCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RemoveCommandDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.management.internal.cli.commands.RemoveCommand.REGION_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,8 +57,8 @@ public class RemoveCommandDUnitTest {
     gfsh.executeAndAssertThat(
         "create region --name=" + PARTITIONED_REGION_NAME + " --type=PARTITION").statusIsSuccess();
 
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + REPLICATE_REGION_NAME, 2);
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + PARTITIONED_REGION_NAME, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REPLICATE_REGION_NAME, 2);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + PARTITIONED_REGION_NAME, 2);
 
     VMProvider.invokeInEveryMember(RemoveCommandDUnitTest::populateTestRegions, server1, server2);
   }

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ShowMetricsDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ShowMetricsDUnitTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.management.internal.cli.commands;
 
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -92,7 +93,7 @@ public class ShowMetricsDUnitTest {
         bean = mgmtService.getDistributedSystemMXBean();
         break;
       case 2:
-        bean = mgmtService.getDistributedRegionMXBean("/" + regionName);
+        bean = mgmtService.getDistributedRegionMXBean(SEPARATOR + regionName);
         break;
       case 3:
         ObjectName memberMBeanName = mgmtService.getMemberMBeanName(distributedMember);
@@ -100,7 +101,7 @@ public class ShowMetricsDUnitTest {
         break;
       case 4:
         ObjectName regionMBeanName =
-            mgmtService.getRegionMBeanName(distributedMember, "/" + regionName);
+            mgmtService.getRegionMBeanName(distributedMember, SEPARATOR + regionName);
         bean = mgmtService.getMBeanInstance(regionMBeanName, RegionMXBean.class);
         break;
       case 5:

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
@@ -14,13 +14,14 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.File;
 
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.CacheExistsException;
-import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.SingleGfshCommand;
@@ -76,7 +77,7 @@ public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
         }
       }
 
-      if (regionName.equals(Region.SEPARATOR)) {
+      if (regionName.equals(SEPARATOR)) {
         return ResultModel.createError(CliStrings.INVALID_REGION_NAME);
       }
 
@@ -99,10 +100,13 @@ public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
             compressorClassName = "";
           }
 
-          String resultMessage = DiskStoreImpl.modifyRegion(diskStoreName, dirs, "/" + regionName,
-              lruEvictionAlgo, lruEvictionAction, lruEvictionLimitString, concurrencyLevelString,
-              initialCapacityString, loadFactorString, compressorClassName, statisticsEnabledString,
-              offHeapString, false);
+          String resultMessage =
+              DiskStoreImpl.modifyRegion(diskStoreName, dirs, SEPARATOR + regionName,
+                  lruEvictionAlgo, lruEvictionAction, lruEvictionLimitString,
+                  concurrencyLevelString,
+                  initialCapacityString, loadFactorString, compressorClassName,
+                  statisticsEnabledString,
+                  offHeapString, false);
 
           return ResultModel.createInfo(resultMessage);
         } else {
@@ -111,7 +115,7 @@ public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
         }
       } else {
         if (remove) {
-          DiskStoreImpl.destroyRegion(diskStoreName, dirs, "/" + regionName);
+          DiskStoreImpl.destroyRegion(diskStoreName, dirs, SEPARATOR + regionName);
           return ResultModel.createInfo("The region " + regionName
               + " was successfully removed from the disk store " + diskStoreName);
         } else {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.management.internal.cli.remote.CommandExecutor.RUN_ON_MEMBER_CHANGE_NOT_PERSISTED;
 import static org.apache.geode.management.internal.cli.remote.CommandExecutor.SERVICE_NOT_RUNNING_CHANGE_NOT_PERSISTED;
 
@@ -168,7 +169,7 @@ public class CreateIndexCommand extends GfshCommand {
   // returned here should not have "."
   String getValidRegionName(String regionPath) {
     String regionName = regionPath.trim().split(" ")[0];
-    regionName = StringUtils.removeStart(regionName, "/");
+    regionName = StringUtils.removeStart(regionName, SEPARATOR);
     if (regionName.contains(".")) {
       regionName = regionName.substring(0, regionName.indexOf('.'));
     }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyIndexCommand.java
@@ -16,6 +16,7 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.geode.cache.Region.SEPARATOR;
 
 import java.util.List;
 import java.util.Set;
@@ -71,7 +72,7 @@ public class DestroyIndexCommand extends SingleGfshCommand {
 
     String regionName = null;
     if (regionPath != null) {
-      regionName = regionPath.startsWith("/") ? regionPath.substring(1) : regionPath;
+      regionName = regionPath.startsWith(SEPARATOR) ? regionPath.substring(1) : regionPath;
     }
 
     RegionConfig.Index indexInfo = new RegionConfig.Index();

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DestroyRegionCommand.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.lang.Identifiable.find;
 
 import java.util.HashSet;
@@ -101,7 +102,7 @@ public class DestroyRegionCommand extends GfshCommand {
 
   void checkForJDBCMapping(String regionPath) {
     String regionName = regionPath;
-    if (regionPath.startsWith("/")) {
+    if (regionPath.startsWith(SEPARATOR)) {
       regionName = regionPath.substring(1);
     }
     InternalConfigurationPersistenceService ccService = getConfigurationPersistenceService();

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -103,8 +105,8 @@ public class RebalanceCommand extends GfshCommand {
     rsltList.add(8, String.valueOf(results.getTimeInMilliseconds()));
     rsltList.add(9, String.valueOf(results.getNumOfMembers()));
     String regionName = results.getRegionName();
-    if (!regionName.startsWith("/")) {
-      regionName = "/" + regionName;
+    if (!regionName.startsWith(SEPARATOR)) {
+      regionName = SEPARATOR + regionName;
     }
     rsltList.add(10, regionName);
 

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RedundancyCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RedundancyCommand.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.NO_REDUNDANT_COPIES_FOR_REGIONS;
 import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.PRIMARY_TRANSFERS_COMPLETED;
 import static org.apache.geode.internal.cache.control.RestoreRedundancyResultsImpl.PRIMARY_TRANSFER_TIME;
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.control.RegionRedundancyStatus;
 import org.apache.geode.cache.control.RestoreRedundancyResults;
 import org.apache.geode.distributed.DistributedMember;
@@ -320,8 +320,8 @@ public class RedundancyCommand extends GfshCommand {
   DistributedMember getOneMemberForRegion(String regionName) {
     String regionNameWithSeparator = regionName;
     // The getAssociatedMembers method requires region names start with '/'
-    if (!regionName.startsWith(CacheConfig.SEPARATOR)) {
-      regionNameWithSeparator = CacheConfig.SEPARATOR + regionName;
+    if (!regionName.startsWith(SEPARATOR)) {
+      regionNameWithSeparator = SEPARATOR + regionName;
     }
     return RebalanceOperationPerformer.getAssociatedMembers(regionNameWithSeparator,
         (InternalCache) getCache());

--- a/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/fake/Fakes.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.test.fake;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.mock;
@@ -159,7 +160,7 @@ public class Fakes {
     when(region.getCache()).thenReturn(cache);
     when(region.getRegionService()).thenReturn(cache);
     when(region.getName()).thenReturn(name);
-    when(region.getFullPath()).thenReturn("/" + name);
+    when(region.getFullPath()).thenReturn(SEPARATOR + name);
     return region;
   }
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.lucene;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 import static org.apache.geode.internal.Assert.fail;
@@ -516,7 +517,7 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
   @Test
   @Parameters(method = "getListOfRegionTestTypes")
   public void verifyCreateDestroyDefinedIndex(RegionTestableType regionType) {
-    String[] regionNames = {REGION_NAME, "/" + REGION_NAME};
+    String[] regionNames = {REGION_NAME, SEPARATOR + REGION_NAME};
     for (String regionName : regionNames) {
       dataStore1.invoke(createIndex(INDEX_NAME, regionName, "field1"));
       dataStore1.invoke(() -> verifyDefinedIndexCreated(INDEX_NAME, regionName));

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.lucene.internal.cli;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -647,7 +648,7 @@ public class LuceneIndexCommandsIntegrationTest {
   public void testDestroyNonExistentSingleIndex() throws Exception {
     createRegion();
     String expectedStatus = String.format("Lucene index %s was not found in region %s",
-        new Object[] {INDEX_NAME, '/' + REGION_NAME});
+        new Object[] {INDEX_NAME, SEPARATOR + REGION_NAME});
 
     gfsh.executeAndAssertThat("destroy lucene index --name=index --region=region").statusIsSuccess()
         .containsOutput(expectedStatus);

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneRegionListener.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneRegionListener.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.lucene.internal;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -78,7 +80,8 @@ public class LuceneRegionListener implements RegionListener {
   public RegionAttributes beforeCreate(Region parent, String regionName, RegionAttributes attrs,
       InternalRegionArguments internalRegionArgs) {
     RegionAttributes updatedRA = attrs;
-    String path = parent == null ? "/" + regionName : parent.getFullPath() + "/" + regionName;
+    String path =
+        parent == null ? SEPARATOR + regionName : parent.getFullPath() + SEPARATOR + regionName;
 
     if (path.equals(this.regionPath) && this.beforeCreateInvoked.compareAndSet(false, true)) {
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.cache.lucene.internal;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.cache.Region.SEPARATOR_CHAR;
 import static org.apache.geode.internal.serialization.DataSerializableFixedID.CREATE_REGION_MESSAGE_LUCENE;
 
 import java.util.ArrayList;
@@ -174,10 +176,10 @@ public class LuceneServiceImpl implements InternalLuceneService {
   }
 
   public static String getUniqueIndexName(String indexName, String regionPath) {
-    if (!regionPath.startsWith("/")) {
-      regionPath = "/" + regionPath;
+    if (!regionPath.startsWith(SEPARATOR)) {
+      regionPath = SEPARATOR + regionPath;
     }
-    return indexName + "#" + regionPath.replace('/', '_');
+    return indexName + "#" + regionPath.replace(SEPARATOR_CHAR, '_');
   }
 
   public static String getUniqueIndexRegionName(String indexName, String regionPath,
@@ -202,8 +204,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
       final Map<String, Analyzer> fieldAnalyzers, final LuceneSerializer serializer,
       boolean allowOnExistingRegion, final String... fields) {
 
-    if (!regionPath.startsWith("/")) {
-      regionPath = "/" + regionPath;
+    if (!regionPath.startsWith(SEPARATOR)) {
+      regionPath = SEPARATOR + regionPath;
     }
 
     // We must always register the index (this is where IndexAlreadyExistsException is detected)
@@ -449,8 +451,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
   }
 
   protected void destroyIndex(String indexName, String regionPath, boolean initiator) {
-    if (!regionPath.startsWith("/")) {
-      regionPath = "/" + regionPath;
+    if (!regionPath.startsWith(SEPARATOR)) {
+      regionPath = SEPARATOR + regionPath;
     }
     LuceneIndexImpl indexImpl = (LuceneIndexImpl) getIndex(indexName, regionPath);
     if (indexImpl == null) {
@@ -464,8 +466,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
   }
 
   public void destroyDefinedIndex(String indexName, String regionPath) {
-    if (!regionPath.startsWith("/")) {
-      regionPath = "/" + regionPath;
+    if (!regionPath.startsWith(SEPARATOR)) {
+      regionPath = SEPARATOR + regionPath;
     }
     String uniqueIndexName = LuceneServiceImpl.getUniqueIndexName(indexName, regionPath);
     if (definedIndexMap.containsKey(uniqueIndexName)) {
@@ -484,8 +486,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
   }
 
   protected RegionListener getRegionListener(String indexName, String regionPath) {
-    if (!regionPath.startsWith("/")) {
-      regionPath = "/" + regionPath;
+    if (!regionPath.startsWith(SEPARATOR)) {
+      regionPath = SEPARATOR + regionPath;
     }
     RegionListener rl = null;
     for (RegionListener listener : cache.getRegionListeners()) {
@@ -506,8 +508,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
   }
 
   protected void destroyIndexes(String regionPath, boolean initiator) {
-    if (!regionPath.startsWith("/")) {
-      regionPath = "/" + regionPath;
+    if (!regionPath.startsWith(SEPARATOR)) {
+      regionPath = SEPARATOR + regionPath;
     }
     List<LuceneIndexImpl> indexesToDestroy = new ArrayList<>();
     for (LuceneIndex index : getAllIndexes()) {
@@ -533,8 +535,8 @@ public class LuceneServiceImpl implements InternalLuceneService {
   }
 
   public void destroyDefinedIndexes(String regionPath) {
-    if (!regionPath.startsWith("/")) {
-      regionPath = "/" + regionPath;
+    if (!regionPath.startsWith(SEPARATOR)) {
+      regionPath = SEPARATOR + regionPath;
     }
 
     // Iterate the defined indexes to get the ones for the regionPath

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneCreateIndexFunction.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.cache.lucene.internal.cli.functions;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.lucene.internal.CreateLuceneCommandParametersValidator.validateLuceneIndexName;
 import static org.apache.geode.cache.lucene.internal.CreateLuceneCommandParametersValidator.validateRegionName;
 
@@ -121,7 +122,7 @@ public class LuceneCreateIndexFunction implements InternalFunction {
   }
 
   protected XmlEntity getXmlEntity(String regionPath) {
-    String regionName = StringUtils.stripStart(regionPath, "/");
+    String regionName = StringUtils.stripStart(regionPath, SEPARATOR);
     return new XmlEntity(CacheXml.REGION, "name", regionName);
   }
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDestroyIndexFunction.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/cli/functions/LuceneDestroyIndexFunction.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.cache.lucene.internal.cli.functions;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.cache.execute.FunctionContext;
@@ -88,7 +90,7 @@ public class LuceneDestroyIndexFunction implements InternalFunction {
   }
 
   protected XmlEntity getXmlEntity(String indexName, String regionPath) {
-    String regionName = StringUtils.stripStart(regionPath, "/");
+    String regionName = StringUtils.stripStart(regionPath, SEPARATOR);
     return new XmlEntity(CacheXml.REGION, "name", regionName, LuceneXmlConstants.PREFIX,
         LuceneXmlConstants.NAMESPACE, LuceneXmlConstants.INDEX, "name", indexName);
   }

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/directory/DumpDirectoryFiles.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/directory/DumpDirectoryFiles.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.cache.lucene.internal.directory;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
+
 import java.io.File;
 import java.util.Collection;
 
@@ -75,7 +77,7 @@ public class DumpDirectoryFiles implements InternalFunction {
         FileSystem fs = directory.getFileSystem();
 
         String bucketName = index.getName() + "_" + repo.getRegion().getFullPath();
-        bucketName = bucketName.replace("/", "_");
+        bucketName = bucketName.replace(SEPARATOR, "_");
         File bucketDirectory = new File(exportLocation, bucketName);
         bucketDirectory.mkdirs();
         fs.export(bucketDirectory);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexCreationProfileJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexCreationProfileJUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.cache.lucene.internal;
 
 import static junitparams.JUnitParamsRunner.$;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.CANNOT_CREATE_LUCENE_INDEX_DIFFERENT_ANALYZERS;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.CANNOT_CREATE_LUCENE_INDEX_DIFFERENT_ANALYZERS_1;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.CANNOT_CREATE_LUCENE_INDEX_DIFFERENT_ANALYZERS_2;
@@ -111,7 +112,8 @@ public class LuceneIndexCreationProfileJUnitTest {
   @Parameters(method = "getCheckCompatibilityProfiles")
   public void testCheckCompatibility(LuceneIndexCreationProfile myProfile,
       LuceneIndexCreationProfile otherProfile, String expectedResult) {
-    assertEquals(expectedResult, otherProfile.checkCompatibility("/" + REGION_NAME, myProfile));
+    assertEquals(expectedResult,
+        otherProfile.checkCompatibility(SEPARATOR + REGION_NAME, myProfile));
   }
 
   private Object[] getCheckCompatibilityProfiles() {

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneRegionListenerJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneRegionListenerJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.lucene.internal;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -63,10 +64,10 @@ public class LuceneRegionListenerJUnitTest {
     InternalRegionArguments internalRegionArgs = mock(InternalRegionArguments.class);
     when(internalRegionArgs.addCacheServiceProfile(any())).thenReturn(internalRegionArgs);
 
-    LuceneRegionListener listener = new LuceneRegionListener(service, name, "/" + regionPath,
+    LuceneRegionListener listener = new LuceneRegionListener(service, name, SEPARATOR + regionPath,
         fields, analyzer, null, serializer);
     listener.beforeCreate(null, regionPath, attributes, internalRegionArgs);
-    verify(service).beforeDataRegionCreated(eq(name), eq("/" + regionPath), eq(attributes),
+    verify(service).beforeDataRegionCreated(eq(name), eq(SEPARATOR + regionPath), eq(attributes),
         eq(analyzer), any(), eq(aeqId), eq(serializer), any());
   }
 }

--- a/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheOperationsJUnitTest.java
+++ b/geode-protobuf/src/integrationTest/java/org/apache/geode/internal/protocol/protobuf/v1/acceptance/CacheOperationsJUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.protocol.protobuf.v1.acceptance;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_ENABLED_COMPONENTS;
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_KEYSTORE;
 import static org.apache.geode.distributed.ConfigurationProperties.SSL_KEYSTORE_PASSWORD;
@@ -285,7 +286,7 @@ public class CacheOperationsJUnitTest {
         response.getMessageTypeCase());
     RegionAPI.GetRegionNamesResponse getRegionsResponse = response.getGetRegionNamesResponse();
     assertEquals(1, getRegionsResponse.getRegionsCount());
-    assertEquals("/" + TEST_REGION, getRegionsResponse.getRegions(0));
+    assertEquals(SEPARATOR + TEST_REGION, getRegionsResponse.getRegions(0));
   }
 
   private void validatePutAllResponse(Socket socket,

--- a/geode-pulse/src/integrationTest/java/org/apache/geode/tools/pulse/controllers/PulseControllerJUnitTest.java
+++ b/geode-pulse/src/integrationTest/java/org/apache/geode/tools/pulse/controllers/PulseControllerJUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.tools.pulse.controllers;
 
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.tools.pulse.internal.data.Cluster.CLUSTER_STAT_GARBAGE_COLLECTION;
 import static org.apache.geode.tools.pulse.internal.data.Cluster.CLUSTER_STAT_MEMORY_USAGE;
 import static org.apache.geode.tools.pulse.internal.data.Cluster.CLUSTER_STAT_THROUGHPUT_READS;
@@ -86,7 +87,7 @@ public class PulseControllerJUnitTest {
   private static final String PHYSICAL_HOST_NAME = "physical-host-1";
   private static final String PRINCIPAL_USER = "test-user";
   private static final String REGION_NAME = "mock-region";
-  private static final String REGION_PATH = "/" + REGION_NAME;
+  private static final String REGION_PATH = SEPARATOR + REGION_NAME;
   private static final String REGION_TYPE = "PARTITION";
   private static final Principal PRINCIPAL = () -> PRINCIPAL_USER;
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -4074,7 +4074,7 @@ public class WANTestBase extends DistributedTestCase {
             .untilAsserted(() -> assertEquals(connected, bean.isConnected()));
 
         ObjectName regionBeanName = service.getRegionMBeanName(
-            cache.getDistributedSystem().getDistributedMember(), "/" + regionPath);
+            cache.getDistributedSystem().getDistributedMember(), SEPARATOR + regionPath);
         RegionMXBean rBean = service.getMBeanInstance(regionBeanName, RegionMXBean.class);
         assertTrue(rBean.isGatewayEnabled());
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/WANManagementDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/WANManagementDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -301,7 +302,7 @@ public class WANManagementDUnitTest extends ManagementTestBase {
     String regionName = getTestMethodName() + "_PR";
     sender.invoke(() -> WANTestBase.createPartitionedRegion(regionName, "pn", 0, 13, false));
 
-    String regionPath = "/" + regionName;
+    String regionPath = SEPARATOR + regionName;
     managing.invoke(() -> {
       ManagementService service = WANTestBase.getManagementService();
       await()

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRegionCommandDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.lang.Identifiable.find;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,7 +76,7 @@ public class AlterRegionCommandDUnitTest {
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + regionName)
         .statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 1);
 
     // Associate the async-event-queue
     gfsh.executeAndAssertThat(
@@ -114,11 +115,11 @@ public class AlterRegionCommandDUnitTest {
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region1Name)
         .statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region1Name, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + region1Name, 1);
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region2Name)
         .statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region2Name, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + region2Name, 1);
 
     // Associate the async-event-queue to both regions (second one should fail because they are not
     // co-located)
@@ -168,7 +169,7 @@ public class AlterRegionCommandDUnitTest {
 
     gfsh.executeAndAssertThat("create region --type=PARTITION_PERSISTENT --name=" + regionName
         + " --disk-store=diskStore").statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 1);
 
     // Make sure that the next invocations also fail and that the changes are not persisted to the
     // cluster configuration service. See GEODE-6551.
@@ -217,7 +218,7 @@ public class AlterRegionCommandDUnitTest {
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + regionName)
         .statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 1);
 
     // Associate the gateway-sender
     gfsh.executeAndAssertThat(
@@ -257,11 +258,11 @@ public class AlterRegionCommandDUnitTest {
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region1Name)
         .statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region1Name, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + region1Name, 1);
 
     gfsh.executeAndAssertThat("create region --type=PARTITION --name=" + region2Name)
         .statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + region2Name, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + region2Name, 1);
 
     // Associate the gateway-sender to both regions (second one should fail because they are not
     // co-located)
@@ -312,7 +313,7 @@ public class AlterRegionCommandDUnitTest {
 
     gfsh.executeAndAssertThat("create region --type=PARTITION_PERSISTENT --name=" + regionName
         + " --disk-store=diskStore").statusIsSuccess();
-    locator.waitUntilRegionIsReadyOnExactlyThisManyServers("/" + regionName, 1);
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 1);
 
     // Make sure that the next invocations also fail and that the changes are not persisted to the
     // cluster configuration service. See GEODE-6551.


### PR DESCRIPTION
For greater consistency across the codebase, the Region.SEPARATOR and Region.SEPARATOR_CHAR constants should be used instead of hardcoded "/" and '/' in region names/paths.

Authored-by: Donal Evans <doevans@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
