### PR TITLE
GEODE-8309: fix ping to return its parameter

### DIFF
--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/PingNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/PingNativeRedisAcceptanceTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal.executor.connection;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TestRule;
+import org.testcontainers.containers.GenericContainer;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+
+public class PingNativeRedisAcceptanceTest extends PingIntegrationTest {
+
+  private static GenericContainer redisContainer;
+
+  // Docker compose does not work on windows in CI. Ignore this test on windows
+  // Using a RuleChain to make sure we ignore the test before the rule comes into play
+  @ClassRule
+  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+
+  @BeforeClass
+  public static void setUp() {
+    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
+    redisContainer.start();
+    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/PingIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/PingIntegrationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal.executor.connection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static redis.clients.jedis.Protocol.Command.PING;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.junit.categories.RedisTest;
+
+@Category({RedisTest.class})
+public class PingIntegrationTest {
+  protected static int REDIS_CLIENT_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+  protected static Jedis jedis;
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @BeforeClass
+  public static void setUp() {
+    jedis = new Jedis("localhost", server.getPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    jedis.close();
+  }
+
+  @Test
+  public void ping_withNoArgs_returnsPong() {
+    String result = jedis.ping();
+    assertThat(result).isEqualTo("PONG");
+  }
+
+  @Test
+  public void ping_withArg_returnsArg() {
+    String result = jedis.ping("hello world");
+    assertThat(result).isEqualTo("hello world");
+  }
+
+  @Test
+  public void ping_withBinaryArg_returnsBinaryArg() {
+    byte[] binaryArg = new byte[256];
+    byte byteValue = Byte.MIN_VALUE;
+    for (int i = 0; i < binaryArg.length; i++) {
+      binaryArg[i] = byteValue++;
+    }
+    byte[] result = jedis.ping(binaryArg);
+    assertThat(result).isEqualTo(binaryArg);
+  }
+
+  @Test
+  public void ping_withTwoArgs_fails() {
+    assertThatThrownBy(() -> jedis.sendCommand(PING, "one", "two"))
+        .hasMessageContaining("ERR wrong number of arguments for 'ping' command");
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -15,6 +15,8 @@
  */
 package org.apache.geode.redis.internal.executor.connection;
 
+import java.util.List;
+
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -27,6 +29,11 @@ public class PingExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    return RedisResponse.string(PING_RESPONSE);
+    List<byte[]> commandElems = command.getProcessedCommand();
+    Object result = PING_RESPONSE;
+    if (commandElems.size() > 1) {
+      result = commandElems.get(1);
+    }
+    return RedisResponse.bulkString(result);
   }
 }


### PR DESCRIPTION
Added ping integration tests.
Now if ping is given a parameter it will be returned instead of PONG.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
