### PR TITLE
GEODE-8268: clean up ExecutionHandlerContext

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -347,6 +347,15 @@ public class GeodeRedisServer {
     return regionProvider;
   }
 
+  public PubSub getPubSub() {
+    return pubSub;
+  }
+
+  public EventLoopGroup getSubscriberGroup() {
+    return subscriberGroup;
+  }
+
+
   private void initializeRedis() {
     synchronized (cache) {
 
@@ -489,8 +498,8 @@ public class GeodeRedisServer {
         pipeline.addLast(ByteToCommandDecoder.class.getSimpleName(), new ByteToCommandDecoder());
         pipeline.addLast(new WriteTimeoutHandler(10));
         pipeline.addLast(ExecutionHandlerContext.class.getSimpleName(),
-            new ExecutionHandlerContext(socketChannel, cache, regionProvider, GeodeRedisServer.this,
-                redisPasswordBytes, pubSub, subscriberGroup));
+            new ExecutionHandlerContext(socketChannel, GeodeRedisServer.this,
+                redisPasswordBytes));
       }
     };
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
@@ -42,6 +42,8 @@ public class SubscribeExecutor extends AbstractExecutor {
       items.add(item);
     }
 
+    context.changeChannelEventLoopGroup(context.getSubscriberGroup());
+
     return RedisResponse.flattenedArray(items);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/server/ShutDownExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/server/ShutDownExecutor.java
@@ -25,7 +25,7 @@ public class ShutDownExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
+    context.getServer().shutdown();
     return RedisResponse.nil();
   }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -33,7 +33,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.DecoderException;
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -60,51 +59,31 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
 
   private static final Logger logger = LogService.getLogger();
 
-  private final Cache cache;
   private final GeodeRedisServer server;
+  private final Client client;
   private final Channel channel;
-  private final EventLoopGroup subscriberEventLoopGroup;
   private final AtomicBoolean needChannelFlush;
   private final ByteBufAllocator byteBufAllocator;
-  private final RegionProvider regionProvider;
   private final byte[] authPassword;
 
   private boolean isAuthenticated;
-
-  private final PubSub pubSub;
-
-  public PubSub getPubSub() {
-    return pubSub;
-  }
 
   /**
    * Default constructor for execution contexts.
    *
    * @param channel Channel used by this context, should be one to one
-   * @param cache The Geode cache instance of this vm
-   * @param regionProvider The region provider of this context
    * @param server Instance of the server it is attached to, only used so that any execution
    *        can initiate a shutdown
    * @param password Authentication password for each context, can be null
    */
-  public ExecutionHandlerContext(Channel channel, Cache cache, RegionProvider regionProvider,
-      GeodeRedisServer server, byte[] password,
-      PubSub pubSub,
-      EventLoopGroup subscriberEventLoopGroup) {
-    this.pubSub = pubSub;
-    if (channel == null || cache == null || regionProvider == null || server == null) {
-      throw new IllegalArgumentException("Only the authentication password may be null");
-    }
-    this.cache = cache;
+  public ExecutionHandlerContext(Channel channel, GeodeRedisServer server, byte[] password) {
     this.server = server;
     this.channel = channel;
-    this.subscriberEventLoopGroup = subscriberEventLoopGroup;
+    this.client = new Client(channel);
     this.needChannelFlush = new AtomicBoolean(false);
     this.byteBufAllocator = this.channel.alloc();
-    this.regionProvider = regionProvider;
     this.authPassword = password;
-    this.isAuthenticated = password != null ? false : true;
-
+    this.isAuthenticated = password == null;
   }
 
   private void flushChannel() {
@@ -205,7 +184,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   private void executeCommand(ChannelHandlerContext ctx, Command command) throws Exception {
     RedisResponse response;
 
-    if (!isAuthenticated) {
+    if (!isAuthenticated()) {
       response = handleUnAuthenticatedCommand(command);
       writeToChannel(response);
       return;
@@ -220,11 +199,6 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     if (command.isUnimplemented()) {
       logger.info("Failed " + command.getCommandType() + " because it is not implemented.");
       writeToChannel(RedisResponse.error(command.getCommandType() + " is not implemented."));
-      return;
-    }
-
-    if (command.isOfType(RedisCommandType.SHUTDOWN)) {
-      this.server.shutdown();
       return;
     }
 
@@ -264,7 +238,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     if (command.isOfType(SUBSCRIBE)) {
       CountDownLatch latch = new CountDownLatch(0);
       ctx.channel().deregister().addListener((ChannelFutureListener) future -> {
-        subscriberEventLoopGroup.register(ctx.channel()).sync();
+        server.getSubscriberGroup().register(ctx.channel()).sync();
         latch.countDown();
       });
       latch.await();
@@ -293,7 +267,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
    * Gets the provider of Regions
    */
   public RegionProvider getRegionProvider() {
-    return this.regionProvider;
+    return server.getRegionProvider();
   }
 
   /**
@@ -328,7 +302,16 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   }
 
   public Client getClient() {
-    return new Client(channel);
+    return client;
   }
+
+  public GeodeRedisServer getServer() {
+    return server;
+  }
+
+  public PubSub getPubSub() {
+    return server.getPubSub();
+  }
+
 
 }


### PR DESCRIPTION
The ShutdownExecutor now implements the shutdown command
instead of it being embedded in the ExecutionHandlerContext.
The SubscribeExecutor now takes care of changing its channel to a different thread group.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
