### PR TITLE
GEODE-8130: use single region for Sets and Hashes

### DIFF
--- a/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
@@ -70,8 +70,8 @@ public class GeodeRedisServerRule extends SerializableExternalResource {
     return server.getKeyRegistrar();
   }
 
-  public RegionProvider getRegionCache() {
-    return server.getRegionCache();
+  public RegionProvider getRegionProvider() {
+    return server.getRegionProvider();
   }
 
   public RedisLockService getLockService() {

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/RedisDistDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/RedisDistDUnitTest.java
@@ -110,6 +110,7 @@ public class RedisDistDUnitTest implements Serializable {
   }
 
   @Test
+  @Ignore("GEODE-8127")
   public void testConcurrentSaddOperations_runWithoutException_orDataLoss()
       throws InterruptedException {
     List<String> set1 = new ArrayList<>();
@@ -118,14 +119,14 @@ public class RedisDistDUnitTest implements Serializable {
 
     final String setName = "keyset";
 
+    Jedis jedis = new Jedis(LOCALHOST, server1Port, JEDIS_TIMEOUT);
+
     AsyncInvocation<Void> remoteSaddInvocation =
         client1.invokeAsync(new ConcurrentSADDOperation(server1Port, setName, set1));
 
     client2.invoke(new ConcurrentSADDOperation(server2Port, setName, set2));
 
     remoteSaddInvocation.await();
-
-    Jedis jedis = new Jedis(LOCALHOST, server1Port, JEDIS_TIMEOUT);
 
     Set<String> smembers = jedis.smembers(setName);
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
@@ -35,12 +35,7 @@ import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -50,14 +45,12 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.exceptions.JedisDataException;
 
-import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})
@@ -161,61 +154,6 @@ public class HashesIntegrationTest {
     jedis.hdel("farm", "chicken");
 
     assertThat(jedis.exists("farm")).isFalse();
-  }
-
-  @Ignore("GEODE-7905")
-  @Test
-  public void testConcurrentHDelConsistentlyUpdatesMetaInformation()
-      throws ExecutionException, InterruptedException {
-    ByteArrayWrapper keyAsByteArray = new ByteArrayWrapper("hash".getBytes());
-    AtomicLong errorCount = new AtomicLong();
-    CyclicBarrier startCyclicBarrier = new CyclicBarrier(2, () -> {
-      boolean keyIsRegistered = server.getKeyRegistrar().isRegistered(keyAsByteArray);
-      boolean containsKey = server.getRegionCache().getHashRegion().containsKey(keyAsByteArray);
-
-      if (keyIsRegistered != containsKey) {
-        errorCount.getAndIncrement();
-        jedis.hset("hash", "field", "value");
-        jedis.del("hash");
-      }
-    });
-
-    ExecutorService pool = Executors.newFixedThreadPool(2);
-
-    Callable<Long> callable1 = () -> {
-      Long removedCount = 0L;
-      for (int i = 0; i < 1000; i++) {
-        try {
-          Long result = jedis.hdel("hash", "field");
-          startCyclicBarrier.await();
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
-      }
-      return removedCount;
-    };
-
-    Callable<Long> callable2 = () -> {
-      Long addedCount = 0L;
-      for (int i = 0; i < 1000; i++) {
-        try {
-          addedCount += jedis2.hset("hash", "field", "value");
-          startCyclicBarrier.await();
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
-      }
-      return addedCount;
-    };
-
-    Future<Long> future1 = pool.submit(callable1);
-    Future<Long> future2 = pool.submit(callable2);
-
-    future1.get();
-    future2.get();
-
-    assertThat(errorCount.get())
-        .as("Inconsistency between keyRegistrar and backing store detected.").isEqualTo(0L);
   }
 
   @Test

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisServerIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisServerIntegrationTest.java
@@ -59,11 +59,11 @@ public class RedisServerIntegrationTest {
   }
 
   @Test
-  public void initializeRedisCreatesFourRegions() {
-    redisServer = new GeodeRedisServer();
+  public void initializeRedisCreatesTwoRegions() {
+    redisServer = new GeodeRedisServer(redisPort);
     redisServer.start();
-    assertThat(cache.rootRegions()).hasSize(4);
-    assertThat(cache.getRegion(GeodeRedisServer.REDIS_META_DATA_REGION)).isNotNull();
+    assertThat(cache.rootRegions()).hasSize(2);
+    assertThat(cache.getRegion(GeodeRedisServer.REDIS_DATA_REGION)).isNotNull();
   }
 
   @Test

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.redis;
 
 import static java.lang.Integer.parseInt;
-import static org.apache.geode.redis.internal.GeodeRedisServer.REDIS_META_DATA_REGION;
+import static org.apache.geode.redis.internal.GeodeRedisServer.REDIS_DATA_REGION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -583,7 +583,7 @@ public class StringsIntegrationTest {
   @Test
   public void testSet_protectedRedisDataType_throwsRedisDataTypeMismatchException() {
     assertThatThrownBy(
-        () -> jedis.set(REDIS_META_DATA_REGION, "something else"))
+        () -> jedis.set(REDIS_DATA_REGION, "something else"))
             .isInstanceOf(JedisDataException.class)
             .hasMessageContaining("protected");
   }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SRemIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SRemIntegrationTest.java
@@ -187,7 +187,7 @@ public class SRemIntegrationTest {
     AtomicLong errorCount = new AtomicLong();
     CyclicBarrier startCyclicBarrier = new CyclicBarrier(2, () -> {
       boolean keyIsRegistered = server.getKeyRegistrar().isRegistered(keyAsByteArray);
-      boolean containsKey = server.getRegionCache().getSetRegion().containsKey(keyAsByteArray);
+      boolean containsKey = server.getRegionProvider().getDataRegion().containsKey(keyAsByteArray);
 
       if (keyIsRegistered != containsKey) {
         errorCount.getAndIncrement();

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SetsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SetsIntegrationTest.java
@@ -37,7 +37,6 @@ import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
 import org.apache.geode.redis.GeodeRedisServerRule;
-import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})
@@ -92,7 +91,8 @@ public class SetsIntegrationTest {
     setValue[0] = "set value that should never get added";
 
     exceptionRule.expect(JedisDataException.class);
-    exceptionRule.expectMessage(RedisConstants.ERROR_WRONG_TYPE);
+    exceptionRule
+        .expectMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
 
     jedis.set(key, stringValue);
     jedis.sadd(key, setValue);

--- a/geode-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -6,6 +6,10 @@ org/apache/geode/redis/internal/DoubleWrapper,2
 fromData,9
 toData,9
 
+org/apache/geode/redis/internal/KeyRegistrar$RedisDataTransformer,2
+fromData,14
+toData,9
+
 org/apache/geode/redis/internal/executor/hash/RedisHash,2
 fromData,9
 toData,9

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
@@ -35,6 +35,7 @@ import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.TransactionException;
 import org.apache.geode.cache.TransactionId;
 import org.apache.geode.cache.UnsupportedOperationInTransactionException;
+import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
 import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -55,7 +56,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   private static final Logger logger = LogService.getLogger();
   private static final int WAIT_REGION_DSTRYD_MILLIS = 100;
   private static final int MAXIMUM_NUM_RETRIES = (1000 * 60) / WAIT_REGION_DSTRYD_MILLIS; // 60
-                                                                                          // seconds
+  // seconds
   private final RedisLockService lockService;
 
   private final Cache cache;
@@ -99,7 +100,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
    * @param password Authentication password for each context, can be null
    */
   public ExecutionHandlerContext(Channel channel, Cache cache, RegionProvider regionProvider,
-      GeodeRedisServer server, byte[] password, KeyRegistrar keyRegistrar, PubSub pubSub,
+      GeodeRedisServer server, byte[] password,
+      KeyRegistrar keyRegistrar, PubSub pubSub,
       RedisLockService lockService) {
     this.keyRegistrar = keyRegistrar;
     this.lockService = lockService;
@@ -167,6 +169,19 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
 
   private ByteBuf getExceptionResponse(ChannelHandlerContext ctx, Throwable cause) {
     ByteBuf response;
+    if (cause instanceof FunctionException) {
+      Throwable th = cause.getCause();
+      if (th == null) {
+        FunctionException functionException = (FunctionException) cause;
+        if (functionException.getExceptions() != null) {
+          th = functionException.getExceptions().get(0);
+        }
+      }
+      if (th != null) {
+        cause = th;
+      }
+    }
+
     if (cause instanceof RedisDataTypeMismatchException) {
       response = Coder.getWrongTypeResponse(this.byteBufAllocator, cause.getMessage());
     } else if (cause instanceof DecoderException

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -65,7 +65,6 @@ import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
-import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.EntryEvent;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
@@ -84,8 +83,6 @@ import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.redis.internal.executor.CommandFunction;
-import org.apache.geode.redis.internal.executor.hash.RedisHash;
-import org.apache.geode.redis.internal.executor.set.RedisSet;
 import org.apache.geode.redis.internal.serverinitializer.NamedThreadFactory;
 
 /**
@@ -97,8 +94,8 @@ import org.apache.geode.redis.internal.serverinitializer.NamedThreadFactory;
  * Each Redis data type instance is stored in a separate {@link Region} except for the Strings and
  * HyperLogLogs which are collectively stored in one Region respectively. That Region along with a
  * meta data region used internally are protected so the client may not store keys with the name
- * {@link GeodeRedisServer#REDIS_META_DATA_REGION} or {@link GeodeRedisServer#STRING_REGION}. The
- * default Region type is {@link RegionShortcut#PARTITION} although this can be changed by
+ * {@link GeodeRedisServer#REDIS_DATA_REGION} or {@link GeodeRedisServer#STRING_REGION}. The
+ * default Region type is {@link RegionShortcut#PARTITION_REDUNDANT} although this can be changed by
  * specifying the SystemProperty {@value #DEFAULT_REGION_SYS_PROP_NAME} to a type defined by {@link
  * RegionShortcut}. If the {@link GeodeRedisServer#NUM_THREADS_SYS_PROP_NAME} system property is set
  * to 0, one thread per client will be created. Otherwise a worker thread pool of specified size is
@@ -119,7 +116,7 @@ import org.apache.geode.redis.internal.serverinitializer.NamedThreadFactory;
  * HMSET, HSETNX, HLEN, HSCAN, HSET, HVALS
  * <p>
  * Supported Set commands - SADD, SCARD, SDIFF, SDIFFSTORE, SINTER, SINTERSTORE, SISMEMBER,
- * SMEMBERS, SMOVE, SREM, SPOP, SRANDMEMBER, SCAN, SUNION, SUNIONSTORE
+ * SMEMBERS, SMOVE, SREM, SPOP, SRANDMEMBER, SSCAN, SUNION, SUNIONSTORE
  * <p>
  * Supported SortedSet commands - ZADD, ZCARD, ZCOUNT, ZINCRBY, ZLEXCOUNT, ZRANGE, ZRANGEBYLEX,
  * ZRANGEBYSCORE, ZRANK, ZREM, ZREMRANGEBYLEX, ZREMRANGEBYRANK, ZREMRANGEBYSCORE, ZREVRANGE,
@@ -221,7 +218,7 @@ public class GeodeRedisServer {
   @SuppressWarnings("deprecation")
   private org.apache.geode.LogWriter logger;
 
-  private RegionProvider regionCache;
+  private RegionProvider regionProvider;
 
   private final MetaCacheListener metaListener;
 
@@ -243,29 +240,17 @@ public class GeodeRedisServer {
   public static final String STRING_REGION = "ReDiS_StRiNgS";
 
   /**
-   * TThe field that defines the name of the {@link Region} which holds non-named hash. The current
-   * value of this field is {@value #HASH_REGION}.
-   */
-  public static final String HASH_REGION = "ReDiS_HASH";
-
-  /**
-   * TThe field that defines the name of the {@link Region} which holds sets. The current value of
-   * this field is {@value #SET_REGION}.
-   */
-  public static final String SET_REGION = "ReDiS_SET";
-
-
-  /**
    * The field that defines the name of the {@link Region} which holds all of the HyperLogLogs. The
    * current value of this field is {@code HLL_REGION}.
    */
   public static final String HLL_REGION = "ReDiS_HlL";
 
   /**
-   * The field that defines the name of the {@link Region} which holds all of the Redis meta data.
-   * The current value of this field is {@code REDIS_META_DATA_REGION}.
+   * The name of the region that holds data stored in redis.
+   * Currently this is the meta data but at some point the value for a particular
+   * type will be changed to an instance of {@link RedisData}
    */
-  public static final String REDIS_META_DATA_REGION = "ReDiS_MeTa_DaTa";
+  public static final String REDIS_DATA_REGION = "ReDiS_DaTa";
 
   /**
    * The system property name used to set the default {@link Region} creation type. The property
@@ -448,8 +433,8 @@ public class GeodeRedisServer {
   }
 
   @VisibleForTesting
-  public RegionProvider getRegionCache() {
-    return regionCache;
+  public RegionProvider getRegionProvider() {
+    return regionProvider;
   }
 
   private void initializeRedis() {
@@ -457,9 +442,7 @@ public class GeodeRedisServer {
       Region<ByteArrayWrapper, ByteArrayWrapper> stringsRegion;
 
       Region<ByteArrayWrapper, HyperLogLogPlus> hLLRegion;
-      Region<ByteArrayWrapper, RedisHash> redisHash;
-      Region<String, RedisDataType> redisMetaData;
-      Region<ByteArrayWrapper, RedisSet> redisSet;
+      Region<ByteArrayWrapper, RedisData> redisData;
       InternalCache gemFireCache = (InternalCache) cache;
 
       if ((stringsRegion = cache.getRegion(STRING_REGION)) == null) {
@@ -473,37 +456,25 @@ public class GeodeRedisServer {
         hLLRegion = regionFactory.create(HLL_REGION);
       }
 
-      if ((redisHash = cache.getRegion(HASH_REGION)) == null) {
-        RegionFactory<ByteArrayWrapper, RedisHash> regionFactory =
-            gemFireCache.createRegionFactory(DEFAULT_REGION_TYPE);
-        redisHash = regionFactory.create(HASH_REGION);
-      }
-
-      if ((redisSet = cache.getRegion(SET_REGION)) == null) {
-        RegionFactory<ByteArrayWrapper, RedisSet> regionFactory =
-            gemFireCache.createRegionFactory(DEFAULT_REGION_TYPE);
-        redisSet = regionFactory.create(SET_REGION);
-      }
-
-      if ((redisMetaData = cache.getRegion(REDIS_META_DATA_REGION)) == null) {
-        InternalRegionFactory<String, RedisDataType> redisMetaDataFactory =
-            gemFireCache.createInternalRegionFactory();
+      if ((redisData = cache.getRegion(REDIS_DATA_REGION)) == null) {
+        InternalRegionFactory<ByteArrayWrapper, RedisData> redisMetaDataFactory =
+            gemFireCache.createInternalRegionFactory(DEFAULT_REGION_TYPE);
         redisMetaDataFactory.addCacheListener(metaListener);
-        redisMetaDataFactory.setDataPolicy(DataPolicy.REPLICATE);
         redisMetaDataFactory.setInternalRegion(true).setIsUsedForMetaRegion(true);
-        redisMetaData = redisMetaDataFactory.create(REDIS_META_DATA_REGION);
+        redisData = redisMetaDataFactory.create(REDIS_DATA_REGION);
       }
 
-      keyRegistrar = new KeyRegistrar(redisMetaData);
+      keyRegistrar = new KeyRegistrar(redisData);
       hashLockService = new RedisLockService();
       pubSub = new PubSubImpl(new Subscriptions());
-      regionCache = new RegionProvider(stringsRegion, hLLRegion, keyRegistrar,
-          expirationFutures, expirationExecutor, DEFAULT_REGION_TYPE, redisHash, redisSet);
-      redisMetaData.put(REDIS_META_DATA_REGION, RedisDataType.REDIS_PROTECTED);
-      redisMetaData.put(HLL_REGION, RedisDataType.REDIS_PROTECTED);
-      redisMetaData.put(STRING_REGION, RedisDataType.REDIS_PROTECTED);
-      redisMetaData.put(SET_REGION, RedisDataType.REDIS_PROTECTED);
-      redisMetaData.put(HASH_REGION, RedisDataType.REDIS_PROTECTED);
+      regionProvider = new RegionProvider(stringsRegion, hLLRegion, keyRegistrar,
+          expirationFutures, expirationExecutor, DEFAULT_REGION_TYPE, redisData);
+      keyRegistrar.register(Coder.stringToByteArrayWrapper(REDIS_DATA_REGION),
+          RedisDataType.REDIS_PROTECTED);
+      keyRegistrar.register(Coder.stringToByteArrayWrapper(HLL_REGION),
+          RedisDataType.REDIS_PROTECTED);
+      keyRegistrar.register(Coder.stringToByteArrayWrapper(STRING_REGION),
+          RedisDataType.REDIS_PROTECTED);
 
       CommandFunction.register();
     }
@@ -511,6 +482,8 @@ public class GeodeRedisServer {
     checkForRegions();
     registerLockServiceMBean();
   }
+
+  public static final int PROTECTED_KEY_COUNT = 3;
 
   @VisibleForTesting
   public RedisLockService getLockService() {
@@ -537,20 +510,28 @@ public class GeodeRedisServer {
   }
 
   private void checkForRegions() {
-    Collection<Entry<String, RedisDataType>> entrySet = keyRegistrar.keyInfos();
-    for (Entry<String, RedisDataType> entry : entrySet) {
-      String regionName = entry.getKey();
-      RedisDataType type = entry.getValue();
-      Region<?, ?> newRegion = cache.getRegion(regionName);
-      if (newRegion == null && type != RedisDataType.REDIS_STRING && type != RedisDataType.REDIS_HLL
-          && type != RedisDataType.REDIS_PROTECTED) {
-        try {
-          regionCache
-              .createRemoteRegionReferenceLocally(Coder.stringToByteArrayWrapper(regionName), type);
-        } catch (Exception e) {
-          if (logger.errorEnabled()) {
-            logger.error(e);
-          }
+    Collection<Entry<ByteArrayWrapper, RedisData>> entrySet = keyRegistrar.keyInfos();
+    for (Entry<ByteArrayWrapper, RedisData> entry : entrySet) {
+      ByteArrayWrapper key = entry.getKey();
+      RedisDataType type = entry.getValue().getType();
+      if (!regionProvider.typeUsesDynamicRegions(type)) {
+        continue;
+      }
+      if (cache.getRegion(key.toString()) != null) {
+        // TODO: this seems to be correct (i.e. no need to call createRemoteRegionReferenceLocally
+        // if region already exists).
+        // HOWEVER: createRemoteRegionReferenceLocally ends up doing nothing if the region does not
+        // exist. So this caller of createRemoteRegionReferenceLocally basically does nothing.
+        // createRemoteRegionReferenceLocally might be needed even if the region exists because
+        // local state needs to be initialized (like indexes and queries).
+        continue;
+      }
+      try {
+        regionProvider.createRemoteRegionReferenceLocally(key, type);
+      } catch (Exception e) {
+        // TODO: this eats the exception so if something really is wrong we don't fail but just log.
+        if (logger.errorEnabled()) {
+          logger.error(e);
         }
       }
     }
@@ -642,7 +623,7 @@ public class GeodeRedisServer {
         pipeline.addLast(ByteToCommandDecoder.class.getSimpleName(), new ByteToCommandDecoder());
         pipeline.addLast(new WriteTimeoutHandler(10));
         pipeline.addLast(ExecutionHandlerContext.class.getSimpleName(),
-            new ExecutionHandlerContext(socketChannel, cache, regionCache, GeodeRedisServer.this,
+            new ExecutionHandlerContext(socketChannel, cache, regionProvider, GeodeRedisServer.this,
                 redisPasswordBytes,
                 keyRegistrar, pubSub, hashLockService));
       }
@@ -687,17 +668,13 @@ public class GeodeRedisServer {
    *
    * @param event EntryEvent from meta data region
    */
-  private void afterKeyCreate(EntryEvent<String, RedisDataType> event) {
+  private void afterKeyCreate(EntryEvent<ByteArrayWrapper, RedisData> event) {
     if (event.isOriginRemote()) {
-      final String key = event.getKey();
-      final RedisDataType value = event.getNewValue();
-      if (value != RedisDataType.REDIS_STRING && value != RedisDataType.REDIS_HLL
-          && value != RedisDataType.REDIS_PROTECTED) {
-        try {
-          regionCache.createRemoteRegionReferenceLocally(Coder.stringToByteArrayWrapper(key),
-              value);
-        } catch (RegionDestroyedException ignore) { // Region already destroyed, ignore
-        }
+      final ByteArrayWrapper key = event.getKey();
+      final RedisData value = event.getNewValue();
+      try {
+        regionProvider.createRemoteRegionReferenceLocally(key, value.getType());
+      } catch (RegionDestroyedException ignore) { // Region already destroyed, ignore
       }
     }
   }
@@ -706,29 +683,22 @@ public class GeodeRedisServer {
    * When a key is removed then this function will make sure the associated queries with the key are
    * also removed from each vm to avoid unnecessary data retention
    */
-  private void afterKeyDestroy(EntryEvent<String, RedisDataType> event) {
+  private void afterKeyDestroy(EntryEvent<ByteArrayWrapper, RedisData> event) {
     if (event.isOriginRemote()) {
-      final String key = event.getKey();
-      final RedisDataType value = event.getOldValue();
-      if (value != null && value != RedisDataType.REDIS_STRING && value != RedisDataType.REDIS_HLL
-          && value != RedisDataType.REDIS_PROTECTED) {
-        ByteArrayWrapper kW = Coder.stringToByteArrayWrapper(key);
-        Region<?, ?> r = regionCache.getRegion(kW);
-        if (r != null) {
-          regionCache.removeRegionReferenceLocally(kW, value);
-        }
-      }
+      final ByteArrayWrapper key = event.getKey();
+      final RedisData value = event.getOldValue();
+      regionProvider.removeRegionReferenceLocally(key, value.getType());
     }
   }
 
-  private class MetaCacheListener extends CacheListenerAdapter<String, RedisDataType> {
+  private class MetaCacheListener extends CacheListenerAdapter<ByteArrayWrapper, RedisData> {
     @Override
-    public void afterCreate(EntryEvent<String, RedisDataType> event) {
+    public void afterCreate(EntryEvent<ByteArrayWrapper, RedisData> event) {
       afterKeyCreate(event);
     }
 
     @Override
-    public void afterDestroy(EntryEvent<String, RedisDataType> event) {
+    public void afterDestroy(EntryEvent<ByteArrayWrapper, RedisData> event) {
       afterKeyDestroy(event);
     }
   }
@@ -758,7 +728,7 @@ public class GeodeRedisServer {
       serverChannel.close();
       c.syncUninterruptibly();
       c2.syncUninterruptibly();
-      regionCache.close();
+      regionProvider.close();
       if (mainThread != null) {
         mainThread.interrupt();
       }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/KeyRegistrar.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/KeyRegistrar.java
@@ -14,16 +14,21 @@
  */
 package org.apache.geode.redis.internal;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.geode.DataSerializer;
+import org.apache.geode.InvalidDeltaException;
 import org.apache.geode.cache.Region;
 
 public class KeyRegistrar {
-  private Region<String, RedisDataType> redisMetaRegion;
+  private Region<ByteArrayWrapper, RedisData> redisDataRegion;
 
-  public KeyRegistrar(Region<String, RedisDataType> redisMetaRegion) {
-    this.redisMetaRegion = redisMetaRegion;
+  public KeyRegistrar(Region<ByteArrayWrapper, RedisData> redisDataRegion) {
+    this.redisDataRegion = redisDataRegion;
   }
 
   /**
@@ -31,39 +36,119 @@ public class KeyRegistrar {
    * store the key:datatype association in the metadataRegion
    */
   public void register(ByteArrayWrapper key, RedisDataType type) {
-    RedisDataType existingType = this.redisMetaRegion.putIfAbsent(key.toString(), type);
-    if (!isValidDataType(existingType, type)) {
-      throwDataTypeException(key, existingType);
+    RedisData existingValue = this.redisDataRegion.putIfAbsent(key, transformType(type));
+    if (!isValidDataType(existingValue, type)) {
+      throwDataTypeException(key, existingValue);
+    }
+  }
+
+  /**
+   * TODO: This class should go away once all data types implement RedisData.
+   */
+  private static class RedisDataTransformer implements RedisData {
+    private RedisDataType type;
+
+    public RedisDataTransformer(RedisDataType type) {
+      this.type = type;
+    }
+
+    public RedisDataTransformer() {
+      // needed for serialization
+    }
+
+    @Override
+    public RedisDataType getType() {
+      return type;
+    }
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+      DataSerializer.writeEnum(type, out);
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+      type = DataSerializer.readEnum(RedisDataType.class, in);
+    }
+
+    @Override
+    public boolean hasDelta() {
+      return false;
+    }
+
+    @Override
+    public void toDelta(DataOutput out) throws IOException {}
+
+    @Override
+    public void fromDelta(DataInput in) throws IOException, InvalidDeltaException {}
+  }
+
+  private static final RedisDataTransformer REDIS_SORTEDSET_DATA =
+      new RedisDataTransformer(RedisDataType.REDIS_SORTEDSET);
+  private static final RedisDataTransformer REDIS_LIST_DATA =
+      new RedisDataTransformer(RedisDataType.REDIS_LIST);
+  private static final RedisDataTransformer REDIS_STRING_DATA =
+      new RedisDataTransformer(RedisDataType.REDIS_STRING);
+  private static final RedisDataTransformer REDIS_PROTECTED_DATA =
+      new RedisDataTransformer(RedisDataType.REDIS_PROTECTED);
+  private static final RedisDataTransformer REDIS_HLL_DATA =
+      new RedisDataTransformer(RedisDataType.REDIS_HLL);
+  private static final RedisDataTransformer REDIS_PUBSUB_DATA =
+      new RedisDataTransformer(RedisDataType.REDIS_PUBSUB);
+
+  /**
+   * TODO: This method should only exist while we still have data types that have not implemented
+   * this RedisData interface. Once they all implement it then we can get rid of this.
+   */
+  private RedisData transformType(RedisDataType type) {
+    switch (type) {
+      case REDIS_SORTEDSET:
+        return REDIS_SORTEDSET_DATA;
+      case REDIS_LIST:
+        return REDIS_LIST_DATA;
+      case REDIS_STRING:
+        return REDIS_STRING_DATA;
+      case REDIS_PROTECTED:
+        return REDIS_PROTECTED_DATA;
+      case REDIS_HLL:
+        return REDIS_HLL_DATA;
+      case REDIS_PUBSUB:
+        return REDIS_PUBSUB_DATA;
+      case REDIS_HASH:
+      case REDIS_SET:
+        throw new IllegalStateException(
+            type + " should never be added as a type to the data region");
+      default:
+        throw new IllegalStateException("unexpected RedisDataType: " + type);
     }
   }
 
   public boolean unregister(ByteArrayWrapper key) {
-    return this.redisMetaRegion.remove(key.toString()) != null;
-  }
-
-  public boolean unregisterIfType(ByteArrayWrapper key, RedisDataType expectedType) {
-    return redisMetaRegion.remove(key.toString(), expectedType);
+    return this.redisDataRegion.remove(key) != null;
   }
 
   public boolean isRegistered(ByteArrayWrapper key) {
-    return this.redisMetaRegion.containsKey(key.toString());
+    return this.redisDataRegion.containsKey(key);
   }
 
-  public Set<String> keys() {
-    Set<String> keysWithProtected = this.redisMetaRegion.keySet();
-    return keysWithProtected;
+  public Set<ByteArrayWrapper> keys() {
+    return this.redisDataRegion.keySet();
   }
 
-  public Set<Map.Entry<String, RedisDataType>> keyInfos() {
-    return this.redisMetaRegion.entrySet();
+  public Set<Map.Entry<ByteArrayWrapper, RedisData>> keyInfos() {
+    return this.redisDataRegion.entrySet();
   }
 
   public int numKeys() {
-    return this.redisMetaRegion.size() - RedisConstants.NUM_DEFAULT_KEYS;
+    return this.redisDataRegion.size() - GeodeRedisServer.PROTECTED_KEY_COUNT;
   }
 
   public RedisDataType getType(ByteArrayWrapper key) {
-    return this.redisMetaRegion.get(key.toString());
+    RedisData currentValue = redisDataRegion.get(key);
+    if (currentValue == null) {
+      return null;
+    }
+    return currentValue.getType();
   }
 
   /**
@@ -74,9 +159,12 @@ public class KeyRegistrar {
    * @param type Type to check to
    */
   public void validate(ByteArrayWrapper key, RedisDataType type) {
-    RedisDataType currentType = redisMetaRegion.get(key.toString());
-    if (!isValidDataType(currentType, type)) {
-      throwDataTypeException(key, currentType);
+    RedisData currentValue = redisDataRegion.get(key);
+    if (currentValue != null) {
+      RedisDataType currentType = currentValue.getType();
+      if (!isValidDataType(currentType, type)) {
+        throwDataTypeException(key, currentType);
+      }
     }
   }
 
@@ -86,7 +174,18 @@ public class KeyRegistrar {
    * @param key Key to check
    */
   public boolean isProtected(ByteArrayWrapper key) {
-    return RedisDataType.REDIS_PROTECTED.equals(redisMetaRegion.get(key.toString()));
+    RedisData redisData = redisDataRegion.get(key);
+    if (redisData == null) {
+      return false;
+    }
+    return RedisDataType.REDIS_PROTECTED.equals(redisData.getType());
+  }
+
+  private boolean isValidDataType(RedisData actualData, RedisDataType expectedDataType) {
+    if (actualData == null) {
+      return true;
+    }
+    return isValidDataType(actualData.getType(), expectedDataType);
   }
 
   private boolean isValidDataType(RedisDataType actualDataType, RedisDataType expectedDataType) {
@@ -95,6 +194,10 @@ public class KeyRegistrar {
 
   private boolean isKeyUnused(RedisDataType dataType) {
     return dataType == null;
+  }
+
+  private void throwDataTypeException(ByteArrayWrapper key, RedisData data) {
+    throwDataTypeException(key, data.getType());
   }
 
   private void throwDataTypeException(ByteArrayWrapper key, RedisDataType dataType) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -17,8 +17,6 @@ package org.apache.geode.redis.internal;
 
 public class RedisConstants {
 
-  public static final int NUM_DEFAULT_KEYS = 3;
-
   /*
    * Responses
    */

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisData.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisData.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal;
+
+import org.apache.geode.DataSerializable;
+import org.apache.geode.Delta;
+
+public interface RedisData extends Delta, DataSerializable {
+  RedisDataType getType();
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -20,13 +20,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.RedisCommandType;
+import org.apache.geode.redis.internal.RedisData;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.set.RedisSetInRegion;
 import org.apache.geode.redis.internal.executor.set.SingleResultCollector;
@@ -45,10 +45,9 @@ public class CommandFunction extends SingleResultRedisFunction {
     FunctionService.registerFunction(new CommandFunction(stripedExecutor));
   }
 
-  @SuppressWarnings("unchecked")
   public static <T> T execute(RedisCommandType command,
       ByteArrayWrapper key,
-      Object commandArguments, Region region) {
+      Object commandArguments, Region<ByteArrayWrapper, RedisData> region) {
     SingleResultCollector<T> rc = new SingleResultCollector<>();
     FunctionService
         .onRegion(region)
@@ -82,11 +81,7 @@ public class CommandFunction extends SingleResultRedisFunction {
       }
       case SREM: {
         ArrayList<ByteArrayWrapper> membersToRemove = (ArrayList<ByteArrayWrapper>) args[1];
-        callable = () -> {
-          AtomicBoolean setWasDeleted = new AtomicBoolean();
-          long srem = new RedisSetInRegion(localRegion).srem(key, membersToRemove, setWasDeleted);
-          return new Object[] {srem, setWasDeleted.get()};
-        };
+        callable = () -> new RedisSetInRegion(localRegion).srem(key, membersToRemove);
         break;
       }
       case DEL:
@@ -145,7 +140,6 @@ public class CommandFunction extends SingleResultRedisFunction {
   }
 
 
-  @SuppressWarnings("unchecked")
   private Callable<Object> executeDel(ByteArrayWrapper key, Region localRegion,
       RedisDataType delType) {
     switch (delType) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/EmptyRedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/EmptyRedisHash.java
@@ -22,17 +22,18 @@ import java.util.List;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.RedisData;
 import org.apache.geode.redis.internal.executor.hash.RedisHash;
 
 public class EmptyRedisHash extends RedisHash {
   @Override
-  public synchronized int hset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hset(Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToSet, boolean nx) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public synchronized int hdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hdel(Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToRemove) {
     return 0;
   }
@@ -41,4 +42,25 @@ public class EmptyRedisHash extends RedisHash {
   public synchronized Collection<ByteArrayWrapper> hgetall() {
     return emptyList();
   }
+
+  @Override
+  public synchronized boolean isEmpty() {
+    return true;
+  }
+
+  @Override
+  public synchronized boolean containsKey(ByteArrayWrapper field) {
+    return false;
+  }
+
+  @Override
+  public synchronized ByteArrayWrapper get(ByteArrayWrapper field) {
+    return null;
+  }
+
+  @Override
+  public synchronized int size() {
+    return 0;
+  }
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/FlushAllExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/FlushAllExecutor.java
@@ -18,9 +18,11 @@ import java.util.Map.Entry;
 
 import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.cache.UnsupportedOperationInTransactionException;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.RedisData;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class FlushAllExecutor extends AbstractExecutor {
@@ -31,11 +33,11 @@ public class FlushAllExecutor extends AbstractExecutor {
       throw new UnsupportedOperationInTransactionException();
     }
 
-    for (Entry<String, RedisDataType> e : context.getKeyRegistrar().keyInfos()) {
+    for (Entry<ByteArrayWrapper, RedisData> e : context.getKeyRegistrar().keyInfos()) {
       try {
-        String skey = e.getKey();
-        RedisDataType type = e.getValue();
-        removeEntry(Coder.stringToByteWrapper(skey), type, context);
+        ByteArrayWrapper skey = e.getKey();
+        RedisDataType type = e.getValue().getType();
+        removeEntry(skey, type, context);
       } catch (EntryDestroyedException e1) {
         continue;
       }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/KeysExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/KeysExecutor.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
@@ -39,7 +40,7 @@ public class KeysExecutor extends AbstractExecutor {
     }
 
     String glob = Coder.bytesToString(commandElems.get(1));
-    Set<String> allKeys = context.getKeyRegistrar().keys();
+    Set<ByteArrayWrapper> allKeys = context.getKeyRegistrar().keys();
     List<String> matchingKeys = new ArrayList<String>();
 
     Pattern pattern;
@@ -51,10 +52,14 @@ public class KeysExecutor extends AbstractExecutor {
       return;
     }
 
-    for (String key : allKeys) {
-      if (!(key.equals(GeodeRedisServer.REDIS_META_DATA_REGION)
-          || key.equals(GeodeRedisServer.STRING_REGION) || key.equals(GeodeRedisServer.HLL_REGION))
-          && pattern.matcher(key).matches()) {
+    for (ByteArrayWrapper bytesKey : allKeys) {
+      String key = bytesKey.toString();
+      if (key.equals(GeodeRedisServer.REDIS_DATA_REGION)
+          || key.equals(GeodeRedisServer.STRING_REGION)
+          || key.equals(GeodeRedisServer.HLL_REGION)) {
+        continue;
+      }
+      if (pattern.matcher(key).matches()) {
         matchingKeys.add(key);
       }
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
@@ -113,9 +113,9 @@ public class ScanExecutor extends AbstractScanExecutor {
     int numElements = 0;
     int i = -1;
     for (String key : (Collection<String>) list) {
-      if (key.equals(GeodeRedisServer.REDIS_META_DATA_REGION)
-          || key.equals(GeodeRedisServer.STRING_REGION) || key
-              .equals(GeodeRedisServer.HLL_REGION)) {
+      if (key.equals(GeodeRedisServer.REDIS_DATA_REGION)
+          || key.equals(GeodeRedisServer.STRING_REGION)
+          || key.equals(GeodeRedisServer.HLL_REGION)) {
         continue;
       }
       i++;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HDelExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HDelExecutor.java
@@ -21,7 +21,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
 /**
  * <pre>
@@ -47,17 +46,11 @@ public class HDelExecutor extends HashExecutor {
     List<ByteArrayWrapper> commandElems = command.getProcessedCommandWrappers();
 
     ByteArrayWrapper key = command.getKey();
-    checkDataType(key, RedisDataType.REDIS_HASH, context);
     RedisHashCommands redisHashCommands =
-        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getHashRegion());
+        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     ArrayList<ByteArrayWrapper> fieldsToDelete =
         new ArrayList<>(commandElems.subList(2, commandElems.size()));
     int numDeleted = redisHashCommands.hdel(key, fieldsToDelete);
-    if (numDeleted != 0) {
-      if (!context.getRegionProvider().getHashRegion().containsKey(key)) {
-        context.getKeyRegistrar().unregisterIfType(key, RedisDataType.REDIS_HASH);
-      }
-    }
     command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), numDeleted));
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
@@ -48,7 +48,7 @@ public class HGetAllExecutor extends HashExecutor {
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     ByteArrayWrapper key = command.getKey();
     RedisHashCommands redisHashCommands =
-        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getHashRegion());
+        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     Collection<ByteArrayWrapper> fieldsAndValues = redisHashCommands.hgetall(key);
     try {
       command.setResponse(Coder.getArrayResponse(context.getByteBufAllocator(), fieldsAndValues));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetExecutor.java
@@ -47,8 +47,8 @@ public class HGetExecutor extends HashExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
-    RedisHash entry = getMap(context, key);
-    ByteArrayWrapper valueWrapper = entry.get(field);
+    RedisHash redisHash = getRedisHash(context, key);
+    ByteArrayWrapper valueWrapper = redisHash.get(field);
     try {
       if (valueWrapper != null) {
         command.setResponse(

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HLenExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HLenExecutor.java
@@ -15,8 +15,6 @@
 package org.apache.geode.redis.internal.executor.hash;
 
 
-import org.apache.geode.cache.TimeoutException;
-import org.apache.geode.redis.internal.AutoCloseableLock;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
@@ -40,23 +38,8 @@ public class HLenExecutor extends HashExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     ByteArrayWrapper key = command.getKey();
-    final int size;
-
-    try (AutoCloseableLock regionLock = withRegionLock(context, key)) {
-      RedisHash map = getMap(context, key);
-      size = map.size();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      command.setResponse(
-          Coder.getErrorResponse(context.getByteBufAllocator(), "Thread interrupted."));
-      return;
-    } catch (TimeoutException e) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(),
-          "Timeout acquiring lock. Please try again."));
-      return;
-    }
-
-    command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), size));
+    RedisHash map = getRedisHash(context, key);
+    command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), map.size()));
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
@@ -20,7 +20,6 @@ import java.util.List;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
 /**
  * <pre>
@@ -48,9 +47,7 @@ public class HMGetExecutor extends HashExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
-    RedisHash map = getMap(context, key);
-
-    checkDataType(key, RedisDataType.REDIS_HASH, context);
+    RedisHash map = getRedisHash(context, key);
 
     ArrayList<ByteArrayWrapper> fields = new ArrayList<ByteArrayWrapper>();
     for (int i = 2; i < commandElems.size(); i++) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMSetExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMSetExecutor.java
@@ -21,7 +21,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
 /**
  * <pre>
@@ -52,9 +51,8 @@ public class HMSetExecutor extends HashExecutor {
     List<ByteArrayWrapper> commandElems = command.getProcessedCommandWrappers();
 
     ByteArrayWrapper key = command.getKey();
-    context.getKeyRegistrar().register(key, RedisDataType.REDIS_HASH);
     RedisHashCommands redisHashCommands =
-        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getHashRegion());
+        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     ArrayList<ByteArrayWrapper> fieldsToSet =
         new ArrayList<>(commandElems.subList(2, commandElems.size()));
     redisHashCommands.hset(key, fieldsToSet, false);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.redis.internal.executor.hash;
 
+import static org.apache.geode.redis.internal.executor.RedisHashInRegion.checkType;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -40,10 +42,9 @@ public class HScanExecutor extends AbstractScanExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
-    RedisHash hash =
-        context.getRegionProvider().getHashRegion().get(key);
+    RedisHash hash = checkType(context.getRegionProvider().getDataRegion().get(key));
 
-    if (hash == null || hash.isEmpty()) {
+    if (hash.isEmpty()) {
       command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ERROR_CURSOR));
       return;
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HSetExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HSetExecutor.java
@@ -21,7 +21,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
 /**
  * <pre>
@@ -45,10 +44,9 @@ public class HSetExecutor extends HashExecutor {
     List<ByteArrayWrapper> commandElems = command.getProcessedCommandWrappers();
 
     ByteArrayWrapper key = command.getKey();
-    context.getKeyRegistrar().register(key, RedisDataType.REDIS_HASH);
 
     RedisHashCommands redisHashCommands =
-        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getHashRegion());
+        new RedisHashCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
 
     ArrayList<ByteArrayWrapper> fieldsToSet =
         new ArrayList<>(commandElems.subList(2, commandElems.size()));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HValsExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HValsExecutor.java
@@ -14,13 +14,11 @@
  */
 package org.apache.geode.redis.internal.executor.hash;
 
-import java.util.Collection;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
 /**
  * <pre>
@@ -51,23 +49,15 @@ public class HValsExecutor extends HashExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     ByteArrayWrapper key = command.getKey();
-    checkDataType(key, RedisDataType.REDIS_HASH, context);
 
-    RedisHash map =
-        context.getRegionProvider().getHashRegion().get(key);
+    RedisHash map = getRedisHash(context, key);
 
-    if (map == null) {
+    if (map.isEmpty()) {
       command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
       return;
     }
 
-    Collection<ByteArrayWrapper> vals = map.values();
-    if (vals.isEmpty()) {
-      command.setResponse(Coder.getEmptyArrayResponse(context.getByteBufAllocator()));
-      return;
-    }
-
-    respondBulkStrings(command, context, vals);
+    respondBulkStrings(command, context, map.values());
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
@@ -26,15 +26,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
-import org.apache.geode.Delta;
 import org.apache.geode.InvalidDeltaException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.RedisData;
+import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.EmptyRedisHash;
 
-public class RedisHash implements Delta, DataSerializable {
+public class RedisHash implements RedisData {
   public static final RedisHash EMPTY = new EmptyRedisHash();
   private HashMap<ByteArrayWrapper, ByteArrayWrapper> hash;
   /**
@@ -101,7 +101,7 @@ public class RedisHash implements Delta, DataSerializable {
     }
   }
 
-  public synchronized int hset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hset(Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToSet, boolean nx) {
     int fieldsAdded = 0;
     Iterator<ByteArrayWrapper> iterator = fieldsToSet.iterator();
@@ -127,7 +127,7 @@ public class RedisHash implements Delta, DataSerializable {
     return fieldsAdded;
   }
 
-  public synchronized int hdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hdel(Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToRemove) {
     int fieldsRemoved = 0;
     for (ByteArrayWrapper fieldToRemove : fieldsToRemove) {
@@ -152,7 +152,7 @@ public class RedisHash implements Delta, DataSerializable {
     return result;
   }
 
-  private void storeChanges(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  private void storeChanges(Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper key,
       boolean doingAdds) {
     if (hasDelta()) {
       if (!doingAdds && hash.isEmpty()) {
@@ -200,5 +200,10 @@ public class RedisHash implements Delta, DataSerializable {
 
   public synchronized boolean containsKey(ByteArrayWrapper field) {
     return hash.containsKey(field);
+  }
+
+  @Override
+  public RedisDataType getType() {
+    return RedisDataType.REDIS_HASH;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommandsFunctionExecutor.java
@@ -25,15 +25,16 @@ import java.util.List;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.RedisData;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.CommandFunction;
 
 @SuppressWarnings("unchecked")
 public class RedisHashCommandsFunctionExecutor implements RedisHashCommands {
 
-  private final Region<ByteArrayWrapper, RedisHash> region;
+  private final Region<ByteArrayWrapper, RedisData> region;
 
-  public RedisHashCommandsFunctionExecutor(Region region) {
+  public RedisHashCommandsFunctionExecutor(Region<ByteArrayWrapper, RedisData> region) {
     this.region = region;
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/EmptyRedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/EmptyRedisSet.java
@@ -22,11 +22,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.RedisData;
 
 class EmptyRedisSet extends RedisSet {
 
@@ -36,7 +36,7 @@ class EmptyRedisSet extends RedisSet {
   }
 
   @Override
-  synchronized Collection<ByteArrayWrapper> spop(Region<ByteArrayWrapper, RedisSet> region,
+  synchronized Collection<ByteArrayWrapper> spop(Region<ByteArrayWrapper, RedisData> region,
       ByteArrayWrapper key, int popCount) {
     return emptyList();
   }
@@ -58,14 +58,13 @@ class EmptyRedisSet extends RedisSet {
 
   @Override
   synchronized long sadd(ArrayList<ByteArrayWrapper> membersToAdd,
-      Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key) {
+      Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper key) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   synchronized long srem(ArrayList<ByteArrayWrapper> membersToRemove,
-      Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key,
-      AtomicBoolean setWasDeleted) {
+      Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper key) {
     return 0;
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
@@ -28,8 +27,7 @@ public interface RedisSetCommands {
 
   long sadd(ByteArrayWrapper key, ArrayList<ByteArrayWrapper> membersToAdd);
 
-  long srem(ByteArrayWrapper key, ArrayList<ByteArrayWrapper> membersToAdd,
-      AtomicBoolean setWasDeleted);
+  long srem(ByteArrayWrapper key, ArrayList<ByteArrayWrapper> membersToRemove);
 
   Set<ByteArrayWrapper> smembers(ByteArrayWrapper key);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionExecutor.java
@@ -29,19 +29,19 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.RedisData;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.CommandFunction;
 
 public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
 
-  private final Region<ByteArrayWrapper, RedisSet> region;
+  private final Region<ByteArrayWrapper, RedisData> region;
 
-  public RedisSetCommandsFunctionExecutor(Region<ByteArrayWrapper, RedisSet> region) {
+  public RedisSetCommandsFunctionExecutor(Region<ByteArrayWrapper, RedisData> region) {
     this.region = region;
   }
 
@@ -52,15 +52,8 @@ public class RedisSetCommandsFunctionExecutor implements RedisSetCommands {
 
   @SuppressWarnings("unchecked")
   @Override
-  public long srem(ByteArrayWrapper key, ArrayList<ByteArrayWrapper> membersToRemove,
-      AtomicBoolean setWasDeleted) {
-    Object[] resultList =
-        CommandFunction.execute(SREM, key, membersToRemove, region);
-
-    long membersRemoved = (long) resultList[0];
-    Boolean wasDeleted = (Boolean) resultList[1];
-    setWasDeleted.set(wasDeleted);
-    return membersRemoved;
+  public long srem(ByteArrayWrapper key, ArrayList<ByteArrayWrapper> membersToRemove) {
+    return CommandFunction.execute(SREM, key, membersToRemove, region);
   }
 
   @Override

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SAddExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SAddExecutor.java
@@ -21,7 +21,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
 public class SAddExecutor extends SetExecutor {
 
@@ -30,11 +29,8 @@ public class SAddExecutor extends SetExecutor {
 
     List<ByteArrayWrapper> commandElements = command.getProcessedCommandWrappers();
 
-    // Save key
-    context.getKeyRegistrar().register(command.getKey(), RedisDataType.REDIS_SET);
-
     RedisSetCommands redisSetCommands =
-        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
 
     ArrayList<ByteArrayWrapper> membersToAdd =
         new ArrayList<>(commandElements.subList(2, commandElements.size()));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SCardExecutor.java
@@ -28,7 +28,7 @@ public class SCardExecutor extends SetExecutor {
     ByteArrayWrapper key = command.getKey();
     checkDataType(key, RedisDataType.REDIS_SET, context);
     RedisSetCommands redisSetCommands =
-        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     int size = redisSetCommands.scard(key);
     command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), size));
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
@@ -22,17 +22,14 @@ import org.apache.geode.redis.internal.CoderException;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants;
-import org.apache.geode.redis.internal.RedisDataType;
 
 public class SMembersExecutor extends SetExecutor {
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     ByteArrayWrapper key = command.getKey();
-    checkDataType(key, RedisDataType.REDIS_SET, context);
-
     RedisSetCommands redisSetCommands =
-        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     Set<ByteArrayWrapper> members = redisSetCommands.smembers(key);
 
     try {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
@@ -36,7 +36,7 @@ public class SPopExecutor extends SetExecutor {
 
     ByteArrayWrapper key = command.getKey();
     RedisSetCommands redisSetCommands =
-        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     Collection<ByteArrayWrapper> popped = redisSetCommands.spop(key, popCount);
     if (popped.isEmpty()) {
       command.setResponse(Coder.getNilResponse(context.getByteBufAllocator()));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
@@ -54,7 +54,7 @@ public class SRandMemberExecutor extends SetExecutor {
     }
 
     RedisSetCommands redisSetCommands =
-        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     Collection<ByteArrayWrapper> results = redisSetCommands.srandmember(key, count);
     try {
       if (results.isEmpty()) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
@@ -16,13 +16,11 @@ package org.apache.geode.redis.internal.executor.set;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
 public class SRemExecutor extends SetExecutor {
   @Override
@@ -31,30 +29,18 @@ public class SRemExecutor extends SetExecutor {
 
     ByteArrayWrapper key = command.getKey();
 
-    checkDataType(key, RedisDataType.REDIS_SET, context);
-
     RedisSetCommands redisSetCommands =
-        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
 
     ArrayList<ByteArrayWrapper> membersToRemove =
         new ArrayList<>(
             commandElements
                 .subList(2, commandElements.size()));
 
-    AtomicBoolean setWasDeleted = new AtomicBoolean();
-
     long membersRemoved =
         redisSetCommands.srem(
             key,
-            membersToRemove,
-            setWasDeleted);
-    if (setWasDeleted.get()) {
-      context
-          .getKeyRegistrar()
-          .unregisterIfType(
-              key,
-              RedisDataType.REDIS_SET);
-    }
+            membersToRemove);
 
     command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), membersRemoved));
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -98,7 +98,7 @@ public class SScanExecutor extends AbstractScanExecutor {
     }
 
     RedisSetCommands redisSetCommands =
-        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getSetRegion());
+        new RedisSetCommandsFunctionExecutor(context.getRegionProvider().getDataRegion());
     List<Object> returnList = redisSetCommands.sscan(key, matchPattern, count, cursor);
     command.setResponse(Coder.getScanResponse(context.getByteBufAllocator(), returnList));
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetExecutor.java
@@ -20,6 +20,7 @@ import org.apache.geode.cache.TimeoutException;
 import org.apache.geode.redis.internal.AutoCloseableLock;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.RedisData;
 import org.apache.geode.redis.internal.RedisLockService;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 
@@ -31,12 +32,12 @@ public abstract class SetExecutor extends AbstractExecutor {
    * @param context the execution handler
    * @return the set Region
    */
-  Region<ByteArrayWrapper, RedisSet> getRegion(
+  Region<ByteArrayWrapper, RedisData> getRegion(
       ExecutionHandlerContext context) {
 
     return context
         .getRegionProvider()
-        .getSetRegion();
+        .getDataRegion();
   }
 
   protected AutoCloseableLock withRegionLock(

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
@@ -26,7 +26,7 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
+import org.apache.geode.redis.internal.RedisData;
 import org.apache.geode.redis.internal.RegionProvider;
 
 public abstract class SetOpExecutor extends SetExecutor {
@@ -65,7 +65,7 @@ public abstract class SetOpExecutor extends SetExecutor {
       List<byte[]> commandElems, int setsStartIndex,
       RegionProvider regionProvider, ByteArrayWrapper destination,
       ByteArrayWrapper firstSetKey) {
-    Region<ByteArrayWrapper, RedisSet> region = this.getRegion(context);
+    Region<ByteArrayWrapper, RedisData> region = this.getRegion(context);
     Set<ByteArrayWrapper> firstSet = new RedisSetInRegion(region).smembers(firstSetKey);
 
     List<Set<ByteArrayWrapper>> setList = new ArrayList<>();
@@ -91,7 +91,6 @@ public abstract class SetOpExecutor extends SetExecutor {
       if (resultSet != null) {
         if (!resultSet.isEmpty()) {
           region.put(destination, new RedisSet(resultSet));
-          context.getKeyRegistrar().register(destination, RedisDataType.REDIS_SET);
         }
         command
             .setResponse(

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SynchronizedStripedExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SynchronizedStripedExecutor.java
@@ -45,6 +45,8 @@ public class SynchronizedStripedExecutor implements StripedExecutor {
     synchronized (getSync(stripeId)) {
       try {
         return callable.call();
+      } catch (RuntimeException re) {
+        throw re;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/RegionProviderJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/RegionProviderJUnitTest.java
@@ -29,8 +29,6 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.internal.hll.HyperLogLogPlus;
-import org.apache.geode.redis.internal.executor.hash.RedisHash;
-import org.apache.geode.redis.internal.executor.set.RedisSet;
 
 
 /**
@@ -46,8 +44,7 @@ public class RegionProviderJUnitTest {
 
   private ExecutionHandlerContext context;
 
-  private Region<ByteArrayWrapper, RedisHash> hashRegion;
-  private Region<ByteArrayWrapper, RedisSet> setRegion;
+  private Region<ByteArrayWrapper, RedisData> dataRegion;
 
   /**
    * Setup data, objects mocks for the test case
@@ -66,16 +63,14 @@ public class RegionProviderJUnitTest {
     Cache cache = Mockito.mock(Cache.class);
     Region<Object, Object> newRegion = org.mockito.Mockito.mock(Region.class);
 
-    setRegion = Mockito.mock(Region.class);
+    dataRegion = Mockito.mock(Region.class);
 
     Mockito.when(cache.getRegion(NEW_REGION_NM)).thenReturn(newRegion);
 
     RegionShortcut defaultShortcut = RegionShortcut.PARTITION;
 
-    hashRegion = Mockito.mock(Region.class);
-
     regionProvider = new RegionProvider(stringsRegion, hLLRegion, keyRegistrar, expirationsMap,
-        expirationExecutor, defaultShortcut, hashRegion, setRegion, cache);
+        expirationExecutor, defaultShortcut, dataRegion, cache);
     context = Mockito.mock(ExecutionHandlerContext.class);
 
   }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/AbstractExecutorJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/AbstractExecutorJUnitTest.java
@@ -26,16 +26,8 @@ import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.executor.string.SetExecutor;
 
-/**
- * Test for AbstractExecutor
- *
- *
- */
 public class AbstractExecutorJUnitTest {
 
-  /**
-   * Test the remove entry mehtod
-   */
   @Test
   public void testRemoveEntry() {
     // Create any instance of the AbstractExecutor


### PR DESCRIPTION
Now redis has a single "data" region that holds all the redis keys and for sets and hashes the data stored in the set/hash.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you

to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
