### PR TITLE
GEODE-8387: fix SET*STORE commands handling of empty results

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SDiffIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SDiffIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.executor.set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -121,6 +122,27 @@ public class SDiffIntegrationTest {
     Set<String> copyResultSet = jedis.smembers("copySet");
     assertThat(copySetSize).isEqualTo(secondSet.length);
     assertThat(copyResultSet.toArray()).containsExactlyInAnyOrder((Object[]) secondSet);
+  }
+
+  @Test
+  public void testSDiffStore_withNonExistentKeys() {
+    String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
+    jedis.sadd("set1", firstSet);
+
+    Long resultSize = jedis.sdiffstore("set1", "nonExistent1", "nonExistent2");
+    assertThat(resultSize).isEqualTo(0);
+    assertThat(jedis.exists("set1")).isFalse();
+  }
+
+  @Test
+  public void testSDiffStore_withNonSetKey() {
+    String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
+    jedis.sadd("set1", firstSet);
+    jedis.set("string1", "value1");
+
+    assertThatThrownBy(() -> jedis.sdiffstore("set1", "string1"))
+        .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
+    assertThat(jedis.exists("set1")).isTrue();
   }
 
   @Test

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SInterIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SInterIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.executor.set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -121,6 +122,27 @@ public class SInterIntegrationTest {
     Set<String> copyResultSet = jedis.smembers("copySet");
     assertThat(copySetSize).isEqualTo(0);
     assertThat(copyResultSet).isEmpty();
+  }
+
+  @Test
+  public void testSInterStore_withNonExistentKeys() {
+    String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
+    jedis.sadd("set1", firstSet);
+
+    Long resultSize = jedis.sinterstore("set1", "nonExistent1", "nonExistent2");
+    assertThat(resultSize).isEqualTo(0);
+    assertThat(jedis.exists("set1")).isFalse();
+  }
+
+  @Test
+  public void testSInterStore_withNonSetKey() {
+    String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
+    jedis.sadd("set1", firstSet);
+    jedis.set("string1", "value1");
+
+    assertThatThrownBy(() -> jedis.sinterstore("set1", "string1"))
+        .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
+    assertThat(jedis.exists("set1")).isTrue();
   }
 
   @Test

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSet.java
@@ -120,9 +120,14 @@ class NullRedisSet extends RedisSet {
       ByteArrayWrapper destination,
       ArrayList<Set<ByteArrayWrapper>> nonDestinationSets) {
     RedisSet destinationSet = helper.getRedisSet(destination);
-    RedisSet redisSet = new RedisSet(computeSetOp(setOp, nonDestinationSets, destinationSet));
-    helper.getRegion().put(destination, redisSet);
-    return redisSet.scard();
+    Set<ByteArrayWrapper> result = computeSetOp(setOp, nonDestinationSets, destinationSet);
+    if (result.isEmpty()) {
+      helper.getRegion().remove(destination);
+      return 0;
+    } else {
+      helper.getRegion().put(destination, new RedisSet(result));
+      return result.size();
+    }
   }
 
   private Set<ByteArrayWrapper> computeSetOp(SetOp setOp,


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
