### PR TITLE
GEODE-8243: Use java.exe on Windows in Launcher tests

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/LocatorLauncherWithCustomLogConfigAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/LocatorLauncherWithCustomLogConfigAcceptanceTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.launchers;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.internal.lang.SystemUtils.isWindows;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
@@ -63,9 +64,10 @@ public class LocatorLauncherWithCustomLogConfigAcceptanceTest {
         .as("java.home is not null")
         .isNotNull();
 
-    javaBin = Paths.get(javaHome, "bin", "java");
+    String java = isWindows() ? "java.exe" : "java";
+    javaBin = Paths.get(javaHome, "bin", java);
     assertThat(javaBin)
-        .as("JAVA_HOME/bin/java exists")
+        .as("JAVA_HOME/bin/" + java + " exists")
         .exists();
   }
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/LocatorLauncherWithPulseAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/LocatorLauncherWithPulseAcceptanceTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.launchers;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.internal.lang.SystemUtils.isWindows;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -57,9 +58,10 @@ public class LocatorLauncherWithPulseAcceptanceTest {
         .as("java.home is not null")
         .isNotNull();
 
-    javaBin = Paths.get(javaHome, "bin", "java");
+    String java = isWindows() ? "java.exe" : "java";
+    javaBin = Paths.get(javaHome, "bin", java);
     assertThat(javaBin)
-        .as("JAVA_HOME/bin/java exists")
+        .as("JAVA_HOME/bin/" + java + " exists")
         .exists();
   }
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/LocatorLauncherWithPulseAndCustomLogConfigAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/LocatorLauncherWithPulseAndCustomLogConfigAcceptanceTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.launchers;
 
 import static java.nio.file.Files.copy;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.internal.lang.SystemUtils.isWindows;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
@@ -68,9 +69,10 @@ public class LocatorLauncherWithPulseAndCustomLogConfigAcceptanceTest {
         .as("java.home is not null")
         .isNotNull();
 
-    javaBin = Paths.get(javaHome, "bin", "java");
+    String java = isWindows() ? "java.exe" : "java";
+    javaBin = Paths.get(javaHome, "bin", java);
     assertThat(javaBin)
-        .as("JAVA_HOME/bin/java exists")
+        .as("JAVA_HOME/bin/" + java + " exists")
         .exists();
   }
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/ServerLauncherWithCustomLogConfigAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/launchers/ServerLauncherWithCustomLogConfigAcceptanceTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.launchers;
 
 import static java.nio.file.Files.copy;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.internal.lang.SystemUtils.isWindows;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
@@ -62,9 +63,10 @@ public class ServerLauncherWithCustomLogConfigAcceptanceTest {
         .as("java.home is not null")
         .isNotNull();
 
-    javaBin = Paths.get(javaHome, "bin", "java");
+    String java = isWindows() ? "java.exe" : "java";
+    javaBin = Paths.get(javaHome, "bin", java);
     assertThat(javaBin)
-        .as("JAVA_HOME/bin/java exists")
+        .as("JAVA_HOME/bin/" + java + " exists")
         .exists();
   }
 


### PR DESCRIPTION
The Launcher acceptance tests fail on Windows because the tests are hardcoded to use java instead of java.exe.