### PR TITLE
GEODE-8413: CI failure: MergeLogFilesIntegrationTest.testDircountZero fails on Windows

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/MergeLogFilesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/logging/MergeLogFilesIntegrationTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.logging;
 
-import static java.io.File.separator;
 import static org.apache.geode.logging.internal.spi.LogWriterLevel.ALL;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +44,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ErrorCollector;
 
 import org.apache.geode.LogWriter;
+import org.apache.geode.internal.util.IOUtils;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.junit.categories.LoggingTest;
 
@@ -115,12 +115,11 @@ public class MergeLogFilesIntegrationTest {
 
   @Test
   public void testDircountZero() throws Exception {
-    final String resourcePath1 =
-        MergeLogFilesIntegrationTest.class.getResource("dir1" + separator + "systemlog.txt")
-            .getPath();
-    final String resourcePath2 =
-        MergeLogFilesIntegrationTest.class.getResource("dir2" + separator + "systemlog.txt")
-            .getPath();
+    final String file = MergeLogFilesIntegrationTest.class
+        .getResource("MergeLogFilesIntegrationTest.txt").getPath();
+    final String path = new File(file).getParentFile().getPath();
+    final String resourcePath1 = IOUtils.appendToPath(path, "dir1", "systemlog.txt");
+    final String resourcePath2 = IOUtils.appendToPath(path, "dir2", "systemlog.txt");
     final List<File> files = Arrays.asList(
         new File(resourcePath1),
         new File(resourcePath2));

--- a/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/MergeLogFilesIntegrationTest.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/internal/logging/MergeLogFilesIntegrationTest.txt
@@ -1,0 +1,1 @@
+placeholder file to locate subdirectories for this test


### PR DESCRIPTION
Fixing directory path formation problem for Windows.  I've tested these changes on a Mac and on a Windows machine.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
