### PR TITLE
GEODE-8427: fix flaky test and do not throw memberDeparted

### DIFF
--- a/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionAcceptanceTest.java
@@ -19,9 +19,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.testcontainers.containers.GenericContainer;
-import redis.clients.jedis.Jedis;
 
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.redis.session.RedisSessionDUnitTest;
 import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
@@ -32,16 +30,17 @@ public class NativeRedisSessionAcceptanceTest extends RedisSessionDUnitTest {
 
   @BeforeClass
   public static void setup() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-    ports.put(APP1, availablePorts[0]);
-    ports.put(APP2, availablePorts[1]);
-    ports.put(SERVER1, redisContainer.getFirstMappedPort());
-
-    jedisConnectedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
+    setupAppPorts();
+    setupNativeRedis();
+    setupClient();
     startSpringApp(APP1, DEFAULT_SESSION_TIMEOUT, ports.get(SERVER1));
     startSpringApp(APP2, DEFAULT_SESSION_TIMEOUT, ports.get(SERVER1));
+  }
+
+  protected static void setupNativeRedis() {
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
+    redisContainer.start();
+    ports.put(SERVER1, redisContainer.getFirstMappedPort());
   }
 
   @Test

--- a/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionAcceptanceTest.java
@@ -39,7 +39,7 @@ public class NativeRedisSessionAcceptanceTest extends RedisSessionDUnitTest {
     ports.put(APP2, availablePorts[1]);
     ports.put(SERVER1, redisContainer.getFirstMappedPort());
 
-    jedisConnetedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
+    jedisConnectedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
     startSpringApp(APP1, DEFAULT_SESSION_TIMEOUT, ports.get(SERVER1));
     startSpringApp(APP2, DEFAULT_SESSION_TIMEOUT, ports.get(SERVER1));
   }

--- a/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionExpirationAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionExpirationAcceptanceTest.java
@@ -19,9 +19,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.testcontainers.containers.GenericContainer;
-import redis.clients.jedis.Jedis;
 
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.redis.session.SessionExpirationDUnitTest;
 import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
@@ -32,17 +30,19 @@ public class NativeRedisSessionExpirationAcceptanceTest extends SessionExpiratio
 
   @BeforeClass
   public static void setup() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    int[] availablePorts = AvailablePortHelper.getRandomAvailableTCPPorts(2);
-    ports.put(APP1, availablePorts[0]);
-    ports.put(APP2, availablePorts[1]);
-    ports.put(SERVER1, redisContainer.getFirstMappedPort());
-
-    jedisConnectedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
+    setupAppPorts();
+    setupNativeRedis();
+    setupClient();
     startSpringApp(APP1, SHORT_SESSION_TIMEOUT, ports.get(SERVER1));
     startSpringApp(APP2, SHORT_SESSION_TIMEOUT, ports.get(SERVER1));
   }
+
+  protected static void setupNativeRedis() {
+    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
+    redisContainer.start();
+    ports.put(SERVER1, redisContainer.getFirstMappedPort());
+  }
+
 
   @Test
   public void sessionShouldTimeout_whenAppFailsOverToAnotherRedisServer() {

--- a/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionExpirationAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionExpirationAcceptanceTest.java
@@ -39,7 +39,7 @@ public class NativeRedisSessionExpirationAcceptanceTest extends SessionExpiratio
     ports.put(APP2, availablePorts[1]);
     ports.put(SERVER1, redisContainer.getFirstMappedPort());
 
-    jedisConnetedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
+    jedisConnectedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
     startSpringApp(APP1, SHORT_SESSION_TIMEOUT, ports.get(SERVER1));
     startSpringApp(APP2, SHORT_SESSION_TIMEOUT, ports.get(SERVER1));
   }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
@@ -274,6 +274,14 @@ public class CrashAndNoRepeatDUnitTest {
         iterationCount += 1;
       } catch (JedisConnectionException ex) {
         if (ex.getMessage().contains("Unexpected end of stream.")) {
+          if (!doWithRetry(() -> connect(jedisRef).get(key)).endsWith(appendString)) {
+            // give some time for the in-flight op to be done
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              Thread.interrupted();
+            }
+          }
           if (doWithRetry(() -> connect(jedisRef).get(key)).endsWith(appendString)) {
             iterationCount += 1;
           }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
@@ -274,14 +274,6 @@ public class CrashAndNoRepeatDUnitTest {
         iterationCount += 1;
       } catch (JedisConnectionException ex) {
         if (ex.getMessage().contains("Unexpected end of stream.")) {
-          if (!doWithRetry(() -> connect(jedisRef).get(key)).endsWith(appendString)) {
-            // give some time for the in-flight op to be done
-            try {
-              Thread.sleep(1000);
-            } catch (InterruptedException e) {
-              Thread.interrupted();
-            }
-          }
           if (doWithRetry(() -> connect(jedisRef).get(key)).endsWith(appendString)) {
             iterationCount += 1;
           }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
@@ -26,30 +26,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import io.lettuce.core.ClientOptions;
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisCommandExecutionException;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisCommands;
-import io.lettuce.core.resource.ClientResources;
 import org.apache.logging.log4j.Logger;
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 import org.apache.geode.cache.control.RebalanceFactory;
 import org.apache.geode.cache.control.RebalanceResults;
 import org.apache.geode.cache.control.ResourceManager;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
-import org.apache.geode.redis.session.springRedisTestApplication.config.DUnitSocketAddressResolver;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
@@ -73,10 +68,9 @@ public class CrashAndNoRepeatDUnitTest {
   private static MemberVM server3;
 
   private static int[] redisPorts;
-
-  private RedisClient redisClient;
-  private StatefulRedisConnection<String, String> connection;
-  private RedisCommands<String, String> commands;
+  private static final String LOCAL_HOST = "127.0.0.1";
+  private static final int JEDIS_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
 
   @Rule
   public ExecutorServiceRule executor = new ExecutorServiceRule();
@@ -119,35 +113,10 @@ public class CrashAndNoRepeatDUnitTest {
 
   }
 
-  @Before
-  public void before() {
-    String redisPort1 = "" + redisPorts[0];
-    String redisPort2 = "" + redisPorts[1];
-    String redisPort3 = "" + redisPorts[2];
-    // For now only tell the client about redisPort1.
-    // That server is never restarted so clients should
-    // never fail due to the server they are connected to failing.
-    DUnitSocketAddressResolver dnsResolver =
-        new DUnitSocketAddressResolver(new String[] {redisPort1});
-
-    ClientResources resources = ClientResources.builder()
-        .socketAddressResolver(dnsResolver)
-        .build();
-
-    redisClient = RedisClient.create(resources, "redis://localhost");
-    redisClient.setOptions(ClientOptions.builder()
-        .autoReconnect(true)
-        .build());
-    connection = redisClient.connect();
-    commands = connection.sync();
+  private synchronized Jedis connect(AtomicReference<Jedis> jedisRef) {
+    jedisRef.set(new Jedis(LOCAL_HOST, redisPorts[0], JEDIS_TIMEOUT));
+    return jedisRef.get();
   }
-
-  @After
-  public void after() {
-    connection.close();
-    redisClient.shutdown();
-  }
-
 
   private MemberVM startRedisVM(int vmID, int redisPort) {
     int locatorPort = locator.getPort();
@@ -166,15 +135,10 @@ public class CrashAndNoRepeatDUnitTest {
     AtomicBoolean running3 = new AtomicBoolean(true);
     AtomicBoolean running4 = new AtomicBoolean(false);
 
-    Runnable task1 = null;
-    Runnable task2 = null;
-    Runnable task3 = null;
-    Runnable task4 = null;
-
-    task1 = () -> appendPerformAndVerify(0, 20000, running1);
-    task2 = () -> appendPerformAndVerify(1, 20000, running2);
-    task3 = () -> appendPerformAndVerify(3, 20000, running3);
-    task4 = () -> appendPerformAndVerify(4, 1000, running4);
+    Runnable task1 = () -> appendPerformAndVerify(1, 20000, running1);
+    Runnable task2 = () -> appendPerformAndVerify(2, 20000, running2);
+    Runnable task3 = () -> appendPerformAndVerify(3, 20000, running3);
+    Runnable task4 = () -> appendPerformAndVerify(4, 1000, running4);
 
     Future<Void> future1 = executor.runAsync(task1);
     Future<Void> future2 = executor.runAsync(task2);
@@ -215,15 +179,10 @@ public class CrashAndNoRepeatDUnitTest {
     AtomicBoolean running3 = new AtomicBoolean(true);
     AtomicBoolean running4 = new AtomicBoolean(false);
 
-    Runnable task1 = null;
-    Runnable task2 = null;
-    Runnable task3 = null;
-    Runnable task4 = null;
-
-    task1 = () -> renamePerformAndVerify(0, 20000, running1);
-    task2 = () -> renamePerformAndVerify(1, 20000, running2);
-    task3 = () -> renamePerformAndVerify(3, 20000, running3);
-    task4 = () -> renamePerformAndVerify(4, 1000, running4);
+    Runnable task1 = () -> renamePerformAndVerify(1, 20000, running1);
+    Runnable task2 = () -> renamePerformAndVerify(2, 20000, running2);
+    Runnable task3 = () -> renamePerformAndVerify(3, 20000, running3);
+    Runnable task4 = () -> renamePerformAndVerify(4, 1000, running4);
 
     Future<Void> future1 = executor.runAsync(task1);
     Future<Void> future2 = executor.runAsync(task2);
@@ -260,8 +219,8 @@ public class CrashAndNoRepeatDUnitTest {
     while (true) {
       try {
         return supplier.get();
-      } catch (RedisCommandExecutionException ex) {
-        if (!ex.getMessage().contains("memberDeparted")) {
+      } catch (JedisConnectionException ex) {
+        if (!ex.getMessage().contains("Unexpected end of stream.")) {
           throw ex;
         }
       }
@@ -269,67 +228,85 @@ public class CrashAndNoRepeatDUnitTest {
   }
 
   private void renamePerformAndVerify(int index, int minimumIterations, AtomicBoolean isRunning) {
+    final AtomicReference<Jedis> jedisRef = new AtomicReference<>();
+    connect(jedisRef);
     String newKey = null;
     String baseKey = "rename-key-" + index;
-    commands.set(baseKey + "-0", "value");
+    jedisRef.get().set(baseKey + "-0", "value");
     int iterationCount = 0;
 
     while (iterationCount < minimumIterations || isRunning.get()) {
       String oldKey = baseKey + "-" + iterationCount;
       newKey = baseKey + "-" + (iterationCount + 1);
       try {
-        commands.rename(oldKey, newKey);
+        jedisRef.get().rename(oldKey, newKey);
         iterationCount += 1;
-      } catch (RedisCommandExecutionException e) {
-        if (e.getMessage().contains("memberDeparted")) {
-          if (doWithRetry(() -> commands.exists(oldKey)) == 0) {
+      } catch (JedisConnectionException ex) {
+        if (ex.getMessage().contains("Unexpected end of stream.")) {
+          if (!doWithRetry(() -> connect(jedisRef).exists(oldKey))) {
             iterationCount += 1;
           }
-        } else if (e.getMessage().contains("no such key")) {
+        } else if (ex.getMessage().contains("no such key")) {
           iterationCount += 1;
         } else {
-          throw e;
+          throw ex;
         }
       }
     }
 
-    assertThat(commands.keys(baseKey + "-*").size()).isEqualTo(1);
-    assertThat(commands.exists(newKey)).isEqualTo(1);
+    assertThat(jedisRef.get().keys(baseKey + "-*").size()).isEqualTo(1);
+    assertThat(jedisRef.get().exists(newKey)).isTrue();
 
     logger.info("--->>> RENAME test ran {} iterations", iterationCount);
+    jedisRef.get().disconnect();
   }
 
   private void appendPerformAndVerify(int index, int minimumIterations, AtomicBoolean isRunning) {
     String key = "append-key-" + index;
     int iterationCount = 0;
+    final AtomicReference<Jedis> jedisRef = new AtomicReference<>();
+    connect(jedisRef);
 
     while (iterationCount < minimumIterations || isRunning.get()) {
-      String appendString = "" + iterationCount % 2;
+      String appendString = "-" + key + "-" + iterationCount + "-";
       try {
-        commands.append(key, appendString);
+        jedisRef.get().append(key, appendString);
         iterationCount += 1;
-      } catch (RedisCommandExecutionException e) {
-        if (e.getMessage().contains("memberDeparted")) {
-          if (doWithRetry(() -> commands.get(key)).endsWith(appendString)) {
+      } catch (JedisConnectionException ex) {
+        if (ex.getMessage().contains("Unexpected end of stream.")) {
+          if (!doWithRetry(() -> connect(jedisRef).get(key)).endsWith(appendString)) {
+            // give some time for the in-flight op to be done
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              Thread.interrupted();
+            }
+          }
+          if (doWithRetry(() -> connect(jedisRef).get(key)).endsWith(appendString)) {
             iterationCount += 1;
           }
         } else {
-          throw e;
+          throw ex;
         }
       }
     }
 
-    String storedString = commands.get(key);
+    String storedString = jedisRef.get().get(key);
+    int idx = 0;
     for (int i = 0; i < iterationCount; i++) {
-      String expectedValue = "" + i % 2;
-      if (!expectedValue.equals("" + storedString.charAt(i))) {
-        Assert.fail("unexpected " + storedString.charAt(i) + " at index " + i + " in string "
+      String expectedValue = "-" + key + "-" + i + "-";
+      String foundValue = storedString.substring(idx, idx + expectedValue.length());
+      if (!expectedValue.equals(foundValue)) {
+        Assert.fail("unexpected " + foundValue + " at index " + i + " iterationCount="
+            + iterationCount + " in string "
             + storedString);
         break;
       }
+      idx += expectedValue.length();
     }
 
     logger.info("--->>> APPEND test ran {} iterations", iterationCount);
+    jedisRef.get().disconnect();
   }
 
   private static void rebalanceAllRegions(MemberVM vm) {

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
@@ -129,6 +129,7 @@ public class CrashAndNoRepeatDUnitTest {
   }
 
   @Test
+  @Ignore("GEODE-8393")
   public void givenServerCrashesDuringAPPEND_thenDataIsNotLost() throws Exception {
     AtomicBoolean running1 = new AtomicBoolean(true);
     AtomicBoolean running2 = new AtomicBoolean(true);

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Supplier;
 
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
@@ -241,18 +240,6 @@ public class HashesAndCrashesDUnitTest {
     future3.get();
   }
 
-  private <T> T doWithRetry(Supplier<T> supplier) {
-    while (true) {
-      try {
-        return supplier.get();
-      } catch (RedisCommandExecutionException ex) {
-        if (!ex.getMessage().contains("memberDeparted")) {
-          throw ex;
-        }
-      }
-    }
-  }
-
   private void hsetPerformAndVerify(int index, int minimumIterations, AtomicBoolean isRunning) {
     String key = "hset-key-" + index;
     int iterationCount = 0;
@@ -262,12 +249,7 @@ public class HashesAndCrashesDUnitTest {
       try {
         commands.hset(key, fieldName, "value-" + iterationCount);
         iterationCount += 1;
-      } catch (RedisCommandExecutionException e) {
-        if (e.getMessage().contains("memberDeparted")) {
-          if (doWithRetry(() -> commands.hexists(key, fieldName))) {
-            iterationCount += 1;
-          }
-        }
+      } catch (RedisCommandExecutionException ignore) {
       }
     }
 
@@ -289,12 +271,7 @@ public class HashesAndCrashesDUnitTest {
       try {
         commands.sadd(key, member);
         iterationCount += 1;
-      } catch (RedisCommandExecutionException e) {
-        if (e.getMessage().contains("memberDeparted")) {
-          if (doWithRetry(() -> commands.sismember(key, member))) {
-            iterationCount += 1;
-          }
-        }
+      } catch (RedisCommandExecutionException ignore) {
       }
     }
 
@@ -318,12 +295,7 @@ public class HashesAndCrashesDUnitTest {
       try {
         commands.set(key, key);
         iterationCount += 1;
-      } catch (RedisCommandExecutionException e) {
-        if (e.getMessage().contains("memberDeparted")) {
-          if (doWithRetry(() -> commands.exists(key)) == 1) {
-            iterationCount += 1;
-          }
-        }
+      } catch (RedisCommandExecutionException ignore) {
       }
     }
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_AD
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
 import static org.apache.geode.redis.internal.GeodeRedisServer.ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM;
+import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisCommandExecutionException;
+import io.lettuce.core.RedisException;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.resource.ClientResources;
@@ -46,6 +48,7 @@ import org.junit.Test;
 import org.apache.geode.cache.control.RebalanceFactory;
 import org.apache.geode.cache.control.RebalanceResults;
 import org.apache.geode.cache.control.ResourceManager;
+import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.session.springRedisTestApplication.config.DUnitSocketAddressResolver;
@@ -120,6 +123,7 @@ public class HashesAndCrashesDUnitTest {
 
   @Before
   public void before() {
+    addIgnoredException(FunctionException.class);
     String redisPort1 = "" + redisPorts[0];
     String redisPort2 = "" + redisPorts[1];
     String redisPort3 = "" + redisPorts[2];
@@ -250,6 +254,12 @@ public class HashesAndCrashesDUnitTest {
         commands.hset(key, fieldName, "value-" + iterationCount);
         iterationCount += 1;
       } catch (RedisCommandExecutionException ignore) {
+      } catch (RedisException ex) {
+        if (ex.getMessage().contains("Connection reset by peer")) {
+          // ignore it
+        } else {
+          throw ex;
+        }
       }
     }
 
@@ -272,6 +282,12 @@ public class HashesAndCrashesDUnitTest {
         commands.sadd(key, member);
         iterationCount += 1;
       } catch (RedisCommandExecutionException ignore) {
+      } catch (RedisException ex) {
+        if (ex.getMessage().contains("Connection reset by peer")) {
+          // ignore it
+        } else {
+          throw ex;
+        }
       }
     }
 
@@ -296,6 +312,12 @@ public class HashesAndCrashesDUnitTest {
         commands.set(key, key);
         iterationCount += 1;
       } catch (RedisCommandExecutionException ignore) {
+      } catch (RedisException ex) {
+        if (ex.getMessage().contains("Connection reset by peer")) {
+          // ignore it
+        } else {
+          throw ex;
+        }
       }
     }
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
@@ -37,7 +37,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.exceptions.JedisException;
 
 import org.apache.geode.redis.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
@@ -178,21 +177,7 @@ public class PubSubDUnitTest {
 
     cluster.crashVM(2);
 
-    // Depending on the timing of this call, it may catch a function error (due to member departed)
-    // and return 0 as a result. Regardless, it should NOT hang.
-    boolean published = false;
-    do {
-      try {
-        result = publisher1.publish(CHANNEL_NAME, "hello again");
-        published = true;
-      } catch (JedisException ex) {
-        if (ex.getMessage().contains("memberDeparted")) {
-          // retry
-        } else {
-          throw ex;
-        }
-      }
-    } while (!published);
+    result = publisher1.publish(CHANNEL_NAME, "hello again");
     assertThat(result).isLessThanOrEqualTo(1);
 
     mockSubscriber1.unsubscribe(CHANNEL_NAME);

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
@@ -37,6 +37,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 
 import org.apache.geode.redis.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
@@ -177,7 +178,20 @@ public class PubSubDUnitTest {
 
     cluster.crashVM(2);
 
-    result = publisher1.publish(CHANNEL_NAME, "hello again");
+    boolean published = false;
+    do {
+      try {
+        result = publisher1.publish(CHANNEL_NAME, "hello again");
+        published = true;
+      } catch (JedisConnectionException ex) {
+        if (ex.getMessage().contains("Unexpected end of stream.")) {
+          publisher1 = new Jedis(LOCAL_HOST, redisServerPort3, 120000);
+          // fall through and retry
+        } else {
+          throw ex;
+        }
+      }
+    } while (!published);
     assertThat(result).isLessThanOrEqualTo(1);
 
     mockSubscriber1.unsubscribe(CHANNEL_NAME);

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/RedisSessionDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/RedisSessionDUnitTest.java
@@ -30,8 +30,7 @@ public class RedisSessionDUnitTest extends SessionDUnitTest {
   @BeforeClass
   public static void setup() {
     SessionDUnitTest.setup();
-    startSpringApp(APP1, DEFAULT_SESSION_TIMEOUT, ports.get(SERVER1), ports.get(SERVER2));
-    startSpringApp(APP2, DEFAULT_SESSION_TIMEOUT, ports.get(SERVER2), ports.get(SERVER1));
+    setupSpringApps(DEFAULT_SESSION_TIMEOUT);
   }
 
   @Test
@@ -40,7 +39,7 @@ public class RedisSessionDUnitTest extends SessionDUnitTest {
     String sessionId = getSessionId(sessionCookie);
 
     Map<String, String> sessionInfo =
-        jedisConnectedToServer1.hgetAll("spring:session:sessions:" + sessionId);
+        commands.hgetall("spring:session:sessions:" + sessionId);
 
     assertThat(sessionInfo.get("sessionAttr:NOTES")).contains("note1");
   }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/RedisSessionDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/RedisSessionDUnitTest.java
@@ -40,7 +40,7 @@ public class RedisSessionDUnitTest extends SessionDUnitTest {
     String sessionId = getSessionId(sessionCookie);
 
     Map<String, String> sessionInfo =
-        jedisConnetedToServer1.hgetAll("spring:session:sessions:" + sessionId);
+        jedisConnectedToServer1.hgetAll("spring:session:sessions:" + sessionId);
 
     assertThat(sessionInfo.get("sessionAttr:NOTES")).contains("note1");
   }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
@@ -135,27 +135,15 @@ public abstract class SessionDUnitTest {
 
   protected String createNewSessionWithNote(int sessionApp, String note) {
     HttpEntity<String> request = new HttpEntity<>(note);
-    boolean noteAdded = false;
     String sessionCookie = "";
-    do {
-      try {
-        HttpHeaders resultHeaders = new RestTemplate()
-            .postForEntity(
-                "http://localhost:" + ports.get(sessionApp)
-                    + "/addSessionNote",
-                request,
-                String.class)
-            .getHeaders();
-        sessionCookie = resultHeaders.getFirst("Set-Cookie");
-        noteAdded = true;
-      } catch (HttpServerErrorException e) {
-        if (e.getMessage().contains("memberDeparted")) {
-          // retry
-        } else {
-          throw e;
-        }
-      }
-    } while (!noteAdded);
+    HttpHeaders resultHeaders = new RestTemplate()
+        .postForEntity(
+            "http://localhost:" + ports.get(sessionApp)
+                + "/addSessionNote",
+            request,
+            String.class)
+        .getHeaders();
+    sessionCookie = resultHeaders.getFirst("Set-Cookie");
 
     return sessionCookie;
   }
@@ -193,29 +181,12 @@ public abstract class SessionDUnitTest {
     List<String> notes = new ArrayList<>();
     Collections.addAll(notes, getSessionNotes(sessionApp, sessionCookie));
     HttpEntity<String> request = new HttpEntity<>(note, requestHeaders);
-    boolean noteAdded = false;
-    do {
-      try {
-        new RestTemplate()
-            .postForEntity(
-                "http://localhost:" + ports.get(sessionApp) + "/addSessionNote",
-                request,
-                String.class)
-            .getHeaders();
-        noteAdded = true;
-      } catch (HttpServerErrorException e) {
-        if (e.getMessage().contains("memberDeparted")) {
-          List<String> updatedNotes = new ArrayList<>();
-          Collections.addAll(updatedNotes, getSessionNotes(sessionApp, sessionCookie));
-          if (notes.containsAll(updatedNotes)) {
-            noteAdded = true;
-          }
-          e.printStackTrace();
-        } else {
-          throw e;
-        }
-      }
-    } while (!noteAdded);
+    new RestTemplate()
+        .postForEntity(
+            "http://localhost:" + ports.get(sessionApp) + "/addSessionNote",
+            request,
+            String.class)
+        .getHeaders();
   }
 
   protected String getSessionId(String sessionCookie) {

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
@@ -70,7 +70,7 @@ public abstract class SessionDUnitTest {
   protected static final Map<Integer, Integer> ports = new HashMap<>();
   public static ConfigurableApplicationContext springApplicationContext;
 
-  protected static Jedis jedisConnetedToServer1;
+  protected static Jedis jedisConnectedToServer1;
   protected static final int JEDIS_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
 
@@ -87,19 +87,19 @@ public abstract class SessionDUnitTest {
     ports.put(SERVER1, cluster.getRedisPort(SERVER1));
     ports.put(SERVER2, cluster.getRedisPort(SERVER2));
 
-    jedisConnetedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
+    jedisConnectedToServer1 = new Jedis("localhost", ports.get(SERVER1), JEDIS_TIMEOUT);
   }
 
   @AfterClass
   public static void cleanupAfterClass() {
-    jedisConnetedToServer1.disconnect();
+    jedisConnectedToServer1.disconnect();
     stopSpringApp(APP1);
     stopSpringApp(APP2);
   }
 
   @After
   public void cleanupAfterTest() {
-    jedisConnetedToServer1.flushAll();
+    jedisConnectedToServer1.flushAll();
   }
 
   protected static void startRedisServer(int server) {

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -76,7 +76,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
 
     refreshSession(sessionCookie, APP2);
 
-    assertThat(jedisConnetedToServer1.ttl("spring:session:sessions:expires:" + sessionId))
+    assertThat(jedisConnectedToServer1.ttl("spring:session:sessions:expires:" + sessionId))
         .isGreaterThan(0);
 
     assertThat(getSessionNotes(APP1, sessionCookie)).isNotNull();
@@ -111,7 +111,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
   private void waitForTheSessionToExpire(String sessionId) {
     GeodeAwaitility.await().ignoreExceptions().atMost((SHORT_SESSION_TIMEOUT + 5), TimeUnit.SECONDS)
         .until(
-            () -> jedisConnetedToServer1.ttl("spring:session:sessions:expires:" + sessionId) == -2);
+            () -> jedisConnectedToServer1.ttl("spring:session:sessions:expires:" + sessionId) == -2);
   }
 
   private void refreshSession(String sessionCookie, int sessionApp) {

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -111,7 +111,8 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
   private void waitForTheSessionToExpire(String sessionId) {
     GeodeAwaitility.await().ignoreExceptions().atMost((SHORT_SESSION_TIMEOUT + 5), TimeUnit.SECONDS)
         .until(
-            () -> jedisConnectedToServer1.ttl("spring:session:sessions:expires:" + sessionId) == -2);
+            () -> jedisConnectedToServer1
+                .ttl("spring:session:sessions:expires:" + sessionId) == -2);
   }
 
   private void refreshSession(String sessionCookie, int sessionApp) {

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -45,8 +45,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
   @BeforeClass
   public static void setup() {
     SessionDUnitTest.setup();
-    startSpringApp(APP1, SHORT_SESSION_TIMEOUT, ports.get(SERVER1), ports.get(SERVER2));
-    startSpringApp(APP2, SHORT_SESSION_TIMEOUT, ports.get(SERVER2), ports.get(SERVER1));
+    setupSpringApps(SHORT_SESSION_TIMEOUT);
   }
 
   @Test
@@ -76,7 +75,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
 
     refreshSession(sessionCookie, APP2);
 
-    assertThat(jedisConnectedToServer1.ttl("spring:session:sessions:expires:" + sessionId))
+    assertThat(commands.ttl("spring:session:sessions:expires:" + sessionId))
         .isGreaterThan(0);
 
     assertThat(getSessionNotes(APP1, sessionCookie)).isNotNull();
@@ -110,9 +109,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
 
   private void waitForTheSessionToExpire(String sessionId) {
     GeodeAwaitility.await().ignoreExceptions().atMost((SHORT_SESSION_TIMEOUT + 5), TimeUnit.SECONDS)
-        .until(
-            () -> jedisConnectedToServer1
-                .ttl("spring:session:sessions:expires:" + sessionId) == -2);
+        .until(() -> commands.ttl("spring:session:sessions:expires:" + sessionId) == -2);
   }
 
   private void refreshSession(String sessionCookie, int sessionApp) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -169,6 +169,13 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       response = RedisResponse.error(cause.getMessage());
     } else if (cause instanceof FunctionInvocationTargetException) {
       // This indicates a member departed
+      // Pause for a second before doing the disconnect to give any part of
+      // this operation that is in flight a chance to complete
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        Thread.interrupted();
+      }
       logger.warn(
           "Closing client connection because one of the servers doing this operation departed.");
       channelInactive(ctx);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -169,13 +169,6 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       response = RedisResponse.error(cause.getMessage());
     } else if (cause instanceof FunctionInvocationTargetException) {
       // This indicates a member departed
-      // Pause for a second before doing the disconnect to give any part of
-      // this operation that is in flight a chance to complete
-      try {
-        Thread.sleep(1000);
-      } catch (InterruptedException e) {
-        Thread.interrupted();
-      }
       logger.warn(
           "Closing client connection because one of the servers doing this operation departed.");
       channelInactive(ctx);


### PR DESCRIPTION
The flaky test is being disabled by this PR and the jira ticket for it will remain open.
Instead of throwing a "memberDeparted" exception message the server will now
log a warning and then disconnect the client. Depending on the client it may then
initiate a reconnect and retry the operation.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
