### PR TITLE
GEODE-8396: Fixing NullPointerException in create jdbc-mapping command

### DIFF
--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommand.java
@@ -38,7 +38,6 @@ import org.apache.geode.annotations.Experimental;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.CacheConfig.AsyncEventQueue;
 import org.apache.geode.cache.configuration.DeclarableType;
-import org.apache.geode.cache.configuration.RegionAttributesDataPolicy;
 import org.apache.geode.cache.configuration.RegionAttributesType;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.connectors.jdbc.JdbcAsyncWriter;
@@ -387,8 +386,7 @@ public class CreateMappingCommand extends SingleGfshCommand {
       String queueName) {
     AsyncEventQueue asyncEventQueue = new AsyncEventQueue();
     asyncEventQueue.setId(queueName);
-    boolean isPartitioned = attributes.getDataPolicy().equals(RegionAttributesDataPolicy.PARTITION)
-        || attributes.getDataPolicy().equals(RegionAttributesDataPolicy.PERSISTENT_PARTITION);
+    boolean isPartitioned = MappingCommandUtils.isPartition(attributes);
     asyncEventQueue.setParallel(isPartitioned);
     DeclarableType listener = new DeclarableType();
     listener.setClassName(JdbcAsyncWriter.class.getName());

--- a/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtils.java
+++ b/geode-connectors/src/main/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtils.java
@@ -20,6 +20,7 @@ import static org.apache.geode.cache.Region.SEPARATOR_CHAR;
 
 import java.util.ArrayList;
 
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.CacheElement;
 import org.apache.geode.cache.configuration.RegionAttributesDataPolicy;
@@ -98,6 +99,16 @@ public class MappingCommandUtils {
     } else {
       return false;
     }
+  }
+
+  public static boolean isPartition(RegionAttributesType attributesType) {
+    boolean isPartitioned = false;
+    if (attributesType.getDataPolicy() != null) {
+      isPartitioned = attributesType.getDataPolicy().isPartition();
+    } else if (attributesType.getRefid() != null) {
+      isPartitioned = RegionShortcut.valueOf(attributesType.getRefid()).isPartition();
+    }
+    return isPartitioned;
   }
 
   public static String createAsyncEventQueueName(String regionPath) {

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandTest.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.CacheConfig.AsyncEventQueue;
 import org.apache.geode.cache.configuration.CacheElement;
@@ -629,6 +630,23 @@ public class CreateMappingCommandTest {
     when(cacheConfig.getAsyncEventQueues()).thenReturn(queueList);
     when(matchingRegionAttributes.getDataPolicy())
         .thenReturn(RegionAttributesDataPolicy.PARTITION);
+
+    createRegionMappingCommand.updateConfigForGroup(null, cacheConfig, arguments);
+
+    assertThat(queueList.get(0).isParallel()).isTrue();
+  }
+
+  @Test
+  public void updateClusterConfigWithOneMatchingPartitionedRegionRefidCreatesParallelAsyncEventQueue() {
+    List<RegionConfig> list = new ArrayList<>();
+    List<CacheElement> listCacheElements = new ArrayList<>();
+    when(matchingRegion.getCustomRegionElements()).thenReturn(listCacheElements);
+    list.add(matchingRegion);
+    when(cacheConfig.getRegions()).thenReturn(list);
+    List<CacheConfig.AsyncEventQueue> queueList = new ArrayList<>();
+    when(cacheConfig.getAsyncEventQueues()).thenReturn(queueList);
+    when(matchingRegionAttributes.getDataPolicy()).thenReturn(null);
+    when(matchingRegionAttributes.getRefid()).thenReturn(RegionShortcut.PARTITION.name());
 
     createRegionMappingCommand.updateConfigForGroup(null, cacheConfig, arguments);
 

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtilsTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtilsTest.java
@@ -24,9 +24,12 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.configuration.CacheConfig;
 import org.apache.geode.cache.configuration.CacheConfig.AsyncEventQueue;
 import org.apache.geode.cache.configuration.CacheElement;
+import org.apache.geode.cache.configuration.RegionAttributesDataPolicy;
+import org.apache.geode.cache.configuration.RegionAttributesType;
 import org.apache.geode.cache.configuration.RegionConfig;
 import org.apache.geode.connectors.jdbc.internal.configuration.RegionMapping;
 import org.apache.geode.distributed.ConfigurationPersistenceService;
@@ -40,12 +43,14 @@ public class MappingCommandUtilsTest {
   ConfigurationPersistenceService configurationPersistenceService;
   CacheConfig cacheConfig;
   RegionConfig regionConfig;
+  RegionAttributesType regionAttributesType;
 
   @Before
   public void setup() {
     configurationPersistenceService = mock(ConfigurationPersistenceService.class);
     cacheConfig = mock(CacheConfig.class);
     regionConfig = mock(RegionConfig.class);
+    regionAttributesType = mock(RegionAttributesType.class);
   }
 
   @Test
@@ -130,6 +135,43 @@ public class MappingCommandUtilsTest {
     when(cacheConfig.getAsyncEventQueues()).thenReturn(asyncEventQueues);
 
     boolean result = MappingCommandUtils.isMappingSynchronous(cacheConfig, regionConfig);
+
+    assertThat(result).isEqualTo(false);
+  }
+
+  @Test
+  public void testIsPartitionWithPartitionDataPolicyReturnsTrue() {
+    when(regionAttributesType.getDataPolicy()).thenReturn(RegionAttributesDataPolicy.PARTITION);
+
+    boolean result = MappingCommandUtils.isPartition(regionAttributesType);
+
+    assertThat(result).isEqualTo(true);
+  }
+
+  @Test
+  public void testIsPartitionWithPersistentPartitionDataPolicyReturnsTrue() {
+    when(regionAttributesType.getDataPolicy())
+        .thenReturn(RegionAttributesDataPolicy.PERSISTENT_PARTITION);
+
+    boolean result = MappingCommandUtils.isPartition(regionAttributesType);
+
+    assertThat(result).isEqualTo(true);
+  }
+
+  @Test
+  public void testIsPartitionWithPersistentPartitionRefidReturnsTrue() {
+    when(regionAttributesType.getRefid()).thenReturn(RegionShortcut.PARTITION.name());
+
+    boolean result = MappingCommandUtils.isPartition(regionAttributesType);
+
+    assertThat(result).isEqualTo(true);
+  }
+
+  @Test
+  public void testIsPartitionWithReplicateDataPolicyReturnsFalse() {
+    when(regionAttributesType.getDataPolicy()).thenReturn(RegionAttributesDataPolicy.REPLICATE);
+
+    boolean result = MappingCommandUtils.isPartition(regionAttributesType);
 
     assertThat(result).isEqualTo(false);
   }

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtilsTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/cli/MappingCommandUtilsTest.java
@@ -168,6 +168,25 @@ public class MappingCommandUtilsTest {
   }
 
   @Test
+  public void testIsPartitionWithLocalRefidReturnsFalse() {
+    when(regionAttributesType.getRefid()).thenReturn(RegionShortcut.LOCAL.name());
+
+    boolean result = MappingCommandUtils.isPartition(regionAttributesType);
+
+    assertThat(result).isEqualTo(false);
+  }
+
+  @Test
+  public void testIsPartitionWithDataPolicyAndRefidIsNullReturnsFalse() {
+    when(regionAttributesType.getDataPolicy()).thenReturn(null);
+    when(regionAttributesType.getRefid()).thenReturn(null);
+
+    boolean result = MappingCommandUtils.isPartition(regionAttributesType);
+
+    assertThat(result).isEqualTo(false);
+  }
+
+  @Test
   public void testIsPartitionWithReplicateDataPolicyReturnsFalse() {
     when(regionAttributesType.getDataPolicy()).thenReturn(RegionAttributesDataPolicy.REPLICATE);
 


### PR DESCRIPTION
Fixed the determination of partitioned region in CreateMappingCommand#createAsyncQueue.
------
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
