### PR TITLE
GEODE-8347: use same benchmarks branch as geode branch

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -455,7 +455,7 @@ jobs:
 {% for run_var in (benchmarks.flavors) %}
 - name: Benchmark{{ run_var.title }}
   public: true
-  max_in_flight: 2
+  max_in_flight: {{ run_var.max_in_flight }}
   plan:
   - get: geode-ci
     passed: &benchmark-inputs

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -18,17 +18,20 @@
 benchmarks:
   baseline_branch: ''
   baseline_version: '1.12.0'
-  benchmark_branch: develop
+  benchmark_branch: ((geode-build-branch))
   flavors:
   - title: '_base'
     flag: ''
     options: ''
+    max_in_flight: 4
   - title: '_with_ssl'
     flag: '-PwithSsl -PtestJVM=/usr/lib/jvm/java-11-openjdk-amd64/'
     options: '--tests=*GetBenchmark --tests=*PutBenchmark'
+    max_in_flight: 1
   - title: '_with_security_manager'
     flag: '-PwithSecurityManager'
     options: '--tests=Partitioned*'
+    max_in_flight: 2
 
 build_test:
   ARTIFACT_SLUG: build


### PR DESCRIPTION
Geode 1.12 release included geode-benchmarks from support/1.12, but the pipeline definition is still using benchmarks from develop, as is 1.13.  Fix to use matching branch names between geode and geode-examples.  Also rebalance max_in_flight based on how long each benchmark job takes.