### PR TITLE
DRAFT: Do not queue tmpDroppedEvents when stopping gateway sender

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
@@ -257,6 +257,12 @@ public interface GatewaySender {
   boolean isRunning();
 
   /**
+   * Returns whether or not this GatewaySender is starting.
+   * Set to false when the sender is stopped.
+   */
+  boolean isStarting();
+
+  /**
    * Returns whether or not this GatewaySender is paused.
    *
    */

--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
@@ -257,10 +257,10 @@ public interface GatewaySender {
   boolean isRunning();
 
   /**
-   * Returns whether or not this GatewaySender is starting.
-   * Set to false when the sender is stopped.
+   * Returns whether or not this GatewaySender was manually stopped.
+   * Set to false when the sender is asked to be started.
    */
-  boolean isStarting();
+  boolean wasManuallyStopped();
 
   /**
    * Returns whether or not this GatewaySender is paused.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -911,11 +911,11 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   @Override
-  public boolean isStarting() {
+  public boolean wasManuallyStopped() {
     if (this.eventProcessor != null) {
-      return this.eventProcessor.isStarting();
+      return this.eventProcessor.wasManuallyStopped();
     }
-    logger.info("toberal isStarting eventProcessor is null for sender: {}", this);
+    logger.info("toberal wasManuallyStopped eventProcessor is null for sender: {}", this);
     return false;
   }
 
@@ -1041,12 +1041,12 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       }
 
       // If this gateway is not running, return
-      logger.info("toberal received event {}, isRunning: {}, isPrimary: {}, is Starting: {} ",
-          event.getEventId(), isRunning(), isPrimary(), isStarting());
+      logger.info(
+          "toberal received event {}, isRunning: {}, isPrimary: {}, wasManuallyStopped: {} ",
+          event.getEventId(), isRunning(), isPrimary(), wasManuallyStopped());
 
       if (!isRunning()) {
-        // logger.info("toberal received event while not running. isStarting: {}", isStarting());
-        if (isPrimary() && isStarting()) {
+        if (isPrimary() && !wasManuallyStopped()) {
           // if (isPrimary()) {
           // toberal. These are the events filling up the memory when the sender is stopped.
           // Can we do something with them???

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -89,6 +89,11 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
   private volatile boolean isStopped = true;
 
   /**
+   * A boolean verifying whether this <code>AbstractGatewaySenderEventProcessor</code> is starting.
+   */
+  private volatile boolean isStarting = true;
+
+  /**
    * A boolean verifying whether this <code>AbstractGatewaySenderEventProcessor</code> is paused.
    */
   protected volatile boolean isPaused = false;
@@ -152,6 +157,8 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
     this.sender = (AbstractGatewaySender) sender;
     this.batchSize = sender.getBatchSize();
     this.threadMonitoring = tMonitoring;
+    logger.info("toberal starting AbstractGatewaySenderEventProcessor. string: {}, sender: {}",
+        string, sender);
   }
 
   public Object getRunningStateLock() {
@@ -180,10 +187,22 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
     return this.isStopped;
   }
 
+  public boolean isStarting() {
+    // logger.info("toberal isStarting: {}, sender: {}, thread: {}", isStarting, sender,
+    // Thread.currentThread().getId());
+    return isStarting;
+  }
+
+  protected void setIsStarting(boolean isStarting) {
+    // logger.info("toberal setIsStarting to {}", isStarting);
+    this.isStarting = isStarting;
+  }
+
   protected void setIsStopped(boolean isStopped) {
     if (isStopped) {
       this.isStopped = true;
       this.failureLogInterval.clear();
+      setIsStarting(false);
     } else {
       this.isStopped = isStopped;
     }
@@ -1138,6 +1157,7 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
   public void setRunningStatus() throws Exception {
     GemFireException ex = null;
     try {
+      setIsStarting(true);
       this.initializeEventDispatcher();
     } catch (GemFireException e) {
       ex = e;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -89,9 +89,10 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
   private volatile boolean isStopped = true;
 
   /**
-   * A boolean verifying whether this <code>AbstractGatewaySenderEventProcessor</code> is starting.
+   * A boolean verifying whether this <code>AbstractGatewaySenderEventProcessor</code>
+   * wasManuallyStopped.
    */
-  private volatile boolean isStarting = true;
+  private volatile boolean wasManuallyStopped = false;
 
   /**
    * A boolean verifying whether this <code>AbstractGatewaySenderEventProcessor</code> is paused.
@@ -187,22 +188,23 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
     return this.isStopped;
   }
 
-  public boolean isStarting() {
-    // logger.info("toberal isStarting: {}, sender: {}, thread: {}", isStarting, sender,
+  public boolean wasManuallyStopped() {
+    // logger.info("toberal wasManuallyStopped: {}, sender: {}, thread: {}", wasManuallyStopped,
+    // sender,
     // Thread.currentThread().getId());
-    return isStarting;
+    return wasManuallyStopped;
   }
 
-  protected void setIsStarting(boolean isStarting) {
-    // logger.info("toberal setIsStarting to {}", isStarting);
-    this.isStarting = isStarting;
+  protected void setWasManuallyStopped(boolean wasManuallyStopped) {
+    // logger.info("toberal setIsStarting to {}", wasManuallyStopped);
+    this.wasManuallyStopped = wasManuallyStopped;
   }
 
   protected void setIsStopped(boolean isStopped) {
     if (isStopped) {
       this.isStopped = true;
       this.failureLogInterval.clear();
-      setIsStarting(false);
+      setWasManuallyStopped(false);
     } else {
       this.isStopped = isStopped;
     }
@@ -1157,7 +1159,6 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
   public void setRunningStatus() throws Exception {
     GemFireException ex = null;
     try {
-      setIsStarting(true);
       this.initializeEventDispatcher();
     } catch (GemFireException e) {
       ex = e;

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderOperationsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderOperationsDUnitTest.java
@@ -419,6 +419,7 @@ public class ParallelGatewaySenderOperationsDUnitTest extends WANTestBase {
    * case in the way that when the sender is starting from stopped state, puts are simultaneously
    * happening on the region by another thread.
    */
+  // toberal run this test case to check if GatewaySender.isStarting() is effective
   @Test
   public void testParallelPropagationSenderStartAfterStop_Scenario2() throws Exception {
     addIgnoredException("Broken pipe");

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderOperationsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderOperationsDUnitTest.java
@@ -419,7 +419,7 @@ public class ParallelGatewaySenderOperationsDUnitTest extends WANTestBase {
    * case in the way that when the sender is starting from stopped state, puts are simultaneously
    * happening on the region by another thread.
    */
-  // toberal run this test case to check if GatewaySender.isStarting() is effective
+  // toberal run this test case to check if GatewaySender.wasManuallyStopped() is effective
   @Test
   public void testParallelPropagationSenderStartAfterStop_Scenario2() throws Exception {
     addIgnoredException("Broken pipe");

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
@@ -342,7 +342,7 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
     vm5.invoke(() -> validateQueueSizeStat("ln", 0));
   }
 
-  // toberal run this test case to check if GatewaySender.isStarting() is effective
+  // toberal run this test case to check if GatewaySender.wasManuallyStopped() is effective
   @Test
   public void testRestartSerialGatewaySendersWhilePutting() throws Exception {
     int lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
@@ -342,6 +342,7 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
     vm5.invoke(() -> validateQueueSizeStat("ln", 0));
   }
 
+  // toberal run this test case to check if GatewaySender.isStarting() is effective
   @Test
   public void testRestartSerialGatewaySendersWhilePutting() throws Exception {
     int lnPort = vm0.invoke(() -> createFirstLocatorWithDSId(1));


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

DO NOT REVIEW
This is a tentative solution to the problem of heap exhaustion with tmpDroppedEvents elements after stopping a gateway receiver.