### PR TITLE
GEODE-8238: message loss during shutdown in Shutdown Hook when JVM exits

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
@@ -267,6 +267,7 @@ public class DirectChannel {
         final List cons = new ArrayList(destinations.length);
         ConnectExceptions ce = getConnections(mgr, msg, destinations, orderedMsg, retry, ackTimeout,
             ackSDTimeout, cons);
+
         if (directReply && msg.getProcessorId() > 0) { // no longer a direct-reply message?
           directReply = false;
         }
@@ -689,11 +690,6 @@ public class DirectChannel {
 
     }
   }
-
-  public void closeEndpoint(InternalDistributedMember member, String reason) {
-    closeEndpoint(member, reason, true);
-  }
-
 
   /**
    * Closes any connections used to communicate with the given jgroupsAddress.

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -1261,7 +1261,7 @@ public class Connection implements Runnable {
    * Invoking this method ensures that the proper synchronization is done.
    */
   void requestClose(String reason) {
-    close(reason, true, true, false, false);
+    close(reason, true, false, false, false);
   }
 
   boolean isClosing() {
@@ -1519,9 +1519,6 @@ public class Connection implements Runnable {
   }
 
   private void readMessages() {
-    if (closing.get()) {
-      return;
-    }
     // take a snapshot of uniqueId to detect reconnect attempts
     SocketChannel channel;
     try {
@@ -3268,8 +3265,9 @@ public class Connection implements Runnable {
 
   @Override
   public String toString() {
-    return String.valueOf(remoteAddr) + '@' + uniqueId
-        + (remoteVersion != null ? '(' + remoteVersion.toString() + ')' : "");
+    return remoteAddr + "(uid=" + uniqueId + ")"
+        + (remoteVersion != null && remoteVersion != Version.CURRENT
+            ? "(v" + remoteVersion.toString() + ')' : "");
   }
 
   /**


### PR DESCRIPTION
Remove invocation of removeEndpoint when a shared/unordered connection
shuts down.  Endpoint cleanup is already initiated by DistributionImpl
during membership view installation, so it isn't needed here.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
