### PR TITLE
GEODE-8199: optimize ByteArrayWrapper serialization and memory usage

### DIFF
--- a/geode-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1,5 +1,5 @@
 org/apache/geode/redis/internal/ByteArrayWrapper,2
-fromData,20
+fromData,9
 toData,9
 
 org/apache/geode/redis/internal/DoubleWrapper,2

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Coder.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Coder.java
@@ -301,7 +301,7 @@ public class Coder {
       return null;
     }
     try {
-      return new String(bytes, CHARSET).intern();
+      return new String(bytes, CHARSET);
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/Command.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/Command.java
@@ -47,10 +47,9 @@ public class Command {
     this.response = null;
 
     RedisCommandType type;
-    String commandName = null;
     try {
       byte[] charCommand = commandElems.get(0);
-      commandName = Coder.bytesToString(charCommand).toUpperCase();
+      String commandName = Coder.bytesToString(charCommand).toUpperCase();
       type = RedisCommandType.valueOf(commandName);
     } catch (Exception e) {
       type = RedisCommandType.UNKNOWN;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -21,8 +21,10 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ResourceEvent;
 import org.apache.geode.distributed.internal.ResourceEventsListener;
+import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.CacheService;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
 
@@ -35,8 +37,16 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
   public boolean init(Cache cache) {
     this.cache = (InternalCache) cache;
     this.cache.getInternalDistributedSystem().addResourceListener(this);
+    registerDataSerializables();
 
     return this.cache.getInternalDistributedSystem().getConfig().getRedisEnabled();
+  }
+
+  private void registerDataSerializables() {
+    InternalDataSerializer.getDSFIDSerializer().registerDSFID(
+        DataSerializableFixedID.REDIS_BYTE_ARRAY_WRAPPER,
+        ByteArrayWrapper.class);
+
   }
 
   @Override

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
@@ -336,7 +336,7 @@ public interface DataSerializableFixedID extends SerializationVersions, BasicSer
   byte PR_INDEX_CREATION_REPLY_MSG = 68;
   byte PR_MANAGE_BUCKET_REPLY_MESSAGE = 69;
 
-  // 70 unused
+  byte REDIS_BYTE_ARRAY_WRAPPER = 70;
 
   byte UPDATE_MESSAGE = 71;
   byte REPLY_MESSAGE = 72;


### PR DESCRIPTION
ByteArrayWrapper now implements DataSerializableFixedID which should save us ~40 bytes each time it is serialized.

ByteArrayWrapper no longer caches its "hash" and "string" form which will cut down its memory overhead by over 70%.
When we convert a sequence of bytes to a String, the Coder no longer calls "intern" which will also save some memory and time.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
