### PR TITLE
GEODE-8217: Deserialize attribute before update and remove.

### DIFF
--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionIntegrationTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionIntegrationTest.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.geode.modules.session.catalina;
 
 import static org.apache.geode.cache.RegionShortcut.PARTITION;

--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionIntegrationTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionIntegrationTest.java
@@ -1,0 +1,95 @@
+package org.apache.geode.modules.session.catalina;
+
+import static org.apache.geode.cache.RegionShortcut.PARTITION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionAttributeListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+
+import org.apache.catalina.Context;
+import org.apache.juli.logging.Log;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.internal.util.BlobHelper;
+import org.apache.geode.modules.session.catalina.callback.SessionExpirationCacheListener;
+import org.apache.geode.modules.session.catalina.internal.DeltaSessionStatistics;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+public abstract class AbstractDeltaSessionIntegrationTest<DeltaSessionManagerT extends DeltaSessionManager<?>, DeltaSessionT extends DeltaSession> {
+  protected static final String KEY = "key1";
+  protected static final String REGION_NAME = "sessions";
+
+  protected Region<String, HttpSession> region;
+  protected final DeltaSessionManagerT manager;
+  protected final Context context = mock(Context.class);
+
+  @Rule
+  public ServerStarterRule server = new ServerStarterRule().withAutoStart();
+
+  protected AbstractDeltaSessionIntegrationTest(final DeltaSessionManagerT manager) {
+    this.manager = manager;
+  }
+
+  @Before
+  public void before() {
+    region = server.getCache()
+        .<String, HttpSession>createRegionFactory(PARTITION)
+        .addCacheListener(new SessionExpirationCacheListener())
+        .create(REGION_NAME);
+
+    when(manager.getLogger()).thenReturn(mock(Log.class));
+    when(manager.getRegionName()).thenReturn(REGION_NAME);
+    when(manager.getSessionCache()).thenReturn(mock(SessionCache.class));
+    when(manager.getSessionCache().getOperatingRegion()).thenReturn(region);
+    whenGetPreferDeserializedForm(manager);
+
+    final DeltaSessionStatistics stats = mock(DeltaSessionStatistics.class);
+    when(manager.getStatistics()).thenReturn(stats);
+  }
+
+  @SuppressWarnings("deprecation")
+  private void whenGetPreferDeserializedForm(DeltaSessionManager<?> manager) {
+    when(manager.getPreferDeserializedForm()).thenReturn(true);
+  }
+
+  protected abstract DeltaSessionT newSession(final DeltaSessionManagerT manager);
+
+  @Test
+  public void serializedAttributesNotLeakedWhenSessionInvalidated() throws IOException {
+    final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
+    when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
+
+    final DeltaSessionT session = spy(newSession(manager));
+    session.setId(KEY, false);
+    session.setValid(true);
+    session.setOwner(manager);
+
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    region.put(session.getId(), session);
+
+    session.invalidate();
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeRemoved(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isEqualTo(value1);
+  }
+}

--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionManagerTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionManagerTest.java
@@ -64,9 +64,9 @@ import org.apache.geode.cache.query.internal.LinkedResultSet;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.modules.session.catalina.internal.DeltaSessionStatistics;
 
-public abstract class AbstractDeltaSessionManagerTest {
+public abstract class AbstractDeltaSessionManagerTest<DeltaSessionManagerT extends DeltaSessionManager<?>> {
 
-  protected DeltaSessionManager manager;
+  protected DeltaSessionManagerT manager;
   protected AbstractSessionCache sessionCache;
   protected Cache cache;
   protected Log logger;

--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
@@ -64,12 +64,17 @@ public abstract class AbstractDeltaSessionTest {
     when(manager.getContextName()).thenReturn("contextName");
     when(manager.getStatistics()).thenReturn(stats);
     when(manager.isBackingCacheAvailable()).thenReturn(true);
-    when(manager.getPreferDeserializedForm()).thenReturn(true);
+    setupDeprecated();
     // For Client/Server behavior and some PeerToPeer use cases the session region and operating
     // regions
     // will be the same.
     when(sessionCache.getOperatingRegion()).thenReturn(sessionRegion);
     when(logger.isDebugEnabled()).thenReturn(true);
+  }
+
+  @SuppressWarnings("deprecation")
+  protected void setupDeprecated() {
+    when(manager.getPreferDeserializedForm()).thenReturn(true);
   }
 
   @Test

--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
@@ -63,6 +63,8 @@ public abstract class AbstractDeltaSessionTest {
     when(manager.getLogger()).thenReturn(logger);
     when(manager.getContextName()).thenReturn(contextName);
     when(manager.getStatistics()).thenReturn(stats);
+    when(manager.isBackingCacheAvailable()).thenReturn(true);
+    when(manager.getPreferDeserializedForm()).thenReturn(true);
     // For Client/Server behavior and some PeerToPeer use cases the session region and operating
     // regions
     // will be the same.

--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.modules.session.catalina;
 
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,19 +50,18 @@ import org.apache.geode.modules.session.catalina.internal.DeltaSessionStatistics
 public abstract class AbstractDeltaSessionTest {
 
   protected final DeltaSessionManager manager = mock(DeltaSessionManager.class);
-  private final Region<String, HttpSession> sessionRegion = mock(Region.class);
+  private final Region<String, HttpSession> sessionRegion = uncheckedCast(mock(Region.class));
   private final SessionCache sessionCache = mock(ClientServerSessionCache.class);
-  DeltaSessionStatistics stats = mock(DeltaSessionStatistics.class);
-  private final String sessionRegionName = "sessionRegionName";
-  private final String contextName = "contextName";
+  private final DeltaSessionStatistics stats = mock(DeltaSessionStatistics.class);
   private final Log logger = mock(Log.class);
 
   @Before
   public void setup() {
+    String sessionRegionName = "sessionRegionName";
     when(manager.getRegionName()).thenReturn(sessionRegionName);
     when(manager.getSessionCache()).thenReturn(sessionCache);
     when(manager.getLogger()).thenReturn(logger);
-    when(manager.getContextName()).thenReturn(contextName);
+    when(manager.getContextName()).thenReturn("contextName");
     when(manager.getStatistics()).thenReturn(stats);
     when(manager.isBackingCacheAvailable()).thenReturn(true);
     when(manager.getPreferDeserializedForm()).thenReturn(true);
@@ -83,8 +83,7 @@ public abstract class AbstractDeltaSessionTest {
 
   @Test
   public void sessionConstructionDoesNotThrowExceptionWithValidArgument() {
-    final DeltaSession session = new DeltaSession(manager);
-
+    new DeltaSession(manager);
     verify(logger).debug(anyString());
   }
 
@@ -126,7 +125,7 @@ public abstract class AbstractDeltaSessionTest {
     final List<DeltaSessionAttributeEvent> events = new ArrayList<>();
     events.add(event1);
     events.add(event2);
-    final Region<String, DeltaSessionInterface> region = mock(Region.class);
+    final Region<String, DeltaSessionInterface> region = uncheckedCast(mock(Region.class));
     final DeltaSession session = spy(new DeltaSession(manager));
 
     session.applyAttributeEvents(region, events);
@@ -145,7 +144,7 @@ public abstract class AbstractDeltaSessionTest {
     final String sessionId = "invalidatedSession";
     doReturn(sessionId).when(session).getId();
 
-    assertThatThrownBy(() -> session.commit()).isInstanceOf(IllegalStateException.class)
+    assertThatThrownBy(session::commit).isInstanceOf(IllegalStateException.class)
         .hasMessage("commit: Session " + sessionId + " already invalidated");
   }
 
@@ -153,7 +152,7 @@ public abstract class AbstractDeltaSessionTest {
   public void getSizeInBytesReturnsProperValueForMultipleAttributes() {
     final String attrName1 = "attrName1";
     final String attrName2 = "attrName2";
-    final List attrList = new ArrayList<String>();
+    final List<String> attrList = new ArrayList<>();
     attrList.add(attrName1);
     attrList.add(attrName2);
 

--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractDeltaSessionTest.java
@@ -46,9 +46,9 @@ import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.modules.session.catalina.internal.DeltaSessionAttributeEvent;
 import org.apache.geode.modules.session.catalina.internal.DeltaSessionStatistics;
 
-public class DeltaSessionTest {
+public abstract class AbstractDeltaSessionTest {
 
-  private final DeltaSessionManager manager = mock(DeltaSessionManager.class);
+  protected final DeltaSessionManager manager = mock(DeltaSessionManager.class);
   private final Region<String, HttpSession> sessionRegion = mock(Region.class);
   private final SessionCache sessionCache = mock(ClientServerSessionCache.class);
   DeltaSessionStatistics stats = mock(DeltaSessionStatistics.class);
@@ -195,11 +195,4 @@ public class DeltaSessionTest {
     assertThat(result).isEqualTo(serializedObj);
   }
 
-  // @Test
-  // public void testToData() throws IOException {
-  // DeltaSession session = spy(new DeltaSession(manager));
-  // DataOutput out = mock(DataOutput.class);
-  //
-  // session.toData(out);
-  // }
 }

--- a/extensions/geode-modules-tomcat7/src/integrationTest/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
+++ b/extensions/geode-modules-tomcat7/src/integrationTest/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
@@ -12,17 +12,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.modules.session.catalina;
 
-import org.apache.catalina.connector.Response;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@Deprecated
-public final class Tomcat6CommitSessionValve
-    extends AbstractCommitSessionValve<Tomcat6CommitSessionValve> {
+
+
+public class DeltaSession7Test
+    extends AbstractDeltaSessionIntegrationTest<Tomcat7DeltaSessionManager, DeltaSession7> {
+
+  public DeltaSession7Test() {
+    super(mock(Tomcat7DeltaSessionManager.class));
+  }
 
   @Override
-  protected Response wrapResponse(Response response) {
-    return response;
+  public void before() {
+    super.before();
+    when(manager.getContainer()).thenReturn(context);
   }
+
+  @Override
+  protected DeltaSession7 newSession(Tomcat7DeltaSessionManager manager) {
+    return new DeltaSession7(manager);
+  }
+
 }

--- a/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
+++ b/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.modules.session.catalina;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpSessionAttributeListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+
+import org.apache.catalina.Context;
+import org.apache.juli.logging.Log;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.internal.util.BlobHelper;
+
+public class DeltaSession7Test extends AbstractDeltaSessionTest {
+  final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
+
+  @Before
+  @Override
+  public void setup() {
+    super.setup();
+
+    final Context context = mock(Context.class);
+    when(manager.getContainer()).thenReturn(context);
+    when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
+    when(context.getLogger()).thenReturn(mock(Log.class));
+  }
+
+  @Test
+  public void serializedAttributesNotLeakedInAttributeReplaceEvent() throws IOException {
+    final DeltaSession7 session = spy(new DeltaSession7(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    final Object value2 = "value2";
+    session.setAttribute(name, value2);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeReplaced(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isEqualTo(value1);
+  }
+
+  @Test
+  public void serializedAttributesNotLeakedInAttributeRemovedEvent() throws IOException {
+    final DeltaSession7 session = spy(new DeltaSession7(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    session.removeAttribute(name);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeRemoved(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isEqualTo(value1);
+  }
+
+  @Test
+  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferSerializedFormFalse()
+      throws IOException {
+    setPreferSeserializedForm();
+
+    final DeltaSession7 session = spy(new DeltaSession7(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    final Object value2 = "value2";
+    session.setAttribute(name, value2);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeReplaced(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isInstanceOf(byte[].class);
+  }
+
+  @Test
+  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferSerializedFormFalse()
+      throws IOException {
+    setPreferSeserializedForm();
+
+    final DeltaSession7 session = spy(new DeltaSession7(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    session.removeAttribute(name);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeRemoved(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isInstanceOf(byte[].class);
+  }
+
+  @SuppressWarnings("deprecation")
+  protected void setPreferSeserializedForm() {
+    when(manager.getPreferDeserializedForm()).thenReturn(false);
+  }
+
+}

--- a/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
+++ b/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpSessionAttributeListener;
 import javax.servlet.http.HttpSessionBindingEvent;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Manager;
 import org.apache.juli.logging.Log;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +36,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.internal.util.BlobHelper;
 
-public class DeltaSession7Test extends AbstractDeltaSessionTest {
+public class DeltaSession7Test extends AbstractDeltaSessionTest<DeltaSession7> {
   final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
 
   @Before
@@ -47,6 +48,11 @@ public class DeltaSession7Test extends AbstractDeltaSessionTest {
     when(manager.getContainer()).thenReturn(context);
     when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
     when(context.getLogger()).thenReturn(mock(Log.class));
+  }
+
+  @Override
+  protected DeltaSession7 newDeltaSession(Manager manager) {
+    return new DeltaSession7(manager);
   }
 
   @Test

--- a/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
+++ b/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession7Test.java
@@ -89,9 +89,9 @@ public class DeltaSession7Test extends AbstractDeltaSessionTest {
   }
 
   @Test
-  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferSerializedFormFalse()
+  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferDeserializedFormFalse()
       throws IOException {
-    setPreferSeserializedForm();
+    setPreferDeserializedFormFalse();
 
     final DeltaSession7 session = spy(new DeltaSession7(manager));
     session.setValid(true);
@@ -112,9 +112,9 @@ public class DeltaSession7Test extends AbstractDeltaSessionTest {
   }
 
   @Test
-  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferSerializedFormFalse()
+  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferDeserializedFormFalse()
       throws IOException {
-    setPreferSeserializedForm();
+    setPreferDeserializedFormFalse();
 
     final DeltaSession7 session = spy(new DeltaSession7(manager));
     session.setValid(true);
@@ -134,7 +134,7 @@ public class DeltaSession7Test extends AbstractDeltaSessionTest {
   }
 
   @SuppressWarnings("deprecation")
-  protected void setPreferSeserializedForm() {
+  protected void setPreferDeserializedFormFalse() {
     when(manager.getPreferDeserializedForm()).thenReturn(false);
   }
 

--- a/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/Tomcat7DeltaSessionManagerTest.java
+++ b/extensions/geode-modules-tomcat7/src/test/java/org/apache/geode/modules/session/catalina/Tomcat7DeltaSessionManagerTest.java
@@ -34,7 +34,8 @@ import org.junit.Test;
 
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 
-public class Tomcat7DeltaSessionManagerTest extends AbstractDeltaSessionManagerTest {
+public class Tomcat7DeltaSessionManagerTest
+    extends AbstractDeltaSessionManagerTest<Tomcat7DeltaSessionManager> {
   private Pipeline pipeline;
 
   @Before

--- a/extensions/geode-modules-tomcat8/build.gradle
+++ b/extensions/geode-modules-tomcat8/build.gradle
@@ -38,16 +38,17 @@ dependencies {
     testImplementation('junit:junit')
     testImplementation('org.assertj:assertj-core')
     testImplementation('org.mockito:mockito-core')
+    testImplementation('pl.pragmatists:JUnitParams')
     testImplementation(project(':extensions:geode-modules-test'))
     distributedTestImplementation('org.httpunit:httpunit')
     distributedTestImplementation('org.apache.tomcat:tomcat-jaspic-api:' + DependencyConstraints.get('tomcat8.version'))
     distributedTestImplementation('org.springframework:spring-core')
     compile(project(':geode-core'))
     compile(project(':extensions:geode-modules')) {
-        exclude group: 'org.apache.tomcat'
+      exclude group: 'org.apache.tomcat'
     }
     testImplementation(project(':extensions:geode-modules')) {
-        exclude group: 'org.apache.tomcat'
+      exclude group: 'org.apache.tomcat'
     }
 
 

--- a/extensions/geode-modules-tomcat8/src/integrationTest/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
+++ b/extensions/geode-modules-tomcat8/src/integrationTest/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
@@ -12,17 +12,29 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.modules.session.catalina;
 
-import org.apache.catalina.connector.Response;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@Deprecated
-public final class Tomcat6CommitSessionValve
-    extends AbstractCommitSessionValve<Tomcat6CommitSessionValve> {
+
+
+public class DeltaSession8Test
+    extends AbstractDeltaSessionIntegrationTest<Tomcat8DeltaSessionManager, DeltaSession8> {
+
+  public DeltaSession8Test() {
+    super(mock(Tomcat8DeltaSessionManager.class));
+  }
 
   @Override
-  protected Response wrapResponse(Response response) {
-    return response;
+  public void before() {
+    super.before();
+    when(manager.getContext()).thenReturn(context);
   }
+
+  @Override
+  protected DeltaSession8 newSession(Tomcat8DeltaSessionManager manager) {
+    return new DeltaSession8(manager);
+  }
+
 }

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
@@ -35,7 +35,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.internal.util.BlobHelper;
 
-public class DeltaSessionTest extends AbstractDeltaSessionTest {
+public class DeltaSession8Test extends AbstractDeltaSessionTest {
   final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
 
   @Before
@@ -51,7 +51,7 @@ public class DeltaSessionTest extends AbstractDeltaSessionTest {
 
   @Test
   public void serializedAttributesNotLeakedInAttributeReplaceEvent() throws IOException {
-    final DeltaSession session = spy(new DeltaSession(manager));
+    final DeltaSession8 session = spy(new DeltaSession8(manager));
     session.setValid(true);
     final String name = "attribute";
     final Object value1 = "value1";
@@ -71,7 +71,7 @@ public class DeltaSessionTest extends AbstractDeltaSessionTest {
 
   @Test
   public void serializedAttributesNotLeakedInAttributeRemovedEvent() throws IOException {
-    final DeltaSession session = spy(new DeltaSession(manager));
+    final DeltaSession8 session = spy(new DeltaSession8(manager));
     session.setValid(true);
     final String name = "attribute";
     final Object value1 = "value1";
@@ -93,7 +93,7 @@ public class DeltaSessionTest extends AbstractDeltaSessionTest {
       throws IOException {
     setPreferSeserializedForm();
 
-    final DeltaSession session = spy(new DeltaSession(manager));
+    final DeltaSession8 session = spy(new DeltaSession8(manager));
     session.setValid(true);
     final String name = "attribute";
     final Object value1 = "value1";
@@ -116,7 +116,7 @@ public class DeltaSessionTest extends AbstractDeltaSessionTest {
       throws IOException {
     setPreferSeserializedForm();
 
-    final DeltaSession session = spy(new DeltaSession(manager));
+    final DeltaSession8 session = spy(new DeltaSession8(manager));
     session.setValid(true);
     final String name = "attribute";
     final Object value1 = "value1";

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpSessionAttributeListener;
 import javax.servlet.http.HttpSessionBindingEvent;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Manager;
 import org.apache.juli.logging.Log;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +36,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.internal.util.BlobHelper;
 
-public class DeltaSession8Test extends AbstractDeltaSessionTest {
+public class DeltaSession8Test extends AbstractDeltaSessionTest<DeltaSession8> {
   final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
 
   @Before
@@ -47,6 +48,11 @@ public class DeltaSession8Test extends AbstractDeltaSessionTest {
     when(manager.getContext()).thenReturn(context);
     when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
     when(context.getLogger()).thenReturn(mock(Log.class));
+  }
+
+  @Override
+  protected DeltaSession8 newDeltaSession(Manager manager) {
+    return new DeltaSession8(manager);
   }
 
   @Test

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession8Test.java
@@ -89,9 +89,9 @@ public class DeltaSession8Test extends AbstractDeltaSessionTest {
   }
 
   @Test
-  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferSerializedFormFalse()
+  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferDeserializedFormFalse()
       throws IOException {
-    setPreferSeserializedForm();
+    setPreferDeserializedFormFalse();
 
     final DeltaSession8 session = spy(new DeltaSession8(manager));
     session.setValid(true);
@@ -112,9 +112,9 @@ public class DeltaSession8Test extends AbstractDeltaSessionTest {
   }
 
   @Test
-  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferSerializedFormFalse()
+  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferDeserializedFormFalse()
       throws IOException {
-    setPreferSeserializedForm();
+    setPreferDeserializedFormFalse();
 
     final DeltaSession8 session = spy(new DeltaSession8(manager));
     session.setValid(true);
@@ -134,7 +134,7 @@ public class DeltaSession8Test extends AbstractDeltaSessionTest {
   }
 
   @SuppressWarnings("deprecation")
-  protected void setPreferSeserializedForm() {
+  protected void setPreferDeserializedFormFalse() {
     when(manager.getPreferDeserializedForm()).thenReturn(false);
   }
 

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSessionTest.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSessionTest.java
@@ -27,17 +27,25 @@ import java.io.IOException;
 import javax.servlet.http.HttpSessionAttributeListener;
 import javax.servlet.http.HttpSessionBindingEvent;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.apache.catalina.Context;
 import org.apache.juli.logging.Log;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.internal.util.BlobHelper;
 
+@RunWith(JUnitParamsRunner.class)
 public class DeltaSessionTest extends AbstractDeltaSessionTest {
 
   @Test
-  public void serializedAttributesNotLeakedInAttributeReplaceEvent() throws IOException {
+  @Parameters({"true", "false"})
+  public void serializedAttributesNotLeakedInAttributeReplaceEvent(
+      final boolean preferDeserializedForm) throws IOException {
+    when(manager.getPreferDeserializedForm()).thenReturn(preferDeserializedForm);
+
     final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
 
     final Context context = mock(Context.class);
@@ -64,7 +72,11 @@ public class DeltaSessionTest extends AbstractDeltaSessionTest {
   }
 
   @Test
-  public void serializedAttributesNotLeakedInAttributeRemovedEvent() throws IOException {
+  @Parameters({"true", "false"})
+  public void serializedAttributesNotLeakedInAttributeRemovedEvent(
+      final boolean preferDeserializedForm) throws IOException {
+    when(manager.getPreferDeserializedForm()).thenReturn(preferDeserializedForm);
+
     final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
 
     final Context context = mock(Context.class);

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSessionTest.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/DeltaSessionTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.modules.session.catalina;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.http.HttpSessionAttributeListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+
+import org.apache.catalina.Context;
+import org.apache.juli.logging.Log;
+import org.junit.Test;
+
+import org.apache.geode.internal.util.BlobHelper;
+
+public class DeltaSessionTest extends AbstractDeltaSessionTest {
+
+  @Test
+  public void serializedAttributesNotLeakedInAttributeReplaceEvent() throws IOException {
+
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    AtomicReference<Object> eventValue = new AtomicReference<>();
+
+    HttpSessionAttributeListener listener = new HttpSessionAttributeListener() {
+      @Override
+      public void attributeAdded(HttpSessionBindingEvent event) {}
+
+      @Override
+      public void attributeRemoved(HttpSessionBindingEvent event) {}
+
+      @Override
+      public void attributeReplaced(HttpSessionBindingEvent event) {
+        eventValue.set(event.getValue());
+      }
+    };
+
+    final Context context = mock(Context.class);
+    when(manager.getContext()).thenReturn(context);
+    when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
+    when(context.getLogger()).thenReturn(mock(Log.class));
+
+    DeltaSession session = spy(new DeltaSession(manager));
+    session.setValid(true);
+    // simulates initial deserialized state with serialized attribute values.
+    final String attributeName = "attribute";
+    session.getAttributes().put(attributeName, serializedValue1);
+
+    final Object value2 = "value2";
+    session.setAttribute(attributeName, value2);
+    assertThat(eventValue.get()).isEqualTo(value1);
+  }
+
+  @Test
+  public void serializedAttributesNotLeakedInAttributeRemovedEvent() throws IOException {
+
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    AtomicReference<Object> eventValue = new AtomicReference<>();
+
+    HttpSessionAttributeListener listener = new HttpSessionAttributeListener() {
+      @Override
+      public void attributeAdded(HttpSessionBindingEvent event) {}
+
+      @Override
+      public void attributeRemoved(HttpSessionBindingEvent event) {
+        eventValue.set(event.getValue());
+      }
+
+      @Override
+      public void attributeReplaced(HttpSessionBindingEvent event) {}
+    };
+
+    final Context context = mock(Context.class);
+    when(manager.getContext()).thenReturn(context);
+    when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
+    when(context.getLogger()).thenReturn(mock(Log.class));
+
+    DeltaSession session = spy(new DeltaSession(manager));
+    session.setValid(true);
+    // simulates initial deserialized state with serialized attribute values.
+    final String attributeName = "attribute";
+    session.getAttributes().put(attributeName, serializedValue1);
+
+    session.removeAttribute(attributeName);
+    assertThat(eventValue.get()).isEqualTo(value1);
+  }
+
+}

--- a/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/Tomcat8DeltaSessionManagerTest.java
+++ b/extensions/geode-modules-tomcat8/src/test/java/org/apache/geode/modules/session/catalina/Tomcat8DeltaSessionManagerTest.java
@@ -33,7 +33,8 @@ import org.junit.Test;
 
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 
-public class Tomcat8DeltaSessionManagerTest extends AbstractDeltaSessionManagerTest {
+public class Tomcat8DeltaSessionManagerTest
+    extends AbstractDeltaSessionManagerTest<Tomcat8DeltaSessionManager> {
   private Pipeline pipeline;
 
   @Before

--- a/extensions/geode-modules-tomcat9/src/integrationTest/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
+++ b/extensions/geode-modules-tomcat9/src/integrationTest/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
@@ -12,17 +12,27 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.modules.session.catalina;
 
-import org.apache.catalina.connector.Response;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
-@Deprecated
-public final class Tomcat6CommitSessionValve
-    extends AbstractCommitSessionValve<Tomcat6CommitSessionValve> {
+public class DeltaSession9Test
+    extends AbstractDeltaSessionIntegrationTest<Tomcat9DeltaSessionManager, DeltaSession9> {
+
+  public DeltaSession9Test() {
+    super(mock(Tomcat9DeltaSessionManager.class));
+  }
 
   @Override
-  protected Response wrapResponse(Response response) {
-    return response;
+  public void before() {
+    super.before();
+    when(manager.getContext()).thenReturn(context);
   }
+
+  @Override
+  protected DeltaSession9 newSession(Tomcat9DeltaSessionManager manager) {
+    return new DeltaSession9(manager);
+  }
+
 }

--- a/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
+++ b/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.modules.session.catalina;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpSessionAttributeListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+
+import org.apache.catalina.Context;
+import org.apache.juli.logging.Log;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.internal.util.BlobHelper;
+
+public class DeltaSession9Test extends AbstractDeltaSessionTest {
+  final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
+
+  @Before
+  @Override
+  public void setup() {
+    super.setup();
+
+    final Context context = mock(Context.class);
+    when(manager.getContext()).thenReturn(context);
+    when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
+    when(context.getLogger()).thenReturn(mock(Log.class));
+  }
+
+  @Test
+  public void serializedAttributesNotLeakedInAttributeReplaceEvent() throws IOException {
+    final DeltaSession9 session = spy(new DeltaSession9(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    final Object value2 = "value2";
+    session.setAttribute(name, value2);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeReplaced(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isEqualTo(value1);
+  }
+
+  @Test
+  public void serializedAttributesNotLeakedInAttributeRemovedEvent() throws IOException {
+    final DeltaSession9 session = spy(new DeltaSession9(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    session.removeAttribute(name);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeRemoved(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isEqualTo(value1);
+  }
+
+  @Test
+  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferSerializedFormFalse()
+      throws IOException {
+    setPreferSeserializedForm();
+
+    final DeltaSession9 session = spy(new DeltaSession9(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    final Object value2 = "value2";
+    session.setAttribute(name, value2);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeReplaced(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isInstanceOf(byte[].class);
+  }
+
+  @Test
+  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferSerializedFormFalse()
+      throws IOException {
+    setPreferSeserializedForm();
+
+    final DeltaSession9 session = spy(new DeltaSession9(manager));
+    session.setValid(true);
+    final String name = "attribute";
+    final Object value1 = "value1";
+    final byte[] serializedValue1 = BlobHelper.serializeToBlob(value1);
+    // simulates initial deserialized state with serialized attribute values.
+    session.getAttributes().put(name, serializedValue1);
+
+    session.removeAttribute(name);
+
+    final ArgumentCaptor<HttpSessionBindingEvent> event =
+        ArgumentCaptor.forClass(HttpSessionBindingEvent.class);
+    verify(listener).attributeRemoved(event.capture());
+    verifyNoMoreInteractions(listener);
+    assertThat(event.getValue().getValue()).isInstanceOf(byte[].class);
+  }
+
+  @SuppressWarnings("deprecation")
+  protected void setPreferSeserializedForm() {
+    when(manager.getPreferDeserializedForm()).thenReturn(false);
+  }
+
+}

--- a/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
+++ b/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
@@ -89,9 +89,9 @@ public class DeltaSession9Test extends AbstractDeltaSessionTest {
   }
 
   @Test
-  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferSerializedFormFalse()
+  public void serializedAttributesLeakedInAttributeReplaceEventWhenPreferDeserializedFormFalse()
       throws IOException {
-    setPreferSeserializedForm();
+    setPreferDeserializedFormFalse();
 
     final DeltaSession9 session = spy(new DeltaSession9(manager));
     session.setValid(true);
@@ -112,9 +112,9 @@ public class DeltaSession9Test extends AbstractDeltaSessionTest {
   }
 
   @Test
-  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferSerializedFormFalse()
+  public void serializedAttributesLeakedInAttributeRemovedEventWhenPreferDeserializedFormFalse()
       throws IOException {
-    setPreferSeserializedForm();
+    setPreferDeserializedFormFalse();
 
     final DeltaSession9 session = spy(new DeltaSession9(manager));
     session.setValid(true);
@@ -134,7 +134,7 @@ public class DeltaSession9Test extends AbstractDeltaSessionTest {
   }
 
   @SuppressWarnings("deprecation")
-  protected void setPreferSeserializedForm() {
+  protected void setPreferDeserializedFormFalse() {
     when(manager.getPreferDeserializedForm()).thenReturn(false);
   }
 

--- a/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
+++ b/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/DeltaSession9Test.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpSessionAttributeListener;
 import javax.servlet.http.HttpSessionBindingEvent;
 
 import org.apache.catalina.Context;
+import org.apache.catalina.Manager;
 import org.apache.juli.logging.Log;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,7 +36,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.internal.util.BlobHelper;
 
-public class DeltaSession9Test extends AbstractDeltaSessionTest {
+public class DeltaSession9Test extends AbstractDeltaSessionTest<DeltaSession9> {
   final HttpSessionAttributeListener listener = mock(HttpSessionAttributeListener.class);
 
   @Before
@@ -47,6 +48,11 @@ public class DeltaSession9Test extends AbstractDeltaSessionTest {
     when(manager.getContext()).thenReturn(context);
     when(context.getApplicationEventListeners()).thenReturn(new Object[] {listener});
     when(context.getLogger()).thenReturn(mock(Log.class));
+  }
+
+  @Override
+  protected DeltaSession9 newDeltaSession(Manager manager) {
+    return new DeltaSession9(manager);
   }
 
   @Test

--- a/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/Tomcat9DeltaSessionManagerTest.java
+++ b/extensions/geode-modules-tomcat9/src/test/java/org/apache/geode/modules/session/catalina/Tomcat9DeltaSessionManagerTest.java
@@ -33,7 +33,8 @@ import org.junit.Test;
 
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 
-public class Tomcat9DeltaSessionManagerTest extends AbstractDeltaSessionManagerTest {
+public class Tomcat9DeltaSessionManagerTest
+    extends AbstractDeltaSessionManagerTest<Tomcat9DeltaSessionManager> {
   private Pipeline pipeline;
 
   @Before

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
@@ -352,7 +352,6 @@ public class DeltaSession extends StandardSession
   @Override
   public void invalidate() {
     super.invalidate();
-    // getOperatingRegion().destroy(this.id, true); // already done in super (remove)
     getDeltaSessionManager().getStatistics().incSessionsInvalidated();
   }
 
@@ -651,8 +650,7 @@ public class DeltaSession extends StandardSession
   @Override
   public int getSizeInBytes() {
     int size = 0;
-    @SuppressWarnings("unchecked")
-    Enumeration<String> attributeNames = (Enumeration<String>) getAttributeNames();
+    Enumeration<String> attributeNames = uncheckedCast(getAttributeNames());
     while (attributeNames.hasMoreElements()) {
       // Don't use getAttribute() because we don't want to deserialize the value.
       Object value = getAttributeWithoutDeserialize(attributeNames.nextElement());
@@ -664,13 +662,11 @@ public class DeltaSession extends StandardSession
     return size;
   }
 
-  @SuppressWarnings({"unchecked"})
   private Map<String, byte[]> getSerializedAttributes() {
     // Iterate the values and serialize them if necessary before sending them to the server. This
     // makes the application classes unnecessary on the server.
     Map<String, byte[]> serializedAttributes = new ConcurrentHashMap<>();
-    for (Object o : getAttributes().entrySet()) {
-      Map.Entry<String, Object> entry = (Map.Entry<String, Object>) o;
+    for (Map.Entry<String, Object> entry : getAttributes().entrySet()) {
       Object value = entry.getValue();
       byte[] serializedValue = value instanceof byte[] ? (byte[]) value : serialize(value);
       serializedAttributes.put(entry.getKey(), serializedValue);

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
@@ -77,6 +77,10 @@ public class DeltaSession extends StandardSession
 
   private transient boolean expired = false;
 
+  /**
+   * @deprecated No replacement. Always refer deserialized form.
+   */
+  @Deprecated
   private transient boolean preferDeserializedForm = true;
 
   private byte[] serializedPrincipal;
@@ -215,7 +219,7 @@ public class DeltaSession extends StandardSession
       hasDelta = false;
       applyRemotely = false;
       enableGatewayDeltaReplication = sessionManager.getEnableGatewayDeltaReplication();
-      preferDeserializedForm = sessionManager.getPreferDeserializedForm();
+      setOwnerDeprecated(sessionManager);
 
       // Initialize transient variables
       if (listeners == null) {
@@ -230,6 +234,11 @@ public class DeltaSession extends StandardSession
     } else {
       throw new IllegalArgumentException(this + ": The Manager must be an AbstractManager");
     }
+  }
+
+  @SuppressWarnings("deprecation")
+  private void setOwnerDeprecated(DeltaSessionManager sessionManager) {
+    preferDeserializedForm = sessionManager.getPreferDeserializedForm();
   }
 
   private void checkBackingCacheAvailable() {
@@ -264,7 +273,6 @@ public class DeltaSession extends StandardSession
       DeltaSessionAttributeEvent event =
           new DeltaSessionUpdateAttributeEvent(name, serializedValue);
       queueAttributeEvent(event, true);
-
 
       // Distribute the update
       if (!isCommitEnabled()) {
@@ -472,8 +480,9 @@ public class DeltaSession extends StandardSession
 
   @Override
   public void commit() {
-    if (!isValidInternal())
+    if (!isValidInternal()) {
       throw new IllegalStateException("commit: Session " + getId() + " already invalidated");
+    }
     // (STRING_MANAGER.getString("deltaSession.commit.ise", getId()));
 
     synchronized (changeLock) {

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSession.java
@@ -78,7 +78,7 @@ public class DeltaSession extends StandardSession
   private transient boolean expired = false;
 
   /**
-   * @deprecated No replacement. Always refer deserialized form.
+   * @deprecated No replacement. Always prefer deserialized form.
    */
   @Deprecated
   private transient boolean preferDeserializedForm = true;

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
@@ -111,6 +111,10 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
 
   private static final boolean DEFAULT_ENABLE_COMMIT_VALVE_FAILFAST = false;
 
+  /**
+   * @deprecated No replacement. Always refer deserialized form.
+   */
+  @Deprecated
   private static final boolean DEFAULT_PREFER_DESERIALIZED_FORM = true;
 
   /*
@@ -134,6 +138,10 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
 
   private boolean enableDebugListener = DEFAULT_ENABLE_DEBUG_LISTENER;
 
+  /**
+   * @deprecated No replacement. Always refer deserialized form.
+   */
+  @Deprecated
   private boolean preferDeserializedForm = DEFAULT_PREFER_DESERIALIZED_FORM;
 
   private Timer timer;
@@ -269,11 +277,24 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
     return sessionCache.isBackingCacheAvailable();
   }
 
+  /**
+   * @deprecated No replacement. Always refer deserialized form.
+   */
+  @Deprecated
   @Override
   public void setPreferDeserializedForm(boolean enable) {
+    log.warn("Use of deprecated preferDeserializedForm property to be removed in future release.");
+    if (!enable) {
+      log.warn(
+          "Use of HttpSessionAttributeListener may result in serialized form in HttpSessionBindingEvent.");
+    }
     preferDeserializedForm = enable;
   }
 
+  /**
+   * @deprecated No replacement. Always refer deserialized form.
+   */
+  @Deprecated
   @Override
   public boolean getPreferDeserializedForm() {
     return preferDeserializedForm;
@@ -824,7 +845,7 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
    * anything.
    *
    * @throws ClassNotFoundException if a serialized class cannot be found during the reload
-   * @throws IOException            if an input/output error occurs
+   * @throws IOException if an input/output error occurs
    */
   private void doLoad() throws ClassNotFoundException, IOException {
     Context context = getTheContext();
@@ -898,8 +919,7 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
         session.setManager(this);
 
         final Region<String, HttpSession> region = getSessionCache().getOperatingRegion();
-        final DeltaSessionInterface
-            existingSession =
+        final DeltaSessionInterface existingSession =
             (DeltaSessionInterface) region.get(session.getId());
         // Check whether the existing session is newer
         if (existingSession != null

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
@@ -68,7 +68,7 @@ import org.apache.geode.modules.util.ContextMapper;
 import org.apache.geode.modules.util.RegionConfiguration;
 import org.apache.geode.modules.util.RegionHelper;
 
-public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCommitSessionValve>
+public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCommitSessionValve<?>>
     extends ManagerBase
     implements Lifecycle, PropertyChangeListener, SessionManager, DeltaSessionManagerConfiguration {
 

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManager.java
@@ -112,7 +112,7 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
   private static final boolean DEFAULT_ENABLE_COMMIT_VALVE_FAILFAST = false;
 
   /**
-   * @deprecated No replacement. Always refer deserialized form.
+   * @deprecated No replacement. Always prefer deserialized form.
    */
   @Deprecated
   private static final boolean DEFAULT_PREFER_DESERIALIZED_FORM = true;
@@ -139,7 +139,7 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
   private boolean enableDebugListener = DEFAULT_ENABLE_DEBUG_LISTENER;
 
   /**
-   * @deprecated No replacement. Always refer deserialized form.
+   * @deprecated No replacement. Always prefer deserialized form.
    */
   @Deprecated
   private boolean preferDeserializedForm = DEFAULT_PREFER_DESERIALIZED_FORM;
@@ -278,7 +278,7 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
   }
 
   /**
-   * @deprecated No replacement. Always refer deserialized form.
+   * @deprecated No replacement. Always prefer deserialized form.
    */
   @Deprecated
   @Override
@@ -292,7 +292,7 @@ public abstract class DeltaSessionManager<CommitSessionValveT extends AbstractCo
   }
 
   /**
-   * @deprecated No replacement. Always refer deserialized form.
+   * @deprecated No replacement. Always prefer deserialized form.
    */
   @Deprecated
   @Override

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManagerConfiguration.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManagerConfiguration.java
@@ -1,0 +1,51 @@
+package org.apache.geode.modules.session.catalina;
+
+/**
+ * Method used by Catalina XML configuration.
+ */
+@SuppressWarnings("unused")
+interface DeltaSessionManagerConfiguration {
+
+  void setRegionName(String regionName);
+
+  String getRegionName();
+
+  void setEnableLocalCache(boolean enableLocalCache);
+
+  boolean getEnableLocalCache();
+
+  void setMaxActiveSessions(int maxActiveSessions);
+
+  int getMaxActiveSessions();
+
+  void setRegionAttributesId(String regionType);
+
+  String getRegionAttributesId();
+
+  void setEnableGatewayDeltaReplication(boolean enableGatewayDeltaReplication);
+
+  boolean getEnableGatewayDeltaReplication();
+
+  void setEnableGatewayReplication(boolean enableGatewayReplication);
+
+  boolean getEnableGatewayReplication();
+
+  void setEnableDebugListener(boolean enableDebugListener);
+
+  boolean getEnableDebugListener();
+
+  boolean isCommitValveEnabled();
+
+  void setEnableCommitValve(boolean enable);
+
+  boolean isCommitValveFailfastEnabled();
+
+  void setEnableCommitValveFailfast(boolean enable);
+
+  boolean isBackingCacheAvailable();
+
+  void setPreferDeserializedForm(boolean enable);
+
+  boolean getPreferDeserializedForm();
+
+}

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManagerConfiguration.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManagerConfiguration.java
@@ -60,13 +60,13 @@ interface DeltaSessionManagerConfiguration {
   boolean isBackingCacheAvailable();
 
   /**
-   * @deprecated No replacement. Always refer deserialized form.
+   * @deprecated No replacement. Always prefer deserialized form.
    */
   @Deprecated
   void setPreferDeserializedForm(boolean enable);
 
   /**
-   * @deprecated No replacement. Always refer deserialized form.
+   * @deprecated No replacement. Always prefer deserialized form.
    */
   @Deprecated
   boolean getPreferDeserializedForm();

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManagerConfiguration.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/DeltaSessionManagerConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.geode.modules.session.catalina;
 
 /**
@@ -44,8 +59,16 @@ interface DeltaSessionManagerConfiguration {
 
   boolean isBackingCacheAvailable();
 
+  /**
+   * @deprecated No replacement. Always refer deserialized form.
+   */
+  @Deprecated
   void setPreferDeserializedForm(boolean enable);
 
+  /**
+   * @deprecated No replacement. Always refer deserialized form.
+   */
+  @Deprecated
   boolean getPreferDeserializedForm();
 
 }

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/JvmRouteBinderValve.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/JvmRouteBinderValve.java
@@ -64,15 +64,7 @@ public class JvmRouteBinderValve extends ValveBase {
           manager.getLogger().debug(builder);
         }
         // Get the original session
-        Session session = null;
-        try {
-          session = manager.findSession(sessionId);
-        } catch (IOException e) {
-          String builder = this + ": Caught exception attempting to find session "
-              + sessionId + " in " + manager;
-          manager.getLogger().warn(builder, e);
-        }
-
+        final Session session = manager.findSession(sessionId);
         if (session == null) {
           String builder = this + ": Did not find session " + sessionId
               + " to failover in " + manager;

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/SessionManager.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/SessionManager.java
@@ -38,6 +38,10 @@ public interface SessionManager {
 
   boolean isBackingCacheAvailable();
 
+  /**
+   * @deprecated no replacement. Always prefer deserialized form.
+   */
+  @Deprecated
   boolean getPreferDeserializedForm();
 
   String getStatisticsName();

--- a/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/callback/SessionExpirationCacheListener.java
+++ b/extensions/geode-modules/src/main/java/org/apache/geode/modules/session/catalina/callback/SessionExpirationCacheListener.java
@@ -30,7 +30,7 @@ public class SessionExpirationCacheListener extends CacheListenerAdapter<String,
 
   @Override
   public void afterDestroy(EntryEvent<String, HttpSession> event) {
-    // A Session expired. If it was destroyed by GemFire expiration, process it.
+    // A Session expired. If it was destroyed by Geode expiration, process it.
     // If it was destroyed via Session.invalidate, ignore it since it has
     // already been processed.
     DeltaSessionInterface session = null;

--- a/extensions/session-testing-war/src/main/java/org/apache/geode/modules/session/AccessAttributeValueListener.java
+++ b/extensions/session-testing-war/src/main/java/org/apache/geode/modules/session/AccessAttributeValueListener.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.modules.session;
+
+import javax.servlet.http.HttpSessionAttributeListener;
+import javax.servlet.http.HttpSessionBindingEvent;
+
+public class AccessAttributeValueListener implements HttpSessionAttributeListener {
+  @Override
+  public void attributeAdded(HttpSessionBindingEvent event) {
+    System.out.println("event created value is " + (String) event.getValue());
+  }
+
+  @Override
+  public void attributeRemoved(HttpSessionBindingEvent event) {
+    System.out.println("event removed value is " + (String) event.getValue());
+  }
+
+  @Override
+  public void attributeReplaced(HttpSessionBindingEvent event) {
+    System.out.println("event replaced value is " + (String) event.getValue());
+  }
+}

--- a/extensions/session-testing-war/src/main/webapp/WEB-INF/web.xml
+++ b/extensions/session-testing-war/src/main/webapp/WEB-INF/web.xml
@@ -48,4 +48,8 @@ limitations under the License.
     <listener-class>org.apache.geode.modules.session.SessionCountingListener</listener-class>
   </listener>
 
+  <listener>
+    <listener-class>org.apache.geode.modules.session.AccessAttributeValueListener</listener-class>
+  </listener>
+
 </web-app>

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/LogChecker.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/LogChecker.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.session.tests;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+public class LogChecker {
+  private static List<String> suspectStrings;
+  private static List<String> excludeStrings;
+  private static Logger logger = LogService.getLogger();
+
+  static {
+    suspectStrings = new ArrayList<>();
+    suspectStrings.add(java.lang.ClassCastException.class.getName());
+    suspectStrings.add(java.lang.NullPointerException.class.getName());
+    excludeStrings = new ArrayList<>();
+    excludeStrings.add("[fine");
+  }
+
+  static void checkLogs(File dir) {
+    List<File> logsToCheck = getLogs(dir);
+    checkLogs(logsToCheck);
+  }
+
+  private static List<File> getLogs(File currentDir) {
+    logger.info("Getting all logs visible from " + currentDir);
+    List<File> logList = new ArrayList<>();
+    getLogs(currentDir, logList);
+    return logList;
+  }
+
+  private static void getLogs(File currentDir, List<File> logs) {
+    File[] dirContents = currentDir.listFiles();
+    if (dirContents == null) {
+      return;
+    }
+    for (File aFile : dirContents) {
+      if (aFile.isDirectory()) {
+        getLogs(aFile, logs);
+      } else {
+        String fileName = aFile.getName();
+        if (fileName.startsWith("container") && fileName.endsWith(".log")) {
+          logs.add(aFile);
+        } else if (fileName.startsWith("gemfire") && fileName.endsWith(".log")) {
+          logs.add(aFile);
+        }
+      }
+    }
+  }
+
+  private static void checkLogs(List<File> logsToCheck) {
+    BufferedReader reader = null;
+    String line;
+    for (File aFile : logsToCheck) {
+      logger.info("Checking " + aFile.getAbsolutePath());
+      try {
+        try {
+          reader = new BufferedReader(new FileReader(aFile.getAbsoluteFile()));
+        } catch (FileNotFoundException e) {
+          throw new RuntimeException(e);
+        }
+        line = readNextLine(reader);
+        while (line != null) {
+          if (contains(suspectStrings, line) && !contains(excludeStrings, line)) {
+            throw new RuntimeException(aFile.getAbsolutePath() + " contains " + line + "\n");
+          }
+          line = readNextLine(reader);
+        }
+      } finally {
+        close(reader);
+      }
+    }
+  }
+
+  private static String readNextLine(BufferedReader reader) {
+    String line;
+    try {
+      line = reader.readLine();
+      return line;
+    } catch (IOException e) {
+      logger.info("Caught " + e);
+      return null;
+    }
+  }
+
+  private static boolean contains(List<String> targetStrs, String aStr) {
+    for (String target : targetStrs) {
+      if (aStr.contains(target)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static void close(BufferedReader reader) {
+    if (reader != null) {
+      try {
+        reader.close();
+      } catch (IOException e) {
+        logger.info("Caught " + e + " while closing " + reader);
+      }
+    }
+  }
+}


### PR DESCRIPTION
When preferDeserializedForm is true we deserialize the previous attributes before update or remove.

Deprecates preferDeserializedForm since when false it's unclear when you will get serialized or unserialized forms of attributes.

