### PR TITLE
GEODE-8379: Allow microseconds value to be zero

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/TimeIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/TimeIntegrationTest.java
@@ -54,7 +54,7 @@ public class TimeIntegrationTest {
 
     assertThat(timestamp).hasSize(2);
     assertThat(Long.parseLong(timestamp.get(0))).isGreaterThan(0);
-    assertThat(Long.parseLong(timestamp.get(1))).isGreaterThan(0);
+    assertThat(Long.parseLong(timestamp.get(1))).isNotNegative();
   }
 
 }


### PR DESCRIPTION
Fix flaky test, Redis "TIME" command microseconds value can be zero.