### PR TITLE
GEODE-8230: run benchmarks in parallel with other CI jobs

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -139,6 +139,11 @@ groups:
   - {{test.name}}Test{{java_test_version.name}}
   {%- endfor -%}
 {%- endfor %}
+- name: Benchmarks
+  jobs:
+  {%- for run_var in (benchmarks.flavors) %}
+  - Benchmark{{ run_var.title }}
+  {%- endfor %}
 - name: Semver Management
   jobs:
   {%- for semverPiece in ['major', 'minor', 'patch'] %}

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -86,7 +86,7 @@ GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 
 {% macro all_gating_jobs() %}
   {%- for test in (tests) if not test.name=="StressNew" -%}
-  {%- for java_test_version in (java_test_versions) %}
+  {%- for java_test_version in (java_test_versions) if ((not test.ONLY_JDK is defined) or test.ONLY_JDK==java_test_version.version) %}
 - {{test.name}}Test{{java_test_version.name}}
   {%- endfor -%}
   {%- endfor -%}
@@ -116,7 +116,7 @@ groups:
   jobs:
   - {{ build_test.name }}
   {%- for test in (tests) if test.PLATFORM=="linux" and not test.name=="StressNew" -%}
-    {% for java_test_version in (java_test_versions) %}
+    {% for java_test_version in (java_test_versions) if ((not test.ONLY_JDK is defined) or test.ONLY_JDK==java_test_version.version) %}
   - {{test.name}}Test{{java_test_version.name}}
     {%- endfor -%}
   {%- endfor %}
@@ -127,7 +127,7 @@ groups:
   jobs:
   - {{ build_test.name }}
   {%- for test in (tests) if test.PLATFORM=="windows" -%}
-    {% for java_test_version in (java_test_versions) %}
+    {% for java_test_version in (java_test_versions) if ((not test.ONLY_JDK is defined) or test.ONLY_JDK==java_test_version.version) %}
   - {{test.name}}Test{{java_test_version.name}}
     {%- endfor -%}
   {%- endfor %}
@@ -135,7 +135,7 @@ groups:
 - name: {{java_test_version.name}}
   jobs:
   - {{ build_test.name }}
-  {%- for test in (tests) if not test.name=="StressNew" %}
+  {%- for test in (tests) if (not test.name=="StressNew") and ((not test.ONLY_JDK is defined) or test.ONLY_JDK==java_test_version.version) %}
   - {{test.name}}Test{{java_test_version.name}}
   {%- endfor -%}
 {%- endfor %}
@@ -608,7 +608,7 @@ jobs:
 {%- for test in tests if not test.name=="StressNew" %}
   {%- set parameters = {} %}
   {%- do deep_merge(parameters, test) %}
-  {%- for java_test_version in (java_test_versions) %}
+  {%- for java_test_version in (java_test_versions) if ((not test.ONLY_JDK is defined) or test.ONLY_JDK==java_test_version.version) %}
     {%- if java_test_version.override is defined and java_test_version.override[test.name] is defined %}
       {%- do deep_merge(parameters, java_test_version.override[test.name]) %}
     {%- endif %}

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -90,6 +90,9 @@ GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 - {{test.name}}Test{{java_test_version.name}}
   {%- endfor -%}
   {%- endfor -%}
+  {%- for run_var in (benchmarks.flavors) %}
+- Benchmark{{ run_var.title }}
+  {%- endfor -%}
 {% endmacro %}
 
 groups:
@@ -101,24 +104,14 @@ groups:
   {%- if repository.upstream_fork != "apache" or repository.branch == "develop" or repository.branch.startswith("support/") %}
   - PublishArtifacts
   {%- endif %}
-  {%- for flavor in (benchmarks.flavors) %}
-  - Benchmark{{flavor.title}}
-  {%- endfor %}
 - name: complete
   jobs:
   - {{ build_test.name }}
-  {%- for test in (tests) if not test.name=="StressNew" -%}
-    {%- for java_test_version in (java_test_versions) %}
-  - {{test.name}}Test{{java_test_version.name}}
-    {%- endfor -%}
-  {%- endfor %}
-  - UpdatePassingTokens
+  {{- all_gating_jobs() | indent(2) }}
   {%- if repository.upstream_fork != "apache" or repository.branch == "develop" or repository.branch.startswith("support/") %}
   - PublishArtifacts
   {%- endif %}
-  {%- for flavor in (benchmarks.flavors) %}
-  - Benchmark{{flavor.title}}
-  {%- endfor %}
+  - UpdatePassingTokens
 - name: linux
   jobs:
   - {{ build_test.name }}
@@ -408,9 +401,7 @@ jobs:
 {%- if repository.upstream_fork != "apache" or repository.branch == "develop" or repository.branch.startswith("support/") %}
       - PublishArtifacts
 {% else %}
-      {% for flavor in (benchmarks.flavors) %}
-      - Benchmark{{flavor.title}}
-      {% endfor %}
+      {{- all_gating_jobs() | indent(6) }}
 {% endif %}
       trigger: true
     - get: geode-build-version
@@ -459,22 +450,20 @@ jobs:
 {% for run_var in (benchmarks.flavors) %}
 - name: Benchmark{{ run_var.title }}
   public: true
-  max_in_flight: 3
+  max_in_flight: 2
   plan:
   - get: geode-ci
-    passed:
-    {{ all_gating_jobs() | indent(4) }}
+    passed: &benchmark-inputs
+    - Build
   - get: alpine-tools-image
   - aggregate:
     - get: geode
-      passed:
-      {{ all_gating_jobs() | indent(6) }}
+      passed: *benchmark-inputs
       trigger: true
     - get: geode-benchmarks
     - get: geode-build-version
       trigger: true
-      passed:
-      {{ all_gating_jobs() | indent(6) }}
+      passed: *benchmark-inputs
     - put: concourse-metadata-resource
   - do:
     - task: run_benchmarks{{ run_var.title }}
@@ -536,9 +525,7 @@ jobs:
   - aggregate:
     - get: geode-ci
       passed: &publish-passed-inputs
-      {% for flavor in (benchmarks.flavors) %}
-      - Benchmark{{flavor.title}}
-      {% endfor %}
+      {{- all_gating_jobs() | indent(6) }}
     - get: alpine-tools-image
     - get: geode
       passed: *publish-passed-inputs

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -85,6 +85,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 30m
   GRADLE_TASK: test
   MAX_IN_FLIGHT: 1
+  ONLY_JDK: 8
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'true'
   PLATFORM: linux
@@ -209,6 +210,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 1h
   GRADLE_TASK: geode-assembly:japicmp
   MAX_IN_FLIGHT: 1
+  ONLY_JDK: 8
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: linux


### PR DESCRIPTION
before, we ran Build, then all <x>Test jobs in parallel (which takes ~5 hours), then all Benchmark<x> jobs (which takes ~5 hours).

Presumably the benchmarks were run after all tests, on the premise that benchmarks are meaningless if the code is not correct.  However, required PR checks now prevent incorrect code from getting into develop in the first place, and the remaining occasional failures are flaky, so it's rather arbitrary to gate benchmarks on a lottery.

However, faster feedback has clear benefits, hence this PR to cut our CI pipeline from 10 hours to 5 hours.

Also eliminates redundant jobs (ApiCheck and UnitTest are deterministic and already have required JDK11 flavors in the PR pipeline, so JDK8 flavor only is more than sufficient in the develop pipeline)

Also decreases benchmarks max_in_flight from 3 to 2, since now that we have support branches, we don't want to max our quota just from develop.  Some sort of global "pool" resource might be a more elegant way to manage this resource quota across pipelines.