### PR TITLE
GEODE-8179: gfsh query cmd returns incorrect results if '=' sign is missing

### DIFF
--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
@@ -123,26 +123,24 @@ public class GfshParser extends SimpleParser {
 
     List<String> furtherSplitWithEquals = new ArrayList<>();
     for (String token : splitWithWhiteSpaces) {
-      int indexOfFirstEqual = token.indexOf('=');
-      int indexOfFirstDoubleQuote = token.indexOf('"');
-      int indexOfFirstSingleQuote = token.indexOf('\'');
-      if (indexOfFirstEqual < 0 || token.startsWith("-D")) {
+      // do not split with "=" if this part starts with quotes or is part of -D
+      if (token.startsWith("'") || token.startsWith("\"") || token.startsWith("-D")) {
         furtherSplitWithEquals.add(token);
-      } else {
-        if (indexOfFirstDoubleQuote == 0 || indexOfFirstSingleQuote == 0) {
-          furtherSplitWithEquals.add(token);
-        } else if ((indexOfFirstDoubleQuote < 0 && indexOfFirstSingleQuote < 0)
-            || (indexOfFirstEqual < indexOfFirstDoubleQuote)
-            || (indexOfFirstEqual < indexOfFirstSingleQuote)) {
-          String left = token.substring(0, indexOfFirstEqual);
-          String right = token.substring(indexOfFirstEqual + 1);
-          if (left.length() > 0) {
-            furtherSplitWithEquals.add(left);
-          }
-          if (right.length() > 0) {
-            furtherSplitWithEquals.add(right);
-          }
-        }
+        continue;
+      }
+      // if this token has equal sign, split around the first occurrence of it
+      int indexOfFirstEqual = token.indexOf('=');
+      if (indexOfFirstEqual < 0) {
+        furtherSplitWithEquals.add(token);
+        continue;
+      }
+      String left = token.substring(0, indexOfFirstEqual);
+      String right = token.substring(indexOfFirstEqual + 1);
+      if (left.length() > 0) {
+        furtherSplitWithEquals.add(left);
+      }
+      if (right.length() > 0) {
+        furtherSplitWithEquals.add(right);
       }
     }
     return furtherSplitWithEquals;

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
@@ -122,20 +122,29 @@ public class GfshParser extends SimpleParser {
     List<String> splitWithWhiteSpaces = splitWithWhiteSpace(userInput);
 
     List<String> furtherSplitWithEquals = new ArrayList<>();
+    boolean doNotRemoveEqualsInNextToken = false;
     for (String token : splitWithWhiteSpaces) {
-      // if this token has equal sign, split around the first occurrence of it
-      int indexOfFirstEqual = token.indexOf('=');
-      if (indexOfFirstEqual < 0) {
+      if (doNotRemoveEqualsInNextToken) {
         furtherSplitWithEquals.add(token);
+        doNotRemoveEqualsInNextToken = false;
       } else {
-        String left = token.substring(0, indexOfFirstEqual);
-        String right = token.substring(indexOfFirstEqual + 1);
-        if (left.length() > 0) {
-          furtherSplitWithEquals.add(left);
+        // if this token has equal sign, split around the first occurrence of it
+        int indexOfFirstEqual = token.indexOf('=');
+        if (indexOfFirstEqual < 0) {
+          furtherSplitWithEquals.add(token);
+        } else {
+          String left = token.substring(0, indexOfFirstEqual);
+          String right = token.substring(indexOfFirstEqual + 1);
+          if (left.length() > 0) {
+            furtherSplitWithEquals.add(left);
+          }
+          if (right.length() > 0) {
+            furtherSplitWithEquals.add(right);
+          }
         }
-        if (right.length() > 0) {
-          furtherSplitWithEquals.add(right);
-        }
+      }
+      if (token.equals("--query") || token.equals("--J")) {
+        doNotRemoveEqualsInNextToken = true;
       }
     }
     return furtherSplitWithEquals;
@@ -200,7 +209,6 @@ public class GfshParser extends SimpleParser {
   @Override
   public GfshParseResult parse(String userInput) {
     String rawInput = convertToSimpleParserInput(userInput);
-
     // this tells the simpleParser not to interpret backslash as escaping character
     rawInput = rawInput.replace("\\", "\\\\");
     // User SimpleParser to parse the input

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/GfshParser.java
@@ -122,17 +122,18 @@ public class GfshParser extends SimpleParser {
     List<String> splitWithWhiteSpaces = splitWithWhiteSpace(userInput);
 
     List<String> furtherSplitWithEquals = new ArrayList<>();
-    boolean doNotRemoveEqualsInNextToken = false;
     for (String token : splitWithWhiteSpaces) {
-      if (doNotRemoveEqualsInNextToken) {
+      int indexOfFirstEqual = token.indexOf('=');
+      int indexOfFirstDoubleQuote = token.indexOf('"');
+      int indexOfFirstSingleQuote = token.indexOf('\'');
+      if (indexOfFirstEqual < 0 || token.startsWith("-D")) {
         furtherSplitWithEquals.add(token);
-        doNotRemoveEqualsInNextToken = false;
       } else {
-        // if this token has equal sign, split around the first occurrence of it
-        int indexOfFirstEqual = token.indexOf('=');
-        if (indexOfFirstEqual < 0) {
+        if (indexOfFirstDoubleQuote == 0 || indexOfFirstSingleQuote == 0) {
           furtherSplitWithEquals.add(token);
-        } else {
+        } else if ((indexOfFirstDoubleQuote < 0 && indexOfFirstSingleQuote < 0)
+            || (indexOfFirstEqual < indexOfFirstDoubleQuote)
+            || (indexOfFirstEqual < indexOfFirstSingleQuote)) {
           String left = token.substring(0, indexOfFirstEqual);
           String right = token.substring(indexOfFirstEqual + 1);
           if (left.length() > 0) {
@@ -142,9 +143,6 @@ public class GfshParser extends SimpleParser {
             furtherSplitWithEquals.add(right);
           }
         }
-      }
-      if (token.equals("--query") || token.equals("--J")) {
-        doNotRemoveEqualsInNextToken = true;
       }
     }
     return furtherSplitWithEquals;

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/GfshParserJUnitTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/GfshParserJUnitTest.java
@@ -60,6 +60,46 @@ public class GfshParserJUnitTest {
   }
 
   @Test
+  public void testQuerySplitUserInputDoubleQuotesWithoutEquals() {
+    input = "query --query \"select * from " + SEPARATOR + "region\"";
+    tokens = GfshParser.splitUserInput(input);
+    assertThat(tokens.size()).isEqualTo(3);
+    assertThat(tokens.get(0)).isEqualTo("query");
+    assertThat(tokens.get(1)).isEqualTo("--query");
+    assertThat(tokens.get(2)).isEqualTo("\"select * from " + SEPARATOR + "region\"");
+  }
+
+  @Test
+  public void testQuerySplitUserInputSingleQuotesWithoutEquals() {
+    input = "query --query 'select * from " + SEPARATOR + "region'";
+    tokens = GfshParser.splitUserInput(input);
+    assertThat(tokens.size()).isEqualTo(3);
+    assertThat(tokens.get(0)).isEqualTo("query");
+    assertThat(tokens.get(1)).isEqualTo("--query");
+    assertThat(tokens.get(2)).isEqualTo("'select * from " + SEPARATOR + "region'");
+  }
+
+  @Test
+  public void testQuerySplitUserInputWithEqualsInQuery() {
+    input = "query --query 'select * from " + SEPARATOR + "region r where r <= 5'";
+    tokens = GfshParser.splitUserInput(input);
+    assertThat(tokens.size()).isEqualTo(3);
+    assertThat(tokens.get(0)).isEqualTo("query");
+    assertThat(tokens.get(1)).isEqualTo("--query");
+    assertThat(tokens.get(2)).isEqualTo("'select * from " + SEPARATOR + "region r where r <= 5'");
+  }
+
+  @Test
+  public void testQuerySplitUserInputWithDoubleEqualsInQuery() {
+    input = "query --query 'select * from " + SEPARATOR + "region r where r == 5'";
+    tokens = GfshParser.splitUserInput(input);
+    assertThat(tokens.size()).isEqualTo(3);
+    assertThat(tokens.get(0)).isEqualTo("query");
+    assertThat(tokens.get(1)).isEqualTo("--query");
+    assertThat(tokens.get(2)).isEqualTo("'select * from " + SEPARATOR + "region r where r == 5'");
+  }
+
+  @Test
   public void testSplitUserInputWithMixedQuotes() {
     input = "command option='test1 \"test \" test1'";
     tokens = GfshParser.splitUserInput(input);
@@ -83,6 +123,18 @@ public class GfshParserJUnitTest {
   }
 
   @Test
+  public void testSplitUserInputWithJWithNoEquals() {
+    input =
+        "start server --name=server1  --J \"-Dgemfire.start-dev-rest-api=true\" --J '-Dgemfire.http-service-port=8080' --J '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=30000'";
+    tokens = GfshParser.splitUserInput(input);
+    assertThat(tokens.size()).isEqualTo(10);
+    assertThat(tokens.get(5)).isEqualTo("\"-Dgemfire.start-dev-rest-api=true\"");
+    assertThat(tokens.get(7)).isEqualTo("'-Dgemfire.http-service-port=8080'");
+    assertThat(tokens.get(9))
+        .isEqualTo("'-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=30000'");
+  }
+
+  @Test
   public void splitWithWhiteSpacesExceptQuoted() {
     input = "create region --cache-writer=\"my.abc{'k1' : 'v   1', 'k2' : 'v2'}\"";
     tokens = GfshParser.splitUserInput(input);
@@ -94,6 +146,16 @@ public class GfshParserJUnitTest {
   public void testSplitUserInputWithJNoQuotes() {
     input =
         "start server --name=server1  --J=-Dgemfire.start-dev-rest-api=true --J=-Dgemfire.http-service-port=8080";
+    tokens = GfshParser.splitUserInput(input);
+    assertThat(tokens.size()).isEqualTo(8);
+    assertThat(tokens.get(5)).isEqualTo("-Dgemfire.start-dev-rest-api=true");
+    assertThat(tokens.get(7)).isEqualTo("-Dgemfire.http-service-port=8080");
+  }
+
+  @Test
+  public void testSplitUserInputWithJNoQuotesNoEquals() {
+    input =
+        "start server --name=server1  --J -Dgemfire.start-dev-rest-api=true --J -Dgemfire.http-service-port=8080";
     tokens = GfshParser.splitUserInput(input);
     assertThat(tokens.size()).isEqualTo(8);
     assertThat(tokens.get(5)).isEqualTo("-Dgemfire.start-dev-rest-api=true");


### PR DESCRIPTION
When parsing the user input in gfsh, the first `=` character position was used to split strings which were expected to follow the pattern `--parameter=value`. But if the `=` sign is not introduced, the `=` is deleted in `--parameter` and `value` (if exists).

In the case of `--query` parameter, the value of the parameter (the query itself) is very likely to contain a `=`, which could be removed from the query.

With this modification, if a query is introduced without the `=` between `--query` and the query statement, the `=` will not be removed from the query.

I also have included the `--J` parameter in this check, because its value is always containing a `=`.