### PR TITLE
GEODE-8298: Member version comparison sense inconsistent when deciding on multicast

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/membership/InternalDistributedMember.java
@@ -545,7 +545,7 @@ public class InternalDistributedMember
     return memberIdentifier.getUniqueId();
   }
 
-  public void setVersionForTest(KnownVersion v) {
+  public void setVersionForTest(Version v) {
     memberIdentifier.setVersionForTest(v);
   }
 

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberDataVersionJUnitTest.java
@@ -85,13 +85,6 @@ public class GMSMemberDataVersionJUnitTest {
     validate(newMember);
   }
 
-  @Test
-  public void testSetVersionOrdinal() {
-    final GMSMemberData memberData = new GMSMemberData();
-    memberData.setVersionOrdinal(unknownVersionOrdinal);
-    validate(memberData);
-  }
-
   private AbstractShortAssert<?> validate(final MemberData memberData) {
     return assertThat(memberData.getVersionOrdinal()).isEqualTo(unknownVersionOrdinal);
   }

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
@@ -59,8 +59,8 @@ import org.apache.geode.distributed.internal.membership.gms.interfaces.HealthMon
 import org.apache.geode.distributed.internal.membership.gms.interfaces.JoinLeave;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Messenger;
 import org.apache.geode.internal.serialization.DSFIDSerializer;
+import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.Version;
-import org.apache.geode.internal.serialization.VersionOrdinal;
 import org.apache.geode.internal.serialization.Versioning;
 import org.apache.geode.internal.serialization.internal.DSFIDSerializerImpl;
 import org.apache.geode.test.junit.categories.MembershipTest;
@@ -68,10 +68,10 @@ import org.apache.geode.test.junit.categories.MembershipTest;
 @Category({MembershipTest.class})
 public class GMSMembershipJUnitTest {
 
-  private static final VersionOrdinal OLDER_THAN_CURRENT_VERSION =
-      Versioning.getVersionOrdinal((short) (Version.CURRENT_ORDINAL - 1));
-  private static final VersionOrdinal NEWER_THAN_CURRENT_VERSION =
-      Versioning.getVersionOrdinal((short) (Version.CURRENT_ORDINAL + 1));;
+  private static final Version OLDER_THAN_CURRENT_VERSION =
+      Versioning.getVersion((short) (KnownVersion.CURRENT_ORDINAL - 1));
+  private static final Version NEWER_THAN_CURRENT_VERSION =
+      Versioning.getVersion((short) (KnownVersion.CURRENT_ORDINAL + 1));;
   private static final int DEFAULT_PORT = 8888;
 
   private Services services;
@@ -350,7 +350,7 @@ public class GMSMembershipJUnitTest {
   @Test
   public void testIsMulticastAllowedWithCurrentVersionSurpriseMember() {
     MembershipView<MemberIdentifier> view = createMembershipView();
-    manager.addSurpriseMember(createSurpriseMember(Version.CURRENT));
+    manager.addSurpriseMember(createSurpriseMember(KnownVersion.CURRENT));
 
     manager.processView(view);
 
@@ -370,7 +370,7 @@ public class GMSMembershipJUnitTest {
   @Test
   public void testIsMulticastAllowedWithOldVersionViewMember() {
     MembershipView<MemberIdentifier> view = createMembershipView();
-    view.getMembers().get(0).setVersionObjectForTest(OLDER_THAN_CURRENT_VERSION);
+    view.getMembers().get(0).setVersionForTest(OLDER_THAN_CURRENT_VERSION);
 
     manager.processView(view);
 
@@ -389,17 +389,17 @@ public class GMSMembershipJUnitTest {
   @Test
   public void testMulticastAllowedWithNewVersionViewMember() {
     MembershipView<MemberIdentifier> view = createMembershipView();
-    view.getMembers().get(0).setVersionObjectForTest(NEWER_THAN_CURRENT_VERSION);
+    view.getMembers().get(0).setVersionForTest(NEWER_THAN_CURRENT_VERSION);
 
     manager.processView(view);
 
     assertThat(manager.getGMSManager().isMulticastAllowed()).isTrue();
   }
 
-  private MemberIdentifier createSurpriseMember(VersionOrdinal version) {
+  private MemberIdentifier createSurpriseMember(Version version) {
     MemberIdentifier surpriseMember = createMemberID(DEFAULT_PORT + 5);
     surpriseMember.setVmViewId(3);
-    surpriseMember.setVersionObjectForTest(version);
+    surpriseMember.setVersionForTest(version);
     return surpriseMember;
   }
 

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSMembershipJUnitTest.java
@@ -344,7 +344,7 @@ public class GMSMembershipJUnitTest {
     surpriseMember.setVersionObjectForTest(Version.GEODE_1_1_0);
     manager.addSurpriseMember(surpriseMember);
 
-    assertTrue(manager.isDisableMulticastForRollingUpgrade(view));
+    assertTrue(manager.isDisableMulticastForRollingUpgrade(view, Version.CURRENT));
   }
 
   @Test
@@ -361,7 +361,24 @@ public class GMSMembershipJUnitTest {
     surpriseMember.setVersionObjectForTest(Version.CURRENT);
     manager.addSurpriseMember(surpriseMember);
 
-    assertFalse(manager.isDisableMulticastForRollingUpgrade(view));
+    assertFalse(manager.isDisableMulticastForRollingUpgrade(view, Version.CURRENT));
+  }
+
+  @Test
+  public void testMulticastWithHigherVersionSurpriseMember() throws Exception {
+    manager.getGMSManager().start();
+    manager.getGMSManager().started();
+    manager.isJoining = true;
+
+    List<MemberIdentifier> viewmembers = Arrays.asList(mockMembers[0], mockMembers[1], myMemberId);
+    MembershipView view = new MembershipView(myMemberId, 2, viewmembers);
+
+    MemberIdentifier surpriseMember = mockMembers[0];
+    surpriseMember.setVmViewId(3);
+    surpriseMember.setVersionObjectForTest(Version.CURRENT);
+    manager.addSurpriseMember(surpriseMember);
+
+    assertFalse(manager.isDisableMulticastForRollingUpgrade(view, Version.GEODE_1_1_0));
   }
 
   @Test
@@ -374,7 +391,7 @@ public class GMSMembershipJUnitTest {
     viewmembers.get(0).setVersionObjectForTest(Version.GEODE_1_1_0);
     MembershipView view = new MembershipView(myMemberId, 2, viewmembers);
 
-    assertTrue(manager.isDisableMulticastForRollingUpgrade(view));
+    assertTrue(manager.isDisableMulticastForRollingUpgrade(view, Version.CURRENT));
   }
 
   @Test
@@ -387,6 +404,19 @@ public class GMSMembershipJUnitTest {
     viewmembers.get(0).setVersionObjectForTest(Version.CURRENT);
     MembershipView view = new MembershipView(myMemberId, 2, viewmembers);
 
-    assertFalse(manager.isDisableMulticastForRollingUpgrade(view));
+    assertFalse(manager.isDisableMulticastForRollingUpgrade(view, Version.CURRENT));
+  }
+
+  @Test
+  public void testMulticastWithHigherVersionViewMember() throws Exception {
+    manager.getGMSManager().start();
+    manager.getGMSManager().started();
+    manager.isJoining = true;
+
+    List<MemberIdentifier> viewmembers = Arrays.asList(mockMembers[0], mockMembers[1], myMemberId);
+    viewmembers.get(0).setVersionObjectForTest(Version.CURRENT);
+    MembershipView view = new MembershipView(myMemberId, 2, viewmembers);
+
+    assertFalse(manager.isDisableMulticastForRollingUpgrade(view, Version.GEODE_1_1_0));
   }
 }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberData.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberData.java
@@ -50,8 +50,6 @@ public interface MemberData {
 
   String getUniqueTag();
 
-  void setVersionOrdinal(short versionOrdinal);
-
   void setUUID(UUID u);
 
   UUID getUUID();

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberData.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberData.java
@@ -21,7 +21,6 @@ import java.net.InetAddress;
 import org.jgroups.util.UUID;
 
 import org.apache.geode.internal.serialization.DeserializationContext;
-import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.Version;
 
@@ -90,7 +89,7 @@ public interface MemberData {
 
   void setVmKind(int vmKind);
 
-  void setVersion(KnownVersion v);
+  void setVersion(Version v);
 
   void setDirectChannelPort(int directPort);
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberIdentifier.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MemberIdentifier.java
@@ -27,7 +27,6 @@ import org.jgroups.util.UUID;
 
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.DeserializationContext;
-import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.serialization.Version;
 
@@ -191,7 +190,7 @@ public interface MemberIdentifier extends DataSerializableFixedID {
 
   String getUniqueId();
 
-  void setVersionForTest(KnownVersion v);
+  void setVersionForTest(Version v);
 
   void setUniqueTag(String tag);
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
@@ -502,8 +502,8 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
 
 
   @Override
-  public void setVersion(KnownVersion version) {
-   this.version = version;
+  public void setVersion(Version version) {
+    this.version = version;
   }
 
   @Override

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMemberData.java
@@ -236,11 +236,6 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
   }
 
   @Override
-  public void setVersionOrdinal(short versionOrdinal) {
-    this.version = Versioning.getVersion(versionOrdinal);
-  }
-
-  @Override
   public void setUUID(UUID u) {
     if (u == null) {
       this.uuidLSBs = 0;
@@ -507,8 +502,8 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
 
 
   @Override
-  public void setVersion(KnownVersion v) {
-    setVersionOrdinal(v.ordinal());
+  public void setVersion(KnownVersion version) {
+   this.version = version;
   }
 
   @Override
@@ -583,7 +578,7 @@ public class GMSMemberData implements MemberData, Comparable<GMSMemberData> {
   @Override
   public void readEssentialData(DataInput in,
       DeserializationContext context) throws IOException, ClassNotFoundException {
-    setVersionOrdinal(VersioningIO.readOrdinal(in));
+    setVersion(Versioning.getVersion(VersioningIO.readOrdinal(in)));
 
     int flags = in.readShort();
     this.networkPartitionDetectionEnabled = (flags & NPD_ENABLED_BIT) != 0;

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -360,7 +360,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
   /**
    * Analyze a given view object, generate events as appropriate
    */
-  public void processView(long newViewId, MembershipView<ID> newView) {
+  public void processView(MembershipView<ID> newView) {
     // Sanity check...
     if (logger.isDebugEnabled()) {
       StringBuilder msg = new StringBuilder(200);
@@ -383,14 +383,13 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
       // Save previous view, for delta analysis
       MembershipView<ID> priorView = latestView;
 
-      if (newViewId < priorView.getViewId()) {
+      if (newView.getViewId() < priorView.getViewId()) {
         // ignore this view since it is old news
         return;
       }
 
       // update the view to reflect our changes, so that
       // callbacks will see the new (updated) view.
-      long newlatestViewId = newViewId;
       MembershipView<ID> newlatestView = new MembershipView<>(newView, newView.getViewId());
 
       // look for additions
@@ -978,7 +977,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
         }
       }
 
-      viewExecutor.submit(() -> processView(viewArg.getViewId(), viewArg));
+      viewExecutor.submit(() -> processView(viewArg));
 
     } finally {
       latestViewWriteLock.unlock();
@@ -1037,7 +1036,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
         // message from non-member - ignore
       }
     } else if (o.isGmsView()) { // view event
-      processView(o.gmsView.getViewId(), o.gmsView);
+      processView(o.gmsView);
     } else if (o.isSurpriseConnect()) { // connect
       processSurpriseConnect(o.member);
     } else {

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -62,7 +62,6 @@ import org.apache.geode.distributed.internal.membership.api.QuorumChecker;
 import org.apache.geode.distributed.internal.membership.api.StopShunningMarker;
 import org.apache.geode.distributed.internal.membership.gms.interfaces.Manager;
 import org.apache.geode.internal.serialization.KnownVersion;
-import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
 import org.apache.geode.logging.internal.executors.LoggingThread;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -523,7 +522,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
 
   private boolean anyMemberHasOlderVersion(final Stream<ID> members) {
     return members
-        .anyMatch(member -> Version.CURRENT.isNewerThan(member.getVersionOrdinalObject()));
+        .anyMatch(member -> KnownVersion.CURRENT.isNewerThan(member.getVersion()));
   }
 
   @Override

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -378,7 +378,8 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
     // incoming events will not be lost in terms of our global view.
     latestViewWriteLock.lock();
     try {
-      disableMulticastForRollingUpgrade = isDisableMulticastForRollingUpgrade(newView);
+      disableMulticastForRollingUpgrade =
+          isDisableMulticastForRollingUpgrade(newView, Version.CURRENT);
 
       // Save previous view, for delta analysis
       MembershipView<ID> priorView = latestView;
@@ -515,13 +516,13 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
     }
   }
 
-  boolean isDisableMulticastForRollingUpgrade(MembershipView<ID> newView) {
+  boolean isDisableMulticastForRollingUpgrade(MembershipView<ID> newView, Version version) {
     return Stream.concat(surpriseMembers.entrySet().stream().map(entry -> entry.getKey()),
         newView.getMembers().stream())
         .anyMatch(member -> {
           final VersionOrdinal memberVersionOrdinal = member.getVersionOrdinalObject();
           return memberVersionOrdinal != null
-              && memberVersionOrdinal.compareTo(Version.CURRENT) < 0;
+              && memberVersionOrdinal.compareTo(version) < 0;
         });
   }
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/MemberIdentifierImpl.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/MemberIdentifierImpl.java
@@ -982,7 +982,7 @@ public class MemberIdentifierImpl implements MemberIdentifier, DataSerializableF
     return sb.toString();
   }
 
-  public void setVersionForTest(KnownVersion v) {
+  public void setVersionForTest(Version v) {
     memberData.setVersion(v);
     cachedToString = null;
   }


### PR DESCRIPTION
[GEODE-8298](https://issues.apache.org/jira/browse/GEODE-8298)
These changes fix inconsistent version comparison in `GMSMembership.processView()`.

The goal of the comparison is to find the oldest Geode version and if that version is older than the local version, disable multicast. The code responsible for this was extracted from `processView` to a new method `containsOldVersionMember` to allow for better unit testing.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
