### PR TITLE
GEODE-8250: Create new custom log config acceptance tests

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTest.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.logging;
+
+import static java.nio.file.Files.copy;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
+import static org.apache.geode.test.assertj.LogFileAssert.assertThat;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
+import static org.apache.geode.test.util.ResourceUtils.getResource;
+
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import org.apache.geode.test.junit.rules.RequiresGeodeHome;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+
+public class LocatorWithCustomLogConfigAcceptanceTest {
+
+  private static final String CONFIG_WITH_GEODE_PLUGINS_FILE_NAME =
+      "LocatorWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml";
+  private static final String CONFIG_WITHOUT_GEODE_PLUGINS_FILE_NAME =
+      "LocatorWithCustomLogConfigAcceptanceTestWithoutGeodePlugins.xml";
+
+  private String locatorName;
+  private Path workingDir;
+  private int locatorPort;
+  private int httpPort;
+  private int rmiPort;
+  private Path configWithGeodePluginsFile;
+  private Path configWithoutGeodePluginsFile;
+  private Path locatorLogFile;
+  private Path pulseLogFile;
+  private Path customLogFile;
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+  @Rule
+  public RequiresGeodeHome requiresGeodeHome = new RequiresGeodeHome();
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule
+  public TestName testName = new TestName();
+
+  @Before
+  public void setUpLogConfigFiles() {
+    configWithGeodePluginsFile = createFileFromResource(
+        getResource(CONFIG_WITH_GEODE_PLUGINS_FILE_NAME), temporaryFolder.getRoot(),
+        CONFIG_WITH_GEODE_PLUGINS_FILE_NAME)
+            .toPath();
+
+    configWithoutGeodePluginsFile = createFileFromResource(
+        getResource(CONFIG_WITHOUT_GEODE_PLUGINS_FILE_NAME), temporaryFolder.getRoot(),
+        CONFIG_WITHOUT_GEODE_PLUGINS_FILE_NAME)
+            .toPath();
+  }
+
+  @Before
+  public void setUpOutputFiles() {
+    locatorName = testName.getMethodName();
+
+    workingDir = temporaryFolder.getRoot().toPath().toAbsolutePath();
+    locatorLogFile = workingDir.resolve(locatorName + ".log");
+    pulseLogFile = workingDir.resolve("pulse.log");
+    customLogFile = workingDir.resolve("custom.log");
+  }
+
+  @Before
+  public void setUpRandomPorts() {
+    int[] ports = getRandomAvailableTCPPorts(3);
+
+    locatorPort = ports[0];
+    httpPort = ports[1];
+    rmiPort = ports[2];
+  }
+
+  @After
+  public void stopLocator() {
+    gfshRule.execute("stop locator --dir=" + workingDir);
+  }
+
+  @Test
+  public void locatorLauncherUsesDefaultLoggingConfig() {
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + locatorName,
+        "--dir=" + workingDir,
+        "--port=" + locatorPort,
+        "--J=-Dgemfire.jmx-manager=true",
+        "--J=-Dgemfire.jmx-manager-start=true",
+        "--J=-Dgemfire.jmx-manager-http-port=" + httpPort,
+        "--J=-Dgemfire.jmx-manager-port=" + rmiPort);
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(locatorLogFile.toFile())
+          .as(locatorLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Located war: geode-pulse")
+          .contains("Adding webapp /pulse")
+          .contains("Starting server location for Distribution Locator")
+          .doesNotContain("geode-pulse war file was not found")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+
+      assertThat(pulseLogFile.toFile())
+          .as(pulseLogFile.toFile().getAbsolutePath())
+          .exists();
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+    });
+  }
+
+  @Test
+  public void locatorLauncherUsesSpecifiedConfigFileWithoutGeodePlugins() {
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + locatorName,
+        "--dir=" + workingDir,
+        "--port=" + locatorPort,
+        "--J=-Dgemfire.jmx-manager=true",
+        "--J=-Dgemfire.jmx-manager-start=true",
+        "--J=-Dgemfire.jmx-manager-http-port=" + httpPort,
+        "--J=-Dgemfire.jmx-manager-port=" + rmiPort,
+        "--J=-Dlog4j.configurationFile=" + configWithoutGeodePluginsFile.toAbsolutePath());
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(locatorLogFile.toFile())
+          .as(locatorLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(pulseLogFile.toFile())
+          .as(pulseLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Located war: geode-pulse")
+          .contains("Adding webapp /pulse")
+          .contains("Starting server location for Distribution Locator")
+          .doesNotContain("geode-pulse war file was not found")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+
+  @Test
+  public void locatorLauncherUsesConfigFileInClasspathWithoutGeodePlugins() throws Exception {
+    copy(configWithoutGeodePluginsFile, workingDir.resolve("log4j2.xml"));
+
+    String classpath = workingDir.toFile().getAbsolutePath();
+
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + locatorName,
+        "--dir=" + workingDir,
+        "--port=" + locatorPort,
+        "--classpath", classpath,
+        "--J=-Dgemfire.jmx-manager=true",
+        "--J=-Dgemfire.jmx-manager-start=true",
+        "--J=-Dgemfire.jmx-manager-http-port=" + httpPort,
+        "--J=-Dgemfire.jmx-manager-port=" + rmiPort);
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(locatorLogFile.toFile())
+          .as(locatorLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(pulseLogFile.toFile())
+          .as(pulseLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Located war: geode-pulse")
+          .contains("Adding webapp /pulse")
+          .contains("Starting server location for Distribution Locator")
+          .doesNotContain("geode-pulse war file was not found")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+
+  @Test
+  public void locatorLauncherUsesSpecifiedConfigFileWithGeodePlugins() {
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + locatorName,
+        "--dir=" + workingDir,
+        "--port=" + locatorPort,
+        "--J=-Dgemfire.jmx-manager=true",
+        "--J=-Dgemfire.jmx-manager-start=true",
+        "--J=-Dgemfire.jmx-manager-http-port=" + httpPort,
+        "--J=-Dgemfire.jmx-manager-port=" + rmiPort,
+        "--J=-Dlog4j.configurationFile=" + configWithGeodePluginsFile.toAbsolutePath());
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(locatorLogFile.toFile())
+          .as(locatorLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Located war: geode-pulse")
+          .contains("Adding webapp /pulse")
+          .contains("Starting server location for Distribution Locator")
+          .doesNotContain("geode-pulse war file was not found")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+
+      assertThat(pulseLogFile.toFile())
+          .as(pulseLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Located war: geode-pulse")
+          .contains("Adding webapp /pulse")
+          .contains("Starting server location for Distribution Locator")
+          .doesNotContain("geode-pulse war file was not found")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+
+  @Test
+  public void locatorLauncherUsesConfigFileInClasspathWithGeodePlugins() throws Exception {
+    copy(configWithGeodePluginsFile, temporaryFolder.getRoot().toPath().resolve("log4j2.xml"));
+
+    String classpath = workingDir.toFile().getAbsolutePath();
+
+    String startLocatorCommand = String.join(" ",
+        "start locator",
+        "--name=" + locatorName,
+        "--dir=" + workingDir,
+        "--port=" + locatorPort,
+        "--classpath", classpath,
+        "--J=-Dgemfire.jmx-manager=true",
+        "--J=-Dgemfire.jmx-manager-start=true",
+        "--J=-Dgemfire.jmx-manager-http-port=" + httpPort,
+        "--J=-Dgemfire.jmx-manager-port=" + rmiPort);
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(locatorLogFile.toFile())
+          .as(locatorLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Located war: geode-pulse")
+          .contains("Adding webapp /pulse")
+          .contains("Starting server location for Distribution Locator")
+          .doesNotContain("geode-pulse war file was not found")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+
+      assertThat(pulseLogFile.toFile())
+          .as(pulseLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Located war: geode-pulse")
+          .contains("Adding webapp /pulse")
+          .contains("Starting server location for Distribution Locator")
+          .doesNotContain("geode-pulse war file was not found")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+}

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.logging;
+
+import static java.nio.file.Files.copy;
+import static org.apache.geode.test.assertj.LogFileAssert.assertThat;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.util.ResourceUtils.createFileFromResource;
+import static org.apache.geode.test.util.ResourceUtils.getResource;
+
+import java.nio.file.Path;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import org.apache.geode.test.junit.rules.RequiresGeodeHome;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+
+public class ServerWithCustomLogConfigAcceptanceTest {
+
+  private static final String CONFIG_WITH_GEODE_PLUGINS_FILE_NAME =
+      "ServerWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml";
+  private static final String CONFIG_WITHOUT_GEODE_PLUGINS_FILE_NAME =
+      "ServerWithCustomLogConfigAcceptanceTestWithoutGeodePlugins.xml";
+
+  private String serverName;
+  private Path workingDir;
+  private Path configWithGeodePluginsFile;
+  private Path configWithoutGeodePluginsFile;
+  private Path serverLogFile;
+  private Path customLogFile;
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+  @Rule
+  public RequiresGeodeHome requiresGeodeHome = new RequiresGeodeHome();
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule
+  public TestName testName = new TestName();
+
+  @Before
+  public void setUpLogConfigFiles() {
+    configWithGeodePluginsFile = createFileFromResource(
+        getResource(CONFIG_WITH_GEODE_PLUGINS_FILE_NAME), temporaryFolder.getRoot(),
+        CONFIG_WITH_GEODE_PLUGINS_FILE_NAME)
+            .toPath();
+
+    configWithoutGeodePluginsFile = createFileFromResource(
+        getResource(CONFIG_WITHOUT_GEODE_PLUGINS_FILE_NAME), temporaryFolder.getRoot(),
+        CONFIG_WITHOUT_GEODE_PLUGINS_FILE_NAME)
+            .toPath();
+  }
+
+  @Before
+  public void setUpOutputFiles() {
+    serverName = testName.getMethodName();
+
+    workingDir = temporaryFolder.getRoot().toPath().toAbsolutePath();
+    serverLogFile = workingDir.resolve(serverName + ".log");
+    customLogFile = workingDir.resolve("custom.log");
+  }
+
+  @After
+  public void stopServer() {
+    gfshRule.execute("stop server --dir=" + workingDir);
+  }
+
+  @Test
+  public void serverLauncherUsesDefaultLoggingConfig() {
+    String startLocatorCommand = String.join(" ",
+        "start server",
+        "--name=" + serverName,
+        "--dir=" + workingDir,
+        "--disable-default-server",
+        "--locators=\"\"");
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(serverLogFile.toFile())
+          .as(serverLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Server " + serverName + " startup completed in ")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+    });
+  }
+
+  @Test
+  public void serverLauncherUsesSpecifiedConfigFileWithoutGeodePlugins() {
+    String startLocatorCommand = String.join(" ",
+        "start server",
+        "--name=" + serverName,
+        "--dir=" + workingDir,
+        "--disable-default-server",
+        "--locators=\"\"",
+        "--J=-Dlog4j.configurationFile=" + configWithoutGeodePluginsFile.toAbsolutePath());
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(serverLogFile.toFile())
+          .as(serverLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Server " + serverName + " startup completed in ")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+
+  @Test
+  public void serverLauncherUsesConfigFileInClasspathWithoutGeodePlugins() throws Exception {
+    copy(configWithoutGeodePluginsFile, workingDir.resolve("log4j2.xml"));
+
+    String classpath = workingDir.toFile().getAbsolutePath();
+
+    String startLocatorCommand = String.join(" ",
+        "start server",
+        "--name=" + serverName,
+        "--dir=" + workingDir,
+        "--disable-default-server",
+        "--locators=\"\"",
+        "--classpath", classpath);
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(serverLogFile.toFile())
+          .as(serverLogFile.toFile().getAbsolutePath())
+          .doesNotExist();
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Server " + serverName + " startup completed in ")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+
+  @Test
+  public void serverLauncherUsesSpecifiedConfigFileWithGeodePlugins() {
+    String startLocatorCommand = String.join(" ",
+        "start server",
+        "--name=" + serverName,
+        "--dir=" + workingDir,
+        "--disable-default-server",
+        "--locators=\"\"",
+        "--J=-Dlog4j.configurationFile=" + configWithGeodePluginsFile.toAbsolutePath());
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(serverLogFile.toFile())
+          .as(serverLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Server " + serverName + " startup completed in ")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Server " + serverName + " startup completed in ")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+
+  @Test
+  public void serverLauncherUsesConfigFileInClasspathWithGeodePlugins() throws Exception {
+    copy(configWithGeodePluginsFile, temporaryFolder.getRoot().toPath().resolve("log4j2.xml"));
+
+    String classpath = workingDir.toFile().getAbsolutePath();
+
+    String startLocatorCommand = String.join(" ",
+        "start server",
+        "--name=" + serverName,
+        "--dir=" + workingDir,
+        "--disable-default-server",
+        "--locators=\"\"",
+        "--classpath", classpath);
+
+    gfshRule.execute(startLocatorCommand);
+
+    await().untilAsserted(() -> {
+      assertThat(serverLogFile.toFile())
+          .as(serverLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Server " + serverName + " startup completed in ")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+
+      assertThat(customLogFile.toFile())
+          .as(customLogFile.toFile().getAbsolutePath())
+          .exists()
+          .contains("Server " + serverName + " startup completed in ")
+          .doesNotContain("java.lang.IllegalStateException: No factory method found for class");
+    });
+  }
+}

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
@@ -1,0 +1,49 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance with the License. You may obtain a
+  ~ copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License
+  ~ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  ~ or implied. See the License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+    <Properties>
+        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
+    </Properties>
+    <Appenders>
+        <File name="FILE" fileName="custom.log">
+            <PatternLayout pattern="${geode-pattern}"/>
+        </File>
+        <GeodeLogWriter name="LOGWRITER">
+            <PatternLayout pattern="${geode-pattern}"/>
+        </GeodeLogWriter>
+        <GeodeLogWriter name="SECURITYLOGWRITER" security="true">
+            <PatternLayout pattern="${geode-pattern}"/>
+        </GeodeLogWriter>
+        <GeodeAlert name="ALERT"/>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.gemstone" level="INFO" additivity="true"/>
+        <Logger name="org.apache.geode" level="INFO" additivity="true">
+            <filters>
+                <MarkerFilter marker="GEODE_VERBOSE" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </filters>
+        </Logger>
+        <Logger name="org.apache.geode.security" level="INFO" additivity="false">
+            <AppenderRef ref="SECURITYLOGWRITER"/>
+        </Logger>
+        <Logger name="org.jgroups" level="FATAL" additivity="true"/>
+        <Logger name="org.eclipse.jetty" level="INFO" additivity="true"/>
+        <Root level="INFO">
+            <AppenderRef ref="FILE"/>
+            <AppenderRef ref="LOGWRITER"/>
+            <AppenderRef ref="ALERT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTestWithoutGeodePlugins.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTestWithoutGeodePlugins.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance with the License. You may obtain a
+  ~ copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License
+  ~ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  ~ or implied. See the License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<Configuration status="WARN" shutdownHook="disable">
+    <Properties>
+        <Property name="custom-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    </Properties>
+    <Appenders>
+        <File name="FILE" fileName="custom.log">
+            <PatternLayout pattern="${custom-pattern}"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.gemstone" level="INFO" additivity="true"/>
+        <Logger name="org.apache.geode" level="INFO" additivity="true">
+            <filters>
+                <MarkerFilter marker="GEODE_VERBOSE" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </filters>
+        </Logger>
+        <Logger name="org.jgroups" level="FATAL" additivity="true"/>
+        <Logger name="org.eclipse.jetty" level="INFO" additivity="true"/>
+        <Root level="INFO">
+            <AppenderRef ref="FILE"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
@@ -1,0 +1,49 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance with the License. You may obtain a
+  ~ copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License
+  ~ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  ~ or implied. See the License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+    <Properties>
+        <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
+    </Properties>
+    <Appenders>
+        <File name="FILE" fileName="custom.log">
+            <PatternLayout pattern="${geode-pattern}"/>
+        </File>
+        <GeodeLogWriter name="LOGWRITER">
+            <PatternLayout pattern="${geode-pattern}"/>
+        </GeodeLogWriter>
+        <GeodeLogWriter name="SECURITYLOGWRITER" security="true">
+            <PatternLayout pattern="${geode-pattern}"/>
+        </GeodeLogWriter>
+        <GeodeAlert name="ALERT"/>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.gemstone" level="INFO" additivity="true"/>
+        <Logger name="org.apache.geode" level="INFO" additivity="true">
+            <filters>
+                <MarkerFilter marker="GEODE_VERBOSE" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </filters>
+        </Logger>
+        <Logger name="org.apache.geode.security" level="INFO" additivity="false">
+            <AppenderRef ref="SECURITYLOGWRITER"/>
+        </Logger>
+        <Logger name="org.jgroups" level="FATAL" additivity="true"/>
+        <Logger name="org.eclipse.jetty" level="INFO" additivity="true"/>
+        <Root level="INFO">
+            <AppenderRef ref="FILE"/>
+            <AppenderRef ref="LOGWRITER"/>
+            <AppenderRef ref="ALERT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTestWithoutGeodePlugins.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTestWithoutGeodePlugins.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+  ~ agreements. See the NOTICE file distributed with this work for additional information regarding
+  ~ copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance with the License. You may obtain a
+  ~ copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed under the License
+  ~ is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  ~ or implied. See the License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<Configuration status="WARN" shutdownHook="disable">
+    <Properties>
+        <Property name="custom-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
+    </Properties>
+    <Appenders>
+        <File name="FILE" fileName="custom.log">
+            <PatternLayout pattern="${custom-pattern}"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Logger name="com.gemstone" level="INFO" additivity="true"/>
+        <Logger name="org.apache.geode" level="INFO" additivity="true">
+            <filters>
+                <MarkerFilter marker="GEODE_VERBOSE" onMatch="DENY" onMismatch="NEUTRAL"/>
+            </filters>
+        </Logger>
+        <Logger name="org.jgroups" level="FATAL" additivity="true"/>
+        <Logger name="org.eclipse.jetty" level="INFO" additivity="true"/>
+        <Root level="INFO">
+            <AppenderRef ref="FILE"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/geode-junit/src/main/java/org/apache/geode/test/assertj/internal/AbstractLogFileAssert.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/assertj/internal/AbstractLogFileAssert.java
@@ -51,6 +51,11 @@ public abstract class AbstractLogFileAssert<SELF extends AbstractLogFileAssert<S
     return myself;
   }
 
+  public SELF doesNotExist() {
+    files.assertDoesNotExist(info, actual);
+    return myself;
+  }
+
   public SELF contains(String... value) {
     assertContains(info, actual, charset, value);
     return myself;


### PR DESCRIPTION
New tests to discover and verify that use of custom log configs works
when using GFSH to start Locator and Server.
