### PR TITLE
GEODE-8355: add `public: true` to the test job in long-running-test

### DIFF
--- a/ci/pipelines/mass-test-run/jinja.template.yml
+++ b/ci/pipelines/mass-test-run/jinja.template.yml
@@ -213,6 +213,7 @@ jobs:
     {%- endif %}
 - name: {{test.name}}Test{{java_test_version.name}}
   max_in_flight: 10
+  public: true
   plan:
   - do:
     {{- plan_resource_gets(test) |indent(4) }}


### PR DESCRIPTION
Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
