### PR TITLE
GEODE-8079: Fix DistributedRegion Validations

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -260,16 +260,14 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
         // Fix for Bug#51491. Once decided to support this configuration we have call
         // addShadowPartitionedRegionForUserRR
         if (this.sender.getId().contains(AsyncEventQueueImpl.ASYNC_EVENT_QUEUE_PREFIX)) {
-          throw new AsyncEventQueueConfigurationException(
-              String.format(
-                  "Parallel Async Event Queue %s can not be used with replicated region %s",
-                  new Object[] {
-                      AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(this.sender.getId()),
-                      userRegion.getFullPath()}));
+          throw new AsyncEventQueueConfigurationException(String.format(
+              "Parallel Async Event Queue %s can not be used with replicated region %s",
+              AsyncEventQueueImpl.getAsyncEventQueueIdFromSenderId(this.sender.getId()),
+              userRegion.getFullPath()));
         }
         throw new GatewaySenderConfigurationException(
-            String.format("Parallel gateway sender %s can not be used with replicated region %s",
-                new Object[] {this.sender.getId(), userRegion.getFullPath()}));
+            String.format("Parallel Gateway Sender %s can not be used with replicated region %s",
+                this.sender.getId(), userRegion.getFullPath()));
       }
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
@@ -14,8 +14,11 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.cache.asyncqueue.internal.AsyncEventQueueImpl.getSenderIdFromAsyncEventQueueId;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.anyObject;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -25,24 +28,30 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 
 import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.versions.RegionVersionHolder;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.cache.versions.VersionSource;
+import org.apache.geode.internal.cache.wan.AsyncEventQueueConfigurationException;
+import org.apache.geode.internal.cache.wan.GatewaySenderConfigurationException;
 
 
 public class DistributedRegionTest {
-  private RegionVersionVector vector;
-  private RegionVersionHolder holder;
-  private VersionSource lostMemberVersionID;
+  private RegionVersionVector<VersionSource<Object>> vector;
+  private RegionVersionHolder<VersionSource<Object>> holder;
+  private VersionSource<Object> lostMemberVersionID;
   private InternalDistributedMember member;
 
   @Before
+  @SuppressWarnings("unchecked")
   public void setup() {
     vector = mock(RegionVersionVector.class);
     holder = mock(RegionVersionHolder.class);
@@ -56,7 +65,7 @@ public class DistributedRegionTest {
     EntryEventImpl mockEntryEventImpl = mock(EntryEventImpl.class);
     Object returnValue = new Object();
 
-    when(mockDistributedRegion.validatedDestroy(anyObject(), eq(mockEntryEventImpl)))
+    when(mockDistributedRegion.validatedDestroy(any(), eq(mockEntryEventImpl)))
         .thenReturn(returnValue);
 
     assertThat(mockDistributedRegion.validatedDestroy(new Object(), mockEntryEventImpl))
@@ -179,5 +188,76 @@ public class DistributedRegionTest {
     distributedRegion.performSynchronizeForLostMemberTask(member, lostMemberVersionID);
 
     verify(distributedRegion, never()).synchronizeForLostMember(member, lostMemberVersionID);
+  }
+
+  @Test
+  public void validateAsynchronousEventDispatcherShouldDoNothingWhenDispatcherIdCanNotBeFound() {
+    InternalCache internalCache = mock(InternalCache.class);
+    when(internalCache.getAllGatewaySenders())
+        .thenReturn(Collections.singleton(mock(GatewaySender.class)));
+    DistributedRegion distributedRegion = mock(DistributedRegion.class);
+    when(distributedRegion.getCache()).thenReturn(internalCache);
+    doCallRealMethod().when(distributedRegion).validateAsynchronousEventDispatcher(anyString());
+
+    distributedRegion.validateAsynchronousEventDispatcher("nonExistingDispatcher");
+  }
+
+  @Test
+  public void validateAsynchronousEventDispatcherShouldDoNothingWhenFoundDispatcherIsSerial() {
+    String senderId = "mySender";
+    GatewaySender serialSender = mock(GatewaySender.class);
+    when(serialSender.isParallel()).thenReturn(false);
+    when(serialSender.getId()).thenReturn(senderId);
+    InternalCache internalCache = mock(InternalCache.class);
+    when(internalCache.getAllGatewaySenders()).thenReturn(Collections.singleton(serialSender));
+    DistributedRegion distributedRegion = mock(DistributedRegion.class);
+    when(distributedRegion.getCache()).thenReturn(internalCache);
+    doCallRealMethod().when(distributedRegion).validateAsynchronousEventDispatcher(anyString());
+
+    distributedRegion.validateAsynchronousEventDispatcher(senderId);
+  }
+
+  @Test
+  public void validateAsynchronousEventDispatcherShouldThrowExceptionWhenDispatcherIdMatchesAnExistingParallelAsyncEventQueue() {
+    String senderId = "senderId";
+    String regionPath = "thisRegion";
+    String internalSenderId = getSenderIdFromAsyncEventQueueId(senderId);
+    GatewaySender parallelAsyncEventQueue = mock(GatewaySender.class);
+    when(parallelAsyncEventQueue.isParallel()).thenReturn(true);
+    when(parallelAsyncEventQueue.getId()).thenReturn(internalSenderId);
+    InternalCache internalCache = mock(InternalCache.class);
+    when(internalCache.getAllGatewaySenders())
+        .thenReturn(Collections.singleton(parallelAsyncEventQueue));
+    DistributedRegion distributedRegion = mock(DistributedRegion.class);
+    when(distributedRegion.getCache()).thenReturn(internalCache);
+    when(distributedRegion.getFullPath()).thenReturn(regionPath);
+    doCallRealMethod().when(distributedRegion).validateAsynchronousEventDispatcher(anyString());
+
+    assertThatThrownBy(
+        () -> distributedRegion.validateAsynchronousEventDispatcher(internalSenderId))
+            .isInstanceOf(AsyncEventQueueConfigurationException.class)
+            .hasMessage("Parallel Async Event Queue " + senderId
+                + " can not be used with replicated region " + regionPath);
+  }
+
+  @Test
+  public void validateAsynchronousEventDispatcherShouldThrowExceptionWhenDispatcherIdMatchesAnExistingParallelGatewaySender() {
+    String senderId = "senderId";
+    String regionPath = "thisRegion";
+    GatewaySender parallelGatewaySender = mock(GatewaySender.class);
+    when(parallelGatewaySender.isParallel()).thenReturn(true);
+    when(parallelGatewaySender.getId()).thenReturn(senderId);
+    InternalCache internalCache = mock(InternalCache.class);
+    when(internalCache.getAllGatewaySenders())
+        .thenReturn(Collections.singleton(parallelGatewaySender));
+    DistributedRegion distributedRegion = mock(DistributedRegion.class);
+    when(distributedRegion.getCache()).thenReturn(internalCache);
+    when(distributedRegion.getFullPath()).thenReturn(regionPath);
+    doCallRealMethod().when(distributedRegion).validateAsynchronousEventDispatcher(anyString());
+
+    assertThatThrownBy(() -> distributedRegion.validateAsynchronousEventDispatcher(senderId))
+        .isInstanceOf(GatewaySenderConfigurationException.class)
+        .hasMessage("Parallel Gateway Sender " + senderId
+            + " can not be used with replicated region " + regionPath);
   }
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -40,7 +40,6 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.apache.geode.test.util.ResourceUtils.createTempFileFromResource;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -2047,27 +2046,6 @@ public class WANTestBase extends DistributedTestCase {
           "Test " + getTestMethodName() + " failed to start GatewayReceiver on port " + port, e);
     }
     return port;
-  }
-
-  public static void createReceiverWithBindAddress(int locPort) {
-    WANTestBase test = new WANTestBase();
-    Properties props = test.getDistributedSystemProperties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
-    props.setProperty(LOCATORS, "localhost[" + locPort + "]");
-
-    InternalDistributedSystem ds = test.getSystem(props);
-    cache = CacheFactory.create(ds);
-    GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
-    fact.setStartPort(port);
-    fact.setEndPort(port);
-    fact.setManualStart(true);
-    fact.setBindAddress("200.112.204.10");
-    GatewayReceiver receiver = fact.create();
-    assertThatThrownBy(receiver::start)
-        .isInstanceOf(GatewayReceiverException.class)
-        .hasMessageContaining("No available free port found in the given range");
   }
 
   public static int createReceiverWithSSL(int locPort) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanValidationsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanValidationsDUnitTest.java
@@ -14,36 +14,41 @@
  */
 package org.apache.geode.internal.cache.wan.misc;
 
+import static java.util.Arrays.asList;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.wan.GatewayEventFilter;
+import org.apache.geode.cache.wan.GatewayReceiver;
+import org.apache.geode.cache.wan.GatewayReceiverFactory;
 import org.apache.geode.cache.wan.GatewaySender.OrderPolicy;
 import org.apache.geode.cache.wan.GatewayTransportFilter;
 import org.apache.geode.cache30.MyGatewayTransportFilter1;
 import org.apache.geode.cache30.MyGatewayTransportFilter2;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.DistributedRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.SenderIdMonitor;
 import org.apache.geode.internal.cache.wan.Filter70;
+import org.apache.geode.internal.cache.wan.GatewayReceiverException;
 import org.apache.geode.internal.cache.wan.GatewaySenderException;
 import org.apache.geode.internal.cache.wan.MyGatewayTransportFilter3;
 import org.apache.geode.internal.cache.wan.MyGatewayTransportFilter4;
 import org.apache.geode.internal.cache.wan.WANTestBase;
-import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.WanTest;
 
@@ -54,774 +59,34 @@ public class WanValidationsDUnitTest extends WANTestBase {
     super();
   }
 
-  /**
-   * Test to make sure that serial sender Ids configured in Distributed Region is same across all DR
-   * nodes TODO : Should this validation hold tru now. Discuss. If I have 2 members on Which DR is
-   * defined. But sender is defined on only one member. How can I add the instance on the sender in
-   * Region which does not have a sender. I can bypass the existing validation for the DR with
-   * SerialGatewaySender. But for PR with SerialGatewaySender, we need to send the adjunct message.
-   * Find out the way to send the adjunct message to the member on which serialGatewaySender is
-   * available.
-   */
-
-  @Test
-  public void testSameSerialGatewaySenderIdAcrossSameDistributedRegion() throws Exception {
-    IgnoredException.addIgnoredException("another cache has the same region defined");
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-      Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-
-      createCacheInVMs(lnPort, vm4, vm5);
-
-      vm4.invoke(
-          () -> WANTestBase.createSender("ln1", 2, false, 10, 100, false, false, null, true));
-      vm4.invoke(
-          () -> WANTestBase.createSender("ln2", 2, false, 10, 100, false, false, null, true));
-
-      vm5.invoke(
-          () -> WANTestBase.createSender("ln2", 2, false, 10, 100, false, false, null, true));
-      vm5.invoke(
-          () -> WANTestBase.createSender("ln3", 2, false, 10, 100, false, false, null, true));
-
-      vm4.invoke(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln1,ln2",
-          isOffHeap()));
-
-      vm5.invoke(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln2,ln3",
-          isOffHeap()));
-      fail("Expected IllegalStateException with incompatible gateway sender ids message");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException)
-          || !(e.getCause().getMessage().contains("Cannot create Region"))) {
-        Assert.fail("Expected IllegalStateException with incompatible gateway sender ids message",
-            e);
-      }
+  private SenderIdMonitor getSenderIdMonitor(Region<Object, Object> r) {
+    if (r instanceof DistributedRegion) {
+      return ((DistributedRegion) r).getSenderIdMonitor();
+    } else if (r instanceof PartitionedRegion) {
+      return ((PartitionedRegion) r).getSenderIdMonitor();
+    } else {
+      throw new IllegalStateException(
+          "expected region to be distributed or partitioned but it was: " + r.getClass());
     }
   }
 
+  private void verifyIdConsistencyWarning(String regionName, boolean expected,
+      boolean gatewaySenderId) {
+    Region<Object, Object> r = cache.getRegion(Region.SEPARATOR + regionName);
+    SenderIdMonitor senderIdMonitor = getSenderIdMonitor(r);
 
-  /**
-   * Validate that ParallelGatewaySender can be added to Distributed region
-   *
-   *
-   *
-   * Below test is disabled intentionally Replicated region with Parallel Async Event queue
-   * is not supported. Test is added for the same
-   * ReplicatedRegion_ParallelWANPropagationDUnitTest#test_DR_PGS_1Nodes_Put_Receiver
-   *
-   * We are gone support this configuration in upcoming releases
-   */
-
-  @Ignore("Bug51491")
-  @Test
-  public void testParallelGatewaySenderForDistributedRegion() throws Exception {
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-      Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-
-      createCacheInVMs(lnPort, vm4, vm5);
-
-      vm4.invoke(
-          () -> WANTestBase.createSender("ln1", 2, true, 10, 100, false, false, null, false));
-
-      vm5.invoke(
-          () -> WANTestBase.createSender("ln2", 2, true, 10, 100, false, false, null, false));
-
-      vm4.invoke(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln1",
-          isOffHeap()));
-
-      vm5.invoke(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln1",
-          isOffHeap()));
-
-    } catch (Exception e) {
-      Assert.fail("Caught Exception", e);
+    if (gatewaySenderId) {
+      assertThat(senderIdMonitor.getGatewaySenderIdsDifferWarningMessage()).isEqualTo(expected);
+    } else {
+      assertThat(senderIdMonitor.getAsyncQueueIdsDifferWarningMessage()).isEqualTo(expected);
     }
   }
 
-  /**
-   * Test to make sure that serial sender Ids configured in partitioned regions should be same
-   * across all PR members
-   */
-  @Test
-  public void testSameSerialGatewaySenderIdAcrossSamePartitionedRegion() throws Exception {
-    IgnoredException.addIgnoredException("another cache has the same region defined");
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm4, vm5);
-
-      vm4.invoke(
-          () -> WANTestBase.createSender("ln1", 2, false, 10, 100, false, false, null, true));
-      vm4.invoke(
-          () -> WANTestBase.createSender("ln2", 2, false, 10, 100, false, false, null, true));
-
-      vm5.invoke(
-          () -> WANTestBase.createSender("ln2", 2, false, 10, 100, false, false, null, true));
-      vm5.invoke(
-          () -> WANTestBase.createSender("ln3", 2, false, 10, 100, false, false, null, true));
-
-      vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln1,ln2",
-          1, 100, isOffHeap()));
-      vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln2,ln3",
-          1, 100, isOffHeap()));
-      fail("Expected IllegalStateException with incompatible gateway sender ids message");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException)
-          || !(e.getCause().getMessage().contains("Cannot create Region"))) {
-        Assert.fail("Expected IllegalStateException with incompatible gateway sender ids message",
-            e);
-      }
+  private void verifyIdConsistencyWarningOnVms(String regionName, boolean expected,
+      boolean gatewaySenderId) {
+    for (VM vm : asList(vm4, vm5, vm6, vm7)) {
+      vm.invoke(() -> verifyIdConsistencyWarning(regionName, expected, gatewaySenderId));
     }
-  }
-
-
-  @Test
-  public void testReplicatedSerialAsyncEventQueueWithPersistenceEnabled() {
-    IgnoredException.addIgnoredException("another cache has the same region defined");
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm4, vm5);
-
-
-      vm4.invoke(() -> WANTestBase.createReplicatedRegionWithAsyncEventQueue(
-          getTestMethodName() + "_RR", "ln1", isOffHeap()));
-      vm5.invoke(() -> WANTestBase.createReplicatedRegionWithAsyncEventQueue(
-          getTestMethodName() + "_RR", "ln2", isOffHeap()));
-      fail("Expected IllegalStateException with incompatible gateway sender ids message");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException)
-          || !(e.getCause().getMessage().contains("Cannot create Region"))) {
-        Assert.fail("Expected IllegalStateException with incompatible gateway sender ids message",
-            e);
-      }
-    }
-  }
-
-  /**
-   * Test to make sure that parallel sender Ids configured in partitioned regions should be same
-   * across all PR members
-   */
-  @Test
-  public void testSameParallelGatewaySenderIdAcrossSamePartitionedRegion() throws Exception {
-    IgnoredException.addIgnoredException("another cache has the same region defined");
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm4, vm5);
-
-      vm4.invoke(() -> WANTestBase.createSender("ln1", 2, true, 10, 100, false, false, null, true));
-      vm4.invoke(() -> WANTestBase.createSender("ln2", 2, true, 10, 100, false, false, null, true));
-
-      vm5.invoke(() -> WANTestBase.createSender("ln2", 2, true, 10, 100, false, false, null, true));
-      vm5.invoke(() -> WANTestBase.createSender("ln3", 2, true, 10, 100, false, false, null, true));
-
-      vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln1,ln2",
-          1, 100, isOffHeap()));
-      vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln2,ln3",
-          1, 100, isOffHeap()));
-
-      fail("Expected IllegalStateException with incompatible gateway sender ids message");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException)
-          || !(e.getCause().getMessage().contains("Cannot create Region"))) {
-        Assert.fail("Expected IllegalStateException with incompatible gateway sender ids message",
-            e);
-      }
-    }
-  }
-
-  /**
-   * Test to make sure that same parallel gateway sender id can be used by 2 different PRs
-   *
-   */
-  @Ignore
-  @Test
-  public void testSameParallelGatewaySenderIdAcrossDifferentPartitionedRegion() throws Exception {
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm1);
-
-      vm1.invoke(() -> WANTestBase.createSender("ln1_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-      vm1.invoke(() -> WANTestBase.createSender("ln2_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR1", null, "ln1_Parallel,ln2_Parallel", null, isOffHeap()));
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR2", null, "ln1_Parallel,ln2_Parallel", null, isOffHeap()));
-
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage()
-          .contains("cannot have the same parallel gateway sender id"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void testSameParallelGatewaySenderIdAcrossColocatedPartitionedRegion() throws Exception {
-    IgnoredException.addIgnoredException("another cache has the same region defined");
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm1);
-
-      vm1.invoke(() -> WANTestBase.createSender("ln1_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-      vm1.invoke(() -> WANTestBase.createSender("ln2_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR1", null, "ln1_Parallel", null, isOffHeap()));
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR2", null, "ln1_Parallel,ln2_Parallel",
-          getTestMethodName() + "_PR1", isOffHeap()));
-      // now we support this
-      // fail("Expected IllegalStateException with incompatible gateway sender ids in colocated
-      // regions");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage()
-          .contains("should have same parallel gateway sender ids"))) {
-        Assert.fail(
-            "Expected IllegalStateException with incompatible gateway sender ids in colocated regions",
-            e);
-      }
-    }
-  }
-
-  /**
-   * Validate that if Colocated partitioned region doesn't want to add a PGS even if its parent has
-   * one then it is fine
-   *
-   */
-
-  @Test
-  public void testSameParallelGatewaySenderIdAcrossColocatedPartitionedRegion2() throws Exception {
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm1);
-
-      vm1.invoke(() -> WANTestBase.createSender("ln1_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-      vm1.invoke(() -> WANTestBase.createSender("ln2_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR1", null, "ln1_Parallel", null, isOffHeap()));
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR2", null, null, getTestMethodName() + "_PR1", isOffHeap()));
-
-    } catch (Exception e) {
-      Assert.fail("The tests caught Exception.", e);
-    }
-  }
-
-  /**
-   * Validate that if Colocated partitioned region has a subset of PGS then it is fine.
-   *
-   */
-
-  @Test
-  public void testSameParallelGatewaySenderIdAcrossColocatedPartitionedRegion3() throws Exception {
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm1);
-
-      vm1.invoke(() -> WANTestBase.createSender("ln1_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-      vm1.invoke(() -> WANTestBase.createSender("ln2_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR1", null, "ln1_Parallel,ln2_Parallel", null, isOffHeap()));
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR2", null, "ln1_Parallel", getTestMethodName() + "_PR1",
-          isOffHeap()));
-
-    } catch (Exception e) {
-      Assert.fail("The tests caught Exception.", e);
-    }
-  }
-
-  /**
-   * Validate that if Colocated partitioned region has a superset of PGS then Exception is thrown.
-   *
-   */
-
-  @Test
-  public void testSameParallelGatewaySenderIdAcrossColocatedPartitionedRegion4() throws Exception {
-    try {
-      Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-      createCacheInVMs(lnPort, vm1);
-
-      vm1.invoke(() -> WANTestBase.createSender("ln1_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-      vm1.invoke(() -> WANTestBase.createSender("ln2_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-      vm1.invoke(() -> WANTestBase.createSender("ln3_Parallel", 2, true, 10, 100, false, false,
-          null, true));
-
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR1", null, "ln1_Parallel,ln2_Parallel", null, isOffHeap()));
-      vm1.invoke(() -> WANTestBase.createPartitionedRegionWithSerialParallelSenderIds(
-          getTestMethodName() + "_PR2", null, "ln1_Parallel,ln2_Parallel,ln3_Parallel",
-          getTestMethodName() + "_PR1", isOffHeap()));
-      // now we support this
-      // fail("Expected IllegalStateException with incompatible gateway sender ids in colocated
-      // regions");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage()
-          .contains("should have same parallel gateway sender ids"))) {
-        Assert.fail(
-            "Expected IllegalStateException with incompatible gateway sender ids in colocated regions",
-            e);
-      }
-    }
-  }
-
-  /**
-   * SerialGatewaySender and ParallelGatewaySender with same name is allowed
-   */
-  @Test
-  public void testSerialGatewaySenderAndParallelGatewaySenderWithSameName() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-    try {
-      vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, true, 100, false, false,
-          null, null, true, false));
-      fail("Expected IllegalStateException : Sender names should be different.");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException)
-          || !(e.getCause().getMessage().contains("is already defined in this cache"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  // remote ds ids should be same
-  @Test
-  public void testSameRemoteDSAcrossSameSender() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 3, false, 100, false, false,
-          null, null, true, false));
-      fail("Expected IllegalStateException : Remote Ds Ids should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with remote ds id"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  // sender with same name should be either serial or parallel but not both.
-  @Test
-  public void testSerialSenderOnBothCache() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, true, 100, false, false,
-          null, null, true, false));
-      fail("Expected IllegalStateException : is not serial Gateway Sender");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage()
-          .contains("because another cache has the same sender as serial gateway sender"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  // sender with same name should be either serial or parallel but not both.
-  @Test
-  public void testParallelSenderOnBothCache() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, true, 100, false, false, null,
-        null, true, false));
-
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-          null, null, true, false));
-      fail("Expected IllegalStateException : is not parallel Gateway Sender");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage()
-          .contains("because another cache has the same sender as parallel gateway sender"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  // isBatchConflation should be same across the same sender
-  @Test
-  public void testBatchConflation() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-
-    // isBatchConflation
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, true, false,
-          null, null, true, false));
-      fail("Expected IllegalStateException : isBatchConflation Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "another cache has the same Gateway Sender defined with isBatchConflationEnabled"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  // isPersistentEnabled should be same across the same sender
-  @Test
-  public void testisPersistentEnabled() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, true,
-          null, null, true, false));
-      fail("Expected IllegalStateException : isPersistentEnabled Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with isPersistentEnabled"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void testAlertThreshold() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 50, false, false,
-          null, null, true, false));
-      fail("Expected IllegalStateException : alertThreshold Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with alertThreshold"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void testManualStart() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-          null, null, false, false));
-      fail("Expected IllegalStateException : manualStart Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with manual start"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void testGatewayEventFilters() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    ArrayList<GatewayEventFilter> eventFilters = new ArrayList<GatewayEventFilter>();
-    eventFilters.add(new MyGatewayEventFilter());
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-        eventFilters, null, true, false));
-    try {
-      eventFilters.clear();
-      eventFilters.add(new Filter70());
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-          eventFilters, null, true, false));
-      fail("Expected IllegalStateException : GatewayEventFilters Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with GatewayEventFilters"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void testGatewayEventFilters2() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    ArrayList<GatewayEventFilter> eventFilters = new ArrayList<GatewayEventFilter>();
-    eventFilters.add(new MyGatewayEventFilter());
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-        eventFilters, null, true, false));
-    try {
-      eventFilters.clear();
-      eventFilters.add(new MyGatewayEventFilter());
-      eventFilters.add(new Filter70());
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-          eventFilters, null, true, false));
-      fail("Expected IllegalStateException : GatewayEventFilters Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with GatewayEventFilters"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void testGatewayTransportFilters() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    ArrayList<GatewayTransportFilter> transportFilters = new ArrayList<GatewayTransportFilter>();
-    transportFilters.add(new MyGatewayTransportFilter1());
-    transportFilters.add(new MyGatewayTransportFilter2());
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        transportFilters, true, false));
-    try {
-      transportFilters.clear();
-      transportFilters.add(new MyGatewayTransportFilter3());
-      transportFilters.add(new MyGatewayTransportFilter4());
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-          null, transportFilters, true, false));
-      fail("Expected IllegalStateException : GatewayEventFilters Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with GatewayTransportFilters"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void testGatewayTransportFiltersOrder() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    ArrayList<GatewayTransportFilter> transportFilters = new ArrayList<GatewayTransportFilter>();
-    transportFilters.add(new MyGatewayTransportFilter1());
-    transportFilters.add(new MyGatewayTransportFilter2());
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        transportFilters, true, false));
-    try {
-      transportFilters.clear();
-      transportFilters.add(new MyGatewayTransportFilter2());
-      transportFilters.add(new MyGatewayTransportFilter1());
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-          null, transportFilters, true, false));
-      fail("Expected IllegalStateException : GatewayEventFilters Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with GatewayTransportFilters"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-
-  @Test
-  public void testIsDiskSynchronous() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false, null,
-        null, true, false));
-
-    try {
-      vm2.invoke(() -> WANTestBase.createSenderForValidations("ln", 2, false, 100, false, false,
-          null, null, true, true));
-      fail("Expected IllegalStateException : isDiskSynchronous Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with isDiskSynchronous"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  /**
-   * This test has been added for the defect # 44372. A single VM hosts a cache server as well as a
-   * Receiver. Expected: Cache.getCacheServer should return only the cache server and not the
-   * Receiver
-   */
-  @Test
-  public void test_GetCacheServersDoesNotReturnReceivers() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm4);
-    vm4.invoke(() -> WANTestBase.createReceiver());
-
-    vm4.invoke(() -> WANTestBase.createCacheServer());
-
-    Map cacheServers = (Map) vm4.invoke(() -> WANTestBase.getCacheServers());
-
-    assertEquals("Cache.getCacheServers returned incorrect BridgeServers: ", 1,
-        cacheServers.get("BridgeServer"));
-    assertEquals("Cache.getCacheServers returned incorrect ReceiverServers: ", 0,
-        cacheServers.get("ReceiverServer"));
-  }
-
-  /**
-   * Added for the defect # 44372. Two VMs are part of the DS. One VM hosts a cache server while
-   * the other hosts a Receiver. Expected: Cache.getCacheServers should only return the bridge
-   * server and not the Receiver.
-   */
-  @Test
-  public void test_GetCacheServersDoesNotReturnReceivers_Scenario2() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    createCacheInVMs(lnPort, vm4);
-    vm4.invoke(() -> WANTestBase.createReceiver());
-    createCacheInVMs(lnPort, vm5);
-
-    vm5.invoke(() -> WANTestBase.createCacheServer());
-
-    Map cacheServers_vm4 = (Map) vm4.invoke(() -> WANTestBase.getCacheServers());
-    Map cacheServers_vm5 = (Map) vm5.invoke(() -> WANTestBase.getCacheServers());
-
-    assertEquals("Cache.getCacheServers on vm4 returned incorrect BridgeServers: ", 0,
-        cacheServers_vm4.get("BridgeServer"));
-    assertEquals("Cache.getCacheServers on vm4 returned incorrect ReceiverServers: ", 0,
-        cacheServers_vm4.get("ReceiverServer"));
-
-    assertEquals("Cache.getCacheServers on vm5 returned incorrect BridgeServers: ", 1,
-        cacheServers_vm5.get("BridgeServer"));
-    assertEquals("Cache.getCacheServers on vm5 returned incorrect ReceiverServers: ", 0,
-        cacheServers_vm5.get("ReceiverServer"));
-
-  }
-
-
-  // dispatcher threads are same across all the nodes for ParallelGatewaySender
-  /*
-   * We are allowing number of dispatcher threads for parallel sender to differ on number of
-   * machines
-   */
-  @Ignore
-  @Test
-  public void testDispatcherThreadsForParallelGatewaySender() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createConcurrentSender("ln", 2, true, 100, 10, false, false, null,
-        true, 5, OrderPolicy.KEY));
-
-    // dispatcher threads
-    try {
-      vm2.invoke(() -> WANTestBase.createConcurrentSender("ln", 2, true, 100, 10, false, false,
-          null, true, 4, OrderPolicy.KEY));
-      fail("Expected IllegalStateException : dispatcher threads Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with dispatcherThread"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-
-  // dispatcher threads are same across all the nodes for ParallelGatewaySender
-  /*
-   * For Parallel sender, thread policy is not supported which is checked at the time of sender
-   * creation. policy KEY and Partition are same for PGS. Hence disabling the tests
-   */
-  @Ignore
-  @Test
-  public void testOrderPolicyForParallelGatewaySender() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm1, vm2);
-
-    vm1.invoke(() -> WANTestBase.createConcurrentSender("ln", 2, true, 100, 10, false, false, null,
-        true, 5, OrderPolicy.KEY));
-
-    // dispatcher threads
-    try {
-      vm2.invoke(() -> WANTestBase.createConcurrentSender("ln", 2, true, 100, 10, false, false,
-          null, true, 5, OrderPolicy.PARTITION));
-      fail("Expected IllegalStateException : order policy Should match");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof IllegalStateException) || !(e.getCause().getMessage().contains(
-          "because another cache has the same Gateway Sender defined with orderPolicy"))) {
-        Assert.fail("Expected IllegalStateException", e);
-      }
-    }
-  }
-
-  @Test
-  public void test_RR_Serial_warnAboutGatewaySenderIdsConsistency() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-
-    createCacheInVMs(nyPort, vm2);
-    vm2.invoke(createReceiverReplicatedRegion());
-    vm2.invoke(() -> WANTestBase.createReceiver());
-
-    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-
-    vm4.invoke(() -> WANTestBase.startSender("ln"));
-
-    vm4.invoke(createReceiverReplicatedRegion());
-    vm5.invoke(createReceiverReplicatedRegion());
-    vm6.invoke(createReceiverReplicatedRegion());
-    vm7.invoke(createReceiverReplicatedRegion());
-
-    String regionName = getTestMethodName() + "_RR";
-    vm4.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm5.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-
-    verifyNoGatewaySenderIdWarning(regionName);
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 10));
-    verifyGatewaySenderIdWarning(regionName);
-
-    // now add the sender on the other vms so they will be consistent
-    vm6.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm7.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 10));
-    verifyNoGatewaySenderIdWarning(regionName);
   }
 
   private void verifyGatewaySenderIdWarning(String regionName) {
@@ -840,578 +105,1012 @@ public class WanValidationsDUnitTest extends WANTestBase {
     verifyIdConsistencyWarningOnVms(regionName, false, true);
   }
 
-  private void verifyIdConsistencyWarningOnVms(String regionName, boolean expected,
-      boolean gatewaySenderId) {
-    for (VM vm : Arrays.asList(vm4, vm5, vm6, vm7)) {
-      vm.invoke(() -> verifyIdConsistencyWarning(regionName, expected, gatewaySenderId));
-    }
-  }
+  /**
+   * Test to make sure that serial sender Ids configured in Distributed Region is same across all DR
+   * nodes TODO : Should this validation hold tru now. Discuss. If I have 2 members on Which DR is
+   * defined. But sender is defined on only one member. How can I add the instance on the sender in
+   * Region which does not have a sender. I can bypass the existing validation for the DR with
+   * SerialGatewaySender. But for PR with SerialGatewaySender, we need to send the adjunct message.
+   * Find out the way to send the adjunct message to the member on which serialGatewaySender is
+   * available.
+   */
+  @Test
+  public void replicateRegionCreationShouldFailWhenSerialGatewaySenderIdsAreDifferentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
 
-  private void verifyIdConsistencyWarning(String regionName, boolean expected,
-      boolean gatewaySenderId) {
-    Region r = cache.getRegion(Region.SEPARATOR + regionName);
-    SenderIdMonitor senderIdMonitor = getSenderIdMonitor(r);
-    if (gatewaySenderId) {
-      assertThat(senderIdMonitor.getGatewaySenderIdsDifferWarningMessage()).isEqualTo(expected);
-    } else {
-      assertThat(senderIdMonitor.getAsyncQueueIdsDifferWarningMessage()).isEqualTo(expected);
-    }
-  }
+    createCacheInVMs(lnPort, vm4, vm5);
 
-  private SenderIdMonitor getSenderIdMonitor(Region r) {
-    if (r instanceof DistributedRegion) {
-      return ((DistributedRegion) r).getSenderIdMonitor();
-    } else if (r instanceof PartitionedRegion) {
-      return ((PartitionedRegion) r).getSenderIdMonitor();
-    } else {
-      throw new IllegalStateException(
-          "expected region to be distributed or partitioned but it was: " + r.getClass());
-    }
+    vm4.invoke(() -> {
+      createSender("ln1", 2, false, 10, 100, false, false, null, true);
+      createSender("ln2", 2, false, 10, 100, false, false, null, true);
+    });
+
+    vm5.invoke(() -> {
+      createSender("ln2", 2, false, 10, 100, false, false, null, true);
+      createSender("ln3", 2, false, 10, 100, false, false, null, true);
+    });
+
+    vm4.invoke(() -> createReplicatedRegion(getTestMethodName() + "_RR", "ln1,ln2", isOffHeap()));
+
+    vm5.invoke(() -> {
+      assertThatThrownBy(
+          () -> createReplicatedRegion(getTestMethodName() + "_RR", "ln2,ln3", isOffHeap()))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("Cannot create Region");
+    });
   }
 
   @Test
-  public void test_RR_SerialAsyncEventQueue_warnAboutAsyncEventQueueIdsConsistency()
-      throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+  public void replicateRegionCreationShouldFailWhenAsyncEventQueueIdsAreDifferentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm4, vm5);
 
-    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+    vm4.invoke(() -> createReplicatedRegionWithAsyncEventQueue(getTestMethodName() + "_RR", "ln1",
+        isOffHeap()));
+    vm5.invoke(() -> {
+      assertThatThrownBy(() -> createReplicatedRegionWithAsyncEventQueue(
+          getTestMethodName() + "_RR", "ln2", isOffHeap()))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("Cannot create Region");
+    });
+  }
+
+  /**
+   * Test to make sure that serial sender Ids configured in partitioned regions should be same
+   * across all PR members
+   */
+  @Test
+  public void partitionRegionCreationShouldFailWhenSerialGatewaySenderIdsAreDifferentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm4, vm5);
+
+    vm4.invoke(() -> {
+      createSender("ln1", 2, false, 10, 100, false, false, null, true);
+      createSender("ln2", 2, false, 10, 100, false, false, null, true);
+    });
+
+    vm5.invoke(() -> {
+      createSender("ln2", 2, false, 10, 100, false, false, null, true);
+      createSender("ln3", 2, false, 10, 100, false, false, null, true);
+    });
 
     vm4.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm5.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm6.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm7.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
+        () -> createPartitionedRegion(getTestMethodName() + "_PR", "ln1,ln2", 1, 100, isOffHeap()));
 
-    vm4.invoke(createReceiverReplicatedRegion());
-    vm5.invoke(createReceiverReplicatedRegion());
-    vm6.invoke(createReceiverReplicatedRegion());
-    vm7.invoke(createReceiverReplicatedRegion());
+    vm5.invoke(() -> {
+      assertThatThrownBy(() -> createPartitionedRegion(getTestMethodName() + "_PR", "ln2,ln3", 1,
+          100, isOffHeap()))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("Cannot create Region");
+    });
+  }
+
+  /**
+   * Test to make sure that parallel sender Ids configured in partitioned regions should be same
+   * across all PR members
+   */
+  @Test
+  public void partitionRegionCreationShouldFailWhenParallelGatewaySenderIdsAreDifferentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm4, vm5);
+
+    vm4.invoke(() -> {
+      createSender("ln1", 2, true, 10, 100, false, false, null, true);
+      createSender("ln2", 2, true, 10, 100, false, false, null, true);
+    });
+
+    vm5.invoke(() -> {
+      createSender("ln2", 2, true, 10, 100, false, false, null, true);
+      createSender("ln3", 2, true, 10, 100, false, false, null, true);
+    });
+
+    vm4.invoke(
+        () -> createPartitionedRegion(getTestMethodName() + "_PR", "ln1,ln2", 1, 100, isOffHeap()));
+    vm5.invoke(() -> {
+      assertThatThrownBy(() -> createPartitionedRegion(getTestMethodName() + "_PR", "ln2,ln3", 1,
+          100, isOffHeap()))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("Cannot create Region");
+    });
+  }
+
+  /**
+   * Test to make sure that same parallel gateway sender id can not be used by 2 non co-located PRs
+   */
+  @Test
+  public void sameParallelGatewaySenderCanNotBeAttachedToDifferentPartitionRegionsWhenTheyAreNotCoLocated() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1);
+
+    vm1.invoke(() -> {
+      createSender("ln1_Parallel", 2, true, 10, 100, false, false, null, true);
+      createSender("ln2_Parallel", 2, true, 10, 100, false, false, null, true);
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR1", null,
+          "ln1_Parallel,ln2_Parallel", null, isOffHeap());
+      assertThatThrownBy(() -> createPartitionedRegionWithSerialParallelSenderIds(
+          getTestMethodName() + "_PR2", null, "ln1_Parallel,ln2_Parallel", null, isOffHeap()))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("cannot have the same parallel gateway sender id");
+    });
+  }
+
+  @Test
+  public void sameParallelGatewaySenderCanBeAttachedToDifferentPartitionRegionsWhenTheyAreCoLocated() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1);
+
+    vm1.invoke(() -> {
+      createSender("ln1_Parallel", 2, true, 10, 100, false, false, null, true);
+      createSender("ln2_Parallel", 2, true, 10, 100, false, false, null, true);
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR1", null,
+          "ln1_Parallel", null, isOffHeap());
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR2", null,
+          "ln1_Parallel,ln2_Parallel", getTestMethodName() + "_PR1", isOffHeap());
+    });
+  }
+
+  /**
+   * Validate that if Colocated partitioned region doesn't want to add a PGS even if its parent has
+   * one then it is fine
+   */
+  @Test
+  public void coLocatedPartitionRegionDoesNotNeedToHaveParallelGatewaySenderUsedByRootPartitionRegion() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1);
+
+    vm1.invoke(() -> {
+      createSender("ln1_Parallel", 2, true, 10, 100, false, false, null, true);
+      createSender("ln2_Parallel", 2, true, 10, 100, false, false, null, true);
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR1", null,
+          "ln1_Parallel", null, isOffHeap());
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR2", null, null,
+          getTestMethodName() + "_PR1", isOffHeap());
+    });
+  }
+
+  /**
+   * Validate that if Colocated partitioned region has a subset of PGS then it is fine.
+   */
+  @Test
+  public void coLocatedPartitionRegionCanHaveSubSetOfParallelGatewaySendersUsedByRootPartitionRegion() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1);
+
+    vm1.invoke(() -> {
+      createSender("ln1_Parallel", 2, true, 10, 100, false, false, null, true);
+      createSender("ln2_Parallel", 2, true, 10, 100, false, false, null, true);
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR1", null,
+          "ln1_Parallel,ln2_Parallel", null, isOffHeap());
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR2", null,
+          "ln1_Parallel", getTestMethodName() + "_PR1", isOffHeap());
+    });
+  }
+
+  /**
+   * Validate that if Colocated partitioned region has a superset of PGS then Exception is thrown.
+   */
+  @Test
+  public void coLocatedPartitionRegionCanHaveSuperSetOfParallelGatewaySendersUsedByRootPartitionRegion() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1);
+
+    vm1.invoke(() -> {
+      createSender("ln1_Parallel", 2, true, 10, 100, false, false, null, true);
+      createSender("ln2_Parallel", 2, true, 10, 100, false, false, null, true);
+      createSender("ln3_Parallel", 2, true, 10, 100, false, false, null, true);
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR1", null,
+          "ln1_Parallel,ln2_Parallel", null, isOffHeap());
+      createPartitionedRegionWithSerialParallelSenderIds(getTestMethodName() + "_PR2", null,
+          "ln1_Parallel,ln2_Parallel,ln3_Parallel", getTestMethodName() + "_PR1", isOffHeap());
+    });
+  }
+
+  /**
+   * SerialGatewaySender and ParallelGatewaySender with same name is not allowed
+   */
+  @Test
+  public void gatewaySenderIdShouldBeUnique() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1);
+
+    vm1.invoke(() -> {
+      createSenderForValidations("ln", 2, false, 100, false, false, null, null, true, false);
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, true, 100, false, false, null,
+          null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("is already defined in this cache");
+    });
+  }
+
+  // sender with same name should be either serial or parallel but not both.
+  @Test
+  public void canNotCreateParallelGatewaySenderIfAnotherSerialGatewaySenderHasBeenCreatedWithSameId() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null, null, true,
+        false));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, true, 100, false, false, null,
+          null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same sender as serial gateway sender");
+    });
+  }
+
+  // sender with same name should be either serial or parallel but not both.
+  @Test
+  public void canNotCreateSerialGatewaySenderIfAnotherParallelGatewaySenderHasBeenCreatedWithSameId() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, true, 100, false, false, null, null, true,
+        false));
+
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, false, null,
+          null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same sender as parallel gateway sender");
+    });
+  }
+
+  /**
+   * A single VM hosts a cache server as well as a Receiver.
+   * Expected: Cache.getCacheServer should return only the cache server and not the Receiver.
+   */
+  @Test
+  public void getCacheServersShouldNotReturnGatewayReceivers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm4);
+
+    vm4.invoke(() -> {
+      createReceiver();
+      createCacheServer();
+    });
+
+    @SuppressWarnings("rawtypes")
+    Map cacheServers = vm4.invoke(WANTestBase::getCacheServers);
+    assertThat(cacheServers.get("BridgeServer"))
+        .as("Cache.getCacheServers returned incorrect BridgeServers")
+        .isEqualTo(1);
+    assertThat(cacheServers.get("ReceiverServer"))
+        .as("Cache.getCacheServers returned incorrect ReceiverServers")
+        .isEqualTo(0);
+  }
+
+  /**
+   * Two VMs are part of the DS. One VM hosts a cache server while the other hosts a Receiver.
+   * Expected: Cache.getCacheServers should only return the bridge server and not the Receiver.
+   */
+  @Test
+  public void getCacheServersShouldNotReturnGatewayReceivers_Scenario2() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm4);
+    vm4.invoke(WANTestBase::createReceiver);
+
+    createCacheInVMs(lnPort, vm5);
+    vm5.invoke(WANTestBase::createCacheServer);
+
+    @SuppressWarnings("rawtypes")
+    Map cacheServers_vm4 = vm4.invoke(WANTestBase::getCacheServers);
+    assertThat(cacheServers_vm4.get("BridgeServer"))
+        .as("Cache.getCacheServers on vm4 returned incorrect BridgeServers")
+        .isEqualTo(0);
+    assertThat(cacheServers_vm4.get("ReceiverServer"))
+        .as("Cache.getCacheServers on vm4 returned incorrect ReceiverServers")
+        .isEqualTo(0);
+
+    @SuppressWarnings("rawtypes")
+    Map cacheServers_vm5 = vm5.invoke(WANTestBase::getCacheServers);
+    assertThat(cacheServers_vm5.get("BridgeServer"))
+        .as("Cache.getCacheServers on vm4 returned incorrect BridgeServers")
+        .isEqualTo(1);
+    assertThat(cacheServers_vm5.get("ReceiverServer"))
+        .as("Cache.getCacheServers on vm4 returned incorrect ReceiverServers")
+        .isEqualTo(0);
+  }
+
+  // isBatchConflation should be same across the same sender
+  @Test
+  public void batchConflationShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null, null, true,
+        false));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, true, false, null,
+          null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "another cache has the same Gateway Sender defined with isBatchConflationEnabled");
+    });
+  }
+
+  // remote ds ids should be same
+  @Test
+  public void distributedSystemIdShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null, null, true,
+        false));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 3, false, 100, false, false, null,
+          null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with remote ds id");
+    });
+  }
+
+  // isPersistentEnabled should be same across the same sender
+  @Test
+  public void isPersistentShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null, null, true,
+        false));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, true, null,
+          null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with isPersistentEnabled");
+    });
+  }
+
+  @Test
+  public void alertThresholdShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null, null, true,
+        false));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 50, false, false, null,
+          null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with alertThreshold");
+    });
+  }
+
+  @Test
+  public void manualStartShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null, null, true,
+        false));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, false, null,
+          null, false, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with manual start");
+    });
+  }
+
+  @Test
+  public void gatewayEventFiltersShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    List<GatewayEventFilter> eventFilters = new ArrayList<>();
+    eventFilters.add(new MyGatewayEventFilter());
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, eventFilters,
+        null, true, false));
+
+    eventFilters.clear();
+    eventFilters.add(new Filter70());
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, false,
+          eventFilters, null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with GatewayEventFilters");
+
+    });
+  }
+
+  @Test
+  public void gatewayEventFiltersShouldBeConsistentAcrossMembers_Scenario2() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    ArrayList<GatewayEventFilter> eventFilters = new ArrayList<>();
+    eventFilters.add(new MyGatewayEventFilter());
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, eventFilters,
+        null, true, false));
+
+    eventFilters.clear();
+    eventFilters.add(new MyGatewayEventFilter());
+    eventFilters.add(new Filter70());
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, false,
+          eventFilters, null, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with GatewayEventFilters");
+    });
+  }
+
+  @Test
+  public void gatewayTransportFiltersShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    ArrayList<GatewayTransportFilter> transportFilters = new ArrayList<>();
+    transportFilters.add(new MyGatewayTransportFilter1());
+    transportFilters.add(new MyGatewayTransportFilter2());
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null,
+        transportFilters, true, false));
+
+    transportFilters.clear();
+    transportFilters.add(new MyGatewayTransportFilter3());
+    transportFilters.add(new MyGatewayTransportFilter4());
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, false, null,
+          transportFilters, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with GatewayTransportFilters");
+    });
+  }
+
+  @Test
+  public void gatewayTransportFilterOrderShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    ArrayList<GatewayTransportFilter> transportFilters = new ArrayList<>();
+    transportFilters.add(new MyGatewayTransportFilter1());
+    transportFilters.add(new MyGatewayTransportFilter2());
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null,
+        transportFilters, true, false));
+
+    transportFilters.clear();
+    transportFilters.add(new MyGatewayTransportFilter2());
+    transportFilters.add(new MyGatewayTransportFilter1());
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, false, null,
+          transportFilters, true, false))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with GatewayTransportFilters");
+    });
+  }
+
+  @Test
+  public void diskSynchronizationPolicyShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createSenderForValidations("ln", 2, false, 100, false, false, null, null, true,
+        false));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createSenderForValidations("ln", 2, false, 100, false, false, null,
+          null, true, true))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with isDiskSynchronous");
+    });
+  }
+
+  /*
+   * Dispatcher threads are same across all the nodes for ParallelGatewaySender.
+   * Ignored because we are now allowing number of dispatcher threads for parallel sender to differ
+   * on different members.
+   */
+  @Test
+  @Ignore
+  public void dispatcherThreadsForParallelGatewaySenderShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createConcurrentSender("ln", 2, true, 100, 10, false, false, null, true, 5,
+        OrderPolicy.KEY));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createConcurrentSender("ln", 2, true, 100, 10, false, false, null,
+          true, 4, OrderPolicy.KEY))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with dispatcherThread");
+    });
+  }
+
+  /*
+   * For Parallel sender, thread policy is not supported which is checked at the time of sender
+   * creation. policy KEY and Partition are same for PGS. Hence disabling the tests
+   */
+  @Test
+  @Ignore
+  public void orderPolicyForParallelGatewaySenderShouldBeConsistentAcrossMembers() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm1, vm2);
+
+    vm1.invoke(() -> createConcurrentSender("ln", 2, true, 100, 10, false, false, null, true, 5,
+        OrderPolicy.KEY));
+    vm2.invoke(() -> {
+      assertThatThrownBy(() -> createConcurrentSender("ln", 2, true, 100, 10, false, false, null,
+          true, 5, OrderPolicy.PARTITION))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining(
+                  "because another cache has the same Gateway Sender defined with orderPolicy");
+    });
+  }
+
+  @Test
+  public void warningShouldBeLoggedWhenSerialGatewaySenderIsNotConfiguredAcrossAllMembersHostingTheReplicateRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
+
+    createCacheInVMs(nyPort, vm2);
+    vm2.invoke(() -> {
+      createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap());
+      createReceiver();
+    });
+
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+    vm4.invoke(() -> {
+      createSender("ln", 2, false, 100, 10, false, false, null, true);
+      startSender("ln");
+    });
+
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm
+        .invoke(() -> createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap())));
 
     String regionName = getTestMethodName() + "_RR";
-    vm4.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-    vm5.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-
-    verifyNoAsyncEventQueueIdWarning(regionName);
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 1000));
-    verifyAsyncEventQueueIdWarning(regionName);
-
-    vm6.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-    vm7.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 1000));
-    verifyNoAsyncEventQueueIdWarning(regionName);
-  }
-
-  protected SerializableRunnableIF createReceiverReplicatedRegion() {
-    return () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap());
-  }
-
-  @Test
-  public void testBug50434_RR_Serial_Pass() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-
-    createCacheInVMs(nyPort, vm2);
-    vm2.invoke(createReceiverReplicatedRegion());
-    vm2.invoke(() -> WANTestBase.createReceiver());
-
-    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-
-    vm4.invoke(() -> WANTestBase.startSender("ln"));
-
-    vm4.invoke(createReceiverReplicatedRegion());
-    vm5.invoke(createReceiverReplicatedRegion());
-    vm6.invoke(createReceiverReplicatedRegion());
-    vm7.invoke(createReceiverReplicatedRegion());
-
-    vm4.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-
-    vm5.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-
-    vm6.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-
-    vm7.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-
-    vm4.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
-
-    vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_RR", 10));
-
-    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_RR", 10));
-  }
-
-  @Test
-  public void testBug50434_RR_SerialAsyncEventQueue_Pass() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
-    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm5.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm6.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm7.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-
-    vm4.invoke(createReceiverReplicatedRegion());
-    vm5.invoke(createReceiverReplicatedRegion());
-    vm6.invoke(createReceiverReplicatedRegion());
-    vm7.invoke(createReceiverReplicatedRegion());
-
-    vm4.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-    vm5.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-    vm6.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-    vm7.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_RR", "ln"));
-
-    vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
-
-    vm4.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 1000));// primary sender
-    vm5.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 0));// secondary
-    vm6.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 0));// secondary
-    vm7.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 0));// secondary
-  }
-
-  @Test
-  public void test_PR_Serial_warnAboutGatewaySenderIdsConsistency() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-
-    createCacheInVMs(nyPort, vm2);
-    vm2.invoke(() -> WANTestBase.createReceiver());
-    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_RR", null, 1, 100,
-        isOffHeap()));
-
-    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    vm5.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    vm6.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    vm7.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-
-    startSenderInVMs("ln", vm4, vm5, vm6, vm7);
-
-    String regionName = getTestMethodName() + "_PR";
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-
-    vm4.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm5.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-
-    vm4.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
+    vm4.invoke(() -> addSenderThroughAttributesMutator(regionName, "ln"));
+    vm5.invoke(() -> addSenderThroughAttributesMutator(regionName, "ln"));
 
     verifyNoGatewaySenderIdWarning(regionName);
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 10));
+    vm4.invoke(() -> doPuts(regionName, 10));
     verifyGatewaySenderIdWarning(regionName);
 
     // now add the sender on the other vms so they will be consistent
-    vm6.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm7.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 10));
+    asList(vm6, vm7)
+        .forEach(vm -> vm.invoke(() -> addSenderThroughAttributesMutator(regionName, "ln")));
+    vm4.invoke(() -> doPuts(regionName, 10));
     verifyNoGatewaySenderIdWarning(regionName);
   }
 
   @Test
-  public void test_PR_SerialAsyncEventQueue_warnAboutAsyncEventQueueIdsConsistency()
-      throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
+  public void warningShouldBeLoggedWhenSerialAsyncEventQueueIsNotConfiguredAcrossAllMembersHostingTheReplicateRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
 
-    vm4.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm5.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm6.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm7.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createAsyncEventQueue("ln", false, 100, 100, false, false, null, false);
+      createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap());
+    }));
 
-    String regionName = getTestMethodName() + "_PR";
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 100, isOffHeap()));
-
-    vm4.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-    vm5.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
+    String regionName = getTestMethodName() + "_RR";
+    asList(vm4, vm5).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(regionName, "ln");
+    }));
 
     verifyNoAsyncEventQueueIdWarning(regionName);
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 1000));
+    vm4.invoke(() -> doPuts(regionName, 1000));
     verifyAsyncEventQueueIdWarning(regionName);
 
-    vm6.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-    vm7.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 1000));
+    asList(vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(regionName, "ln");
+    }));
+
+    vm4.invoke(() -> doPuts(regionName, 1000));
     verifyNoAsyncEventQueueIdWarning(regionName);
   }
 
   @Test
-  public void testBug50434_PR_Serial_Pass() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+  public void warningShouldBeLoggedWhenSerialGatewaySenderIsNotConfiguredAcrossAllMembersHostingThePartitionRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2);
-    vm2.invoke(() -> WANTestBase.createReceiver());
-    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
+    vm2.invoke(() -> {
+      createReceiver();
+      createPartitionedRegion(getTestMethodName() + "_RR", null, 1, 100, isOffHeap());
+    });
 
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    vm5.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    vm6.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    vm7.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createSender("ln", 2, false, 100, 10, false, false, null, true);
+    }));
     startSenderInVMs("ln", vm4, vm5, vm6, vm7);
 
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
+    String regionName = getTestMethodName() + "_PR";
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createPartitionedRegion(regionName, null, 3, 100, isOffHeap());
+    }));
+    asList(vm4, vm5).forEach(vm -> vm.invoke(() -> {
+      addSenderThroughAttributesMutator(regionName, "ln");
+    }));
+    vm4.invoke(() -> waitForSenderRunningState("ln"));
 
-    vm4.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm5.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm6.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm7.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
+    verifyNoGatewaySenderIdWarning(regionName);
+    vm4.invoke(() -> doPuts(regionName, 10));
+    verifyGatewaySenderIdWarning(regionName);
 
-    vm4.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
-
-    vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 10));
-
-    vm4.invoke(() -> WANTestBase.validateQueueContents("ln", 0));
-
-    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10));
+    // now add the sender on the other vms so they will be consistent
+    asList(vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addSenderThroughAttributesMutator(regionName, "ln");
+    }));
+    vm4.invoke(() -> doPuts(regionName, 10));
+    verifyNoGatewaySenderIdWarning(regionName);
   }
 
   @Test
-  public void testBug50434_PR_SerialAsyncEventQueue_Pass() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-
+  public void warningShouldBeLoggedWhenSerialAsyncEventQueueIsNotConfiguredAcrossAllMembersHostingThePartitionRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
 
-    vm4.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm5.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm6.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
-    vm7.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", false, 100, 100, false, false, null, false));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createAsyncEventQueue("ln", false, 100, 100, false, false, null, false);
+    }));
 
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
-        isOffHeap()));
+    String regionName = getTestMethodName() + "_PR";
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createPartitionedRegion(regionName, null, 3, 100, isOffHeap());
+    }));
+    asList(vm4, vm5).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(regionName, "ln");
+    }));
 
-    vm4.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm5.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm6.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm7.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
+    verifyNoAsyncEventQueueIdWarning(regionName);
+    vm4.invoke(() -> doPuts(regionName, 1000));
+    verifyAsyncEventQueueIdWarning(regionName);
 
-    vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
-
-    vm4.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 1000));// primary sender
-    vm5.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 0));// secondary
-    vm6.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 0));// secondary
-    vm7.invoke(() -> WANTestBase.validateAsyncEventListener("ln", 0));// secondary
+    asList(vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(regionName, "ln");
+    }));
+    vm4.invoke(() -> doPuts(regionName, 1000));
+    verifyNoAsyncEventQueueIdWarning(regionName);
   }
 
   @Test
-  public void test_PR_Parallel_warnAboutGatewaySenderIdsConsistency() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+  public void warningShouldBeLoggedWhenParallelGatewaySenderIsNotConfiguredAcrossAllMembersHostingThePartitionRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2);
-    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm2.invoke(() -> WANTestBase.createReceiver());
+    vm2.invoke(() -> {
+      createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10, isOffHeap());
+      createReceiver();
+    });
 
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
-    vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+    asList(vm4, vm5).forEach(vm -> vm.invoke(() -> {
+      createSender("ln", 2, true, 100, 10, false, false, null, true);
+    }));
     startSenderInVMs("ln", vm4, vm5);
 
     String regionName = getTestMethodName() + "_PR";
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createPartitionedRegion(regionName, null, 3, 10, isOffHeap());
+    }));
+    asList(vm4, vm5).forEach(vm -> vm.invoke(() -> {
+      addSenderThroughAttributesMutator(regionName, "ln");
+    }));
 
-    vm4.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm5.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-
-    vm4.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
-
+    vm4.invoke(() -> waitForSenderRunningState("ln"));
     verifyNoGatewaySenderIdWarning(regionName);
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 10));
+    vm4.invoke(() -> doPuts(regionName, 10));
     verifyGatewaySenderIdWarning(regionName);
 
     // now add the sender on the other vms so they will be consistent
-    vm6.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm7.invoke(() -> WANTestBase.addSenderThroughAttributesMutator(regionName, "ln"));
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 10));
+    asList(vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addSenderThroughAttributesMutator(regionName, "ln");
+    }));
+
+    vm4.invoke(() -> doPuts(regionName, 10));
     verifyNoGatewaySenderIdWarning(regionName);
   }
 
   @Test
-  public void test_PR_ParallelAsyncEventQueue_warnAboutAsyncEventQueueIdsConsistency()
-      throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+  public void warningShouldBeLoggedWhenParallelAsyncEventQueueIsNotConfiguredAcrossAllMembersHostingThePartitionRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
 
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
-    vm5.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
-    vm6.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
-    vm7.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
-
     String regionName = getTestMethodName() + "_PR";
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 3, 10, isOffHeap()));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createAsyncEventQueue("ln", true, 100, 100, false, false, null, false);
+      createPartitionedRegion(regionName, null, 3, 10, isOffHeap());
+    }));
 
-    vm4.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
-    vm5.invoke(() -> WANTestBase.addAsyncEventQueueThroughAttributesMutator(regionName, "ln"));
+    asList(vm4, vm5).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(regionName, "ln");
+    }));
 
     verifyNoAsyncEventQueueIdWarning(regionName);
-    vm4.invoke(() -> WANTestBase.doPuts(regionName, 10));
+    vm4.invoke(() -> doPuts(regionName, 10));
     verifyAsyncEventQueueIdWarning(regionName);
   }
 
   @Test
-  public void whenSendersAreAddedUsingAttributesMutatorThenEventsMustBeSuccessfullyReceviedByRemoteSite()
-      throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+  public void serialGatewaySenderShouldBeSuccessfullyAttachedToReplicateRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2);
-    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm2.invoke(() -> WANTestBase.createReceiver());
+    vm2.invoke(() -> {
+      createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap());
+      createReceiver();
+    });
 
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+    vm4.invoke(() -> {
+      createSender("ln", 2, false, 100, 10, false, false, null, true);
+      startSender("ln");
+    });
 
-    vm4.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
-    vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
-    vm6.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
-    vm7.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap());
+    }));
 
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addSenderThroughAttributesMutator(getTestMethodName() + "_RR", "ln");
+    }));
 
+    vm4.invoke(() -> {
+      waitForSenderRunningState("ln");
+      doPuts(getTestMethodName() + "_RR", 10);
+    });
+
+    vm2.invoke(() -> validateRegionSize(getTestMethodName() + "_RR", 10));
+  }
+
+  @Test
+  public void serialAsyncEventQueueShouldBeSuccessfullyAttachedToReplicateRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createAsyncEventQueue("ln", false, 100, 100, false, false, null, false);
+      createReplicatedRegion(getTestMethodName() + "_RR", null, isOffHeap());
+    }));
+
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_RR", "ln");
+    }));
+
+    vm4.invoke(() -> doPuts(getTestMethodName() + "_RR", 1000));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_RR", "ln");
+    }));
+
+    // primary sender
+    vm4.invoke(() -> validateAsyncEventListener("ln", 1000));
+
+    // secondary senders
+    asList(vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      validateAsyncEventListener("ln", 0);
+    }));
+  }
+
+  @Test
+  public void serialGatewaySenderShouldBeSuccessfullyAttachedToPartitionRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
+
+    createCacheInVMs(nyPort, vm2);
+    vm2.invoke(() -> {
+      createReceiver();
+      createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100, isOffHeap());
+    });
+
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createSender("ln", 2, false, 100, 10, false, false, null, true);
+    }));
     startSenderInVMs("ln", vm4, vm5, vm6, vm7);
 
-    vm4.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm5.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm6.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm7.invoke(
-        () -> WANTestBase.addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100, isOffHeap());
+    }));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln");
+    }));
 
-    vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 10));
+    vm4.invoke(() -> {
+      waitForSenderRunningState("ln");
+      doPuts(getTestMethodName() + "_PR", 10);
+      validateQueueContents("ln", 0);
+    });
 
-    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10));
+    vm2.invoke(() -> validateRegionSize(getTestMethodName() + "_PR", 10));
   }
 
   @Test
-  public void testBug50434_PR_ParallelAsyncEventQueue_Pass() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+  public void serialAsyncEventQueueShouldBeSuccessfullyAttachedToPartitionRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
 
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createAsyncEventQueue("ln", false, 100, 100, false, false, null, false);
+      createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100, isOffHeap());
+    }));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln");
+    }));
 
-    vm4.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
-    vm5.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
-    vm6.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
-    vm7.invoke(
-        () -> WANTestBase.createAsyncEventQueue("ln", true, 100, 100, false, false, null, false));
+    vm4.invoke(() -> doPuts(getTestMethodName() + "_PR", 1000));
 
-    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10,
-        isOffHeap()));
+    // primary sender
+    vm4.invoke(() -> validateAsyncEventListener("ln", 1000));
 
-    vm4.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm5.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm6.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-    vm7.invoke(() -> WANTestBase
-        .addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
-
-    vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 256));
-
-    vm4.invoke(() -> WANTestBase.waitForAsyncQueueToGetEmpty("ln"));
-    vm5.invoke(() -> WANTestBase.waitForAsyncQueueToGetEmpty("ln"));
-    vm6.invoke(() -> WANTestBase.waitForAsyncQueueToGetEmpty("ln"));
-    vm7.invoke(() -> WANTestBase.waitForAsyncQueueToGetEmpty("ln"));
-
-    int vm4size = (Integer) vm4.invoke(() -> WANTestBase.getAsyncEventListenerMapSize("ln"));
-    int vm5size = (Integer) vm5.invoke(() -> WANTestBase.getAsyncEventListenerMapSize("ln"));
-    int vm6size = (Integer) vm6.invoke(() -> WANTestBase.getAsyncEventListenerMapSize("ln"));
-    int vm7size = (Integer) vm7.invoke(() -> WANTestBase.getAsyncEventListenerMapSize("ln"));
-
-    assertEquals(vm4size + vm5size + vm6size + vm7size, 256);
+    // secondary senders
+    asList(vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      validateAsyncEventListener("ln", 0);
+    }));
   }
 
   @Test
-  public void testBug51367_WrongBindAddressOnGatewayReceiver() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+  public void parallelAsyncEventQueueShouldBeSuccessfullyAttachedToPartitionRegionTroughAttributesMutator() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
 
-    vm2.invoke(() -> WANTestBase.createReceiverWithBindAddress(lnPort));
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createAsyncEventQueue("ln", true, 100, 100, false, false, null, false);
+      createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10, isOffHeap());
+    }));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addAsyncEventQueueThroughAttributesMutator(getTestMethodName() + "_PR", "ln");
+    }));
+
+    vm4.invoke(() -> doPuts(getTestMethodName() + "_PR", 256));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      waitForAsyncQueueToGetEmpty("ln");
+    }));
+
+    int vm4size = vm4.invoke(() -> getAsyncEventListenerMapSize("ln"));
+    int vm5size = vm5.invoke(() -> getAsyncEventListenerMapSize("ln"));
+    int vm6size = vm6.invoke(() -> getAsyncEventListenerMapSize("ln"));
+    int vm7size = vm7.invoke(() -> getAsyncEventListenerMapSize("ln"));
+
+    assertThat(vm4size + vm5size + vm6size + vm7size).isEqualTo(256);
+  }
+
+  @Test
+  public void whenSendersAreAddedUsingAttributesMutatorThenEventsMustBeSuccessfullyReceivedByRemoteSite() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
+
+    createCacheInVMs(nyPort, vm2);
+    vm2.invoke(() -> {
+      createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10, isOffHeap());
+      createReceiver();
+    });
+
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createSender("ln", 2, true, 100, 10, false, false, null, true);
+      createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 10, isOffHeap());
+    }));
+    startSenderInVMs("ln", vm4, vm5, vm6, vm7);
+
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln");
+    }));
+
+    vm4.invoke(() -> doPuts(getTestMethodName() + "_PR", 10));
+    vm2.invoke(() -> validateRegionSize(getTestMethodName() + "_PR", 10));
+  }
+
+  @Test
+  public void gatewayReceiverCreationFailsAndDoesNotHangWhenConfiguredBindAddressIsNotUsable() {
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+
+    vm2.invoke(() -> {
+      Properties props = getDistributedSystemProperties();
+      props.setProperty(MCAST_PORT, "0");
+      props.setProperty(LOCATORS, "localhost[" + lnPort + "]");
+      cache = new CacheFactory(props).create();
+
+      GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
+      int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+      fact.setStartPort(port);
+      fact.setEndPort(port);
+      fact.setManualStart(true);
+      fact.setBindAddress("200.112.204.10");
+      GatewayReceiver receiver = fact.create();
+      assertThatThrownBy(receiver::start)
+          .isInstanceOf(GatewayReceiverException.class)
+          .hasMessageContaining("No available free port found in the given range");
+    });
   }
 
   @Test
   public void testBug50247_NonPersistentSenderWithPersistentRegion() {
     IgnoredException.addIgnoredException("could not get remote locator information");
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
     createCacheInVMs(lnPort, vm4, vm5);
 
-    vm4.invoke(() -> WANTestBase.createSender("ln1", 2, true, 10, 100, false, false, null, false));
-    assertThatThrownBy(() -> vm4.invoke(() -> WANTestBase
-        .createPartitionedRegionWithPersistence(getTestMethodName() + "_PR", "ln1", 1, 100)))
+    vm4.invoke(() -> createSender("ln1", 2, true, 10, 100, false, false, null, false));
+    assertThatThrownBy(() -> vm4.invoke(
+        () -> createPartitionedRegionWithPersistence(getTestMethodName() + "_PR", "ln1", 1, 100)))
             .withFailMessage(
                 "Expected GatewaySenderException with incompatible gateway sender ids and region")
             .hasRootCauseInstanceOf(GatewaySenderException.class)
             .hasStackTraceContaining("can not be attached to persistent region ");
 
-    vm5.invoke(() -> WANTestBase.createPartitionedRegionWithPersistence(getTestMethodName() + "_PR",
-        "ln1", 1, 100));
-    assertThatThrownBy(() -> vm5
-        .invoke(() -> WANTestBase.createSender("ln1", 2, true, 10, 100, false, false, null, false)))
+    vm5.invoke(
+        () -> createPartitionedRegionWithPersistence(getTestMethodName() + "_PR", "ln1", 1, 100));
+    assertThatThrownBy(
+        () -> vm5.invoke(() -> createSender("ln1", 2, true, 10, 100, false, false, null, false)))
             .withFailMessage(
                 "Expected GatewaySenderException with incompatible gateway sender ids and region")
             .hasRootCauseInstanceOf(GatewaySenderException.class)
             .hasStackTraceContaining("can not be attached to persistent region ");
   }
 
-
   /**
-   * Test configuration::
-   *
-   * Region: Replicated WAN: Serial Number of WAN sites: 2 Region persistence enabled: false Async
-   * channel persistence enabled: false
+   * Test configuration:
+   * Region: Replicated
+   * WAN: Serial
+   * Number of WAN sites: 2
+   * Region persistence enabled: false
+   * Async channel persistence enabled: false
    */
   @Test
   public void testReplicatedSerialAsyncEventQueueWith2WANSites() {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> createFirstRemoteLocator(2, lnPort));
 
     // ------------ START - CREATE CACHE, REGION ON LOCAL SITE ------------//
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    vm4.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-    vm5.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
-
-    vm4.invoke(() -> WANTestBase.createAsyncEventQueue("lnAsync", false, 100, 100, false, false,
-        null, false));
-    vm5.invoke(() -> WANTestBase.createAsyncEventQueue("lnAsync", false, 100, 100, false, false,
-        null, false));
-    vm6.invoke(() -> WANTestBase.createAsyncEventQueue("lnAsync", false, 100, 100, false, false,
-        null, false));
-    vm7.invoke(() -> WANTestBase.createAsyncEventQueue("lnAsync", false, 100, 100, false, false,
-        null, false));
-
+    asList(vm4, vm5).forEach(vm -> vm.invoke(() -> {
+      createSender("ln", 2, false, 100, 10, false, false, null, true);
+    }));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createAsyncEventQueue("lnAsync", false, 100, 100, false, false, null, false);
+    }));
     startSenderInVMs("ln", vm4, vm5);
-
-    vm4.invoke(() -> WANTestBase.createReplicatedRegionWithSenderAndAsyncEventQueue(
-        getTestMethodName() + "_RR", "ln", "lnAsync", isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createReplicatedRegionWithSenderAndAsyncEventQueue(
-        getTestMethodName() + "_RR", "ln", "lnAsync", isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createReplicatedRegionWithSenderAndAsyncEventQueue(
-        getTestMethodName() + "_RR", "ln", "lnAsync", isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createReplicatedRegionWithSenderAndAsyncEventQueue(
-        getTestMethodName() + "_RR", "ln", "lnAsync", isOffHeap()));
+    asList(vm4, vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      createReplicatedRegionWithSenderAndAsyncEventQueue(getTestMethodName() + "_RR", "ln",
+          "lnAsync", isOffHeap());
+    }));
     // ------------- END - CREATE CACHE, REGION ON LOCAL SITE -------------//
 
     // ------------- START - CREATE CACHE ON REMOTE SITE ---------------//
     createCacheInVMs(nyPort, vm2, vm3);
     createReceiverInVMs(vm2, vm3);
 
-    vm2.invoke(() -> WANTestBase.createSender("ny", 1, false, 100, 10, false, false, null, true));
-    vm3.invoke(() -> WANTestBase.createSender("ny", 1, false, 100, 10, false, false, null, true));
-
-    vm2.invoke(() -> WANTestBase.createAsyncEventQueue("nyAsync", false, 100, 100, false, false,
-        null, false));
-    vm3.invoke(() -> WANTestBase.createAsyncEventQueue("nyAsync", false, 100, 100, false, false,
-        null, false));
-
+    asList(vm2, vm3).forEach(vm -> vm.invoke(() -> {
+      createSender("ny", 1, false, 100, 10, false, false, null, true);
+      createAsyncEventQueue("nyAsync", false, 100, 100, false, false, null, false);
+    }));
     startSenderInVMs("ny", vm2, vm3);
-
-    vm2.invoke(() -> WANTestBase.createReplicatedRegionWithSenderAndAsyncEventQueue(
-        getTestMethodName() + "_RR", "ny", "nyAsync", isOffHeap()));
-    vm3.invoke(() -> WANTestBase.createReplicatedRegionWithSenderAndAsyncEventQueue(
-        getTestMethodName() + "_RR", "ny", "nyAsync", isOffHeap()));
-
+    asList(vm2, vm3).forEach(vm -> vm.invoke(() -> {
+      createReplicatedRegionWithSenderAndAsyncEventQueue(getTestMethodName() + "_RR", "ny",
+          "nyAsync", isOffHeap());
+    }));
     // ------------- END - CREATE CACHE, REGION ON REMOTE SITE -------------//
 
-    vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
+    vm4.invoke(() -> doPuts(getTestMethodName() + "_RR", 1000));
 
     // validate AsyncEventListener on local site
-    vm4.invoke(() -> WANTestBase.validateAsyncEventListener("lnAsync", 1000));// primary sender
-    vm5.invoke(() -> WANTestBase.validateAsyncEventListener("lnAsync", 0));// secondary
-    vm6.invoke(() -> WANTestBase.validateAsyncEventListener("lnAsync", 0));// secondary
-    vm7.invoke(() -> WANTestBase.validateAsyncEventListener("lnAsync", 0));// secondary
+    // primary sender
+    vm4.invoke(() -> validateAsyncEventListener("lnAsync", 1000));
+
+    // secondary senders
+    asList(vm5, vm6, vm7).forEach(vm -> vm.invoke(() -> {
+      validateAsyncEventListener("lnAsync", 0);
+    }));
 
     // validate region size on remote site
-    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_RR", 1000));
-    vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_RR", 1000));
+    asList(vm2, vm3).forEach(vm -> vm.invoke(() -> {
+      validateRegionSize(getTestMethodName() + "_RR", 1000);
+    }));
 
     // validate AsyncEventListener on remote site
-    vm2.invoke(() -> WANTestBase.validateAsyncEventListener("nyAsync", 1000));// primary sender
-    vm3.invoke(() -> WANTestBase.validateAsyncEventListener("nyAsync", 0));// secondary
-
+    vm2.invoke(() -> validateAsyncEventListener("nyAsync", 1000));// primary sender
+    vm3.invoke(() -> validateAsyncEventListener("nyAsync", 0)); // secondary sender
   }
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -94,9 +94,9 @@ public class CreateRegionCommandDUnitTest {
         + " --gateway-sender-id=" + gatewaySenderName)
         .statusIsError()
         .containsOutput("server-1",
-            "Parallel gateway sender " + gatewaySenderName
+            "Parallel Gateway Sender " + gatewaySenderName
                 + " can not be used with replicated region /" + regionName)
-        .containsOutput("server-2", "Parallel gateway sender " + gatewaySenderName
+        .containsOutput("server-2", "Parallel Gateway Sender " + gatewaySenderName
             + " can not be used with replicated region /" + regionName);
 
     // The exception must be thrown early in the initialization, so the region itself shouldn't be

--- a/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -161,7 +161,7 @@ public class WANConfigurationJUnitTest {
 
     assertThatThrownBy(() -> regionFactory.create("test_GatewaySender_Parallel_DistributedRegion"))
         .isInstanceOf(GatewaySenderConfigurationException.class).hasMessage(
-            "Parallel gateway sender NYSender can not be used with replicated region /test_GatewaySender_Parallel_DistributedRegion");
+            "Parallel Gateway Sender NYSender can not be used with replicated region /test_GatewaySender_Parallel_DistributedRegion");
   }
 
   @Test


### PR DESCRIPTION
Attaching a parallel gateway-sender or async-event-queue to a
Replicate Region through the AttributesMutator class now throws an
exception instead of wrongly assigning the dispatcher to the region.

- Fixed several warnings.
- Added unit and distributed tests.
- Replaced usages of 'junit.Assert' by 'assertj'.
- Changed test methods to use more meaningful names.
- Removed references to old ids used by another ticketing system.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
