### PR TITLE
GEODE-8459: Redis API for Geode handles errors when member disconnects

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -31,9 +31,11 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.handler.codec.DecoderException;
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.ForcedDisconnectException;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
+import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.ParameterRequirements.RedisParametersMismatchException;
@@ -167,8 +169,10 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     } else if (cause instanceof IllegalStateException
         || cause instanceof RedisParametersMismatchException) {
       response = RedisResponse.error(cause.getMessage());
-    } else if (cause instanceof FunctionInvocationTargetException) {
-      // This indicates a member departed
+    } else if (cause instanceof FunctionInvocationTargetException
+        || cause instanceof DistributedSystemDisconnectedException
+        || cause instanceof ForcedDisconnectException) {
+      // This indicates a member departed or got disconnected
       logger.warn(
           "Closing client connection because one of the servers doing this operation departed.");
       channelInactive(ctx);


### PR DESCRIPTION
Redis API for Geode should properly handle DistributedSystemDisconnectedException and ForcedDisconnectException when member disconnects. Client should be closed and a null response should be returned.
