### PR TITLE
GEODE-8346: Add try/catch around Entry.getValue in CompiledComparison

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.AmbiguousNameException;
 import org.apache.geode.cache.query.FunctionDomainException;
@@ -85,10 +86,18 @@ public class CompiledComparison extends AbstractCompiledValue
     Object right = _right.evaluate(context);
 
     if (context.isCqQueryContext() && left instanceof Region.Entry) {
-      left = ((Region.Entry) left).getValue();
+      try {
+        left = ((Region.Entry<?, ?>) left).getValue();
+      } catch (EntryDestroyedException ex) {
+        left = null;
+      }
     }
     if (context.isCqQueryContext() && right instanceof Region.Entry) {
-      right = ((Region.Entry) right).getValue();
+      try {
+        right = ((Region.Entry<?, ?>) right).getValue();
+      } catch (EntryDestroyedException ex) {
+        right = null;
+      }
     }
 
     if (left == null || right == null) {


### PR DESCRIPTION
Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
