### PR TITLE
GEODE-7792: configure logging for geode-membership integration tests

### DIFF
--- a/geode-membership/build.gradle
+++ b/geode-membership/build.gradle
@@ -38,9 +38,7 @@ dependencies {
     //Jgroups is a core component of our membership system.
     implementation('org.jgroups:jgroups')
 
-    testImplementation(project(':geode-junit')) {
-        exclude module: 'geode-logging'
-    }
+    testImplementation(project(':geode-junit'))
     testImplementation(project(':geode-concurrency-test'))
 
     testImplementation('org.mockito:mockito-core')
@@ -49,16 +47,11 @@ dependencies {
 
     testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
-    integrationTestImplementation(project(':geode-junit')) {
-        exclude module: 'geode-logging'
-    }
+    integrationTestImplementation(project(':geode-junit'))
     integrationTestImplementation('pl.pragmatists:JUnitParams')
-    distributedTestImplementation(project(':geode-junit')) {
-        exclude module: 'geode-logging'
-    }
-    distributedTestImplementation(project(':geode-dunit')) {
-        exclude module: 'geode-logging'
-    }
+    distributedTestImplementation(project(':geode-junit'))
+    distributedTestImplementation(project(':geode-dunit'))
+    integrationTestRuntime('org.apache.logging.log4j:log4j-core')
     distributedTestImplementation('pl.pragmatists:JUnitParams')
     distributedTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
     upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))

--- a/geode-membership/src/integrationTest/resources/log4j2.xml
+++ b/geode-membership/src/integrationTest/resources/log4j2.xml
@@ -15,7 +15,7 @@
   -->
 <Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.distributed.internal.membership">
   <Properties>
-    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
+    <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>
   </Properties>
   <Appenders>


### PR DESCRIPTION
hexTid is not available to the geode-membership module.  I'm replacing
it with tid, which is supported by the logger implementation used by
membership tests.  This will let us see thread ID numbers in the logs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
