### PR TITLE
GEODE-8131: reader thread blocked attempting to issue an alert

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -3027,17 +3027,13 @@ public class Connection implements Runnable {
         failureMsg = "ClassNotFound deserializing message";
         failureEx = ex;
         rpId = md.getRPid();
-        // log at info level first in case fatal-level alert notification becomes blocked
-        logger.info(failureMsg, failureEx);
-        logger.fatal(failureMsg, failureEx.toString());
+        logAtInfoAndFatal(failureMsg, failureEx);
       } catch (IOException ex) {
         owner.getConduit().getStats().decMessagesBeingReceived(md.size());
         failureMsg = "IOException deserializing message";
         failureEx = ex;
         rpId = md.getRPid();
-        // log at info level first in case fatal-level alert notification becomes blocked
-        logger.info(failureMsg, failureEx);
-        logger.fatal(failureMsg, failureEx);
+        logAtInfoAndFatal(failureMsg, failureEx);
       } catch (InterruptedException ex) {
         interrupted = true;
         owner.getConduit().getCancelCriterion().checkCancelInProgress(ex);
@@ -3058,9 +3054,7 @@ public class Connection implements Runnable {
         failureMsg = "Unexpected failure deserializing message";
         failureEx = ex;
         rpId = md.getRPid();
-        // log at info level first in case fatal-level alert notification becomes blocked
-        logger.info(failureMsg, failureEx);
-        logger.fatal(failureMsg, failureEx);
+        logAtInfoAndFatal(failureMsg, failureEx);
       } finally {
         msgLength = md.size();
         releaseMsgDestreamer(messageId, md);
@@ -3099,6 +3093,20 @@ public class Connection implements Runnable {
         sendFailureReply(rpId, failureMsg, failureEx, directAck);
       }
     }
+  }
+
+  /**
+   * For exceptions that we absolutely must see in the log files, use this method
+   * to log the problem first at "info" level and then at "fatal" level. We do this
+   * in case the "fatal" level log entry generates an alert that gets blocked in
+   * transmitting the data to an alert listener like the JMX Manager
+   */
+  private void logAtInfoAndFatal(String failureMsg, Throwable failureEx) {
+    // log at info level first in case fatal-level alert notification becomes blocked
+    logger.info(failureMsg, failureEx);
+    // log at fatal-level with toString() on the exception since this will generate an
+    // alert
+    logger.fatal(failureMsg, failureEx.toString());
   }
 
   void readHandshakeForSender(DataInputStream dis, ByteBuffer peerDataBuffer) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -3027,13 +3027,17 @@ public class Connection implements Runnable {
         failureMsg = "ClassNotFound deserializing message";
         failureEx = ex;
         rpId = md.getRPid();
-        logger.fatal("ClassNotFound deserializing message: {}", ex.toString());
+        // log at info level first in case fatal-level alert notification becomes blocked
+        logger.info(failureMsg, failureEx);
+        logger.fatal(failureMsg, failureEx.toString());
       } catch (IOException ex) {
         owner.getConduit().getStats().decMessagesBeingReceived(md.size());
         failureMsg = "IOException deserializing message";
         failureEx = ex;
         rpId = md.getRPid();
-        logger.fatal("IOException deserializing message", failureEx);
+        // log at info level first in case fatal-level alert notification becomes blocked
+        logger.info(failureMsg, failureEx);
+        logger.fatal(failureMsg, failureEx);
       } catch (InterruptedException ex) {
         interrupted = true;
         owner.getConduit().getCancelCriterion().checkCancelInProgress(ex);
@@ -3054,7 +3058,9 @@ public class Connection implements Runnable {
         failureMsg = "Unexpected failure deserializing message";
         failureEx = ex;
         rpId = md.getRPid();
-        logger.fatal("Unexpected failure deserializing message", failureEx);
+        // log at info level first in case fatal-level alert notification becomes blocked
+        logger.info(failureMsg, failureEx);
+        logger.fatal(failureMsg, failureEx);
       } finally {
         msgLength = md.size();
         releaseMsgDestreamer(messageId, md);


### PR DESCRIPTION
This PR does not solve the problem of the alert system causing a P2P
message reader to block but instead ensures that the reader thread will
write deserialization information to the log before issuing a fatal
alert.  If the alert level is set to "info" this won't help, but no-one
would set the alert level to that level.

Along the way I removed some duplicate strings.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
