### PR TITLE
Revert "GEODE-8432: use regionPath directly instead of getRegion when…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -693,14 +693,15 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
 
     boolean isDREvent = isDREvent(sender.getCache(), value);
 
-    String regionPath = value.getRegionPath();
-    if (!isDREvent) {
-      regionPath = ColocationHelper
-          .getLeaderRegion((PartitionedRegion) sender.getCache().getRegion(regionPath))
-          .getFullPath();
+    Region region = value.getRegion();
+    String regionPath = null;
+    if (isDREvent) {
+      regionPath = region.getFullPath();
+    } else {
+      regionPath = ColocationHelper.getLeaderRegion((PartitionedRegion) region).getFullPath();
     }
     if (isDebugEnabled) {
-      logger.debug("Put is for the region {}", regionPath);
+      logger.debug("Put is for the region {}", region);
     }
     if (!this.userRegionNameToShadowPRMap.containsKey(regionPath)) {
       if (isDebugEnabled) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueueJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueueJUnitTest.java
@@ -17,9 +17,7 @@ package org.apache.geode.internal.cache.wan.parallel;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,7 +37,6 @@ import org.mockito.stubbing.Answer;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.DataPolicy;
-import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.PartitionAttributesFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.AbstractBucketRegionQueue;
@@ -76,52 +73,6 @@ public class ParallelGatewaySenderQueueJUnitTest {
     metaRegionFactory = mock(MetaRegionFactory.class);
     queue = new ParallelGatewaySenderQueue(sender, Collections.emptySet(), 0, 1, metaRegionFactory,
         false);
-  }
-
-  @Test
-  public void whenReplicatedDataRegionNotReadyShouldNotThrowException() throws Exception {
-    GatewaySenderEventImpl event = mock(GatewaySenderEventImpl.class);
-    when(event.makeHeapCopyIfOffHeap()).thenReturn(event);
-    when(event.getRegion()).thenReturn(null);
-    String regionPath = "/testRegion";
-    when(event.getRegionPath()).thenReturn(regionPath);
-    Mockito.doThrow(new IllegalStateException()).when(event).release();
-    Queue backingList = new LinkedList();
-    backingList.add(event);
-
-    queue = spy(queue);
-    doReturn(true).when(queue).isDREvent(any(), any());
-    boolean putDone = queue.put(event);
-    assertThat(putDone).isFalse();
-  }
-
-  @Test
-  public void whenPartitionedDataRegionNotReadyShouldNotThrowException() throws Exception {
-    GatewaySenderEventImpl event = mock(GatewaySenderEventImpl.class);
-    when(event.makeHeapCopyIfOffHeap()).thenReturn(event);
-    when(event.getRegion()).thenReturn(null);
-    String regionPath = "/testRegion";
-    when(event.getRegionPath()).thenReturn(regionPath);
-    PartitionedRegion region = mock(PartitionedRegion.class);
-    when(region.getFullPath()).thenReturn(regionPath);
-    when(cache.getRegion(regionPath)).thenReturn(region);
-    PartitionAttributes pa = mock(PartitionAttributes.class);
-    when(region.getPartitionAttributes()).thenReturn(pa);
-    when(pa.getColocatedWith()).thenReturn(null);
-
-    Mockito.doThrow(new IllegalStateException()).when(event).release();
-    Queue backingList = new LinkedList();
-    backingList.add(event);
-
-    BucketRegionQueue bucketRegionQueue = mockBucketRegionQueue(backingList);
-
-    TestableParallelGatewaySenderQueue queue = new TestableParallelGatewaySenderQueue(sender,
-        Collections.emptySet(), 0, 1, metaRegionFactory);
-    queue.setMockedAbstractBucketRegionQueue(bucketRegionQueue);
-
-    queue = spy(queue);
-    boolean putDone = queue.put(event);
-    assertThat(putDone).isFalse();
   }
 
   @Test


### PR DESCRIPTION
… put eve… (#5459)"

This reverts commit 8021084e4fdb4e03ef8495a190cc1618a6db67ba.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
