### PR TITLE
GEODE-8114: Refactor set

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/EmptyRedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/EmptyRedisHash.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.executor;
 
+import static java.util.Collections.emptyList;
 
 import java.util.Collection;
 import java.util.List;
@@ -22,40 +23,22 @@ import java.util.List;
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.executor.hash.RedisHash;
-import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
 
-public class RedisHashInRegion implements RedisHashCommands {
-  private final Region<ByteArrayWrapper, RedisHash> localRegion;
-
-  public RedisHashInRegion(Region localRegion) {
-    this.localRegion = localRegion;
+public class EmptyRedisHash extends RedisHash {
+  @Override
+  public synchronized int doHset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+      List<ByteArrayWrapper> fieldsToSet, boolean nx) {
+    throw new UnsupportedOperationException();
   }
 
   @Override
-  public int hset(ByteArrayWrapper key, List<ByteArrayWrapper> fieldsToSet, boolean NX) {
-    RedisHash hash = localRegion.get(key);
-    if (hash != null) {
-      return hash.doHset(localRegion, key, fieldsToSet, NX);
-    } else {
-      localRegion.put(key, new RedisHash(fieldsToSet));
-      return fieldsToSet.size() / 2;
-    }
+  public synchronized int doHdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+      List<ByteArrayWrapper> fieldsToRemove) {
+    return 0;
   }
 
   @Override
-  public int hdel(ByteArrayWrapper key, List<ByteArrayWrapper> fieldsToRemove) {
-    RedisHash hash = localRegion.getOrDefault(key, RedisHash.EMPTY);
-    return hash.doHdel(localRegion, key, fieldsToRemove);
-  }
-
-  @Override
-  public Collection<ByteArrayWrapper> hgetall(ByteArrayWrapper key) {
-    RedisHash hash = localRegion.getOrDefault(key, RedisHash.EMPTY);
-    return hash.doHgetall();
-  }
-
-  @Override
-  public boolean del(ByteArrayWrapper key) {
-    return localRegion.remove(key) != null;
+  public synchronized Collection<ByteArrayWrapper> doHgetall() {
+    return emptyList();
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/EmptyRedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/EmptyRedisHash.java
@@ -26,19 +26,19 @@ import org.apache.geode.redis.internal.executor.hash.RedisHash;
 
 public class EmptyRedisHash extends RedisHash {
   @Override
-  public synchronized int doHset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToSet, boolean nx) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public synchronized int doHdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToRemove) {
     return 0;
   }
 
   @Override
-  public synchronized Collection<ByteArrayWrapper> doHgetall() {
+  public synchronized Collection<ByteArrayWrapper> hgetall() {
     return emptyList();
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor;
+
+import static java.util.Collections.emptyList;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.executor.hash.RedisHash;
+import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
+
+class RedisHashInRegion implements RedisHashCommands {
+  private Region<ByteArrayWrapper, RedisHash> localRegion;
+
+  public RedisHashInRegion(Region localRegion) {
+    this.localRegion = localRegion;
+  }
+
+  @Override
+  public int hset(ByteArrayWrapper key, List<ByteArrayWrapper> fieldsToSet, boolean NX) {
+    RedisHash hash = localRegion.get(key);
+    if (hash != null) {
+      return hash.doHset(localRegion, key, fieldsToSet, NX);
+    } else {
+      localRegion.put(key, new RedisHash(fieldsToSet));
+      return fieldsToSet.size() / 2;
+    }
+  }
+
+  @Override
+  public int hdel(ByteArrayWrapper key, List<ByteArrayWrapper> fieldsToRemove) {
+    RedisHash hash = localRegion.get(key);
+    if (hash != null) {
+      return hash.doHdel(localRegion, key, fieldsToRemove);
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public Collection<ByteArrayWrapper> hgetall(ByteArrayWrapper key) {
+    RedisHash hash = localRegion.get(key);
+    if (hash != null) {
+      return hash.doHgetall();
+    } else {
+      return emptyList();
+    }
+  }
+
+  @Override
+  public boolean del(ByteArrayWrapper key) {
+    return localRegion.remove(key) != null;
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
@@ -44,18 +44,20 @@ public class RedisHashInRegion implements RedisHashCommands {
 
   @Override
   public int hdel(ByteArrayWrapper key, List<ByteArrayWrapper> fieldsToRemove) {
-    RedisHash hash = localRegion.getOrDefault(key, RedisHash.EMPTY);
-    return hash.hdel(localRegion, key, fieldsToRemove);
+    return getRedisHash(key).hdel(localRegion, key, fieldsToRemove);
   }
 
   @Override
   public Collection<ByteArrayWrapper> hgetall(ByteArrayWrapper key) {
-    RedisHash hash = localRegion.getOrDefault(key, RedisHash.EMPTY);
-    return hash.hgetall();
+    return getRedisHash(key).hgetall();
   }
 
   @Override
   public boolean del(ByteArrayWrapper key) {
     return localRegion.remove(key) != null;
+  }
+
+  private RedisHash getRedisHash(ByteArrayWrapper key) {
+    return localRegion.getOrDefault(key, RedisHash.EMPTY);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
@@ -35,7 +35,7 @@ public class RedisHashInRegion implements RedisHashCommands {
   public int hset(ByteArrayWrapper key, List<ByteArrayWrapper> fieldsToSet, boolean NX) {
     RedisHash hash = localRegion.get(key);
     if (hash != null) {
-      return hash.doHset(localRegion, key, fieldsToSet, NX);
+      return hash.hset(localRegion, key, fieldsToSet, NX);
     } else {
       localRegion.put(key, new RedisHash(fieldsToSet));
       return fieldsToSet.size() / 2;
@@ -45,13 +45,13 @@ public class RedisHashInRegion implements RedisHashCommands {
   @Override
   public int hdel(ByteArrayWrapper key, List<ByteArrayWrapper> fieldsToRemove) {
     RedisHash hash = localRegion.getOrDefault(key, RedisHash.EMPTY);
-    return hash.doHdel(localRegion, key, fieldsToRemove);
+    return hash.hdel(localRegion, key, fieldsToRemove);
   }
 
   @Override
   public Collection<ByteArrayWrapper> hgetall(ByteArrayWrapper key) {
     RedisHash hash = localRegion.getOrDefault(key, RedisHash.EMPTY);
-    return hash.doHgetall();
+    return hash.hgetall();
   }
 
   @Override

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisHashInRegion.java
@@ -27,7 +27,7 @@ import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
 public class RedisHashInRegion implements RedisHashCommands {
   private final Region<ByteArrayWrapper, RedisHash> localRegion;
 
-  public RedisHashInRegion(Region localRegion) {
+  public RedisHashInRegion(Region<ByteArrayWrapper, RedisHash> localRegion) {
     this.localRegion = localRegion;
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
@@ -101,7 +101,7 @@ public class RedisHash implements Delta, DataSerializable {
     }
   }
 
-  public synchronized int doHset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToSet, boolean nx) {
     int fieldsAdded = 0;
     Iterator<ByteArrayWrapper> iterator = fieldsToSet.iterator();
@@ -127,7 +127,7 @@ public class RedisHash implements Delta, DataSerializable {
     return fieldsAdded;
   }
 
-  public synchronized int doHdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int hdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToRemove) {
     int fieldsRemoved = 0;
     for (ByteArrayWrapper fieldToRemove : fieldsToRemove) {
@@ -143,7 +143,7 @@ public class RedisHash implements Delta, DataSerializable {
     return fieldsRemoved;
   }
 
-  public synchronized Collection<ByteArrayWrapper> doHgetall() {
+  public synchronized Collection<ByteArrayWrapper> hgetall() {
     ArrayList<ByteArrayWrapper> result = new ArrayList<>();
     for (Map.Entry<ByteArrayWrapper, ByteArrayWrapper> entry : hash.entrySet()) {
       result.add(entry.getKey());

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
@@ -32,8 +32,10 @@ import org.apache.geode.Delta;
 import org.apache.geode.InvalidDeltaException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.executor.EmptyRedisHash;
 
 public class RedisHash implements Delta, DataSerializable {
+  public static final RedisHash EMPTY = new EmptyRedisHash();
   private HashMap<ByteArrayWrapper, ByteArrayWrapper> hash;
   /**
    * When deltas are adds it will always contain an even number of field/value pairs.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHash.java
@@ -16,8 +16,6 @@
 
 package org.apache.geode.redis.internal.executor.hash;
 
-import static java.util.Collections.emptyList;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -45,41 +43,6 @@ public class RedisHash implements Delta, DataSerializable {
   // true if deltas contains adds; false if removes
   private transient boolean deltasAreAdds;
 
-
-  public static boolean del(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key) {
-    return region.remove(key) != null;
-  }
-
-  public static int hset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
-      List<ByteArrayWrapper> fieldsToSet, boolean nx) {
-    RedisHash hash = region.get(key);
-    if (hash != null) {
-      return hash.doHset(region, key, fieldsToSet, nx);
-    } else {
-      region.put(key, new RedisHash(fieldsToSet));
-      return fieldsToSet.size() / 2;
-    }
-  }
-
-  public static int hdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
-      List<ByteArrayWrapper> fieldsToRemove) {
-    RedisHash hash = region.get(key);
-    if (hash != null) {
-      return hash.doHdel(region, key, fieldsToRemove);
-    } else {
-      return 0;
-    }
-  }
-
-  public static Collection<ByteArrayWrapper> hgetall(
-      Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key) {
-    RedisHash hash = region.get(key);
-    if (hash != null) {
-      return hash.doHgetall();
-    } else {
-      return emptyList();
-    }
-  }
 
   public RedisHash(List<ByteArrayWrapper> fieldsToSet) {
     hash = new HashMap<>();
@@ -136,7 +99,7 @@ public class RedisHash implements Delta, DataSerializable {
     }
   }
 
-  private synchronized int doHset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int doHset(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToSet, boolean nx) {
     int fieldsAdded = 0;
     Iterator<ByteArrayWrapper> iterator = fieldsToSet.iterator();
@@ -162,7 +125,7 @@ public class RedisHash implements Delta, DataSerializable {
     return fieldsAdded;
   }
 
-  private synchronized int doHdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
+  public synchronized int doHdel(Region<ByteArrayWrapper, RedisHash> region, ByteArrayWrapper key,
       List<ByteArrayWrapper> fieldsToRemove) {
     int fieldsRemoved = 0;
     for (ByteArrayWrapper fieldToRemove : fieldsToRemove) {
@@ -178,7 +141,7 @@ public class RedisHash implements Delta, DataSerializable {
     return fieldsRemoved;
   }
 
-  private synchronized Collection<ByteArrayWrapper> doHgetall() {
+  public synchronized Collection<ByteArrayWrapper> doHgetall() {
     ArrayList<ByteArrayWrapper> result = new ArrayList<>();
     for (Map.Entry<ByteArrayWrapper, ByteArrayWrapper> entry : hash.entrySet()) {
       result.add(entry.getKey());

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/EmptyRedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/EmptyRedisSet.java
@@ -31,12 +31,12 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
 class EmptyRedisSet extends RedisSet {
 
   @Override
-  synchronized List<Object> doSscan(Pattern matchPattern, int count, int cursor) {
+  synchronized List<Object> sscan(Pattern matchPattern, int count, int cursor) {
     return emptyList();
   }
 
   @Override
-  synchronized Collection<ByteArrayWrapper> doSpop(Region<ByteArrayWrapper, RedisSet> region,
+  synchronized Collection<ByteArrayWrapper> spop(Region<ByteArrayWrapper, RedisSet> region,
       ByteArrayWrapper key, int popCount) {
     return emptyList();
   }
@@ -47,30 +47,30 @@ class EmptyRedisSet extends RedisSet {
   }
 
   @Override
-  public synchronized boolean contains(ByteArrayWrapper member) {
+  public synchronized boolean sismember(ByteArrayWrapper member) {
     return false;
   }
 
   @Override
-  public synchronized int size() {
+  public synchronized int scard() {
     return 0;
   }
 
   @Override
-  synchronized long doSadd(ArrayList<ByteArrayWrapper> membersToAdd,
+  synchronized long sadd(ArrayList<ByteArrayWrapper> membersToAdd,
       Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  synchronized long doSrem(ArrayList<ByteArrayWrapper> membersToRemove,
+  synchronized long srem(ArrayList<ByteArrayWrapper> membersToRemove,
       Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key,
       AtomicBoolean setWasDeleted) {
     return 0;
   }
 
   @Override
-  synchronized Set<ByteArrayWrapper> members() {
+  synchronized Set<ByteArrayWrapper> smembers() {
     return emptySet();
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/EmptyRedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/EmptyRedisSet.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.set;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+
+class EmptyRedisSet extends RedisSet {
+
+  @Override
+  synchronized List<Object> doSscan(Pattern matchPattern, int count, int cursor) {
+    return emptyList();
+  }
+
+  @Override
+  synchronized Collection<ByteArrayWrapper> doSpop(Region<ByteArrayWrapper, RedisSet> region,
+      ByteArrayWrapper key, int popCount) {
+    return emptyList();
+  }
+
+  @Override
+  synchronized Collection<ByteArrayWrapper> srandmember(int count) {
+    return emptyList();
+  }
+
+  @Override
+  public synchronized boolean contains(ByteArrayWrapper member) {
+    return false;
+  }
+
+  @Override
+  public synchronized int size() {
+    return 0;
+  }
+
+  @Override
+  synchronized long doSadd(ArrayList<ByteArrayWrapper> membersToAdd,
+      Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  synchronized long doSrem(ArrayList<ByteArrayWrapper> membersToRemove,
+      Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key,
+      AtomicBoolean setWasDeleted) {
+    return 0;
+  }
+
+  @Override
+  synchronized Set<ByteArrayWrapper> members() {
+    return emptySet();
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -46,6 +46,7 @@ import org.apache.geode.redis.internal.Coder;
  */
 public class RedisSet implements Delta, DataSerializable {
 
+  public static transient RedisSet EMPTY = new EmptyRedisSet();
   private HashSet<ByteArrayWrapper> members;
   private transient ArrayList<ByteArrayWrapper> deltas;
   // true if deltas contains adds; false if removes

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.set;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -64,101 +63,7 @@ public class RedisSet implements Delta, DataSerializable {
   // for serialization
   public RedisSet() {}
 
-  public static long sadd(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key,
-      ArrayList<ByteArrayWrapper> membersToAdd) {
-
-    RedisSet redisSet = region.get(key);
-
-    if (redisSet != null) {
-      // update existing value
-      return redisSet.doSadd(membersToAdd, region, key);
-    } else {
-      region.create(key, new RedisSet(membersToAdd));
-      return membersToAdd.size();
-    }
-  }
-
-  public static long srem(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key,
-      ArrayList<ByteArrayWrapper> membersToRemove,
-      AtomicBoolean setWasDeleted) {
-    RedisSet redisSet = region.get(key);
-    long numRemoved;
-    if (redisSet == null) {
-      numRemoved = 0;
-    } else {
-      numRemoved = redisSet.doSrem(membersToRemove, region, key, setWasDeleted);
-    }
-    return numRemoved;
-  }
-
-  public static boolean del(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key) {
-    return region.remove(key) != null;
-  }
-
-  public static Set<ByteArrayWrapper> smembers(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.members();
-    } else {
-      return emptySet();
-    }
-  }
-
-  public static int scard(Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.size();
-    } else {
-      return 0;
-    }
-  }
-
-  public static boolean sismember(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key, ByteArrayWrapper member) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.contains(member);
-    } else {
-      return false;
-    }
-  }
-
-  public static Collection<ByteArrayWrapper> srandmember(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key, int count) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.srandmember(count);
-    } else {
-      return emptyList();
-    }
-  }
-
-  public static Collection<ByteArrayWrapper> spop(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key, int popCount) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.doSpop(region, key, popCount);
-    } else {
-      return emptyList();
-    }
-  }
-
-  public static List<Object> sscan(Region<ByteArrayWrapper, RedisSet> region,
-      ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
-    RedisSet RedisSet = region.get(key);
-    if (RedisSet != null) {
-      return RedisSet.doSscan(matchPattern, count, cursor);
-    } else {
-      return emptyList();
-    }
-  }
-
-
-  private synchronized List<Object> doSscan(Pattern matchPattern, int count, int cursor) {
+  synchronized List<Object> doSscan(Pattern matchPattern, int count, int cursor) {
     List<Object> returnList = new ArrayList<>();
     int size = members.size();
     int beforeCursor = 0;
@@ -193,7 +98,7 @@ public class RedisSet implements Delta, DataSerializable {
     return returnList;
   }
 
-  private synchronized Collection<ByteArrayWrapper> doSpop(
+  synchronized Collection<ByteArrayWrapper> doSpop(
       Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key, int popCount) {
     int originalSize = size();
     if (originalSize == 0) {
@@ -230,7 +135,7 @@ public class RedisSet implements Delta, DataSerializable {
     return popped;
   }
 
-  private synchronized Collection<ByteArrayWrapper> srandmember(int count) {
+  synchronized Collection<ByteArrayWrapper> srandmember(int count) {
     int membersSize = members.size();
 
     if (membersSize <= count && count != 1) {
@@ -314,7 +219,7 @@ public class RedisSet implements Delta, DataSerializable {
    * @param key the name of the set to add to
    * @return the number of members actually added; -1 if concurrent modification
    */
-  private synchronized long doSadd(ArrayList<ByteArrayWrapper> membersToAdd,
+  synchronized long doSadd(ArrayList<ByteArrayWrapper> membersToAdd,
       Region<ByteArrayWrapper, RedisSet> region,
       ByteArrayWrapper key) {
 
@@ -340,7 +245,7 @@ public class RedisSet implements Delta, DataSerializable {
    * @param setWasDeleted set to true if this method deletes the set
    * @return the number of members actually removed; -1 if concurrent modification
    */
-  private synchronized long doSrem(ArrayList<ByteArrayWrapper> membersToRemove,
+  synchronized long doSrem(ArrayList<ByteArrayWrapper> membersToRemove,
       Region<ByteArrayWrapper, RedisSet> region,
       ByteArrayWrapper key, AtomicBoolean setWasDeleted) {
 
@@ -371,7 +276,7 @@ public class RedisSet implements Delta, DataSerializable {
    *
    * @return a set containing all the members in this set
    */
-  private synchronized Set<ByteArrayWrapper> members() {
+  synchronized Set<ByteArrayWrapper> members() {
     return new HashSet<>(members);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSet.java
@@ -64,7 +64,7 @@ public class RedisSet implements Delta, DataSerializable {
   // for serialization
   public RedisSet() {}
 
-  synchronized List<Object> doSscan(Pattern matchPattern, int count, int cursor) {
+  synchronized List<Object> sscan(Pattern matchPattern, int count, int cursor) {
     List<Object> returnList = new ArrayList<>();
     int size = members.size();
     int beforeCursor = 0;
@@ -99,9 +99,9 @@ public class RedisSet implements Delta, DataSerializable {
     return returnList;
   }
 
-  synchronized Collection<ByteArrayWrapper> doSpop(
+  synchronized Collection<ByteArrayWrapper> spop(
       Region<ByteArrayWrapper, RedisSet> region, ByteArrayWrapper key, int popCount) {
-    int originalSize = size();
+    int originalSize = scard();
     if (originalSize == 0) {
       return emptyList();
     }
@@ -164,11 +164,11 @@ public class RedisSet implements Delta, DataSerializable {
     return result;
   }
 
-  public synchronized boolean contains(ByteArrayWrapper member) {
+  public synchronized boolean sismember(ByteArrayWrapper member) {
     return members.contains(member);
   }
 
-  public synchronized int size() {
+  public synchronized int scard() {
     return members.size();
   }
 
@@ -220,7 +220,7 @@ public class RedisSet implements Delta, DataSerializable {
    * @param key the name of the set to add to
    * @return the number of members actually added; -1 if concurrent modification
    */
-  synchronized long doSadd(ArrayList<ByteArrayWrapper> membersToAdd,
+  synchronized long sadd(ArrayList<ByteArrayWrapper> membersToAdd,
       Region<ByteArrayWrapper, RedisSet> region,
       ByteArrayWrapper key) {
 
@@ -246,7 +246,7 @@ public class RedisSet implements Delta, DataSerializable {
    * @param setWasDeleted set to true if this method deletes the set
    * @return the number of members actually removed; -1 if concurrent modification
    */
-  synchronized long doSrem(ArrayList<ByteArrayWrapper> membersToRemove,
+  synchronized long srem(ArrayList<ByteArrayWrapper> membersToRemove,
       Region<ByteArrayWrapper, RedisSet> region,
       ByteArrayWrapper key, AtomicBoolean setWasDeleted) {
 
@@ -277,7 +277,7 @@ public class RedisSet implements Delta, DataSerializable {
    *
    * @return a set containing all the members in this set
    */
-  synchronized Set<ByteArrayWrapper> members() {
+  synchronized Set<ByteArrayWrapper> smembers() {
     return new HashSet<>(members);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
@@ -57,53 +57,50 @@ public class RedisSetInRegion implements RedisSetCommands {
   public long srem(
       ByteArrayWrapper key,
       ArrayList<ByteArrayWrapper> membersToRemove, AtomicBoolean setWasDeleted) {
-    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.srem(membersToRemove, region, key, setWasDeleted);
-  }
-
-  public boolean del(ByteArrayWrapper key) {
-    return region.remove(key) != null;
+    return getRedisSet(key).srem(membersToRemove, region, key, setWasDeleted);
   }
 
   @Override
   public Set<ByteArrayWrapper> smembers(
       ByteArrayWrapper key) {
-    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.smembers();
+    return getRedisSet(key).smembers();
   }
 
   @Override
   public int scard(ByteArrayWrapper key) {
-    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.scard();
+    return getRedisSet(key).scard();
   }
 
   @Override
   public boolean sismember(
       ByteArrayWrapper key, ByteArrayWrapper member) {
-    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.sismember(member);
+    return getRedisSet(key).sismember(member);
   }
 
   @Override
   public Collection<ByteArrayWrapper> srandmember(
       ByteArrayWrapper key, int count) {
-    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.srandmember(count);
+    return getRedisSet(key).srandmember(count);
   }
 
   @Override
   public Collection<ByteArrayWrapper> spop(
       ByteArrayWrapper key, int popCount) {
-    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.spop(region, key, popCount);
+    return getRedisSet(key).spop(region, key, popCount);
   }
 
   @Override
   public List<Object> sscan(
       ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
-    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.sscan(matchPattern, count, cursor);
+    return getRedisSet(key).sscan(matchPattern, count, cursor);
   }
 
+  @Override
+  public boolean del(ByteArrayWrapper key) {
+    return region.remove(key) != null;
+  }
+
+  private RedisSet getRedisSet(ByteArrayWrapper key) {
+    return region.getOrDefault(key, RedisSet.EMPTY);
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
@@ -15,9 +15,6 @@
 
 package org.apache.geode.redis.internal.executor.set;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -34,7 +31,7 @@ import org.apache.geode.redis.internal.ByteArrayWrapper;
  * removed once readers are changed to also use the {@link SynchronizedStripedExecutor}.
  */
 public class RedisSetInRegion implements RedisSetCommands {
-  private Region<ByteArrayWrapper, RedisSet> region;
+  private final Region<ByteArrayWrapper, RedisSet> region;
 
   @SuppressWarnings("unchecked")
   public RedisSetInRegion(Region<ByteArrayWrapper, RedisSet> region) {
@@ -60,10 +57,7 @@ public class RedisSetInRegion implements RedisSetCommands {
   public long srem(
       ByteArrayWrapper key,
       ArrayList<ByteArrayWrapper> membersToRemove, AtomicBoolean setWasDeleted) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet == null) {
-      return 0L;
-    }
+    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
     return redisSet.doSrem(membersToRemove, region, key, setWasDeleted);
   }
 
@@ -74,70 +68,42 @@ public class RedisSetInRegion implements RedisSetCommands {
   @Override
   public Set<ByteArrayWrapper> smembers(
       ByteArrayWrapper key) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.members();
-    } else {
-      return emptySet();
-    }
+    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
+    return redisSet.members();
   }
 
   @Override
   public int scard(ByteArrayWrapper key) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.size();
-    } else {
-      return 0;
-    }
+    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
+    return redisSet.size();
   }
 
   @Override
   public boolean sismember(
       ByteArrayWrapper key, ByteArrayWrapper member) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.contains(member);
-    } else {
-      return false;
-    }
+    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
+    return redisSet.contains(member);
   }
 
   @Override
   public Collection<ByteArrayWrapper> srandmember(
       ByteArrayWrapper key, int count) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.srandmember(count);
-    } else {
-      return emptyList();
-    }
+    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
+    return redisSet.srandmember(count);
   }
 
   @Override
   public Collection<ByteArrayWrapper> spop(
       ByteArrayWrapper key, int popCount) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.doSpop(region, key, popCount);
-    } else {
-      return emptyList();
-    }
+    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
+    return redisSet.doSpop(region, key, popCount);
   }
 
   @Override
   public List<Object> sscan(
       ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
-    RedisSet redisSet = region.get(key);
-    if (redisSet != null) {
-      return redisSet.doSscan(matchPattern, count, cursor);
-    } else {
-      return emptyList();
-    }
+    RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
+    return redisSet.doSscan(matchPattern, count, cursor);
   }
 
-  // private RedisSet get(ByteArrayWrapper key) {
-  // RedisSet redisSet = region.get(key);
-  // return redisSet == null? new RedisSet(new ArrayList<>()) : redisSet;
-  // }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
@@ -46,7 +46,7 @@ public class RedisSetInRegion implements RedisSetCommands {
     RedisSet redisSet = region.get(key);
 
     if (redisSet != null) {
-      return redisSet.doSadd(membersToAdd, region, key);
+      return redisSet.sadd(membersToAdd, region, key);
     } else {
       region.create(key, new RedisSet(membersToAdd));
       return membersToAdd.size();
@@ -58,7 +58,7 @@ public class RedisSetInRegion implements RedisSetCommands {
       ByteArrayWrapper key,
       ArrayList<ByteArrayWrapper> membersToRemove, AtomicBoolean setWasDeleted) {
     RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.doSrem(membersToRemove, region, key, setWasDeleted);
+    return redisSet.srem(membersToRemove, region, key, setWasDeleted);
   }
 
   public boolean del(ByteArrayWrapper key) {
@@ -69,20 +69,20 @@ public class RedisSetInRegion implements RedisSetCommands {
   public Set<ByteArrayWrapper> smembers(
       ByteArrayWrapper key) {
     RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.members();
+    return redisSet.smembers();
   }
 
   @Override
   public int scard(ByteArrayWrapper key) {
     RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.size();
+    return redisSet.scard();
   }
 
   @Override
   public boolean sismember(
       ByteArrayWrapper key, ByteArrayWrapper member) {
     RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.contains(member);
+    return redisSet.sismember(member);
   }
 
   @Override
@@ -96,14 +96,14 @@ public class RedisSetInRegion implements RedisSetCommands {
   public Collection<ByteArrayWrapper> spop(
       ByteArrayWrapper key, int popCount) {
     RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.doSpop(region, key, popCount);
+    return redisSet.spop(region, key, popCount);
   }
 
   @Override
   public List<Object> sscan(
       ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
     RedisSet redisSet = region.getOrDefault(key, RedisSet.EMPTY);
-    return redisSet.doSscan(matchPattern, count, cursor);
+    return redisSet.sscan(matchPattern, count, cursor);
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetInRegion.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.set;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.ByteArrayWrapper;
+
+/**
+ * This class still uses "synchronized" to protect the underlying HashSet even though all writers do
+ * so under the {@link SynchronizedStripedExecutor}. The synchronization on this class can be
+ * removed once readers are changed to also use the {@link SynchronizedStripedExecutor}.
+ */
+public class RedisSetInRegion implements RedisSetCommands {
+  private Region<ByteArrayWrapper, RedisSet> region;
+
+  @SuppressWarnings("unchecked")
+  public RedisSetInRegion(Region<ByteArrayWrapper, RedisSet> region) {
+    this.region = region;
+  }
+
+  @Override
+  public long sadd(
+      ByteArrayWrapper key,
+      ArrayList<ByteArrayWrapper> membersToAdd) {
+
+    RedisSet redisSet = region.get(key);
+
+    if (redisSet != null) {
+      return redisSet.doSadd(membersToAdd, region, key);
+    } else {
+      region.create(key, new RedisSet(membersToAdd));
+      return membersToAdd.size();
+    }
+  }
+
+  @Override
+  public long srem(
+      ByteArrayWrapper key,
+      ArrayList<ByteArrayWrapper> membersToRemove, AtomicBoolean setWasDeleted) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet == null) {
+      return 0L;
+    }
+    return redisSet.doSrem(membersToRemove, region, key, setWasDeleted);
+  }
+
+  public boolean del(ByteArrayWrapper key) {
+    return region.remove(key) != null;
+  }
+
+  @Override
+  public Set<ByteArrayWrapper> smembers(
+      ByteArrayWrapper key) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.members();
+    } else {
+      return emptySet();
+    }
+  }
+
+  @Override
+  public int scard(ByteArrayWrapper key) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.size();
+    } else {
+      return 0;
+    }
+  }
+
+  @Override
+  public boolean sismember(
+      ByteArrayWrapper key, ByteArrayWrapper member) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.contains(member);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public Collection<ByteArrayWrapper> srandmember(
+      ByteArrayWrapper key, int count) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.srandmember(count);
+    } else {
+      return emptyList();
+    }
+  }
+
+  @Override
+  public Collection<ByteArrayWrapper> spop(
+      ByteArrayWrapper key, int popCount) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.doSpop(region, key, popCount);
+    } else {
+      return emptyList();
+    }
+  }
+
+  @Override
+  public List<Object> sscan(
+      ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
+    RedisSet redisSet = region.get(key);
+    if (redisSet != null) {
+      return redisSet.doSscan(matchPattern, count, cursor);
+    } else {
+      return emptyList();
+    }
+  }
+
+  // private RedisSet get(ByteArrayWrapper key) {
+  // RedisSet redisSet = region.get(key);
+  // return redisSet == null? new RedisSet(new ArrayList<>()) : redisSet;
+  // }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.set;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.TimeoutException;
@@ -56,8 +55,9 @@ public class SMoveExecutor extends SetExecutor {
       }
 
       boolean removed =
-          RedisSet.srem(region, source, new ArrayList<>(Collections.singletonList(member)),
-              new AtomicBoolean()) == 1;
+          new RedisSetInRegion(region).srem(source,
+              new ArrayList<>(Collections.singletonList(member)),
+              null) == 1;
       // TODO: native redis SMOVE that empties the src set causes it to no longer exist
 
       if (!removed) {
@@ -65,7 +65,8 @@ public class SMoveExecutor extends SetExecutor {
       } else {
         try (AutoCloseableLock destinationLock = withRegionLock(context, destination)) {
           // TODO: this should invoke a function in case the primary for destination is remote
-          RedisSet.sadd(region, destination, new ArrayList<>(Collections.singletonList(member)));
+          new RedisSetInRegion(region).sadd(destination,
+              new ArrayList<>(Collections.singletonList(member)));
           context.getKeyRegistrar().register(destination, RedisDataType.REDIS_SET);
           context.getKeyRegistrar().register(source, RedisDataType.REDIS_SET);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SetOpExecutor.java
@@ -66,13 +66,13 @@ public abstract class SetOpExecutor extends SetExecutor {
       RegionProvider regionProvider, ByteArrayWrapper destination,
       ByteArrayWrapper firstSetKey) {
     Region<ByteArrayWrapper, RedisSet> region = this.getRegion(context);
-    Set<ByteArrayWrapper> firstSet = RedisSet.smembers(region, firstSetKey);
+    Set<ByteArrayWrapper> firstSet = new RedisSetInRegion(region).smembers(firstSetKey);
 
     List<Set<ByteArrayWrapper>> setList = new ArrayList<>();
     for (int i = setsStartIndex; i < commandElems.size(); i++) {
       ByteArrayWrapper key = new ByteArrayWrapper(commandElems.get(i));
 
-      Set<ByteArrayWrapper> entry = RedisSet.smembers(region, key);
+      Set<ByteArrayWrapper> entry = new RedisSetInRegion(region).smembers(key);
       if (entry != null) {
         setList.add(entry);
       } else if (this instanceof SInterExecutor) {


### PR DESCRIPTION
I broke up the `RedisSet` and `RedisHash` classes by moving the static methods into separate non-static classes.  I also made canonical empty classes, so we don't have to do as much null-checking.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
