### PR TITLE
GEODE-8333: Fix PUBSUB hang

### DIFF
--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -39,6 +40,7 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisException;
 
+import org.apache.geode.logging.internal.executors.LoggingThread;
 import org.apache.geode.redis.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -49,6 +51,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 public class PubSubDUnitTest {
 
   public static final String CHANNEL_NAME = "salutations";
+  public static final int JEDIS_TIMEOUT = Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
 
   @ClassRule
   public static RedisClusterStartupRule cluster = new RedisClusterStartupRule(6);
@@ -126,6 +129,67 @@ public class PubSubDUnitTest {
   }
 
   @Test
+  public void shouldNotHang_givenPublishingAndSubscribingSimultaneously() {
+    ArrayList<Thread> threads = new ArrayList<>();
+    AtomicInteger subscribeCount = new AtomicInteger();
+    AtomicInteger publishCount = new AtomicInteger();
+    Random random = new Random();
+
+    for (int i = 0; i < 200; i++) {
+      String channelName = "theBestChannel" + i;
+      Thread thread = new LoggingThread(channelName, () -> {
+        ArrayList<MockSubscriber> mockSubscribers = new ArrayList<>();
+        ArrayList<JedisWithLatch> clients = new ArrayList<>();
+        for (int j = 0; j < 5; j++) {
+          CountDownLatch latch = new CountDownLatch(1);
+          MockSubscriber mockSubscriber = new MockSubscriber(latch);
+          executor.submit(() -> {
+            Jedis client = getConnection(random);
+            JedisWithLatch jedisWithLatch = new JedisWithLatch(client);
+            clients.add(jedisWithLatch);
+            client.subscribe(mockSubscriber, channelName);
+            subscribeCount.getAndIncrement();
+            jedisWithLatch.finishSubscribe();
+          });
+          try {
+            latch.await();
+          } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+          mockSubscribers.add(mockSubscriber);
+        }
+
+        Jedis localPublisher = getConnection(random);
+        localPublisher.publish(channelName, "hi");
+        publishCount.getAndIncrement();
+        try {
+          localPublisher.close();
+        } catch (Exception ex) {
+        }
+
+        mockSubscribers.forEach(s -> {
+          GeodeAwaitility.await().ignoreExceptions()
+              .until(() -> s.getReceivedMessages().get(0).equals("hi"));
+          s.unsubscribe(channelName);
+        });
+        clients.forEach(JedisWithLatch::close);
+      });
+      threads.add(thread);
+      thread.start();
+    }
+
+    threads.forEach(thread -> {
+      try {
+        thread.join();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    });
+    assertThat(publishCount.get()).isEqualTo(200);
+    assertThat(subscribeCount.get()).isEqualTo(1000);
+  }
+
+  @Test
   public void shouldContinueToFunction_whenOneServerShutsDownGracefully_givenTwoSubscribersOnePublisher()
       throws InterruptedException {
     CountDownLatch latch = new CountDownLatch(2);
@@ -133,13 +197,12 @@ public class PubSubDUnitTest {
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
     MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
 
-    Future<Void> subscriber1Future = executor.submit(
-        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
-    Future<Void> subscriber2Future = executor.submit(
-        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+    Future<Void> subscriber1Future =
+        executor.submit(() -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future =
+        executor.submit(() -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
 
-    assertThat(latch.await(30, TimeUnit.SECONDS))
-        .as("channel subscription was not received")
+    assertThat(latch.await(30, TimeUnit.SECONDS)).as("channel subscription was not received")
         .isTrue();
 
     Long result = publisher1.publish(CHANNEL_NAME, "hello");
@@ -164,13 +227,12 @@ public class PubSubDUnitTest {
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
     MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
 
-    Future<Void> subscriber1Future = executor.submit(
-        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
-    Future<Void> subscriber2Future = executor.submit(
-        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+    Future<Void> subscriber1Future =
+        executor.submit(() -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future =
+        executor.submit(() -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
 
-    assertThat(latch.await(30, TimeUnit.SECONDS))
-        .as("channel subscription was not received")
+    assertThat(latch.await(30, TimeUnit.SECONDS)).as("channel subscription was not received")
         .isTrue();
 
     Long result = publisher1.publish(CHANNEL_NAME, "hello");
@@ -216,13 +278,12 @@ public class PubSubDUnitTest {
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
     MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
 
-    Future<Void> subscriber1Future = executor.submit(
-        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
-    Future<Void> subscriber2Future = executor.submit(
-        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+    Future<Void> subscriber1Future =
+        executor.submit(() -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future =
+        executor.submit(() -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
 
-    assertThat(latch.await(30, TimeUnit.SECONDS))
-        .as("channel subscription was not received")
+    assertThat(latch.await(30, TimeUnit.SECONDS)).as("channel subscription was not received")
         .isTrue();
 
     Long resultPublisher1 = publisher1.publish(CHANNEL_NAME, "hello");
@@ -249,13 +310,12 @@ public class PubSubDUnitTest {
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
     MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
 
-    Future<Void> subscriber1Future = executor.submit(
-        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
-    Future<Void> subscriber2Future = executor.submit(
-        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+    Future<Void> subscriber1Future =
+        executor.submit(() -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future =
+        executor.submit(() -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
 
-    assertThat(latch.await(30, TimeUnit.SECONDS))
-        .as("channel subscription was not received")
+    assertThat(latch.await(30, TimeUnit.SECONDS)).as("channel subscription was not received")
         .isTrue();
 
     Long result = publisher1.publish(CHANNEL_NAME, "hello");
@@ -277,13 +337,12 @@ public class PubSubDUnitTest {
     MockSubscriber mockSubscriber1 = new MockSubscriber(latch);
     MockSubscriber mockSubscriber2 = new MockSubscriber(latch);
 
-    Future<Void> subscriber1Future = executor.submit(
-        () -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
-    Future<Void> subscriber2Future = executor.submit(
-        () -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
+    Future<Void> subscriber1Future =
+        executor.submit(() -> subscriber1.subscribe(mockSubscriber1, CHANNEL_NAME));
+    Future<Void> subscriber2Future =
+        executor.submit(() -> subscriber2.subscribe(mockSubscriber2, CHANNEL_NAME));
 
-    assertThat(latch.await(30, TimeUnit.SECONDS))
-        .as("channel subscription was not received")
+    assertThat(latch.await(30, TimeUnit.SECONDS)).as("channel subscription was not received")
         .isTrue();
 
     List<Future<Void>> futures = new LinkedList<>();
@@ -410,10 +469,8 @@ public class PubSubDUnitTest {
   }
 
   private void waitForRestart() {
-    await()
-        .untilAsserted(() -> gfsh.executeAndAssertThat("list members")
-            .statusIsSuccess()
-            .hasTableSection()
+    await().untilAsserted(
+        () -> gfsh.executeAndAssertThat("list members").statusIsSuccess().hasTableSection()
             .hasColumn("Name")
             .containsOnly("locator-0", "server-1", "server-2", "server-3", "server-4", "server-5"));
   }
@@ -424,5 +481,49 @@ public class PubSubDUnitTest {
 
   private void reconnectSubscriber2() {
     subscriber2 = new Jedis(LOCAL_HOST, redisServerPort2);
+  }
+
+
+  private static class JedisWithLatch {
+    public final Jedis jedis;
+    public final CountDownLatch latch;
+
+    JedisWithLatch(Jedis jedis) {
+      this.latch = new CountDownLatch(1);
+      this.jedis = jedis;
+    }
+
+    public void finishSubscribe() {
+      latch.countDown();
+    }
+
+    public void close() {
+      try {
+        latch.await();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      jedis.close();
+    }
+  }
+
+  private Jedis getConnection(Random random) {
+    Jedis client;
+
+    for (int i = 0; i < 10; i++) {
+      int randPort = random.nextInt(4) + 1;
+      client = new Jedis("localhost", cluster.getRedisPort(randPort), JEDIS_TIMEOUT);
+      try {
+        client.ping();
+        return client;
+      } catch (Exception e) {
+        try {
+          client.close();
+        } catch (Exception exception) {
+
+        }
+      }
+    }
+    throw new RuntimeException("Tried 10 times, but could not get a good connection.");
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -93,7 +93,9 @@ public class GeodeRedisServer {
         new PassiveExpirationManager(regionProvider.getDataRegion(), redisStats);
     nettyRedisServer = new NettyRedisServer(() -> cache.getInternalDistributedSystem().getConfig(),
         regionProvider, pubSub,
-        this::allowUnsupportedCommands, this::shutdown, port, bindAddress, redisStats);
+        this::allowUnsupportedCommands, this::shutdown, port, bindAddress, redisStats,
+        cache.getInternalDistributedSystem().getDistributionManager().getExecutors()
+            .getWaitingThreadPool());
   }
 
   public void setAllowUnsupportedCommands(boolean allowUnsupportedCommands) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -401,6 +401,10 @@ public enum RedisCommandType {
     return supportLevel == UNIMPLEMENTED;
   }
 
+  public boolean isAsync() {
+    return this == PUBLISH;
+  }
+
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext executionHandlerContext) {
     parameterRequirements.checkParameters(command, executionHandlerContext);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
@@ -34,7 +34,6 @@ public class PublishExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-
     executorService.submit(new PublishingRunnable(context, command));
     return null;
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
@@ -16,8 +16,6 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import io.netty.buffer.ByteBuf;
 
@@ -29,15 +27,12 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class PublishExecutor extends AbstractExecutor {
 
-  private ExecutorService executorService = Executors.newSingleThreadExecutor();
-
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    executorService.submit(new PublishingRunnable(context, command));
+    context.getBackgroundExecutor().submit(new PublishingRunnable(context, command));
     return null;
   }
-
 
   public static class PublishingRunnable implements Runnable {
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
@@ -17,11 +17,8 @@ package org.apache.geode.redis.internal.executor.pubsub;
 
 import java.util.List;
 
-import io.netty.buffer.ByteBuf;
-
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -53,7 +50,7 @@ public class PublishExecutor extends AbstractExecutor {
         long publishCount =
             context.getPubSub()
                 .publish(context.getRegionProvider().getDataRegion(), channelName, message);
-        ByteBuf response = Coder.getIntegerResponse(context.getByteBufAllocator(), publishCount);
+        RedisResponse response = RedisResponse.integer(publishCount);
         context.endAsyncCommandExecution(command, response);
       } catch (Throwable ex) {
         context.endAsyncCommandExecution(command, ex);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
@@ -42,8 +42,6 @@ public class SubscribeExecutor extends AbstractExecutor {
       items.add(item);
     }
 
-    context.changeChannelEventLoopGroup(context.getSubscriberGroup());
-
     return RedisResponse.flattenedArray(items);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
@@ -19,6 +19,8 @@ import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import io.netty.channel.ChannelHandlerContext;
+
 import org.apache.geode.redis.internal.RedisCommandType;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -175,5 +177,25 @@ public class Command {
   public String wrongNumberOfArgumentsError() {
     return String.format("wrong number of arguments for '%s' command",
         getCommandType().toString().toLowerCase());
+  }
+
+  private long asyncStartTime;
+
+  public void setAsyncStartTime(long start) {
+    asyncStartTime = start;
+  }
+
+  public long getAsyncStartTime() {
+    return asyncStartTime;
+  }
+
+  private ChannelHandlerContext channelHandlerContext;
+
+  public void setChannelHandlerContext(ChannelHandlerContext ctx) {
+    channelHandlerContext = ctx;
+  }
+
+  public ChannelHandlerContext getChannelHandlerContext() {
+    return channelHandlerContext;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.netty;
 
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.function.Supplier;
 
@@ -68,6 +69,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   private final Supplier<Boolean> allowUnsupportedSupplier;
   private final Runnable shutdownInvoker;
   private final RedisStats redisStats;
+  private final ExecutorService backgroundExecutor;
   private final LinkedBlockingQueue<Command> commandQueue = new LinkedBlockingQueue<>();
 
   private boolean isAuthenticated;
@@ -82,6 +84,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       Supplier<Boolean> allowUnsupportedSupplier,
       Runnable shutdownInvoker,
       RedisStats redisStats,
+      ExecutorService backgroundExecutor,
       byte[] password) {
     this.channel = channel;
     this.regionProvider = regionProvider;
@@ -89,6 +92,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     this.allowUnsupportedSupplier = allowUnsupportedSupplier;
     this.shutdownInvoker = shutdownInvoker;
     this.redisStats = redisStats;
+    this.backgroundExecutor = backgroundExecutor;
     this.client = new Client(channel);
     this.byteBufAllocator = this.channel.alloc();
     this.authPassword = password;
@@ -394,5 +398,9 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
 
   public PubSub getPubSub() {
     return pubsub;
+  }
+
+  public ExecutorService getBackgroundExecutor() {
+    return backgroundExecutor;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
@@ -79,7 +79,6 @@ public class NettyRedisServer {
   private final RedisStats redisStats;
   private final EventLoopGroup selectorGroup;
   private final EventLoopGroup workerGroup;
-  private final EventLoopGroup subscriberGroup;
   private final InetAddress bindAddress;
   private final Channel serverChannel;
   private final int serverPort;
@@ -101,7 +100,6 @@ public class NettyRedisServer {
     this.bindAddress = getBindAddress(requestedAddress);
     selectorGroup = createEventLoopGroup("Selector", false, 1);
     workerGroup = createEventLoopGroup("Worker", true, 0);
-    subscriberGroup = createEventLoopGroup("Subscriber", true, 0);
     serverChannel = createChannel(port);
     serverPort = getActualPort();
     logStartupMessage();
@@ -158,7 +156,7 @@ public class NettyRedisServer {
         pipeline.addLast(ByteToCommandDecoder.class.getSimpleName(), new ByteToCommandDecoder());
         pipeline.addLast(new WriteTimeoutHandler(10));
         pipeline.addLast(ExecutionHandlerContext.class.getSimpleName(),
-            new ExecutionHandlerContext(socketChannel, regionProvider, pubsub, subscriberGroup,
+            new ExecutionHandlerContext(socketChannel, regionProvider, pubsub,
                 allowUnsupportedSupplier, shutdownInvoker, redisStats, redisPasswordBytes));
       }
     };

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
@@ -26,6 +26,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Supplier;
 
@@ -77,6 +78,7 @@ public class NettyRedisServer {
   private final Supplier<Boolean> allowUnsupportedSupplier;
   private final Runnable shutdownInvoker;
   private final RedisStats redisStats;
+  private final ExecutorService backgroundExecutor;
   private final EventLoopGroup selectorGroup;
   private final EventLoopGroup workerGroup;
   private final InetAddress bindAddress;
@@ -87,13 +89,14 @@ public class NettyRedisServer {
       RegionProvider regionProvider, PubSub pubsub,
       Supplier<Boolean> allowUnsupportedSupplier,
       Runnable shutdownInvoker, int port, String requestedAddress,
-      RedisStats redisStats) {
+      RedisStats redisStats, ExecutorService backgroundExecutor) {
     this.configSupplier = configSupplier;
     this.regionProvider = regionProvider;
     this.pubsub = pubsub;
     this.allowUnsupportedSupplier = allowUnsupportedSupplier;
     this.shutdownInvoker = shutdownInvoker;
     this.redisStats = redisStats;
+    this.backgroundExecutor = backgroundExecutor;
     if (port < RANDOM_PORT_INDICATOR) {
       throw new IllegalArgumentException("Redis port cannot be less than 0");
     }
@@ -157,7 +160,8 @@ public class NettyRedisServer {
         pipeline.addLast(new WriteTimeoutHandler(10));
         pipeline.addLast(ExecutionHandlerContext.class.getSimpleName(),
             new ExecutionHandlerContext(socketChannel, regionProvider, pubsub,
-                allowUnsupportedSupplier, shutdownInvoker, redisStats, redisPasswordBytes));
+                allowUnsupportedSupplier, shutdownInvoker, redisStats, backgroundExecutor,
+                redisPasswordBytes));
       }
     };
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscription.java
@@ -16,14 +16,12 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
-import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Client;
-import org.apache.geode.redis.internal.netty.Coder;
-import org.apache.geode.redis.internal.netty.CoderException;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public abstract class AbstractSubscription implements Subscription {
@@ -45,8 +43,7 @@ public abstract class AbstractSubscription implements Subscription {
   @Override
   public void publishMessage(byte[] channel, byte[] message,
       PublishResultCollector publishResultCollector) {
-    ByteBuf messageByteBuffer = constructResponse(channel, message);
-    writeToChannel(messageByteBuffer, publishResultCollector);
+    writeToChannel(constructResponse(channel, message), publishResultCollector);
   }
 
   Client getClient() {
@@ -58,16 +55,8 @@ public abstract class AbstractSubscription implements Subscription {
     return this.client.equals(client);
   }
 
-  private ByteBuf constructResponse(byte[] channel, byte[] message) {
-    ByteBuf messageByteBuffer;
-    try {
-      messageByteBuffer = Coder.getArrayResponse(context.getByteBufAllocator(),
-          createResponse(channel, message));
-    } catch (CoderException e) {
-      logger.warn("Unable to encode publish message", e);
-      return null;
-    }
-    return messageByteBuffer;
+  private RedisResponse constructResponse(byte[] channel, byte[] message) {
+    return RedisResponse.array(createResponse(channel, message));
   }
 
   /**
@@ -75,8 +64,8 @@ public abstract class AbstractSubscription implements Subscription {
    * to the client, resulted in an error - for example if the client has disconnected and the write
    * fails. In such cases we need to be able to notify the caller.
    */
-  private void writeToChannel(ByteBuf messageByteBuffer, PublishResultCollector resultCollector) {
-    context.writeToChannel(messageByteBuffer)
+  private void writeToChannel(RedisResponse response, PublishResultCollector resultCollector) {
+    context.writeToChannel(response)
         .addListener((ChannelFutureListener) future -> {
           if (future.cause() == null) {
             resultCollector.success();

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -142,7 +142,6 @@ public class PubSubImpl implements PubSub {
 
   @VisibleForTesting
   long publishMessageToSubscribers(byte[] channel, byte[] message) {
-
     List<Subscription> foundSubscriptions = subscriptions
         .findSubscriptions(channel);
     if (foundSubscriptions.isEmpty()) {

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
@@ -22,8 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelPromise;
 import io.netty.channel.DefaultChannelPromise;
@@ -31,6 +29,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import org.junit.Test;
 
+import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Client;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -43,8 +42,7 @@ public class PubSubImplJUnitTest {
     ExecutionHandlerContext mockContext = mock(ExecutionHandlerContext.class);
 
     FailingChannelFuture mockFuture = new FailingChannelFuture();
-    when(mockContext.writeToChannel((ByteBuf) any())).thenReturn(mockFuture);
-    when(mockContext.getByteBufAllocator()).thenReturn(new PooledByteBufAllocator());
+    when(mockContext.writeToChannel((RedisResponse) any())).thenReturn(mockFuture);
 
     Client deadClient = mock(Client.class);
     when(deadClient.isDead()).thenReturn(true);


### PR DESCRIPTION
PUBSUB hangs with concurrent publishers and subscribers on multiple
servers. Changed Publish executor to execute publish on background
thread (the DistributionManager's waiting pool is used). Removed separate separate subscriber group.  Added DUnit test to
recreate failure.
To preserve the order of incoming commands, even when some of them are running asynchronously in background threads, a command queue now exists. When an async commands comes in (currently only PUBLISH is async) then it goes in the queue and is started. Any other commands that come in while it is in progress are added to the a queue. Once the async command completes it also drains the command queue down to the next async command it finds in it.

Co-authored-by: Murtuza Boxwala <mboxwala@pivotal.io>