### PR TITLE
GEODE-8138: Improve semantics of the redis-port option

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1914,17 +1914,6 @@ public interface ConfigurationProperties {
    */
   String OFF_HEAP_MEMORY_SIZE = "off-heap-memory-size";
   /**
-   * The static String definition of the <i>"redis-port"</i> property <a name="redis-port"/a>
-   * </p>
-   * <U>Description</U>: Specifies the port on which the server listens for Redis API for Geode
-   * connections. A value of 0 selects a random port.</td>
-   * </p>
-   * <U>Default</U>: 6379
-   * </p>
-   * <U>Allowed values</U>: 0..65535
-   */
-  String REDIS_PORT = "redis-port";
-  /**
    * The static String definition of the <i>"redis-bind-address"</i> property <a
    * name="redis-bind-address"/a>
    * </p>
@@ -1935,16 +1924,6 @@ public interface ConfigurationProperties {
    * <U>Default</U>: ""
    */
   String REDIS_BIND_ADDRESS = "redis-bind-address";
-  /**
-   * The static String definition of the <i>"redis-password"</i> property <a
-   * name="redis-password"/a>
-   * </p>
-   * <U>Description</U>: Specifies the password that the server uses when a client attempts to
-   * authenticate.
-   * </p>
-   * <U>Default</U>: no password set
-   */
-  String REDIS_PASSWORD = "redis-password";
   /**
    * The static String definition of the <i>"redis-enabled"</i> property <a
    * name="redis-enabled"/a>
@@ -1963,6 +1942,27 @@ public interface ConfigurationProperties {
    * </p>
    */
   String REDIS_ENABLED = "redis-enabled";
+  /**
+   * The static String definition of the <i>"redis-password"</i> property <a
+   * name="redis-password"/a>
+   * </p>
+   * <U>Description</U>: Specifies the password that the server uses when a client attempts to
+   * authenticate.
+   * </p>
+   * <U>Default</U>: no password set
+   */
+  String REDIS_PASSWORD = "redis-password";
+  /**
+   * The static String definition of the <i>"redis-port"</i> property <a name="redis-port"/a>
+   * </p>
+   * <U>Description</U>: Specifies the port on which the server listens for Redis API for Geode
+   * connections. A value of 0 selects a random port.</td>
+   * </p>
+   * <U>Default</U>: 6379
+   * </p>
+   * <U>Allowed values</U>: 0..65535
+   */
+  String REDIS_PORT = "redis-port";
   /**
    * The static String definition of the <i>"lock-memory"</i> property <a name="lock-memory"/a>
    * </p>

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1946,6 +1946,24 @@ public interface ConfigurationProperties {
    */
   String REDIS_PASSWORD = "redis-password";
   /**
+   * The static String definition of the <i>"redis-enabled"</i> property <a
+   * name="redis-enabled"/a>
+   * </p>
+   * <U>Description</U>: When the default value of false, the Redis API for Geode is not available.
+   * Set to true to enable the Redis API for Geode.</td>
+   * </p>
+   * <U>Default</U>: false
+   * <td>redis-enabled</td>
+   * <td>When the default value of false, the Redis API for <%=vars.product_name%> is not available.
+   * Set
+   * to true to enable the Redis API for <%=vars.product_name%>.</td>
+   * <td>S</td>
+   * <td>false</td>
+   * </tr>
+   * </p>
+   */
+  String REDIS_ENABLED = "redis-enabled";
+  /**
    * The static String definition of the <i>"lock-memory"</i> property <a name="lock-memory"/a>
    * </p>
    * <U>Description</U>: Include this option to lock GemFire heap and off-heap memory pages into

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -1312,14 +1312,14 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
         "The protocol that GemFireMemcachedServer understands. Default is ASCII. Values may be ASCII or BINARY");
     m.put(MEMCACHED_BIND_ADDRESS,
         "The address the GemFireMemcachedServer will listen on for remote connections. Default is \"\" which causes the GemFireMemcachedServer to listen on the host's default address. This property is ignored if memcached-port is \"0\".");
-    m.put(REDIS_PORT,
-        "Specifies the port on which the server listens for Redis API for Geode connections. A value of 0 selects a random port.  Default is 6379.");
     m.put(REDIS_BIND_ADDRESS,
         "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, localhost is requested from the operating system.");
-    m.put(REDIS_PASSWORD,
-        "Specifies the password that the server uses when a client attempts to authenticate. The default is none and no authentication will be required.");
     m.put(REDIS_ENABLED,
         "When the default value of false, the Redis API for Geode is not available.  Set to true to enable the Redis API for Geode.");
+    m.put(REDIS_PASSWORD,
+        "Specifies the password that the server uses when a client attempts to authenticate. The default is none and no authentication will be required.");
+    m.put(REDIS_PORT,
+        "Specifies the port on which the server listens for Redis API for Geode connections. A value of 0 selects a random port.  Default is 6379.");
     m.put(ENABLE_CLUSTER_CONFIGURATION,
         "Enables cluster configuration support in dedicated locators.  This allows the locator to share configuration information amongst members and save configuration changes made using GFSH.");
     m.put(ENABLE_MANAGEMENT_REST_SERVICE,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -112,6 +112,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.MEMCACHED_PRO
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.OFF_HEAP_MEMORY_SIZE;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PASSWORD;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDUNDANCY_ZONE;
@@ -1312,11 +1313,13 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
     m.put(MEMCACHED_BIND_ADDRESS,
         "The address the GemFireMemcachedServer will listen on for remote connections. Default is \"\" which causes the GemFireMemcachedServer to listen on the host's default address. This property is ignored if memcached-port is \"0\".");
     m.put(REDIS_PORT,
-        "The port GeodeRedisServer will listen on. Default is 0. Set to zero to disable GeodeRedisServer.");
+        "Specifies the port on which the server listens for Redis API for Geode connections. A value of 0 selects a random port.  Default is 6379.");
     m.put(REDIS_BIND_ADDRESS,
-        "The address the GeodeRedisServer will listen on for remote connections. Default is \"\" which causes the GeodeRedisServer to listen on the host's default address. This property is ignored if redis-port is \"0\".");
+        "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, localhost is requested from the operating system.");
     m.put(REDIS_PASSWORD,
-        "The password which client of GeodeRedisServer must use to authenticate themselves. The default is none and no authentication will be required.");
+        "Specifies the password that the server uses when a client attempts to authenticate. The default is none and no authentication will be required.");
+    m.put(REDIS_ENABLED,
+        "When the default value of false, the Redis API for Geode is not available.  Set to true to enable the Redis API for Geode.");
     m.put(ENABLE_CLUSTER_CONFIGURATION,
         "Enables cluster configuration support in dedicated locators.  This allows the locator to share configuration information amongst members and save configuration changes made using GFSH.");
     m.put(ENABLE_MANAGEMENT_REST_SERVICE,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -3468,23 +3468,6 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   String DEFAULT_MEMCACHED_BIND_ADDRESS = "";
 
   /**
-   * Returns the value of the {@link ConfigurationProperties#REDIS_PORT} property
-   *
-   * @return the port on which GeodeRedisServer should be started
-   *
-   * @since GemFire 8.0
-   */
-  @ConfigAttributeGetter(name = REDIS_PORT)
-  int getRedisPort();
-
-  @ConfigAttributeSetter(name = REDIS_PORT)
-  void setRedisPort(int value);
-
-  @ConfigAttribute(type = Integer.class, min = -1, max = 65535)
-  String REDIS_PORT_NAME = REDIS_PORT;
-  int DEFAULT_REDIS_PORT = 6379;
-
-  /**
    * Returns the value of the {@link ConfigurationProperties#REDIS_BIND_ADDRESS} property
    * <p>
    * Returns the value of the
@@ -3503,6 +3486,27 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttribute(type = String.class)
   String REDIS_BIND_ADDRESS_NAME = REDIS_BIND_ADDRESS;
   String DEFAULT_REDIS_BIND_ADDRESS = "";
+
+  /**
+   * Returns the value of the {@link ConfigurationProperties#REDIS_ENABLED} property
+   * <p>
+   * Returns the value of the
+   * {@link ConfigurationProperties#REDIS_ENABLED} property
+   *
+   * @return boolean value indicating whether or not a Redis API for Geode Server should be started
+   *
+   * @since GemFire 14.0
+   */
+  @ConfigAttributeGetter(name = REDIS_ENABLED)
+  boolean getRedisServiceEnabled();
+
+  @ConfigAttributeSetter(name = REDIS_ENABLED)
+  void setRedisServiceEnabled(boolean redisServiceEnabled);
+
+
+  @ConfigAttribute(type = Boolean.class)
+  String REDIS_ENABLED_NAME = REDIS_ENABLED;
+  boolean DEFAULT_REDIS_ENABLED = false;
 
   /**
    * Returns the value of the {@link ConfigurationProperties#REDIS_PASSWORD} property
@@ -3525,25 +3529,21 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   String DEFAULT_REDIS_PASSWORD = "";
 
   /**
-   * Returns the value of the {@link ConfigurationProperties#REDIS_ENABLED} property
-   * <p>
-   * Returns the value of the
-   * {@link ConfigurationProperties#REDIS_ENABLED} property
+   * Returns the value of the {@link ConfigurationProperties#REDIS_PORT} property
    *
-   * @return boolean value indicating whether or not a Redis API for Geode Server should be started
+   * @return the port on which GeodeRedisServer should be started
    *
-   * @since GemFire 14.0
+   * @since GemFire 8.0
    */
-  @ConfigAttributeGetter(name = REDIS_ENABLED)
-  boolean getRedisServiceEnabled();
+  @ConfigAttributeGetter(name = REDIS_PORT)
+  int getRedisPort();
 
-  @ConfigAttributeSetter(name = REDIS_ENABLED)
-  void setRedisServiceEnabled(boolean redisServiceEnabled);
+  @ConfigAttributeSetter(name = REDIS_PORT)
+  void setRedisPort(int value);
 
-
-  @ConfigAttribute(type = Boolean.class)
-  String REDIS_ENABLED_NAME = REDIS_ENABLED;
-  boolean DEFAULT_REDIS_ENABLED = false;
+  @ConfigAttribute(type = Integer.class, min = -1, max = 65535)
+  String REDIS_PORT_NAME = REDIS_PORT;
+  int DEFAULT_REDIS_PORT = 6379;
 
   // Added for the HTTP service
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -3498,10 +3498,10 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * @since GemFire 14.0
    */
   @ConfigAttributeGetter(name = REDIS_ENABLED)
-  boolean getRedisServiceEnabled();
+  boolean getRedisEnabled();
 
   @ConfigAttributeSetter(name = REDIS_ENABLED)
-  void setRedisServiceEnabled(boolean redisServiceEnabled);
+  void setRedisEnabled(boolean redisEnabled);
 
 
   @ConfigAttribute(type = Boolean.class)

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -112,6 +112,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.MEMCACHED_PRO
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.OFF_HEAP_MEMORY_SIZE;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PASSWORD;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDUNDANCY_ZONE;
@@ -3481,7 +3482,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
 
   @ConfigAttribute(type = Integer.class, min = -1, max = 65535)
   String REDIS_PORT_NAME = REDIS_PORT;
-  int DEFAULT_REDIS_PORT = 0;
+  int DEFAULT_REDIS_PORT = 6379;
 
   /**
    * Returns the value of the {@link ConfigurationProperties#REDIS_BIND_ADDRESS} property
@@ -3522,6 +3523,27 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttribute(type = String.class)
   String REDIS_PASSWORD_NAME = REDIS_PASSWORD;
   String DEFAULT_REDIS_PASSWORD = "";
+
+  /**
+   * Returns the value of the {@link ConfigurationProperties#REDIS_ENABLED} property
+   * <p>
+   * Returns the value of the
+   * {@link ConfigurationProperties#REDIS_ENABLED} property
+   *
+   * @return boolean value indicating whether or not a Redis API for Geode Server should be started
+   *
+   * @since GemFire 14.0
+   */
+  @ConfigAttributeGetter(name = REDIS_ENABLED)
+  boolean getRedisServiceEnabled();
+
+  @ConfigAttributeSetter(name = REDIS_ENABLED)
+  void setRedisServiceEnabled(boolean redisServiceEnabled);
+
+
+  @ConfigAttribute(type = Boolean.class)
+  String REDIS_ENABLED_NAME = REDIS_ENABLED;
+  boolean DEFAULT_REDIS_ENABLED = false;
 
   // Added for the HTTP service
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -499,6 +499,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
   private String redisPassword = DEFAULT_REDIS_PASSWORD;
 
+  private Boolean redisServiceEnabled = DEFAULT_REDIS_ENABLED;
+
   private boolean jmxManager =
       Boolean.getBoolean(InternalLocator.FORCE_LOCATOR_DM_TYPE) || DEFAULT_JMX_MANAGER;
   private boolean jmxManagerStart = DEFAULT_JMX_MANAGER_START;
@@ -789,6 +791,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     redisPort = other.getRedisPort();
     redisBindAddress = other.getRedisBindAddress();
     redisPassword = other.getRedisPassword();
+    redisServiceEnabled = other.getRedisServiceEnabled();
     userCommandPackages = other.getUserCommandPackages();
 
     // following added for 8.0
@@ -3207,7 +3210,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(httpServicePort, that.httpServicePort).append(startDevRestApi, that.startDevRestApi)
         .append(memcachedPort, that.memcachedPort)
         .append(distributedTransactions, that.distributedTransactions)
-        .append(redisPort, that.redisPort).append(jmxManager, that.jmxManager)
+        .append(jmxManager, that.jmxManager)
         .append(jmxManagerStart, that.jmxManagerStart).append(jmxManagerPort, that.jmxManagerPort)
         .append(jmxManagerHttpPort, that.jmxManagerHttpPort)
         .append(jmxManagerUpdateRate, that.jmxManagerUpdateRate)
@@ -3257,7 +3260,10 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(httpServiceBindAddress, that.httpServiceBindAddress)
         .append(memcachedProtocol, that.memcachedProtocol)
         .append(memcachedBindAddress, that.memcachedBindAddress)
-        .append(redisBindAddress, that.redisBindAddress).append(redisPassword, that.redisPassword)
+        .append(redisBindAddress, that.redisBindAddress)
+        .append(redisPassword, that.redisPassword)
+        .append(redisPort, that.redisPort)
+        .append(redisServiceEnabled, that.redisServiceEnabled)
         .append(jmxManagerBindAddress, that.jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients, that.jmxManagerHostnameForClients)
         .append(jmxManagerPasswordFile, that.jmxManagerPasswordFile)
@@ -3352,7 +3358,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(loadSharedConfigurationFromDir).append(clusterConfigDir).append(httpServicePort)
         .append(httpServiceBindAddress).append(startDevRestApi).append(memcachedPort)
         .append(memcachedProtocol).append(memcachedBindAddress).append(distributedTransactions)
-        .append(redisPort).append(redisBindAddress).append(redisPassword).append(jmxManager)
+        .append(redisPort).append(redisBindAddress).append(redisPassword)
+        .append(redisServiceEnabled).append(jmxManager)
         .append(jmxManagerStart).append(jmxManagerPort).append(jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients).append(jmxManagerPasswordFile)
         .append(jmxManagerAccessFile).append(jmxManagerHttpPort).append(jmxManagerUpdateRate)
@@ -3480,6 +3487,16 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   @Override
   public void setRedisPassword(String password) {
     redisPassword = password;
+  }
+
+  @Override
+  public boolean getRedisServiceEnabled() {
+    return redisServiceEnabled;
+  }
+
+  @Override
+  public void setRedisServiceEnabled(boolean redisEnabled) {
+    redisServiceEnabled = redisEnabled;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -488,18 +488,19 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   private boolean distributedTransactions = DEFAULT_DISTRIBUTED_TRANSACTIONS;
 
   /**
-   * port on which GeodeRedisServer is started
-   */
-  private int redisPort = DEFAULT_REDIS_PORT;
-
-  /**
    * Bind address for GeodeRedisServer
    */
   private String redisBindAddress = DEFAULT_REDIS_BIND_ADDRESS;
 
+  private Boolean redisServiceEnabled = DEFAULT_REDIS_ENABLED;
+
   private String redisPassword = DEFAULT_REDIS_PASSWORD;
 
-  private Boolean redisServiceEnabled = DEFAULT_REDIS_ENABLED;
+  /**
+   * port on which GeodeRedisServer is started
+   */
+  private int redisPort = DEFAULT_REDIS_PORT;
+
 
   private boolean jmxManager =
       Boolean.getBoolean(InternalLocator.FORCE_LOCATOR_DM_TYPE) || DEFAULT_JMX_MANAGER;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -492,7 +492,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    */
   private String redisBindAddress = DEFAULT_REDIS_BIND_ADDRESS;
 
-  private Boolean redisServiceEnabled = DEFAULT_REDIS_ENABLED;
+  private Boolean redisEnabled = DEFAULT_REDIS_ENABLED;
 
   private String redisPassword = DEFAULT_REDIS_PASSWORD;
 
@@ -792,7 +792,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     redisPort = other.getRedisPort();
     redisBindAddress = other.getRedisBindAddress();
     redisPassword = other.getRedisPassword();
-    redisServiceEnabled = other.getRedisServiceEnabled();
+    redisEnabled = other.getRedisEnabled();
     userCommandPackages = other.getUserCommandPackages();
 
     // following added for 8.0
@@ -3264,7 +3264,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(redisBindAddress, that.redisBindAddress)
         .append(redisPassword, that.redisPassword)
         .append(redisPort, that.redisPort)
-        .append(redisServiceEnabled, that.redisServiceEnabled)
+        .append(redisEnabled, that.redisEnabled)
         .append(jmxManagerBindAddress, that.jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients, that.jmxManagerHostnameForClients)
         .append(jmxManagerPasswordFile, that.jmxManagerPasswordFile)
@@ -3360,7 +3360,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(httpServiceBindAddress).append(startDevRestApi).append(memcachedPort)
         .append(memcachedProtocol).append(memcachedBindAddress).append(distributedTransactions)
         .append(redisPort).append(redisBindAddress).append(redisPassword)
-        .append(redisServiceEnabled).append(jmxManager)
+        .append(redisEnabled).append(jmxManager)
         .append(jmxManagerStart).append(jmxManagerPort).append(jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients).append(jmxManagerPasswordFile)
         .append(jmxManagerAccessFile).append(jmxManagerHttpPort).append(jmxManagerUpdateRate)
@@ -3491,13 +3491,13 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public boolean getRedisServiceEnabled() {
-    return redisServiceEnabled;
+  public boolean getRedisEnabled() {
+    return redisEnabled;
   }
 
   @Override
-  public void setRedisServiceEnabled(boolean redisEnabled) {
-    redisServiceEnabled = redisEnabled;
+  public void setRedisEnabled(boolean redisServiceEnabled) {
+    redisEnabled = redisServiceEnabled;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -2563,14 +2563,14 @@ public class CliStrings {
       "The gemfire.properties file for configuring the Cache Server's distributed system. The file's path can be absolute or relative to the gfsh working directory.";
   public static final String START_SERVER__REDIS_PORT = ConfigurationProperties.REDIS_PORT;
   public static final String START_SERVER__REDIS_PORT__HELP =
-      "Sets the port that the Geode Redis service listens on for Redis clients.";
+      "Specifies the port on which the server listens for Redis API for Geode connections. A value of 0 selects a random port.  Default is 6379.";
   public static final String START_SERVER__REDIS_BIND_ADDRESS =
       ConfigurationProperties.REDIS_BIND_ADDRESS;
   public static final String START_SERVER__REDIS_BIND_ADDRESS__HELP =
-      "Sets the IP address the Geode Redis service listens on for Redis clients. The default is to bind to the first non-loopback address for this machine.";
+      "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, localhost is requested from the operating system.";
   public static final String START_SERVER__REDIS_PASSWORD = ConfigurationProperties.REDIS_PASSWORD;
   public static final String START_SERVER__REDIS_PASSWORD__HELP =
-      "Sets the authentication password for GeodeRedisServer";
+      "Specifies the password that the server uses when a client attempts to authenticate. The default is none and no authentication will be required.";
   public static final String START_SERVER__SECURITY_PROPERTIES = "security-properties-file";
   public static final String START_SERVER__SECURITY_PROPERTIES__HELP =
       "The gfsecurity.properties file for configuring the Server's security configuration in the distributed system. The file's path can be absolute or relative to gfsh directory.";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -2561,9 +2561,6 @@ public class CliStrings {
   public static final String START_SERVER__PROPERTIES = "properties-file";
   public static final String START_SERVER__PROPERTIES__HELP =
       "The gemfire.properties file for configuring the Cache Server's distributed system. The file's path can be absolute or relative to the gfsh working directory.";
-  public static final String START_SERVER__REDIS_PORT = ConfigurationProperties.REDIS_PORT;
-  public static final String START_SERVER__REDIS_PORT__HELP =
-      "Specifies the port on which the server listens for Redis API for Geode connections. A value of 0 selects a random port.  Default is 6379.";
   public static final String START_SERVER__REDIS_BIND_ADDRESS =
       ConfigurationProperties.REDIS_BIND_ADDRESS;
   public static final String START_SERVER__REDIS_BIND_ADDRESS__HELP =
@@ -2571,6 +2568,9 @@ public class CliStrings {
   public static final String START_SERVER__REDIS_PASSWORD = ConfigurationProperties.REDIS_PASSWORD;
   public static final String START_SERVER__REDIS_PASSWORD__HELP =
       "Specifies the password that the server uses when a client attempts to authenticate. The default is none and no authentication will be required.";
+  public static final String START_SERVER__REDIS_PORT = ConfigurationProperties.REDIS_PORT;
+  public static final String START_SERVER__REDIS_PORT__HELP =
+      "Specifies the port on which the server listens for Redis API for Geode connections. A value of 0 selects a random port.  Default is 6379.";
   public static final String START_SERVER__SECURITY_PROPERTIES = "security-properties-file";
   public static final String START_SERVER__SECURITY_PROPERTIES__HELP =
       "The gfsecurity.properties file for configuring the Server's security configuration in the distributed system. The file's path can be absolute or relative to gfsh directory.";

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -103,7 +103,7 @@ public class DistributionConfigJUnitTest {
   @Test
   public void testGetAttributeNames() {
     String[] attNames = AbstractDistributionConfig._getAttNames();
-    assertThat(attNames.length).isEqualTo(168);
+    assertThat(attNames.length).isEqualTo(169);
 
     List boolList = new ArrayList();
     List intList = new ArrayList();
@@ -137,7 +137,7 @@ public class DistributionConfigJUnitTest {
 
     // TODO - This makes no sense. One has no idea what the correct expected number of attributes
     // are.
-    assertEquals(35, boolList.size());
+    assertEquals(36, boolList.size());
     assertEquals(35, intList.size());
     assertEquals(88, stringList.size());
     assertEquals(5, fileList.size());

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -494,6 +494,13 @@ specified, localhost is requested from the operating system.</td>
 <td><code>""</code></td>
 </tr>
 <tr>
+<td>redis-enabled</td>
+<td>When the default value of false, the Redis API for <%=vars.product_name%> is not available.  Set
+to true to enable the Redis API for <%=vars.product_name%>.</td>
+<td>S</td>
+<td>false</td>
+</tr>
+<tr>
 <td>redis-password</td>
 <td>Specifies the password that the server uses when a client attempts to authenticate.</td>
 <td>S</td>
@@ -504,13 +511,6 @@ specified, localhost is requested from the operating system.</td>
 <td>Specifies the port on which the server listens for Redis API for <%=vars.product_name%> connections. A value of 0 selects a random port.</td>
 <td>S</td>
 <td>6379</td>
-</tr>
-<tr>
-<td>redis-service-enabled</td>
-<td>When the default value of false, the Redis API for <%=vars.product_name%> is not available.  Set
-to true to enable the Redis API for <%=vars.product_name%>.</td>
-<td>S</td>
-<td>false</td>
 </tr>
 <tr>
 <td>redundancy-zone</td>

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -302,7 +302,7 @@ public class StartServerCommand extends OfflineGfshCommand {
     StartMemberUtils.setPropertyIfNotNull(gemfireProperties,
         ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS, httpServiceBindAddress);
 
-    // if redis-port, redis-bind-address. or redis-password are specified in the command line,
+    // if redis-port, redis-bind-address, or redis-password are specified in the command line,
     // REDIS_ENABLED should be set to true
     String stringRedisPort;
     stringRedisPort = redisPort == null ? "" : redisPort.toString();

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -301,6 +301,17 @@ public class StartServerCommand extends OfflineGfshCommand {
         ConfigurationProperties.HTTP_SERVICE_PORT, httpServicePort);
     StartMemberUtils.setPropertyIfNotNull(gemfireProperties,
         ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS, httpServiceBindAddress);
+
+    // if redis-port, redis-bind-address. or redis-password are specified in the command line,
+    // REDIS_ENABLED should be set to true
+    String stringRedisPort;
+    stringRedisPort = redisPort == null ? "" : redisPort.toString();
+
+    if (StringUtils.isNotBlank(stringRedisPort) || StringUtils.isNotBlank(redisPassword)
+        || StringUtils.isNotBlank(redisBindAddress)) {
+      gemfireProperties.setProperty(ConfigurationProperties.REDIS_ENABLED, "true");
+    }
+
     // if username is specified in the command line, it will overwrite what's set in the
     // properties file
     if (StringUtils.isNotBlank(userName)) {

--- a/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
@@ -46,7 +46,7 @@ public class GeodeRedisServerRule extends SerializableExternalResource {
   @Override
   protected void before() throws Throwable {
     cache = cacheFactory.create();
-    server = new GeodeRedisServer("localhost", -1);
+    server = new GeodeRedisServer("localhost", 0);
     server.start();
   }
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -17,6 +17,7 @@
 package org.apache.geode.redis;
 
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,7 +38,8 @@ public class GeodeRedisServerStartupDUnitTest {
   public void startupOnDefaultPort() {
     MemberVM server = cluster.startServerVM(0, s -> s
         .withProperty(REDIS_PORT, "6379")
-        .withProperty(REDIS_BIND_ADDRESS, "localhost"));
+        .withProperty(REDIS_BIND_ADDRESS, "localhost")
+        .withProperty(REDIS_ENABLED, "true"));
 
     server.invoke(() -> {
       GeodeRedisService service = ClusterStartupRule.getCache().getService(GeodeRedisService.class);
@@ -46,10 +48,11 @@ public class GeodeRedisServerStartupDUnitTest {
   }
 
   @Test
-  public void startupOnRandomPort_whenPortIsNegativeOne() {
+  public void startupOnRandomPort_whenPortIsZero() {
     MemberVM server = cluster.startServerVM(0, s -> s
-        .withProperty(REDIS_PORT, "-1")
-        .withProperty(REDIS_BIND_ADDRESS, "localhost"));
+        .withProperty(REDIS_PORT, "0")
+        .withProperty(REDIS_BIND_ADDRESS, "localhost")
+        .withProperty(REDIS_ENABLED, "true"));
 
     server.invoke(() -> {
       GeodeRedisService service = ClusterStartupRule.getCache().getService(GeodeRedisService.class);
@@ -58,7 +61,7 @@ public class GeodeRedisServerStartupDUnitTest {
   }
 
   @Test
-  public void doNotStartup_whenPortIsZero() {
+  public void doNotStartup_whenRedisServiceIsNotEnabled() {
     MemberVM server = cluster.startServerVM(0, s -> s
         .withProperty(REDIS_PORT, "0")
         .withProperty(REDIS_BIND_ADDRESS, "localhost"));

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
@@ -20,6 +20,7 @@ import static java.lang.String.valueOf;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -96,18 +97,22 @@ public class PubSubDUnitTest {
     serverProperties1.setProperty(REDIS_PORT, valueOf(ports[0]));
     serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
     serverProperties1.setProperty(LOG_LEVEL, "warn");
+    serverProperties1.setProperty(REDIS_ENABLED, "true");
 
     serverProperties2.setProperty(REDIS_PORT, valueOf(ports[1]));
     serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
     serverProperties2.setProperty(LOG_LEVEL, "warn");
+    serverProperties2.setProperty(REDIS_ENABLED, "true");
 
     serverProperties3.setProperty(REDIS_PORT, valueOf(ports[2]));
     serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
     serverProperties3.setProperty(LOG_LEVEL, "warn");
+    serverProperties3.setProperty(REDIS_ENABLED, "true");
 
     serverProperties4.setProperty(REDIS_PORT, valueOf(ports[3]));
     serverProperties4.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
     serverProperties4.setProperty(LOG_LEVEL, "warn");
+    serverProperties4.setProperty(REDIS_ENABLED, "true");
 
     locator = cluster.startLocatorVM(0, locatorProperties);
     server1 = cluster.startServerVM(1, serverProperties1, locator.getPort());

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/RedisDistDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/RedisDistDUnitTest.java
@@ -79,6 +79,7 @@ public class RedisDistDUnitTest implements Serializable {
     Properties redisProps = new Properties();
     redisProps.setProperty("redis-bind-address", LOCALHOST);
     redisProps.setProperty("redis-port", Integer.toString(ports[0]));
+    redisProps.setProperty("redis-enabled", "true");
     redisProps.setProperty("log-level", "warn");
     cluster.startServerVM(1, redisProps, locator.getPort());
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/ExpireDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/ExpireDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.executors;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -74,12 +75,15 @@ public class ExpireDUnitTest {
 
     serverProperties1.setProperty(REDIS_PORT, Integer.toString(availablePorts[0]));
     serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties1.setProperty(REDIS_ENABLED, "true");
 
     serverProperties2.setProperty(REDIS_PORT, Integer.toString(availablePorts[1]));
     serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties2.setProperty(REDIS_ENABLED, "true");
 
     serverProperties3.setProperty(REDIS_PORT, Integer.toString(availablePorts[2]));
     serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties3.setProperty(REDIS_ENABLED, "true");
 
     locator = clusterStartUp.startLocatorVM(0, locatorProperties);
     server1 = clusterStartUp.startServerVM(1, serverProperties1, locator.getPort());

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/hash/HMsetDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/hash/HMsetDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.executors.hash;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,12 +77,15 @@ public class HMsetDUnitTest {
 
     serverProperties1.setProperty(REDIS_PORT, Integer.toString(availablePorts[0]));
     serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties1.setProperty(REDIS_ENABLED, "true");
 
     serverProperties2.setProperty(REDIS_PORT, Integer.toString(availablePorts[1]));
     serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties2.setProperty(REDIS_ENABLED, "true");
 
     serverProperties3.setProperty(REDIS_PORT, Integer.toString(availablePorts[2]));
     serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties3.setProperty(REDIS_ENABLED, "true");
 
     locator = clusterStartUp.startLocatorVM(0, locatorProperties);
     server1 = clusterStartUp.startServerVM(1, serverProperties1, locator.getPort());

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/hash/HsetDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/hash/HsetDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.executors.hash;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,12 +77,15 @@ public class HsetDUnitTest {
 
     serverProperties1.setProperty(REDIS_PORT, Integer.toString(availablePorts[0]));
     serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties1.setProperty(REDIS_ENABLED, "true");
 
     serverProperties2.setProperty(REDIS_PORT, Integer.toString(availablePorts[1]));
     serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties2.setProperty(REDIS_ENABLED, "true");
 
     serverProperties3.setProperty(REDIS_PORT, Integer.toString(availablePorts[2]));
     serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties3.setProperty(REDIS_ENABLED, "true");
 
     locator = clusterStartUp.startLocatorVM(0, locatorProperties);
     server1 = clusterStartUp.startServerVM(1, serverProperties1, locator.getPort());

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/keys/ExistsDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/keys/ExistsDUnitTest.java
@@ -55,6 +55,7 @@ public class ExistsDUnitTest implements Serializable {
     Properties redisProps = new Properties();
     redisProps.setProperty("redis-bind-address", LOCALHOST);
     redisProps.setProperty("redis-port", Integer.toString(ports[0]));
+    redisProps.setProperty("redis-enabled", "true");
     redisProps.setProperty("log-level", "warn");
     cluster.startServerVM(1, redisProps, locator.getPort());
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/keys/PersistDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/keys/PersistDUnitTest.java
@@ -73,6 +73,7 @@ public class PersistDUnitTest implements Serializable {
     Properties redisProps = new Properties();
     redisProps.setProperty("redis-bind-address", LOCALHOST);
     redisProps.setProperty("redis-port", Integer.toString(ports[0]));
+    redisProps.setProperty("redis-enabled", "true");
     redisProps.setProperty("log-level", "warn");
     cluster.startServerVM(1, redisProps, locator.getPort());
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/set/SaddDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/set/SaddDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.executors.set;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,12 +77,15 @@ public class SaddDUnitTest {
 
     serverProperties1.setProperty(REDIS_PORT, Integer.toString(availablePorts[0]));
     serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties1.setProperty(REDIS_ENABLED, "true");
 
     serverProperties2.setProperty(REDIS_PORT, Integer.toString(availablePorts[1]));
     serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties2.setProperty(REDIS_ENABLED, "true");
 
     serverProperties3.setProperty(REDIS_PORT, Integer.toString(availablePorts[2]));
     serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties3.setProperty(REDIS_ENABLED, "true");
 
     locator = clusterStartUp.startLocatorVM(0, locatorProperties);
     server1 = clusterStartUp.startServerVM(1, serverProperties1, locator.getPort());

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/set/SremDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/executors/set/SremDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.executors.set;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,12 +77,15 @@ public class SremDUnitTest {
 
     serverProperties1.setProperty(REDIS_PORT, Integer.toString(availablePorts[0]));
     serverProperties1.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties1.setProperty(REDIS_ENABLED, "true");
 
     serverProperties2.setProperty(REDIS_PORT, Integer.toString(availablePorts[1]));
     serverProperties2.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties2.setProperty(REDIS_ENABLED, "true");
 
     serverProperties3.setProperty(REDIS_PORT, Integer.toString(availablePorts[2]));
     serverProperties3.setProperty(REDIS_BIND_ADDRESS, LOCAL_HOST);
+    serverProperties3.setProperty(REDIS_ENABLED, "true");
 
     locator = clusterStartUp.startLocatorVM(0, locatorProperties);
     server1 = clusterStartUp.startServerVM(1, serverProperties1, locator.getPort());

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
@@ -115,6 +115,7 @@ public abstract class SessionDUnitTest {
     Properties redisPropsForServer = new Properties();
     redisPropsForServer.setProperty("redis-bind-address", "localHost");
     redisPropsForServer.setProperty("redis-port", "" + ports.get(server));
+    redisPropsForServer.setProperty("redis-enabled", "true");
     redisPropsForServer.setProperty("log-level", "info");
     return redisPropsForServer;
   }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/ConcurrentStartIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/ConcurrentStartIntegrationTest.java
@@ -76,7 +76,7 @@ public class ConcurrentStartIntegrationTest {
     for (int i = 0; i < n; i++) {
       final int j = i;
       Runnable r = () -> {
-        GeodeRedisServer s = new GeodeRedisServer(-1);
+        GeodeRedisServer s = new GeodeRedisServer(0);
         s.start();
         s.shutdown();
       };

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/SSLTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/SSLTest.java
@@ -43,6 +43,7 @@ public class SSLTest {
       .withSSL("server", true, true)
       .withProperty("redis-bind-address", "localhost")
       .withProperty("redis-port", "11211")
+      .withProperty("redis-enabled", "true")
       .withAutoStart();
 
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -261,7 +261,7 @@ public class GeodeRedisServer {
    *
    * @param bindAddress The address to which the server will attempt to bind to
    * @param port The port the server will bind to, will use {@value #DEFAULT_REDIS_SERVER_PORT}
-   *        by default if argument is less than or equal to 0
+   *        by default, and will throw IllegalArgumentException if argument is less than 0
    */
   public GeodeRedisServer(String bindAddress, int port) {
     this(bindAddress, port, null);
@@ -275,7 +275,7 @@ public class GeodeRedisServer {
    *
    * @param bindAddress The address to which the server will attempt to bind to
    * @param port The port the server will bind to, will throw an IllegalArgumentException if
-   *        argument is less than {@value #RANDOM_PORT_INDICATOR}. If the port is
+   *        argument is less than 0. If the port is
    *        {@value #RANDOM_PORT_INDICATOR} a random port is assigned.
    * @param logLevel The logging level to be used by GemFire
    */

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -105,7 +105,7 @@ public class GeodeRedisServer {
    */
   public static final int DEFAULT_REDIS_SERVER_PORT = 6379;
 
-  private static final int RANDOM_PORT_INDICATOR = -1;
+  private static final int RANDOM_PORT_INDICATOR = 0;
 
   /**
    * The number of threads that will work on handling requests
@@ -241,7 +241,7 @@ public class GeodeRedisServer {
    * to the first non-loopback address
    */
   public GeodeRedisServer() {
-    this(null, -1, null);
+    this(null, RANDOM_PORT_INDICATOR, null);
   }
 
   /**
@@ -274,13 +274,16 @@ public class GeodeRedisServer {
    * effect.
    *
    * @param bindAddress The address to which the server will attempt to bind to
-   * @param port The port the server will bind to, will use {@value #DEFAULT_REDIS_SERVER_PORT}
-   *        by default if argument is less than -1. If the port is {@value #RANDOM_PORT_INDICATOR}
-   *        a random port is assigned.
+   * @param port The port the server will bind to, will throw an IllegalArgumentException if
+   *        argument is less than {@value #RANDOM_PORT_INDICATOR}. If the port is
+   *        {@value #RANDOM_PORT_INDICATOR} a random port is assigned.
    * @param logLevel The logging level to be used by GemFire
    */
   public GeodeRedisServer(String bindAddress, int port, String logLevel) {
-    serverPort = port < RANDOM_PORT_INDICATOR ? DEFAULT_REDIS_SERVER_PORT : port;
+    if (port < RANDOM_PORT_INDICATOR) {
+      throw new IllegalArgumentException("Redis port cannot be less than 0");
+    }
+    serverPort = port;
     this.bindAddress = bindAddress;
     this.logLevel = logLevel;
     numWorkerThreads = setNumWorkerThreads();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -36,7 +36,7 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
     this.cache = (InternalCache) cache;
     this.cache.getInternalDistributedSystem().addResourceListener(this);
 
-    return this.cache.getInternalDistributedSystem().getConfig().getRedisServiceEnabled();
+    return this.cache.getInternalDistributedSystem().getConfig().getRedisEnabled();
   }
 
   @Override
@@ -54,7 +54,7 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
   private void startRedisServer(InternalCache cache) {
     InternalDistributedSystem system = cache.getInternalDistributedSystem();
 
-    if (system.getConfig().getRedisServiceEnabled()) {
+    if (system.getConfig().getRedisEnabled()) {
       int port = system.getConfig().getRedisPort();
       String bindAddress = system.getConfig().getRedisBindAddress();
       assert bindAddress != null;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -36,9 +36,7 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
     this.cache = (InternalCache) cache;
     this.cache.getInternalDistributedSystem().addResourceListener(this);
 
-    int port = this.cache.getInternalDistributedSystem().getConfig().getRedisPort();
-
-    return port != 0;
+    return this.cache.getInternalDistributedSystem().getConfig().getRedisServiceEnabled();
   }
 
   @Override
@@ -55,8 +53,9 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
 
   private void startRedisServer(InternalCache cache) {
     InternalDistributedSystem system = cache.getInternalDistributedSystem();
-    int port = system.getConfig().getRedisPort();
-    if (port != 0) {
+
+    if (system.getConfig().getRedisServiceEnabled()) {
+      int port = system.getConfig().getRedisPort();
       String bindAddress = system.getConfig().getRedisBindAddress();
       assert bindAddress != null;
       if (bindAddress.equals(DistributionConfig.DEFAULT_REDIS_BIND_ADDRESS)) {


### PR DESCRIPTION
- Introduce a Geode parameter - `redis-enabled` which is `false` by default. This parameter determines whether the service is started or not.
- Set the default `redis-port` value to `6379`
- `redis-port` range is 0..65535
- When `redis-port=0`, and `redis-enabled=true` the service will start on an ephemeral port.
- When `gfsh` is used with `--redis-port`, `--redis-password`, or `--redis-bind-address`, it should automatically set `redis-enabled=true`

`gemfire_properties.html.md.erb` updated as part of this PR: https://github.com/apache/geode/pull/5130