### PR TITLE
GEODE-8111: Fix create gw receiver --manual-start doc

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -417,8 +417,8 @@ if this option is specified and cluster configuration is enabled.
 </tr>
 <tr>
 <td><span class="keyword parmname">\-\-manual-start</span></td>
-<td>Boolean value that specifies whether you need to manually start the gateway receiver. If you specify this option without a value, the default is &quot;true&quot; the gateway receiver must be started manually.</td>
-<td>true</td>
+<td>Boolean value that specifies whether you need to manually start the gateway receiver. When specified without providing a boolean value or when specified and set to &quot;true&quot;, the gateway receiver must be started manually.</td>
+<td>false</td>
 </tr>
 <tr>
 <td><span class="keyword parmname">\-\-start-port</span></td>
@@ -459,7 +459,7 @@ if this option is specified and cluster configuration is enabled.
 </tr>
 <tr>
 <td><span class="keyword parmname">\-\-if-not-exists</span></td>
-<td>When specified without providing a boolean value or when specified and set to true, gateway receivers will not be created if they already exist. Command output reports the status of each creation attempt.
+<td>When specified without providing a boolean value or when specified and set to &quot;true&quot;, gateway receivers will not be created if they already exist. Command output reports the status of each creation attempt.
 </td>
 <td>false</td>
 </tr>


### PR DESCRIPTION
Documentation of `--manual-start` option of `create gateway-receiver` gfsh command wrongly states that the default option is `true`.
But taking a look at the code it can be verified that the default option is false.
