### PR TITLE
GEODE-8409: S*STORE need to handle target that is not a redis set

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SDiffIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SDiffIntegrationTest.java
@@ -126,9 +126,19 @@ public class SDiffIntegrationTest {
 
   @Test
   public void testSDiffStore_withNonExistentKeys() {
-    jedis.set("set1", "stringValue");
+    String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
+    jedis.sadd("set1", firstSet);
 
     Long resultSize = jedis.sdiffstore("set1", "nonExistent1", "nonExistent2");
+    assertThat(resultSize).isEqualTo(0);
+    assertThat(jedis.exists("set1")).isFalse();
+  }
+
+  @Test
+  public void testSDiffStore_withNonExistentKeys_andNonSetTarget() {
+    jedis.set("string1", "stringValue");
+
+    Long resultSize = jedis.sdiffstore("string1", "nonExistent1", "nonExistent2");
     assertThat(resultSize).isEqualTo(0);
     assertThat(jedis.exists("set1")).isFalse();
   }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SInterIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SInterIntegrationTest.java
@@ -126,9 +126,19 @@ public class SInterIntegrationTest {
 
   @Test
   public void testSInterStore_withNonExistentKeys() {
-    jedis.set("set1", "stringValue");
+    String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
+    jedis.sadd("set1", firstSet);
 
     Long resultSize = jedis.sinterstore("set1", "nonExistent1", "nonExistent2");
+    assertThat(resultSize).isEqualTo(0);
+    assertThat(jedis.exists("set1")).isFalse();
+  }
+
+  @Test
+  public void testSInterStore_withNonExistentKeys_andNonSetTarget() {
+    jedis.set("string1", "stringValue");
+
+    Long resultSize = jedis.sinterstore("string1", "nonExistent1", "nonExistent2");
     assertThat(resultSize).isEqualTo(0);
     assertThat(jedis.exists("set1")).isFalse();
   }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SUnionIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SUnionIntegrationTest.java
@@ -118,9 +118,19 @@ public class SUnionIntegrationTest {
 
   @Test
   public void testSUnionStore_withNonExistentKeys() {
-    jedis.set("set1", "stringValue");
+    String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
+    jedis.sadd("set1", firstSet);
 
     Long resultSize = jedis.sunionstore("set1", "nonExistent1", "nonExistent2");
+    assertThat(resultSize).isEqualTo(0);
+    assertThat(jedis.exists("set1")).isFalse();
+  }
+
+  @Test
+  public void testSUnionStore_withNonExistentKeys_andNonSetTarget() {
+    jedis.set("string1", "stringValue");
+
+    Long resultSize = jedis.sunionstore("string1", "nonExistent1", "nonExistent2");
     assertThat(resultSize).isEqualTo(0);
     assertThat(jedis.exists("set1")).isFalse();
   }


### PR DESCRIPTION
Restore tests for nonexistent keys against a Set data type.