### PR TITLE
GEODE-7956: correct legal region names

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
@@ -24,7 +24,7 @@ import org.apache.geode.cache.Region;
 
 public class RegionNameValidation {
 
-  private static final Pattern NAME_PATTERN = Pattern.compile("[aA-zZ0-9-_.]+");
+  private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9-_.]+");
 
   static Pattern getNamePattern() {
     return NAME_PATTERN;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
@@ -24,7 +24,7 @@ import org.apache.geode.cache.Region;
 
 public class RegionNameValidation {
 
-  private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9-_.]+");
+  private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z\\[\\]0-9-_.]+");
 
   static Pattern getNamePattern() {
     return NAME_PATTERN;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionNameValidation.java
@@ -24,7 +24,7 @@ import org.apache.geode.cache.Region;
 
 public class RegionNameValidation {
 
-  private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z\\[\\]0-9-_.]+");
+  private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9-_.^`\\[\\]\\\\]+");
 
   static Pattern getNamePattern() {
     return NAME_PATTERN;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/RegionNameValidationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/RegionNameValidationTest.java
@@ -137,6 +137,46 @@ public class RegionNameValidationTest {
   }
 
   @Test
+  public void startingAndEndingWithSquareBracketsIsOk() {
+    validate("[validRegionName]");
+  }
+
+  @Test
+  public void containingSquareBracketsIsOk() {
+    validate("validRegion[EMPTY]Name");
+  }
+
+  @Test
+  public void startingWithCaretIsOk() {
+    validate("^validRegionName");
+  }
+
+  @Test
+  public void containingCaretIsOk() {
+    validate("validRegion^Name");
+  }
+
+  @Test
+  public void endingWithCaretIsOk() {
+    validate("validRegionName^");
+  }
+
+  @Test
+  public void startingWithBackquoteIsOk() {
+    validate("`validRegionName");
+  }
+
+  @Test
+  public void containingBackquoteIsOk() {
+    validate("validRegion`Name");
+  }
+
+  @Test
+  public void endingWithBackquoteIsOk() {
+    validate("validRegionName`");
+  }
+
+  @Test
   public void nameWithDot() throws Exception {
     validate("valid.valid");
   }

--- a/geode-docs/basic_config/data_regions/region_naming.html.md.erb
+++ b/geode-docs/basic_config/data_regions/region_naming.html.md.erb
@@ -24,7 +24,7 @@ follow these region naming guidelines.
 
 -   Characters permitted in region names are alphanumeric characters
 (`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`),
-period (`.`), underscore (`_`), square brackets (`[, ]`) and hyphen (`-`).
+period (`.`), underscore (`_`), square brackets (`[, ]`), hyphen (`-`), caret (`^`) and backqoute (```).
 -   Do not use the slash character (`/`).
 -   Do not begin region names with two underscore characters (`__`),
 as this is reserved for internal use.

--- a/geode-docs/basic_config/data_regions/region_naming.html.md.erb
+++ b/geode-docs/basic_config/data_regions/region_naming.html.md.erb
@@ -22,9 +22,9 @@ limitations under the License.
 To be able to perform all available operations on your data regions,
 follow these region naming guidelines.
 
--   Permitted characters within region names are alphanumeric characters
+-   Characters permitted in region names are alphanumeric characters
 (`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`),
-the dot character (`.`), the underscore character (`_`), the square brackets characters (`[, ]`) and the hyphen character (`-`).
+period (`.`), underscore (`_`), square brackets (`[, ]`) and hyphen (`-`).
 -   Do not use the slash character (`/`).
 -   Do not begin region names with two underscore characters (`__`),
 as this is reserved for internal use.

--- a/geode-docs/basic_config/data_regions/region_naming.html.md.erb
+++ b/geode-docs/basic_config/data_regions/region_naming.html.md.erb
@@ -24,7 +24,7 @@ follow these region naming guidelines.
 
 -   Permitted characters within region names are alphanumeric characters
 (`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`),
-the underscore character (`_`), and the hyphen character (`-`).
+the dot character (`.`), the underscore character (`_`), and the hyphen character (`-`).
 -   Do not use the slash character (`/`).
 -   Do not begin region names with two underscore characters (`__`),
 as this is reserved for internal use.

--- a/geode-docs/basic_config/data_regions/region_naming.html.md.erb
+++ b/geode-docs/basic_config/data_regions/region_naming.html.md.erb
@@ -24,7 +24,7 @@ follow these region naming guidelines.
 
 -   Permitted characters within region names are alphanumeric characters
 (`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`),
-the dot character (`.`), the underscore character (`_`), and the hyphen character (`-`).
+the dot character (`.`), the underscore character (`_`), the square brackets characters (`[, ]`) and the hyphen character (`-`).
 -   Do not use the slash character (`/`).
 -   Do not begin region names with two underscore characters (`__`),
 as this is reserved for internal use.

--- a/geode-docs/basic_config/data_regions/region_naming.html.md.erb
+++ b/geode-docs/basic_config/data_regions/region_naming.html.md.erb
@@ -24,7 +24,7 @@ follow these region naming guidelines.
 
 -   Characters permitted in region names are alphanumeric characters
 (`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`),
-period (`.`), underscore (`_`), square brackets (`[, ]`), hyphen (`-`), caret (`^`) and backqoute (```).
+period (`.`), underscore (`_`), square brackets (`[, ]`), hyphen (`-`), caret (`^`) and backquote (```).
 -   Do not use the slash character (`/`).
 -   Do not begin region names with two underscore characters (`__`),
 as this is reserved for internal use.


### PR DESCRIPTION
With existing regex we supported also: [, ], ^, `, \ in region name.
With a new regex we supported only characters described in the documentation.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
