### PR TITLE
GEODE-8391: Skip assertion if unsupported by host

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortJUnitTest.java
@@ -57,10 +57,14 @@ public class AvailablePortJUnitTest {
 
     assertFalse(AvailablePort.isPortAvailable(port, AvailablePort.SOCKET,
         InetAddress.getByName(LOOPBACK_ADDRESS)));
-    // Get local host will return the hostname for the server, so this should succeed, since we're
-    // bound to the loopback address only.
-    assertTrue(
-        AvailablePort.isPortAvailable(port, AvailablePort.SOCKET, InetAddress.getLocalHost()));
+
+    InetAddress localHostAddress = InetAddress.getLocalHost();
+    // The next assertion assumes that the local host address is not a loopback address. Skip the
+    // assertion on host machines that don't satisfy the assumption.
+    if (!localHostAddress.isLoopbackAddress()) {
+      assertTrue(AvailablePort.isPortAvailable(port, AvailablePort.SOCKET, localHostAddress));
+    }
+
     // This should test all interfaces.
     assertFalse(AvailablePort.isPortAvailable(port, AvailablePort.SOCKET));
   }


### PR DESCRIPTION
An assertion in AvailablePortJUnitTest.testIsPortAvailable() assumes
that the InetAddress for the local host is not a loopback address.
Though this assumption holds in our CI containers, it fails on some
developer's Macs, and perhaps on other hosts.

This commit changes the test to skip that assertion if the local host
address is a loopback address.

Authored-by: Dale Emery <demery@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?
