### PR TITLE
GEODE-8140: scope field in gfsh create RR regions.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1050,6 +1050,17 @@ public class CliStrings {
   public static final String CREATE_REGION__MSG__OBJECT_SIZER_MUST_BE_OBJECTSIZER_AND_DECLARABLE =
       "eviction-object-sizer must implement both ObjectSizer and Declarable interfaces";
 
+  public static final String CREATE_REGION__SCOPE = "scope";
+
+  public static final String CREATE_REGION__SCOPE__HELP =
+      "Sets the scope of the region. Scope cannot be set for Partitioned regions";
+
+  public static final String CREATE_REGION__MSG__SCOPE_CANNOT_BE_SET_ON_PARTITION_REGION =
+      "Scope cannot be set on Partitioned region";
+
+  public static final String CREATE_REGION__SCOPE__SCOPE_CANNOT_BE_SET_IF_TYPE_NOT_SET =
+      "Scope cannot be used if --type is not set in the command";
+
   /* debug command */
   public static final String DEBUG = "debug";
   public static final String DEBUG__HELP = "Enable/Disable debugging output in GFSH.";

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
@@ -84,7 +84,7 @@ public class DescribeRegionCommand extends GfshCommand {
       if (regionDescription.isPartition()) {
         regionDescription.getCndRegionAttributes().remove(RegionAttributesNames.SCOPE);
       } else {
-        String scope = regionDescription.getCndRegionAttributes().get(RegionAttributesNames.SCOPE);
+        String scope = regionDescription.getScope().toString();
         if (scope != null) {
           scope = scope.toLowerCase().replace('_', '-');
           regionDescription.getCndRegionAttributes().put(RegionAttributesNames.SCOPE, scope);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -468,7 +468,7 @@ public class RegionProvider implements Closeable {
               false,
               true, null, null, null, null, null, null, null, null, null, null, null, null, null,
               false,
-              null, null, null, null, null, null, null, null, null, null, null);
+              null, null, null, null, null, null, null, null, null, null, null, null);
 
       r = cache.getRegion(regionPath);
       if (resultModel.getStatus() == Status.ERROR && r == null) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -16,12 +16,16 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.test.dunit.IgnoredException;
@@ -32,6 +36,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
 
 @Category({WanTest.class})
+@RunWith(JUnitParamsRunner.class)
 public class CreateRegionCommandDUnitTest {
   private static MemberVM locator, server1, server2;
 
@@ -51,6 +56,63 @@ public class CreateRegionCommandDUnitTest {
     server2 = lsRule.startServerVM(2, locator.getPort());
 
     gfsh.connectAndVerify(locator);
+  }
+
+  public Object[] replicatedRegionAndScopePairs() {
+    String[] replicatedRegions = {"REPLICATE", "REPLICATE_PERSISTENT", "REPLICATE_PROXY",
+        "REPLICATE_OVERFLOW", "REPLICATE_PERSISTENT_OVERFLOW", "REPLICATE_HEAP_LRU"};
+    String[] scopes = {"DISTRIBUTED_NO_ACK", "DISTRIBUTED_ACK", "LOCAL", "GLOBAL"};
+    Object[] pairs = new Object[replicatedRegions.length * scopes.length];
+    int count = 0;
+    for (String replicatedRegion : replicatedRegions) {
+      for (String scope : scopes) {
+        pairs[count] = new Object[] {replicatedRegion, scope};
+        count++;
+      }
+    }
+    return pairs;
+  }
+
+  public Object[] nonReplicatedRegionAndScopePairs() {
+    String[] scopes = {"DISTRIBUTED_NO_ACK", "DISTRIBUTED_ACK", "LOCAL", "GLOBAL"};
+    String[] nonReplicatedRegions =
+        {"PARTITION", "PARTITION_PERSISTENT", "PARTITION_PROXY", "PARTITION_REDUNDANT",
+            "PARTITION_REDUNDANT_PERSISTENT", "PARTITION_OVERFLOW", "PARTITION_REDUNDANT_OVERFLOW",
+            "PARTITION_PERSISTENT_OVERFLOW", "PARTITION_REDUNDANT_PERSISTENT_OVERFLOW",
+            "PARTITION_HEAP_LRU", "PARTITION_REDUNDANT_HEAP_LRU", "LOCAL", "LOCAL_PERSISTENT",
+            "LOCAL_HEAP_LRU", "LOCAL_OVERFLOW", "LOCAL_PERSISTENT_OVERFLOW"};
+    int count = 0;
+    Object[] pairs = new Object[scopes.length * nonReplicatedRegions.length];
+    for (String nonReplicatedRegion : nonReplicatedRegions) {
+      for (String scope : scopes) {
+        pairs[count] = new Object[] {nonReplicatedRegion, scope};
+        count++;
+      }
+    }
+    return pairs;
+  }
+
+  @Test
+  @TestCaseName("[{index}] {method}(RegionType:{0},Scope:{1})")
+  @Parameters(method = "replicatedRegionAndScopePairs")
+  public void createReplicateRegionCommandWithScopeSetsTheScope(String regionType, String scope) {
+    String regionName = testName.getMethodName();
+    gfsh.executeAndAssertThat(
+        "create region --type=" + regionType + " --scope=" + scope + " --name=" + regionName)
+        .statusIsSuccess();
+    String describeOutputScope = scope.replace("_", "-").toLowerCase();
+    gfsh.executeAndAssertThat("describe region --name=" + regionName).statusIsSuccess()
+        .containsOutput(describeOutputScope);
+  }
+
+  @Test
+  @TestCaseName("[{index}] {method}(RegionType:{0},Scope:{1})")
+  @Parameters(method = "nonReplicatedRegionAndScopePairs")
+  public void createNonReplicatedRegionCommandWithScopeShouldFail(String regionType, String scope) {
+    String regionName = testName.getMethodName();
+    gfsh.executeAndAssertThat(
+        "create region --type=" + regionType + " --scope=" + scope + " --name=" + regionName)
+        .statusIsError();
   }
 
   @Test


### PR DESCRIPTION
	* create region now includes a new field called scope to set the scope
	* This field is only valid for Replicated Regions.
	* describe region for replicated regions will now display the scope too.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
