### PR TITLE
GEODE-8226: change publish to work with non-redis servers present 

### DIFF
--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/PubSubDUnitTest.java
@@ -48,7 +48,7 @@ public class PubSubDUnitTest {
   public static final String CHANNEL_NAME = "salutations";
 
   @ClassRule
-  public static RedisClusterStartupRule cluster = new RedisClusterStartupRule(5);
+  public static RedisClusterStartupRule cluster = new RedisClusterStartupRule(6);
 
   @ClassRule
   public static GfshCommandRule gfsh = new GfshCommandRule();
@@ -69,6 +69,7 @@ public class PubSubDUnitTest {
   private static MemberVM server2;
   private static MemberVM server3;
   private static MemberVM server4;
+  private static MemberVM server5;
 
   private static int redisServerPort1;
   private static int redisServerPort2;
@@ -86,6 +87,7 @@ public class PubSubDUnitTest {
     server2 = cluster.startRedisVM(2, locator.getPort());
     server3 = cluster.startRedisVM(3, locator.getPort());
     server4 = cluster.startRedisVM(4, locator.getPort());
+    server5 = cluster.startServerVM(5, locator.getPort());
 
     redisServerPort1 = cluster.getRedisPort(1);
     redisServerPort2 = cluster.getRedisPort(2);
@@ -117,6 +119,7 @@ public class PubSubDUnitTest {
     server2.stop();
     server3.stop();
     server4.stop();
+    server5.stop();
   }
 
   @Test
@@ -187,24 +190,23 @@ public class PubSubDUnitTest {
 
   private void restartServerVM1() {
     cluster.startRedisVM(1, locator.getPort());
-    await()
-        .untilAsserted(() -> gfsh.executeAndAssertThat("list members")
-            .statusIsSuccess()
-            .hasTableSection()
-            .hasColumn("Name")
-            .containsOnly("locator-0", "server-1", "server-2", "server-3", "server-4"));
+    waitForRestart();
     redisServerPort1 = cluster.getRedisPort(1);
   }
 
   private void restartServerVM2() {
     cluster.startRedisVM(2, locator.getPort());
+    waitForRestart();
+    redisServerPort2 = cluster.getRedisPort(2);
+  }
+
+  private void waitForRestart() {
     await()
         .untilAsserted(() -> gfsh.executeAndAssertThat("list members")
             .statusIsSuccess()
             .hasTableSection()
             .hasColumn("Name")
-            .containsOnly("locator-0", "server-1", "server-2", "server-3", "server-4"));
-    redisServerPort2 = cluster.getRedisPort(2);
+            .containsOnly("locator-0", "server-1", "server-2", "server-3", "server-4", "server-5"));
   }
 
   private void reconnectSubscriber1() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -52,6 +52,7 @@ import org.apache.geode.annotations.Experimental;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
@@ -376,6 +377,7 @@ public class GeodeRedisServer {
           redisKeyCommands.pttl(entry.getKey());
         }
       }
+    } catch (CacheClosedException ignore) {
     } catch (RuntimeException | Error ex) {
       logger.warn("Passive Redis expiration failed. Will try again in 1 second.", ex);
     }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
@@ -34,7 +34,8 @@ public class PublishExecutor extends AbstractExecutor {
     }
 
     String channelName = new String(args.get(1));
-    long publishCount = context.getPubSub().publish(channelName, args.get(2));
+    long publishCount =
+        context.getPubSub().publish(getDataRegion(context), channelName, args.get(2));
 
     return RedisResponse.integer(publishCount);
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -16,11 +16,10 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
-
-import org.apache.geode.cache.Region;
 
 /**
  * Interface that represents the ability to Publish, Subscribe and Unsubscribe from channels.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -20,6 +20,8 @@ import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
+import org.apache.geode.cache.Region;
+
 /**
  * Interface that represents the ability to Publish, Subscribe and Unsubscribe from channels.
  */
@@ -28,11 +30,14 @@ public interface PubSub {
   /**
    * Publish a message on a channel
    *
+   *
    * @param channel to publish to
    * @param message to publish
    * @return the number of messages published
    */
-  long publish(String channel, byte[] message);
+  long publish(
+      Region<ByteArrayWrapper, RedisData> dataRegion,
+      String channel, byte[] message);
 
   /**
    * Subscribe to a channel

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -17,6 +17,8 @@
 package org.apache.geode.redis.internal.pubsub;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.data.ByteArrayWrapper;
+import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -16,15 +16,22 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.cache.partition.PartitionMemberInfo;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.cache.partition.PartitionRegionInfo;
+import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
@@ -49,10 +56,17 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
-  public long publish(String channel, byte[] message) {
+  public long publish(
+      Region<ByteArrayWrapper, RedisData> dataRegion,
+      String channel, byte[] message) {
+    PartitionRegionInfo info = PartitionRegionHelper.getPartitionRegionInfo(dataRegion);
+    Set<DistributedMember> membersWithDataRegion = new HashSet<>();
+    for (PartitionMemberInfo memberInfo : info.getPartitionMemberInfo()) {
+      membersWithDataRegion.add(memberInfo.getDistributedMember());
+    }
     @SuppressWarnings("unchecked")
     ResultCollector<String[], List<Long>> subscriberCountCollector = FunctionService
-        .onMembers()
+        .onMembers(membersWithDataRegion)
         .setArguments(new Object[] {channel, message})
         .execute(REDIS_PUB_SUB_FUNCTION_ID);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -33,6 +33,8 @@ import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.cache.partition.PartitionRegionInfo;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.data.ByteArrayWrapper;
+import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;


### PR DESCRIPTION
Changed PubSubDUnitTest to have an additional non-redis server.
This caused multiple tests in it to fail.
Changed the publish code that uses the FunctionService
to only execute the function on members that have the redis data region.
The tests started passing.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
