### PR TITLE
GEODE-8108: Remove System.out.println calls from geode-redis

### DIFF
--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/springRedisTestApplication/config/SessionListener.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/springRedisTestApplication/config/SessionListener.java
@@ -20,18 +20,23 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.servlet.http.HttpSessionEvent;
 import javax.servlet.http.HttpSessionListener;
 
+import org.apache.logging.log4j.Logger;
 import org.springframework.context.annotation.Configuration;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
 
 @Configuration
 public class SessionListener implements HttpSessionListener {
   public static AtomicLong sessionCount = new AtomicLong(0);
   public static HashSet<String> sessionIds = new HashSet<>();
 
+  private static final Logger logger = LogService.getLogger();
+
   @Override
   public void sessionCreated(HttpSessionEvent event) {
     sessionCount.getAndIncrement();
     sessionIds.add(event.getSession().getId());
-    System.out.println("session created: " + event.getSession().getId());
+    logger.info("session created: " + event.getSession().getId());
     event.getSession().setMaxInactiveInterval(15);
   }
 
@@ -39,6 +44,6 @@ public class SessionListener implements HttpSessionListener {
   public void sessionDestroyed(HttpSessionEvent event) {
     sessionIds.remove(event.getSession().getId());
     sessionCount.getAndDecrement();
-    System.out.println("session destroyed: " + event.getSession().getId());
+    logger.info("session destroyed: " + event.getSession().getId());
   }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/StringsIntegrationTest.java
@@ -962,7 +962,6 @@ public class StringsIntegrationTest {
       return;
     }
     String result = jedis.get(key);
-    // System.out.println(result);
     assertThat(result).isNull();
 
     int psetex = r.nextInt(5000);

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/SubscriptionsIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import io.netty.channel.Channel;
-import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -47,11 +46,6 @@ public class SubscriptionsIntegrationTest {
       }
       return null;
     };
-  }
-
-  @AfterClass
-  public static void after() {
-    System.out.println("done");
   }
 
   @Test


### PR DESCRIPTION
Ticket description, reported by @dschneider-pivotal :
> 
> I noticed in SMoveExecutor a number of System.out.println calls. This should not be done. 
> Either remove the calls (that is what I recommend for SMoveExecutor) or use a logger. 
> I don't know if SMoveExecutor is the only place this happens so a code scan should be done.

`SMoveExecutor` class was already fixed but I searched for other calls to `System.out.println` in `geode-redis` and I have removed them.
I also updated the logger of `GeodeRedisServer` class.