### PR TITLE
GEODE-8404: Simplify AvailablePortHelper

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryDUnitTest.java
@@ -295,7 +295,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
         }
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -637,7 +637,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
           r1.put("key-" + i, new PortfolioPdx(i));
         }
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -650,7 +650,7 @@ public class PdxLocalQueryDUnitTest extends PDXQueryTestBase {
       public Object call() throws Exception {
         Region r1 = getCache().createRegionFactory(RegionShortcut.PARTITION).create(regionName);
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryVersionedClassDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryVersionedClassDUnitTest.java
@@ -69,7 +69,7 @@ public class PdxLocalQueryVersionedClassDUnitTest extends PDXQueryTestBase {
       public Object call() throws Exception {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxQueryDUnitTest.java
@@ -2725,7 +2725,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -2739,7 +2739,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -2831,7 +2831,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.PARTITION).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -2845,7 +2845,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.PARTITION).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -2859,7 +2859,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.PARTITION).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -2977,7 +2977,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -2991,7 +2991,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -3214,7 +3214,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -3228,7 +3228,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -3350,7 +3350,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -3439,7 +3439,7 @@ public class PdxQueryDUnitTest extends PDXQueryTestBase {
       public Object call() throws Exception {
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxStringQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxStringQueryDUnitTest.java
@@ -2011,7 +2011,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
       public Object call() throws Exception {
         Region r1 = getCache().createRegionFactory(RegionShortcut.PARTITION).create(regionName);
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -2025,7 +2025,7 @@ public class PdxStringQueryDUnitTest extends JUnit4CacheTestCase {
         Region r1 = getCache().createRegionFactory(RegionShortcut.PARTITION).create(regionName);
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryParamsAuthorizationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryParamsAuthorizationDUnitTest.java
@@ -74,7 +74,7 @@ public class QueryParamsAuthorizationDUnitTest extends JUnit4CacheTestCase {
       Cache cache = getCache(cf);
       cache.createRegionFactory(RegionShortcut.REPLICATE).create(regName);
       CacheServer server = cache.addCacheServer();
-      int serverPort = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+      int serverPort = AvailablePortHelper.getRandomAvailableTCPPort();
       server.setPort(serverPort);
       server.start();
       return serverPort;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/SelectStarQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/SelectStarQueryDUnitTest.java
@@ -592,7 +592,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
           r1.put("key-" + i, ba);
         }
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -1531,7 +1531,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
         ((GemFireCacheImpl) getCache()).setReadSerializedForTest(true);
         Region r1 = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regName);
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -1622,7 +1622,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
         }
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;
@@ -1644,7 +1644,7 @@ public class SelectStarQueryDUnitTest extends JUnit4CacheTestCase {
         }
 
         CacheServer server = getCache().addCacheServer();
-        int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+        int port = AvailablePortHelper.getRandomAvailableTCPPort();
         server.setPort(port);
         server.start();
         return port;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/PingOpDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/PingOpDistributedTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static java.util.Arrays.asList;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortsForDUnitSite;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -92,7 +92,7 @@ public class PingOpDistributedTest implements Serializable {
 
   @Before
   public void setUp() throws IOException {
-    int[] ports = getRandomAvailableTCPPortsForDUnitSite(2);
+    int[] ports = getRandomAvailableTCPPorts(2);
 
     client = getVM(0);
     server1 = getVM(1);
@@ -160,7 +160,7 @@ public class PingOpDistributedTest implements Serializable {
   public void pingReturnsErrorIfTheTargetServerIsNotAMember() {
     final String poolName = testName.getMethodName();
     parametrizedSetUp(poolName, Collections.singletonList(server1Port));
-    int notUsedPort = getRandomAvailableTCPPortsForDUnitSite(1)[0];
+    int notUsedPort = getRandomAvailableTCPPorts(1)[0];
     InternalDistributedMember fakeDistributedMember =
         new InternalDistributedMember("localhost", notUsedPort);
     client.invoke(() -> {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_LOWER_BOUN
 import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_UPPER_BOUND;
 import static org.apache.geode.internal.AvailablePort.MULTICAST;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRange;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRangeKeepers;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableUDPPort;
 import static org.apache.geode.internal.AvailablePortHelper.initializeUniquePortRange;
@@ -49,7 +48,6 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.junit.runner.RunWith;
 
-import org.apache.geode.internal.AvailablePort.Keeper;
 import org.apache.geode.internal.lang.SystemUtils;
 
 @RunWith(JUnitParamsRunner.class)
@@ -76,30 +74,6 @@ public class AvailablePortHelperIntegrationTest {
         errorCollector.addError(e);
       }
     }
-  }
-
-  @Test
-  public void getRandomAvailableTCPPortRange_returnsNoPorts_ifCountIsZero() {
-    int[] results = getRandomAvailableTCPPortRange(0);
-
-    assertThat(results)
-        .isEmpty();
-  }
-
-  @Test
-  public void getRandomAvailableTCPPortRange_returnsOnePort_ifCountIsOne() {
-    int[] results = getRandomAvailableTCPPortRange(1);
-
-    assertThat(results)
-        .hasSize(1);
-  }
-
-  @Test
-  public void getRandomAvailableTCPPortRange_returnsManyPorts_ifCountIsMany() {
-    int[] results = getRandomAvailableTCPPortRange(10);
-
-    assertThat(results)
-        .hasSize(10);
   }
 
   @Test
@@ -163,95 +137,6 @@ public class AvailablePortHelperIntegrationTest {
   }
 
   @Test
-  public void getRandomAvailableTCPPortRangeKeepers_returnsNoKeepers_ifCountIsZero() {
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(0);
-
-    assertThat(results)
-        .isEmpty();
-  }
-
-  @Test
-  public void getRandomAvailableTCPPortRangeKeepers_returnsOneKeeper_ifCountIsOne() {
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(1);
-
-    assertThat(results)
-        .hasSize(1);
-  }
-
-  @Test
-  public void getRandomAvailableTCPPortRangeKeepers_returnsManyKeepers_ifCountIsMany() {
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(10);
-
-    assertThat(results)
-        .hasSize(10);
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRangeKeepers_returnsUsableKeepers(
-      boolean useMembershipPortRange) {
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(10, useMembershipPortRange);
-
-    results.stream().forEach(keeper ->
-
-    assertThatKeeper(keeper)
-        .isUsable());
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRangeKeepers_returnsUniqueKeepers(
-      boolean useMembershipPortRange) {
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(10, useMembershipPortRange);
-
-    assertThat(keeperPorts(results))
-        .doesNotHaveDuplicates();
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRangeKeepers_returnsNaturallyOrderedPorts(
-      boolean useMembershipPortRange) {
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(10, useMembershipPortRange);
-
-    assertThat(keeperPorts(results))
-        .isSortedAccordingTo(naturalOrder());
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRangeKeepers_returnsConsecutivePorts(
-      boolean useMembershipPortRange) {
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(10, useMembershipPortRange);
-
-    assertThatSequence(keeperPorts(results))
-        .isConsecutive();
-  }
-
-  @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRangeKeepers_returnsPortsInRange(
-      boolean useMembershipPortRange) {
-    int lower =
-        useMembershipPortRange ? DEFAULT_MEMBERSHIP_PORT_RANGE[0] : AVAILABLE_PORTS_LOWER_BOUND;
-    int upper =
-        useMembershipPortRange ? DEFAULT_MEMBERSHIP_PORT_RANGE[1] : AVAILABLE_PORTS_UPPER_BOUND;
-
-    List<Keeper> results = getRandomAvailableTCPPortRangeKeepers(10, useMembershipPortRange);
-
-    keeperPorts(results).forEach(port ->
-
-    assertThat(port)
-        .isGreaterThanOrEqualTo(lower)
-        .isLessThanOrEqualTo(upper));
-  }
-
-  @Test
   public void getRandomAvailableUDPPort_returnsNonZeroUdpPort() {
     int udpPort = getRandomAvailableUDPPort();
 
@@ -286,13 +171,11 @@ public class AvailablePortHelperIntegrationTest {
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPort_returnsUniqueValues(boolean useMembershipPortRange) {
+  public void getRandomAvailableTCPPort_returnsUniqueValues() {
     Collection<Integer> previousPorts = new HashSet<>();
     for (int i = 0; i < 3; ++i) {
 
-      int port = getRandomAvailableTCPPorts(1, useMembershipPortRange)[0];
+      int port = getRandomAvailableTCPPorts(1)[0];
 
       assertThat(previousPorts)
           .doesNotContain(port);
@@ -302,21 +185,19 @@ public class AvailablePortHelperIntegrationTest {
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void initializeUniquePortRange_returnSamePortsForSameRange(
-      boolean useMembershipPortRange) {
+  public void initializeUniquePortRange_returnSamePortsForSameRange() {
     assumeFalse(
-        "Windows has ports scattered throughout the range that makes this test difficult to pass consistently",
+        "Windows has ports scattered throughout the range that makes this test difficult to pass "
+            + "consistently",
         SystemUtils.isWindows());
 
     for (int i = 0; i < 3; ++i) {
 
       initializeUniquePortRange(i);
-      int[] previousPorts = getRandomAvailableTCPPorts(3, useMembershipPortRange);
+      int[] previousPorts = getRandomAvailableTCPPorts(3);
 
       initializeUniquePortRange(i);
-      int[] ports = getRandomAvailableTCPPorts(3, useMembershipPortRange);
+      int[] ports = getRandomAvailableTCPPorts(3);
 
       assertThat(ports)
           .isEqualTo(previousPorts);
@@ -324,19 +205,17 @@ public class AvailablePortHelperIntegrationTest {
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void initializeUniquePortRange_willReturnUniquePortsForUniqueRanges(
-      boolean useMembershipPortRange) {
+  public void initializeUniquePortRange_willReturnUniquePortsForUniqueRanges() {
     assumeFalse(
-        "Windows has ports scattered throughout the range that makes this test difficult to pass consistently",
+        "Windows has ports scattered throughout the range that makes this test difficult to pass "
+            + "consistently",
         SystemUtils.isWindows());
 
     Collection<Integer> previousPorts = new HashSet<>();
     for (int i = 0; i < 3; ++i) {
 
       initializeUniquePortRange(i);
-      int[] results = getRandomAvailableTCPPorts(5, useMembershipPortRange);
+      int[] results = getRandomAvailableTCPPorts(5);
 
       Collection<Integer> ports = toSet(results);
 
@@ -369,26 +248,12 @@ public class AvailablePortHelperIntegrationTest {
         .collect(Collectors.toSet());
   }
 
-  private List<Integer> keeperPorts(List<Keeper> keepers) {
-    return keepers.stream()
-        .map(Keeper::getPort)
-        .collect(Collectors.toList());
-  }
-
   private PortAssertion assertThatPort(int port) {
     return new PortAssertion(port);
   }
 
-  private KeeperAssertion assertThatKeeper(Keeper keeper) {
-    return new KeeperAssertion(keeper);
-  }
-
   private SequenceAssertion assertThatSequence(int[] integers) {
     return new SequenceAssertion(toList(integers));
-  }
-
-  private SequenceAssertion assertThatSequence(List<Integer> integers) {
-    return new SequenceAssertion(integers);
   }
 
   private class PortAssertion {
@@ -417,23 +282,7 @@ public class AvailablePortHelperIntegrationTest {
     }
   }
 
-  private class KeeperAssertion {
-
-    private final Keeper keeper;
-
-    KeeperAssertion(Keeper keeper) {
-      this.keeper = keeper;
-    }
-
-    KeeperAssertion isUsable() {
-      int port = keeper.getPort();
-      keeper.release();
-      assertThatPort(port).isUsable();
-      return this;
-    }
-  }
-
-  private class SequenceAssertion {
+  private static class SequenceAssertion {
 
     private final List<Integer> actual;
 

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/wan/AsyncEventQueueTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/wan/AsyncEventQueueTestBase.java
@@ -180,7 +180,7 @@ public class AsyncEventQueueTestBase extends JUnit4DistributedTestCase {
       Locator.getLocator().stop();
     }
     AsyncEventQueueTestBase test = new AsyncEventQueueTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     Properties props = test.getDistributedSystemProperties();
     props.setProperty(MCAST_PORT, "0");
     // props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
@@ -193,7 +193,7 @@ public class AsyncEventQueueTestBase extends JUnit4DistributedTestCase {
 
   public static Integer createFirstRemoteLocator(int dsId, int remoteLocPort) {
     AsyncEventQueueTestBase test = new AsyncEventQueueTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     Properties props = test.getDistributedSystemProperties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
@@ -944,7 +944,7 @@ public class AsyncEventQueueTestBase extends JUnit4DistributedTestCase {
     InternalDistributedSystem ds = test.getSystem(props);
     cache = CacheFactory.create(ds);
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/OfflineDiskStoreCommandsDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/OfflineDiskStoreCommandsDUnitTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.management.internal.cli.commands;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortsForDUnitSite;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,7 +130,7 @@ public class OfflineDiskStoreCommandsDUnitTest implements Serializable {
     VM locator = getVM(0);
     VM server = getVM(1);
     final int ENTRIES = 100000;
-    int site1Port = getRandomAvailableTCPPortsForDUnitSite(1)[0];
+    int site1Port = getRandomAvailableTCPPort();
 
     File diskStoreDirectory1 = temporaryFolder.newFolder("diskDir1");
     File diskStoreDirectory2 = temporaryFolder.newFolder("diskDir2");
@@ -163,7 +163,7 @@ public class OfflineDiskStoreCommandsDUnitTest implements Serializable {
     VM locator = getVM(0);
     VM server = getVM(1);
     final int ENTRIES = 100000;
-    int site1Port = getRandomAvailableTCPPortsForDUnitSite(1)[0];
+    int site1Port = getRandomAvailableTCPPort();
     String threadName = "Asynchronous disk writer for region";
     int counter = 0;
 
@@ -218,7 +218,7 @@ public class OfflineDiskStoreCommandsDUnitTest implements Serializable {
     VM locator = getVM(0);
     VM server = getVM(1);
     final int ENTRIES = 100000;
-    int site1Port = getRandomAvailableTCPPortsForDUnitSite(1)[0];
+    int site1Port = getRandomAvailableTCPPort();
 
     File diskStoreDirectory1 = temporaryFolder.newFolder("diskDir1");
     File diskStoreDirectory2 = temporaryFolder.newFolder("diskDir2");

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -224,7 +224,7 @@ public class GeodeRedisServerStartupDUnitTest {
 
   @Test
   public void startupFailsGivenPortAlreadyInUse() throws Exception {
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
 
     addIgnoredException("Could not start Server");
     try (Socket interferingSocket = new Socket()) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/UpdateVersionDUnitTest.java
@@ -535,7 +535,7 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
 
   private Integer createFirstRemoteLocator(int dsId, int remoteLocPort) {
     UpdateVersionDUnitTest test = new UpdateVersionDUnitTest();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     Properties props = test.getDistributedSystemProperties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);
@@ -619,7 +619,7 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
     InternalDistributedSystem ds = test.getSystem(props);
     cache = CacheFactory.create(ds);
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     GatewayReceiver receiver = fact.create();
@@ -691,7 +691,7 @@ public class UpdateVersionDUnitTest extends JUnit4DistributedTestCase {
 
   private Integer createFirstLocatorWithDSId(int dsId) {
     UpdateVersionDUnitTest test = new UpdateVersionDUnitTest();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     Properties props = test.getDistributedSystemProperties();
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + dsId);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -314,7 +314,7 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createFirstLocatorWithDSId(int dsId) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, port, port, -1, true);
     return port;
   }
@@ -322,7 +322,7 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createFirstPeerLocator(int dsId) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, port, port, -1, false);
     return port;
   }
@@ -330,7 +330,7 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createSecondLocator(int dsId, int locatorPort) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, locatorPort, port, -1, true);
     return port;
   }
@@ -338,7 +338,7 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createSecondPeerLocator(int dsId, int locatorPort) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, locatorPort, port, -1, false);
     return port;
   }
@@ -346,7 +346,7 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createFirstRemoteLocator(int dsId, int remoteLocPort) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, port, port, remoteLocPort, true);
     return port;
   }
@@ -360,7 +360,7 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createFirstRemotePeerLocator(int dsId, int remoteLocPort) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, port, port, remoteLocPort, false);
     return port;
   }
@@ -368,7 +368,7 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createSecondRemoteLocator(int dsId, int localPort, int remoteLocPort) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, localPort, port, remoteLocPort, true);
     return port;
   }
@@ -390,14 +390,14 @@ public class WANTestBase extends DistributedTestCase {
   public static Integer createSecondRemotePeerLocator(int dsId, int localPort, int remoteLocPort) {
     stopOldLocator();
     WANTestBase test = new WANTestBase();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     test.startLocator(dsId, localPort, port, remoteLocPort, false);
     return port;
   }
 
   public static int createReceiverInSecuredCache() {
     GatewayReceiverFactory fact = WANTestBase.cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);
@@ -2038,7 +2038,7 @@ public class WANTestBase extends DistributedTestCase {
 
   public static int createReceiver() {
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);
@@ -2080,7 +2080,7 @@ public class WANTestBase extends DistributedTestCase {
     InternalDistributedSystem ds = test.getSystem(gemFireProps);
     cache = CacheFactory.create(ds);
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);
@@ -2103,7 +2103,7 @@ public class WANTestBase extends DistributedTestCase {
     InternalDistributedSystem ds = test.getSystem(props);
     cache = CacheFactory.create(ds);
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int receiverPort = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int receiverPort = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(receiverPort);
     fact.setEndPort(receiverPort);
     fact.setManualStart(true);
@@ -2196,7 +2196,7 @@ public class WANTestBase extends DistributedTestCase {
     cache.createDiskStoreFactory().setDiskDirs(new File[] {pdxDir}).setMaxOplogSize(1)
         .create("pdxStore");
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/SenderWithTransportFilterDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/SenderWithTransportFilterDUnitTest.java
@@ -107,7 +107,7 @@ public class SenderWithTransportFilterDUnitTest extends WANTestBase {
     InternalDistributedSystem ds = test.getSystem(props);
     cache = CacheFactory.create(ds);
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     ArrayList<GatewayTransportFilter> transportFilters = new ArrayList<GatewayTransportFilter>();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WANLocatorServerDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WANLocatorServerDUnitTest.java
@@ -58,11 +58,11 @@ public class WANLocatorServerDUnitTest extends WANTestBase {
   @Test
   public void test_3Locators_2Servers() {
 
-    int port1 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port1 = AvailablePortHelper.getRandomAvailableTCPPort();
 
-    int port2 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port2 = AvailablePortHelper.getRandomAvailableTCPPort();
 
-    int port3 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port3 = AvailablePortHelper.getRandomAvailableTCPPort();
 
     vm0.invoke(() -> WANLocatorServerDUnitTest.createLocator(port1, port2, port3, port1));
 
@@ -109,7 +109,7 @@ public class WANLocatorServerDUnitTest extends WANTestBase {
     InternalDistributedSystem ds = test.getSystem(props);
     cache = CacheFactory.create(ds);
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);
@@ -131,7 +131,7 @@ public class WANLocatorServerDUnitTest extends WANTestBase {
     InternalDistributedSystem ds = test.getSystem(props);
     cache = CacheFactory.create(ds);
     CacheServer server = cache.addCacheServer();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     server.setPort(port);
     try {
       server.start();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanAutoDiscoveryDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanAutoDiscoveryDUnitTest.java
@@ -62,7 +62,7 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
   @Test
   public void test_GatewaySender_Started_Before_Locator() {
     try {
-      int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+      int port = AvailablePortHelper.getRandomAvailableTCPPort();
       vm0.invoke(() -> WANTestBase.createCache(port));
       vm0.invoke(
           () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, false));
@@ -341,7 +341,7 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
   @Test
   public void test_RingTopology() {
 
-    int[] ports = AvailablePortHelper.getRandomAvailableTCPPortsForDUnitSite(4);
+    int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(4);
 
     final Set<String> site1LocatorsPort = new HashSet<String>();
     site1LocatorsPort.add("localhost[" + ports[0] + "]");
@@ -397,27 +397,27 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
   @Test
   public void test_3Sites3Locators() {
     final Set<String> site1LocatorsPort = new HashSet<String>();
-    int site1Port1 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site1Port1 = AvailablePortHelper.getRandomAvailableTCPPort();
     site1LocatorsPort.add("localhost[" + site1Port1 + "]");
-    int site1Port2 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site1Port2 = AvailablePortHelper.getRandomAvailableTCPPort();
     site1LocatorsPort.add("localhost[" + site1Port2 + "]");
-    int site1Port3 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site1Port3 = AvailablePortHelper.getRandomAvailableTCPPort();
     site1LocatorsPort.add("localhost[" + site1Port3 + "]");
 
     final Set<String> site2LocatorsPort = new HashSet<String>();
-    int site2Port1 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site2Port1 = AvailablePortHelper.getRandomAvailableTCPPort();
     site2LocatorsPort.add("localhost[" + site2Port1 + "]");
-    int site2Port2 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site2Port2 = AvailablePortHelper.getRandomAvailableTCPPort();
     site2LocatorsPort.add("localhost[" + site2Port2 + "]");
-    int site2Port3 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site2Port3 = AvailablePortHelper.getRandomAvailableTCPPort();
     site2LocatorsPort.add("localhost[" + site2Port3 + "]");
 
     final Set<String> site3LocatorsPort = new HashSet<String>();
-    int site3Port1 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site3Port1 = AvailablePortHelper.getRandomAvailableTCPPort();
     site3LocatorsPort.add("localhost[" + site3Port1 + "]");
-    final int site3Port2 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    final int site3Port2 = AvailablePortHelper.getRandomAvailableTCPPort();
     site3LocatorsPort.add("localhost[" + site3Port2 + "]");
-    int site3Port3 = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int site3Port3 = AvailablePortHelper.getRandomAvailableTCPPort();
     site3LocatorsPort.add("localhost[" + site3Port3 + "]");
 
     Map<Integer, Set<String>> dsVsPort = new HashMap<Integer, Set<String>>();
@@ -560,7 +560,7 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
     int activeThreadCountBefore = Thread.activeCount();
 
     // Start / stop locator
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     WANTestBase.createFirstRemoteLocator(2, port);
     disconnectFromDS();
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanValidationsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanValidationsDUnitTest.java
@@ -1055,7 +1055,7 @@ public class WanValidationsDUnitTest extends WANTestBase {
       cache = new CacheFactory(props).create();
 
       GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-      int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+      int port = AvailablePortHelper.getRandomAvailableTCPPort();
       fact.setStartPort(port);
       fact.setEndPort(port);
       fact.setManualStart(true);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderOperationsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderOperationsDUnitTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.internal.cache.wan.parallel;
 
 import static org.apache.geode.distributed.internal.DistributionConfig.OFF_HEAP_MEMORY_SIZE_NAME;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortsForDUnitSite;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.internal.cache.tier.sockets.Message.MAX_MESSAGE_SIZE_PROPERTY;
 import static org.apache.geode.internal.util.ArrayUtils.asList;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -660,7 +660,7 @@ public class ParallelGatewaySenderOperationsDUnitTest extends WANTestBase {
     String site2SenderId = "site2-sender";
     String site3SenderId = "site3-sender";
     String regionName = testName.getMethodName();
-    int[] ports = getRandomAvailableTCPPortsForDUnitSite(3);
+    int[] ports = getRandomAvailableTCPPorts(3);
     int site1Port = ports[0];
     int site2Port = ports[1];
     int site3Port = ports[2];

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/GatewayReceiverDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/GatewayReceiverDUnitTest.java
@@ -229,7 +229,7 @@ public class GatewayReceiverDUnitTest extends WANTestBase {
 
   public static GatewayReceiver createAndReturnReceiver() {
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);
@@ -246,7 +246,7 @@ public class GatewayReceiverDUnitTest extends WANTestBase {
 
   public static GatewayReceiver createAndReturnUnstartedReceiver() {
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderEventListenerDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderEventListenerDUnitTest.java
@@ -56,7 +56,7 @@ public class SerialGatewaySenderEventListenerDUnitTest extends WANTestBase {
   @Ignore
   @Test
   public void testGatewaySenderEventListenerInvocationWithoutLocator() {
-    int mPort = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int mPort = AvailablePortHelper.getRandomAvailableTCPPort();
     vm4.invoke(() -> WANTestBase.createCacheWithoutLocator(mPort));
     vm5.invoke(() -> WANTestBase.createCacheWithoutLocator(mPort));
     vm6.invoke(() -> WANTestBase.createCacheWithoutLocator(mPort));
@@ -226,7 +226,7 @@ public class SerialGatewaySenderEventListenerDUnitTest extends WANTestBase {
   @Test
   public void testGatewaySenderEventListener_GatewayOperations() {
 
-    int mPort = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int mPort = AvailablePortHelper.getRandomAvailableTCPPort();
     vm4.invoke(() -> WANTestBase.createCacheWithoutLocator(mPort));
     vm5.invoke(() -> WANTestBase.createCacheWithoutLocator(mPort));
     vm6.invoke(() -> WANTestBase.createCacheWithoutLocator(mPort));

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/WANHostNameVerificationDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/WANHostNameVerificationDistributedTest.java
@@ -157,7 +157,7 @@ public class WANHostNameVerificationDistributedTest {
   }
 
   private static void createGatewayReceiver() {
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     GatewayReceiverFactory gwReceiver = getCache().createGatewayReceiverFactory();
     gwReceiver.setStartPort(port);
     gwReceiver.setEndPort(port);

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
@@ -261,7 +261,7 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
 
   private void addCacheServer() throws Exception {
     CacheServer server = getCache().addCacheServer();
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
     server.setPort(port);
     server.start();
   }


### PR DESCRIPTION
Removed the following unused methods:
- `getRandomAvailableTCPPortRange(int)`
- `getRandomAvailableTCPPorts(int,bool)`
- `getRandomAvailableTCPPortRangeKeepers(int)`
- `getRandomAvailableTCPPortRangeKeepers(int,bool)`

Removed two methods that used an ineffective, incorrect calculation to try to distribute ports evenly across VMs:

- `getRandomAvailablePortForDUnitSite()`
- `getRandomAvailableTCPPortsForDUnitSite()`

These methods attempted to distribute ports by using the VM id as a modulus. The intention was something like this (assuming 5 VMs):

VM 1 would get ports 20001, 20006, 20011, 20016, ...
VM 2 would get ports 20002, 20007, 20012, 20017, ...
VM 3 would get ports 20003, 20008, 20013, 20018, ...
VM 4 would get ports 20004, 20009, 20014, 20019, ...
VM 5 would get ports 20000, 20005, 20010, 20015, ...

But the actual calculation distributed ports like this:

VM 1: 20000, 20001, 20002, 20003, 20004, ...
VM 2: 20000, 20002, 20004, 20006, 20008, ...
VM 3: 20001, 20004, 20007, 20010, 20013, ...
VM 4: 20000, 20004, 20008, 20012, 20016, ...
VM 5: 20000, 20005, 20010, 20015, 20020, ...

... with lots of potential port collisions from one VM to another.

The few uses of these methods were replaced by calls to existing methods `getRandomAvailableTCPPort()` and `getRandomAvailableTCPPorts()`, which offer a more reliable method of distributing ports.
