### PR TITLE
GEODE-8144: setting SNI server name is not needed if endpoint verification is disabled

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -281,7 +281,7 @@ public class SSLSocketIntegrationTest {
                 ByteBuffer.allocate(65535),
                 new BufferPool(mock(DMStats.class)));
         final List<SNIServerName> serverNames = sslEngine.getSSLParameters().getServerNames();
-        if (serverNames.stream()
+        if (serverNames != null && serverNames.stream()
             .mapToInt(SNIServerName::getType)
             .anyMatch(type -> type == StandardConstants.SNI_HOST_NAME)) {
           serverException = new AssertionError("found SNI server name in SSL Parameters");

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 import java.io.DataInputStream;
@@ -179,7 +178,7 @@ public class SSLSocketIntegrationTest {
   }
 
   @Test
-  public void securedSocketTransmissionShouldWork() throws Exception {
+  public void securedSocketTransmissionShouldWork() throws Throwable {
     this.serverSocket = this.socketCreator.forCluster().createServerSocket(0, 0, this.localHost);
     this.serverThread = startServer(this.serverSocket, 15000);
 
@@ -197,12 +196,14 @@ public class SSLSocketIntegrationTest {
     await().until(() -> {
       return !serverThread.isAlive();
     });
-    assertNull(serverException);
+    if (serverException != null) {
+      throw serverException;
+    }
     assertThat(this.messageFromClient.get()).isEqualTo(MESSAGE);
   }
 
   @Test
-  public void testSecuredSocketTransmissionShouldWorkUsingNIO() throws Exception {
+  public void testSecuredSocketTransmissionShouldWorkUsingNIO() throws Throwable {
     ServerSocketChannel serverChannel = ServerSocketChannel.open();
     serverSocket = serverChannel.socket();
 
@@ -235,7 +236,9 @@ public class SSLSocketIntegrationTest {
     await().until(() -> {
       return !serverThread.isAlive();
     });
-    assertNull(serverException);
+    if (serverException != null) {
+      throw serverException;
+    }
     // assertThat(this.messageFromClient.get()).isEqualTo(MESSAGE);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -546,10 +546,12 @@ public class SocketCreator extends TcpSocketCreatorImpl {
    */
   public SSLEngine createSSLEngine(String hostName, int port) {
     SSLEngine engine = getSslContext().createSSLEngine(hostName, port);
-    SSLParameters parameters = engine.getSSLParameters();
-    // set server-names so that endpoint identification algorithms can find what's expected
-    if (setServerNames(parameters, new HostAndPort(hostName, port))) {
-      engine.setSSLParameters(parameters);
+    if (sslConfig.doEndpointIdentification()) {
+      // set server-names so that endpoint identification algorithms can find what's expected
+      SSLParameters parameters = engine.getSSLParameters();
+      if (setServerNames(parameters, new HostAndPort(hostName, port))) {
+        engine.setSSLParameters(parameters);
+      }
     }
     return engine;
   }


### PR DESCRIPTION
I've modified the fix for GEODE-8144 to not set the SNI server name parameter
if endpoint verification is disabled.  The parameter is only needed if endpoint
verification is enabled.  Some performance tests that had endpoint identification
disabled were showing degraded perf.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
