### PR TITLE
GEODE-8239 - Add Gradle config to generate manifest file

### DIFF
--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -62,16 +62,14 @@ gradle.taskGraph.whenReady({ graph ->
 gradle.taskGraph.whenReady({ graph ->
   tasks.withType(Jar).each { jar ->
     jar.doFirst {
-      manifest {
-        attributes(
-            "Manifest-Version": "1.0",
-            "Created-By": System.getProperty("user.name"),
-            "Title": rootProject.name,
-            "Version": version,
-            "Organization": productOrg
-        )
+        manifest {
+          attributes.put("Manifest-Version", "1.0")
+          attributes.put("Created-By", System.getProperty("user.name"))
+          attributes.put("Title", rootProject.name)
+          attributes.put("Version", version)
+          attributes.put("Organization", productOrg)
+        }
       }
-    }
     jar.metaInf {
       from("$rootDir/geode-assembly/src/main/dist/LICENSE")
       if (jar.source.filter({ it.name.contains('NOTICE') }).empty) {

--- a/gradle/publish-java.gradle
+++ b/gradle/publish-java.gradle
@@ -28,3 +28,41 @@ publishing {
     }
   }
 }
+
+gradle.taskGraph.whenReady({ graph ->
+  tasks.withType(Jar).each { jar ->
+    jar.doFirst {
+      def projectDependencies = []
+      def runtimeList = []
+
+      configurations.runtimeClasspath
+              .collect { it.name - ".jar" }
+              .each { dependency ->
+                if (dependency.startsWith("geode-")) {
+                  projectDependencies.add(dependency)
+                } else {
+                  runtimeList.add(dependency)
+                }
+              }
+
+      projectDependencies.clone().each { projectDependency ->
+        def geodeProject = projectDependency - "-${version}.jar"
+        if (projectDependencies.contains(geodeProject)) {
+          def parentProject = project(":$geodeProject" - "-$version")
+          if (parentProject != null) {
+            def collect = parentProject.configurations.runtimeClasspath.collect { it.name - ".jar" }
+            runtimeList.removeAll(collect)
+            projectDependencies.removeAll(collect)
+          }
+        }
+      }
+
+      manifest {
+        attributes.put("Class-Path", runtimeList.join(' '))
+        attributes.put("Dependent-Modules", projectDependencies.join(' '))
+        attributes.put("Module-Name", project.name)
+      }
+    }
+  }
+})
+


### PR DESCRIPTION
Add Gradle config to generate manifest file containing 'Class-Path' and 'Dependent-Modules' attributes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
