### PR TITLE
Revert "GEODE-8119: closing threads when offline disk store is executed"

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -2318,7 +2318,7 @@ public class DiskStoreImpl implements DiskStore {
       } catch (RuntimeException e) {
         rte = e;
       }
-      if (!isValidating() && !isOfflineCompacting()) {
+      if (!isOffline()) {
         try {
           // do this before write lock
           stopAsyncFlusher();

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -66,7 +66,6 @@ public class DiskStoreCommandsDUnitTest implements Serializable {
   private static final String GROUP2 = "GROUP2";
   private static final String REGION_1 = "REGION1";
   private static final String DISKSTORE = "DISKSTORE";
-  private static final String IF_FILE_EXT = ".if";
 
   @Rule
   public ClusterStartupRule rule = new ClusterStartupRule();
@@ -515,26 +514,8 @@ public class DiskStoreCommandsDUnitTest implements Serializable {
     assertThat(Files.exists(nonExistingDiskStorePath)).isFalse();
     gfsh.executeAndAssertThat(baseCommand + " --name=" + DISKSTORE + " --disk-dirs="
         + nonExistingDiskStorePath.toAbsolutePath().toString()).statusIsError()
-        .containsOutput("Could not find:");
+        .containsOutput("Could not find disk-dirs:");
     assertThat(Files.exists(nonExistingDiskStorePath)).isFalse();
-  }
-
-  @Test
-  @Parameters({"compact offline-disk-store", "describe offline-disk-store",
-      "upgrade offline-disk-store", "validate offline-disk-store",
-      "alter disk-store --region=testRegion --enable-statistics=true"})
-  public void offlineDiskStoreCommandShouldNotPassIfDiskStoreFileDoesNotExist(
-      String baseCommand) {
-    Path diskStorePath =
-        Paths.get(tempDir.getRoot().getAbsolutePath());
-    assertThat(Files.exists(diskStorePath)).isTrue();
-    Path diskStoreFilePath =
-        Paths.get(diskStorePath + File.separator + "BACKUPnonExistingDiskStore" + IF_FILE_EXT);
-    assertThat(Files.exists(diskStoreFilePath)).isFalse();
-    gfsh.executeAndAssertThat(baseCommand + " --name=nonExistingDiskStore --disk-dirs="
-        + diskStoreFilePath.toAbsolutePath().toString()).statusIsError()
-        .containsOutput("Could not find:");
-    assertThat(Files.exists(diskStoreFilePath)).isFalse();
   }
 
   @Test

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreCommandIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/AlterDiskStoreCommandIntegrationTest.java
@@ -17,9 +17,6 @@ package org.apache.geode.management.internal.cli.commands;
 
 import static org.mockito.Mockito.spy;
 
-import java.io.File;
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,9 +34,8 @@ public class AlterDiskStoreCommandIntegrationTest {
 
   @Rule
   public GfshParserRule gfsh = new GfshParserRule();
-  private GfshCommand command;
-  private static final String IF_FILE_EXT = ".if";
 
+  private GfshCommand command;
 
   @Before
   public void before() {
@@ -47,7 +43,7 @@ public class AlterDiskStoreCommandIntegrationTest {
   }
 
   @Test
-  public void removeOptionMustBeUsedAlone() throws IOException {
+  public void removeOptionMustBeUsedAlone() {
     CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
     csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, "diskStoreName");
     csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, "regionName");
@@ -56,39 +52,7 @@ public class AlterDiskStoreCommandIntegrationTest {
     csb.addOption(CliStrings.ALTER_DISK_STORE__REMOVE, "true");
     String commandString = csb.toString();
 
-    tempDir.newFile("BACKUPdiskStoreName.if");
     gfsh.executeAndAssertThat(command, commandString).statusIsError()
         .containsOutput("Cannot use the --remove=true parameter with any other parameters");
   }
-
-  @Test
-  public void testDirValidation() throws IOException {
-    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
-    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, "diskStoreName");
-    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, "regionName");
-    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, "wrongDiskDir");
-    csb.addOption(CliStrings.ALTER_DISK_STORE__CONCURRENCY__LEVEL, "5");
-    String commandString = csb.toString();
-
-    File tempFile = tempDir.newFile("BACKUPdiskStoreName" + IF_FILE_EXT);
-    gfsh.executeAndAssertThat(command, commandString).statusIsError()
-        .containsOutput("Could not find: \"wrongDiskDir" + File.separator + tempFile.getName());
-  }
-
-  @Test
-  public void testNameValidation() throws IOException {
-    String diskStoreName = "diskStoreName";
-    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.ALTER_DISK_STORE);
-    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKSTORENAME, diskStoreName);
-    csb.addOption(CliStrings.ALTER_DISK_STORE__REGIONNAME, "regionName");
-    csb.addOption(CliStrings.ALTER_DISK_STORE__DISKDIRS, tempDir.getRoot().toString());
-    csb.addOption(CliStrings.ALTER_DISK_STORE__CONCURRENCY__LEVEL, "5");
-    String commandString = csb.toString();
-
-    gfsh.executeAndAssertThat(command, commandString).statusIsError()
-        .containsOutput(
-            "Could not find: \"" + tempDir.getRoot().toString() + File.separator + "BACKUP"
-                + diskStoreName + IF_FILE_EXT);
-  }
-
 }

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommandIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommandIntegrationTest.java
@@ -15,20 +15,15 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.cache.RegionShortcut;
-import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
-import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
@@ -39,8 +34,6 @@ public class DescribeDiskStoreCommandIntegrationTest {
   private static final String REGION_NAME = "test-region";
   private static final String MEMBER_NAME = "testServer";
   private static final String DISK_STORE_NAME = "testDiskStore";
-  private static final String WRONG_DISK_STORE_NAME = "wrongTestDiskStore";
-  private static final String IF_FILE_EXT = ".if";
 
   private static final List<String> expectedData = Arrays.asList("Disk Store ID", "Disk Store Name",
       "Member ID", "Member Name", "Allow Force Compaction", "Auto Compaction",
@@ -62,9 +55,6 @@ public class DescribeDiskStoreCommandIntegrationTest {
 
   @ClassRule
   public static GfshCommandRule gfsh = new GfshCommandRule().withTimeout(1);
-
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
 
   @Test
   public void commandFailsWithoutOptions() throws Exception {
@@ -107,31 +97,5 @@ public class DescribeDiskStoreCommandIntegrationTest {
     String cmd = "describe disk-store --name=" + DISK_STORE_NAME + " --member=" + MEMBER_NAME;
     gfsh.executeAndAssertThat(cmd).statusIsSuccess()
         .containsOutput(expectedData.toArray(new String[0]));
-  }
-
-  @Test
-  public void testDirValidation() throws Exception {
-    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.DESCRIBE_OFFLINE_DISK_STORE);
-    csb.addOption(CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKSTORENAME, DISK_STORE_NAME);
-    csb.addOption(CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKDIRS, "wrongDiskDir");
-    String commandString = csb.toString();
-
-    gfsh.executeAndAssertThat(commandString).statusIsError()
-        .containsOutput("Could not find: \"wrongDiskDir" + File.separator + "BACKUP"
-            + DISK_STORE_NAME + IF_FILE_EXT);
-  }
-
-  @Test
-  public void testNameValidation() throws Exception {
-    CommandStringBuilder csb = new CommandStringBuilder(CliStrings.DESCRIBE_OFFLINE_DISK_STORE);
-    csb.addOption(CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKSTORENAME, WRONG_DISK_STORE_NAME);
-    csb.addOption(CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKDIRS,
-        tempDir.getRoot().getAbsolutePath());
-    String commandString = csb.toString();
-
-    gfsh.executeAndAssertThat(commandString).statusIsError()
-        .containsOutput(
-            "Could not find: \"" + tempDir.getRoot().toString() + File.separator + "BACKUP"
-                + WRONG_DISK_STORE_NAME + IF_FILE_EXT);
   }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
@@ -60,12 +60,11 @@ public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
           help = CliStrings.ALTER_DISK_STORE__REMOVE__HELP, specifiedDefaultValue = "true",
           unspecifiedDefaultValue = "false") boolean remove) {
 
-    String validatedDirectoriesAndFile =
-        DiskStoreCommandsUtils.validatedDirectoriesAndFile(diskDirs, diskStoreName);
-    if (validatedDirectoriesAndFile != null) {
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
       throw new IllegalArgumentException(
-          "Could not find: \""
-              + validatedDirectoriesAndFile + "\"");
+          "Could not find " + CliStrings.ALTER_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
     }
 
     try {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
@@ -50,12 +50,11 @@ public class CompactOfflineDiskStoreCommand extends SingleGfshCommand {
       @CliOption(key = CliStrings.COMPACT_OFFLINE_DISK_STORE__J,
           help = CliStrings.COMPACT_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
 
-    String validatedDirectoriesAndFile =
-        DiskStoreCommandsUtils.validatedDirectoriesAndFile(diskDirs, diskStoreName);
-    if (validatedDirectoriesAndFile != null) {
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
       throw new IllegalArgumentException(
-          "Could not find: \""
-              + validatedDirectoriesAndFile + "\"");
+          "Could not find " + CliStrings.COMPACT_OFFLINE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
     }
 
     ResultModel result = new ResultModel();

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
@@ -43,13 +43,11 @@ public class DescribeOfflineDiskStoreCommand extends SingleGfshCommand {
       @CliOption(key = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__REGIONNAME,
           help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__REGIONNAME__HELP) String regionName) {
 
-    String validatedDirectoriesAndFile =
-        DiskStoreCommandsUtils.validatedDirectoriesAndFile(diskDirs, diskStoreName);
-
-    if (validatedDirectoriesAndFile != null) {
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
       throw new IllegalArgumentException(
-          "Could not find: \""
-              + validatedDirectoriesAndFile + "\"");
+          "Could not find " + CliStrings.DESCRIBE_OFFLINE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
     }
 
     try {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsUtils.java
@@ -34,8 +34,6 @@ import org.apache.geode.management.internal.util.ManagementUtils;
 class DiskStoreCommandsUtils {
   private static final Logger logger = LogService.getLogger();
 
-  public static final String IF_FILE_EXT = ".if";
-
   private static final String LOG4J_CONFIGURATION_FILE_PROPERTY = "log4j.configurationFile";
 
   static void configureLogging(final List<String> commandList) {
@@ -47,23 +45,23 @@ class DiskStoreCommandsUtils {
     commandList.add("-D" + LOG4J_CONFIGURATION_FILE_PROPERTY + "=" + configFilePropertyValue);
   }
 
-  static String validatedDirectoriesAndFile(String[] diskDirs, String name) {
+  static String validatedDirectories(String[] diskDirs) {
     String invalidDirectories = null;
     StringBuilder builder = null;
-    File diskDirAndFile;
+    File diskDir;
     for (String diskDirPath : diskDirs) {
-      diskDirAndFile = new File(diskDirPath, "BACKUP" + name + IF_FILE_EXT);
-      if (!diskDirAndFile.exists()) {
+      diskDir = new File(diskDirPath);
+      if (!diskDir.exists()) {
         if (builder == null) {
           builder = new StringBuilder();
         } else if (builder.length() != 0) {
           builder.append(", ");
         }
-        builder.append(diskDirAndFile);
+        builder.append(diskDirPath);
       }
-      if (builder != null) {
-        invalidDirectories = builder.toString();
-      }
+    }
+    if (builder != null) {
+      invalidDirectories = builder.toString();
     }
     return invalidDirectories;
   }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
@@ -50,12 +50,11 @@ public class UpgradeOfflineDiskStoreCommand extends SingleGfshCommand {
       @CliOption(key = CliStrings.UPGRADE_OFFLINE_DISK_STORE__J,
           help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__J__HELP) String[] jvmProps) {
 
-    String validatedDirectoriesAndFileAndFile =
-        DiskStoreCommandsUtils.validatedDirectoriesAndFile(diskDirs, diskStoreName);
-    if (validatedDirectoriesAndFileAndFile != null) {
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
       throw new IllegalArgumentException(
-          "Could not find: \""
-              + validatedDirectoriesAndFileAndFile + "\"");
+          "Could not find " + CliStrings.UPGRADE_OFFLINE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
     }
 
     ResultModel result = new ResultModel();

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ValidateDiskStoreCommand.java
@@ -46,12 +46,11 @@ public class ValidateDiskStoreCommand extends GfshCommand {
       @CliOption(key = CliStrings.VALIDATE_DISK_STORE__J,
           help = CliStrings.VALIDATE_DISK_STORE__J__HELP) String[] jvmProps) {
 
-    String validatedDirectoriesAndFile =
-        DiskStoreCommandsUtils.validatedDirectoriesAndFile(diskDirs, diskStoreName);
-    if (validatedDirectoriesAndFile != null) {
+    String validatedDirectories = DiskStoreCommandsUtils.validatedDirectories(diskDirs);
+    if (validatedDirectories != null) {
       throw new IllegalArgumentException(
-          "Could not find: \""
-              + validatedDirectoriesAndFile + "\"");
+          "Could not find " + CliStrings.VALIDATE_DISK_STORE__DISKDIRS + ": \""
+              + validatedDirectories + "\"");
     }
 
     ResultModel result = new ResultModel();


### PR DESCRIPTION
This reverts commit c3c226a822538cb25e3945b75eef6977a985716e.

Intermittent errors were observed while executing some internal tests and commit [c3c226a](https://github.com/apache/geode/commit/c3c226a822538cb25e3945b75eef6977a985716e) was determined to be responsible. As of yet, no local reproduction of the issue is available, but work is ongoing to provide a test that can be used to debug the issue.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
