### PR TITLE
DRAFT: fix create region with gw-sender vs alter region --gw-sender d…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1254,13 +1254,8 @@ public class PartitionedRegion extends LocalRegion
   void distributeUpdatedProfileOnSenderCreation() {
     if (!(this.isClosed || this.isLocallyDestroyed)) {
       // tell others of the change in status
-      // alberto Is the below sentence necessary? It provokes a different behavior of Geode between
-      // creating a region with a gateway sender and creating it and then altering it.
-      // This method is called by addGatewaySenderId which is called when altering the region
-      // to add a new sender but not when creating the region with the sender.
-      // this.requiresNotification = true;
-      // new UpdateAttributesProcessor(this).distribute(false);
-      new UpdateAttributesProcessor(this).distribute(true);
+      this.requiresNotification = true;
+      new UpdateAttributesProcessor(this).distribute(false);
     }
   }
 
@@ -1269,6 +1264,10 @@ public class PartitionedRegion extends LocalRegion
     super.addGatewaySenderId(gatewaySenderId);
     new UpdateAttributesProcessor(this).distribute();
     GatewaySender sender = getCache().getGatewaySender(gatewaySenderId);
+    // alberto distributeUpdatedProfileOnSenderCreation() is not called
+    // when creating the region with the gateway sender. If called here
+    // it provokes a different behavior between creating a region with
+    // a gateway sender and creating it and then altering it.
     if (sender != null && !sender.isParallel()) {
       ((PartitionedRegion) this).distributeUpdatedProfileOnSenderCreation();
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1254,8 +1254,13 @@ public class PartitionedRegion extends LocalRegion
   void distributeUpdatedProfileOnSenderCreation() {
     if (!(this.isClosed || this.isLocallyDestroyed)) {
       // tell others of the change in status
-      this.requiresNotification = true;
-      new UpdateAttributesProcessor(this).distribute(false);
+      // alberto Is the below sentence necessary? It provokes a different behavior of Geode between
+      // creating a region with a gateway sender and creating it and then altering it.
+      // This method is called by addGatewaySenderId which is called when altering the region
+      // to add a new sender but not when creating the region with the sender.
+      // this.requiresNotification = true;
+      // new UpdateAttributesProcessor(this).distribute(false);
+      new UpdateAttributesProcessor(this).distribute(true);
     }
   }
 
@@ -1264,10 +1269,6 @@ public class PartitionedRegion extends LocalRegion
     super.addGatewaySenderId(gatewaySenderId);
     new UpdateAttributesProcessor(this).distribute();
     GatewaySender sender = getCache().getGatewaySender(gatewaySenderId);
-    // alberto distributeUpdatedProfileOnSenderCreation() is not called
-    // when creating the region with the gateway sender. If called here
-    // it provokes a different behavior between creating a region with
-    // a gateway sender and creating it and then altering it.
     if (sender != null && !sender.isParallel()) {
       ((PartitionedRegion) this).distributeUpdatedProfileOnSenderCreation();
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1254,7 +1254,11 @@ public class PartitionedRegion extends LocalRegion
   void distributeUpdatedProfileOnSenderCreation() {
     if (!(this.isClosed || this.isLocallyDestroyed)) {
       // tell others of the change in status
-      this.requiresNotification = true;
+      // alberto Is the below sentence necessary? It provokes a different behavior of Geode between
+      // creating a region with a gateway sender and creating it and then altering it.
+      // This method is called by addGatewaySenderId which is called when altering the region
+      // to add a new sender but not when creating the region with the sender.
+      // this.requiresNotification = true;
       new UpdateAttributesProcessor(this).distribute(false);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -1254,11 +1254,7 @@ public class PartitionedRegion extends LocalRegion
   void distributeUpdatedProfileOnSenderCreation() {
     if (!(this.isClosed || this.isLocallyDestroyed)) {
       // tell others of the change in status
-      // alberto Is the below sentence necessary? It provokes a different behavior of Geode between
-      // creating a region with a gateway sender and creating it and then altering it.
-      // This method is called by addGatewaySenderId which is called when altering the region
-      // to add a new sender but not when creating the region with the sender.
-      // this.requiresNotification = true;
+      this.requiresNotification = true;
       new UpdateAttributesProcessor(this).distribute(false);
     }
   }
@@ -1267,8 +1263,14 @@ public class PartitionedRegion extends LocalRegion
   public void addGatewaySenderId(String gatewaySenderId) {
     super.addGatewaySenderId(gatewaySenderId);
     new UpdateAttributesProcessor(this).distribute();
-    ((PartitionedRegion) this).distributeUpdatedProfileOnSenderCreation();
     GatewaySender sender = getCache().getGatewaySender(gatewaySenderId);
+    // alberto distributeUpdatedProfileOnSenderCreation() is not called
+    // when creating the region with the gateway sender. If called here
+    // it provokes a different behavior between creating a region with
+    // a gateway sender and creating it and then altering it.
+    if (sender != null && !sender.isParallel()) {
+      ((PartitionedRegion) this).distributeUpdatedProfileOnSenderCreation();
+    }
     if (sender != null && sender.isParallel() && sender.isRunning()) {
       AbstractGatewaySender senderImpl = (AbstractGatewaySender) sender;
       ((ConcurrentParallelGatewaySenderQueue) senderImpl.getQueues().toArray(new RegionQueue[1])[0])

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -813,6 +813,9 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
                 } else {
                   tempQueue.add(value);
                   putDone = true;
+                  logger.info(
+                      "alberto The value {} is enqueued to the tempQueue for the BucketRegionQueue: {}, bucketId: {}.",
+                      value, bucketFullPath, bucketId);
                   // For debugging purpose.
                   if (isDebugEnabled) {
                     logger.debug(

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
@@ -190,6 +190,11 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
         isOffHeap());
   }
 
+  protected SerializableRunnableIF createPartitionedRegionRedundancy1RunnableNoSenders() {
+    return () -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
+        isOffHeap());
+  }
+
   protected SerializableRunnableIF waitForSenderRunnable() {
     return () -> WANTestBase.waitForSenderRunningState("ln");
   }
@@ -1129,6 +1134,65 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
 
     assertEquals(2000, (vm2Acks + vm3Acks + vm4Acks + vm5Acks));
 
+  }
+
+  /**
+   * Test that when a parallel gateway sender is added to a partitioned region through attributes
+   * mutator,
+   * transaction events are not sent to all region members but only to those who are hosting the
+   * bucket for the event
+   * and thus events are not stored in the TempQueueMap of the ParallelGatewaySenderQueue
+   *
+   */
+  @Test
+  public void testParallelPropagationTxNotificationsNotSentToAllRegionMembersWhenAddingParallelGatewaySenderThroughAttributesMutator()
+      throws Exception {
+    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+
+    createCacheInVMs(nyPort, vm2, vm3);
+
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+
+    vm4.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+    vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+    vm6.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+    vm7.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+
+    vm4.invoke(createPartitionedRegionRedundancy1RunnableNoSenders());
+    vm5.invoke(createPartitionedRegionRedundancy1RunnableNoSenders());
+    vm6.invoke(createPartitionedRegionRedundancy1RunnableNoSenders());
+    vm7.invoke(createPartitionedRegionRedundancy1RunnableNoSenders());
+
+    vm2.invoke(createReceiverPartitionedRegionRedundancy1());
+    vm3.invoke(createReceiverPartitionedRegionRedundancy1());
+
+    vm4.invoke(() -> addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
+    vm5.invoke(() -> addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
+    vm6.invoke(() -> addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
+    vm7.invoke(() -> addSenderThroughAttributesMutator(getTestMethodName() + "_PR", "ln"));
+
+    startSenderInVMs("ln", vm4, vm5, vm6, vm7);
+
+    // before doing any puts, let the senders be running in order to ensure that
+    // not a single event will be lost
+    vm4.invoke(waitForSenderRunnable());
+    vm5.invoke(waitForSenderRunnable());
+    vm6.invoke(waitForSenderRunnable());
+    vm7.invoke(waitForSenderRunnable());
+
+    vm4.invoke(() -> WANTestBase.doTxPuts(getTestMethodName() + "_PR"));
+
+    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 3));
+    vm4.invoke(() -> WANTestBase.verifyQueueSize("ln", 3));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 0));
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 0));
+
+    vm4.invoke(() -> WANTestBase.validateEmptyTempQueueMap("ln"));
+    vm5.invoke(() -> WANTestBase.validateEmptyTempQueueMap("ln"));
+    vm6.invoke(() -> WANTestBase.validateEmptyTempQueueMap("ln"));
+    vm7.invoke(() -> WANTestBase.validateEmptyTempQueueMap("ln"));
   }
 
   private static RegionShortcut[] getRegionShortcuts() {


### PR DESCRIPTION
…ifference

This is a draft PR to see if it fixes, without any undesired effect, the difference in behavior in Geode between creating a region with a gateway sender or creating a region without it and then altering the region to add the gateway sender. In the second case, when executing transactions on partitioned regions, all members in the region are notified and not only those that host the entries corresponding to the transaction. 
The notification in the members who do not host entries for the transaction provokes that they try to queue the event in the gateway sender queue but as they do not host a bucket for the entry in the event, they are queued in ParallelGatewaySenderQueue.tempQueue. These events are removed from there when the event is sent by the primary gateway sender but if the remote site is stopped, these events stored in tempQueue could end up filling up the heap of the member.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
