### PR TITLE
GEODE-8089: more redis set ops use functions

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractScanExecutor.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor;
 
-import java.util.Collection;
-import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.geode.redis.internal.org.apache.hadoop.fs.GlobPattern;
@@ -30,9 +28,6 @@ public abstract class AbstractScanExecutor extends AbstractExecutor {
       "Cursor is invalid, dataset may have been altered if this is cursor from a previous scan";
 
   protected final int DEFAULT_COUNT = 10;
-
-  protected abstract List<?> getIteration(Collection<?> list, Pattern matchPatter, int count,
-      int cursor);
 
   /**
    * @param pattern A glob pattern.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -78,7 +78,14 @@ public class CommandFunction implements Function<Object[]> {
             (members) -> resultSender.lastResult(members));
         break;
       case SCARD:
-        DeltaSet.scard(resultSender, localRegion, key);
+        stripedExecutor.execute(key,
+            () -> RedisSet.scard(localRegion, key),
+            (size) -> resultSender.lastResult(size));
+        break;
+      case SISMEMBER:
+        stripedExecutor.execute(key,
+            () -> RedisSet.sismember(localRegion, key, commandArgs.get(0)),
+            (exists) -> resultSender.lastResult(exists));
         break;
       default:
         throw new UnsupportedOperationException(ID + " does not yet support " + command);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -99,6 +99,13 @@ public class CommandFunction implements Function<Object[]> {
             (members) -> resultSender.lastResult(members));
         break;
       }
+      case SPOP: {
+        int popCount = (int) args[1];
+        stripedExecutor.execute(key,
+            () -> RedisSet.spop(localRegion, key, popCount),
+            (members) -> resultSender.lastResult(members));
+        break;
+      }
       default:
         throw new UnsupportedOperationException(ID + " does not yet support " + command);
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -77,6 +77,9 @@ public class CommandFunction implements Function<Object[]> {
             () -> RedisSet.members(localRegion, key),
             (members) -> resultSender.lastResult(members));
         break;
+      case SCARD:
+        DeltaSet.scard(resultSender, localRegion, key);
+        break;
       default:
         throw new UnsupportedOperationException(ID + " does not yet support " + command);
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.executor;
 
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Function;
@@ -103,6 +104,15 @@ public class CommandFunction implements Function<Object[]> {
         int popCount = (int) args[1];
         stripedExecutor.execute(key,
             () -> RedisSet.spop(localRegion, key, popCount),
+            (members) -> resultSender.lastResult(members));
+        break;
+      }
+      case SSCAN: {
+        Pattern matchPattern = (Pattern) args[0];
+        int count = (int) args[1];
+        int cursor = (int) args[2];
+        stripedExecutor.execute(key,
+            () -> RedisSet.sscan(localRegion, key, matchPattern, count, cursor),
             (members) -> resultSender.lastResult(members));
         break;
       }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -78,7 +78,7 @@ public class CommandFunction implements Function<Object[]> {
         break;
       case SMEMBERS:
         stripedExecutor.execute(key,
-            () -> RedisSet.members(localRegion, key),
+            () -> RedisSet.smembers(localRegion, key),
             (members) -> resultSender.lastResult(members));
         break;
       case SCARD:

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
@@ -106,8 +106,7 @@ public class ScanExecutor extends AbstractScanExecutor {
   }
 
   @SuppressWarnings("unchecked")
-  @Override
-  protected List<?> getIteration(Collection<?> list, Pattern matchPattern, int count, int cursor) {
+  private List<?> getIteration(Collection<?> list, Pattern matchPattern, int count, int cursor) {
     List<String> returnList = new ArrayList<String>();
     int size = list.size();
     int beforeCursor = 0;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -126,7 +126,6 @@ public class HScanExecutor extends AbstractScanExecutor {
   }
 
   @SuppressWarnings("unchecked")
-  @Override
   protected List<Object> getIteration(Collection<?> list, Pattern matchPattern, int count,
       int cursor) {
     List<Object> returnList = new ArrayList<Object>();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -98,6 +98,16 @@ public class RedisSet implements Delta, DataSerializable {
     }
   }
 
+  public static int scard(Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.size();
+    } else {
+      return -1;
+    }
+  }
+
+
   public synchronized boolean contains(ByteArrayWrapper member) {
     return members.contains(member);
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -107,6 +107,16 @@ public class RedisSet implements Delta, DataSerializable {
     }
   }
 
+  public static boolean sismember(Region<ByteArrayWrapper, RedisSet> region,
+                                   ByteArrayWrapper key, ByteArrayWrapper member) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.contains(member);
+    } else {
+      return false;
+    }
+  }
+
 
   public synchronized boolean contains(ByteArrayWrapper member) {
     return members.contains(member);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -15,12 +15,14 @@
 
 package org.apache.geode.redis.internal.executor.set;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -98,7 +100,7 @@ public class RedisSet implements Delta, DataSerializable {
     if (redisSet != null) {
       return redisSet.members();
     } else {
-      return Collections.emptySet();
+      return emptySet();
     }
   }
 
@@ -107,7 +109,7 @@ public class RedisSet implements Delta, DataSerializable {
     if (redisSet != null) {
       return redisSet.size();
     } else {
-      return -1;
+      return 0;
     }
   }
 
@@ -127,7 +129,7 @@ public class RedisSet implements Delta, DataSerializable {
     if (redisSet != null) {
       return redisSet.srandmember(count);
     } else {
-      return null;
+      return emptyList();
     }
   }
 
@@ -137,7 +139,7 @@ public class RedisSet implements Delta, DataSerializable {
     if (redisSet != null) {
       return redisSet.doSpop(region, key, popCount);
     } else {
-      return null;
+      return emptyList();
     }
   }
 
@@ -147,7 +149,7 @@ public class RedisSet implements Delta, DataSerializable {
     if (RedisSet != null) {
       return RedisSet.doSscan(matchPattern, count, cursor);
     } else {
-      return null;
+      return emptyList();
     }
   }
 
@@ -191,7 +193,7 @@ public class RedisSet implements Delta, DataSerializable {
       Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key, int popCount) {
     int originalSize = size();
     if (originalSize == 0) {
-      return null;
+      return emptyList();
     }
 
     if (popCount >= originalSize) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -112,7 +112,7 @@ public class RedisSet implements Delta, DataSerializable {
   }
 
   public static boolean sismember(Region<ByteArrayWrapper, RedisSet> region,
-                                   ByteArrayWrapper key, ByteArrayWrapper member) {
+      ByteArrayWrapper key, ByteArrayWrapper member) {
     RedisSet redisSet = region.get(key);
     if (redisSet != null) {
       return redisSet.contains(member);
@@ -122,7 +122,7 @@ public class RedisSet implements Delta, DataSerializable {
   }
 
   public static Collection<ByteArrayWrapper> srandmember(Region<ByteArrayWrapper, RedisSet> region,
-                                                          ByteArrayWrapper key, int count) {
+      ByteArrayWrapper key, int count) {
     RedisSet redisSet = region.get(key);
     if (redisSet != null) {
       return redisSet.srandmember(count);
@@ -132,7 +132,7 @@ public class RedisSet implements Delta, DataSerializable {
   }
 
   public static Collection<ByteArrayWrapper> spop(Region<ByteArrayWrapper, RedisSet> region,
-                                                   ByteArrayWrapper key, int popCount) {
+      ByteArrayWrapper key, int popCount) {
     RedisSet redisSet = region.get(key);
     if (redisSet != null) {
       return redisSet.doSpop(region, key, popCount);
@@ -142,7 +142,7 @@ public class RedisSet implements Delta, DataSerializable {
   }
 
   public static List<Object> sscan(Region<ByteArrayWrapper, RedisSet> region,
-                                    ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
+      ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
     RedisSet RedisSet = region.get(key);
     if (RedisSet != null) {
       return RedisSet.doSscan(matchPattern, count, cursor);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -128,7 +128,7 @@ public class RedisSet implements Delta, DataSerializable {
     }
   }
 
-  private static Collection<ByteArrayWrapper> spop(Region<ByteArrayWrapper, RedisSet> region,
+  public static Collection<ByteArrayWrapper> spop(Region<ByteArrayWrapper, RedisSet> region,
                                                    ByteArrayWrapper key, int popCount) {
     RedisSet redisSet = region.get(key);
     if (redisSet != null) {
@@ -140,19 +140,18 @@ public class RedisSet implements Delta, DataSerializable {
 
   private synchronized Collection<ByteArrayWrapper> doSpop(
       Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key, int popCount) {
-    ArrayList<ByteArrayWrapper> popped = new ArrayList<>();
     int originalSize = size();
     if (originalSize == 0) {
       return null;
     }
 
     if (popCount >= originalSize) {
-      popped.addAll(members);
-      members.clear();
-      region.remove(key, this); // TODO remove from key registry
-      return popped;
+      // TODO: need to also cause key to be removed from the metaregion
+      region.remove(key, this);
+      return this.members;
     }
 
+    ArrayList<ByteArrayWrapper> popped = new ArrayList<>();
     ByteArrayWrapper[] setMembers = members.toArray(new ByteArrayWrapper[originalSize]);
     Random rand = new Random();
     while (popped.size() < popCount) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -92,7 +92,7 @@ public class RedisSet implements Delta, DataSerializable {
     return region.remove(key) != null;
   }
 
-  public static Set<ByteArrayWrapper> members(Region<ByteArrayWrapper, RedisSet> region,
+  public static Set<ByteArrayWrapper> smembers(Region<ByteArrayWrapper, RedisSet> region,
       ByteArrayWrapper key) {
     RedisSet redisSet = region.get(key);
     if (redisSet != null) {
@@ -365,7 +365,7 @@ public class RedisSet implements Delta, DataSerializable {
    *
    * @return a set containing all the members in this set
    */
-  synchronized Set<ByteArrayWrapper> members() {
+  private synchronized Set<ByteArrayWrapper> members() {
     return new HashSet<>(members);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -31,7 +31,7 @@ public interface RedisSetCommands {
   long srem(ByteArrayWrapper key, ArrayList<ByteArrayWrapper> membersToAdd,
       AtomicBoolean setWasDeleted);
 
-  Set<ByteArrayWrapper> members(ByteArrayWrapper key);
+  Set<ByteArrayWrapper> smembers(ByteArrayWrapper key);
 
   boolean del(ByteArrayWrapper key);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -17,8 +17,10 @@ package org.apache.geode.redis.internal.executor.set;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 
@@ -40,5 +42,7 @@ public interface RedisSetCommands {
   Collection<ByteArrayWrapper> srandmember(ByteArrayWrapper key, int count);
 
   Collection<ByteArrayWrapper> spop(ByteArrayWrapper key, int popCount);
+
+  List<Object> sscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor);
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -31,4 +31,7 @@ public interface RedisSetCommands {
   Set<ByteArrayWrapper> members(ByteArrayWrapper key);
 
   boolean del(ByteArrayWrapper key);
+
+  int scard(ByteArrayWrapper key);
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -34,4 +34,6 @@ public interface RedisSetCommands {
 
   int scard(ByteArrayWrapper key);
 
+  boolean sismember(ByteArrayWrapper key, ByteArrayWrapper member);
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -39,4 +39,6 @@ public interface RedisSetCommands {
 
   Collection<ByteArrayWrapper> srandmember(ByteArrayWrapper key, int count);
 
+  Collection<ByteArrayWrapper> spop(ByteArrayWrapper key, int popCount);
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -44,5 +44,4 @@ public interface RedisSetCommands {
   Collection<ByteArrayWrapper> spop(ByteArrayWrapper key, int popCount);
 
   List<Object> sscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor);
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.set;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -35,5 +36,7 @@ public interface RedisSetCommands {
   int scard(ByteArrayWrapper key);
 
   boolean sismember(ByteArrayWrapper key, ByteArrayWrapper member);
+
+  Collection<ByteArrayWrapper> srandmember(ByteArrayWrapper key, int count);
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.executor.set;
 
 import static org.apache.geode.redis.internal.RedisCommandType.DEL;
 import static org.apache.geode.redis.internal.RedisCommandType.SADD;
+import static org.apache.geode.redis.internal.RedisCommandType.SCARD;
 import static org.apache.geode.redis.internal.RedisCommandType.SMEMBERS;
 import static org.apache.geode.redis.internal.RedisCommandType.SREM;
 
@@ -76,6 +77,12 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
   @Override
   public boolean del(ByteArrayWrapper key) {
     ResultCollector<Object[], List<Boolean>> results = executeFunction(DEL, key, null);
+    return results.getResult().get(0);
+  }
+
+  @Override
+  public int scard(ByteArrayWrapper key) {
+    ResultCollector<Object[], List<Integer>> results = executeFunction(SCARD, key,null);
     return results.getResult().get(0);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -88,7 +88,7 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
 
   @Override
   public int scard(ByteArrayWrapper key) {
-    ResultCollector<Object[], List<Integer>> results = executeFunction(SCARD, key,null);
+    ResultCollector<Object[], List<Integer>> results = executeFunction(SCARD, key, null);
     return results.getResult().get(0);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -20,6 +20,7 @@ import static org.apache.geode.redis.internal.RedisCommandType.SADD;
 import static org.apache.geode.redis.internal.RedisCommandType.SCARD;
 import static org.apache.geode.redis.internal.RedisCommandType.SISMEMBER;
 import static org.apache.geode.redis.internal.RedisCommandType.SMEMBERS;
+import static org.apache.geode.redis.internal.RedisCommandType.SPOP;
 import static org.apache.geode.redis.internal.RedisCommandType.SRANDMEMBER;
 import static org.apache.geode.redis.internal.RedisCommandType.SREM;
 
@@ -99,6 +100,13 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
   public Collection<ByteArrayWrapper> srandmember(ByteArrayWrapper key, int count) {
     ResultCollector<Object[], List<Collection<ByteArrayWrapper>>> results =
         executeFunction(SRANDMEMBER, key, count);
+    return results.getResult().get(0);
+  }
+
+  @Override
+  public Collection<ByteArrayWrapper> spop(int popCount) {
+    ResultCollector<Object[], List<Collection<ByteArrayWrapper>>> results =
+        executeFunction(SPOP, popCount);
     return results.getResult().get(0);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -23,6 +23,7 @@ import static org.apache.geode.redis.internal.RedisCommandType.SMEMBERS;
 import static org.apache.geode.redis.internal.RedisCommandType.SPOP;
 import static org.apache.geode.redis.internal.RedisCommandType.SRANDMEMBER;
 import static org.apache.geode.redis.internal.RedisCommandType.SREM;
+import static org.apache.geode.redis.internal.RedisCommandType.SSCAN;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.FunctionService;
@@ -107,6 +109,13 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
   public Collection<ByteArrayWrapper> spop(int popCount) {
     ResultCollector<Object[], List<Collection<ByteArrayWrapper>>> results =
         executeFunction(SPOP, popCount);
+    return results.getResult().get(0);
+  }
+
+  @Override
+  public List<Object> sscan(Pattern matchPattern, int count, int cursor) {
+    ResultCollector<Object[], List<List<Object>>> results =
+        executeFunction(SSCAN, new Object[] {matchPattern, count, cursor});
     return results.getResult().get(0);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -74,7 +74,7 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
   }
 
   @Override
-  public Set<ByteArrayWrapper> members(ByteArrayWrapper key) {
+  public Set<ByteArrayWrapper> smembers(ByteArrayWrapper key) {
     ResultCollector<Object[], List<Set<ByteArrayWrapper>>> results =
         executeFunction(SMEMBERS, key, null);
     return results.getResult().get(0);
@@ -106,16 +106,16 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
   }
 
   @Override
-  public Collection<ByteArrayWrapper> spop(int popCount) {
+  public Collection<ByteArrayWrapper> spop(ByteArrayWrapper key, int popCount) {
     ResultCollector<Object[], List<Collection<ByteArrayWrapper>>> results =
-        executeFunction(SPOP, popCount);
+        executeFunction(SPOP, key, popCount);
     return results.getResult().get(0);
   }
 
   @Override
-  public List<Object> sscan(Pattern matchPattern, int count, int cursor) {
+  public List<Object> sscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
     ResultCollector<Object[], List<List<Object>>> results =
-        executeFunction(SSCAN, new Object[] {matchPattern, count, cursor});
+        executeFunction(SSCAN, key, new Object[] {matchPattern, count, cursor});
     return results.getResult().get(0);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.executor.set;
 import static org.apache.geode.redis.internal.RedisCommandType.DEL;
 import static org.apache.geode.redis.internal.RedisCommandType.SADD;
 import static org.apache.geode.redis.internal.RedisCommandType.SCARD;
+import static org.apache.geode.redis.internal.RedisCommandType.SISMEMBER;
 import static org.apache.geode.redis.internal.RedisCommandType.SMEMBERS;
 import static org.apache.geode.redis.internal.RedisCommandType.SREM;
 
@@ -83,6 +84,14 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
   @Override
   public int scard(ByteArrayWrapper key) {
     ResultCollector<Object[], List<Integer>> results = executeFunction(SCARD, key,null);
+    return results.getResult().get(0);
+  }
+
+  @Override
+  public boolean sismember(ByteArrayWrapper member) {
+    ArrayList<ByteArrayWrapper> commandArguments = new ArrayList<>();
+    commandArguments.add(member);
+    ResultCollector<Object[], List<Boolean>> results = executeFunction(SISMEMBER, commandArguments);
     return results.getResult().get(0);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -20,9 +20,11 @@ import static org.apache.geode.redis.internal.RedisCommandType.SADD;
 import static org.apache.geode.redis.internal.RedisCommandType.SCARD;
 import static org.apache.geode.redis.internal.RedisCommandType.SISMEMBER;
 import static org.apache.geode.redis.internal.RedisCommandType.SMEMBERS;
+import static org.apache.geode.redis.internal.RedisCommandType.SRANDMEMBER;
 import static org.apache.geode.redis.internal.RedisCommandType.SREM;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -88,16 +90,21 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
   }
 
   @Override
-  public boolean sismember(ByteArrayWrapper member) {
-    ArrayList<ByteArrayWrapper> commandArguments = new ArrayList<>();
-    commandArguments.add(member);
-    ResultCollector<Object[], List<Boolean>> results = executeFunction(SISMEMBER, commandArguments);
+  public boolean sismember(ByteArrayWrapper key, ByteArrayWrapper member) {
+    ResultCollector<Object[], List<Boolean>> results = executeFunction(SISMEMBER, key, member);
+    return results.getResult().get(0);
+  }
+
+  @Override
+  public Collection<ByteArrayWrapper> srandmember(ByteArrayWrapper key, int count) {
+    ResultCollector<Object[], List<Collection<ByteArrayWrapper>>> results =
+        executeFunction(SRANDMEMBER, key, count);
     return results.getResult().get(0);
   }
 
   private ResultCollector executeFunction(RedisCommandType command,
       ByteArrayWrapper key,
-      ArrayList<ByteArrayWrapper> commandArguments) {
+      Object commandArguments) {
     return FunctionService
         .onRegion(region)
         .withFilter(Collections.singleton(key))

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
@@ -15,7 +15,6 @@
 package org.apache.geode.redis.internal.executor.set;
 
 
-import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
@@ -38,5 +38,4 @@ public class SCardExecutor extends SetExecutor {
       command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), size));
     }
   }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
@@ -23,8 +23,6 @@ import org.apache.geode.redis.internal.RedisDataType;
 
 public class SCardExecutor extends SetExecutor {
 
-  private static final int NOT_EXISTS = 0;
-
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     ByteArrayWrapper key = command.getKey();
@@ -32,10 +30,6 @@ public class SCardExecutor extends SetExecutor {
     RedisSetCommands redisSetCommands =
         new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
     int size = redisSetCommands.scard(key);
-    if (size == -1) {
-      command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), NOT_EXISTS));
-    } else {
-      command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), size));
-    }
+    command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), size));
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
@@ -30,15 +30,14 @@ public class SCardExecutor extends SetExecutor {
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     ByteArrayWrapper key = command.getKey();
     checkDataType(key, RedisDataType.REDIS_SET, context);
-    Region<ByteArrayWrapper, RedisSet> keyRegion = getRegion(context);
-
-    RedisSet set = keyRegion.get(key);
-    if (set == null) {
+    RedisSetCommands redisSetCommands =
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+    int size = redisSetCommands.scard(key);
+    if (size == -1) {
       command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), NOT_EXISTS));
-      return;
+    } else {
+      command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), size));
     }
-
-    command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), set.size()));
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SIsMemberExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SIsMemberExecutor.java
@@ -45,12 +45,10 @@ public class SIsMemberExecutor extends SetExecutor {
 
     RedisSet set = region.get(key);
 
-    if (set == null) {
-      command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), NOT_EXISTS));
-      return;
-    }
-
-    if (set.contains(member)) {
+    RedisSet geodeRedisSet =
+        new GeodeRedisSetWithFunctions(key, context.getRegionProvider().getSetRegion());
+    boolean isMember = geodeRedisSet.sismember(member);
+    if (isMember) {
       command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), EXISTS));
       // save key for next quick lookup
       context.getKeyRegistrar().register(key, RedisDataType.REDIS_SET);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SIsMemberExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SIsMemberExecutor.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.set;
 
 import java.util.List;
 
-import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
@@ -40,14 +39,9 @@ public class SIsMemberExecutor extends SetExecutor {
     }
 
     ByteArrayWrapper member = new ByteArrayWrapper(commandElems.get(2));
-
-    Region<ByteArrayWrapper, RedisSet> region = this.getRegion(context);
-
-    RedisSet set = region.get(key);
-
-    RedisSet geodeRedisSet =
-        new GeodeRedisSetWithFunctions(key, context.getRegionProvider().getSetRegion());
-    boolean isMember = geodeRedisSet.sismember(member);
+    RedisSetCommands redisSetCommands =
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+    boolean isMember = redisSetCommands.sismember(key, member);
     if (isMember) {
       command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), EXISTS));
       // save key for next quick lookup

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
@@ -33,7 +33,7 @@ public class SMembersExecutor extends SetExecutor {
 
     RedisSetCommands redisSetCommands =
         new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
-    Set<ByteArrayWrapper> members = redisSetCommands.members(key);
+    Set<ByteArrayWrapper> members = redisSetCommands.smembers(key);
 
     try {
       command.setResponse(Coder.getArrayResponse(context.getByteBufAllocator(), members));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
@@ -57,7 +57,7 @@ public class SMoveExecutor extends SetExecutor {
       boolean removed =
           RedisSet.srem(region, source, new ArrayList<>(Collections.singletonList(member)),
               null) == 1;
-      // TODO: what should SMOVE do with a source that it empties? We probably need to delete it.
+      // TODO: native redis SMOVE that empties the src set causes it to no longer exist
 
       if (!removed) {
         command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), NOT_MOVED));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
@@ -38,7 +38,7 @@ public class SPopExecutor extends SetExecutor {
     RedisSetCommands redisSetCommands =
         new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
     Collection<ByteArrayWrapper> popped = redisSetCommands.spop(key, popCount);
-    if (popped == null || popped.isEmpty()) {
+    if (popped.isEmpty()) {
       command.setResponse(Coder.getNilResponse(context.getByteBufAllocator()));
       return;
     }
@@ -54,5 +54,4 @@ public class SPopExecutor extends SetExecutor {
           RedisConstants.SERVER_ERROR_MESSAGE));
     }
   }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
@@ -57,7 +57,7 @@ public class SRandMemberExecutor extends SetExecutor {
         new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
     Collection<ByteArrayWrapper> results = redisSetCommands.srandmember(key, count);
     try {
-      if (results == null || results.isEmpty()) {
+      if (results.isEmpty()) {
         command.setResponse(Coder.getNilResponse(context.getByteBufAllocator()));
       } else if (count == 1) {
         command.setResponse(

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -15,12 +15,10 @@
 package org.apache.geode.redis.internal.executor.set;
 
 
-import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
@@ -102,14 +100,6 @@ public class SScanExecutor extends AbstractScanExecutor {
     RedisSetCommands redisSetCommands =
         new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
     List<Object> returnList = redisSetCommands.sscan(key, matchPattern, count, cursor);
-    if (returnList == null) {
-      returnList = Collections.emptyList();
-    }
     command.setResponse(Coder.getScanResponse(context.getByteBufAllocator(), returnList));
-  }
-
-  private Region<ByteArrayWrapper, RedisSet> getRegion(
-      ExecutionHandlerContext context) {
-    return context.getRegionProvider().getSetRegion();
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
@@ -66,13 +66,13 @@ public abstract class SetOpExecutor extends SetExecutor {
       RegionProvider regionProvider, ByteArrayWrapper destination,
       ByteArrayWrapper firstSetKey) {
     Region<ByteArrayWrapper, RedisSet> region = this.getRegion(context);
-    Set<ByteArrayWrapper> firstSet = RedisSet.members(region, firstSetKey);
+    Set<ByteArrayWrapper> firstSet = RedisSet.smembers(region, firstSetKey);
 
     List<Set<ByteArrayWrapper>> setList = new ArrayList<>();
     for (int i = setsStartIndex; i < commandElems.size(); i++) {
       ByteArrayWrapper key = new ByteArrayWrapper(commandElems.get(i));
 
-      Set<ByteArrayWrapper> entry = RedisSet.members(region, key);
+      Set<ByteArrayWrapper> entry = RedisSet.smembers(region, key);
       if (entry != null) {
         setList.add(entry);
       } else if (this instanceof SInterExecutor) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutor.java
@@ -122,8 +122,7 @@ public class ZScanExecutor extends AbstractScanExecutor {
   }
 
   @SuppressWarnings("unchecked")
-  @Override
-  protected List<?> getIteration(Collection<?> list, Pattern matchPattern, int count, int cursor) {
+  private List<?> getIteration(Collection<?> list, Pattern matchPattern, int count, int cursor) {
     List<Object> returnList = new ArrayList<Object>();
     int size = list.size();
     int beforeCursor = 0;


### PR DESCRIPTION
All set op executors should use the CommandFunction to route the op to the partitionRegion primary.

The following redis set commands have been changed to use functions in the PR:
SCARD
SISMEMBER
SPOP
SRANDMEMBER
SSCAN

This pull request is a WIP to see how easy it would be to change the current implementation to one that uses functions.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
