### PR TITLE
GEODE-8241: Locator observes locator-wait-time

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
@@ -234,7 +234,7 @@ public class MembershipIntegrationTest {
       try {
         start(lateJoiningMembership);
       } catch (MemberStartupException e) {
-        e.printStackTrace();
+        throw new RuntimeException(e);
       }
     });
 
@@ -247,13 +247,14 @@ public class MembershipIntegrationTest {
       try {
         Thread.sleep(2 * minimumJoinWaitTime.toMillis());
         start(coordinatorMembership);
-      } catch (MemberStartupException | InterruptedException e) {
-        e.printStackTrace();
+      } catch (InterruptedException ignored) {
+      } catch (MemberStartupException e) {
+        throw new RuntimeException(e);
       }
     });
 
-    await().untilAsserted(() -> assertThat(coordinatorMembershipStartup).isDone());
-    await().untilAsserted(() -> assertThat(lateJoiningMembershipStartup).isDone());
+    await().untilAsserted(() -> assertThat(coordinatorMembershipStartup).isCompleted());
+    await().untilAsserted(() -> assertThat(lateJoiningMembershipStartup).isCompleted());
 
     await().untilAsserted(
         () -> assertThat(coordinatorMembership.getView().getMembers()).hasSize(2));

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.distributed.internal.membership.gms;
 
 import static org.apache.geode.distributed.internal.membership.api.MembershipConfig.DEFAULT_LOCATOR_WAIT_TIME;
+import static org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave.FIND_LOCATOR_RETRY_SLEEP;
+import static org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave.JOIN_RETRY_SLEEP;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -221,8 +223,8 @@ public class MembershipIntegrationTest {
         new int[] {coordinatorLocatorPort, lateJoiningLocatorPort};
 
     final Duration minimumJoinWaitTime = Duration
-        .ofMillis(2_000) // expected amount of sleep time per loop in GMSJoinLeave.join()
-        .multipliedBy(lateJoiningMembershipLocatorPorts.length * 2); // expected number of loops
+        .ofMillis(JOIN_RETRY_SLEEP + FIND_LOCATOR_RETRY_SLEEP) // amount of sleep time per retry
+        .multipliedBy(lateJoiningMembershipLocatorPorts.length * 2); // expected number of retries
     final int locatorWaitTime = (int) (3 * minimumJoinWaitTime.getSeconds());
 
     final MembershipConfig lateJoiningMembershipConfig =

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -300,6 +300,11 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
     return viewInstallationLock;
   }
 
+  @VisibleForTesting
+  public static int getMinimumRetriesBeforeBecomingCoordinator(int locatorsSize) {
+    return locatorsSize * 2;
+  }
+
   /**
    * attempt to join the distributed system loop send a join request to a locator & get a response
    * <p>
@@ -329,7 +334,8 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
       long startTime = System.currentTimeMillis();
       long locatorGiveUpTime = startTime + locatorWaitTime;
       long giveupTime = startTime + timeout;
-      int minimumRetriesBeforeBecomingCoordinator = locators.size() * 2;
+      int minimumRetriesBeforeBecomingCoordinator =
+          getMinimumRetriesBeforeBecomingCoordinator(locators.size());
 
       for (int tries = 0; !this.isJoined && !this.isStopping; tries++) {
         logger.debug("searching for the membership coordinator");

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -331,13 +331,14 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
         boolean found = findCoordinator();
         logger.info("Discovery state after looking for membership coordinator is {}",
             state);
+        long now = System.currentTimeMillis();
         if (found) {
           logger.info("found possible coordinator {}", state.possibleCoordinator);
           if (localAddress.preferredForCoordinator()
               && state.possibleCoordinator.equals(this.localAddress)) {
             // if we haven't contacted a member of a cluster maybe this node should
             // become the coordinator.
-            if (state.joinedMembersContacted <= 0 &&
+            if (state.joinedMembersContacted <= 0 && (now >= locatorGiveUpTime) &&
                 (tries >= minimumRetriesBeforeBecomingCoordinator ||
                     state.locatorsContacted >= locators.size())) {
               synchronized (viewInstallationLock) {
@@ -360,7 +361,6 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
             }
           }
         } else {
-          long now = System.currentTimeMillis();
           if (state.locatorsContacted <= 0) {
             if (now > locatorGiveUpTime) {
               // break out of the loop and return false

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -91,8 +91,13 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
   /**
    * amount of time to sleep before trying to join after a failed attempt
    */
-  private static final int JOIN_RETRY_SLEEP =
+  public static final int JOIN_RETRY_SLEEP =
       Integer.getInteger(GeodeGlossary.GEMFIRE_PREFIX + "join-retry-sleep", 1000);
+
+  /**
+   * amount of time to sleep before trying to contact a locator after a failed attempt
+   */
+  public static final int FIND_LOCATOR_RETRY_SLEEP = 1_000;
 
   /**
    * time to wait for a broadcast message to be transmitted by jgroups
@@ -1189,7 +1194,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
           logger.info("Exception thrown when contacting a locator", problem);
           if (state.locatorsContacted == 0 && System.currentTimeMillis() < giveUpTime) {
             try {
-              Thread.sleep(1000);
+              Thread.sleep(FIND_LOCATOR_RETRY_SLEEP);
             } catch (InterruptedException e) {
               Thread.currentThread().interrupt();
               services.getCancelCriterion().checkCancelInProgress(e);


### PR DESCRIPTION
In the case where a locator starts up and is unable to connect to any
other locators, it may decide to become the membership coordinator even
if locator-wait-time has not elapsed.

This change addresses this issue by requiring a locator to wait for
locator-wait-time before deciding to become the coordinator.

Co-authored-by: Aaron Lindsey <alindsey@vmware.com>
Co-Authored-By: Vincent Ford <vford@pivotal.io>
Co-authored-by: Bill Burcham <bburcham@pivotal.io>
