### PR TITLE
GEODE-8382: Run Redis tests against Redis API for Geode

### DIFF
--- a/ci/images/google-geode-builder/scripts/setup.sh
+++ b/ci/images/google-geode-builder/scripts/setup.sh
@@ -33,7 +33,7 @@ curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 apt-get update
 set +e && apt-get purge -y google-cloud-sdk lxc-docker && set -e
-apt-get install -y --no-install-recommends \
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     aptitude \
     ca-certificates \
     cgroupfs-mount \
@@ -49,6 +49,7 @@ apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
     rsync \
+    tcl \
     tmux \
     unzip \
     vim

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -140,6 +140,19 @@ tests:
   PLATFORM: linux
   RAM: '210'
   name: Upgrade
+- ARTIFACT_SLUG: redistests
+  CALL_STACK_TIMEOUT: '1200'
+  CPUS: '4'
+  DUNIT_PARALLEL_FORKS: '0'
+  EXECUTE_TEST_TIMEOUT: 30m
+  GRADLE_TASK: ':geode-redis:redisAPITest'
+  MAX_IN_FLIGHT: 1
+  ONLY_JDK: 11
+  PARALLEL_DUNIT: 'false'
+  PARALLEL_GRADLE: 'true'
+  PLATFORM: linux
+  RAM: '16'
+  name: Redis
 - ARTIFACT_SLUG: stressnewtestfiles
   CALL_STACK_TIMEOUT: '20700'
   CPUS: '96'

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -151,7 +151,7 @@ tests:
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'true'
   PLATFORM: linux
-  RAM: '16'
+  RAM: '8'
   name: Redis
 - ARTIFACT_SLUG: stressnewtestfiles
   CALL_STACK_TIMEOUT: '20700'

--- a/ci/scripts/execute_redis_tests.sh
+++ b/ci/scripts/execute_redis_tests.sh
@@ -18,11 +18,16 @@
 # limitations under the License.
 
 cd ..
+
+# We are currently using a personal fork for this repo because our code does not implement all
+# Redis commands.  Once all commands needed to run relevant test files are implemented, we hope to
+# use Redis's repo instead.
 git clone --config transfer.fsckObjects=false https://github.com/prettyClouds/redis.git
 cd redis
 git checkout tests-geode-redis
 
-JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"  \
+export JAVA_HOME=${JAVA_TEST_PATH}
+
 ../geode-assembly/build/install/apache-geode/bin/gfsh start server \
   --J=-Denable-redis-unsupported-commands=true \
   --name=server1 \
@@ -36,7 +41,7 @@ failCount=0
 
 ((failCount+=$?))
 
-JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64" \
+
 ../geode-assembly/build/install/apache-geode/bin/gfsh start server \
   --J=-Denable-redis-unsupported-commands=true \
   --name=server2 \

--- a/ci/scripts/execute_redis_tests.sh
+++ b/ci/scripts/execute_redis_tests.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd ..
+git clone --config transfer.fsckObjects=false https://github.com/prettyClouds/redis.git
+cd redis
+git checkout tests-geode-redis
+
+JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"  \
+../geode-assembly/build/install/apache-geode/bin/gfsh start server \
+  --J=-Denable-redis-unsupported-commands=true \
+  --name=server1 \
+  --redis-port=6380 \
+  --redis-bind-address=127.0.0.1 \
+  --redis-password=foobar
+
+failCount=0
+
+./runtest --host 127.0.0.1 --port 6380 --single unit/auth
+
+((failCount+=$?))
+
+JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64" \
+../geode-assembly/build/install/apache-geode/bin/gfsh start server \
+  --J=-Denable-redis-unsupported-commands=true \
+  --name=server2 \
+  --server-port=0 \
+  --redis-port=6379 \
+  --redis-bind-address=127.0.0.1
+
+./runtest --host 127.0.0.1 --port 6379 --single unit/type/set --single unit/expire
+
+((failCount+=$?))
+
+exit $failCount

--- a/ci/scripts/execute_tests.sh
+++ b/ci/scripts/execute_tests.sh
@@ -106,6 +106,6 @@ EXEC_COMMAND="bash -c 'echo Building with: $SEP \
   cd geode $SEP \
   cp gradlew gradlewStrict $SEP \
   sed -e 's/JAVA_HOME/GRADLE_JVM/g' -i.bak gradlewStrict $SEP \
-  GRADLE_JVM=${JAVA_BUILD_PATH} ./gradlewStrict ${GRADLE_ARGS}'"
+  GRADLE_JVM=${JAVA_BUILD_PATH} JAVA_TEST_PATH=${JAVA_TEST_PATH} ./gradlewStrict ${GRADLE_ARGS}'"
 echo "${EXEC_COMMAND}"
 ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "${EXEC_COMMAND}"

--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -87,3 +87,12 @@ configurations{
     exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
   }
 }
+
+tasks.register("redisAPITest") {
+  dependsOn ':geode-assembly:installDist'
+  doLast {
+    exec {
+      executable "../ci/scripts/execute_redis_tests.sh"
+    }
+  }
+}


### PR DESCRIPTION
We would like to run Redis's tests against Redis API for Geode.  Tests will run a separate job in the PR and main pipelines.  It has been included in the 'tests' jinja variables.

Co-authored-by: Murtuza Boxwala <mboxwala@pivotal.io>