### PR TITLE
GEODE-8329: Fix for durable CQ reqistration recovery

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -1112,7 +1112,8 @@ public class QueueManagerImpl implements QueueManager {
             .set(((DefaultQueryService) this.pool.getQueryService()).getUserAttributes(name));
       }
       try {
-        if (((CqStateImpl) cqi.getState()).getState() != CqStateImpl.INIT) {
+        if (((CqStateImpl) cqi.getState()).getState() != CqStateImpl.INIT
+            && cqi.isDurable() == isDurable) {
           cqi.createOn(recoveredConnection, isDurable);
         }
       } finally {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
@@ -50,10 +50,13 @@ import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.internal.cache.ClientServerObserverAdapter;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 @Category({ClientSubscriptionTest.class})
@@ -142,6 +145,99 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     // Stop the server
     this.server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
   }
+
+  /**
+   * Test that durable CQ is correctly re-registered to new server after the failover and
+   * that the durable client functionality works as expected.
+   * Steps:
+   * 1. Start two servers
+   * 2. Start durable client without HA and register durable CQs
+   * 3. Shutdown the server that is hosting CQs subscription queue (primary server)
+   * 4. Wait for the durable client to perform the failover to the another server
+   * 5. Shutdown the durable client with keepAlive flag set to true
+   * 6. Provision remaining server with the data that should fulfil CQ condition and fill the queue
+   * 7. Start the durable client again and check that it receives correct events from queue
+   */
+  @Test
+  public void testDurableCQServerFailoverWithoutHAConfigured()
+      throws Exception {
+    String greaterThan5Query = "select * from " + SEPARATOR + regionName + " p where p.ID > 5";
+    String allQuery = "select * from " + SEPARATOR + regionName + " p where p.ID > -1";
+    String lessThan5Query = "select * from " + SEPARATOR + regionName + " p where p.ID < 5";
+
+    // Start a server 1
+    server1Port = this.server1VM
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+
+    // Start server 2
+    server2Port = this.server2VM.invoke(CacheServerTestUtil.class,
+        "createCacheServer", new Object[] {regionName, Boolean.TRUE});
+
+    // Start a durable client that is kept alive on the server when it stops normally
+    durableClientId = getName() + "_client";
+    CacheServerTestUtil.createCacheClient(
+        getClientPool(NetworkUtils.getServerHostName(), server1Port, server2Port, true, 0),
+        regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE);
+
+    // register non durable cq
+    createCq("GreaterThan5", greaterThan5Query, false).execute();
+
+    // register durable cqs
+    createCq("All", allQuery, true).execute();
+    createCq("LessThan5", lessThan5Query, true).execute();
+
+    // send client ready
+    CacheServerTestUtil.getClientCache().readyForEvents();
+
+    int oldPrimaryPort = getPrimaryServerPort();
+    // Close the server that is hosting subscription queue
+    VM primary = getPrimaryServerVM();
+    primary.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+
+    // Wait until failover to the another server is successfully performed
+    waitForFailoverToPerform(oldPrimaryPort);
+
+    // Stop the durable client
+    CacheServerTestUtil.closeCache(true);
+
+    // Start normal publisher client
+    startClient(publisherClientVM, server1Port, server2Port, regionName);
+
+    // Publish some entries
+    publishEntries(regionName, 10);
+
+    // Restart the durable client
+    CacheServerTestUtil.createCacheClient(
+        getClientPool(NetworkUtils.getServerHostName(), server1Port, server2Port, true, 0),
+        regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE);
+
+    // Re-register non durable cq
+    createCq("GreaterThan5", greaterThan5Query, false).execute();
+
+    // Re-register durable cqs
+    createCq("All", allQuery, true).execute();
+    createCq("LessThan5", lessThan5Query, true).execute();
+
+    // send client ready
+    CacheServerTestUtil.getClientCache().readyForEvents();
+
+    // verify cq events for all 3 cqs
+    checkCqListenerEvents("GreaterThan5", 0 /* numEventsExpected */,
+        /* numEventsToWaitFor */ 15/* secondsToWait */);
+    checkCqListenerEvents("LessThan5", 5 /* numEventsExpected */,
+        /* numEventsToWaitFor */ 20/* secondsToWait */);
+    checkCqListenerEvents("All", 10 /* numEventsExpected */,
+        /* numEventsToWaitFor */ 20/* secondsToWait */);
+
+    primary = getPrimaryServerVM();
+    // Stop the durable client
+    CacheServerTestUtil.closeCache(false);
+    // Stop the publisher client
+    this.publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+    // Stop the remaining server
+    primary.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
+  }
+
 
   /**
    * Test functionality to close the cq and drain all events from the ha queue from the server This
@@ -781,6 +877,8 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
 
   @Test
   public void testGetAllDurableCqsFromServer() {
+
+
     // Start server 1
     server1Port = this.server1VM.invoke(CacheServerTestUtil.class,
         "createCacheServer", new Object[] {regionName, Boolean.TRUE});
@@ -966,6 +1064,39 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
           }
         };
     vm.invoke(cacheSerializableRunnable);
+  }
+
+  public VM getPrimaryServerVM() {
+    if (this.server1Port == getPrimaryServerPort()) {
+      return server1VM;
+    } else {
+      return server2VM;
+    }
+  }
+
+  public int getPrimaryServerPort() {
+    PoolImpl pool = CacheServerTestUtil.getPool();
+    ServerLocation primaryServerLocation = pool.getPrimary();
+    return primaryServerLocation.getPort();
+  }
+
+  public void waitForFailoverToPerform(int oldPrimaryPort) {
+    final PoolImpl pool = CacheServerTestUtil.getPool();
+    WaitCriterion ev = new WaitCriterion() {
+      @Override
+      public boolean done() {
+        logger.info("Jale waiting failover");
+        return pool.getPrimary() != null && pool.getPrimary().getPort() != oldPrimaryPort;
+      }
+
+      @Override
+      public String description() {
+        return null;
+      }
+    };
+
+    GeodeAwaitility.await().untilAsserted(ev);
+    assertNotNull(pool.getPrimary());
   }
 
   void registerDurableCq(final String cqName) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
@@ -60,10 +60,12 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.cache.ha.HARegionQueue;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 
 public class DurableClientTestBase extends JUnit4DistributedTestCase {
@@ -170,6 +172,32 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
   void verifyDurableClientNotPresent(int durableClientTimeout, String durableClientId,
       final VM serverVM) {
     verifyDurableClientPresence(durableClientTimeout, durableClientId, serverVM, 0);
+  }
+
+  void waitForDurableClientPresence(String durableClientId, VM serverVM, final int count) {
+    serverVM.invoke(() -> {
+      if (count > 0) {
+
+        WaitCriterion ev = new WaitCriterion() {
+          @Override
+          public boolean done() {
+            checkNumberOfClientProxies(count);
+            CacheClientProxy proxy = getClientProxy();
+
+            if (proxy != null && durableClientId.equals(proxy.getDurableId())) {
+              return true;
+            }
+            return false;
+          }
+
+          @Override
+          public String description() {
+            return null;
+          }
+        };
+        GeodeAwaitility.await().untilAsserted(ev);
+      }
+    });
   }
 
   void verifyDurableClientPresence(int durableClientTimeout, String durableClientId,
@@ -723,15 +751,6 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
     vm.invoke(() -> {
       CacheServerTestUtil.createCacheClient(
           getClientPool(NetworkUtils.getServerHostName(), serverPort1, false),
-          regionName);
-      assertThat(CacheServerTestUtil.getClientCache()).isNotNull();
-    });
-  }
-
-  void startClient(VM vm, int serverPort1, int server2Port, String regionName) {
-    vm.invoke(() -> {
-      CacheServerTestUtil.createCacheClient(
-          getClientPool(NetworkUtils.getServerHostName(), serverPort1, server2Port, false),
           regionName);
       assertThat(CacheServerTestUtil.getClientCache()).isNotNull();
     });


### PR DESCRIPTION
This change solves the issue when the client without configured HA is
wrongly re-registering durable CQs as non durable during the server
failover.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
