### PR TITLE
GEODE-8389: reconnect attempt fails due to distribution configuration…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -1128,7 +1128,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   private void validateConfigurationProperties(final Map<Object, Object> props) {
     for (Object o : props.keySet()) {
       String propertyName = (String) o;
-      if (isInternalPropertyName(propertyName)) {
+      if (isInternalAttribute(propertyName)) {
         continue;
       }
       Object value = null;
@@ -1549,31 +1549,31 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   /**
-   * internal configuration properties not in ConfigurationProperties but that may be in
-   * properties fed to a DistributionConfigImpl constructor.
-   */
-  static Set<String> internalPropertyNames = new HashSet<>(Arrays.asList(
-      LOG_WRITER_NAME, DS_CONFIG_NAME,
-      DS_QUORUM_CHECKER_NAME, DS_RECONNECTING_NAME,
-      SECURITY_LOG_WRITER_NAME, LOG_OUTPUTSTREAM_NAME,
-      SECURITY_LOG_OUTPUTSTREAM_NAME));
-
-  /**
    * a collection of configuration properties that are used to skip some security properties
    * during initialization due to dependency issues
    */
-  static Set<String> specialPropertyNames = new HashSet<>(Arrays.asList(CLUSTER_SSL_ENABLED,
+  private Set<String> specialPropertyNames = new HashSet<>(Arrays.asList(CLUSTER_SSL_ENABLED,
       SECURITY_PEER_AUTH_INIT, SECURITY_PEER_AUTHENTICATOR,
       LOG_WRITER_NAME, DS_CONFIG_NAME,
       SECURITY_LOG_WRITER_NAME, LOG_OUTPUTSTREAM_NAME,
       SECURITY_LOG_OUTPUTSTREAM_NAME));
 
-  boolean isInternalPropertyName(String propName) {
-    return internalPropertyNames.contains(propName);
-  }
-
   boolean isSpecialPropertyName(String propName) {
     return specialPropertyNames.contains(propName);
+  }
+
+  /**
+   * returns true if the given name is annotated as an InternalConfigAttribute.
+   * These attributes are used to hold internal, runtime objects such as
+   * an auto-reconnect quorum checker and are not settable as distributed system
+   * properties.
+   */
+  boolean isInternalAttribute(String propName) {
+    return internalAttributeNames.contains(propName);
+  }
+
+  Set<String> getInternalAttributeNames() {
+    return Collections.unmodifiableSet(internalAttributeNames);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigAttribute.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalConfigAttribute.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * marks internal configuration option names in DistributionConfig
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InternalConfigAttribute {
+}

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -190,12 +191,24 @@ public class DistributionConfigJUnitTest {
     DistributionConfigImpl config = new DistributionConfigImpl(new Properties());
     Properties configProperties = new Properties();
     configProperties.putAll(config.getProps());
-    assertThat(config.isInternalPropertyName(DistributionConfig.DS_QUORUM_CHECKER_NAME)).isTrue();
-    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, false))).isTrue();
-    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, true))).isTrue();
-    configProperties.setProperty(DistributionConfig.DS_QUORUM_CHECKER_NAME, "quorum checker");
-    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, false))).isTrue();
-    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, true))).isTrue();
+    Set<String> internalAttributeNames = config.getInternalAttributeNames();
+    assertThat(internalAttributeNames).isNotEmpty();
+    // make sure that DS_QUORUM_CHECKER_NAME is tested (GEODE-8389)
+    assertThat(internalAttributeNames).contains(DistributionConfig.DS_QUORUM_CHECKER_NAME);
+    for (String attributeName : config.getInternalAttributeNames()) {
+      assertThat(config.isInternalAttribute(attributeName)).isTrue()
+          .withFailMessage(
+              attributeName + " is not considered to be internal, but is annotated to be internal");
+      assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, false))).isTrue()
+          .withFailMessage("sameAs failed for " + attributeName);
+      assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, true))).isTrue()
+          .withFailMessage("sameAs failed for " + attributeName);
+      configProperties.put(attributeName, new Object());
+      assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, false))).isTrue()
+          .withFailMessage("sameAs failed for " + attributeName);
+      assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, true))).isTrue()
+          .withFailMessage("sameAs failed for " + attributeName);
+    }
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -186,6 +186,19 @@ public class DistributionConfigJUnitTest {
   }
 
   @Test
+  public void internalPropertiesAreIgnoredInSameAsCheck() {
+    DistributionConfigImpl config = new DistributionConfigImpl(new Properties());
+    Properties configProperties = new Properties();
+    configProperties.putAll(config.getProps());
+    assertThat(config.isInternalPropertyName(DistributionConfig.DS_QUORUM_CHECKER_NAME)).isTrue();
+    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, false))).isTrue();
+    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, true))).isTrue();
+    configProperties.setProperty(DistributionConfig.DS_QUORUM_CHECKER_NAME, "quorum checker");
+    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, false))).isTrue();
+    assertThat(config.sameAs(DistributionConfigImpl.produce(configProperties, true))).isTrue();
+  }
+
+  @Test
   public void everyAttrHasValidGetter() {
     for (String attr : attributes.keySet()) {
       Method getter = getters.get(attr);


### PR DESCRIPTION
… validation checks

disregard internal property names when checking for equality.  These
properties are used to carry information that does not come from
gemfire.properties.

@kamilla1201 @luissson 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
