### PR TITLE
GEODE-8302: Fixed 'events not queued conflated' stats when group-tran…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
@@ -39,8 +39,9 @@ public interface GatewaySenderFactory {
    * Indicates whether events belonging to the same transaction must be
    * delivered inside the same batch, i.e. they cannot be spread across different
    * batches.
-   * Can only be enabled on serial gateway senders with just one dispatcher
+   * It can only be enabled on serial gateway senders with just one dispatcher
    * thread or on parallel gateway senders.
+   * Besides, it cannot be enabled if batch conflation is enabled.
    *
    * @param groupTransactionEvents boolean to indicate whether events from
    *        the same transaction must be delivered inside

--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
@@ -29,7 +29,7 @@ public interface GatewaySenderFactory {
 
   /**
    * Indicates whether all VMs need to distribute events to remote site. In this case only the
-   * events originating in a particular VM will be in dispatched in order.
+   * events originating in a particular VM will be dispatched in order.
    *
    * @param isParallel boolean to indicate whether distribution policy is parallel
    */
@@ -39,9 +39,9 @@ public interface GatewaySenderFactory {
    * Indicates whether events belonging to the same transaction must be
    * delivered inside the same batch, i.e. they cannot be spread across different
    * batches.
-   * It can only be enabled on serial gateway senders with just one dispatcher
-   * thread or on parallel gateway senders.
-   * Besides, it cannot be enabled if batch conflation is enabled.
+   * <code>groupTransactionEvents</code> can be enabled only on parallel gateway senders
+   * or on serial gateway senders with just one dispatcher thread.
+   * It cannot be enabled if batch conflation is enabled.
    *
    * @param groupTransactionEvents boolean to indicate whether events from
    *        the same transaction must be delivered inside

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -106,8 +106,8 @@ public class SerialGatewaySenderQueue implements RegionQueue {
   private final Deque<Long> peekedIds = new LinkedBlockingDeque<Long>();
 
   /**
-   * Contains the peekedIds but not including those that were peeked to complete a transaction
-   * inside a batch when groupTransactionEvents is set.
+   * Contains the peekedIds, excepting those peeked to complete transactions
+   * inside a batch.
    */
   private final Deque<Long> peekedIdsWithoutExtra = new LinkedBlockingDeque<Long>();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -784,7 +784,7 @@ public class SerialGatewaySenderQueue implements RegionQueue {
         logger.trace("{}: Trying head key + offset: {}", this, currentKey);
       }
       currentKey = inc(currentKey);
-      if (this.stats != null) {
+      if (!mustGroupTransactionEvents() && this.stats != null) {
         this.stats.incEventsNotQueuedConflated();
       }
     }

--- a/geode-docs/reference/topics/cache_xml.html.md.erb
+++ b/geode-docs/reference/topics/cache_xml.html.md.erb
@@ -298,7 +298,7 @@ Configures a gateway sender to distribute region events to another <%=vars.produ
 <tr>
 <td>group-transaction-events</td>
 <td>Boolean value to ensure that all the events of a transaction are sent in the same batch, i.e., they are never spread across different batches.
-<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gateway senders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must set to false.</p>
+<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gateway senders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must be set to false.</p>
 <p><b>Note:</b> In order to work for a transaction, the regions to which the transaction events belong must be replicated by the same set of senders with this flag enabled.</p></td>
 <td>false</td>
 </tr>

--- a/geode-docs/reference/topics/cache_xml.html.md.erb
+++ b/geode-docs/reference/topics/cache_xml.html.md.erb
@@ -298,7 +298,7 @@ Configures a gateway sender to distribute region events to another <%=vars.produ
 <tr>
 <td>group-transaction-events</td>
 <td>Boolean value to ensure that all the events of a transaction are sent in the same batch, i.e., they are never spread across different batches.
-<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gateway senders with the <code class="ph codeph">parallel</code> attribute set to true.</p>
+<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gateway senders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must set to false.</p>
 <p><b>Note:</b> In order to work for a transaction, the regions to which the transaction events belong must be replicated by the same set of senders with this flag enabled.</p></td>
 <td>false</td>
 </tr>

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -635,7 +635,7 @@ create gateway-sender --id=value --remote-distributed-system-id=value
 <tr>
 <td><span class="keyword parmname">\-\-group-transaction-events</span></td>
 <td>Boolean value to ensure that all the events of a transaction are sent in the same batch, i.e., they are never spread across different batches.
-<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gatewaysenders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must be set to false.</p>
+<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gateway senders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must be set to false.</p>
 <p><b>Note:</b> In order to work for a transaction, the regions to which the transaction events belong must be replicated by the same set of senders with this flag enabled.</p></td>
 </td>
 <td>false</td>

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -635,7 +635,7 @@ create gateway-sender --id=value --remote-distributed-system-id=value
 <tr>
 <td><span class="keyword parmname">\-\-group-transaction-events</span></td>
 <td>Boolean value to ensure that all the events of a transaction are sent in the same batch, i.e., they are never spread across different batches.
-<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gatewaysenders with the <code class="ph codeph">parallel</code> attribute set to true.</p>
+<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gatewaysenders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must set to false.</p>
 <p><b>Note:</b> In order to work for a transaction, the regions to which the transaction events belong must be replicated by the same set of senders with this flag enabled.</p></td>
 </td>
 <td>false</td>

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -635,7 +635,7 @@ create gateway-sender --id=value --remote-distributed-system-id=value
 <tr>
 <td><span class="keyword parmname">\-\-group-transaction-events</span></td>
 <td>Boolean value to ensure that all the events of a transaction are sent in the same batch, i.e., they are never spread across different batches.
-<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gatewaysenders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must set to false.</p>
+<p>Only allowed to be set on gateway senders with the <code class="ph codeph">parallel</code> attribute set to false and <code class="ph codeph">dispatcher-threads</code> attribute equal to 1, or on gatewaysenders with the <code class="ph codeph">parallel</code> attribute set to true. Also, the  <code class="ph codeph">enable-batch-conflation</code> attribute of the gateway sender must be set to false.</p>
 <p><b>Note:</b> In order to work for a transaction, the regions to which the transaction events belong must be replicated by the same set of senders with this flag enabled.</p></td>
 </td>
 <td>false</td>

--- a/geode-docs/topologies_and_comm/topology_concepts/multisite_overview.html.md.erb
+++ b/geode-docs/topologies_and_comm/topology_concepts/multisite_overview.html.md.erb
@@ -34,12 +34,14 @@ Gateway senders and receivers are defined at startup in the member caches. A sit
 Geode ensures that all copies of a region eventually reach a consistent state on all members and clients that host the region, including Geode members that distribute region events across a WAN.
 
 Events are sent in batches from gateway senders to receivers. In order to avoid inconsistencies due
-to partial reception of the events belonging to a transaction, you can configure gateway senders to
+to partial reception of the events belonging to a transaction, you can configure gateway senders
+using the `group-transaction-events` property to
 ensure that events belonging to the same transaction are sent together in the same batch.
-<b>Note:</b> This setting is supported only on serial senders with just one dispatcher
-thread, or on parallel senders. In addition, the regions to which the transaction events belong must
-be replicated by the same set of gateway senders that also have this setting enabled.
-Furthermore, this setting cannot be enabled if batch conflation is enabled.
+In order to use transaction event grouping:
+
+- The `group-transaction-events` setting is supported only on serial senders with just one dispatcher thread, or on parallel senders.
+- The regions to which the transaction events belong must be replicated by the same set of gateway senders that also have this setting enabled.
+- This setting cannot be enabled if `enable-batch-conflation` is in effect.
 
 By default, potential WAN conflicts are resolved using a timestamp mechanism. You can optionally install a custom conflict resolver to apply custom logic when determining whether to apply a potentially conflicting update received over a WAN.
 

--- a/geode-docs/topologies_and_comm/topology_concepts/multisite_overview.html.md.erb
+++ b/geode-docs/topologies_and_comm/topology_concepts/multisite_overview.html.md.erb
@@ -39,6 +39,7 @@ ensure that events belonging to the same transaction are sent together in the sa
 <b>Note:</b> This setting is supported only on serial senders with just one dispatcher
 thread, or on parallel senders. In addition, the regions to which the transaction events belong must
 be replicated by the same set of gateway senders that also have this setting enabled.
+Furthermore, this setting cannot be enabled if batch conflation is enabled.
 
 By default, potential WAN conflicts are resolved using a timestamp mechanism. You can optionally install a custom conflict resolver to apply custom logic when determining whether to apply a potentially conflicting update received over a WAN.
 

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -280,6 +280,9 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
       Boolean groupTransactionEvents =
           (Boolean) parseResult
               .getParamValue(CliStrings.CREATE_GATEWAYSENDER__GROUPTRANSACTIONEVENTS);
+      Boolean batchConflationEnabled =
+          (Boolean) parseResult
+              .getParamValue(CliStrings.CREATE_GATEWAYSENDER__ENABLEBATCHCONFLATION);
 
       if (dispatcherThreads != null && dispatcherThreads > 1 && orderPolicy == null) {
         return ResultModel.createError(
@@ -295,6 +298,11 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
           && groupTransactionEvents) {
         return ResultModel.createError(
             "Serial Gateway Sender cannot be created with --group-transaction-events when --dispatcher-threads is greater than 1.");
+      }
+
+      if (groupTransactionEvents && batchConflationEnabled) {
+        return ResultModel.createError(
+            "Gateway Sender cannot be created with --group-transaction-events and --enable-batch-conflation.");
       }
 
       return ResultModel.createInfo("");

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommand.java
@@ -302,7 +302,7 @@ public class CreateGatewaySenderCommand extends SingleGfshCommand {
 
       if (groupTransactionEvents && batchConflationEnabled) {
         return ResultModel.createError(
-            "Gateway Sender cannot be created with --group-transaction-events and --enable-batch-conflation.");
+            "Gateway Sender cannot be created with both --group-transaction-events and --enable-batch-conflation.");
       }
 
       return ResultModel.createInfo("");

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/CreateGatewaySenderCommandTest.java
@@ -180,7 +180,7 @@ public class CreateGatewaySenderCommandTest {
         "create gateway-sender --member=xyz --id=1 --remote-distributed-system-id=1 " +
             "--group-transaction-events --enable-batch-conflation --order-policy=THREAD")
         .statusIsError().containsOutput(
-            "Gateway Sender cannot be created with --group-transaction-events and --enable-batch-conflation");
+            "Gateway Sender cannot be created with both --group-transaction-events and --enable-batch-conflation");
   }
 
   @Test

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
@@ -698,6 +698,8 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
 
     vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10000));
     vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10000));
+    vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm5.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
   }
 
   @Test

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDUnitTest.java
@@ -462,6 +462,8 @@ public class ParallelWANStatsDUnitTest extends WANTestBase {
     assertEquals(1, v4List.get(4) + v5List.get(4) + v6List.get(4) + v7List.get(4));
     // batches redistributed:
     assertEquals(0, v4List.get(5) + v5List.get(5) + v6List.get(5) + v7List.get(5));
+    // events not queued conflated:
+    assertEquals(0, v4List.get(7) + v5List.get(7) + v6List.get(7) + v7List.get(7));
   }
 
   @Test
@@ -605,6 +607,8 @@ public class ParallelWANStatsDUnitTest extends WANTestBase {
     assertEquals(2, (int) v4List.get(4));
     // batches redistributed:
     assertTrue("Batch was not redistributed", (v4List.get(5)) > 0);
+    // events not queued conflated:
+    assertEquals(0, (int) v4List.get(7));
   }
 
   @Test
@@ -782,19 +786,19 @@ public class ParallelWANStatsDUnitTest extends WANTestBase {
     int batchSize = 9;
     boolean groupTransactionEvents = true;
     vm4.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, true, false, null, true,
+        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, false, false, null, true,
             groupTransactionEvents,
             -1));
     vm5.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, true, false, null, true,
+        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, false, false, null, true,
             groupTransactionEvents,
             -1));
     vm6.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, true, false, null, true,
+        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, false, false, null, true,
             groupTransactionEvents,
             -1));
     vm7.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, true, false, null, true,
+        () -> WANTestBase.createSender("ln", 2, true, 100, batchSize, false, false, null, true,
             groupTransactionEvents,
             -1));
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
@@ -330,6 +330,8 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
     inv.join();
     vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
     vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
+    vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm5.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
   }
 
   @Test

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANStatsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANStatsDUnitTest.java
@@ -209,6 +209,7 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
 
     vm4.invoke(() -> WANTestBase.checkQueueStats("ln", 0, entries, entries, entries));
     vm4.invoke(() -> WANTestBase.checkBatchStats("ln", 1, true));
+    vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
 
     // wait until queue is empty
     vm5.invoke(() -> await()
@@ -216,6 +217,7 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
 
     vm5.invoke(() -> WANTestBase.checkQueueStats("ln", 0, entries, 0, 0));
     vm5.invoke(() -> WANTestBase.checkBatchStats("ln", 0, true));
+    vm5.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
   }
 
   @Test
@@ -354,6 +356,7 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
 
     vm4.invoke(() -> WANTestBase.checkQueueStats("ln", 0, entries, entries, entries));
     vm4.invoke(() -> WANTestBase.checkBatchStats("ln", 2, true, true));
+    vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
 
     // wait until queue is empty
     vm5.invoke(() -> await()
@@ -361,6 +364,7 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
 
     vm5.invoke(() -> WANTestBase.checkQueueStats("ln", 0, entries, 0, 0));
     vm5.invoke(() -> WANTestBase.checkBatchStats("ln", 0, true));
+    vm5.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
   }
 
   @Test

--- a/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -104,7 +104,7 @@ public class WANConfigurationJUnitTest {
     assertThatThrownBy(() -> fact.create("NYSender", 2))
         .isInstanceOf(GatewaySenderException.class)
         .hasMessageContaining(
-            "GatewaySender NYSender cannot be created with group transaction events set to true and batch conflation enabled");
+            "GatewaySender NYSender cannot be created with both group transaction events set to true and batch conflation enabled");
   }
 
   /**

--- a/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -95,6 +95,18 @@ public class WANConfigurationJUnitTest {
             "SerialGatewaySender NYSender cannot be created with group transaction events set to true when dispatcher threads is greater than 1");
   }
 
+  @Test
+  public void test_create_GatewaySender_ThrowsException_when_GroupTransactionEvents_isTrue_and_BatchConflation_is_enabled() {
+    cache = new CacheFactory().set(MCAST_PORT, "0").create();
+    GatewaySenderFactory fact = cache.createGatewaySenderFactory();
+    fact.setBatchConflationEnabled(true);
+    fact.setGroupTransactionEvents(true);
+    assertThatThrownBy(() -> fact.create("NYSender", 2))
+        .isInstanceOf(GatewaySenderException.class)
+        .hasMessageContaining(
+            "GatewaySender NYSender cannot be created with group transaction events set to true and batch conflation enabled");
+  }
+
   /**
    * Test to validate that sender with same Id can not be added to cache.
    */

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderFactoryImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderFactoryImpl.java
@@ -247,6 +247,12 @@ public class GatewaySenderFactoryImpl implements InternalGatewaySenderFactory {
         }
       }
     }
+    if (this.attrs.mustGroupTransactionEvents() && this.attrs.isBatchConflationEnabled()) {
+      throw new GatewaySenderException(
+          String.format(
+              "GatewaySender %s cannot be created with group transaction events set to true and batch conflation enabled",
+              id));
+    }
 
     if (this.attrs.isParallel()) {
       if ((this.attrs.getOrderPolicy() != null)

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderFactoryImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderFactoryImpl.java
@@ -250,7 +250,7 @@ public class GatewaySenderFactoryImpl implements InternalGatewaySenderFactory {
     if (this.attrs.mustGroupTransactionEvents() && this.attrs.isBatchConflationEnabled()) {
       throw new GatewaySenderException(
           String.format(
-              "GatewaySender %s cannot be created with group transaction events set to true and batch conflation enabled",
+              "GatewaySender %s cannot be created with both group transaction events set to true and batch conflation enabled",
               id));
     }
 


### PR DESCRIPTION
…saction-events is true

Batch conflation is not compatible with group-transaction-events.
It must be prevented that both are enabled at the same time for
a given gateway sender.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
