### PR TITLE
GEODE-8193: Broken link in statistics list

### DIFF
--- a/geode-docs/reference/statistics_list.html.md.erb
+++ b/geode-docs/reference/statistics_list.html.md.erb
@@ -70,7 +70,7 @@ Performance statistics are collected for each Java application or cache server t
 
 -   **[Region Entry Eviction – Count-Based (LRUStatistics)](#section_374FBD92A3B74F6FA08AA23047929B4F)**
 
--   **[Region Entry Eviction - Heap-based eviction (HeapLRUStatistics)]()#section_3B74F6FA08A374FBD92AA23047929B4F)**
+-   **[Region Entry Eviction - Heap-based eviction (HeapLRUStatistics)](#section_3B74F6FA08A374FBD92AA23047929B4F)**
 
 -   **[Region Entry Eviction – Size-based (MemLRUStatistics)](#section_3D2AA2BCE5B6485699A7B6ADD1C49FF7)**
 


### PR DESCRIPTION
The link of region entry heap-based eviction is wrong and shows the html anchor id in the statistics lists:

* Region Entry Eviction - Heap-based eviction (HeapLRUStatistics)#section_3B74F6FA08A374FBD92AA23047929B4F)

https://geode.apache.org/docs/guide/112/reference/statistics_list.html
