### PR TITLE
GEODE-8462: Make geode server startup fail if geode redis server has a port conflict

### DIFF
--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -92,6 +92,10 @@ configurations{
   }
 }
 
+acceptanceTest {
+  environment 'GEODE_HOME', "$buildDir/../../geode-assembly/build/install/apache-geode"
+}
+
 tasks.register("redisAPITest") {
   dependsOn ':geode-assembly:installDist'
   doLast {

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GeodeRedisServerStartUpAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GeodeRedisServerStartUpAcceptanceTest.java
@@ -37,7 +37,7 @@ public class GeodeRedisServerStartUpAcceptanceTest {
   @Test
   public void shouldReturnErrorMessage_givenSamePortAndAddress() throws IOException {
 
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
 
     String startServerCommand = String.join(" ",
         "start server",
@@ -59,7 +59,7 @@ public class GeodeRedisServerStartUpAcceptanceTest {
   @Test
   public void shouldReturnErrorMessage_givenSamePortAndAllAddresses() throws IOException {
 
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
 
     String startServerCommand = String.join(" ",
         "start server",

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GeodeRedisServerStartUpAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GeodeRedisServerStartUpAcceptanceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.test.junit.rules.gfsh.GfshExecution;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+import org.apache.geode.test.junit.rules.gfsh.GfshScript;
+
+public class GeodeRedisServerStartUpAcceptanceTest {
+
+  @Rule
+  public GfshRule gfshRule = new GfshRule();
+
+  @Test
+  public void shouldReturnErrorMessage_givenSamePortAndAddress() throws IOException {
+
+    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+
+    String startServerCommand = String.join(" ",
+        "start server",
+        "--name", "same-port-and-address-server",
+        "--redis-bind-address", "localhost",
+        "--redis-port", String.valueOf(port));
+    GfshExecution execution;
+
+    try (Socket interferingSocket = new Socket()) {
+      interferingSocket.bind(new InetSocketAddress("localhost", port));
+      execution = GfshScript.of(startServerCommand)
+          .expectFailure()
+          .execute(gfshRule);
+    }
+
+    assertThat(execution.getOutputText()).containsIgnoringCase("address already in use");
+  }
+
+  @Test
+  public void shouldReturnErrorMessage_givenSamePortAndAllAddresses() throws IOException {
+
+    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+
+    String startServerCommand = String.join(" ",
+        "start server",
+        "--name", "same-port-all-addresses-server",
+        "--redis-port", String.valueOf(port));
+    GfshExecution execution;
+
+    try (Socket interferingSocket = new Socket()) {
+      interferingSocket.bind(new InetSocketAddress("0.0.0.0", port));
+      execution = GfshScript.of(startServerCommand)
+          .expectFailure()
+          .execute(gfshRule);
+    }
+
+    assertThat(execution.getOutputText()).containsIgnoringCase("address already in use");
+  }
+
+  @Test
+  public void shouldReturnErrorMessage_givenInvalidBindAddress() {
+
+    String startServerCommand = String.join(" ",
+        "start server",
+        "--name", "invalid-bind-server",
+        "--redis-bind-address", "1.1.1.1");
+    GfshExecution execution;
+
+    execution = GfshScript.of(startServerCommand)
+        .expectFailure()
+        .execute(gfshRule);
+
+    assertThat(execution.getOutputText()).containsIgnoringCase(
+        "The redis-bind-address 1.1.1.1 is not a valid address for this machine");
+  }
+}

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExpireAtNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExpireAtNativeRedisAcceptanceTest.java
@@ -34,16 +34,20 @@ public class ExpireAtNativeRedisAcceptanceTest extends ExpireAtIntegrationTest {
   @ClassRule
   public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
 
+  private static GenericContainer redisContainer;
+
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
+    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
     redisContainer.start();
+
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
   }
 
   @AfterClass
   public static void classLevelTearDown() {
     jedis.close();
+    redisContainer.stop();
   }
 
 }

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -226,7 +226,7 @@ public class GeodeRedisServerStartupDUnitTest {
   public void startupFailsGivenPortAlreadyInUse() throws Exception {
     int port = AvailablePortHelper.getRandomAvailableTCPPort();
 
-    addIgnoredException("Could not start Server");
+    addIgnoredException("Could not start Redis Server");
     try (Socket interferingSocket = new Socket()) {
       interferingSocket.bind(new InetSocketAddress("localhost", port));
       assertThatThrownBy(() -> cluster.startServerVM(0, s -> s
@@ -235,6 +235,19 @@ public class GeodeRedisServerStartupDUnitTest {
           .withProperty(REDIS_ENABLED, "true")))
               .hasRootCauseMessage("Address already in use");
     }
+  }
+
+  @Test
+  public void startupFailsGivenInvalidBindAddress() {
+    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+
+    addIgnoredException("Could not start Redis Server");
+    assertThatThrownBy(() -> cluster.startServerVM(0, s -> s
+        .withProperty(REDIS_PORT, "" + port)
+        .withProperty(REDIS_BIND_ADDRESS, "1.1.1.1")
+        .withProperty(REDIS_ENABLED, "true")))
+            .hasStackTraceContaining(
+                "The redis-bind-address 1.1.1.1 is not a valid address for this machine");
   }
 
   @Test

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -239,7 +239,7 @@ public class GeodeRedisServerStartupDUnitTest {
 
   @Test
   public void startupFailsGivenInvalidBindAddress() {
-    int port = AvailablePortHelper.getRandomAvailablePortForDUnitSite();
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
 
     addIgnoredException("Could not start Redis Server");
     assertThatThrownBy(() -> cluster.startServerVM(0, s -> s


### PR DESCRIPTION

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
