### PR TITLE
GEODE-8423: Updates Redis API for Geode docs 1.13

### DIFF
--- a/geode-book/master_middleman/source/subnavs/geode-subnav.erb
+++ b/geode-book/master_middleman/source/subnavs/geode-subnav.erb
@@ -2185,22 +2185,8 @@ gfsh</a>
                             </li>
                         </ul>
                     </li>
-                    <li class="has_submenu">
+                    <li>
                         <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/redis_api_for_geode.html">Redis API for <%=vars.product_name%></a>
-                        <ul>
-                            <li>
-                                <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/redis_api_for_geode.html#using-the-api">Using the Redis API for <%=vars.product_name%></a>
-                            </li>
-                            <li>
-                                <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/redis_api_for_geode.html#included-commands">Included Redis Commands</a>
-                            </li>
-                            <li>
-                                <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/redis_api_for_geode.html#advantages-over-redis">Advantages of <%=vars.product_name%> over Redis</a>
-                            </li>
-                            <li>
-                                <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/redis_api_for_geode.html#expiration-accuracy">Expiration Accuracy</a>
-                            </li>
-                        </ul>
                     </li>
                     <li class="has_submenu">
                         <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/lucene_integration.html">Apache Lucene Integration</a>

--- a/geode-docs/reference/topics/gemfire_properties.html.md.erb
+++ b/geode-docs/reference/topics/gemfire_properties.html.md.erb
@@ -487,32 +487,6 @@ off-heap-memory-size=120g</code></pre></td>
 <td><em>not set</em></td>
 </tr>
 <tr>
-<td>redis-bind-address</td>
-<td>Specifies the address on which the Redis API for <%=vars.product_name%> is listening. If set to the empty string or this property is not
-specified, the server listens on all local addresses.
-<td>S</td>
-<td><code>""</code></td>
-</tr>
-<tr>
-<td>redis-enabled</td>
-<td>When the default value of false, the Redis API for <%=vars.product_name%> is not available.  Set
-to true to enable the Redis API for <%=vars.product_name%>.</td>
-<td>S</td>
-<td>false</td>
-</tr>
-<tr>
-<td>redis-password</td>
-<td>Specifies the password that the server uses when a client attempts to authenticate.</td>
-<td>S</td>
-<td>no password set</td>
-</tr>
-<tr>
-<td>redis-port</td>
-<td>Specifies the port on which the server listens for Redis API for <%=vars.product_name%> connections. A value of 0 selects a random port.</td>
-<td>S</td>
-<td>6379</td>
-</tr>
-<tr>
 <td>redundancy-zone</td>
 <td>Defines this member's redundancy zone. Used to separate member's into different groups for satisfying partitioned region redundancy. If this property is set, <%=vars.product_name%> will not put redundant copies of data in members with the same redundancy zone setting. 
 See <a href="../../developing/partitioned_regions/configuring_ha_for_pr.html">Configure High Availability for a Partitioned Region</a> for more details.</td>

--- a/geode-docs/tools_modules/book_intro.html.md.erb
+++ b/geode-docs/tools_modules/book_intro.html.md.erb
@@ -41,7 +41,7 @@ limitations under the License.
 
 -   **[Redis API for <%=vars.product_name%>](redis_api_for_geode.html)**
 
-    The Redis API for <%=vars.product_name%> is experimental and currently being updated.  Once completed, it will allow <%=vars.product_name%> to function as a drop-in replacement for a highly-available Redis data store, letting Redis applications take advantage of <%=vars.product_name%>’s scaling capabilities without changing their client code.
+    The Redis API for <%=vars.product_name%> is experimental and currently under development.  Once completed, it will allow <%=vars.product_name%> to function as a drop-in replacement for a highly-available Redis data store, letting Redis applications take advantage of <%=vars.product_name%>’s scaling capabilities without changing their client code.
 
 -   **[Apache Lucene&reg; Integration](lucene_integration.html)**
 

--- a/geode-docs/tools_modules/book_intro.html.md.erb
+++ b/geode-docs/tools_modules/book_intro.html.md.erb
@@ -41,7 +41,7 @@ limitations under the License.
 
 -   **[Redis API for <%=vars.product_name%>](redis_api_for_geode.html)**
 
-    The Redis API for <%=vars.product_name%> allows <%=vars.product_name%> to function as a drop-in replacement for a Redis data store, letting Redis applications take advantage of <%=vars.product_name%>’s scaling capabilities without changing their client code. Redis clients connect to a <%=vars.product_name%> server in the same way they connect to a Redis server, using a hostname and a port number.
+    The Redis API for <%=vars.product_name%> is experimental and currently being updated.  Once completed, it will allow <%=vars.product_name%> to function as a drop-in replacement for a highly-available Redis data store, letting Redis applications take advantage of <%=vars.product_name%>’s scaling capabilities without changing their client code.
 
 -   **[Apache Lucene&reg; Integration](lucene_integration.html)**
 

--- a/geode-docs/tools_modules/redis_api_for_geode.html.md.erb
+++ b/geode-docs/tools_modules/redis_api_for_geode.html.md.erb
@@ -21,11 +21,10 @@ The Redis API for <%=vars.product_name%> allows <%=vars.product_name%> to functi
 replacement for a highly-available Redis data store, letting Redis applications take advantage of
 <%=vars.product_name%>’s scaling capabilities without changing their client code.
 
-This functionality is currently being updated. It is under active development and is expected to be
-released in Geode 1.14.
+This functionality is currently under development.
 
 For more information please review the [Redis API for Geode RFC](https://cwiki.apache.org/confluence/display/GEODE/Geode+Redis+API+Improvements)
 
-If you are interested in experimenting with the Redis APIs on the develop branch, please follow the
-instructions in the geode-redis [README](https://github.com/apache/geode/blob/develop/geode-redis)
-on the develop branch.
+If you are interested in experimenting with the Redis APIs, please follow the instructions in the
+geode-redis [README](https://github.com/apache/geode/blob/develop/geode-redis) on the develop
+branch.

--- a/geode-docs/tools_modules/redis_api_for_geode.html.md.erb
+++ b/geode-docs/tools_modules/redis_api_for_geode.html.md.erb
@@ -1,4 +1,4 @@
-<% set_title("Redis API for", product_name) %>
+<% set_title("Redis API for", product_name, " - EXPERIMENTAL") %>
 
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
@@ -17,107 +17,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-The Redis API for <%=vars.product_name%> allows a single <%=vars.product_name%> cluster to function as a drop-in replacement for a
-highly-available Redis data store with one database, letting Redis applications take advantage of
-<%=vars.product_name%>’s scaling capabilities without changing their client code. Redis clients connect to a <%=vars.product_name%>
-server in the same way they connect to a Redis server, using a hostname and a port number, with
-optional password authentication.
+The Redis API for <%=vars.product_name%> allows <%=vars.product_name%> to function as a drop-in
+replacement for a highly-available Redis data store, letting Redis applications take advantage of
+<%=vars.product_name%>’s scaling capabilities without changing their client code.
 
-<img src="../images/redis_api_for_geode.png" class="image" />
+This functionality is currently being updated. It is under active development and is expected to be
+released in Geode 1.14.
 
-## <a id="using-the-api" class="no-quick-link"></a>Using the Redis API for <%=vars.product_name%>
+For more information please review the [Redis API for Geode RFC](https://cwiki.apache.org/confluence/display/GEODE/Geode+Redis+API+Improvements)
 
-The <%=vars.product_name%> cluster must have at least one server that is set up to handle the incoming Redis
-commands.
-
-Use gfsh to start at least one server with a command of the form:
-
-```pre
-start server \
-  --name=<serverName> \
-  --locators=<locatorPort> \
-  --redis-port=<redisPort> \
-  --redis-bind-address=<redisBindAddress> \
-  --redis-password=<redisPassword>
-```
-
-Replace `<serverName>` with the name of your server.
-
-Replace `<locatorPort>` with your locator port.
-
-Replace `<redisPort>` with the port that the <%=vars.product_name%> server listens on for Redis commands. The typical port used with a Redis cluster is 6379.
-
-Replace `<redisBindAddress>` with the address of the server host.
-
-Replace `<redisPassword>` with the password clients use to authenticate.
-
-To confirm the server is listening, run:
-
-``` pre
-redis-cli -h <redisBindAddress> -p <redisPort> -a <redisPassword> ping
-```
-
-Replace `<redisBindAddress>`,`<redisPort>`, and `<redisPassword>` with the same values as the server.
-
-If the server is functioning properly, you should see a response of `PONG`.
-
-## <a id="included-commands" class="no-quick-link"></a>Included Redis Commands
-
-The Redis API for <%=vars.product_name%> currently supports the following commands.  See [Redis commands](https://redis.io/commands/) for a complete list of and more information on Redis commands.
-
-**Note**: These commands are supported for Redis 5.
-
--   **Connection**: AUTH, PING, QUIT
--   **Hashes**: HGETALL, HMSET, HSET
--   **Keys**: DEL, EXISTS, EXPIRE, EXPIREAT, KEYS, PERSIST, PEXPIRE, PEXPIREAT, PTTL, RENAME, TTL, TYPE
--   **Publish/Subscribe**: PUBLISH, PSUBSCRIBE, PUNSUBSCRIBE, SUBSCRIBE, UNSUBSCRIBE
--   **Sets**: SADD, SMEMBERS, SREM
--   **Strings**: APPEND, GET, SET
-
-The following Redis API for <%=vars.product_name%> commands are **unsupported**. Unsupported
-commands are available to use, but have not been fully tested. There is no guarantee they will work
-exactly as expected.
-
--   **Connection**: ECHO
--   **Hashes**: HDEL, HEXISTS, HGET, HINCRBY, HINCRBYFLOAT, HKEYS, HLEN, HMGET, HSCAN, HSETNX, HVALS
--   **Keys**: SCAN
--   **Server**: DBSIZE, FLUSHALL (no async option), FLUSHDB (no async option), SHUTDOWN, TIME
--   **Sets**: SCARD, SDIFF, SDIFFSTORE, SINTER, SINTERSTORE, SISMEMBER, SMOVE, SPOP, SRANDMEMBER,
-  SSCAN, SUNION, SUNIONSTORE
--   **Strings**: BITCOUNT, BITOP, BITPOS, DECR, DECRBY, GETBIT, GETRANGE, GETSET, INCR, INCRBY, INCRBYFLOAT, MGET,
-  MSET, MSETNX, PSETEX, SETBIT, SETEX, SETNX, SETRANGE, STRLEN
-
-
-If you already have some Geode servers running with Redis enabled, you can execute the following
-command with gfsh to enable unsupported commands:
-
-```pre
-redis --enable-unsupported-commands
-```
-
-You can also enable unsupported commands when you start the Geode server by setting the Java property `enable-redis-unsupported-commands=true`:
-
-```pre
-start server \
-  --J=-Denable-redis-unsupported-commands=true \
-  --name=<serverName> \
-  --locators=<locatorPort> \
-  --redis-port=<redisPort> \
-  --redis-bind-address=<redisBindAddress> \
-  --redis-password=<redisPassword>
-```
-
-Commands not listed above are **not implemented**.
-
-## <a id="advantages-over-redis" class="no-quick-link"></a>Advantages of <%=vars.product_name%> over Redis
-
-<%=vars.product_name%>’s primary advantage is its **scalability**. While the Redis server is single threaded, <%=vars.product_name%> supports high concurrency. Many Redis clients can execute commands on the <%=vars.product_name%> cluster simultaneously.
-
-<%=vars.product_name%>'s architecture and management features help detect and resolve **network partitioning** problems without explicit management on the part of the Redis client.
-
-## <a id="expiration-accuracy" class="no-quick-link"></a>Expiration Accuracy
-
-Keys are expired in two ways, actively and passively:
-
--   With active expiration, expiration is evaluated whenever a key is accessed. If the key is due to expire, it is deleted. Active expiration is accurate to the millisecond.
--   With passive expiration, keys are evaluated every second. If they are due to expire, they are deleted.  Passive expiration is accurate to the second.
+If you are interested in experimenting with the Redis APIs on the develop branch, please follow the
+instructions in the geode-redis [README](https://github.com/apache/geode/blob/develop/geode-redis)
+on the develop branch.


### PR DESCRIPTION
Documentation for Redis API for Geode that will currently be published for 1.13 are not accurate and need to be updated.