### PR TITLE
GEODE-8463: server's log filled with SSLException: Tag mismatch!

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/SSLUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SSLUtil.java
@@ -19,6 +19,7 @@ import java.security.KeyStore;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
+import java.util.Arrays;
 import java.util.Objects;
 
 import javax.net.ssl.KeyManager;
@@ -28,7 +29,9 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
 
+import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
 
 import org.apache.geode.annotations.VisibleForTesting;
 
@@ -38,6 +41,8 @@ public class SSLUtil {
    * this list as new algorithms become available and are supported by Geode. Remove old,
    * no-longer trusted algorithms.
    */
+  protected static final String[] DEFAULT_ALGORITMS_PRE_JAVA11 = {
+      "TLSv1.2"};
   protected static final String[] DEFAULT_ALGORITMS = {
       "TLSv1.3",
       "TLSv1.2"}; // TLSv1.3 is not available in JDK 8 at this time
@@ -47,7 +52,21 @@ public class SSLUtil {
   public static SSLContext getSSLContextInstance(SSLConfig sslConfig)
       throws NoSuchAlgorithmException {
     String[] protocols = sslConfig.getProtocolsAsStringArray();
-    return findSSLContextForProtocols(protocols, DEFAULT_ALGORITMS);
+    String[] protocolsForAny = getDefaultAlgorithms();
+    return findSSLContextForProtocols(protocols, protocolsForAny);
+  }
+
+  /**
+   * Returns the default algorithms that are used to search for an SSLContext
+   * when "any" is given as the protocol by the user.
+   */
+  public static String[] getDefaultAlgorithms() {
+    if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_11)) {
+      return DEFAULT_ALGORITMS;
+    } else {
+      // tlsv1.3 is not supported by Geode before JAVA 11
+      return DEFAULT_ALGORITMS_PRE_JAVA11;
+    }
   }
 
   /**
@@ -64,22 +83,34 @@ public class SSLUtil {
   protected static SSLContext findSSLContextForProtocols(final String[] protocols,
       final String[] protocolsForAny)
       throws NoSuchAlgorithmException {
+    SSLContext result = null;
     for (String protocol : protocols) {
       if (protocol.equalsIgnoreCase("any")) {
         try {
-          return findSSLContextForProtocols(protocolsForAny, new String[0]);
+          result = findSSLContextForProtocols(protocolsForAny, new String[0]);
+          break;
         } catch (NoSuchAlgorithmException e) {
           // none of the default algorithms is available - continue to see if there
           // are any others in the requested list
         }
       }
       try {
-        return SSLContext.getInstance(protocol);
+        result = SSLContext.getInstance(protocol);
+        break;
       } catch (NoSuchAlgorithmException e) {
         // continue
       }
     }
-    throw new NoSuchAlgorithmException();
+    if (result != null) {
+      if (result.getProtocol().equalsIgnoreCase("tlsv1.3") &&
+          SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_10)) {
+        throw new IllegalStateException("TLSv1.3 is not supported for this JRE - please use TLSv1.2"
+            + " or upgrade to Java 11");
+      }
+      return result;
+    }
+    throw new NoSuchAlgorithmException("unable to find support for configured TLS protocols: " +
+        Arrays.toString(protocols));
   }
 
   /** Read an array of values from a string, whitespace or comma separated. */

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SSLUtilTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SSLUtilTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.internal.net;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,6 +24,8 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 
 public class SSLUtilTest {
@@ -73,12 +76,46 @@ public class SSLUtilTest {
   }
 
   @Test
+  public void testAnyAndTLSv1_3() throws NoSuchAlgorithmException {
+    final String[] algorithms = {"any"};
+    final SSLContext sslContextInstance =
+        SSLUtil.findSSLContextForProtocols(algorithms, SSLUtil.getDefaultAlgorithms());
+    if (sslContextInstance.getProtocol().equalsIgnoreCase("tlsv1.3")) {
+      // GEODE-8463: TLSV1.3 is not supported by Geode until Java 11
+      assertThat(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_11));
+    }
+  }
+
+  @Test
+  public void testTLSv1_3_specified() {
+    final String[] algorithms = {"TLSv1.3"};
+    try {
+      final SSLContext sslContextInstance =
+          SSLUtil.findSSLContextForProtocols(algorithms, SSLUtil.getDefaultAlgorithms());
+      if (sslContextInstance.getProtocol().equalsIgnoreCase("tlsv1.3")) {
+        // GEODE-8463: TLSV1.3 is not supported by Geode until Java 11
+        assertThat(SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_11));
+      }
+    } catch (IllegalStateException e) {
+      assertThat(SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_10));
+    } catch (NoSuchAlgorithmException e) {
+      // TLSv1.3 is not available in this JVM
+      try {
+        SSLContext context = SSLContext.getInstance("TLSv1.3");
+        fail("Expected TLSv1.3 to not be supported in this JVM but found " + context);
+      } catch (NoSuchAlgorithmException e2) {
+        // expected
+      }
+    }
+  }
+
+  @Test
   public void getARealProtocolAfterProcessingAny() throws Exception {
-    final String[] algorithms = {"dream weaver", "any", "TLSv1.1"};
+    final String[] algorithms = {"dream weaver", "any", "TLSv1.2"};
     final String[] algorithmsForAny = new String[] {"sweet dreams (are made of this)"};
     final SSLContext sslContextInstance = SSLUtil.findSSLContextForProtocols(algorithms,
         algorithmsForAny);
-    assertThat(sslContextInstance.getProtocol().equalsIgnoreCase("TLSv1.1")).isTrue();
+    assertThat(sslContextInstance.getProtocol().equalsIgnoreCase("TLSv1.2")).isTrue();
   }
 
 }


### PR DESCRIPTION
This disables the use of TLSv1.3 selection if "any" is specified as the
protocol and throws an exception if TLSv1.3 is requested in a JVM older
than Java 11.  Most Java 8 implementations do not support TLSv1.3 - this
is only an issue (presently) with Oracle's 1.8.0_261 and above.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
