### PR TITLE
GEODE-8240: GMSMemberData keeps VersionOrdinal

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/LIFOEvictionAlgoMemoryEnabledRegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/LIFOEvictionAlgoMemoryEnabledRegionJUnitTest.java
@@ -62,7 +62,7 @@ import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * This is a test verifies region is LIFO enabled by MEMORY verifies correct stats updating and
@@ -648,7 +648,7 @@ public class LIFOEvictionAlgoMemoryEnabledRegionJUnitTest {
     @Override
     public boolean fillInValue(final InternalRegion region, final Entry entry,
         final ByteArrayDataInput in, final DistributionManager distributionManager,
-        final Version version) {
+        final VersionOrdinal version) {
       return false;
     }
 

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -282,89 +282,13 @@ toData,12
 toDataPre_GFE_7_1_0_0,12
 toDataPre_GFE_9_0_0_0,12
 
-org/apache/geode/distributed/internal/membership/adapter/LocalViewMessage,2
-fromData,8
-toData,8
-
-org/apache/geode/distributed/internal/membership/gms/GMSMembershipView,2
-fromData,121
-toData,72
-
-org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorRequest,2
-fromData,112
-toData,132
-
-org/apache/geode/distributed/internal/membership/gms/locator/FindCoordinatorResponse,2
-fromData,130
-toData,114
-
-org/apache/geode/distributed/internal/membership/gms/locator/GetViewRequest,2
-fromData,1
-toData,1
-
-org/apache/geode/distributed/internal/membership/gms/locator/GetViewResponse,2
-fromData,20
-toData,17
-
-org/apache/geode/distributed/internal/membership/gms/messages/FinalCheckPassedMessage,2
-fromData,20
-toData,17
-
-org/apache/geode/distributed/internal/membership/gms/messages/HeartbeatMessage,2
-fromData,11
-toData,11
-
-org/apache/geode/distributed/internal/membership/gms/messages/HeartbeatRequestMessage,2
-fromData,30
-toData,27
-
-org/apache/geode/distributed/internal/membership/gms/messages/InstallViewMessage,2
-fromData,60
-toData,56
-
-org/apache/geode/distributed/internal/membership/gms/messages/JoinRequestMessage,2
-fromData,63
-toData,60
-
-org/apache/geode/distributed/internal/membership/gms/messages/JoinResponseMessage,2
-fromData,63
-toData,57
-
-org/apache/geode/distributed/internal/membership/gms/messages/LeaveRequestMessage,2
-fromData,28
-toData,25
-
-org/apache/geode/distributed/internal/membership/gms/messages/NetworkPartitionMessage,2
-fromData,1
-toData,1
-
-org/apache/geode/distributed/internal/membership/gms/messages/RemoveMemberMessage,2
-fromData,28
-toData,25
-
-org/apache/geode/distributed/internal/membership/gms/messages/SuspectMembersMessage,2
-fromData,63
-toData,92
-
-org/apache/geode/distributed/internal/membership/gms/messages/ViewAckMessage,2
-fromData,40
-toData,37
-
 org/apache/geode/distributed/internal/streaming/StreamingOperation$RequestStreamingMessage,2
 fromData,17
 toData,17
 
 org/apache/geode/distributed/internal/streaming/StreamingOperation$StreamingReplyMessage,2
-fromData,425
+fromData,427
 toData,86
-
-org/apache/geode/distributed/internal/tcpserver/InfoResponse,2
-fromData,9
-toData,9
-
-org/apache/geode/distributed/internal/tcpserver/VersionResponse,2
-fromData,11
-toData,11
 
 org/apache/geode/internal/DSFIDFactory,2
 fromData,8
@@ -577,9 +501,6 @@ toData,7
 org/apache/geode/internal/admin/remote/LicenseInfoResponse,2
 fromData,18
 toData,15
-
-org/apache/geode/internal/admin/remote/MissingPersistentIDsRequest,1
-fromData,7
 
 org/apache/geode/internal/admin/remote/MissingPersistentIDsResponse,2
 fromData,129
@@ -977,7 +898,7 @@ toData,22
 org/apache/geode/internal/cache/EventID,4
 fromData,53
 fromDataPre_GFE_8_0_0_0,33
-toData,106
+toData,108
 toDataPre_GFE_8_0_0_0,24
 
 org/apache/geode/internal/cache/EvictionAttributesImpl,2
@@ -1270,8 +1191,8 @@ fromData,38
 toData,35
 
 org/apache/geode/internal/cache/TXRegionLockRequestImpl,2
-fromData,97
-toData,55
+fromData,99
+toData,57
 
 org/apache/geode/internal/cache/TXRemoteCommitMessage$TXRemoteCommitReplyMessage,2
 fromData,18
@@ -1364,8 +1285,8 @@ fromData,22
 toData,19
 
 org/apache/geode/internal/cache/execute/FunctionRemoteContext,2
-fromData,124
-toData,102
+fromData,126
+toData,104
 
 org/apache/geode/internal/cache/ha/HARegionQueue$DispatchedAndCurrentEvents,2
 fromData,37
@@ -1624,8 +1545,8 @@ fromData,74
 toData,68
 
 org/apache/geode/internal/cache/partitioned/PartitionMessage,2
-fromData,60
-toData,113
+fromData,62
+toData,115
 
 org/apache/geode/internal/cache/partitioned/PartitionedRegionFunctionStreamingMessage,2
 fromData,18
@@ -1668,7 +1589,7 @@ fromData,54
 toData,35
 
 org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage,2
-fromData,194
+fromData,187
 toData,201
 
 org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage$RemoveAllReplyMessage,2
@@ -1966,13 +1887,13 @@ fromData,214
 toData,245
 
 org/apache/geode/internal/cache/versions/VersionTag,2
-fromData,225
+fromData,227
 toData,254
 
 org/apache/geode/internal/cache/wan/GatewaySenderAdvisor$GatewaySenderProfile,4
-fromData,283
+fromData,285
 fromDataPre_GFE_8_0_0_0,188
-toData,271
+toData,273
 toDataPre_GFE_8_0_0_0,236
 
 org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackArgument,2
@@ -2089,8 +2010,9 @@ toData,25
 
 org/apache/geode/pdx/internal/PdxField,2
 fromData,99
-toData,105
+toData,107
 
 org/apache/geode/pdx/internal/PdxType,2
 fromData,109
-toData,124
+toData,126
+

--- a/geode-core/src/main/java/org/apache/geode/DataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/DataSerializer.java
@@ -64,6 +64,7 @@ import org.apache.geode.internal.offheap.StoredObject;
 import org.apache.geode.internal.serialization.DSCODE;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.pdx.PdxInstance;
 
@@ -1235,7 +1236,7 @@ public abstract class DataSerializer {
       if (object instanceof HeapDataOutputStream) {
         hdos = (HeapDataOutputStream) object;
       } else {
-        Version v = StaticSerialization.getVersionForDataStreamOrNull(out);
+        VersionOrdinal v = StaticSerialization.getVersionForDataStreamOrNull(out);
         if (v == null) {
           v = Version.CURRENT;
         }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientSideHandshakeImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientSideHandshakeImpl.java
@@ -63,6 +63,7 @@ import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataInputStream;
 import org.apache.geode.internal.serialization.VersionedDataOutputStream;
 import org.apache.geode.security.AuthenticationFailedException;
@@ -270,7 +271,7 @@ public class ClientSideHandshakeImpl extends Handshake implements ClientSideHand
   private InternalDistributedMember readServerMember(DataInputStream p_dis) throws IOException {
 
     byte[] memberBytes = DataSerializer.readByteArray(p_dis);
-    Version v = StaticSerialization.getVersionForDataStreamOrNull(p_dis);
+    final VersionOrdinal v = StaticSerialization.getVersionForDataStreamOrNull(p_dis);
     ByteArrayDataInput dis = new ByteArrayDataInput(memberBytes, v);
     try {
       return DataSerializer.readObject(dis);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -51,6 +51,7 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.OSProcess;
 
 /**
@@ -570,7 +571,7 @@ public class InternalDistributedMember
   }
 
   @Override
-  public Version getVersionObject() {
+  public VersionOrdinal getVersionObject() {
     return memberIdentifier.getVersionObject();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/streaming/StreamingOperation.java
@@ -60,6 +60,7 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -512,7 +513,7 @@ public abstract class StreamingOperation {
       this.msgNum = in.readInt();
       this.lastMsg = in.readBoolean();
       this.pdxReadSerialized = in.readBoolean();
-      Version senderVersion = StaticSerialization.getVersionForDataStream(in);
+      final VersionOrdinal senderVersion = StaticSerialization.getVersionForDataStream(in);
       boolean isSenderAbove_8_1 = senderVersion.compareTo(Version.GFE_81) > 0;
       InternalCache cache = null;
       Boolean initialPdxReadSerialized = false;

--- a/geode-core/src/main/java/org/apache/geode/internal/HeapDataOutputStream.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/HeapDataOutputStream.java
@@ -25,6 +25,7 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.cache.BytesAndBitsForCompactor;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.tcp.ByteBufferInputStream;
 
 /**
@@ -48,7 +49,7 @@ public class HeapDataOutputStream extends
     org.apache.geode.internal.serialization.BufferDataOutputStream
     implements ObjToByteArraySerializer, ByteBufferWriter {
 
-  public HeapDataOutputStream(Version version) {
+  public HeapDataOutputStream(VersionOrdinal version) {
     this(INITIAL_CAPACITY, version);
   }
 
@@ -60,7 +61,7 @@ public class HeapDataOutputStream extends
     super(s);
   }
 
-  public HeapDataOutputStream(int allocSize, Version version) {
+  public HeapDataOutputStream(int allocSize, VersionOrdinal version) {
     this(allocSize, version, false);
   }
 
@@ -70,9 +71,8 @@ public class HeapDataOutputStream extends
 
   /**
    * @param doNotCopy if true then byte arrays/buffers/sources will not be copied to this hdos but
-   *        instead referenced.
    */
-  public HeapDataOutputStream(int allocSize, Version version, boolean doNotCopy) {
+  public HeapDataOutputStream(int allocSize, VersionOrdinal version, boolean doNotCopy) {
     super(allocSize, version, doNotCopy);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -119,6 +119,7 @@ import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.SerializationVersions;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataStream;
 import org.apache.geode.internal.util.concurrent.CopyOnWriteHashMap;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -352,7 +353,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
 
     if (out instanceof VersionedDataStream) {
       VersionedDataStream vout = (VersionedDataStream) out;
-      Version version = vout.getVersion();
+      final VersionOrdinal version = vout.getVersion();
       if (null != version) {
         if (version.compareTo(Version.GEODE_1_9_0) < 0) {
           if (name.equals(POST_GEODE_190_SERVER_CQIMPL)) {
@@ -2176,7 +2177,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
       try {
         ObjectOutput oos = new ObjectOutputStream(stream);
         if (stream instanceof VersionedDataStream) {
-          Version v = ((VersionedDataStream) stream).getVersion();
+          final VersionOrdinal v = ((VersionedDataStream) stream).getVersion();
           if (v != null && v != Version.CURRENT) {
             oos = new VersionedObjectOutput(oos, v);
           }
@@ -2209,7 +2210,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
         return;
       }
       boolean invoked = false;
-      Version v = StaticSerialization.getVersionForDataStreamOrNull(out);
+      final VersionOrdinal v = StaticSerialization.getVersionForDataStreamOrNull(out);
 
       if (Version.CURRENT != v && v != null) {
         // get versions where DataOutput was upgraded
@@ -2278,7 +2279,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
     }
     try {
       boolean invoked = false;
-      Version v = StaticSerialization.getVersionForDataStreamOrNull(in);
+      final VersionOrdinal v = StaticSerialization.getVersionForDataStreamOrNull(in);
       if (Version.CURRENT != v && v != null) {
         // get versions where DataOutput was upgraded
         Version[] versions = null;
@@ -2677,7 +2678,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
       ObjectInput ois = new DSObjectInputStream(stream);
       serializationFilter.setFilterOn((ObjectInputStream) ois);
       if (stream instanceof VersionedDataStream) {
-        Version v = ((VersionedDataStream) stream).getVersion();
+        final VersionOrdinal v = ((VersionedDataStream) stream).getVersion();
         if (Version.CURRENT != v && v != null) {
           ois = new VersionedObjectInput(ois, v);
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/VersionedObjectInput.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/VersionedObjectInput.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal;
 import java.io.IOException;
 import java.io.ObjectInput;
 
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataStream;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.geode.internal.serialization.VersionedDataStream;
 public class VersionedObjectInput implements ObjectInput, VersionedDataStream {
 
   private final ObjectInput in;
-  private final Version version;
+  private final VersionOrdinal version;
 
   /**
    * Creates a VersionedObjectInput that wraps the specified underlying ObjectInput.
@@ -38,7 +38,7 @@ public class VersionedObjectInput implements ObjectInput, VersionedDataStream {
    * @param in the specified {@link ObjectInput}
    * @param version the product version that serialized object on the given {@link ObjectInput}
    */
-  public VersionedObjectInput(ObjectInput in, Version version) {
+  public VersionedObjectInput(ObjectInput in, VersionOrdinal version) {
     this.in = in;
     this.version = version;
   }
@@ -47,7 +47,7 @@ public class VersionedObjectInput implements ObjectInput, VersionedDataStream {
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return this.version;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/VersionedObjectOutput.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/VersionedObjectOutput.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.io.ObjectOutput;
 
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataStream;
 
 /**
@@ -30,7 +31,7 @@ import org.apache.geode.internal.serialization.VersionedDataStream;
 public class VersionedObjectOutput implements ObjectOutput, VersionedDataStream {
 
   private final ObjectOutput out;
-  private final Version version;
+  private final VersionOrdinal version;
 
   /**
    * Creates a VersionedObjectOutput that wraps the specified underlying ObjectOutput.
@@ -38,7 +39,7 @@ public class VersionedObjectOutput implements ObjectOutput, VersionedDataStream 
    * @param out the underlying {@link ObjectOutput}
    * @param version the product version that serialized object on the given {@link ObjectOutput}
    */
-  public VersionedObjectOutput(ObjectOutput out, Version version) {
+  public VersionedObjectOutput(ObjectOutput out, VersionOrdinal version) {
     if (version.compareTo(Version.CURRENT) > 0) {
       Assert.fail("unexpected version: " + version + ", CURRENT: " + Version.CURRENT);
     }
@@ -50,7 +51,7 @@ public class VersionedObjectOutput implements ObjectOutput, VersionedDataStream 
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return this.version;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedPutAllOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedPutAllOperation.java
@@ -62,6 +62,7 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -335,7 +336,7 @@ public class DistributedPutAllOperation extends AbstractUpdateOperation {
      * Constructor to use when receiving a putall from someone else
      */
     public PutAllEntryData(DataInput in, DeserializationContext context, EventID baseEventID,
-        int idx, Version version,
+        int idx, VersionOrdinal version,
         ByteArrayDataInput bytesIn) throws IOException, ClassNotFoundException {
       this.key = context.getDeserializer().readObject(in);
       byte flgs = in.readByte();
@@ -1211,7 +1212,7 @@ public class DistributedPutAllOperation extends AbstractUpdateOperation {
       this.putAllDataSize = (int) InternalDataSerializer.readUnsignedVL(in);
       this.putAllData = new PutAllEntryData[this.putAllDataSize];
       if (this.putAllDataSize > 0) {
-        final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+        final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
         final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
         for (int i = 0; i < this.putAllDataSize; i++) {
           this.putAllData[i] = new PutAllEntryData(in, context, eventId, i, version, bytesIn);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRemoveAllOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedRemoveAllOperation.java
@@ -55,7 +55,7 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -318,7 +318,7 @@ public class DistributedRemoveAllOperation extends AbstractUpdateOperation {
     /**
      * Constructor to use when receiving a putall from someone else
      */
-    public RemoveAllEntryData(DataInput in, EventID baseEventID, int idx, Version version,
+    public RemoveAllEntryData(DataInput in, EventID baseEventID, int idx, VersionOrdinal version,
         ByteArrayDataInput bytesIn,
         DeserializationContext context) throws IOException, ClassNotFoundException {
       this.key = context.getDeserializer().readObject(in);
@@ -991,7 +991,7 @@ public class DistributedRemoveAllOperation extends AbstractUpdateOperation {
       this.removeAllDataSize = (int) InternalDataSerializer.readUnsignedVL(in);
       this.removeAllData = new RemoveAllEntryData[this.removeAllDataSize];
       if (this.removeAllDataSize > 0) {
-        final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+        final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
         final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
         for (int i = 0; i < this.removeAllDataSize; i++) {
           this.removeAllData[i] = new RemoveAllEntryData(in, eventId, i, version, bytesIn, context);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EventID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EventID.java
@@ -46,6 +46,7 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.Breadcrumbs;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -351,7 +352,7 @@ public class EventID implements DataSerializableFixedID, Serializable, Externali
   @Override
   public void toData(DataOutput dop,
       SerializationContext context) throws IOException {
-    Version version = StaticSerialization.getVersionForDataStream(dop);
+    final VersionOrdinal version = StaticSerialization.getVersionForDataStream(dop);
     // if we are sending to old clients we need to reserialize the ID
     // using the client's version to ensure it gets the proper on-wire form
     // of the identifier

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterRoutingInfo.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterRoutingInfo.java
@@ -36,6 +36,7 @@ import org.apache.geode.internal.VersionedDataSerializable;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * This class is used to hold the information about the servers and their Filters (CQs and Interest
@@ -320,7 +321,7 @@ public class FilterRoutingInfo implements VersionedDataSerializable {
     private transient byte[] myData;
 
     /** version of creator of myData, needed for deserialization */
-    private transient Version myDataVersion;
+    private transient VersionOrdinal myDataVersion;
 
     /** Clients that are interested in the event and want values */
     private Set interestedClients;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -98,6 +98,7 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.ObjectIntProcedure;
 import org.apache.geode.logging.internal.executors.LoggingThread;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -814,7 +815,7 @@ public class InitialImageOperation {
    * @param entries entries to add to the region
    * @return false if should abort (region was destroyed or cache was closed)
    */
-  boolean processChunk(List entries, InternalDistributedMember sender, Version remoteVersion)
+  boolean processChunk(List entries, InternalDistributedMember sender, VersionOrdinal remoteVersion)
       throws IOException, ClassNotFoundException {
     final boolean isDebugEnabled = logger.isDebugEnabled();
     final boolean isTraceEnabled = logger.isTraceEnabled();
@@ -2803,7 +2804,7 @@ public class InitialImageOperation {
     private Map<VersionSource, Long> gcVersions;
 
     /** the {@link Version} of the remote peer */
-    private transient Version remoteVersion;
+    private transient VersionOrdinal remoteVersion;
 
     /** The versions in which this message was modified */
     @Immutable

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/NonLocalRegionEntry.java
@@ -35,7 +35,7 @@ import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
 
@@ -196,7 +196,7 @@ public class NonLocalRegionEntry implements RegionEntry, VersionStamp {
 
   @Override
   public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
-      DistributionManager distributionManager, final Version version) {
+      DistributionManager distributionManager, final VersionOrdinal version) {
     throw new UnsupportedOperationException(
         "Not appropriate for PartitionedRegion.NonLocalRegionEntry");
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -106,6 +106,7 @@ import org.apache.geode.internal.sequencelog.EntryLogger;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.UnsupportedSerializationVersionException;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.shared.NativeCalls;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -7220,7 +7221,8 @@ public class Oplog implements CompactableOplog, Flushable {
 
     @Override
     public boolean fillInValue(InternalRegion region, InitialImageOperation.Entry entry,
-        ByteArrayDataInput in, DistributionManager distributionManager, final Version version) {
+        ByteArrayDataInput in, DistributionManager distributionManager,
+        final VersionOrdinal version) {
       return false;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ProxyRegionMap.java
@@ -43,7 +43,7 @@ import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.concurrent.ConcurrentMapWithReusableEntries;
 
 /**
@@ -467,7 +467,7 @@ class ProxyRegionMap extends BaseRegionMap {
 
     @Override
     public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
-        DistributionManager distributionManager, final Version version) {
+        DistributionManager distributionManager, final VersionOrdinal version) {
       throw new UnsupportedOperationException(
           String.format("No entry support on regions with DataPolicy %s",
               DataPolicy.EMPTY));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntry.java
@@ -33,7 +33,7 @@ import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * Internal interface for a region entry. Note that a region is implemented with a ConcurrentHashMap
@@ -178,7 +178,7 @@ public interface RegionEntry {
    */
   boolean fillInValue(InternalRegion region,
       @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in,
-      DistributionManager distributionManager, final Version version);
+      DistributionManager distributionManager, final VersionOrdinal version);
 
   /**
    * Returns true if this entry has overflowed to disk.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -76,6 +76,7 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.executors.LoggingThread;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -938,7 +939,7 @@ public class TXCommitMessage extends PooledDistributionMessage
     return hasFlagsField(StaticSerialization.getVersionForDataStream(in));
   }
 
-  private boolean hasFlagsField(final Version version) {
+  private boolean hasFlagsField(final VersionOrdinal version) {
     return version.compareTo(Version.GEODE_1_7_0) >= 0;
   }
 
@@ -1521,7 +1522,7 @@ public class TXCommitMessage extends PooledDistributionMessage
         this.preserializedBuffer.rewind();
         this.preserializedBuffer.sendTo(out);
       } else if (this.refCount > 1) {
-        Version v = StaticSerialization.getVersionForDataStream(out);
+        final VersionOrdinal v = StaticSerialization.getVersionForDataStream(out);
         HeapDataOutputStream hdos = new HeapDataOutputStream(1024, v);
         basicToData(hdos, context, useShadowKey);
         this.preserializedBuffer = hdos;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ValidatingDiskRegion.java
@@ -38,7 +38,7 @@ import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * A disk region that is created when doing offline validation.
@@ -351,7 +351,7 @@ public class ValidatingDiskRegion extends DiskRegion implements DiskRecoveryStor
 
     @Override
     public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
-        DistributionManager distributionManager, final Version version) {
+        DistributionManager distributionManager, final VersionOrdinal version) {
       return false;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractOplogDiskRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractOplogDiskRegionEntry.java
@@ -29,7 +29,7 @@ import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * Abstract implementation class of RegionEntry interface. This is adds Disk support behavior
@@ -65,7 +65,7 @@ public abstract class AbstractOplogDiskRegionEntry extends AbstractDiskRegionEnt
 
   @Override
   public boolean fillInValue(InternalRegion region, Entry entry, ByteArrayDataInput in,
-      DistributionManager mgr, final Version version) {
+      DistributionManager mgr, final VersionOrdinal version) {
     return Helper.fillInValue(this, entry, region.getDiskRegion(), mgr, in, region, version);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/AbstractRegionEntry.java
@@ -78,7 +78,7 @@ import org.apache.geode.internal.offheap.annotations.Released;
 import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.internal.util.Versionable;
 import org.apache.geode.internal.util.concurrent.CustomEntryConcurrentHashMap;
@@ -329,7 +329,7 @@ public abstract class AbstractRegionEntry implements HashRegionEntry<Object, Obj
   @Override
   public boolean fillInValue(InternalRegion region,
       @Retained(ABSTRACT_REGION_ENTRY_FILL_IN_VALUE) Entry entry, ByteArrayDataInput in,
-      DistributionManager mgr, final Version version) {
+      DistributionManager mgr, final VersionOrdinal version) {
 
     // starting default value
     entry.setSerialized(false);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/DiskEntry.java
@@ -60,6 +60,7 @@ import org.apache.geode.internal.offheap.annotations.Retained;
 import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -297,7 +298,7 @@ public interface DiskEntry extends RegionEntry {
      */
     static boolean fillInValue(DiskEntry de, InitialImageOperation.Entry entry, DiskRegion dr,
         DistributionManager mgr, ByteArrayDataInput in, RegionEntryContext context,
-        Version version) {
+        VersionOrdinal version) {
       @Retained
       @Released
       Object v = null;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/GetMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/GetMessage.java
@@ -60,7 +60,7 @@ import org.apache.geode.internal.offheap.OffHeapHelper;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -342,7 +342,7 @@ public class GetMessage extends PartitionMessageWithDirectReply {
      */
     public VersionTag versionTag;
 
-    public transient Version remoteVersion;
+    public transient VersionOrdinal remoteVersion;
 
     /**
      * Empty constructor to conform to DataSerializable interface

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PutAllPRMessage.java
@@ -72,7 +72,7 @@ import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -230,7 +230,7 @@ public class PutAllPRMessage extends PartitionMessageWithDirectReply {
     this.putAllPRDataSize = (int) InternalDataSerializer.readUnsignedVL(in);
     this.putAllPRData = new PutAllEntryData[putAllPRDataSize];
     if (this.putAllPRDataSize > 0) {
-      final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+      final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
       final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
       for (int i = 0; i < this.putAllPRDataSize; i++) {
         this.putAllPRData[i] = new PutAllEntryData(in, context, null, i, version, bytesIn);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RemoveAllPRMessage.java
@@ -72,7 +72,7 @@ import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -220,12 +220,11 @@ public class RemoveAllPRMessage extends PartitionMessageWithDirectReply {
     if ((flags & HAS_BRIDGE_CONTEXT) != 0) {
       this.bridgeContext = DataSerializer.readObject(in);
     }
-    Version sourceVersion = StaticSerialization.getVersionForDataStream(in);
     this.callbackArg = DataSerializer.readObject(in);
     this.removeAllPRDataSize = (int) InternalDataSerializer.readUnsignedVL(in);
     this.removeAllPRData = new RemoveAllEntryData[removeAllPRDataSize];
     if (this.removeAllPRDataSize > 0) {
-      final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+      final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
       final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
       for (int i = 0; i < this.removeAllPRDataSize; i++) {
         this.removeAllPRData[i] = new RemoveAllEntryData(in, null, i, version, bytesIn, context);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProxyMembershipID.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientProxyMembershipID.java
@@ -42,6 +42,7 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.util.internal.GeodeGlossary;
 
@@ -347,7 +348,7 @@ public class ClientProxyMembershipID
     // {toString(); this.transientPort = ((InternalDistributedMember)this.memberId).getPort();}
   }
 
-  public Version getClientVersion() {
+  public VersionOrdinal getClientVersion() {
     return ((InternalDistributedMember) getDistributedMember()).getVersionObject();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/DistTxEntryEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/DistTxEntryEvent.java
@@ -36,6 +36,7 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 public class DistTxEntryEvent extends EntryEventImpl {
 
@@ -153,7 +154,7 @@ public class DistTxEntryEvent extends EntryEventImpl {
     int putAllSize = DataSerializer.readInteger(in);
     PutAllEntryData[] putAllEntries = new PutAllEntryData[putAllSize];
     if (putAllSize > 0) {
-      final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+      final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
       final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
       for (int i = 0; i < putAllSize; i++) {
         putAllEntries[i] = new PutAllEntryData(in, context, this.eventID, i, version, bytesIn);
@@ -203,7 +204,7 @@ public class DistTxEntryEvent extends EntryEventImpl {
       DeserializationContext context) throws IOException, ClassNotFoundException {
     int removeAllSize = DataSerializer.readInteger(in);
     final RemoveAllEntryData[] removeAllData = new RemoveAllEntryData[removeAllSize];
-    final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+    final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
     final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
     for (int i = 0; i < removeAllSize; i++) {
       removeAllData[i] = new RemoveAllEntryData(in, this.eventID, i, version, bytesIn, context);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteGetMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteGetMessage.java
@@ -51,7 +51,7 @@ import org.apache.geode.internal.offheap.OffHeapHelper;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -219,7 +219,7 @@ public class RemoteGetMessage extends RemoteOperationMessageWithDirectReply {
      */
     public transient byte[] valueInBytes;
 
-    public transient Version remoteVersion;
+    public transient VersionOrdinal remoteVersion;
 
     /**
      * Empty constructor to conform to DataSerializable interface

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemotePutAllMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemotePutAllMessage.java
@@ -64,7 +64,7 @@ import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -237,7 +237,7 @@ public class RemotePutAllMessage extends RemoteOperationMessageWithDirectReply {
     this.putAllDataCount = (int) InternalDataSerializer.readUnsignedVL(in);
     this.putAllData = new PutAllEntryData[putAllDataCount];
     if (this.putAllDataCount > 0) {
-      final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+      final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
       final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
       for (int i = 0; i < this.putAllDataCount; i++) {
         this.putAllData[i] = new PutAllEntryData(in, context, this.eventId, i, version, bytesIn);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteRemoveAllMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteRemoveAllMessage.java
@@ -65,7 +65,7 @@ import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -232,7 +232,7 @@ public class RemoteRemoveAllMessage extends RemoteOperationMessageWithDirectRepl
     this.removeAllDataCount = (int) InternalDataSerializer.readUnsignedVL(in);
     this.removeAllData = new RemoveAllEntryData[removeAllDataCount];
     if (this.removeAllDataCount > 0) {
-      final Version version = StaticSerialization.getVersionForDataStreamOrNull(in);
+      final VersionOrdinal version = StaticSerialization.getVersionForDataStreamOrNull(in);
       final ByteArrayDataInput bytesIn = new ByteArrayDataInput();
       for (int i = 0; i < this.removeAllDataCount; i++) {
         this.removeAllData[i] = new RemoveAllEntryData(in, this.eventId, i, version, bytesIn,

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/VersionedByteBufferInputStream.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/VersionedByteBufferInputStream.java
@@ -18,6 +18,7 @@ package org.apache.geode.internal.tcp;
 import java.nio.ByteBuffer;
 
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataStream;
 
 /**
@@ -57,7 +58,7 @@ public class VersionedByteBufferInputStream extends ByteBufferInputStream
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return this.version;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/VersionedMsgStreamer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/VersionedMsgStreamer.java
@@ -21,6 +21,7 @@ import org.apache.geode.distributed.internal.DMStats;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.internal.net.BufferPool;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataStream;
 
 /**
@@ -42,7 +43,7 @@ class VersionedMsgStreamer extends MsgStreamer implements VersionedDataStream {
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return this.version;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/util/BlobHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/util/BlobHelper.java
@@ -25,6 +25,7 @@ import org.apache.geode.internal.offheap.annotations.Unretained;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DSCODE;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.pdx.internal.PdxInputStream;
 
 /**
@@ -77,7 +78,7 @@ public class BlobHelper {
   /**
    * A blob is a serialized Object. This method returns the deserialized object.
    */
-  public static Object deserializeBlob(byte[] blob, Version version, ByteArrayDataInput in)
+  public static Object deserializeBlob(byte[] blob, VersionOrdinal version, ByteArrayDataInput in)
       throws IOException, ClassNotFoundException {
     Object result;
     final long start = startDeserialization();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/CacheServerBridge.java
@@ -52,7 +52,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
 import org.apache.geode.internal.process.PidUnavailableException;
 import org.apache.geode.internal.process.ProcessUtils;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.ClientHealthStatus;
 import org.apache.geode.management.ClientQueueDetail;
@@ -89,7 +89,7 @@ public class CacheServerBridge extends ServerBridge {
 
   private ClientMembershipListener membershipListener;
 
-  public static final ThreadLocal<Version> clientVersion = new ThreadLocal<Version>();
+  public static final ThreadLocal<VersionOrdinal> clientVersion = new ThreadLocal<>();
 
   protected static int identifyPid() {
     try {
@@ -405,7 +405,7 @@ public class CacheServerBridge extends ServerBridge {
     }
   }
 
-  public Version getClientVersion(ClientConnInfo connInfo) {
+  public VersionOrdinal getClientVersion(ClientConnInfo connInfo) {
     if (cache.getCacheServers().size() == 0) {
       return null;
     }

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxField.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxField.java
@@ -23,6 +23,7 @@ import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.pdx.FieldType;
 
 public class PdxField implements DataSerializable, Comparable<PdxField> {
@@ -172,7 +173,7 @@ public class PdxField implements DataSerializable, Comparable<PdxField> {
       // to set identityField to true.
       // For this reason the pdx delete-field command should only be used after
       // all member have been upgraded to 8.1 or later.
-      Version sourceVersion = StaticSerialization.getVersionForDataStream(out);
+      final VersionOrdinal sourceVersion = StaticSerialization.getVersionForDataStream(out);
       if (sourceVersion.compareTo(Version.GFE_81) >= 0) {
         if (this.deleted) {
           bits |= DELETED_BIT;

--- a/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxType.java
+++ b/geode-core/src/main/java/org/apache/geode/pdx/internal/PdxType.java
@@ -34,6 +34,7 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.tier.sockets.OldClientSupportService;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.pdx.PdxFieldAlreadyExistsException;
 import org.apache.geode.pdx.internal.AutoSerializableManager.AutoClassInfo;
 
@@ -134,7 +135,7 @@ public class PdxType implements DataSerializable {
       // to set noDomainClass to true.
       // For this reason the pdx delete-field command should only be used after
       // all member have been upgraded to 8.1 or later.
-      Version sourceVersion = StaticSerialization.getVersionForDataStream(out);
+      final VersionOrdinal sourceVersion = StaticSerialization.getVersionForDataStream(out);
       if (sourceVersion.compareTo(Version.GFE_81) >= 0) {
         if (this.hasDeletedField) {
           bits |= HAS_DELETED_FIELD_BIT;

--- a/geode-core/src/test/java/org/apache/geode/internal/util/BlobHelperTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/util/BlobHelperTest.java
@@ -40,7 +40,7 @@ import org.apache.geode.internal.serialization.Version;
  * Unit Tests for {@link BlobHelper}.
  *
  * TODO: add coverage for additional methods:
- * <li>{@link BlobHelper#deserializeBlob(byte[], Version, ByteArrayDataInput)}
+ * <li>{@link BlobHelper#deserializeBlob(byte[], org.apache.geode.internal.serialization.VersionOrdinal, ByteArrayDataInput)}
  * <li>{@link BlobHelper#deserializeBuffer(ByteArrayDataInput, int)}
  * <li>{@link BlobHelper#deserializeOffHeapBlob(StoredObject)}
  * <li>{@link BlobHelper#serializeToBlob(Object, Version)}

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
@@ -51,7 +51,7 @@ import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave;
 import org.apache.geode.internal.AvailablePortHelper;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
@@ -659,7 +659,7 @@ public abstract class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase 
   private static void assertVersion(Cache cache, short ordinal) {
     DistributedSystem ds = cache.getDistributedSystem();
     InternalDistributedMember member = (InternalDistributedMember) ds.getDistributedMember();
-    Version thisVersion = member.getVersionObject();
+    final VersionOrdinal thisVersion = member.getVersionObject();
     short thisOrdinal = thisVersion.ordinal();
     if (ordinal != thisOrdinal) {
       throw new Error(

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/eviction/LRUTestEntry.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/eviction/LRUTestEntry.java
@@ -32,7 +32,7 @@ import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionStamp;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 class LRUTestEntry implements EvictableEntry {
 
@@ -64,7 +64,7 @@ class LRUTestEntry implements EvictableEntry {
   @Override
   public boolean fillInValue(final InternalRegion region, final InitialImageOperation.Entry entry,
       final ByteArrayDataInput in, final DistributionManager distributionManager,
-      final Version version) {
+      final VersionOrdinal version) {
     return false;
   }
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneServiceImpl.java
@@ -80,6 +80,7 @@ import org.apache.geode.internal.cache.extension.Extensible;
 import org.apache.geode.internal.cache.xmlcache.XmlGenerator;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -237,7 +238,7 @@ public class LuceneServiceImpl implements InternalLuceneService {
 
   protected void validateAllMembersAreTheSameVersion(PartitionedRegion region) {
     Set<InternalDistributedMember> remoteMembers = region.getRegionAdvisor().adviseAllPRNodes();
-    Version localVersion =
+    final VersionOrdinal localVersion =
         cache.getDistributionManager().getDistributionManagerId().getVersionObject();
     if (!remoteMembers.isEmpty()) {
       for (InternalDistributedMember remoteMember : remoteMembers) {

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal.membership.gms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.InetAddress;
+
+import org.assertj.core.api.AbstractShortAssert;
+import org.junit.Test;
+
+import org.apache.geode.distributed.internal.membership.api.MemberData;
+import org.apache.geode.internal.serialization.DSFIDSerializer;
+import org.apache.geode.internal.serialization.DSFIDSerializerFactory;
+import org.apache.geode.internal.serialization.DeserializationContext;
+import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.internal.serialization.Version;
+
+/**
+ * MemberData has to be able to hold an unknown version ordinal since, during a rolling upgrade,
+ * we may receive a MemberData from a member running a future version of the product.
+ */
+public class GMSMemberDataVersionJUnitTest {
+
+  private final short unknownVersionOrdinal =
+      (short) (Version.CURRENT_ORDINAL + 1);
+
+  @Test
+  public void testConstructor1() {
+    final MemberDataBuilderImpl builder = MemberDataBuilderImpl.newBuilder(null, null);
+    builder.setVersionOrdinal(unknownVersionOrdinal);
+    validate(builder.build());
+  }
+
+  @Test
+  public void testConstructor2() {
+    final GMSMemberData memberData =
+        new GMSMemberData(mock(InetAddress.class), 0, unknownVersionOrdinal, 0, 0, 0);
+    validate(memberData);
+  }
+
+  @Test
+  public void testReadEssentialData() throws IOException, ClassNotFoundException {
+
+    final MemberDataBuilderImpl builder = MemberDataBuilderImpl.newBuilder(null, null);
+    builder.setVersionOrdinal(unknownVersionOrdinal);
+    final MemberData member = builder.build();
+
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    final DataOutput dataOutput = new DataOutputStream(baos);
+    final DSFIDSerializer dsfidSerializer = new DSFIDSerializerFactory().create();
+    final SerializationContext serializationContext =
+        dsfidSerializer.createSerializationContext(dataOutput);
+    member.writeEssentialData(dataOutput, serializationContext);
+
+    final ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+    final DataInputStream stream = new DataInputStream(bais);
+    final DeserializationContext deserializationContext =
+        dsfidSerializer.createDeserializationContext(stream);
+    final DataInput dataInput = new DataInputStream(bais);
+    final GMSMemberData newMember = new GMSMemberData();
+    newMember.readEssentialData(dataInput, deserializationContext);
+
+    validate(newMember);
+  }
+
+  @Test
+  public void testSetVersionOrdinal() {
+    final GMSMemberData memberData = new GMSMemberData();
+    memberData.setVersionOrdinal(unknownVersionOrdinal);
+    validate(memberData);
+  }
+
+  private AbstractShortAssert<?> validate(final MemberData memberData) {
+    return assertThat(memberData.getVersionOrdinal()).isEqualTo(unknownVersionOrdinal);
+  }
+
+}

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberData.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberData.java
@@ -22,7 +22,7 @@ import org.jgroups.util.UUID;
 
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * MemberIdentifiers are created with a MemberData component. Use MemberDataBuilder to create
@@ -45,7 +45,7 @@ public interface MemberData {
 
   short getVersionOrdinal();
 
-  Version getVersion();
+  VersionOrdinal getVersion();
 
   String getUniqueTag();
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberIdentifier.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberIdentifier.java
@@ -29,6 +29,7 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * MemberIdentifier should be implemented by a user of GMS if the default member identifier
@@ -131,7 +132,7 @@ public interface MemberIdentifier extends DataSerializableFixedID {
   /**
    * Get the Geode version of this member
    */
-  Version getVersionObject();
+  VersionOrdinal getVersionObject();
 
   /**
    * Replace the current member data with the given member data. This can be used to fill out a

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -61,6 +61,7 @@ import org.apache.geode.distributed.internal.membership.api.QuorumChecker;
 import org.apache.geode.distributed.internal.membership.api.StopShunningMarker;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Manager;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
 import org.apache.geode.logging.internal.executors.LoggingThread;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -377,17 +378,17 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
     latestViewWriteLock.lock();
     try {
       // first determine the version for multicast message serialization
-      Version version = Version.CURRENT;
+      VersionOrdinal version = Version.CURRENT;
       for (final Entry<ID, Long> internalIDLongEntry : surpriseMembers
           .entrySet()) {
         ID mbr = internalIDLongEntry.getKey();
-        Version itsVersion = mbr.getVersionObject();
+        final VersionOrdinal itsVersion = mbr.getVersionObject();
         if (itsVersion != null && version.compareTo(itsVersion) < 0) {
           version = itsVersion;
         }
       }
       for (ID mbr : newView.getMembers()) {
-        Version itsVersion = mbr.getVersionObject();
+        final VersionOrdinal itsVersion = mbr.getVersionObject();
         if (itsVersion != null && itsVersion.compareTo(version) < 0) {
           version = mbr.getVersionObject();
         }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/MemberIdentifierImpl.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/MemberIdentifierImpl.java
@@ -46,6 +46,7 @@ import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 /**
  * An implementation of {@link MemberIdentifier}
@@ -514,7 +515,7 @@ public class MemberIdentifierImpl implements MemberIdentifier, DataSerializableF
       return version;
     } else {
       // prior to 7.1 member IDs did not serialize their version information
-      Version v = StaticSerialization.getVersionForDataStreamOrNull(in);
+      final VersionOrdinal v = StaticSerialization.getVersionForDataStreamOrNull(in);
       if (v != null) {
         return v.ordinal();
       }
@@ -925,7 +926,7 @@ public class MemberIdentifierImpl implements MemberIdentifier, DataSerializableF
     // write name last to fix bug 45160
     StaticSerialization.writeString(memberData.getName(), out);
 
-    Version outputVersion = StaticSerialization.getVersionForDataStream(out);
+    final VersionOrdinal outputVersion = StaticSerialization.getVersionForDataStream(out);
     if (0 <= outputVersion.compareTo(Version.GFE_90)
         && outputVersion.compareTo(Version.GEODE_1_1_0) < 0) {
       memberData.writeAdditionalData(out);
@@ -983,7 +984,8 @@ public class MemberIdentifierImpl implements MemberIdentifier, DataSerializableF
     memberData.setVersion(v);
   }
 
-  public Version getVersionObject() {
+  @Override
+  public VersionOrdinal getVersionObject() {
     return memberData.getVersion();
   }
 

--- a/geode-old-client-support/src/main/java/com/gemstone/gemfire/OldClientSupportProvider.java
+++ b/geode-old-client-support/src/main/java/com/gemstone/gemfire/OldClientSupportProvider.java
@@ -25,6 +25,7 @@ import org.apache.geode.internal.cache.CacheService;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.tier.sockets.OldClientSupportService;
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataOutputStream;
 import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -107,7 +108,7 @@ public class OldClientSupportProvider implements OldClientSupportService {
     // if the client is old then it needs com.gemstone.gemfire package names
     if (out instanceof VersionedDataOutputStream) {
       VersionedDataOutputStream vout = (VersionedDataOutputStream) out;
-      Version version = vout.getVersion();
+      final VersionOrdinal version = vout.getVersion();
       if (version != null && version.compareTo(Version.GFE_90) < 0) {
         return processClassName(name, GEODE, GEMFIRE, newClassNamesToOld);
       }

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/BufferDataOutputStream.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/BufferDataOutputStream.java
@@ -50,7 +50,7 @@ public class BufferDataOutputStream extends OutputStream implements VersionedDat
   protected LinkedList<ByteBuffer> chunks = null;
   protected int size = 0;
   protected boolean ignoreWrites = false; // added for bug 39569
-  protected Version version;
+  protected VersionOrdinal version;
   protected boolean doNotCopy;
   protected ByteBuffer buffer;
   /**
@@ -62,11 +62,11 @@ public class BufferDataOutputStream extends OutputStream implements VersionedDat
   private Error expansionException = null;
   private int memoPosition;
 
-  public BufferDataOutputStream(int initialCapacity, Version version) {
+  public BufferDataOutputStream(int initialCapacity, VersionOrdinal version) {
     this(initialCapacity, version, false);
   }
 
-  public BufferDataOutputStream(Version version) {
+  public BufferDataOutputStream(VersionOrdinal version) {
     this(INITIAL_CAPACITY, version, false);
   }
 
@@ -89,9 +89,8 @@ public class BufferDataOutputStream extends OutputStream implements VersionedDat
 
   /**
    * @param doNotCopy if true then byte arrays/buffers/sources will not be copied to this hdos but
-   *        instead referenced.
    */
-  public BufferDataOutputStream(int allocSize, Version version, boolean doNotCopy) {
+  public BufferDataOutputStream(int allocSize, VersionOrdinal version, boolean doNotCopy) {
     if (allocSize < SMALLEST_CHUNK_SIZE) {
       this.MIN_CHUNK_SIZE = SMALLEST_CHUNK_SIZE;
     } else {
@@ -102,7 +101,7 @@ public class BufferDataOutputStream extends OutputStream implements VersionedDat
     this.doNotCopy = doNotCopy;
   }
 
-  public BufferDataOutputStream(ByteBuffer initialBuffer, Version version,
+  public BufferDataOutputStream(ByteBuffer initialBuffer, VersionOrdinal version,
       boolean doNotCopy) {
     if (initialBuffer.position() != 0) {
       initialBuffer = initialBuffer.slice();
@@ -163,7 +162,7 @@ public class BufferDataOutputStream extends OutputStream implements VersionedDat
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return version;
   }
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/ByteArrayDataInput.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/ByteArrayDataInput.java
@@ -33,7 +33,7 @@ public class ByteArrayDataInput extends InputStream implements DataInput, Versio
   private int pos;
   /** reusable buffer for readUTF */
   private char[] charBuf;
-  private Version version;
+  private VersionOrdinal version;
 
   /**
    * Create a {@link DataInput} whose contents are empty.
@@ -44,7 +44,7 @@ public class ByteArrayDataInput extends InputStream implements DataInput, Versio
     initialize(bytes, null);
   }
 
-  public ByteArrayDataInput(byte[] bytes, Version version) {
+  public ByteArrayDataInput(byte[] bytes, VersionOrdinal version) {
     initialize(bytes, version);
   }
 
@@ -55,7 +55,7 @@ public class ByteArrayDataInput extends InputStream implements DataInput, Versio
    *        (a copy is not made) so it should not be changed externally.
    * @param version the product version that serialized the object on given bytes
    */
-  public void initialize(byte[] bytes, Version version) {
+  public void initialize(byte[] bytes, VersionOrdinal version) {
     this.bytes = bytes;
     this.nBytes = bytes.length;
     this.pos = 0;
@@ -66,7 +66,7 @@ public class ByteArrayDataInput extends InputStream implements DataInput, Versio
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return version;
   }
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DeserializationContext.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DeserializationContext.java
@@ -20,8 +20,11 @@ package org.apache.geode.internal.serialization;
  */
 public interface DeserializationContext {
 
-  /** return the version of the source/destination of this serializer */
-  Version getSerializationVersion();
+  /**
+   * return the version of the source/destination of this serializer
+   *
+   */
+  VersionOrdinal getSerializationVersion();
 
   /** return the serializer */
   ObjectDeserializer getDeserializer();

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/SerializationContext.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/SerializationContext.java
@@ -24,8 +24,11 @@ package org.apache.geode.internal.serialization;
  */
 public interface SerializationContext {
 
-  /** return the version of the source/destination of this serializer */
-  Version getSerializationVersion();
+  /**
+   * return the version of the source/destination of this serializer
+   *
+   */
+  VersionOrdinal getSerializationVersion();
 
   /** return the serializer */
   ObjectSerializer getSerializer();

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/StaticSerialization.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/StaticSerialization.java
@@ -505,7 +505,7 @@ public class StaticSerialization {
    * {@link DataInput}. Returns
    * null if the version is same as this member's.
    */
-  public static Version getVersionForDataStreamOrNull(DataInput in) {
+  public static VersionOrdinal getVersionForDataStreamOrNull(DataInput in) {
     // check if this is a versioned data input
     if (in instanceof VersionedDataStream) {
       return ((VersionedDataStream) in).getVersion();
@@ -519,10 +519,10 @@ public class StaticSerialization {
    * Get the {@link Version} of the peer or disk store that created this
    * {@link DataInput}.
    */
-  public static Version getVersionForDataStream(DataInput in) {
+  public static VersionOrdinal getVersionForDataStream(DataInput in) {
     // check if this is a versioned data input
     if (in instanceof VersionedDataStream) {
-      final Version v = ((VersionedDataStream) in).getVersion();
+      final VersionOrdinal v = ((VersionedDataStream) in).getVersion();
       return v != null ? v : Version.CURRENT;
     } else {
       // assume latest version
@@ -534,10 +534,10 @@ public class StaticSerialization {
    * Get the {@link Version} of the peer or disk store that created this
    * {@link DataOutput}.
    */
-  public static Version getVersionForDataStream(DataOutput out) {
+  public static VersionOrdinal getVersionForDataStream(DataOutput out) {
     // check if this is a versioned data output
     if (out instanceof VersionedDataStream) {
-      final Version v = ((VersionedDataStream) out).getVersion();
+      final VersionOrdinal v = ((VersionedDataStream) out).getVersion();
       return v != null ? v : Version.CURRENT;
     } else {
       // assume latest version
@@ -550,7 +550,7 @@ public class StaticSerialization {
    * {@link DataOutput}. Returns
    * null if the version is same as this member's.
    */
-  public static Version getVersionForDataStreamOrNull(DataOutput out) {
+  public static VersionOrdinal getVersionForDataStreamOrNull(DataOutput out) {
     // check if this is a versioned data output
     if (out instanceof VersionedDataStream) {
       return ((VersionedDataStream) out).getVersion();

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
@@ -35,7 +35,7 @@ import org.apache.geode.annotations.Immutable;
  * @since GemFire 5.7
  */
 @Immutable
-public class Version implements Comparable<Version> {
+public class Version extends VersionOrdinalImpl {
 
   /** The name of this version */
   private final transient String name;
@@ -51,9 +51,6 @@ public class Version implements Comparable<Version> {
   private final byte minorVersion;
   private final byte release;
   private final byte patch;
-
-  /** byte used as ordinal to represent this <code>Version</code> */
-  private final short ordinal;
 
   public static final int HIGHEST_VERSION = 115;
 
@@ -307,13 +304,13 @@ public class Version implements Comparable<Version> {
   /** Creates a new instance of <code>Version</code> */
   private Version(String product, String name, byte major, byte minor, byte release, byte patch,
       short ordinal) {
+    super(ordinal);
     this.productName = product;
     this.name = name;
     this.majorVersion = major;
     this.minorVersion = minor;
     this.release = release;
     this.patch = patch;
-    this.ordinal = ordinal;
     this.methodSuffix = this.productName + "_" + this.majorVersion + "_" + this.minorVersion + "_"
         + this.release + "_" + this.patch;
     if (ordinal != TOKEN_ORDINAL) {
@@ -515,11 +512,6 @@ public class Version implements Comparable<Version> {
     return this.patch;
   }
 
-  public short ordinal() {
-    return this.ordinal;
-  }
-
-
   /**
    * Returns whether this <code>Version</code> is compatible with the input <code>Version</code>
    *
@@ -528,39 +520,6 @@ public class Version implements Comparable<Version> {
    */
   public boolean compatibleWith(Version version) {
     return true;
-  }
-
-  /**
-   * Finds the Version instance corresponding to the given ordinal and returns the result of
-   * compareTo(Version)
-   *
-   * @param other the ordinal of the other Version object
-   * @return negative if this version is older, positive if this version is newer, 0 if this is the
-   *         same version
-   */
-  public int compareTo(short other) {
-    // first try to find the actual Version object
-    Version v = fromOrdinalNoThrow(other, false);
-    if (v == null) {
-      // failing that we use the old method of comparing Versions:
-      return this.ordinal() - other;
-    }
-    return compareTo(v);
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public int compareTo(Version other) {
-    if (other != null) {
-      // byte min/max can't overflow int, so use (a-b)
-      final int thisOrdinal = this.ordinal;
-      final int otherOrdinal = other.ordinal;
-      return (thisOrdinal - otherOrdinal);
-    } else {
-      return 1;
-    }
   }
 
   /**
@@ -574,37 +533,16 @@ public class Version implements Comparable<Version> {
   }
 
   public static String toString(short ordinal) {
-    if (ordinal <= CURRENT.ordinal) {
-      try {
-        return fromOrdinal(ordinal).toString();
-      } catch (UnsupportedSerializationVersionException uve) {
-        // ignored in toString()
-      }
+    try {
+      return fromOrdinal(ordinal).toString();
+    } catch (UnsupportedSerializationVersionException uve) {
+      // ignored in toString()
     }
-    return "UNKNOWN[ordinal=" + ordinal + ']';
+    return VersionOrdinalImpl.toString(ordinal);
   }
 
-  @Override
-  public boolean equals(Object other) {
-    if (other == this)
-      return true;
-    if (other != null && other.getClass() == Version.class) {
-      return this.ordinal == ((Version) other).ordinal;
-    } else {
-      return false;
-    }
-  }
-
-  public boolean equals(Version other) {
-    return other != null && this.ordinal == other.ordinal;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = 17;
-    final int mult = 37;
-    result = mult * result + this.ordinal;
-    return result;
+  public String toDottedString() {
+    return String.format("%d.%d.%d", majorVersion, minorVersion, patch);
   }
 
   public byte[] toBytes() {
@@ -623,7 +561,4 @@ public class Version implements Comparable<Version> {
         .collect(Collectors.toList());
   }
 
-  public boolean isCurrentVersion() {
-    return this.ordinal == CURRENT.ordinal;
-  }
 }

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionOrdinal.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionOrdinal.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.serialization;
+
+/**
+ * VersionOrdinal is able to represent not only currently-known
+ * Geode versions but future versions as well. This is necessary
+ * because during rolling upgrades Geode manipulates member
+ * identifiers for members running newer versions of the software.
+ * In that case we receive the ordinal over the network
+ * (serialization) but we don't know other version details such as
+ * major/minor/patch version, which are known to the Version class.
+ *
+ * Implementations must define equals() and hashCode() based on
+ * ordinal() result. And since this interface extends Comparable,
+ * implementations must define compareTo() as well.
+ */
+public interface VersionOrdinal extends Comparable<VersionOrdinal> {
+
+  /**
+   * @return the short ordinal value for comparison implementations
+   */
+  public short ordinal();
+
+  /*
+   * What follows is a bunch of comparison methods phrased in terms of version age:
+   * older/newer.
+   */
+
+  /**
+   * Test if this version is older than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is older than version, otherwise false.
+   */
+  boolean isOlderThan(Version version);
+
+  /**
+   * Test if this version is not older than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is the same version or newer, otherwise false.
+   */
+  boolean isNotOlderThan(Version version);
+
+  /**
+   * Test if this version is newer than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is newer than version, otherwise false.
+   */
+  boolean isNewerThan(Version version);
+
+  /**
+   * Test if this version is not newer than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is the same version or older, otherwise false.
+   */
+  boolean isNotNewerThan(Version version);
+
+}

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionOrdinalImpl.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionOrdinalImpl.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.serialization;
+
+public class VersionOrdinalImpl implements VersionOrdinal {
+
+  protected final short ordinal;
+
+  public VersionOrdinalImpl(final short ordinal) {
+    this.ordinal = ordinal;
+  }
+
+  @Override
+  public short ordinal() {
+    return ordinal;
+  }
+
+  @Override
+  public int compareTo(final VersionOrdinal other) {
+    if (other == null) {
+      return 1;
+    } else {
+      return compareTo(other.ordinal());
+    }
+  }
+
+  /**
+   * TODO: eliminate this legacy method in favor of requiring callers to construct a
+   * VersionOrdinalImpl. Inline this logic up in compareTo(VersionOrdinal).
+   */
+  public int compareTo(final short other) {
+    // short min/max can't overflow int, so use (a-b)
+    final int thisOrdinal = this.ordinal;
+    final int otherOrdinal = other;
+    return thisOrdinal - otherOrdinal;
+  }
+
+  @Override
+  public boolean equals(final Object other) {
+    if (other == this)
+      return true;
+    if (other != null && other.getClass() == VersionOrdinalImpl.class) {
+      return this.ordinal == ((VersionOrdinalImpl) other).ordinal;
+    } else {
+      return false;
+    }
+  }
+
+  public boolean equals(final VersionOrdinal other) {
+    return other != null && this.ordinal == other.ordinal();
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    final int mult = 37;
+    result = mult * result + this.ordinal;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return toString(ordinal);
+  }
+
+  /**
+   * TODO: eliminate this legacy method in favor of requiring callers to construct a
+   * VersionOrdinalImpl. Inline this logic up in toString().
+   */
+  public static String toString(short ordinal) {
+    return "UNKNOWN[ordinal=" + ordinal + ']';
+  }
+
+
+  /**
+   * Test if this version is older than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is older than version, otherwise false.
+   */
+  @Override
+  public final boolean isOlderThan(final Version version) {
+    return compareTo(version) < 0;
+  }
+
+  /**
+   * Test if this version is not older than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is the same version or newer, otherwise false.
+   */
+  @Override
+  public final boolean isNotOlderThan(final Version version) {
+    return compareTo(version) >= 0;
+  }
+
+  /**
+   * Test if this version is newer than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is newer than version, otherwise false.
+   */
+  @Override
+  public final boolean isNewerThan(final Version version) {
+    return compareTo(version) > 0;
+  }
+
+  /**
+   * Test if this version is not newer than given version.
+   *
+   * @param version to compare to this version
+   * @return true if this is the same version or older, otherwise false.
+   */
+  @Override
+  public final boolean isNotNewerThan(final Version version) {
+    return compareTo(version) <= 0;
+  }
+
+}

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataInputStream.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataInputStream.java
@@ -45,7 +45,7 @@ public class VersionedDataInputStream extends DataInputStream implements Version
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return this.version;
   }
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataOutputStream.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataOutputStream.java
@@ -43,7 +43,7 @@ public class VersionedDataOutputStream extends DataOutputStream implements Versi
    * {@inheritDoc}
    */
   @Override
-  public Version getVersion() {
+  public VersionOrdinal getVersion() {
     return this.version;
   }
 }

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataStream.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataStream.java
@@ -37,5 +37,5 @@ public interface VersionedDataStream {
    * {@link Version}, then this member cannot do any adjustment to serialization and its the remote
    * peer's responsibility to adjust the serialization/deserialization according to this peer.
    */
-  Version getVersion();
+  VersionOrdinal getVersion();
 }

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/AbstractSerializationContext.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/AbstractSerializationContext.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.serialization.internal;
 
 
 import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.VersionedDataStream;
 
 /**
@@ -25,10 +26,10 @@ import org.apache.geode.internal.serialization.VersionedDataStream;
  */
 public abstract class AbstractSerializationContext {
 
-  <IO> Version getVersionForDataStream(final IO in) {
+  <IO> VersionOrdinal getVersionForDataStream(final IO in) {
     // check if this is a versioned data input
     if (in instanceof VersionedDataStream) {
-      final Version v = ((VersionedDataStream) in).getVersion();
+      final VersionOrdinal v = ((VersionedDataStream) in).getVersion();
       return v != null ? v : Version.getCurrentVersion();
     } else {
       // assume latest version

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/DSFIDSerializerImpl.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/DSFIDSerializerImpl.java
@@ -41,7 +41,7 @@ import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.SerializationVersions;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.Version;
-import org.apache.geode.internal.serialization.VersionedDataStream;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 public class DSFIDSerializerImpl implements DSFIDSerializer {
 
@@ -187,9 +187,9 @@ public class DSFIDSerializerImpl implements DSFIDSerializer {
 
     try {
       boolean invoked = false;
-      Version v = context.getSerializationVersion();
+      final VersionOrdinal v = context.getSerializationVersion();
 
-      if (!v.isCurrentVersion()) {
+      if (!Version.CURRENT.equals(v)) {
         // get versions where DataOutput was upgraded
         SerializationVersions sv = (SerializationVersions) ds;
         Version[] versions = sv.getSerializationVersions();
@@ -216,20 +216,6 @@ public class DSFIDSerializerImpl implements DSFIDSerializer {
         | InvocationTargetException e) {
       throw new IOException(
           "problem invoking toData method on object of class" + ds.getClass().getName(), e);
-    }
-  }
-
-  /**
-   * Get the Version of the peer or disk store that created this {@link DataOutput}.
-   * Returns
-   * zero if the version is same as this member's.
-   */
-  public Version getVersionForDataStreamOrNull(DataOutput out) {
-    // check if this is a versioned data output
-    if (out instanceof VersionedDataStream) {
-      return ((VersionedDataStream) out).getVersion();
-    } else {
-      return null;
     }
   }
 
@@ -306,8 +292,8 @@ public class DSFIDSerializerImpl implements DSFIDSerializer {
     DeserializationContextImpl context = new DeserializationContextImpl(in, this);
     try {
       boolean invoked = false;
-      Version v = context.getSerializationVersion();
-      if (!v.isCurrentVersion() && ds instanceof SerializationVersions) {
+      final VersionOrdinal v = context.getSerializationVersion();
+      if (!Version.CURRENT.equals(v) && ds instanceof SerializationVersions) {
         // get versions where DataOutput was upgraded
         Version[] versions = null;
         SerializationVersions vds = (SerializationVersions) ds;

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/DeserializationContextImpl.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/DeserializationContextImpl.java
@@ -19,7 +19,7 @@ import java.io.DataInput;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.ObjectDeserializer;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 public class DeserializationContextImpl extends AbstractSerializationContext
     implements DeserializationContext {
@@ -33,7 +33,7 @@ public class DeserializationContextImpl extends AbstractSerializationContext
   }
 
   @Override
-  public Version getSerializationVersion() {
+  public VersionOrdinal getSerializationVersion() {
     return getVersionForDataStream(dataInput);
   }
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/SerializationContextImpl.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/internal/SerializationContextImpl.java
@@ -19,7 +19,7 @@ import java.io.DataOutput;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
 import org.apache.geode.internal.serialization.ObjectSerializer;
 import org.apache.geode.internal.serialization.SerializationContext;
-import org.apache.geode.internal.serialization.Version;
+import org.apache.geode.internal.serialization.VersionOrdinal;
 
 public class SerializationContextImpl extends AbstractSerializationContext
     implements SerializationContext {
@@ -33,7 +33,7 @@ public class SerializationContextImpl extends AbstractSerializationContext
   }
 
   @Override
-  public Version getSerializationVersion() {
+  public VersionOrdinal getSerializationVersion() {
     return getVersionForDataStream(dataOutput);
   }
 


### PR DESCRIPTION
[GEODE-8240](https://issues.apache.org/jira/browse/GEODE-8240)

This is the back-port, to 1.12, of this fix: https://github.com/apache/geode/pull/5273 on the `develop` branch.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?