### PR TITLE
GEODE-8099: make those gfsh commands that updates cluster configurati…

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DeregisterDriverCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/DeregisterDriverCommand.java
@@ -28,7 +28,7 @@ import org.apache.geode.cache.configuration.JndiBindingsType;
 import org.apache.geode.distributed.ConfigurationPersistenceService;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.functions.CliFunctionResult;
 import org.apache.geode.management.internal.i18n.CliStrings;
@@ -36,7 +36,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class DeregisterDriverCommand extends SingleGfshCommand {
+public class DeregisterDriverCommand extends GfshCommand {
 
   static final String DEREGISTER_DRIVER = "deregister driver";
   static final String DEREGISTER_DRIVER__HELP = EXPERIMENTAL

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListDriversCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/ListDriversCommand.java
@@ -24,7 +24,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
 import org.apache.geode.management.internal.functions.CliFunctionResult;
@@ -32,7 +32,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class ListDriversCommand extends SingleGfshCommand {
+public class ListDriversCommand extends GfshCommand {
 
   static final String LIST_DRIVERS = "list drivers";
   static final String LIST_DRIVERS__HELP = EXPERIMENTAL

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/RegisterDriverCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/RegisterDriverCommand.java
@@ -25,7 +25,7 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.CliMetaData;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.functions.CliFunctionResult;
 import org.apache.geode.management.internal.i18n.CliStrings;
@@ -33,7 +33,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 @Experimental
-public class RegisterDriverCommand extends SingleGfshCommand {
+public class RegisterDriverCommand extends GfshCommand {
 
   static final String REGISTER_DRIVER = "register driver";
   static final String REGISTER_DRIVER__HELP = EXPERIMENTAL

--- a/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/api/LocatorClusterManagementService.java
@@ -113,7 +113,7 @@ import org.apache.geode.management.runtime.RuntimeInfo;
 public class LocatorClusterManagementService implements ClusterManagementService {
   @VisibleForTesting
   // the dlock service name used by the CMS
-  static final String CMS_DLOCK_SERVICE_NAME = "CMS_DLOCK_SERVICE";
+  public static final String CMS_DLOCK_SERVICE_NAME = "CMS_DLOCK_SERVICE";
   private static final Logger logger = LogService.getLogger();
   private final InternalConfigurationPersistenceService persistenceService;
   private final Map<Class, ConfigurationManager> managers;

--- a/geode-gfsh/src/main/java/org/apache/geode/management/cli/GfshCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/cli/GfshCommand.java
@@ -59,6 +59,14 @@ public abstract class GfshCommand implements CommandMarker {
     return gfsh.isConnectedAndReady();
   }
 
+  /**
+   * For those commands that could possibly change the cluster configuration, they need to
+   * override this method to return true.
+   */
+  public boolean affectsClusterConfiguration() {
+    return false;
+  }
+
   public void authorize(ResourcePermission.Resource resource,
       ResourcePermission.Operation operation, ResourcePermission.Target target) {
     cache.getSecurityService().authorize(resource, operation, target);

--- a/geode-gfsh/src/main/java/org/apache/geode/management/cli/SingleGfshCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/cli/SingleGfshCommand.java
@@ -22,7 +22,10 @@ import org.apache.geode.cache.configuration.CacheConfig;
 
 /**
  * Command class that extends this class can only have one single command method,
- * i.e only one method that is annotated with @CliCommand.
+ * * i.e only one method that is annotated with @CliCommand.
+ *
+ * this is also specific for commands that will need to update cluster configuration. Child classes
+ * are required to implement the "updateConfigForGroup" method.
  */
 @Experimental
 public abstract class SingleGfshCommand extends GfshCommand {
@@ -39,7 +42,11 @@ public abstract class SingleGfshCommand extends GfshCommand {
    *        return value of your command method.
    * @return a boolean indicating whether a change to the cluster configuration was persisted.
    */
-  public boolean updateConfigForGroup(String group, CacheConfig config, Object configObject) {
-    return false;
+  public abstract boolean updateConfigForGroup(String group, CacheConfig config,
+      Object configObject);
+
+  @Override
+  public boolean affectsClusterConfiguration() {
+    return true;
   }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterOfflineDiskStoreCommand.java
@@ -24,11 +24,11 @@ import org.springframework.shell.core.annotation.CliOption;
 import org.apache.geode.cache.CacheExistsException;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.management.cli.CliMetaData;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.i18n.CliStrings;
 
-public class AlterOfflineDiskStoreCommand extends SingleGfshCommand {
+public class AlterOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.ALTER_DISK_STORE, help = CliStrings.ALTER_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)
   public ResultModel alterOfflineDiskStore(

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
@@ -253,4 +253,9 @@ public class AlterRuntimeConfigCommand extends GfshCommand {
       return ResultModel.createInfo("");
     }
   }
+
+  @Override
+  public boolean affectsClusterConfiguration() {
+    return true;
+  }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CompactOfflineDiskStoreCommand.java
@@ -27,15 +27,15 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.cli.SingleGfshCommand;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.result.model.InfoResultModel;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.util.DiskStoreCompacter;
 import org.apache.geode.management.internal.i18n.CliStrings;
 
-public class CompactOfflineDiskStoreCommand extends SingleGfshCommand {
+public class CompactOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.COMPACT_OFFLINE_DISK_STORE,
       help = CliStrings.COMPACT_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DeployCommand.java
@@ -227,4 +227,9 @@ public class DeployCommand extends GfshCommand {
       return result;
     }
   }
+
+  @Override
+  public boolean affectsClusterConfiguration() {
+    return true;
+  }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeOfflineDiskStoreCommand.java
@@ -25,12 +25,12 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.management.cli.CliMetaData;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.i18n.CliStrings;
 
 @SuppressWarnings("deprecation")
-public class DescribeOfflineDiskStoreCommand extends SingleGfshCommand {
+public class DescribeOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.DESCRIBE_OFFLINE_DISK_STORE,
       help = CliStrings.DESCRIBE_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeQueryServiceCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeQueryServiceCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.cache.query.management.configuration.QueryConfigService;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.functions.DescribeQueryServiceFunction;
 import org.apache.geode.management.internal.cli.result.model.DataResultModel;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.functions.CliFunctionResult;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class DescribeQueryServiceCommand extends SingleGfshCommand {
+public class DescribeQueryServiceCommand extends GfshCommand {
 
   static final String COMMAND_NAME = "describe query-service";
   private static final String COMMAND_HELP =

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ExportOfflineDiskStoreCommand.java
@@ -22,12 +22,12 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.management.cli.CliMetaData;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.i18n.CliStrings;
 
-public class ExportOfflineDiskStoreCommand extends SingleGfshCommand {
+public class ExportOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.EXPORT_OFFLINE_DISK_STORE,
       help = CliStrings.EXPORT_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = {CliStrings.TOPIC_GEODE_DISKSTORE})

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/LoadBalanceGatewaySenderCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class LoadBalanceGatewaySenderCommand extends SingleGfshCommand {
+public class LoadBalanceGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.LOAD_BALANCE_GATEWAYSENDER,
       help = CliStrings.LOAD_BALANCE_GATEWAYSENDER__HELP)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/PauseGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/PauseGatewaySenderCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class PauseGatewaySenderCommand extends SingleGfshCommand {
+public class PauseGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.PAUSE_GATEWAYSENDER, help = CliStrings.PAUSE_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeAsyncEventQueueDispatcherCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeAsyncEventQueueDispatcherCommand.java
@@ -22,7 +22,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.functions.ResumeAsyncEventQueueDispatcherFunction;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.functions.CliFunctionResult;
@@ -31,7 +31,7 @@ import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
 
-public class ResumeAsyncEventQueueDispatcherCommand extends SingleGfshCommand {
+public class ResumeAsyncEventQueueDispatcherCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.RESUME_ASYNCEVENTQUEUE,
       help = CliStrings.RESUME_ASYNCEVENTQUEUE__HELP)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ResumeGatewaySenderCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class ResumeGatewaySenderCommand extends SingleGfshCommand {
+public class ResumeGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.RESUME_GATEWAYSENDER, help = CliStrings.RESUME_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewayReceiverCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.GatewayReceiverMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StartGatewayReceiverCommand extends SingleGfshCommand {
+public class StartGatewayReceiverCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.START_GATEWAYRECEIVER,
       help = CliStrings.START_GATEWAYRECEIVER__HELP)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartGatewaySenderCommand.java
@@ -35,7 +35,7 @@ import org.apache.geode.logging.internal.executors.LoggingExecutors;
 import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
@@ -43,7 +43,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StartGatewaySenderCommand extends SingleGfshCommand {
+public class StartGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.START_GATEWAYSENDER, help = CliStrings.START_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewayReceiverCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.GatewayReceiverMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StatusGatewayReceiverCommand extends SingleGfshCommand {
+public class StatusGatewayReceiverCommand extends GfshCommand {
   @CliCommand(value = CliStrings.STATUS_GATEWAYRECEIVER,
       help = CliStrings.STATUS_GATEWAYRECEIVER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StatusGatewaySenderCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StatusGatewaySenderCommand extends SingleGfshCommand {
+public class StatusGatewaySenderCommand extends GfshCommand {
   @CliCommand(value = CliStrings.STATUS_GATEWAYSENDER, help = CliStrings.STATUS_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewayReceiverCommand.java
@@ -26,7 +26,7 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.management.GatewayReceiverMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StopGatewayReceiverCommand extends SingleGfshCommand {
+public class StopGatewayReceiverCommand extends GfshCommand {
   @CliCommand(value = CliStrings.STOP_GATEWAYRECEIVER, help = CliStrings.STOP_GATEWAYRECEIVER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)
   @ResourceOperation(resource = ResourcePermission.Resource.CLUSTER,

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StopGatewaySenderCommand.java
@@ -27,7 +27,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
@@ -35,7 +35,7 @@ import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class StopGatewaySenderCommand extends SingleGfshCommand {
+public class StopGatewaySenderCommand extends GfshCommand {
 
   @CliCommand(value = CliStrings.STOP_GATEWAYSENDER, help = CliStrings.STOP_GATEWAYSENDER__HELP)
   @CliMetaData(relatedTopic = CliStrings.TOPIC_GEODE_WAN)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/UndeployCommand.java
@@ -103,4 +103,9 @@ public class UndeployCommand extends GfshCommand {
 
     return result;
   }
+
+  @Override
+  public boolean affectsClusterConfiguration() {
+    return true;
+  }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/UpgradeOfflineDiskStoreCommand.java
@@ -27,15 +27,15 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.cli.Result;
-import org.apache.geode.management.cli.SingleGfshCommand;
 import org.apache.geode.management.internal.cli.LogWrapper;
 import org.apache.geode.management.internal.cli.result.model.InfoResultModel;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.util.DiskStoreUpgrader;
 import org.apache.geode.management.internal.i18n.CliStrings;
 
-public class UpgradeOfflineDiskStoreCommand extends SingleGfshCommand {
+public class UpgradeOfflineDiskStoreCommand extends GfshCommand {
   @CliCommand(value = CliStrings.UPGRADE_OFFLINE_DISK_STORE,
       help = CliStrings.UPGRADE_OFFLINE_DISK_STORE__HELP)
   @CliMetaData(shellOnly = true, relatedTopic = CliStrings.TOPIC_GEODE_DISKSTORE)

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/remote/CommandExecutor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal.cli.remote;
 
+import static org.apache.geode.management.internal.api.LocatorClusterManagementService.CMS_DLOCK_SERVICE_NAME;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,9 +26,11 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.util.ReflectionUtils;
 
 import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.distributed.DistributedLockService;
 import org.apache.geode.distributed.internal.InternalConfigurationPersistenceService;
 import org.apache.geode.internal.util.ArgumentRedactor;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.cli.SingleGfshCommand;
 import org.apache.geode.management.cli.UpdateAllConfigurationGroupsMarker;
@@ -51,6 +55,12 @@ public class CommandExecutor {
       "Cluster configuration service is not running. Configuration change is not persisted.";
 
   private Logger logger = LogService.getLogger();
+  private final DistributedLockService cmsDlockService;
+
+  // this cmsDlockService could be null for offline commands
+  public CommandExecutor(DistributedLockService cmsDlockService) {
+    this.cmsDlockService = cmsDlockService;
+  }
 
   /**
    *
@@ -73,6 +83,7 @@ public class CommandExecutor {
       logger.info("Executing command: " + ArgumentRedactor.redact(userInput));
     }
 
+    boolean locked = lockCMS(command);
     try {
       Object result = invokeCommand(command, parseResult);
 
@@ -95,7 +106,6 @@ public class CommandExecutor {
       }
       return result;
     }
-
     // for Authorization Exception, we need to throw them for higher level code to catch
     catch (NotAuthorizedException e) {
       logger.error("Not authorized to execute \"" + parseResult + "\".", e);
@@ -132,6 +142,8 @@ public class CommandExecutor {
     } catch (Throwable t) {
       org.apache.geode.SystemFailure.checkFailure();
       throw t;
+    } finally {
+      unlockCMS(locked);
     }
   }
 
@@ -206,5 +218,33 @@ public class CommandExecutor {
     }
 
     return resultModel;
+  }
+
+  @VisibleForTesting
+  boolean lockCMS(Object command) {
+    if (cmsDlockService == null) {
+      return false;
+    }
+    if (!(command instanceof GfshCommand)) {
+      return false;
+    }
+
+    GfshCommand gfshCommand = (GfshCommand) command;
+    if (gfshCommand.getConfigurationPersistenceService() == null) {
+      return false;
+    }
+
+    if (!gfshCommand.affectsClusterConfiguration()) {
+      return false;
+    }
+
+    return cmsDlockService.lock(CMS_DLOCK_SERVICE_NAME, -1, -1);
+  }
+
+  @VisibleForTesting
+  void unlockCMS(boolean locked) {
+    if (locked) {
+      cmsDlockService.unlock(CMS_DLOCK_SERVICE_NAME);
+    }
   }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/remote/MemberCommandService.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/remote/MemberCommandService.java
@@ -16,6 +16,7 @@ package org.apache.geode.management.internal.cli.remote;
 
 import java.util.Map;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.internal.CommandProcessor;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.management.cli.CommandServiceException;
@@ -41,6 +42,12 @@ public class MemberCommandService extends org.apache.geode.management.cli.Comman
     } catch (Exception e) {
       throw new CommandServiceException("Could not load commands.", e);
     }
+  }
+
+  @VisibleForTesting
+  public MemberCommandService(InternalCache cache, CommandProcessor commandProcessor) {
+    this.cache = cache;
+    this.commandProcessor = commandProcessor;
   }
 
   @Override

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/GfshExecutionStrategy.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/GfshExecutionStrategy.java
@@ -74,7 +74,7 @@ public class GfshExecutionStrategy implements ExecutionStrategy {
       synchronized (mutex) {
         Assert.isTrue(isReadyForCommands(), "Not yet ready for commands");
 
-        Object exeuctionResult = new CommandExecutor().execute((GfshParseResult) parseResult);
+        Object exeuctionResult = new CommandExecutor(null).execute((GfshParseResult) parseResult);
         if (exeuctionResult instanceof ResultModel) {
           return new CommandResult((ResultModel) exeuctionResult);
         }

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/remote/MemberCommandServiceTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/remote/MemberCommandServiceTest.java
@@ -17,40 +17,34 @@ package org.apache.geode.management.internal.cli.remote;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.util.Properties;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.cache.internal.CommandProcessor;
-import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.cli.Result;
+import org.apache.geode.management.internal.cli.GfshParser;
 
 public class MemberCommandServiceTest {
   private InternalCache cache;
+  private CommandProcessor commandProcessor;
 
   @Before
   public void init() {
     cache = mock(InternalCache.class);
-    DistributedSystem distributedSystem = mock(DistributedSystem.class);
     SecurityService securityService = mock(SecurityService.class);
-    Properties cacheProperties = new Properties();
-
-    when(cache.getDistributedSystem()).thenReturn(distributedSystem);
-    when(cache.isClosed()).thenReturn(true);
-    when(cache.getSecurityService()).thenReturn(securityService);
-    when(cache.getService(CommandProcessor.class)).thenReturn(new OnlineCommandProcessor());
-    when(distributedSystem.getProperties()).thenReturn(cacheProperties);
+    GfshParser gfshParser = mock(GfshParser.class);
+    CommandExecutor executor = mock(CommandExecutor.class);
+    commandProcessor = new OnlineCommandProcessor(gfshParser,
+        securityService, executor);
   }
 
   @Test
   public void processCommandError() throws Exception {
     @SuppressWarnings("deprecation")
-    MemberCommandService memberCommandService = new MemberCommandService(cache);
+    MemberCommandService memberCommandService = new MemberCommandService(cache, commandProcessor);
 
     Result result = memberCommandService.processCommand("fake command");
 

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/remote/OnlineCommandProcessorTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/remote/OnlineCommandProcessorTest.java
@@ -29,12 +29,12 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.management.internal.cli.CommandManager;
+import org.apache.geode.management.internal.cli.GfshParser;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.security.NotAuthorizedException;
 
 public class OnlineCommandProcessorTest {
-
-  Properties properties;
   SecurityService securityService;
   CommandExecutor executor;
   OnlineCommandProcessor onlineCommandProcessor;
@@ -45,14 +45,14 @@ public class OnlineCommandProcessorTest {
 
   @Before
   public void before() {
-    properties = new Properties();
     securityService = mock(SecurityService.class);
+    GfshParser gfshParser = new GfshParser(new CommandManager(new Properties(), null));
     executor = mock(CommandExecutor.class);
     result = mock(ResultModel.class);
     when(executor.execute(any())).thenReturn(result);
 
     onlineCommandProcessor =
-        new OnlineCommandProcessor(properties, securityService, executor, null);
+        new OnlineCommandProcessor(gfshParser, securityService, executor);
   }
 
   @Test

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/GfshParserRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/GfshParserRule.java
@@ -46,7 +46,8 @@ public class GfshParserRule extends ExternalResource {
   public void before() {
     commandManager = new CommandManager();
     parser = new GfshParser(commandManager);
-    commandExecutor = new CommandExecutor();
+    // GfshParserRule doesn't need dlock service
+    commandExecutor = new CommandExecutor(null);
   }
 
   public GfshParseResult parse(String command) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/gfsh/RedisCommand.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/gfsh/RedisCommand.java
@@ -22,13 +22,13 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.management.cli.SingleGfshCommand;
+import org.apache.geode.management.cli.GfshCommand;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.functions.CliFunctionResult;
 import org.apache.geode.management.internal.security.ResourceOperation;
 import org.apache.geode.security.ResourcePermission;
 
-public class RedisCommand extends SingleGfshCommand {
+public class RedisCommand extends GfshCommand {
   public static final String REDIS = "redis";
   public static final String REDIS__HELP =
       "Commands related to the Redis API for Geode.";


### PR DESCRIPTION
…on thead safe.

* command executor will acquire the lock when executing commands that affects cluster configuration.
* clean up commands that doesn't need to extends implement SingleGfshCommand
* SingleGfshCommand are for those commands that need to update cluster configuration