### PR TITLE
GEODE-8435: restore ability to connect gfsh by serialization version

### DIFF
--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ConnectCommand.java
@@ -171,6 +171,17 @@ public class ConnectCommand extends OfflineGfshCommand {
     // since 1.14, only allow gfsh to connect to cluster that's older than 1.10
     String remoteVersion = null;
     String gfshVersion = gfsh.getVersion();
+    // First: see if serialization versions matches (only works with Geode 1.12 or later cluster)
+    try {
+      String gfshGeodeSerializationVersion = gfsh.getGeodeSerializationVersion();
+      String remoteGeodeSerializationVersion = invoker.getRemoteGeodeSerializationVersion();
+      if (gfshGeodeSerializationVersion.equals(remoteGeodeSerializationVersion)) {
+        return result;
+      }
+    } catch (Exception ignore) {
+    }
+
+    // Fallback: make assumptions based on the product version
     try {
       remoteVersion = invoker.getRemoteVersion();
       int minorVersion = Integer.parseInt(versionComponent(remoteVersion, VERSION_MINOR));


### PR DESCRIPTION
This used to work but was broken recently by changes to rely exclusively on product version.

Although Geode releases were never impacted, loss of this feature causes quite a headache for developers that don't typically pass a product version in their gradle build command, leading to unintuitive errors like `Cannot use a 0.0.0 gfsh client to connect to a 0.0.0 cluster`

Serialization version is the surest way to check gfsh compatibility, since in general it is unwise to make assumptions about product version because it is not intrinsic to Geode.

This PR restores the serialization version check, which was lost during GEODE-8331.  However, serialization version was only exposed in Geode 1.12, and since we are now interoperable back to Geode 1.10, the product version range check is retained as a fallback.