### PR TITLE
GEODE-8133: Fix task chaining for 'devBuild'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ tasks.register('test') {
 }
 
 tasks.register('devBuild') {
+  group 'Build'
   description "A convenience target for a typical developer workflow: apply spotless and assemble all classes."
   dependsOn tasks.named('assemble')
   // Each subproject injects its SpotlessApply as a dependency to this task in the standard config

--- a/gradle/standard-subproject-configuration.gradle
+++ b/gradle/standard-subproject-configuration.gradle
@@ -27,7 +27,7 @@ apply plugin: 'com.github.ben-manes.versions'
 // Within the configure block, 'project' refers to the task-owning project, in this case rootProject
 def thisProjectScoped = project
 
-['clean', 'check', 'test'].each { taskName ->
+['clean', 'assemble', 'check', 'test'].each { taskName ->
   rootProject.tasks.named(taskName).configure {
     dependsOn thisProjectScoped.tasks.named(taskName)
   }


### PR DESCRIPTION
This was broken due to a change in Gradle default task names in the root project. 