### PR TITLE
GEODE-7956: Correct documentation of legal region names (format fix)

### DIFF
--- a/geode-docs/basic_config/data_regions/region_naming.html.md.erb
+++ b/geode-docs/basic_config/data_regions/region_naming.html.md.erb
@@ -24,7 +24,7 @@ follow these region naming guidelines.
 
 -   Characters permitted in region names are alphanumeric characters
 (`ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789`),
-period (`.`), underscore (`_`), square brackets (`[, ]`), hyphen (`-`), caret (`^`) and backquote (```).
+period (`.`), underscore (`_`), square brackets (`[ ]`), hyphen (`-`), caret (`^`) and backquote (`` ` ``).
 -   Do not use the slash character (`/`).
 -   Do not begin region names with two underscore characters (`__`),
 as this is reserved for internal use.


### PR DESCRIPTION
Fix how the back-quote is displayed in the compiled user guide.