### PR TITLE
GEODE-8084: Declare parameter requirements for redis commands

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Command.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Command.java
@@ -157,4 +157,22 @@ public class Command {
     }
     return b.toString();
   }
+
+  public void execute(ExecutionHandlerContext executionHandlerContext) {
+    RedisCommandType type = getCommandType();
+    type.executeCommand(this, executionHandlerContext);
+  }
+
+  boolean isOfType(RedisCommandType type) {
+    return type == getCommandType();
+  }
+
+  public String wrongNumberOfArgumentsError() {
+    return String.format("wrong number of arguments for '%s' command",
+        getCommandType().toString().toLowerCase());
+  }
+
+  boolean isTransactional() {
+    return getCommandType().isTransactional();
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
@@ -39,7 +39,7 @@ import org.apache.geode.cache.query.QueryInvocationTargetException;
 import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.GeodeRedisServer;
-import org.apache.geode.redis.internal.executor.transactions.TransactionExecutor;
+import org.apache.geode.redis.internal.ParameterRequirements.RedisParametersMismatchException;
 
 /**
  * This class extends {@link ChannelInboundHandlerAdapter} from Netty and it is the last part of the
@@ -183,7 +183,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     } else if (cause instanceof InterruptedException || cause instanceof CacheClosedException) {
       response =
           Coder.getErrorResponse(this.byteBufAllocator, RedisConstants.SERVER_ERROR_SHUTDOWN);
-    } else if (cause instanceof IllegalStateException) {
+    } else if (cause instanceof IllegalStateException
+        || cause instanceof RedisParametersMismatchException) {
       response = Coder.getErrorResponse(this.byteBufAllocator, cause.getMessage());
     } else {
       if (logger.isErrorEnabled()) {
@@ -204,33 +205,32 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   }
 
   private void executeCommand(ChannelHandlerContext ctx, Command command) throws Exception {
-    RedisCommandType type = command.getCommandType();
-    Executor exec = type.getExecutor();
     if (isAuthenticated) {
-      if (type == RedisCommandType.SHUTDOWN) {
+      if (command.isOfType(RedisCommandType.SHUTDOWN)) {
         this.server.shutdown();
         return;
       }
-      if (hasTransaction() && !(exec instanceof TransactionExecutor)) {
-        executeWithTransaction(ctx, exec, command);
+
+      if (hasTransaction() && !command.isTransactional()) {
+        executeWithTransaction(ctx, command);
       } else {
-        executeWithoutTransaction(exec, command);
+        executeWithoutTransaction(command);
       }
 
-      if (hasTransaction() && command.getCommandType() != RedisCommandType.MULTI) {
+      if (hasTransaction() && command.isOfType(RedisCommandType.MULTI)) {
         writeToChannel(
             Coder.getSimpleStringResponse(this.byteBufAllocator, RedisConstants.COMMAND_QUEUED));
       } else {
         ByteBuf response = command.getResponse();
         writeToChannel(response);
       }
-    } else if (type == RedisCommandType.QUIT) {
-      exec.executeCommand(command, this);
+    } else if (command.isOfType(RedisCommandType.QUIT)) {
+      command.execute(this);
       ByteBuf response = command.getResponse();
       writeToChannel(response);
       channelInactive(ctx);
-    } else if (type == RedisCommandType.AUTH) {
-      exec.executeCommand(command, this);
+    } else if (command.isOfType(RedisCommandType.AUTH)) {
+      command.execute(this);
       ByteBuf response = command.getResponse();
       writeToChannel(response);
     } else {
@@ -239,19 +239,19 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     }
   }
 
+
   /**
    * Private helper method to execute a command without a transaction, done for special exception
    * handling neatness
    *
-   * @param exec Executor to use
    * @param command Command to execute
    * @throws Exception Throws exception if exception is from within execution and not to be handled
    */
-  private void executeWithoutTransaction(final Executor exec, Command command) throws Exception {
+  private void executeWithoutTransaction(Command command) throws Exception {
     Exception cause = null;
     for (int i = 0; i < MAXIMUM_NUM_RETRIES; i++) {
       try {
-        exec.executeCommand(command, this);
+        command.execute(this);
         return;
       } catch (Exception e) {
         logger.error(e);
@@ -266,13 +266,13 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     throw cause;
   }
 
-  private void executeWithTransaction(ChannelHandlerContext ctx, final Executor exec,
+  private void executeWithTransaction(ChannelHandlerContext ctx,
       Command command) throws Exception {
     CacheTransactionManager txm = cache.getCacheTransactionManager();
     TransactionId transactionId = getTransactionID();
     txm.resume(transactionId);
     try {
-      exec.executeCommand(command, this);
+      command.execute(this);
     } catch (UnsupportedOperationInTransactionException e) {
       command.setResponse(Coder.getErrorResponse(this.byteBufAllocator,
           RedisConstants.ERROR_UNSUPPORTED_OPERATION_IN_TRANSACTION));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Executor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Executor.java
@@ -29,4 +29,7 @@ public interface Executor {
    */
   void executeCommand(Command command, ExecutionHandlerContext context);
 
+  default void execute(Command command, ExecutionHandlerContext context) {
+    executeCommand(command, context);
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/ExactParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/ExactParameterRequirements.java
@@ -12,14 +12,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
+import org.apache.geode.redis.internal.Command;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
 
-public class SInterStoreExecutor extends SInterExecutor {
+public class ExactParameterRequirements implements ParameterRequirements {
+  private int number;
+
+  public ExactParameterRequirements(int number) {
+    this.number = number;
+  }
 
   @Override
-  protected boolean isStorage() {
-    return true;
+  public void checkParameters(Command command, ExecutionHandlerContext executionHandlerContext) {
+    if (command.getProcessedCommand().size() != number) {
+      throw new RedisParametersMismatchException(command.wrongNumberOfArgumentsError());
+    }
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MaximumParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MaximumParameterRequirements.java
@@ -12,14 +12,23 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
+import org.apache.geode.redis.internal.Command;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
 
-public class SInterStoreExecutor extends SInterExecutor {
+public class MaximumParameterRequirements implements ParameterRequirements {
+  private int maximum;
+
+  public MaximumParameterRequirements(int maximum) {
+    this.maximum = maximum;
+  }
 
   @Override
-  protected boolean isStorage() {
-    return true;
+  public void checkParameters(Command command, ExecutionHandlerContext executionHandlerContext) {
+    if (command.getProcessedCommand().size() > maximum) {
+      throw new RedisParametersMismatchException(command.wrongNumberOfArgumentsError());
+    }
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MinimumParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MinimumParameterRequirements.java
@@ -12,14 +12,24 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
+import org.apache.geode.redis.internal.Command;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
 
-public class SInterStoreExecutor extends SInterExecutor {
+public class MinimumParameterRequirements implements ParameterRequirements {
+  private int minimum;
+
+  public MinimumParameterRequirements(int minimum) {
+    this.minimum = minimum;
+  }
 
   @Override
-  protected boolean isStorage() {
-    return true;
+  public void checkParameters(Command command, ExecutionHandlerContext context) {
+    if (command.getProcessedCommand().size() < minimum) {
+      throw new RedisParametersMismatchException(command.wrongNumberOfArgumentsError());
+    }
   }
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MultipleParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MultipleParameterRequirements.java
@@ -18,11 +18,11 @@ package org.apache.geode.redis.internal.ParameterRequirements;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 
-public class MultipleRequirements implements ParameterRequirements {
+public class MultipleParameterRequirements implements ParameterRequirements {
   private final ParameterRequirements parameterRequirements;
   private final ParameterRequirements moreRequirements;
 
-  public MultipleRequirements(
+  public MultipleParameterRequirements(
       ParameterRequirements parameterRequirements, ParameterRequirements moreRequirements) {
     this.parameterRequirements = parameterRequirements;
     this.moreRequirements = moreRequirements;
@@ -32,10 +32,5 @@ public class MultipleRequirements implements ParameterRequirements {
   public void checkParameters(Command command, ExecutionHandlerContext executionHandlerContext) {
     this.moreRequirements.checkParameters(command, executionHandlerContext);
     this.parameterRequirements.checkParameters(command, executionHandlerContext);
-  }
-
-  @Override
-  public ParameterRequirements and(ParameterRequirements moreRequirements) {
-    return new MultipleRequirements(this, moreRequirements);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MultipleRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/MultipleRequirements.java
@@ -12,33 +12,30 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
-import org.apache.geode.cache.Region;
-import org.apache.geode.redis.internal.ByteArrayWrapper;
-import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisDataType;
 
-public class SCardExecutor extends SetExecutor {
+public class MultipleRequirements implements ParameterRequirements {
+  private final ParameterRequirements parameterRequirements;
+  private final ParameterRequirements moreRequirements;
 
-  private static final int NOT_EXISTS = 0;
-
-  @Override
-  public void executeCommand(Command command, ExecutionHandlerContext context) {
-    ByteArrayWrapper key = command.getKey();
-    checkDataType(key, RedisDataType.REDIS_SET, context);
-    Region<ByteArrayWrapper, DeltaSet> keyRegion = getRegion(context);
-
-    DeltaSet set = keyRegion.get(key);
-    if (set == null) {
-      command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), NOT_EXISTS));
-      return;
-    }
-
-    command.setResponse(Coder.getIntegerResponse(context.getByteBufAllocator(), set.size()));
+  public MultipleRequirements(
+      ParameterRequirements parameterRequirements, ParameterRequirements moreRequirements) {
+    this.parameterRequirements = parameterRequirements;
+    this.moreRequirements = moreRequirements;
   }
 
+  @Override
+  public void checkParameters(Command command, ExecutionHandlerContext executionHandlerContext) {
+    this.moreRequirements.checkParameters(command, executionHandlerContext);
+    this.parameterRequirements.checkParameters(command, executionHandlerContext);
+  }
+
+  @Override
+  public ParameterRequirements and(ParameterRequirements moreRequirements) {
+    return new MultipleRequirements(this, moreRequirements);
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements.java
@@ -12,14 +12,18 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
+import org.apache.geode.redis.internal.Command;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
 
-public class SInterStoreExecutor extends SInterExecutor {
+public interface ParameterRequirements {
+  void checkParameters(Command command,
+      ExecutionHandlerContext executionHandlerContext);
 
-  @Override
-  protected boolean isStorage() {
-    return true;
+  default ParameterRequirements and(ParameterRequirements moreRequirements) {
+    return new MultipleRequirements(this, moreRequirements);
   }
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements.java
@@ -23,7 +23,7 @@ public interface ParameterRequirements {
       ExecutionHandlerContext executionHandlerContext);
 
   default ParameterRequirements and(ParameterRequirements moreRequirements) {
-    return new MultipleRequirements(this, moreRequirements);
+    return new MultipleParameterRequirements(this, moreRequirements);
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/RedisParametersMismatchException.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/RedisParametersMismatchException.java
@@ -12,14 +12,13 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
+public class RedisParametersMismatchException extends RuntimeException {
+  private static final long serialVersionUID = -643700717871858072L;
 
-public class SInterStoreExecutor extends SInterExecutor {
-
-  @Override
-  protected boolean isStorage() {
-    return true;
+  public RedisParametersMismatchException(String message) {
+    super(message);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/SpopParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/SpopParameterRequirements.java
@@ -12,14 +12,21 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
+import org.apache.geode.redis.internal.Command;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
 
-public class SInterStoreExecutor extends SInterExecutor {
-
+public class SpopParameterRequirements implements ParameterRequirements {
   @Override
-  protected boolean isStorage() {
-    return true;
+  public void checkParameters(Command command, ExecutionHandlerContext context) {
+    if (command.getProcessedCommand().size() == 3) {
+      try {
+        Integer.parseInt(new String(command.getProcessedCommand().get(2)));
+      } catch (NumberFormatException nex) {
+        throw new RedisParametersMismatchException("value is not an integer or out of range");
+      }
+    }
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/UnspecifiedParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/UnspecifiedParameterRequirements.java
@@ -12,14 +12,16 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis.internal.executor.set;
 
+package org.apache.geode.redis.internal.ParameterRequirements;
 
+import org.apache.geode.redis.internal.Command;
+import org.apache.geode.redis.internal.ExecutionHandlerContext;
 
-public class SInterStoreExecutor extends SInterExecutor {
-
+public class UnspecifiedParameterRequirements implements ParameterRequirements {
   @Override
-  protected boolean isStorage() {
-    return true;
+  public void checkParameters(Command command,
+      ExecutionHandlerContext executionHandlerContext) {
+    return;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -15,6 +15,12 @@
 
 package org.apache.geode.redis.internal;
 
+import org.apache.geode.redis.internal.ParameterRequirements.ExactParameterRequirements;
+import org.apache.geode.redis.internal.ParameterRequirements.MaximumParameterRequirements;
+import org.apache.geode.redis.internal.ParameterRequirements.MinimumParameterRequirements;
+import org.apache.geode.redis.internal.ParameterRequirements.ParameterRequirements;
+import org.apache.geode.redis.internal.ParameterRequirements.SpopParameterRequirements;
+import org.apache.geode.redis.internal.ParameterRequirements.UnspecifiedParameterRequirements;
 import org.apache.geode.redis.internal.executor.AuthExecutor;
 import org.apache.geode.redis.internal.executor.DBSizeExecutor;
 import org.apache.geode.redis.internal.executor.DelExecutor;
@@ -137,6 +143,7 @@ import org.apache.geode.redis.internal.executor.string.StrlenExecutor;
 import org.apache.geode.redis.internal.executor.transactions.DiscardExecutor;
 import org.apache.geode.redis.internal.executor.transactions.ExecExecutor;
 import org.apache.geode.redis.internal.executor.transactions.MultiExecutor;
+import org.apache.geode.redis.internal.executor.transactions.TransactionExecutor;
 import org.apache.geode.redis.internal.executor.transactions.UnwatchExecutor;
 import org.apache.geode.redis.internal.executor.transactions.WatchExecutor;
 
@@ -226,39 +233,41 @@ public enum RedisCommandType {
    *************** Lists *****************
    ***************************************/
 
-  LINDEX(new LIndexExecutor()),
+  LINDEX(new LIndexExecutor(), new MinimumParameterRequirements(3)),
   LINSERT(new LInsertExecutor()),
-  LLEN(new LLenExecutor()),
-  LPOP(new LPopExecutor()),
-  LPUSH(new LPushExecutor()),
-  LPUSHX(new LPushXExecutor()),
-  LRANGE(new LRangeExecutor()),
-  LREM(new LRemExecutor()),
-  LSET(new LSetExecutor()),
-  LTRIM(new LTrimExecutor()),
-  RPOP(new RPopExecutor()),
-  RPUSH(new RPushExecutor()),
-  RPUSHX(new RPushXExecutor()),
+  LLEN(new LLenExecutor(), new MinimumParameterRequirements(2)),
+  LPOP(new LPopExecutor(), new MinimumParameterRequirements(2)),
+  LPUSH(new LPushExecutor(), new MinimumParameterRequirements(3)),
+  LPUSHX(new LPushXExecutor(), new MinimumParameterRequirements(3)),
+  LRANGE(new LRangeExecutor(), new MinimumParameterRequirements(4)),
+  LREM(new LRemExecutor(), new MinimumParameterRequirements(4)),
+  LSET(new LSetExecutor(), new MinimumParameterRequirements(4)),
+  LTRIM(new LTrimExecutor(), new MinimumParameterRequirements(4)),
+  RPOP(new RPopExecutor(), new MinimumParameterRequirements(2)),
+  RPUSH(new RPushExecutor(), new MinimumParameterRequirements(3)),
+  RPUSHX(new RPushXExecutor(), new MinimumParameterRequirements(3)),
 
   /***************************************
    **************** Sets *****************
    ***************************************/
 
-  SADD(new SAddExecutor()),
-  SCARD(new SCardExecutor()),
-  SDIFF(new SDiffExecutor()),
-  SDIFFSTORE(new SDiffStoreExecutor()),
-  SISMEMBER(new SIsMemberExecutor()),
-  SINTER(new SInterExecutor()),
-  SINTERSTORE(new SInterStoreExecutor()),
-  SMEMBERS(new SMembersExecutor()),
-  SMOVE(new SMoveExecutor()),
-  SPOP(new SPopExecutor()),
-  SRANDMEMBER(new SRandMemberExecutor()),
-  SUNION(new SUnionExecutor()),
-  SUNIONSTORE(new SUnionStoreExecutor()),
-  SSCAN(new SScanExecutor()),
-  SREM(new SRemExecutor()),
+  SADD(new SAddExecutor(), new MinimumParameterRequirements(3)),
+  SCARD(new SCardExecutor(), new ExactParameterRequirements(2)),
+  SDIFF(new SDiffExecutor(), new MinimumParameterRequirements(2)),
+  SDIFFSTORE(new SDiffStoreExecutor(), new MinimumParameterRequirements(3)),
+  SISMEMBER(new SIsMemberExecutor(), new ExactParameterRequirements(3)),
+  SINTER(new SInterExecutor(), new MinimumParameterRequirements(2)),
+  SINTERSTORE(new SInterStoreExecutor(), new MinimumParameterRequirements(3)),
+  SMEMBERS(new SMembersExecutor(), new ExactParameterRequirements(2)),
+  SMOVE(new SMoveExecutor(), new ExactParameterRequirements(4)),
+  SPOP(new SPopExecutor(),
+      new MinimumParameterRequirements(2).and(new MaximumParameterRequirements(3))
+          .and(new SpopParameterRequirements())),
+  SRANDMEMBER(new SRandMemberExecutor(), new MinimumParameterRequirements(2)),
+  SUNION(new SUnionExecutor(), new MinimumParameterRequirements(2)),
+  SUNIONSTORE(new SUnionStoreExecutor(), new MinimumParameterRequirements(3)),
+  SSCAN(new SScanExecutor(), new MinimumParameterRequirements(3)),
+  SREM(new SRemExecutor(), new MinimumParameterRequirements(3)),
 
   /***************************************
    ************* Sorted Sets *************
@@ -327,15 +336,23 @@ public enum RedisCommandType {
   UNKNOWN(new UnkownExecutor());
 
   private final Executor executor;
-
-  /**
-   * @return {@link Executor} for the command type
-   */
-  public Executor getExecutor() {
-    return executor;
-  };
+  private final ParameterRequirements parameterRequirements;
 
   private RedisCommandType(Executor executor) {
+    this(executor, new UnspecifiedParameterRequirements());
+  }
+
+  private RedisCommandType(Executor executor, ParameterRequirements parameterRequirements) {
     this.executor = executor;
+    this.parameterRequirements = parameterRequirements;
+  }
+
+  public void executeCommand(Command command, ExecutionHandlerContext executionHandlerContext) {
+    parameterRequirements.checkParameters(command, executionHandlerContext);
+    executor.executeCommand(command, executionHandlerContext);
+  }
+
+  public boolean isTransactional() {
+    return executor instanceof TransactionExecutor;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -156,69 +156,6 @@ public class RedisConstants {
         "The wrong number of arguments or syntax was provided, the format for the PFMERGE command is \"PFMERGE destkey sourcekey [sourcekey ...]\"";
 
     /*
-     * List
-     */
-    public static final String LINDEX =
-        "The wrong number of arguments or syntax was provided, the format for the LINDEX command is \"LINDEX key index";
-    public static final String LINSERT = null;
-    public static final String LLEN =
-        "The wrong number of arguments or syntax was provided, the format for the LLEN command is \"LLEN key";
-    public static final String LPOP =
-        "The wrong number of arguments or syntax was provided, the format for the LPOP command is \"LPOP key";
-    public static final String LPUSH =
-        "The wrong number of arguments or syntax was provided, the format for the LPUSH command is \"LPUSH key value [value ...]";
-    public static final String LPUSHX =
-        "The wrong number of arguments or syntax was provided, the format for the LPUSHX command is \"LPUSHX key value";
-    public static final String LRANGE =
-        "The wrong number of arguments or syntax was provided, the format for the LRANGE command is \"LRANGE key start stop\"";
-    public static final String LREM =
-        "The wrong number of arguments or syntax was provided, the format for the LREM command is \"LREM key count value\"";
-    public static final String LSET =
-        "The wrong number of arguments or syntax was provided, the format for the LSET command is \"LSET key index value\"";
-    public static final String LTRIM =
-        "The wrong number of arguments or syntax was provided, the format for the LTRIM command is \"LTRIM key start stop\"";
-    public static final String RPOP =
-        "The wrong number of arguments or syntax was provided, the format for the RPOP command is \"RPOP key";
-    public static final String RPUSH =
-        "The wrong number of arguments or syntax was provided, the format for the RPUSH command is \"RPUSH key value [value ...]";
-    public static final String RPUSHX =
-        "The wrong number of arguments or syntax was provided, the format for the RPUSHX command is \"RPUSHX key value";
-
-    /*
-     * Set
-     */
-    public static final String SADD =
-        "The wrong number of arguments or syntax was provided, the format for the SADD command is \"SADD key member [member ...]\"";
-    public static final String SCARD =
-        "The wrong number of arguments or syntax was provided, the format for the SCARD command is \"SCARD key\"";
-    public static final String SDIFF =
-        "The wrong number of arguments or syntax was provided, the format for the SDIFF command is \"SDIFF key [key ...]\"";
-    public static final String SDIFFSTORE =
-        "The wrong number of arguments or syntax was provided, the format for the SDIFF command is \"SDIFFSTORE destination key [key ...]\"";
-    public static final String SINTER =
-        "The wrong number of arguments or syntax was provided, the format for the SINTER command is \"SINTER key [key ...]\"";
-    public static final String SINTERSTORE =
-        "The wrong number of arguments or syntax was provided, the format for the SINTERSTORE command is \"SINTERSTORE destination key [key ...]\"";
-    public static final String SISMEMBER =
-        "The wrong number of arguments or syntax was provided, the format for the SISMEMBER command is \"SISMEMBER key member\"";
-    public static final String SMEMBERS =
-        "The wrong number of arguments or syntax was provided, the format for the SMEMBERS command is \"SMEMBERS key\"";
-    public static final String SMOVE =
-        "The wrong number of arguments or syntax was provided, the format for the SMOVE command is \"SMOVE source destination member\"";
-    public static final String SPOP =
-        "The wrong number of arguments or syntax was provided, the format for the SPOP command is \"SPOP key [count]\"";
-    public static final String SRANDMEMBER =
-        "The wrong number of arguments or syntax was provided, the format for the SRANDMEMBER command is \"SRANDMEMBER key [count]\"";
-    public static final String SREM =
-        "The wrong number of arguments or syntax was provided, the format for the SREM command is \"SREM key member [member ...]\"";
-    public static final String SSCAN =
-        "The wrong number of arguments or syntax was provided, the format for the SSCAN command is \"SSCAN key cursor [MATCH pattern] [COUNT count]\"";
-    public static final String SUNION =
-        "The wrong number of arguments or syntax was provided, the format for the SUNION command is \"SUNION key [key ...]\"";
-    public static final String SUNIONSTORE =
-        "The wrong number of arguments or syntax was provided, the format for the SUNIONSTORE command is \"SUNIONSTORE destination key [key ...]\"";
-
-    /*
      * Sorted set
      */
     public static final String ZADD =

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LIndexExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LIndexExecutor.java
@@ -24,7 +24,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.ListQuery;
 
@@ -35,11 +34,6 @@ public class LIndexExecutor extends ListExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.LINDEX));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     byte[] indexArray = commandElems.get(2);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LLenExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LLenExecutor.java
@@ -14,14 +14,12 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import java.util.List;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class LLenExecutor extends ListExecutor {
@@ -30,13 +28,6 @@ public class LLenExecutor extends ListExecutor {
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
-    List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 2) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.LLEN));
-      return;
-    }
-
     ByteArrayWrapper key = command.getKey();
 
     checkDataType(key, RedisDataType.REDIS_LIST, context);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LPopExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LPopExecutor.java
@@ -14,19 +14,12 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-
 
 public class LPopExecutor extends PopExecutor {
 
   @Override
   protected ListDirection popType() {
     return ListDirection.LEFT;
-  }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.LPOP;
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LPushExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LPushExecutor.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 
 public class LPushExecutor extends PushExecutor {
@@ -24,9 +23,5 @@ public class LPushExecutor extends PushExecutor {
     return ListDirection.LEFT;
   }
 
-  @Override
-  public String getArgsError() {
-    return ArityDef.LPUSH;
-  }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LPushXExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LPushXExecutor.java
@@ -14,19 +14,11 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-
-
 public class LPushXExecutor extends PushXExecutor {
 
   @Override
   protected ListDirection pushType() {
     return ListDirection.LEFT;
-  }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.LPUSHX;
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LRangeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LRangeExecutor.java
@@ -24,7 +24,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.ListQuery;
 
@@ -35,11 +34,6 @@ public class LRangeExecutor extends ListExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 4) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.LRANGE));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     byte[] startArray = commandElems.get(2);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LRemExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LRemExecutor.java
@@ -24,7 +24,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.ListQuery;
 
@@ -37,11 +36,6 @@ public class LRemExecutor extends ListExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 4) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.LREM));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     byte[] countArray = commandElems.get(2);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LSetExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LSetExecutor.java
@@ -23,7 +23,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.ListQuery;
 
@@ -39,11 +38,6 @@ public class LSetExecutor extends ListExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 4) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.LSET));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     byte[] indexArray = commandElems.get(2);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LTrimExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/LTrimExecutor.java
@@ -23,7 +23,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.ListQuery;
 
@@ -38,11 +37,6 @@ public class LTrimExecutor extends ListExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 4) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.LTRIM));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     byte[] startArray = commandElems.get(2);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/PopExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/PopExecutor.java
@@ -14,27 +14,17 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import java.util.List;
-
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.Extendable;
 import org.apache.geode.redis.internal.RedisDataType;
 
-public abstract class PopExecutor extends ListExecutor implements Extendable {
+public abstract class PopExecutor extends ListExecutor {
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
-    List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 2) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), getArgsError()));
-      return;
-    }
-
     ByteArrayWrapper key = command.getKey();
 
     checkDataType(key, RedisDataType.REDIS_LIST, context);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/PushExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/PushExecutor.java
@@ -21,21 +21,15 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.Extendable;
 import org.apache.geode.redis.internal.RedisDataType;
 
-public abstract class PushExecutor extends PushXExecutor implements Extendable {
+public abstract class PushExecutor extends PushXExecutor {
 
   private static final int START_VALUES_INDEX = 2;
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), getArgsError()));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/PushXExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/PushXExecutor.java
@@ -21,21 +21,15 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.Extendable;
 import org.apache.geode.redis.internal.RedisDataType;
 
-public abstract class PushXExecutor extends ListExecutor implements Extendable {
+public abstract class PushXExecutor extends ListExecutor {
 
   private static final int NOT_EXISTS = 0;
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), getArgsError()));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/RPopExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/RPopExecutor.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-
 
 public class RPopExecutor extends PopExecutor {
 
@@ -24,9 +22,5 @@ public class RPopExecutor extends PopExecutor {
     return ListDirection.RIGHT;
   }
 
-  @Override
-  public String getArgsError() {
-    return ArityDef.RPOP;
-  }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/RPushExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/RPushExecutor.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 
 public class RPushExecutor extends PushExecutor {
@@ -23,10 +22,4 @@ public class RPushExecutor extends PushExecutor {
   protected ListDirection pushType() {
     return ListDirection.RIGHT;
   }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.RPUSH;
-  }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/RPushXExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/list/RPushXExecutor.java
@@ -14,19 +14,10 @@
  */
 package org.apache.geode.redis.internal.executor.list;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-
-
 public class RPushXExecutor extends PushXExecutor {
 
   @Override
   protected ListDirection pushType() {
     return ListDirection.RIGHT;
   }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.RPUSHX;
-  }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SAddExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SAddExecutor.java
@@ -21,7 +21,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class SAddExecutor extends SetExecutor {
@@ -30,11 +29,6 @@ public class SAddExecutor extends SetExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<ByteArrayWrapper> commandElements = command.getProcessedCommandWrappers();
-
-    if (commandElements.size() < 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SADD));
-      return;
-    }
 
     // Save key
     context.getKeyRegistrar().register(command.getKey(), RedisDataType.REDIS_SET);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SDiffExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SDiffExecutor.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 public class SDiffExecutor extends SetOpExecutor {
 
@@ -40,10 +39,4 @@ public class SDiffExecutor extends SetOpExecutor {
     }
     return copy;
   }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.SDIFF;
-  }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SDiffStoreExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SDiffStoreExecutor.java
@@ -14,18 +14,10 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-
-
 public class SDiffStoreExecutor extends SDiffExecutor {
 
   @Override
   protected boolean isStorage() {
     return true;
-  }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.SDIFFSTORE;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SInterExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SInterExecutor.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 public class SInterExecutor extends SetOpExecutor {
 
@@ -42,11 +41,6 @@ public class SInterExecutor extends SetOpExecutor {
       copy.retainAll(set);
     }
     return copy;
-  }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.SINTER;
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SIsMemberExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SIsMemberExecutor.java
@@ -21,7 +21,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class SIsMemberExecutor extends SetExecutor {
@@ -33,12 +32,6 @@ public class SIsMemberExecutor extends SetExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() != 3) {
-      command
-          .setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SISMEMBER));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     if (!context.getKeyRegistrar().isRegistered(key)) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
-import java.util.List;
 import java.util.Set;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
@@ -23,20 +22,12 @@ import org.apache.geode.redis.internal.CoderException;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class SMembersExecutor extends SetExecutor {
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
-    List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() != 2) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SMEMBERS));
-      return;
-    }
-
     ByteArrayWrapper key = command.getKey();
     checkDataType(key, RedisDataType.REDIS_SET, context);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
@@ -25,7 +25,6 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class SMoveExecutor extends SetExecutor {
@@ -37,11 +36,6 @@ public class SMoveExecutor extends SetExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() != 4) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SMOVE));
-      return;
-    }
 
     ByteArrayWrapper source = command.getKey();
     ByteArrayWrapper destination = new ByteArrayWrapper(commandElems.get(2));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
@@ -27,7 +27,6 @@ import org.apache.geode.redis.internal.CoderException;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 public class SPopExecutor extends SetExecutor {
 
@@ -35,19 +34,8 @@ public class SPopExecutor extends SetExecutor {
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
     int popCount = 1;
-
-    if (commandElems.size() < 2 || commandElems.size() > 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SPOP));
-      return;
-    }
-
     if (commandElems.size() == 3) {
-      try {
-        popCount = Integer.parseInt(new String(commandElems.get(2)));
-      } catch (NumberFormatException nex) {
-        command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SPOP));
-        return;
-      }
+      popCount = Integer.parseInt(new String(commandElems.get(2)));
     }
 
     ByteArrayWrapper key = command.getKey();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
@@ -29,7 +29,6 @@ import org.apache.geode.redis.internal.CoderException;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 public class SRandMemberExecutor extends SetExecutor {
 
@@ -38,12 +37,6 @@ public class SRandMemberExecutor extends SetExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 2) {
-      command
-          .setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SRANDMEMBER));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRemExecutor.java
@@ -22,18 +22,12 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 
 public class SRemExecutor extends SetExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<ByteArrayWrapper> commandElements = command.getProcessedCommandWrappers();
-
-    if (commandElements.size() < 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SREM));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     checkDataType(key, RedisDataType.REDIS_SET, context);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -27,7 +27,6 @@ import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.RedisConstants;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.executor.AbstractScanExecutor;
 
@@ -36,11 +35,6 @@ public class SScanExecutor extends AbstractScanExecutor {
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-
-    if (commandElems.size() < 3) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), ArityDef.SSCAN));
-      return;
-    }
 
     ByteArrayWrapper key = command.getKey();
     checkDataType(key, RedisDataType.REDIS_SET, context);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SUnionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SUnionExecutor.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.geode.redis.internal.ByteArrayWrapper;
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 public class SUnionExecutor extends SetOpExecutor {
 
@@ -37,10 +36,4 @@ public class SUnionExecutor extends SetOpExecutor {
     }
     return addSet;
   }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.SUNION;
-  }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SUnionStoreExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SUnionStoreExecutor.java
@@ -14,19 +14,10 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-
-
 public class SUnionStoreExecutor extends SUnionExecutor {
 
   @Override
   protected boolean isStorage() {
     return true;
   }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.SUNIONSTORE;
-  }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
@@ -26,21 +26,15 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.Extendable;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.RegionProvider;
 
-public abstract class SetOpExecutor extends SetExecutor implements Extendable {
+public abstract class SetOpExecutor extends SetExecutor {
 
   @Override
   public void executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
     int setsStartIndex = isStorage() ? 2 : 1;
-
-    if (commandElems.size() < setsStartIndex + 1) {
-      command.setResponse(Coder.getErrorResponse(context.getByteBufAllocator(), getArgsError()));
-      return;
-    }
 
     RegionProvider regionProvider = context.getRegionProvider();
     ByteArrayWrapper destination = null;

--- a/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
+++ b/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
@@ -1,9 +1,10 @@
 org/apache/geode/internal/hll/CardinalityMergeException,false
 org/apache/geode/redis/internal/CoderException,true,4707944288714910949
 org/apache/geode/redis/internal/MemberNotFoundException,true,4707944288714910949
+org/apache/geode/redis/internal/ParameterRequirements/RedisParametersMismatchException,true,-643700717871858072
 org/apache/geode/redis/internal/PubSubImpl$1,false,this$0:org/apache/geode/redis/internal/PubSubImpl
 org/apache/geode/redis/internal/RedisCommandParserException,true,4707944288714910949
-org/apache/geode/redis/internal/RedisCommandType,false,executor:org/apache/geode/redis/internal/Executor
+org/apache/geode/redis/internal/RedisCommandType,false,executor:org/apache/geode/redis/internal/Executor,parameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements
 org/apache/geode/redis/internal/RedisDataType,false
 org/apache/geode/redis/internal/RedisDataType$1,false
 org/apache/geode/redis/internal/RedisDataType$2,false

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/set/SetExecutorJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/executor/set/SetExecutorJUnitTest.java
@@ -17,10 +17,10 @@
 package org.apache.geode.redis.internal.executor.set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.Executor;
+import org.apache.geode.redis.internal.ParameterRequirements.RedisParametersMismatchException;
 
 public class SetExecutorJUnitTest {
   ExecutionHandlerContext context;
@@ -45,117 +45,108 @@ public class SetExecutorJUnitTest {
 
   @Test
   public void verifyErrorMessageWhenOneArgPassedToSAdd() {
-    Executor sAddExecutor = new SAddExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SADD".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sAddExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenTwoArgsPassedToSAdd() {
-    Executor sAddExecutor = new SAddExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SADD".getBytes());
     commandsAsBytes.add("key1".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sAddExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenOneArgsPassedToSCard() {
-    Executor sCardExecutor = new SCardExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SCARD".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sCardExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenMoreThanTwoArgsPassedToSCard() {
-    Executor sCardExecutor = new SCardExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SCARD".getBytes());
     commandsAsBytes.add("key1".getBytes());
     commandsAsBytes.add("key2".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sCardExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenOneArgPassedToSMembers() {
-    Executor sMembersExecutor = new SMembersExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SMEMBERS".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sMembersExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenMoreThanTwoArgsPassedToSMembers() {
-    Executor sMembersExecutor = new SMembersExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SMEMBERS".getBytes());
     commandsAsBytes.add("key1".getBytes());
     commandsAsBytes.add("key2".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sMembersExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenOneArgPassedToSIsMember() {
-    Executor sIsMemberExecutor = new SIsMemberExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SISMEMBER".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sIsMemberExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenTwoArgsPassedToSIsMember() {
-    Executor sIsMemberExecutor = new SIsMemberExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SISMEMBER".getBytes());
     Command command = new Command(commandsAsBytes);
     commandsAsBytes.add("key1".getBytes());
 
-    sIsMemberExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenMoreThanThreeArgsPassedToSIsMember() {
-    Executor sIsMemberExecutor = new SIsMemberExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SISMEMBER".getBytes());
     commandsAsBytes.add("key1".getBytes());
@@ -163,57 +154,53 @@ public class SetExecutorJUnitTest {
     commandsAsBytes.add("member2".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sIsMemberExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenOneArgsPassedToSMove() {
-    Executor sMoveExecutor = new SMoveExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SMOVE".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sMoveExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenTwoArgsPassedToSMove() {
-    Executor sMoveExecutor = new SMoveExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SMOVE".getBytes());
     commandsAsBytes.add("source".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sMoveExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenThreeArgsPassedToSMove() {
-    Executor sMoveExecutor = new SMoveExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SMOVE".getBytes());
     commandsAsBytes.add("source".getBytes());
     commandsAsBytes.add("dest".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sMoveExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenMoreThanFourArgsPassedToSMove() {
-    Executor sMoveExecutor = new SMoveExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SMOVE".getBytes());
     commandsAsBytes.add("source".getBytes());
@@ -222,200 +209,186 @@ public class SetExecutorJUnitTest {
     commandsAsBytes.add("field2".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sMoveExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenArgsPassedToSDiff() {
-    Executor sdiffExecutor = new SDiffExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SDIFF".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sdiffExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenNoArgsPassedToSDiffStore() {
-    Executor sDiffStoreExecutor = new SDiffStoreExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SDIFFSTORE".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sDiffStoreExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenOneArgPassedToSDiffStore() {
-    Executor sDiffStoreExecutor = new SDiffStoreExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SDIFFSTORE".getBytes());
     commandsAsBytes.add("key1".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sDiffStoreExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenNoArgsPassedToSInter() {
-    Executor sInterExecutor = new SInterExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SINTER".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sInterExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenNoArgsPassedToSInterStore() {
-    Executor sInterStoreExecutor = new SInterStoreExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SINTERSTORE".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sInterStoreExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenOneArgPassedToSInterStore() {
-    Executor sInterStoreExecutor = new SInterStoreExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SINTERSTORE".getBytes());
     commandsAsBytes.add("key1".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sInterStoreExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenNoArgsPassedToSUnion() {
-    Executor sUnionExecutor = new SUnionExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SUNION".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sUnionExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenNoArgsPassedToSUnionStore() {
-    Executor sUnionStoreExecutor = new SUnionStoreExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SUNIONSTORE".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sUnionStoreExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenOneArgPassedToSUnionStore() {
-    Executor sUnionStoreExecutor = new SUnionStoreExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SUNIONSTORE".getBytes());
     commandsAsBytes.add("key1".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sUnionStoreExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenNoArgsPassedToSPop() {
-    Executor sPopExecutor = new SPopExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SPOP".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sPopExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenWrongNANPassedToSPop() {
-    Executor sPopExecutor = new SPopExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SPOP".getBytes());
     commandsAsBytes.add("key1".getBytes());
     commandsAsBytes.add("NAN".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sPopExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("value is not an integer or out of range");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessageWhenMoreTwoArgsPassedToSPop() {
-    Executor sPopExecutor = new SPopExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SPOP".getBytes());
     commandsAsBytes.add("key1".getBytes());
-    commandsAsBytes.add("4".getBytes()); // switch "NAN" to a real number
+    commandsAsBytes.add("4".getBytes());
     commandsAsBytes.add("invalid".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    sPopExecutor.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessage_WhenNoArgsPassedToSRem() {
-    Executor subject = new SRemExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SREM".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    subject.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 
   @Test
   public void verifyErrorMessage_WhenOneArgPassedToSRem() {
-    Executor subject = new SRemExecutor();
     List<byte[]> commandsAsBytes = new ArrayList<>();
     commandsAsBytes.add("SREM".getBytes());
     commandsAsBytes.add("key1".getBytes());
     Command command = new Command(commandsAsBytes);
 
-    subject.executeCommand(command, context);
+    Throwable thrown = catchThrowable(() -> command.execute(context));
 
-    assertThat(command.getResponse().toString(Charset.defaultCharset()))
-        .startsWith("-ERR The wrong number of arguments or syntax was provided");
+    assertThat(thrown).hasMessageContaining("wrong number of arguments");
+    assertThat(thrown).isInstanceOf(RedisParametersMismatchException.class);
   }
 }


### PR DESCRIPTION
This commit replaces the existing 'imperative' parameter checks with a
more declarative style.

It only changes how the parameters for Set and List are checked.  The
others are done through the existing mechanism in the Executors.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
