### PR TITLE
GEODE-8395: fix product name in gfsh help banner

### DIFF
--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/Launcher.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/Launcher.java
@@ -262,7 +262,7 @@ public class Launcher {
 
   private void printUsage(final Gfsh gfsh, final PrintStream stream) {
     int terminalWidth = gfsh.getTerminalWidth();
-    stream.print("Pivotal GemFire(R) v");
+    stream.print(GemFireVersion.getProductName() + " v");
     stream.print(GemFireVersion.getGemFireVersion());
     stream.println(" Command Line Shell" + GfshParser.LINE_SEPARATOR);
     stream.println("USAGE");


### PR DESCRIPTION
New (fixed) behavior:
gfsh --help
Apache Geode v1.14.0 Command Line Shell

Old (incorrect) behavior:
gfsh --help
Pivotal GemFire(R) v1.14.0 Command Line Shell
