### PR TITLE
GEODE-8232: add better error message for unimplemented redis commands

### DIFF
--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/RenameNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/RenameNativeRedisAcceptanceTest.java
@@ -18,6 +18,8 @@ import java.util.Random;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
@@ -40,4 +42,9 @@ public class RenameNativeRedisAcceptanceTest extends RenameIntegrationTest {
     jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
     jedis3 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
   }
+
+  @Override
+  @Test
+  @Ignore("native redis does implement renamenx")
+  public void renamenxIsUnimplemented() {}
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/RenameIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/RenameIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -364,4 +365,11 @@ public class RenameIntegrationTest {
     }
     return strings;
   }
+
+  @Test
+  public void renamenxIsUnimplemented() {
+    assertThatThrownBy(() -> jedis.renamenx("foo", "newfoo"))
+        .hasMessageContaining("RENAMENX is not implemented.");
+  }
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandSupportLevel.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandSupportLevel.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal;
+
+public enum RedisCommandSupportLevel {
+  SUPPORTED,
+  UNSUPPORTED,
+  UNIMPLEMENTED
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -15,6 +15,10 @@
 
 package org.apache.geode.redis.internal;
 
+import static org.apache.geode.redis.internal.RedisCommandSupportLevel.SUPPORTED;
+import static org.apache.geode.redis.internal.RedisCommandSupportLevel.UNIMPLEMENTED;
+import static org.apache.geode.redis.internal.RedisCommandSupportLevel.UNSUPPORTED;
+
 import org.apache.geode.redis.internal.ParameterRequirements.EvenParameterRequirements;
 import org.apache.geode.redis.internal.ParameterRequirements.ExactParameterRequirements;
 import org.apache.geode.redis.internal.ParameterRequirements.MaximumParameterRequirements;
@@ -117,53 +121,53 @@ public enum RedisCommandType {
 
   /*************** Keys ******************/
 
-  DEL(new DelExecutor(), true, new MinimumParameterRequirements(2)),
-  EXISTS(new ExistsExecutor(), true, new MinimumParameterRequirements(2)),
-  EXPIRE(new ExpireExecutor(), true),
-  EXPIREAT(new ExpireAtExecutor(), true),
-  KEYS(new KeysExecutor(), true),
-  PERSIST(new PersistExecutor(), true),
-  PEXPIRE(new PExpireExecutor(), true),
-  PEXPIREAT(new PExpireAtExecutor(), true),
-  PTTL(new PTTLExecutor(), true),
-  RENAME(new RenameExecutor(), true, new ExactParameterRequirements(3)),
-  TTL(new TTLExecutor(), true),
-  TYPE(new TypeExecutor(), true),
+  DEL(new DelExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
+  EXISTS(new ExistsExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
+  EXPIRE(new ExpireExecutor(), SUPPORTED),
+  EXPIREAT(new ExpireAtExecutor(), SUPPORTED),
+  KEYS(new KeysExecutor(), SUPPORTED),
+  PERSIST(new PersistExecutor(), SUPPORTED),
+  PEXPIRE(new PExpireExecutor(), SUPPORTED),
+  PEXPIREAT(new PExpireAtExecutor(), SUPPORTED),
+  PTTL(new PTTLExecutor(), SUPPORTED),
+  RENAME(new RenameExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
+  TTL(new TTLExecutor(), SUPPORTED),
+  TYPE(new TypeExecutor(), SUPPORTED),
 
   /************* Strings *****************/
 
-  APPEND(new AppendExecutor(), true, new ExactParameterRequirements(3)),
-  GET(new GetExecutor(), true, new ExactParameterRequirements(2)),
-  SET(new SetExecutor(), true, new MinimumParameterRequirements(3)),
+  APPEND(new AppendExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
+  GET(new GetExecutor(), SUPPORTED, new ExactParameterRequirements(2)),
+  SET(new SetExecutor(), SUPPORTED, new MinimumParameterRequirements(3)),
 
   /************* Hashes *****************/
 
-  HGETALL(new HGetAllExecutor(), true, new ExactParameterRequirements(2)),
-  HMSET(new HMSetExecutor(), true,
+  HGETALL(new HGetAllExecutor(), SUPPORTED, new ExactParameterRequirements(2)),
+  HMSET(new HMSetExecutor(), SUPPORTED,
       new MinimumParameterRequirements(4).and(new EvenParameterRequirements())),
-  HSET(new HSetExecutor(), true,
+  HSET(new HSetExecutor(), SUPPORTED,
       new MinimumParameterRequirements(4).and(new EvenParameterRequirements())),
 
   /************* Sets *****************/
 
-  SADD(new SAddExecutor(), true, new MinimumParameterRequirements(3)),
-  SMEMBERS(new SMembersExecutor(), true, new ExactParameterRequirements(2)),
-  SREM(new SRemExecutor(), true, new MinimumParameterRequirements(3)),
+  SADD(new SAddExecutor(), SUPPORTED, new MinimumParameterRequirements(3)),
+  SMEMBERS(new SMembersExecutor(), SUPPORTED, new ExactParameterRequirements(2)),
+  SREM(new SRemExecutor(), SUPPORTED, new MinimumParameterRequirements(3)),
 
   /********** Publish Subscribe **********/
 
-  SUBSCRIBE(new SubscribeExecutor(), true),
-  PUBLISH(new PublishExecutor(), true),
-  UNSUBSCRIBE(new UnsubscribeExecutor(), true),
-  PSUBSCRIBE(new PsubscribeExecutor(), true),
-  PUNSUBSCRIBE(new PunsubscribeExecutor(), true),
+  SUBSCRIBE(new SubscribeExecutor(), SUPPORTED),
+  PUBLISH(new PublishExecutor(), SUPPORTED),
+  UNSUBSCRIBE(new UnsubscribeExecutor(), SUPPORTED),
+  PSUBSCRIBE(new PsubscribeExecutor(), SUPPORTED),
+  PUNSUBSCRIBE(new PunsubscribeExecutor(), SUPPORTED),
 
   /*************** Server ****************/
 
-  AUTH(new AuthExecutor(), true),
-  PING(new PingExecutor(), true),
-  QUIT(new QuitExecutor(), true),
-  UNKNOWN(new UnknownExecutor(), true),
+  AUTH(new AuthExecutor(), SUPPORTED),
+  PING(new PingExecutor(), SUPPORTED),
+  QUIT(new QuitExecutor(), SUPPORTED),
+  UNKNOWN(new UnknownExecutor(), SUPPORTED),
 
 
   /***************************************
@@ -174,96 +178,219 @@ public enum RedisCommandType {
    *************** Keys ******************
    ***************************************/
 
-  FLUSHALL(new FlushAllExecutor(), false),
-  FLUSHDB(new FlushAllExecutor(), false),
-  SCAN(new ScanExecutor(), false),
+  FLUSHALL(new FlushAllExecutor(), UNSUPPORTED),
+  FLUSHDB(new FlushAllExecutor(), UNSUPPORTED),
+  SCAN(new ScanExecutor(), UNSUPPORTED),
 
   /***************************************
    ************** Strings ****************
    ***************************************/
 
-  BITCOUNT(new BitCountExecutor(), false),
-  BITOP(new BitOpExecutor(), false),
-  BITPOS(new BitPosExecutor(), false),
-  DECR(new DecrExecutor(), false),
-  DECRBY(new DecrByExecutor(), false),
-  GETBIT(new GetBitExecutor(), false),
-  GETRANGE(new GetRangeExecutor(), false),
-  GETSET(new GetSetExecutor(), false),
-  INCR(new IncrExecutor(), false),
-  INCRBY(new IncrByExecutor(), false),
-  INCRBYFLOAT(new IncrByFloatExecutor(), false),
-  MGET(new MGetExecutor(), false),
-  MSET(new MSetExecutor(), false),
-  MSETNX(new MSetNXExecutor(), false),
-  PSETEX(new PSetEXExecutor(), false),
-  SETEX(new SetEXExecutor(), false),
-  SETBIT(new SetBitExecutor(), false),
-  SETNX(new SetNXExecutor(), false),
-  SETRANGE(new SetRangeExecutor(), false),
-  STRLEN(new StrlenExecutor(), false),
+  BITCOUNT(new BitCountExecutor(), UNSUPPORTED),
+  BITOP(new BitOpExecutor(), UNSUPPORTED),
+  BITPOS(new BitPosExecutor(), UNSUPPORTED),
+  DECR(new DecrExecutor(), UNSUPPORTED),
+  DECRBY(new DecrByExecutor(), UNSUPPORTED),
+  GETBIT(new GetBitExecutor(), UNSUPPORTED),
+  GETRANGE(new GetRangeExecutor(), UNSUPPORTED),
+  GETSET(new GetSetExecutor(), UNSUPPORTED),
+  INCR(new IncrExecutor(), UNSUPPORTED),
+  INCRBY(new IncrByExecutor(), UNSUPPORTED),
+  INCRBYFLOAT(new IncrByFloatExecutor(), UNSUPPORTED),
+  MGET(new MGetExecutor(), UNSUPPORTED),
+  MSET(new MSetExecutor(), UNSUPPORTED),
+  MSETNX(new MSetNXExecutor(), UNSUPPORTED),
+  PSETEX(new PSetEXExecutor(), UNSUPPORTED),
+  SETEX(new SetEXExecutor(), UNSUPPORTED),
+  SETBIT(new SetBitExecutor(), UNSUPPORTED),
+  SETNX(new SetNXExecutor(), UNSUPPORTED),
+  SETRANGE(new SetRangeExecutor(), UNSUPPORTED),
+  STRLEN(new StrlenExecutor(), UNSUPPORTED),
 
   /***************************************
    **************** Hashes ***************
    ***************************************/
 
-  HDEL(new HDelExecutor(), false, new MinimumParameterRequirements(3)),
-  HEXISTS(new HExistsExecutor(), false, new ExactParameterRequirements(3)),
-  HGET(new HGetExecutor(), false, new ExactParameterRequirements(3)),
-  HINCRBY(new HIncrByExecutor(), false, new ExactParameterRequirements(4)),
-  HINCRBYFLOAT(new HIncrByFloatExecutor(), false, new ExactParameterRequirements(4)),
-  HKEYS(new HKeysExecutor(), false, new ExactParameterRequirements(2)),
-  HLEN(new HLenExecutor(), false, new ExactParameterRequirements(2)),
-  HMGET(new HMGetExecutor(), false, new MinimumParameterRequirements(3)),
-  HSCAN(new HScanExecutor(), false, new MinimumParameterRequirements(3)),
-  HSETNX(new HSetNXExecutor(), false, new ExactParameterRequirements(4)),
-  HVALS(new HValsExecutor(), false, new ExactParameterRequirements(2)),
+  HDEL(new HDelExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
+  HEXISTS(new HExistsExecutor(), UNSUPPORTED, new ExactParameterRequirements(3)),
+  HGET(new HGetExecutor(), UNSUPPORTED, new ExactParameterRequirements(3)),
+  HINCRBY(new HIncrByExecutor(), UNSUPPORTED, new ExactParameterRequirements(4)),
+  HINCRBYFLOAT(new HIncrByFloatExecutor(), UNSUPPORTED, new ExactParameterRequirements(4)),
+  HKEYS(new HKeysExecutor(), UNSUPPORTED, new ExactParameterRequirements(2)),
+  HLEN(new HLenExecutor(), UNSUPPORTED, new ExactParameterRequirements(2)),
+  HMGET(new HMGetExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
+  HSCAN(new HScanExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
+  HSETNX(new HSetNXExecutor(), UNSUPPORTED, new ExactParameterRequirements(4)),
+  HVALS(new HValsExecutor(), UNSUPPORTED, new ExactParameterRequirements(2)),
 
   /***************************************
    **************** Sets *****************
    ***************************************/
 
-  SCARD(new SCardExecutor(), false, new ExactParameterRequirements(2)),
-  SDIFF(new SDiffExecutor(), false, new MinimumParameterRequirements(2)),
-  SDIFFSTORE(new SDiffStoreExecutor(), false, new MinimumParameterRequirements(3)),
-  SISMEMBER(new SIsMemberExecutor(), false, new ExactParameterRequirements(3)),
-  SINTER(new SInterExecutor(), false, new MinimumParameterRequirements(2)),
-  SINTERSTORE(new SInterStoreExecutor(), false, new MinimumParameterRequirements(3)),
-  SMOVE(new SMoveExecutor(), false, new ExactParameterRequirements(4)),
-  SPOP(new SPopExecutor(), false,
+  SCARD(new SCardExecutor(), UNSUPPORTED, new ExactParameterRequirements(2)),
+  SDIFF(new SDiffExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
+  SDIFFSTORE(new SDiffStoreExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
+  SISMEMBER(new SIsMemberExecutor(), UNSUPPORTED, new ExactParameterRequirements(3)),
+  SINTER(new SInterExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
+  SINTERSTORE(new SInterStoreExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
+  SMOVE(new SMoveExecutor(), UNSUPPORTED, new ExactParameterRequirements(4)),
+  SPOP(new SPopExecutor(), UNSUPPORTED,
       new MinimumParameterRequirements(2).and(new MaximumParameterRequirements(3))
           .and(new SpopParameterRequirements())),
-  SRANDMEMBER(new SRandMemberExecutor(), false, new MinimumParameterRequirements(2)),
-  SUNION(new SUnionExecutor(), false, new MinimumParameterRequirements(2)),
-  SUNIONSTORE(new SUnionStoreExecutor(), false, new MinimumParameterRequirements(3)),
-  SSCAN(new SScanExecutor(), false, new MinimumParameterRequirements(3)),
+  SRANDMEMBER(new SRandMemberExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
+  SUNION(new SUnionExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
+  SUNIONSTORE(new SUnionStoreExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
+  SSCAN(new SScanExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
 
   /***************************************
    *************** Server ****************
    ***************************************/
 
-  DBSIZE(new DBSizeExecutor(), false),
-  ECHO(new EchoExecutor(), false),
-  TIME(new TimeExecutor(), false),
-  SHUTDOWN(new ShutDownExecutor(), false);
+  DBSIZE(new DBSizeExecutor(), UNSUPPORTED),
+  ECHO(new EchoExecutor(), UNSUPPORTED),
+  TIME(new TimeExecutor(), UNSUPPORTED),
+  SHUTDOWN(new ShutDownExecutor(), UNSUPPORTED),
+
+  /////////// UNIMPLEMENTED /////////////////////
+
+  ACL(null, UNIMPLEMENTED),
+  BGREWRITEAOF(null, UNIMPLEMENTED),
+  BGSAVE(null, UNIMPLEMENTED),
+  BITFIELD(null, UNIMPLEMENTED),
+  BLPOP(null, UNIMPLEMENTED),
+  BRPOP(null, UNIMPLEMENTED),
+  BRPOPLPUSH(null, UNIMPLEMENTED),
+  BZPOPMIN(null, UNIMPLEMENTED),
+  BZPOPMAX(null, UNIMPLEMENTED),
+  CLIENT(null, UNIMPLEMENTED),
+  CLUSTER(null, UNIMPLEMENTED),
+  COMMAND(null, UNIMPLEMENTED),
+  CONFIG(null, UNIMPLEMENTED),
+  DEBUG(null, UNIMPLEMENTED),
+  DISCARD(null, UNIMPLEMENTED),
+  DUMP(null, UNIMPLEMENTED),
+  EVAL(null, UNIMPLEMENTED),
+  EVALSHA(null, UNIMPLEMENTED),
+  EXEC(null, UNIMPLEMENTED),
+  GEOADD(null, UNIMPLEMENTED),
+  GEOHASH(null, UNIMPLEMENTED),
+  GEOPOS(null, UNIMPLEMENTED),
+  GEODIST(null, UNIMPLEMENTED),
+  GEORADIUS(null, UNIMPLEMENTED),
+  GEORADIUSBYMEMBER(null, UNIMPLEMENTED),
+  HELLO(null, UNIMPLEMENTED),
+  INFO(null, UNIMPLEMENTED),
+  LATENCY(null, UNIMPLEMENTED),
+  LASTSAVE(null, UNIMPLEMENTED),
+  LINDEX(null, UNIMPLEMENTED),
+  LINSERT(null, UNIMPLEMENTED),
+  LLEN(null, UNIMPLEMENTED),
+  LOLWUT(null, UNIMPLEMENTED),
+  LPOP(null, UNIMPLEMENTED),
+  LPUSH(null, UNIMPLEMENTED),
+  LPUSHX(null, UNIMPLEMENTED),
+  LRANGE(null, UNIMPLEMENTED),
+  LREM(null, UNIMPLEMENTED),
+  LSET(null, UNIMPLEMENTED),
+  LTRIM(null, UNIMPLEMENTED),
+  MEMORY(null, UNIMPLEMENTED),
+  MIGRATE(null, UNIMPLEMENTED),
+  MODULE(null, UNIMPLEMENTED),
+  MONITOR(null, UNIMPLEMENTED),
+  MOVE(null, UNIMPLEMENTED),
+  MULTI(null, UNIMPLEMENTED),
+  OBJECT(null, UNIMPLEMENTED),
+  PFADD(null, UNIMPLEMENTED),
+  PFCOUNT(null, UNIMPLEMENTED),
+  PFMERGE(null, UNIMPLEMENTED),
+  PSYNC(null, UNIMPLEMENTED),
+  RANDOMKEY(null, UNIMPLEMENTED),
+  READONLY(null, UNIMPLEMENTED),
+  READWRITE(null, UNIMPLEMENTED),
+  RENAMENX(null, UNIMPLEMENTED),
+  RESTORE(null, UNIMPLEMENTED),
+  ROLE(null, UNIMPLEMENTED),
+  RPOP(null, UNIMPLEMENTED),
+  RPOPLPUSH(null, UNIMPLEMENTED),
+  RPUSH(null, UNIMPLEMENTED),
+  RPUSHX(null, UNIMPLEMENTED),
+  SAVE(null, UNIMPLEMENTED),
+  SCRIPT(null, UNIMPLEMENTED),
+  SELECT(null, UNIMPLEMENTED),
+  SLAVEOF(null, UNIMPLEMENTED),
+  REPLICAOF(null, UNIMPLEMENTED),
+  SLOWLOG(null, UNIMPLEMENTED),
+  SORT(null, UNIMPLEMENTED),
+  STRALGO(null, UNIMPLEMENTED),
+  SWAPDB(null, UNIMPLEMENTED),
+  SYNC(null, UNIMPLEMENTED),
+  TOUCH(null, UNIMPLEMENTED),
+  UNLINK(null, UNIMPLEMENTED),
+  UNWATCH(null, UNIMPLEMENTED),
+  WAIT(null, UNIMPLEMENTED),
+  WATCH(null, UNIMPLEMENTED),
+  XINFO(null, UNIMPLEMENTED),
+  XADD(null, UNIMPLEMENTED),
+  XTRIM(null, UNIMPLEMENTED),
+  XDEL(null, UNIMPLEMENTED),
+  XRANGE(null, UNIMPLEMENTED),
+  XREVRANGE(null, UNIMPLEMENTED),
+  XLEN(null, UNIMPLEMENTED),
+  XREAD(null, UNIMPLEMENTED),
+  XGROUP(null, UNIMPLEMENTED),
+  XREADGROUP(null, UNIMPLEMENTED),
+  XACK(null, UNIMPLEMENTED),
+  XCLAIM(null, UNIMPLEMENTED),
+  XPENDING(null, UNIMPLEMENTED),
+  ZADD(null, UNIMPLEMENTED),
+  ZCARD(null, UNIMPLEMENTED),
+  ZCOUNT(null, UNIMPLEMENTED),
+  ZINCRBY(null, UNIMPLEMENTED),
+  ZINTERSTORE(null, UNIMPLEMENTED),
+  ZLEXCOUNT(null, UNIMPLEMENTED),
+  ZPOPMAX(null, UNIMPLEMENTED),
+  ZPOPMIN(null, UNIMPLEMENTED),
+  ZRANGE(null, UNIMPLEMENTED),
+  ZRANGEBYLEX(null, UNIMPLEMENTED),
+  ZREVRANGEBYLEX(null, UNIMPLEMENTED),
+  ZRANGEBYSCORE(null, UNIMPLEMENTED),
+  ZRANK(null, UNIMPLEMENTED),
+  ZREM(null, UNIMPLEMENTED),
+  ZREMRANGEBYLEX(null, UNIMPLEMENTED),
+  ZREMRANGEBYRANK(null, UNIMPLEMENTED),
+  ZREMRANGEBYSCORE(null, UNIMPLEMENTED),
+  ZREVRANGE(null, UNIMPLEMENTED),
+  ZREVRANGEBYSCORE(null, UNIMPLEMENTED),
+  ZREVRANK(null, UNIMPLEMENTED),
+  ZSCORE(null, UNIMPLEMENTED),
+  ZUNIONSCORE(null, UNIMPLEMENTED),
+  ZSCAN(null, UNIMPLEMENTED);
 
   private final Executor executor;
   private final ParameterRequirements parameterRequirements;
-  private final boolean supported;
+  private final RedisCommandSupportLevel supportLevel;
 
-  RedisCommandType(Executor executor, boolean supported) {
-    this(executor, supported, new UnspecifiedParameterRequirements());
+  RedisCommandType(Executor executor, RedisCommandSupportLevel supportLevel) {
+    this(executor, supportLevel, new UnspecifiedParameterRequirements());
   }
 
-  RedisCommandType(Executor executor, boolean supported,
+  RedisCommandType(Executor executor, RedisCommandSupportLevel supportLevel,
       ParameterRequirements parameterRequirements) {
     this.executor = executor;
-    this.supported = supported;
+    this.supportLevel = supportLevel;
     this.parameterRequirements = parameterRequirements;
   }
 
   public boolean isSupported() {
-    return supported;
+    return supportLevel == SUPPORTED;
+  }
+
+  public boolean isUnsupported() {
+    return supportLevel == UNSUPPORTED;
+  }
+
+  public boolean isUnimplemented() {
+    return supportLevel == UNIMPLEMENTED;
   }
 
   public RedisResponse executeCommand(Command command,

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
@@ -66,6 +66,14 @@ public class Command {
     return commandType.isSupported();
   }
 
+  public boolean isUnsupported() {
+    return commandType.isUnsupported();
+  }
+
+  public boolean isUnimplemented() {
+    return commandType.isUnimplemented();
+  }
+
   /**
    * Used to get the command element list
    *

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -211,8 +211,13 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       return;
     }
 
-    if (!(command.isSupported() || allowUnsupportedCommands())) {
+    if (command.isUnsupported() && !allowUnsupportedCommands()) {
       writeToChannel(RedisResponse.error(RedisConstants.ERROR_UNSUPPORTED_COMMAND));
+      return;
+    }
+
+    if (command.isUnimplemented()) {
+      writeToChannel(RedisResponse.error(command.getCommandType() + " is not implemented."));
       return;
     }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -217,6 +217,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     }
 
     if (command.isUnimplemented()) {
+      logger.info("Failed " + command.getCommandType() + " because it is not implemented.");
       writeToChannel(RedisResponse.error(command.getCommandType() + " is not implemented."));
       return;
     }

--- a/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
+++ b/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
@@ -1,5 +1,6 @@
 org/apache/geode/redis/internal/ParameterRequirements/RedisParametersMismatchException,true,-643700717871858072
-org/apache/geode/redis/internal/RedisCommandType,false,executor:org/apache/geode/redis/internal/executor/Executor,parameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,supported:boolean
+org/apache/geode/redis/internal/RedisCommandSupportLevel,false
+org/apache/geode/redis/internal/RedisCommandType,false,executor:org/apache/geode/redis/internal/executor/Executor,parameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,supportLevel:org/apache/geode/redis/internal/RedisCommandSupportLevel
 org/apache/geode/redis/internal/data/RedisDataType,false,toStringValue:java/lang/String
 org/apache/geode/redis/internal/data/RedisDataTypeMismatchException,true,-2451663685348513870
 org/apache/geode/redis/internal/delta/DeltaType,false

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -15,10 +15,10 @@
 
 package org.apache.geode.redis.internal;
 
+import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -144,12 +144,18 @@ public class SupportedCommandsJUnitTest {
 
   @Test
   public void checkAllDefinedCommands_areIncludedInBothLists() {
-    List<String> allCommands = new ArrayList<>(Arrays.asList(supportedCommands));
-    allCommands.addAll(Arrays.asList(unSupportedCommands));
+    List<String> allCommands = new ArrayList<>(asList(supportedCommands));
+    allCommands.addAll(asList(unSupportedCommands));
 
     List<String> definedCommands =
-        Arrays.stream(RedisCommandType.values()).map(Enum::name).collect(Collectors.toList());
+        getAllImplementedCommands().stream().map(Enum::name).collect(Collectors.toList());
 
     assertThat(definedCommands).containsExactlyInAnyOrderElementsOf(allCommands);
+  }
+
+  private List<RedisCommandType> getAllImplementedCommands() {
+    List<RedisCommandType> implementedCommands = new ArrayList<>(asList(RedisCommandType.values()));
+    implementedCommands.removeIf(RedisCommandType::isUnimplemented);
+    return implementedCommands;
   }
 }


### PR DESCRIPTION
If a known redis command that is not implemented is executed then
it will fail with the message '<command> is not implemented'.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
