### PR TITLE
GEODE-8150: Downgrade classgraph to 4.8.52

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -232,7 +232,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.8.68</version>
+        <version>4.8.52</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -115,7 +115,8 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'commons-logging', name: 'commons-logging', version: '1.2')
         api(group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1')
         api(group: 'commons-validator', name: 'commons-validator', version: get('commons-validator.version'))
-        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.68')
+        // Careful when upgrading this dependency: see GEODE-7370 and GEODE-8150.
+        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.52')
         api(group: 'io.micrometer', name: 'micrometer-core', version: get('micrometer.version'))
         api(group: 'io.netty', name: 'netty-all', version: '4.1.48.Final')
         api(group: 'io.swagger', name: 'swagger-annotations', version: '1.5.23')

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -968,7 +968,7 @@ lib/HdrHistogram-2.1.12.jar
 lib/HikariCP-3.4.2.jar
 lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
-lib/classgraph-4.8.68.jar
+lib/classgraph-4.8.52.jar
 lib/commons-beanutils-1.9.4.jar
 lib/commons-codec-1.14.jar
 lib/commons-collections-3.2.2.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -43,7 +43,7 @@ commons-codec-1.14.jar
 commons-collections-3.2.2.jar
 commons-io-2.6.jar
 commons-logging-1.2.jar
-classgraph-4.8.68.jar
+classgraph-4.8.52.jar
 micrometer-core-1.4.1.jar
 swagger-annotations-1.5.23.jar
 fastutil-8.3.1.jar

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -223,7 +223,7 @@ Apache Geode bundles the following files under the BSD 3-Clause License:
     and Sam Harwell
   - ASM v5.0.4 (https://asm.ow2.io) Copyright (c) 2000-2011 INRIA, France
     Telecom
-  - ClassGraph v4.8.68 (https://github.com/classgraph/classgraph), Copyright
+  - ClassGraph v4.8.52 (https://github.com/classgraph/classgraph), Copyright
     (c) 2019 Luke Hutchison
   - JLine v2.12 (http://jline.sourceforge.net), Copyright (c) 2002-2006,
     Marc Prud'hommeaux <mwp1@cornell.edu>


### PR DESCRIPTION
A performance degradation was introduced when upgrading this library
to a more recent version, downgrading to the last known working one
until a full fix is found.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
