### PR TITLE
GEODE-8176: Fix for flaky testPingWrongServer

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -118,7 +118,6 @@ public class ClientServerMiscDUnitTest extends ClientServerMiscDUnitTestBase {
     // send the ping to server1 but use server2's identifier so the ping will be forwarded
     ClientProxyMembershipID proxyID = server1.invoke(
         () -> CacheClientNotifier.getInstance().getClientProxies().iterator().next().getProxyID());
-    logger.info("ProxyID is : " + proxyID);
     server2.invoke(() -> {
       assertThat(ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().contains(proxyID))
           .isFalse();
@@ -133,7 +132,6 @@ public class ClientServerMiscDUnitTest extends ClientServerMiscDUnitTestBase {
               .isEqualTo(1));
       ClientProxyMembershipID proxyIDFound =
           ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().iterator().next();
-      logger.info("ProxyID found in clientHealthMonitor: " + proxyIDFound);
       assertThat(
           ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().contains(proxyID))
               .isTrue();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -18,9 +18,6 @@ package org.apache.geode.internal.cache.tier.sockets;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-
-import java.time.Duration;
 
 import org.junit.Test;
 
@@ -91,7 +88,7 @@ public class ClientServerMiscDUnitTest extends ClientServerMiscDUnitTestBase {
     RegionEntry entry2 = ((LocalRegion) region).getRegionEntry(server_k1);
     int entryVersion2 = entry.getVersionStamp().getEntryVersion();
     server.invoke(() -> {
-      // create a "remote" invalidateion event and invalidate the already-invalid entry
+      // create a "remote" invalidation event and invalidate the already-invalid entry
       LocalRegion localRegion = (LocalRegion) getCache().getRegion(regionPath);
       VersionTag tag = localRegion.getRegionEntry(server_k1).getVersionStamp().asVersionTag();
       InternalDistributedMember id = localRegion.getMyId();
@@ -125,14 +122,15 @@ public class ClientServerMiscDUnitTest extends ClientServerMiscDUnitTestBase {
     server2.invoke(() -> {
       assertThat(ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().contains(proxyID))
           .isFalse();
-      assertEquals(0, ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().size());
+      assertThat(ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().size())
+          .isEqualTo(0);
     });
     PingOp.execute(pool, new ServerLocation(NetworkUtils.getServerHostName(), PORT1), server2ID);
     // if the ping made it to server2 it will have the client's ID in its health monitor
     server2.invoke(() -> {
-      await("For heartbeat to be received").timeout(Duration.ofMinutes(1))
-          .untilAsserted(() -> assertEquals(1,
-              ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().size()));
+      await("For heartbeat to be received").untilAsserted(() -> assertThat(
+          ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().size())
+              .isEqualTo(1));
       ClientProxyMembershipID proxyIDFound =
           ClientHealthMonitor.getInstance().getClientHeartbeats().keySet().iterator().next();
       logger.info("ProxyID found in clientHealthMonitor: " + proxyIDFound);


### PR DESCRIPTION
The DistributedPingMessage is handled asynchronously: I have check that if I introduce a sleep `process()` method of `DistributedPingServer`, the test case fails because the `ClientHealthMonitor` has not received the ping.
I suspect that in the ocassions where the test failed was due to a race condition between the check of the `ClientHealthMonitor` content and the process of the message. So Im introducing a wait when checking the `ClientHealthMonitor` to avoid this.