### PR TITLE
GEODE-8146: use latest winrm in tools image

### DIFF
--- a/ci/images/alpine-tools/Dockerfile
+++ b/ci/images/alpine-tools/Dockerfile
@@ -13,8 +13,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+FROM alpine:latest as winrm-builder
+RUN apk --no-cache add \
+    git \
+    go \
+    musl-dev \
+  && go get -v github.com/masterzen/winrm-cli
+
 FROM openjdk:8-jdk-alpine
 
+COPY --from=winrm-builder /root/go/bin/winrm-cli /usr/local/bin/winrm
 COPY --from=google/cloud-sdk:alpine /google-cloud-sdk /google-cloud-sdk
 #COPY --from=hashicorp/packer:latest /bin/packer /usr/local/bin/packer
 COPY --from=hashicorp/packer:1.4.5 /bin/packer /usr/local/bin/packer
@@ -23,24 +32,17 @@ RUN apk --no-cache add \
       bash \
       curl \
       git \
-      go \
       jq \
-      make \
       musl-dev \
       openssh-client \
       openssl \
-      python \
-      py2-pip \
+      python3 \
+      py3-pip \
       rsync \
       util-linux \
   && gcloud config set core/disable_usage_reporting true \
   && gcloud config set component_manager/disable_update_check true \
   && gcloud config set metrics/environment github_docker_image \
-  && git clone https://github.com/masterzen/winrm-cli \
-  && (cd winrm-cli; git reset --hard 6f0c57dee4569c04f64c44c335752b415e5d73a7 ; GOPATH=$PWD PATH=$PATH:$PWD/bin make) \
-  && cp winrm-cli/bin/winrm /usr/local/bin/ \
-  && rm -rf winrm-cli \
   && gcloud components install -q beta \
   && printf "Host *\n  ServerAliveInterval 60 \n  ServerAliveCountMax 2\n" >> /etc/ssh/ssh_config \
-  && pip2 install awscli \
-  && apk --no-cache del go make
+  && pip3 install awscli

--- a/ci/pipelines/meta/jinja.template.yml
+++ b/ci/pipelines/meta/jinja.template.yml
@@ -23,6 +23,7 @@ resource_types:
   type: docker-image
   source:
     repository: concourse/concourse-pipeline-resource
+    tag: 2.2.0
 
 resources:
 - name: concourse


### PR DESCRIPTION
* Built cleanly in multistage build
* Moved from python2 -> python3
* Pin concourse-pipeline resource

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
