### PR TITLE
GEODE-8240: first try at a fix—not good

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
@@ -43,20 +43,20 @@ import org.apache.geode.internal.serialization.Version;
  */
 public class GMSMemberDataVersionJUnitTest {
 
-  private final Version unknownVersion =
-      Version.UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING;
+  private final short unknownVersionOrdinal =
+      (short)(Version.CURRENT_ORDINAL + 1);
 
   @Test
   public void testConstructor1() {
     final MemberDataBuilderImpl builder = MemberDataBuilderImpl.newBuilder(null, null);
-    builder.setVersionOrdinal(unknownVersion.ordinal());
+    builder.setVersionOrdinal(unknownVersionOrdinal);
     validate(builder.build());
   }
 
   @Test
   public void testConstructor2() {
     final GMSMemberData memberData =
-        new GMSMemberData(mock(InetAddress.class), 0, unknownVersion.ordinal(), 0, 0, 0);
+        new GMSMemberData(mock(InetAddress.class), 0, unknownVersionOrdinal, 0, 0, 0);
     validate(memberData);
   }
 
@@ -64,7 +64,7 @@ public class GMSMemberDataVersionJUnitTest {
   public void testReadEssentialData() throws IOException, ClassNotFoundException {
 
     final MemberDataBuilderImpl builder = MemberDataBuilderImpl.newBuilder(null, null);
-    builder.setVersionOrdinal(unknownVersion.ordinal());
+    builder.setVersionOrdinal(unknownVersionOrdinal);
     final MemberData member = builder.build();
 
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -88,12 +88,12 @@ public class GMSMemberDataVersionJUnitTest {
   @Test
   public void testSetVersionOrdinal() {
     final GMSMemberData memberData = new GMSMemberData();
-    memberData.setVersionOrdinal(unknownVersion.ordinal());
+    memberData.setVersionOrdinal(unknownVersionOrdinal);
     validate(memberData);
   }
 
   private AbstractShortAssert<?> validate(final MemberData memberData) {
-    return assertThat(memberData.getVersionOrdinal()).isEqualTo(unknownVersion.ordinal());
+    return assertThat(memberData.getVersionOrdinal()).isEqualTo(unknownVersionOrdinal);
   }
 
 }

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal.membership.gms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+
+import org.assertj.core.api.AbstractShortAssert;
+import org.junit.Test;
+
+import org.apache.geode.distributed.internal.membership.api.MemberData;
+import org.apache.geode.internal.serialization.DSFIDSerializer;
+import org.apache.geode.internal.serialization.DSFIDSerializerFactory;
+import org.apache.geode.internal.serialization.DeserializationContext;
+import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.internal.serialization.Version;
+
+/**
+ * MemberData has to be able to hold an unknown version ordinal since, during a rolling upgrade,
+ * we may receive a MemberData from a member running a future version of the product.
+ */
+public class GMSMemberDataVersionJUnitTest {
+
+  private final Version unknownVersion =
+      Version.UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING;
+
+  @Test
+  public void testConstructor1() {
+    final MemberDataBuilderImpl builder = MemberDataBuilderImpl.newBuilder(null, null);
+    builder.setVersionOrdinal(unknownVersion.ordinal());
+    validate(builder.build());
+  }
+
+  @Test
+  public void testConstructor2() {
+    final GMSMemberData memberData =
+        new GMSMemberData(mock(InetAddress.class), 0, unknownVersion.ordinal(), 0, 0, 0);
+    validate(memberData);
+  }
+
+  @Test
+  public void testReadEssentialData() throws IOException, ClassNotFoundException {
+
+    final MemberDataBuilderImpl builder = MemberDataBuilderImpl.newBuilder(null, null);
+    builder.setVersionOrdinal(unknownVersion.ordinal());
+    final MemberData member = builder.build();
+
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final DataOutput dataOutput = new DataOutputStream(baos);
+    final DSFIDSerializer dsfidSerializer = new DSFIDSerializerFactory().create();
+    final SerializationContext serializationContext =
+        dsfidSerializer.createSerializationContext(dataOutput);
+    member.writeEssentialData(dataOutput, serializationContext);
+
+    final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    final DataInputStream stream = new DataInputStream(bais);
+    final DeserializationContext deserializationContext =
+        dsfidSerializer.createDeserializationContext(stream);
+    final DataInput dataInput = new DataInputStream(bais);
+    final GMSMemberData newMember = new GMSMemberData();
+    newMember.readEssentialData(dataInput, deserializationContext);
+
+    validate(newMember);
+  }
+
+  @Test
+  public void testSetVersionOrdinal() {
+    final GMSMemberData memberData = new GMSMemberData();
+    memberData.setVersionOrdinal(unknownVersion.ordinal());
+    validate(memberData);
+  }
+
+  private AbstractShortAssert<?> validate(final MemberData memberData) {
+    return assertThat(memberData.getVersionOrdinal()).isEqualTo(unknownVersion.ordinal());
+  }
+
+}

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
@@ -44,7 +44,7 @@ import org.apache.geode.internal.serialization.Version;
 public class GMSMemberDataVersionJUnitTest {
 
   private final short unknownVersionOrdinal =
-      (short)(Version.CURRENT_ORDINAL + 1);
+      (short) (Version.CURRENT_ORDINAL + 1);
 
   @Test
   public void testConstructor1() {

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
@@ -316,6 +316,13 @@ public class Version implements Comparable<Version> {
   public static final Version TEST_VERSION = new Version("TEST", "VERSION", (byte) 0, (byte) 0,
       (byte) 0, (byte) 0, validOrdinalForTesting);
 
+  private static final short UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING_ORDINAL = -2;
+  @Immutable
+  public static final Version UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING =
+      new Version("FUTURE-PRODUCT", "FUTURE-VERSION", (byte) 0, (byte) 0, (byte) 0, (byte) 0,
+          UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING_ORDINAL);
+
+
   /** Creates a new instance of <code>Version</code> */
   private Version(String product, String name, byte major, byte minor, byte release, byte patch,
       short ordinal) {
@@ -328,7 +335,8 @@ public class Version implements Comparable<Version> {
     this.ordinal = ordinal;
     this.methodSuffix = this.productName + "_" + this.majorVersion + "_" + this.minorVersion + "_"
         + this.release + "_" + this.patch;
-    if (ordinal != TOKEN_ORDINAL) {
+    if (ordinal != TOKEN_ORDINAL
+        && ordinal != UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING_ORDINAL) {
       VALUES[this.ordinal] = this;
     }
   }
@@ -345,7 +353,7 @@ public class Version implements Comparable<Version> {
     }
     // for clients also check that there must be a commands object mapping
     // for processing
-    if ((VALUES.length < ordinal + 1) || VALUES[ordinal] == null) {
+    if (ordinal < 0 || (VALUES.length < ordinal + 1) || VALUES[ordinal] == null) {
       throw new UnsupportedSerializationVersionException(String.format(
           "Peer or client version with ordinal %s not supported. Highest known version is %s",
           ordinal, CURRENT.name));

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
@@ -316,13 +316,6 @@ public class Version implements Comparable<Version> {
   public static final Version TEST_VERSION = new Version("TEST", "VERSION", (byte) 0, (byte) 0,
       (byte) 0, (byte) 0, validOrdinalForTesting);
 
-  private static final short UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING_ORDINAL = -2;
-  @Immutable
-  public static final Version UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING =
-      new Version("FUTURE-PRODUCT", "FUTURE-VERSION", (byte) 0, (byte) 0, (byte) 0, (byte) 0,
-          UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING_ORDINAL);
-
-
   /** Creates a new instance of <code>Version</code> */
   private Version(String product, String name, byte major, byte minor, byte release, byte patch,
       short ordinal) {
@@ -335,8 +328,7 @@ public class Version implements Comparable<Version> {
     this.ordinal = ordinal;
     this.methodSuffix = this.productName + "_" + this.majorVersion + "_" + this.minorVersion + "_"
         + this.release + "_" + this.patch;
-    if (ordinal != TOKEN_ORDINAL
-        && ordinal != UNKNOWN_VERSION_FOR_ROLLING_UPGRADE_TESTING_ORDINAL) {
+    if (ordinal != TOKEN_ORDINAL) {
       VALUES[this.ordinal] = this;
     }
   }
@@ -353,7 +345,7 @@ public class Version implements Comparable<Version> {
     }
     // for clients also check that there must be a commands object mapping
     // for processing
-    if (ordinal < 0 || (VALUES.length < ordinal + 1) || VALUES[ordinal] == null) {
+    if ((VALUES.length < ordinal + 1) || VALUES[ordinal] == null) {
       throw new UnsupportedSerializationVersionException(String.format(
           "Peer or client version with ordinal %s not supported. Highest known version is %s",
           ordinal, CURRENT.name));


### PR DESCRIPTION
[GEODE-8240](https://issues.apache.org/jira/browse/GEODE-8240)

**Not ready for review**

This was a first attempt at a fix for GEODE-8240. It'll be abandoned after the ultimate fix (that merged to `develop` on 6/30) makes it through the CI pipeline. Bear with me for a little longer please.

This is a minimalist approach to trying to fix the bug, by allowing `GMSMemberData` to hold unknown (ordinal) product versions received through serialization. Rather than having `GMSMemberData` store a `Version` it stores a `short` to represent the ordinal version. When a caller needs the `Version` it can get it from get it.

A problem arises when a caller needs to recover a `Version` from the ordinal (`short1`) though. It leaves us with two bad options when that ordinal value represents an unknown product version:

1. collapse all unknown product versions into `Version.CURRENT` (silently)
2. allow `UnsupportedSerializationVersionException` to escape `getVersion()`

The former (1) is another version of the very bug we seek to fix. We have just moved it from the set-side (eager) to the get side (lazy). The latter (2) is bad because some callers actually might want (like `GMSMemberData`) to be able to handle unknown product versions. That exception does not differentiate between impossible product version ordinals e.g. -5 and possible-but-unknown ones e.g. 12467.

A separate PR: https://github.com/apache/geode/pull/5273 seeks to resolve the mess by introducing a new type: `VersionOrdinal`.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?
