### PR TITLE
GEODE-8218: Update docs to reflect changes to default redis-bind-address behavior

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1918,8 +1918,8 @@ public interface ConfigurationProperties {
    * name="redis-bind-address"/a>
    * </p>
    * <U>Description</U>: Specifies the address on which the Redis API for Geode is listening. If set
-   * to the empty string or this property is not specified, localhost is requested from the
-   * operating system.
+   * to the empty string or this property is not specified, the server will listen on all local
+   * addresses.
    * </p>
    * <U>Default</U>: ""
    */

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1918,7 +1918,7 @@ public interface ConfigurationProperties {
    * name="redis-bind-address"/a>
    * </p>
    * <U>Description</U>: Specifies the address on which the Redis API for Geode is listening. If set
-   * to the empty string or this property is not specified, the server will listen on all local
+   * to the empty string or this property is not specified, the server listens on all local
    * addresses.
    * </p>
    * <U>Default</U>: ""

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -2571,7 +2571,7 @@ public class CliStrings {
   public static final String START_SERVER__REDIS_BIND_ADDRESS =
       ConfigurationProperties.REDIS_BIND_ADDRESS;
   public static final String START_SERVER__REDIS_BIND_ADDRESS__HELP =
-      "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, localhost is requested from the operating system.";
+      "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, the server will listen on all local addresses.";
   public static final String START_SERVER__REDIS_PASSWORD = ConfigurationProperties.REDIS_PASSWORD;
   public static final String START_SERVER__REDIS_PASSWORD__HELP =
       "Specifies the password that the server uses when a client attempts to authenticate. The default is none and no authentication will be required.";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -2571,7 +2571,7 @@ public class CliStrings {
   public static final String START_SERVER__REDIS_BIND_ADDRESS =
       ConfigurationProperties.REDIS_BIND_ADDRESS;
   public static final String START_SERVER__REDIS_BIND_ADDRESS__HELP =
-      "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, the server will listen on all local addresses.";
+      "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, the server listens on all local addresses.";
   public static final String START_SERVER__REDIS_PASSWORD = ConfigurationProperties.REDIS_PASSWORD;
   public static final String START_SERVER__REDIS_PASSWORD__HELP =
       "Specifies the password that the server uses when a client attempts to authenticate. The default is none and no authentication will be required.";

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -489,7 +489,7 @@ off-heap-memory-size=120g</code></pre></td>
 <tr>
 <td>redis-bind-address</td>
 <td>Specifies the address on which the Redis API for <%=vars.product_name%> is listening. If set to the empty string or this property is not
-specified, the server will listen on all local addresses.
+specified, the server listens on all local addresses.
 <td>S</td>
 <td><code>""</code></td>
 </tr>

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -489,7 +489,7 @@ off-heap-memory-size=120g</code></pre></td>
 <tr>
 <td>redis-bind-address</td>
 <td>Specifies the address on which the Redis API for <%=vars.product_name%> is listening. If set to the empty string or this property is not
-specified, localhost is requested from the operating system.</td>
+specified, the server will listen on all local addresses.
 <td>S</td>
 <td><code>""</code></td>
 </tr>


### PR DESCRIPTION
Geode Redis API now listens on all local addresses when bind-address is not specified. The docs should be updated to reflect this change.