### PR TITLE
GEODE-8201: change internal redis region name to start with double underscore

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -149,7 +149,7 @@ public class GeodeRedisServer {
   /**
    * The name of the region that holds data stored in redis.
    */
-  public static final String REDIS_DATA_REGION = "REDIS_DATA";
+  public static final String REDIS_DATA_REGION = "__REDIS_DATA";
 
   /**
    * System property name that can be used to set the number of threads to be used by the
@@ -302,12 +302,10 @@ public class GeodeRedisServer {
       Region<ByteArrayWrapper, RedisData> redisData;
       InternalCache gemFireCache = (InternalCache) cache;
 
-      if ((redisData = cache.getRegion(REDIS_DATA_REGION)) == null) {
-        InternalRegionFactory<ByteArrayWrapper, RedisData> redisMetaDataFactory =
-            gemFireCache.createInternalRegionFactory(DEFAULT_REGION_TYPE);
-        redisMetaDataFactory.setInternalRegion(true).setIsUsedForMetaRegion(true);
-        redisData = redisMetaDataFactory.create(REDIS_DATA_REGION);
-      }
+      InternalRegionFactory<ByteArrayWrapper, RedisData> redisMetaDataFactory =
+          gemFireCache.createInternalRegionFactory(DEFAULT_REGION_TYPE);
+      redisMetaDataFactory.setInternalRegion(true).setIsUsedForMetaRegion(true);
+      redisData = redisMetaDataFactory.create(REDIS_DATA_REGION);
 
       pubSub = new PubSubImpl(new Subscriptions());
       regionProvider = new RegionProvider(redisData);


### PR DESCRIPTION
The RedisData region name now starts with "__".
Also it now always tries to create the region and will fail
if it already exists.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
