### PR TITLE
GEODE-8158: enhance LocalHostUtil to support anyLocalAddress

### DIFF
--- a/geode-common/src/main/java/org/apache/geode/internal/inet/LocalHostUtil.java
+++ b/geode-common/src/main/java/org/apache/geode/internal/inet/LocalHostUtil.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.inet;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
@@ -217,6 +218,14 @@ public class LocalHostUtil {
   }
 
   /**
+   * Returns the special address that can be used to bind to all local addresses.
+   * In most cases this will be "0.0.0.0".
+   */
+  public static InetAddress getAnyLocalAddress() {
+    return new InetSocketAddress(0).getAddress();
+  }
+
+  /**
    * Returns true if host matches the LOCALHOST.
    */
   public static boolean isLocalHost(Object host) {
@@ -225,6 +234,8 @@ public class LocalHostUtil {
       if (isLocalHost(inetAddress)) {
         return true;
       } else if (inetAddress.isLoopbackAddress()) {
+        return true;
+      } else if (inetAddress.isAnyLocalAddress()) {
         return true;
       } else {
         try {

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -33,6 +33,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.GeodeRedisService;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -132,6 +133,28 @@ public class GeodeRedisServerStartupDUnitTest {
           .withProperty(REDIS_ENABLED, "true")))
               .hasRootCauseMessage("Address already in use");
     }
+  }
+
+  @Test
+  public void startupWorksGivenAnyLocalAddress() {
+    String anyLocal = LocalHostUtil.getAnyLocalAddress().getHostAddress();
+    MemberVM server = cluster.startServerVM(0, s -> s
+        .withProperty(REDIS_PORT, "0")
+        .withProperty(REDIS_BIND_ADDRESS, anyLocal)
+        .withProperty(REDIS_ENABLED, "true"));
+
+    assertThat(cluster.getRedisPort(server))
+        .isNotEqualTo(GeodeRedisServer.DEFAULT_REDIS_SERVER_PORT);
+  }
+
+  @Test
+  public void startupWorksGivenNoBindAddress() {
+    MemberVM server = cluster.startServerVM(0, s -> s
+        .withProperty(REDIS_PORT, "0")
+        .withProperty(REDIS_ENABLED, "true"));
+
+    assertThat(cluster.getRedisPort(server))
+        .isNotEqualTo(GeodeRedisServer.DEFAULT_REDIS_SERVER_PORT);
   }
 
 }


### PR DESCRIPTION
Changed redis to have its default bind address to be anyLocalAddress instead of a single local address.

LocalHostUtil now has anyLocalAddress support.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
