### PR TITLE
GEODE-8300: add Windows checks to PR pipeline

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -22,7 +22,7 @@ groups:
 - name: main
   jobs:
   - {{ build_test.name }}
-{%- for test in tests if test.PLATFORM=="linux" %}
+{%- for test in tests %}
   {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
   - {{test.name}}Test{{java_test_version.name}}
   {%- endfor %}
@@ -250,7 +250,7 @@ jobs:
         get_params: {skip_download: true}
 
 
-{% for test in tests if test.PLATFORM=="linux"%}
+{% for test in tests %}
   {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
 - name: {{test.name}}Test{{java_test_version.name}}
   public: true


### PR DESCRIPTION
since they are required to pass in the main pipeline, developers should be able to verify they pass in PR before merging, otherwise it's both embarrassing to break the main pipeline, and also difficult to figure out how to fix it with no way to run windows tests beforehand.

this initially had some support on the dev list, but it faded toward the end: https://lists.apache.org/x/thread.html/r4d0ad5898654525e59a5367e3ad101a14307118932a6d61fbf3d72cf@%3Cdev.geode.apache.org%3E

it would still be helpful to merge this PR then pause all of the Windows PR jobs.  then at least they could be called into action when needed.