### PR TITLE
GEODE-8375: No-op test to run Redis API for Geode for local development

### DIFF
--- a/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
@@ -30,7 +30,6 @@ import org.apache.geode.test.junit.rules.serializable.SerializableExternalResour
 public class GeodeRedisServerRule extends SerializableExternalResource {
   private GemFireCache cache;
   private GeodeRedisServer server;
-  private String password;
   private CacheFactory cacheFactory;
 
   public GeodeRedisServerRule() {
@@ -42,7 +41,7 @@ public class GeodeRedisServerRule extends SerializableExternalResource {
   }
 
   @Override
-  protected void before() throws Throwable {
+  protected void before() {
     cache = cacheFactory.create();
     server = new GeodeRedisServer("localhost", 0, (InternalCache) cache);
     server.setAllowUnsupportedCommands(true);

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
@@ -32,6 +32,7 @@ public class GeodeServerRunTest {
   @Ignore("This is a no-op test to conveniently run redis api for geode server for local development/testing purposes")
   public void runGeodeServer() {
     LogService.getLogger().warn("Server running on port: " + server.getPort());
-    while(true) {}
+    while (true) {
+    }
   }
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal;
+
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.test.junit.categories.RedisTest;
+
+@Category({RedisTest.class})
+public class GeodeServerRunTest {
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Test
+  @Ignore("This is a no-op test to conveniently run redis api for geode server for local development/testing purposes")
+  public void runGeodeServer() {
+    LogService.getLogger().warn("Server running on port: " + server.getPort());
+    while(true) {}
+  }
+}


### PR DESCRIPTION
No-op test to run Redis API for Geode for local development