### PR TITLE
GEODE-8120: Make GeodeRedisServer internal

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -939,10 +939,6 @@ javadoc/org/apache/geode/ra/GFConnectionFactory.html
 javadoc/org/apache/geode/ra/package-frame.html
 javadoc/org/apache/geode/ra/package-summary.html
 javadoc/org/apache/geode/ra/package-tree.html
-javadoc/org/apache/geode/redis/GeodeRedisServer.html
-javadoc/org/apache/geode/redis/package-frame.html
-javadoc/org/apache/geode/redis/package-summary.html
-javadoc/org/apache/geode/redis/package-tree.html
 javadoc/org/apache/geode/security/AccessControl.html
 javadoc/org/apache/geode/security/AuthInitialize.html
 javadoc/org/apache/geode/security/AuthTokenEnabledComponents.html

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/RedisUsePersistentRegionDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/RedisUsePersistentRegionDUnitTest.java
@@ -24,6 +24,7 @@ import redis.clients.jedis.Jedis;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 public class RedisUsePersistentRegionDUnitTest {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/AuthIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/AuthIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/ConcurrentStartIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/ConcurrentStartIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/GeoIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/GeoIntegrationTest.java
@@ -41,6 +41,7 @@ import redis.clients.jedis.params.GeoRadiusParam;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/HashesIntegrationTest.java
@@ -63,6 +63,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/ListsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/ListsIntegrationTest.java
@@ -34,6 +34,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/PubSubIntegrationTest.java
@@ -35,6 +35,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.mocks.MockBinarySubscriber;
 import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisLockServiceIntegrationTest.java
@@ -31,6 +31,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public class RedisLockServiceIntegrationTest {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisServerIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RedisServerIntegrationTest.java
@@ -30,6 +30,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.AvailablePort;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RenameIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RenameIntegrationTest.java
@@ -42,6 +42,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.junit.categories.RedisTest;
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/SortedSetsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/SortedSetsIntegrationTest.java
@@ -44,6 +44,7 @@ import redis.clients.jedis.Tuple;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
@@ -18,7 +18,7 @@ import static java.lang.Integer.parseInt;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.redis.GeodeRedisServer.REDIS_META_DATA_REGION;
+import static org.apache.geode.redis.internal.GeodeRedisServer.REDIS_META_DATA_REGION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -49,6 +49,7 @@ import redis.clients.jedis.params.SetParams;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.junit.categories.RedisTest;

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExistsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExistsIntegrationTest.java
@@ -32,7 +32,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.redis.ConcurrentLoopingThreads;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public class ExistsIntegrationTest {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireAtIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireAtIntegrationTest.java
@@ -30,7 +30,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public class ExpireAtIntegrationTest {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/ExpireIntegrationTest.java
@@ -30,7 +30,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public class ExpireIntegrationTest {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PersistIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PersistIntegrationTest.java
@@ -32,7 +32,7 @@ import redis.clients.jedis.params.SetParams;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public class PersistIntegrationTest {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PexpireIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/general/PexpireIntegrationTest.java
@@ -28,7 +28,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 
 public class PexpireIntegrationTest {
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SDiffIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SDiffIntegrationTest.java
@@ -36,7 +36,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SInterIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SInterIntegrationTest.java
@@ -36,7 +36,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SMoveIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SMoveIntegrationTest.java
@@ -40,7 +40,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SPopIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SPopIntegrationTest.java
@@ -35,7 +35,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SRemIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SRemIntegrationTest.java
@@ -46,8 +46,8 @@ import redis.clients.jedis.exceptions.JedisDataException;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SUnionIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SUnionIntegrationTest.java
@@ -36,7 +36,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.test.junit.categories.RedisTest;
 
 @Category({RedisTest.class})

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SetsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/sets/SetsIntegrationTest.java
@@ -41,7 +41,7 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.GemFireCache;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
-import org.apache.geode.redis.GeodeRedisServer;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.junit.categories.RedisTest;
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ExecutionHandlerContext.java
@@ -38,7 +38,6 @@ import org.apache.geode.cache.UnsupportedOperationInTransactionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
 import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.logging.internal.log4j.api.LogService;
-import org.apache.geode.redis.GeodeRedisServer;
 import org.apache.geode.redis.internal.ParameterRequirements.RedisParametersMismatchException;
 
 /**

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.redis;
+package org.apache.geode.redis.internal;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.redis.internal.RedisLockServiceMBean.OBJECTNAME__REDISLOCKSERVICE_MBEAN;
@@ -83,17 +83,6 @@ import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.SystemManagementService;
-import org.apache.geode.redis.internal.ByteArrayWrapper;
-import org.apache.geode.redis.internal.ByteToCommandDecoder;
-import org.apache.geode.redis.internal.Coder;
-import org.apache.geode.redis.internal.ExecutionHandlerContext;
-import org.apache.geode.redis.internal.KeyRegistrar;
-import org.apache.geode.redis.internal.PubSub;
-import org.apache.geode.redis.internal.PubSubImpl;
-import org.apache.geode.redis.internal.RedisDataType;
-import org.apache.geode.redis.internal.RedisLockService;
-import org.apache.geode.redis.internal.RegionProvider;
-import org.apache.geode.redis.internal.Subscriptions;
 import org.apache.geode.redis.internal.executor.CommandFunction;
 import org.apache.geode.redis.internal.executor.hash.RedisHash;
 import org.apache.geode.redis.internal.executor.set.RedisSet;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -25,7 +25,6 @@ import org.apache.geode.internal.cache.CacheService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
-import org.apache.geode.redis.GeodeRedisServer;
 
 public class GeodeRedisService implements CacheService, ResourceEventsListener {
   private static final Logger logger = LogService.getLogger();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisDataType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisDataType.java
@@ -15,7 +15,6 @@
 package org.apache.geode.redis.internal;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.redis.GeodeRedisServer;
 
 /**
  * The RedisDataType enum contains the choices to which every {@link Region} on the server must be.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -44,7 +44,6 @@ import org.apache.geode.internal.hll.HyperLogLogPlus;
 import org.apache.geode.management.cli.Result.Status;
 import org.apache.geode.management.internal.cli.commands.CreateRegionCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
-import org.apache.geode.redis.GeodeRedisServer;
 import org.apache.geode.redis.internal.executor.ExpirationExecutor;
 import org.apache.geode.redis.internal.executor.ListQuery;
 import org.apache.geode.redis.internal.executor.SortedSetQuery;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
@@ -20,13 +20,13 @@ import io.netty.buffer.ByteBuf;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.Query;
-import org.apache.geode.redis.GeodeRedisServer;
 import org.apache.geode.redis.internal.ByteArrayWrapper;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.CoderException;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.Executor;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.RedisDataType;
 import org.apache.geode.redis.internal.RegionProvider;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/KeysExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/KeysExecutor.java
@@ -20,10 +20,10 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.geode.redis.GeodeRedisServer;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.org.apache.hadoop.fs.GlobPattern;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/ScanExecutor.java
@@ -20,10 +20,10 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.geode.redis.GeodeRedisServer;
 import org.apache.geode.redis.internal.Coder;
 import org.apache.geode.redis.internal.Command;
 import org.apache.geode.redis.internal.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/ExecutionHandlerContextJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/ExecutionHandlerContextJUnitTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.apache.geode.cache.Cache;
-import org.apache.geode.redis.GeodeRedisServer;
 
 /**
  * Test cases for ExecutionHandlerContext


### PR DESCRIPTION
GeodeRedisServer does not need to be externally accessible.
