### PR TITLE
GEODE-8312: Improve Redis pub/sub capabilities

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubIntegrationTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -29,6 +30,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 import org.apache.geode.redis.mocks.MockBinarySubscriber;
@@ -66,6 +68,27 @@ public class PubSubIntegrationTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
+  public void punsubscribe_whenNonexistent() {
+    assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE, "Nonexistent"))
+        .containsExactly("punsubscribe".getBytes(), "Nonexistent".getBytes(), 0L);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void unsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
+    assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.UNSUBSCRIBE))
+        .containsExactly("unsubscribe".getBytes(), null, 0L);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void punsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
+    assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE))
+        .containsExactly("punsubscribe".getBytes(), null, 0L);
+  }
+
+  @Test
   public void testOneSubscriberOneChannel() {
     List<String> expectedMessages = Arrays.asList("hello");
 
@@ -87,6 +110,170 @@ public class PubSubIntegrationTest {
     waitFor(() -> !subscriberThread.isAlive());
 
     assertThat(mockSubscriber.getReceivedMessages()).isEqualTo(expectedMessages);
+  }
+
+  @Test
+  public void punsubscribe_givenSubscribe_doesNotReduceSubscriptions() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> {
+      subscriber.subscribe(mockSubscriber, "salutations");
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    try {
+      waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+      mockSubscriber.punsubscribe("salutations");
+      waitFor(() -> mockSubscriber.punsubscribeInfos.size() == 1);
+
+      assertThat(mockSubscriber.punsubscribeInfos.get(0).channel).isEqualTo("salutations");
+      assertThat(mockSubscriber.punsubscribeInfos.get(0).count).isEqualTo(1);
+      assertThat(mockSubscriber.getSubscribedChannels()).isEqualTo(1);
+    } finally {
+      // now cleanup the actual subscription
+      mockSubscriber.unsubscribe("salutations");
+      waitFor(() -> !subscriberThread.isAlive());
+    }
+  }
+
+  @Test
+  public void unsubscribe_givenPsubscribe_doesNotReduceSubscriptions() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> {
+      subscriber.psubscribe(mockSubscriber, "salutations");
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    try {
+      waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+      mockSubscriber.unsubscribe("salutations");
+      waitFor(() -> mockSubscriber.unsubscribeInfos.size() == 1);
+
+      assertThat(mockSubscriber.unsubscribeInfos.get(0).channel).isEqualTo("salutations");
+      assertThat(mockSubscriber.unsubscribeInfos.get(0).count).isEqualTo(1);
+      assertThat(mockSubscriber.getSubscribedChannels()).isEqualTo(1);
+    } finally {
+      // now cleanup the actual subscription
+      mockSubscriber.punsubscribe("salutations");
+      waitFor(() -> !subscriberThread.isAlive());
+    }
+  }
+
+  @Test
+  public void unsubscribe_onNonExistentSubscription_doesNotReduceSubscriptions() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+    Runnable runnable = () -> {
+      subscriber.subscribe(mockSubscriber, "salutations");
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    try {
+      waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+      mockSubscriber.unsubscribe("NonExistent");
+      waitFor(() -> mockSubscriber.unsubscribeInfos.size() == 1);
+
+      assertThat(mockSubscriber.unsubscribeInfos.get(0).channel).isEqualTo("NonExistent");
+      assertThat(mockSubscriber.unsubscribeInfos.get(0).count).isEqualTo(1);
+      assertThat(mockSubscriber.getSubscribedChannels()).isEqualTo(1);
+    } finally {
+      // now cleanup the actual subscription
+      mockSubscriber.unsubscribe("salutations");
+      waitFor(() -> !subscriberThread.isAlive());
+    }
+  }
+
+  @Test
+  public void unsubscribe_whenGivenAnEmptyString() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "salutations");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    try {
+      waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+      mockSubscriber.unsubscribe("");
+      waitFor(() -> mockSubscriber.unsubscribeInfos.size() == 1);
+
+      assertThat(mockSubscriber.unsubscribeInfos.get(0).channel).isEqualTo("");
+      assertThat(mockSubscriber.unsubscribeInfos.get(0).count).isEqualTo(1);
+      assertThat(mockSubscriber.getSubscribedChannels()).isEqualTo(1);
+    } finally {
+      // now cleanup the actual subscription
+      mockSubscriber.unsubscribe();
+      waitFor(() -> !subscriberThread.isAlive());
+    }
+  }
+
+  @Test
+  public void unsubscribeWithEmptyChannel_doesNotUnsubscribeExistingChannels() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "salutations");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    try {
+      waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+      mockSubscriber.unsubscribe("");
+      waitFor(() -> mockSubscriber.unsubscribeInfos.size() == 1);
+
+      Long result = publisher.publish("salutations", "heyho");
+      waitFor(() -> mockSubscriber.getReceivedMessages().size() == 1);
+
+      assertThat(result).isEqualTo(1);
+      assertThat(mockSubscriber.getReceivedMessages().get(0)).isEqualTo("heyho");
+    } finally {
+      // now cleanup the actual subscription
+      mockSubscriber.unsubscribe();
+      waitFor(() -> !subscriberThread.isAlive());
+    }
+  }
+
+  @Test
+  public void canSubscribeToAnEmptyString() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+    Long result = publisher.publish("", "blank");
+    assertThat(result).isEqualTo(1);
+
+    mockSubscriber.unsubscribe("");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
+
+    assertThat(mockSubscriber.getReceivedMessages()).containsExactly("blank");
+  }
+
+  @Test
+  public void punsubscribe_onNonExistentSubscription_doesNotReduceSubscriptions() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+    Runnable runnable = () -> {
+      subscriber.psubscribe(mockSubscriber, "salutations");
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    try {
+      waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+      mockSubscriber.punsubscribe("NonExistent");
+      waitFor(() -> mockSubscriber.punsubscribeInfos.size() == 1);
+
+      assertThat(mockSubscriber.punsubscribeInfos.get(0).channel).isEqualTo("NonExistent");
+      assertThat(mockSubscriber.punsubscribeInfos.get(0).count).isEqualTo(1);
+      assertThat(mockSubscriber.getSubscribedChannels()).isEqualTo(1);
+    } finally {
+      // now cleanup the actual subscription
+      mockSubscriber.punsubscribe("salutations");
+      waitFor(() -> !subscriberThread.isAlive());
+    }
   }
 
   @Test
@@ -117,6 +304,33 @@ public class PubSubIntegrationTest {
   }
 
   @Test
+  public void testSubscribeAndPublishUsingBinaryData() {
+    byte[] binaryBlob = new byte[256];
+    for (int i = 0; i < 256; i++) {
+      binaryBlob[i] = (byte) i;
+    }
+
+    MockBinarySubscriber mockSubscriber = new MockBinarySubscriber();
+
+    Runnable runnable = () -> {
+      subscriber.subscribe(mockSubscriber, binaryBlob);
+    };
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+
+    Long result = publisher.publish(binaryBlob, binaryBlob);
+    assertThat(result).isEqualTo(1);
+
+    mockSubscriber.unsubscribe(binaryBlob);
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
+
+    assertThat(mockSubscriber.getReceivedMessages().get(0)).isEqualTo(binaryBlob);
+  }
+
+  @Test
   public void testOneSubscriberSubscribingToTwoChannels() {
     List<String> expectedMessages = Arrays.asList("hello", "howdy");
     MockSubscriber mockSubscriber = new MockSubscriber();
@@ -135,11 +349,108 @@ public class PubSubIntegrationTest {
     assertThat(result).isEqualTo(1);
     mockSubscriber.unsubscribe("salutations");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+    assertThat(mockSubscriber.unsubscribeInfos).hasSize(1);
+    assertThat(mockSubscriber.unsubscribeInfos.get(0).channel).isEqualTo("salutations");
+    assertThat(mockSubscriber.unsubscribeInfos.get(0).count).isEqualTo(1);
+    mockSubscriber.unsubscribeInfos.clear();
     mockSubscriber.unsubscribe("yuletide");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    assertThat(mockSubscriber.unsubscribeInfos).hasSize(1);
+    assertThat(mockSubscriber.unsubscribeInfos.get(0).channel).isEqualTo("yuletide");
+    assertThat(mockSubscriber.unsubscribeInfos.get(0).count).isEqualTo(0);
     waitFor(() -> !subscriberThread.isAlive());
 
     assertThat(mockSubscriber.getReceivedMessages()).isEqualTo(expectedMessages);
+  }
+
+  @Test
+  public void testSubscribingAndUnsubscribingFromMultipleChannels() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "salutations", "yuletide");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+
+    mockSubscriber.unsubscribe("yuletide", "salutations");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
+
+    List<String> unsubscribedChannels = mockSubscriber.unsubscribeInfos.stream()
+        .map(x -> x.channel).collect(Collectors.toList());
+    assertThat(unsubscribedChannels).containsExactlyInAnyOrder("salutations", "yuletide");
+
+    List<Integer> channelCounts = mockSubscriber.unsubscribeInfos.stream()
+        .map(x -> x.count).collect(Collectors.toList());
+    assertThat(channelCounts).containsExactlyInAnyOrder(1, 0);
+
+  }
+
+  @Test
+  public void testUnsubscribingImplicitlyFromAllChannels() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "salutations", "yuletide");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+
+    mockSubscriber.unsubscribe();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
+
+    List<String> unsubscribedChannels = mockSubscriber.unsubscribeInfos.stream()
+        .map(x -> x.channel).collect(Collectors.toList());
+    assertThat(unsubscribedChannels).containsExactlyInAnyOrder("salutations", "yuletide");
+
+    List<Integer> channelCounts = mockSubscriber.unsubscribeInfos.stream()
+        .map(x -> x.count).collect(Collectors.toList());
+    assertThat(channelCounts).containsExactlyInAnyOrder(1, 0);
+
+    Long result = publisher.publish("salutations", "greetings");
+    assertThat(result).isEqualTo(0);
+  }
+
+  @Test
+  public void testPsubscribingAndPunsubscribingFromMultipleChannels() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> subscriber.psubscribe(mockSubscriber, "sal*", "yul*");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+
+    mockSubscriber.punsubscribe("yul*", "sal*");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
+    assertThat(mockSubscriber.punsubscribeInfos).containsExactly(
+        new MockSubscriber.UnsubscribeInfo("yul*", 1),
+        new MockSubscriber.UnsubscribeInfo("sal*", 0));
+  }
+
+  @Test
+  public void testPunsubscribingImplicitlyFromAllChannels() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    Runnable runnable = () -> subscriber.psubscribe(mockSubscriber, "sal*", "yul*");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+
+    mockSubscriber.punsubscribe();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+    waitFor(() -> !subscriberThread.isAlive());
+    assertThat(mockSubscriber.punsubscribeInfos).containsExactly(
+        new MockSubscriber.UnsubscribeInfo("sal*", 1),
+        new MockSubscriber.UnsubscribeInfo("yul*", 0));
   }
 
   @Test
@@ -164,12 +475,18 @@ public class PubSubIntegrationTest {
     mockSubscriber1.unsubscribe("salutations");
     waitFor(() -> mockSubscriber1.getSubscribedChannels() == 0);
     waitFor(() -> !subscriber1Thread.isAlive());
+    assertThat(mockSubscriber1.unsubscribeInfos).hasSize(1);
+    assertThat(mockSubscriber1.unsubscribeInfos.get(0).channel).isEqualTo("salutations");
+    assertThat(mockSubscriber1.unsubscribeInfos.get(0).count).isEqualTo(0);
 
     result = publisher.publish("salutations", "goodbye");
     assertThat(result).isEqualTo(1);
     mockSubscriber2.unsubscribe("salutations");
     waitFor(() -> mockSubscriber2.getSubscribedChannels() == 0);
     waitFor(() -> !subscriber2Thread.isAlive());
+    assertThat(mockSubscriber2.unsubscribeInfos).hasSize(1);
+    assertThat(mockSubscriber2.unsubscribeInfos.get(0).channel).isEqualTo("salutations");
+    assertThat(mockSubscriber2.unsubscribeInfos.get(0).count).isEqualTo(0);
 
     assertThat(mockSubscriber1.getReceivedMessages()).isEqualTo(Collections.singletonList("hello"));
     assertThat(mockSubscriber2.getReceivedMessages()).isEqualTo(Arrays.asList("hello", "goodbye"));
@@ -201,6 +518,8 @@ public class PubSubIntegrationTest {
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
 
     waitFor(() -> !subscriberThread.isAlive());
+    assertThat(mockSubscriber.unsubscribeInfos)
+        .containsExactly(new MockSubscriber.UnsubscribeInfo("salutations", 0));
     assertThat(mockSubscriber.getReceivedMessages()).isEqualTo(Collections.singletonList("hello"));
   }
 
@@ -252,6 +571,8 @@ public class PubSubIntegrationTest {
     mockSubscriber.punsubscribe("sal*s");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
     waitFor(() -> !subscriberThread.isAlive());
+    assertThat(mockSubscriber.punsubscribeInfos)
+        .containsExactly(new MockSubscriber.UnsubscribeInfo("sal*s", 0));
   }
 
   @Test
@@ -283,6 +604,8 @@ public class PubSubIntegrationTest {
     mockSubscriber.punsubscribe("sal*s");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
     waitFor(() -> !subscriberThread.isAlive());
+    assertThat(mockSubscriber.punsubscribeInfos)
+        .containsExactly(new MockSubscriber.UnsubscribeInfo("sal*s", 0));
   }
 
   @Test
@@ -305,11 +628,17 @@ public class PubSubIntegrationTest {
 
     mockSubscriber.punsubscribe("sal*s");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+    assertThat(mockSubscriber.punsubscribeInfos).hasSize(1);
+    assertThat(mockSubscriber.punsubscribeInfos.get(0).channel).isEqualTo("sal*s");
+    assertThat(mockSubscriber.punsubscribeInfos.get(0).count).isEqualTo(1);
 
     mockSubscriber.unsubscribe("salutations");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
 
     waitFor(() -> !subscriberThread.isAlive());
+    assertThat(mockSubscriber.unsubscribeInfos).hasSize(1);
+    assertThat(mockSubscriber.unsubscribeInfos.get(0).channel).isEqualTo("salutations");
+    assertThat(mockSubscriber.unsubscribeInfos.get(0).count).isEqualTo(0);
 
     assertThat(mockSubscriber.getReceivedMessages()).containsExactly("hello");
     assertThat(mockSubscriber.getReceivedPMessages()).containsExactly("hello");

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
@@ -116,7 +116,7 @@ public class SubscriptionsIntegrationTest {
     Callable<Void> addingCallable =
         functionSpinner(x -> subscriptions.add(new DummySubscription()));
     Callable<Void> findSubscriptionsCallable =
-        functionSpinner(x -> subscriptions.findSubscriptions("channel"));
+        functionSpinner(x -> subscriptions.findSubscriptions("channel".getBytes()));
 
     Future<Void> addingFuture = executor.submit(addingCallable);
     Future<Void> existsFuture = executor.submit(findSubscriptionsCallable);
@@ -137,11 +137,11 @@ public class SubscriptionsIntegrationTest {
     for (int i = 0; i < ITERATIONS; i++) {
       Client client = new Client(mock(Channel.class));
       clients.add(client);
-      subscriptions.add(new ChannelSubscription(client, "channel", context));
+      subscriptions.add(new ChannelSubscription(client, "channel".getBytes(), context));
     }
 
     Callable<Void> removeCallable = () -> {
-      clients.forEach(c -> subscriptions.remove(c));
+      clients.forEach(subscriptions::remove);
       return null;
     };
     Callable<Void> existsCallable = () -> {
@@ -168,7 +168,7 @@ public class SubscriptionsIntegrationTest {
     for (int i = 0; i < ITERATIONS; i++) {
       Client client = new Client(mock(Channel.class));
       clients.add(client);
-      subscriptions.add(new ChannelSubscription(client, "channel", context));
+      subscriptions.add(new ChannelSubscription(client, "channel".getBytes(), context));
     }
 
     Callable<Void> removeCallable = () -> {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
@@ -30,7 +30,7 @@ public class DummySubscription implements Subscription {
   }
 
   @Override
-  public void publishMessage(String channel, byte[] message,
+  public void publishMessage(byte[] channel, byte[] message,
       PublishResultCollector publishResultCollector) {}
 
   @Override
@@ -39,17 +39,17 @@ public class DummySubscription implements Subscription {
   }
 
   @Override
-  public boolean matches(String channel) {
+  public boolean matches(byte[] channel) {
     return false;
   }
 
   @Override
-  public List<Object> createResponse(String channel, byte[] message) {
+  public List<Object> createResponse(byte[] channel, byte[] message) {
     return null;
   }
 
   @Override
-  public String getChannelName() {
+  public byte[] getChannelName() {
     return null;
   }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
@@ -47,4 +47,9 @@ public class DummySubscription implements Subscription {
   public List<Object> createResponse(String channel, byte[] message) {
     return null;
   }
+
+  @Override
+  public String getChannelName() {
+    return null;
+  }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -19,6 +19,7 @@ package org.apache.geode.redis.mocks;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import redis.clients.jedis.JedisPubSub;
 
@@ -33,6 +34,58 @@ public class MockSubscriber extends JedisPubSub {
   public List<String> getReceivedPMessages() {
     return new ArrayList<>(receivedPMessages);
   }
+
+  public final List<UnsubscribeInfo> unsubscribeInfos =
+      Collections.synchronizedList(new ArrayList<>());
+  public final List<UnsubscribeInfo> punsubscribeInfos =
+      Collections.synchronizedList(new ArrayList<>());
+
+  @Override
+  public void onUnsubscribe(String channel, int subscribedChannels) {
+    unsubscribeInfos.add(new UnsubscribeInfo(channel, subscribedChannels));
+  }
+
+  @Override
+  public void onPUnsubscribe(String pattern, int subscribedChannels) {
+    punsubscribeInfos.add(new UnsubscribeInfo(pattern, subscribedChannels));
+  }
+
+  public static class UnsubscribeInfo {
+    public final String channel;
+    public final int count;
+
+    public UnsubscribeInfo(String channel, int count) {
+      this.channel = channel;
+      this.count = count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof UnsubscribeInfo)) {
+        return false;
+      }
+      UnsubscribeInfo that = (UnsubscribeInfo) o;
+      return count == that.count &&
+          Objects.equals(channel, that.channel);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(channel, count);
+    }
+
+    @Override
+    public String toString() {
+      return "UnsubscribeInfo{" +
+          "channel='" + channel + '\'' +
+          ", count=" + count +
+          '}';
+    }
+  }
+
 
   @Override
   public void onMessage(String channel, String message) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -164,9 +164,9 @@ public enum RedisCommandType {
 
   SUBSCRIBE(new SubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
   PUBLISH(new PublishExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
-  UNSUBSCRIBE(new UnsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
+  UNSUBSCRIBE(new UnsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(1)),
   PSUBSCRIBE(new PsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
-  PUNSUBSCRIBE(new PunsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
+  PUNSUBSCRIBE(new PunsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(1)),
 
   UNKNOWN(new UnknownExecutor(), SUPPORTED),
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
@@ -29,9 +29,8 @@ public class PublishExecutor extends AbstractExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> args = command.getProcessedCommand();
 
-    String channelName = new String(args.get(1));
     long publishCount =
-        context.getPubSub().publish(getDataRegion(context), channelName, args.get(2));
+        context.getPubSub().publish(getDataRegion(context), args.get(1), args.get(2));
 
     return RedisResponse.integer(publishCount);
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
@@ -17,10 +17,14 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -33,17 +37,45 @@ public class PunsubscribeExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    byte[] pattern = command.getProcessedCommand().get(1);
-    long subscriptionCount =
-        context
-            .getPubSub()
-            .punsubscribe(new GlobPattern(new String(pattern)), context.getClient());
 
-    ArrayList<Object> items = new ArrayList<>();
-    items.add("punsubscribe");
-    items.add(pattern);
-    items.add(subscriptionCount);
+    List<String> channelNames = extractChannelNames(command);
+    if (channelNames.isEmpty()) {
+      channelNames = context.getPubSub().findSubscribedChannels(context.getClient());
+    }
 
-    return RedisResponse.array(items);
+    Collection<Collection<?>> response = punsubscribe(context, channelNames);
+
+    return RedisResponse.flattenedArray(response);
+  }
+
+  private List<String> extractChannelNames(Command command) {
+    return command.getProcessedCommandWrappers().stream()
+        .skip(1)
+        .map(ByteArrayWrapper::toString)
+        .collect(Collectors.toList());
+  }
+
+  private Collection<Collection<?>> punsubscribe(ExecutionHandlerContext context,
+      List<String> channelNames) {
+    Collection<Collection<?>> response = new ArrayList<>();
+
+    if (channelNames.isEmpty()) {
+      response.add(createItem(null, 0));
+    } else {
+      for (String channel : channelNames) {
+        long subscriptionCount =
+            context.getPubSub().punsubscribe(new GlobPattern(channel), context.getClient());
+        response.add(createItem(channel, subscriptionCount));
+      }
+    }
+    return response;
+  }
+
+  private ArrayList<Object> createItem(String channel, long subscriptionCount) {
+    ArrayList<Object> oneItem = new ArrayList<>();
+    oneItem.add("punsubscribe");
+    oneItem.add(channel);
+    oneItem.add(subscriptionCount);
+    return oneItem;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
@@ -33,7 +33,7 @@ public class SubscribeExecutor extends AbstractExecutor {
       Collection<Object> item = new ArrayList<>();
       byte[] channelName = command.getProcessedCommand().get(i);
       long subscribedChannels =
-          context.getPubSub().subscribe(new String(channelName), context, context.getClient());
+          context.getPubSub().subscribe(channelName, context, context.getClient());
 
       item.add("subscribe");
       item.add(channelName);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
@@ -32,7 +32,7 @@ public class UnsubscribeExecutor extends AbstractExecutor {
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
 
-    List<String> channelNames = extractChannelNames(command);
+    List<byte[]> channelNames = extractChannelNames(command);
     if (channelNames.isEmpty()) {
       channelNames = context.getPubSub().findSubscribedChannels(context.getClient());
     }
@@ -42,21 +42,21 @@ public class UnsubscribeExecutor extends AbstractExecutor {
     return RedisResponse.flattenedArray(response);
   }
 
-  private List<String> extractChannelNames(Command command) {
+  private List<byte[]> extractChannelNames(Command command) {
     return command.getProcessedCommandWrappers().stream()
         .skip(1)
-        .map(ByteArrayWrapper::toString)
+        .map(ByteArrayWrapper::toBytes)
         .collect(Collectors.toList());
   }
 
   private Collection<Collection<?>> unsubscribe(ExecutionHandlerContext context,
-      List<String> channelNames) {
+      List<byte[]> channelNames) {
     Collection<Collection<?>> response = new ArrayList<>();
 
     if (channelNames.isEmpty()) {
       response.add(createItem(null, 0));
     } else {
-      for (String channel : channelNames) {
+      for (byte[] channel : channelNames) {
         long subscriptionCount =
             context.getPubSub().unsubscribe(channel, context.getClient());
 
@@ -67,7 +67,7 @@ public class UnsubscribeExecutor extends AbstractExecutor {
     return response;
   }
 
-  private ArrayList<Object> createItem(String channelName, long subscriptionCount) {
+  private ArrayList<Object> createItem(byte[] channelName, long subscriptionCount) {
     ArrayList<Object> oneItem = new ArrayList<>();
     oneItem.add("unsubscribe");
     oneItem.add(channelName);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
@@ -16,34 +16,63 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import org.apache.logging.log4j.Logger;
-
-import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class UnsubscribeExecutor extends AbstractExecutor {
-  private static final Logger logger = LogService.getLogger();
 
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    List<byte[]> commandElems = command.getProcessedCommand();
 
-    byte[] channelName = commandElems.get(1);
-    long subscriptionCount =
-        context.getPubSub().unsubscribe(new String(channelName), context.getClient());
+    List<String> channelNames = extractChannelNames(command);
+    if (channelNames.isEmpty()) {
+      channelNames = context.getPubSub().findSubscribedChannels(context.getClient());
+    }
 
-    ArrayList<Object> items = new ArrayList<>();
-    items.add("unsubscribe");
-    items.add(channelName);
-    items.add(subscriptionCount);
+    Collection<Collection<?>> response = unsubscribe(context, channelNames);
 
-    return RedisResponse.array(items);
+    return RedisResponse.flattenedArray(response);
+  }
+
+  private List<String> extractChannelNames(Command command) {
+    return command.getProcessedCommandWrappers().stream()
+        .skip(1)
+        .map(ByteArrayWrapper::toString)
+        .collect(Collectors.toList());
+  }
+
+  private Collection<Collection<?>> unsubscribe(ExecutionHandlerContext context,
+      List<String> channelNames) {
+    Collection<Collection<?>> response = new ArrayList<>();
+
+    if (channelNames.isEmpty()) {
+      response.add(createItem(null, 0));
+    } else {
+      for (String channel : channelNames) {
+        long subscriptionCount =
+            context.getPubSub().unsubscribe(channel, context.getClient());
+
+        response.add(createItem(channel, subscriptionCount));
+      }
+    }
+
+    return response;
+  }
+
+  private ArrayList<Object> createItem(String channelName, long subscriptionCount) {
+    ArrayList<Object> oneItem = new ArrayList<>();
+    oneItem.add("unsubscribe");
+    oneItem.add(channelName);
+    oneItem.add(subscriptionCount);
+    return oneItem;
   }
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -352,7 +352,7 @@ public class Coder {
   }
 
   public static byte[] stringToBytes(String string) {
-    if (string == null || string.equals("")) {
+    if (string == null) {
       return null;
     }
     try {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -188,13 +188,6 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       return;
     }
 
-    if (command.isOfType(RedisCommandType.SELECT)
-        || command.isOfType(RedisCommandType.CONFIG)
-        || command.isOfType(RedisCommandType.PUBSUB)) {
-      writeToChannel(RedisResponse.ok());
-      return;
-    }
-
     if (command.isUnsupported() && !allowUnsupportedCommands()) {
       writeToChannel(
           RedisResponse.error(command.getCommandType() + RedisConstants.ERROR_UNSUPPORTED_COMMAND));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -188,6 +188,13 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       return;
     }
 
+    if (command.isOfType(RedisCommandType.SELECT)
+        || command.isOfType(RedisCommandType.CONFIG)
+        || command.isOfType(RedisCommandType.PUBSUB)) {
+      writeToChannel(RedisResponse.ok());
+      return;
+    }
+
     if (command.isUnsupported() && !allowUnsupportedCommands()) {
       writeToChannel(
           RedisResponse.error(command.getCommandType() + RedisConstants.ERROR_UNSUPPORTED_COMMAND));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscription.java
@@ -43,7 +43,7 @@ public abstract class AbstractSubscription implements Subscription {
   }
 
   @Override
-  public void publishMessage(String channel, byte[] message,
+  public void publishMessage(byte[] channel, byte[] message,
       PublishResultCollector publishResultCollector) {
     ByteBuf messageByteBuffer = constructResponse(channel, message);
     writeToChannel(messageByteBuffer, publishResultCollector);
@@ -58,7 +58,7 @@ public abstract class AbstractSubscription implements Subscription {
     return this.client.equals(client);
   }
 
-  private ByteBuf constructResponse(String channel, byte[] message) {
+  private ByteBuf constructResponse(byte[] channel, byte[] message) {
     ByteBuf messageByteBuffer;
     try {
       messageByteBuffer = Coder.getArrayResponse(context.getByteBufAllocator(),

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
@@ -26,9 +26,9 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
  * This class represents a single channel subscription as created by the SUBSCRIBE command
  */
 class ChannelSubscription extends AbstractSubscription {
-  private String channel;
+  private byte[] channel;
 
-  public ChannelSubscription(Client client, String channel, ExecutionHandlerContext context) {
+  public ChannelSubscription(Client client, byte[] channel, ExecutionHandlerContext context) {
     super(client, context);
 
     if (channel == null) {
@@ -38,23 +38,25 @@ class ChannelSubscription extends AbstractSubscription {
   }
 
   @Override
-  public List<Object> createResponse(String channel, byte[] message) {
+  public List<Object> createResponse(byte[] channel, byte[] message) {
     return Arrays.asList("message", channel, message);
   }
 
   @Override
   public boolean isEqualTo(Object channelOrPattern, Client client) {
-    return this.channel != null && this.channel.equals(channelOrPattern)
+    return channel != null
+        && channelOrPattern instanceof byte[]
+        && Arrays.equals(channel, (byte[]) channelOrPattern)
         && this.getClient().equals(client);
   }
 
   @Override
-  public boolean matches(String channel) {
-    return this.channel.equals(channel);
+  public boolean matches(byte[] channel) {
+    return Arrays.equals(this.channel, channel);
   }
 
   @Override
-  public String getChannelName() {
+  public byte[] getChannelName() {
     return channel;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
@@ -53,4 +53,8 @@ class ChannelSubscription extends AbstractSubscription {
     return this.channel.equals(channel);
   }
 
+  @Override
+  public String getChannelName() {
+    return channel;
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
@@ -39,7 +39,7 @@ class PatternSubscription extends AbstractSubscription {
   }
 
   @Override
-  public List<Object> createResponse(String channel, byte[] message) {
+  public List<Object> createResponse(byte[] channel, byte[] message) {
     return Arrays.asList("pmessage", pattern.globPattern(), channel, message);
   }
 
@@ -50,12 +50,12 @@ class PatternSubscription extends AbstractSubscription {
   }
 
   @Override
-  public boolean matches(String channel) {
-    return pattern.matches(channel);
+  public boolean matches(byte[] channel) {
+    return pattern.matches(new String(channel));
   }
 
   @Override
-  public String getChannelName() {
-    return pattern.globPattern();
+  public byte[] getChannelName() {
+    return pattern.globPattern().getBytes();
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
@@ -54,4 +54,8 @@ class PatternSubscription extends AbstractSubscription {
     return pattern.matches(channel);
   }
 
+  @Override
+  public String getChannelName() {
+    return pattern.globPattern();
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import java.util.List;
+
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisData;
@@ -77,4 +79,13 @@ public interface PubSub {
    * @return the number of channels still subscribed to by the client
    */
   long punsubscribe(GlobPattern pattern, Client client);
+
+  /**
+   * Return a list of channel names that a client has subscribed to
+   *
+   * @param client the Client which is to be queried
+   * @return the list of channels
+   */
+  List<String> findSubscribedChannels(Client client);
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -40,7 +40,7 @@ public interface PubSub {
    */
   long publish(
       Region<ByteArrayWrapper, RedisData> dataRegion,
-      String channel, byte[] message);
+      byte[] channel, byte[] message);
 
   /**
    * Subscribe to a channel
@@ -50,7 +50,7 @@ public interface PubSub {
    * @param client a Client instance making the request
    * @return the number of channels subscribed to
    */
-  long subscribe(String channel, ExecutionHandlerContext context, Client client);
+  long subscribe(byte[] channel, ExecutionHandlerContext context, Client client);
 
   /**
    * Subscribe to a pattern
@@ -69,7 +69,7 @@ public interface PubSub {
    * @param client the Client which is to be unsubscribed
    * @return the number of channels still subscribed to by the client
    */
-  long unsubscribe(String channel, Client client);
+  long unsubscribe(byte[] channel, Client client);
 
   /**
    * Unsubscribe from a previously subscribed pattern
@@ -86,6 +86,6 @@ public interface PubSub {
    * @param client the Client which is to be queried
    * @return the list of channels
    */
-  List<String> findSubscribedChannels(Client client);
+  List<byte[]> findSubscribedChannels(Client client);
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -61,7 +61,7 @@ public class PubSubImpl implements PubSub {
   @Override
   public long publish(
       Region<ByteArrayWrapper, RedisData> dataRegion,
-      String channel, byte[] message) {
+      byte[] channel, byte[] message) {
     PartitionRegionInfo info = PartitionRegionHelper.getPartitionRegionInfo(dataRegion);
     Set<DistributedMember> membersWithDataRegion = new HashSet<>();
     for (PartitionMemberInfo memberInfo : info.getPartitionMemberInfo()) {
@@ -86,7 +86,7 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
-  public long subscribe(String channel, ExecutionHandlerContext context, Client client) {
+  public long subscribe(byte[] channel, ExecutionHandlerContext context, Client client) {
     return subscriptions.subscribe(channel, context, client);
   }
 
@@ -106,7 +106,7 @@ public class PubSubImpl implements PubSub {
       public void execute(FunctionContext<Object[]> context) {
         Object[] publishMessage = context.getArguments();
         long subscriberCount =
-            publishMessageToSubscribers((String) publishMessage[0], (byte[]) publishMessage[1]);
+            publishMessageToSubscribers((byte[]) publishMessage[0], (byte[]) publishMessage[1]);
         context.getResultSender().lastResult(subscriberCount);
       }
 
@@ -124,7 +124,7 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
-  public long unsubscribe(String channel, Client client) {
+  public long unsubscribe(byte[] channel, Client client) {
     return subscriptions.unsubscribe(channel, client);
   }
 
@@ -134,14 +134,14 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
-  public List<String> findSubscribedChannels(Client client) {
+  public List<byte[]> findSubscribedChannels(Client client) {
     return subscriptions.findSubscriptions(client).stream()
         .map(Subscription::getChannelName)
         .collect(Collectors.toList());
   }
 
   @VisibleForTesting
-  long publishMessageToSubscribers(String channel, byte[] message) {
+  long publishMessageToSubscribers(byte[] channel, byte[] message) {
 
     List<Subscription> foundSubscriptions = subscriptions
         .findSubscriptions(channel);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
@@ -34,7 +34,7 @@ public interface Subscription {
   /**
    * Will publish a message to the designated channel.
    */
-  void publishMessage(String channel, byte[] message,
+  void publishMessage(byte[] channel, byte[] message,
       PublishResultCollector publishResultCollector);
 
   /**
@@ -45,16 +45,16 @@ public interface Subscription {
   /**
    * Verifies that the subscription channel or pattern matches the designated channel.
    */
-  boolean matches(String channel);
+  boolean matches(byte[] channel);
 
   /**
    * The response dependent on the type of the subscription
    */
-  List<Object> createResponse(String channel, byte[] message);
+  List<Object> createResponse(byte[] channel, byte[] message);
 
   /**
    * Return the subscription name. In the case of a pattern the string representation of the
    * pattern is returned.
    */
-  String getChannelName();
+  byte[] getChannelName();
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
@@ -51,4 +51,10 @@ public interface Subscription {
    * The response dependent on the type of the subscription
    */
   List<Object> createResponse(String channel, byte[] message);
+
+  /**
+   * Return the subscription name. In the case of a pattern the string representation of the
+   * pattern is returned.
+   */
+  String getChannelName();
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
@@ -61,7 +61,7 @@ public class Subscriptions {
    * @param channelOrPattern the channel or pattern
    * @return a list of subscriptions
    */
-  public List<Subscription> findSubscriptions(String channelOrPattern) {
+  public List<Subscription> findSubscriptions(byte[] channelOrPattern) {
     return subscriptions.stream()
         .filter(subscription -> subscription.matches(channelOrPattern))
         .collect(Collectors.toList());
@@ -98,7 +98,7 @@ public class Subscriptions {
     return subscriptions.size();
   }
 
-  public synchronized long subscribe(String channel, ExecutionHandlerContext context,
+  public synchronized long subscribe(byte[] channel, ExecutionHandlerContext context,
       Client client) {
     if (!exists(channel, client)) {
       add(new ChannelSubscription(client, channel, context));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
@@ -20,7 +20,10 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 /**
  * Class that manages both channel and pattern subscriptions.
@@ -34,7 +37,8 @@ public class Subscriptions {
    * @param channelOrPattern channel or pattern
    * @param client a client connection
    */
-  public boolean exists(Object channelOrPattern, Client client) {
+  @VisibleForTesting
+  boolean exists(Object channelOrPattern, Client client) {
     return subscriptions.stream()
         .anyMatch(subscription -> subscription.isEqualTo(channelOrPattern, client));
   }
@@ -66,7 +70,8 @@ public class Subscriptions {
   /**
    * Add a new subscription
    */
-  public void add(Subscription subscription) {
+  @VisibleForTesting
+  void add(Subscription subscription) {
     subscriptions.add(subscription);
   }
 
@@ -80,14 +85,38 @@ public class Subscriptions {
   /**
    * Remove a single subscription
    */
-  public void remove(Object channel, Client client) {
-    subscriptions.removeIf(subscription -> subscription.isEqualTo(channel, client));
+  @VisibleForTesting
+  boolean remove(Object channel, Client client) {
+    return subscriptions.removeIf(subscription -> subscription.isEqualTo(channel, client));
   }
 
   /**
    * @return the total number of all local subscriptions
    */
-  public int size() {
+  @VisibleForTesting
+  int size() {
     return subscriptions.size();
   }
+
+  public synchronized long subscribe(String channel, ExecutionHandlerContext context,
+      Client client) {
+    if (!exists(channel, client)) {
+      add(new ChannelSubscription(client, channel, context));
+    }
+    return findSubscriptions(client).size();
+  }
+
+  public synchronized long psubscribe(GlobPattern pattern, ExecutionHandlerContext context,
+      Client client) {
+    if (!exists(pattern, client)) {
+      add(new PatternSubscription(client, pattern, context));
+    }
+    return findSubscriptions(client).size();
+  }
+
+  public synchronized long unsubscribe(Object channelOrPattern, Client client) {
+    remove(channelOrPattern, client);
+    return findSubscriptions(client).size();
+  }
+
 }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
@@ -51,13 +51,14 @@ public class PubSubImplJUnitTest {
 
     ChannelSubscription subscription =
         spy(new ChannelSubscription(deadClient,
-            "sally", mockContext));
+            "sally".getBytes(), mockContext));
 
     subscriptions.add(subscription);
 
     PubSubImpl subject = new PubSubImpl(subscriptions);
 
-    Long numberOfSubscriptions = subject.publishMessageToSubscribers("sally", "message".getBytes());
+    Long numberOfSubscriptions =
+        subject.publishMessageToSubscribers("sally".getBytes(), "message".getBytes());
 
     assertThat(numberOfSubscriptions).isEqualTo(0);
     assertThat(subscriptions.findSubscriptions(deadClient)).isEmpty();

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
@@ -36,10 +36,10 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
     Client client = new Client(channel);
 
-    subscriptions.add(new ChannelSubscription(client, "subscriptions", context));
+    subscriptions.add(new ChannelSubscription(client, "subscriptions".getBytes(), context));
 
-    assertThat(subscriptions.exists("subscriptions", client)).isTrue();
-    assertThat(subscriptions.exists("unknown", client)).isFalse();
+    assertThat(subscriptions.exists("subscriptions".getBytes(), client)).isTrue();
+    assertThat(subscriptions.exists("unknown".getBytes(), client)).isFalse();
   }
 
   @Test
@@ -66,7 +66,7 @@ public class SubscriptionsJUnitTest {
     GlobPattern globPattern1 = new GlobPattern("sub*s");
     GlobPattern globPattern2 = new GlobPattern("subscriptions");
 
-    subscriptions.add(new ChannelSubscription(client, "subscriptions", context));
+    subscriptions.add(new ChannelSubscription(client, "subscriptions".getBytes(), context));
 
     assertThat(subscriptions.exists(globPattern1, client)).isFalse();
     assertThat(subscriptions.exists(globPattern2, client)).isFalse();
@@ -81,11 +81,11 @@ public class SubscriptionsJUnitTest {
     Client client = new Client(channel);
     GlobPattern globby = new GlobPattern("sub*s");
 
-    subscriptions.add(new ChannelSubscription(client, "subscriptions", context));
+    subscriptions.add(new ChannelSubscription(client, "subscriptions".getBytes(), context));
     subscriptions.add(new PatternSubscription(client, globby, context));
 
     assertThat(subscriptions.exists(globby, client)).isTrue();
-    assertThat(subscriptions.exists("subscriptions", client)).isTrue();
+    assertThat(subscriptions.exists("subscriptions".getBytes(), client)).isTrue();
   }
 
 
@@ -110,8 +110,9 @@ public class SubscriptionsJUnitTest {
     Client clientTwo = new Client(mockChannelTwo);
 
     ChannelSubscription subscriptionOne =
-        new ChannelSubscription(clientOne, "subscriptions", context);
-    ChannelSubscription subscriptionTwo = new ChannelSubscription(clientTwo, "monkeys", context);
+        new ChannelSubscription(clientOne, "subscriptions".getBytes(), context);
+    ChannelSubscription subscriptionTwo =
+        new ChannelSubscription(clientTwo, "monkeys".getBytes(), context);
 
     subscriptions.add(subscriptionOne);
     subscriptions.add(subscriptionTwo);
@@ -129,8 +130,9 @@ public class SubscriptionsJUnitTest {
     Client clientTwo = new Client(mockChannelTwo);
 
     ChannelSubscription subscriptionOne =
-        new ChannelSubscription(clientOne, "subscriptions", context);
-    ChannelSubscription subscriptionTwo = new ChannelSubscription(clientTwo, "monkeys", context);
+        new ChannelSubscription(clientOne, "subscriptions".getBytes(), context);
+    ChannelSubscription subscriptionTwo =
+        new ChannelSubscription(clientTwo, "monkeys".getBytes(), context);
 
     subscriptions.add(subscriptionOne);
     subscriptions.add(subscriptionTwo);
@@ -151,11 +153,12 @@ public class SubscriptionsJUnitTest {
     Client client = new Client(mockChannelOne);
 
     ChannelSubscription channelSubscriberOne =
-        new ChannelSubscription(client, "subscriptions", context);
+        new ChannelSubscription(client, "subscriptions".getBytes(), context);
     GlobPattern pattern = new GlobPattern("monkeys");
     PatternSubscription patternSubscriber = new PatternSubscription(client,
         pattern, context);
-    ChannelSubscription channelSubscriberTwo = new ChannelSubscription(client, "monkeys", context);
+    ChannelSubscription channelSubscriberTwo =
+        new ChannelSubscription(client, "monkeys".getBytes(), context);
 
     subscriptions.add(channelSubscriberOne);
     subscriptions.add(patternSubscriber);


### PR DESCRIPTION
- Add ability to [P]UNSUBSCRIBE from multiple channels.
- Match Redis semantics when subscribing to empty channel name - (`""`)
- Interact with plain channel names as `byte[]`s instead of `String`s - (fixes issues on Windows when subscribing with arbitrary byte[] names).