### PR TITLE
GEODE-8348: Add benchmarks EC2 image builder job.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ bin/
 .metadata/
 /ci/pipelines/meta/meta.properties.local
 /dev-tools/docker/docs/build-docs-output.txt
+fly

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -176,7 +176,7 @@ resources:
   source:
     branch: {{benchmarks.benchmark_branch}}
     depth: 1
-    uri: https://github.com/apache/geode-benchmarks.git
+    uri: https://github.com/((geode-fork))/geode-benchmarks.git
 - name: geode-build-version
   type: semver
   source:
@@ -487,6 +487,7 @@ jobs:
           FLAGS: {{ run_var.flag }}
           TAG_POSTFIX: {{ run_var.title }}
           TEST_OPTIONS: {{ run_var.options }}
+          PURPOSE: ((pipeline-prefix))geode-benchmarks
         run:
           path: geode-ci/ci/scripts/run_benchmarks.sh
         inputs:

--- a/ci/pipelines/images/jinja.template.yml
+++ b/ci/pipelines/images/jinja.template.yml
@@ -63,6 +63,14 @@ resources:
     repository: openjdk
     tag: 8
 
+- name: geode-benchmarks-image
+  type: git
+  source:
+    branch: ((geode-build-branch))
+    paths:
+    - infrastructure/scripts/aws/image
+    uri: https://github.com/((geode-fork))/geode-benchmarks.git
+
 - name: google-geode-builder
   type: git
   source:
@@ -227,6 +235,39 @@ jobs:
     params:
       build: build-concourse-dockerfile/ci/docker
       tag_as_latest: true
+
+- name: build-geode-benchmarks-image
+  public: ((public-pipelines))
+  serial: true
+  plan:
+  - in_parallel:
+    - get: geode-benchmarks-image
+      trigger: true
+    - get: alpine-tools-docker-image
+      passed: [build-alpine-tools-docker-image]
+  - task: build-image
+    timeout: 1h
+    image: alpine-tools-docker-image
+    config:
+      inputs:
+      - name: geode-benchmarks-image
+      outputs:
+      - name: results
+      platform: linux
+      params:
+        AWS_ACCESS_KEY_ID: ((benchmarks-access-key-id))
+        AWS_SECRET_ACCESS_KEY: ((benchmarks-secret-access-key))
+        AWS_DEFAULT_REGION: us-west-2
+        AWS_REGION: us-west-2
+        PURPOSE: ((pipeline-prefix))geode-benchmarks
+      run:
+        path: bash
+        args:
+          - -ec
+          - |-
+            pushd geode-benchmarks-image/infrastructure/scripts/aws/image
+            packer build -var "purpose=${PURPOSE}" packer.json
+            popd
 
 - name: build-google-geode-builder
   public: ((public-pipelines))

--- a/ci/pipelines/meta/jinja.template.yml
+++ b/ci/pipelines/meta/jinja.template.yml
@@ -416,7 +416,7 @@ jobs:
   public: ((!public-pipelines))
   serial: true
   plan:
-  - aggregate:
+  - in_parallel:
     - get: meta-mini-dockerfile
       trigger: true
   - put: meta-mini-image


### PR DESCRIPTION
* Add EC2 builder job to images.
* Benchmarks job uses branch-specific image.
* Change benchmarks source repository location to the deployed fork's repo instead
  of forcing apache.
* download our own copy of fly to use when deploying pipelines via deploy_meta.sh.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
