### PR TITLE
DRAFT: Do not store dropped events in stopped primary gateway sender when po…

### DIFF
--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1715,6 +1715,20 @@ public class WANTestBase extends DistributedTestCase {
     }
   }
 
+  public static void stopSenderInVMsAsync(String senderId, VM... vms) {
+    List<AsyncInvocation> tasks = new LinkedList<>();
+    for (VM vm : vms) {
+      tasks.add(vm.invokeAsync(() -> stopSender(senderId)));
+    }
+    for (AsyncInvocation invocation : tasks) {
+      try {
+        invocation.await();
+      } catch (InterruptedException e) {
+        fail("Stopping senders was interrupted");
+      }
+    }
+  }
+
   public static void stopSender(String senderId) {
     final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
     IgnoredException exp =

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationLoopBackDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationLoopBackDUnitTest.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.cache.wan.WANTestBase;
+import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.junit.categories.WanTest;
 
@@ -370,8 +371,8 @@ public class ParallelWANPropagationLoopBackDUnitTest extends WANTestBase {
    */
   @Test
   public void unstartedSenderShouldNotAddReceivedEventsIntoTmpDropped() throws Exception {
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(2));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(1, lnPort));
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(2));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(1, lnPort));
 
     // create receiver on site-ln and site-ny
     createCacheInVMs(lnPort, vm2, vm4);
@@ -379,60 +380,303 @@ public class ParallelWANPropagationLoopBackDUnitTest extends WANTestBase {
     createCacheInVMs(nyPort, vm3, vm5);
     createReceiverInVMs(vm3, vm5);
 
-    // create senders on site-ln, Note: sender-id is its destination, i.e. ny
+    // create senders on site-ny, Note: sender-id is its destination, i.e. ny
     vm2.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, true));
     vm4.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, true));
 
-    // create senders on site-ny, Note: sender-id is its destination, i.e. ln
+    // create senders on site-ln, Note: sender-id is its destination, i.e. ln
     vm3.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
     vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
 
-    // create PR on site-ln
+    // create PR on site-ny
     vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
         isOffHeap()));
     vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
         isOffHeap()));
 
-    // create PR on site-ny
+    // create PR on site-ln
     vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
         isOffHeap()));
     vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
         isOffHeap()));
 
-    // start sender on site-ln
+    // start sender on site-ny
     startSenderInVMs("ny", vm2, vm4);
-    // Do 100 puts on site-ln
-    vm2.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 100));
 
-    // verify site-ny received the 100 events
+    // do 100 puts on site-ln
+    vm3.invoke(() -> WANTestBase.doPutsFrom(getTestMethodName() + "_PR", 0, 100));
+
+    // verify site-ny have 100 entries
     vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
     vm5.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
 
-    // verify tmpDroppedEvents should be 0 at site-ny
-    vm3.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ln", 0));
-    vm5.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ln", 0));
-
-    // do next 100 puts on site-ny
-    vm3.invoke(() -> WANTestBase.doPutsFrom(getTestMethodName() + "_PR", 100, 200));
-
-    // verify site-ny have 200 entries
-    vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 200));
-    vm5.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 200));
-
-    // verify tmpDroppedEvents should be 100 at site-ny, because the sender is not started yet
+    // verify tmpDroppedEvents should be 100 at site-ln, because the sender is not started yet
     vm3.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ln", 100));
     vm5.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ln", 100));
 
     // verify site-ln has not received the events from site-ny yet
-    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
-    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 0));
+    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 0));
 
-    // start sender on site-ny
+    // start sender on site-ln
     startSenderInVMsAsync("ln", vm3, vm5);
 
     // verify tmpDroppedEvents should be 0 now at site-ny
     vm3.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ln", 0));
     vm5.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ln", 0));
+
+    vm3.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+    vm5.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
   }
 
+  /**
+   * Test that gateway sender's secondary queues do not keep dropped events
+   * by the primary gateway sender received while it was starting but was not
+   * started yet, after the primary finishes starting.
+   * Site-LN: dsid=2: senderId="ny": vm2, vm4
+   * Site-NY: dsid=1: senderId="ln": vm3, vm6
+   * NY site's sender's manual-start=true
+   * LN site's sender's manual-start=true
+   *
+   * put some events from LN and start the sender in NY simultaneously
+   * Make sure there are no events in tmpDroppedEvents and the queues are drained.
+   */
+  @Test
+  public void startedSenderReceivingEventsWhileStartingShouldDrainQueues()
+      throws Exception {
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(2));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(1, lnPort));
+
+    createCacheInVMs(lnPort, vm2, vm4);
+    createReceiverInVMs(vm2, vm4);
+    createCacheInVMs(nyPort, vm3, vm5);
+    createReceiverInVMs(vm3, vm5);
+
+    vm2.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, true));
+    vm4.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, true));
+
+    vm3.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+    vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true));
+
+    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+
+    vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+
+    AsyncInvocation inv =
+        vm2.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
+    startSenderInVMsAsync("ny", vm2, vm4);
+    inv.join();
+
+    vm2.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+    vm4.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+
+    vm2.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+    vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+  }
+
+  /**
+   * Test that gateway sender's secondary queues do not keep dropped events
+   * by the primary gateway sender received while it was stopping after it is started again.
+   * Site-LN: dsid=2: senderId="ny": vm2, vm4
+   * Site-NY: dsid=1: senderId="ln": vm3, vm6
+   * NY site's sender's manual-start=false
+   * LN site's sender's manual-start=false
+   *
+   * put some events from LN and stop the sender in NY simultaneously
+   * Start the sender in NY.
+   * Make sure there are no events in tmpDroppedEvents and the queues are drained.
+   */
+  @Test
+  public void startedSenderReceivingEventsWhileStoppingShouldDrainQueues()
+      throws Exception {
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(2));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(1, lnPort));
+
+    createCacheInVMs(lnPort, vm2, vm4);
+    createReceiverInVMs(vm2, vm4);
+    createCacheInVMs(nyPort, vm3, vm5);
+    createReceiverInVMs(vm3, vm5);
+
+    vm2.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, false));
+    vm4.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, false));
+
+    vm3.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, false));
+    vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, false));
+
+    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+
+    vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+
+    AsyncInvocation inv =
+        vm2.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
+    stopSenderInVMsAsync("ny", vm2, vm4);
+    inv.join();
+
+    startSenderInVMsAsync("ny", vm2, vm4);
+
+    vm2.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+    vm4.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+
+    vm2.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+    vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+  }
+
+  /**
+   * Test that a stopped gateway sender receiving events
+   * does not store them in tmpDroppedEvents but after started
+   * does not leave any event in the
+   * gateway sender's secondary queues.
+   * Site-LN: dsid=2: senderId="ny": vm2, vm4
+   * Site-NY: dsid=1: senderId="ln": vm3, vm6
+   * NY site's sender's manual-start=false
+   * LN site's sender's manual-start=false
+   *
+   * put some events from LN and stop the sender in NY simultaneously
+   * Start the sender in NY.
+   * Make sure there are no events in tmpDroppedEvents and the queues are drained.
+   */
+  @Test
+  public void stoppedSenderShouldNotAddEventsToTmpDroppedEventsButStillDrainQueuesWhenStarted()
+      throws Exception {
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(2));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(1, lnPort));
+
+    createCacheInVMs(lnPort, vm2, vm4);
+    createReceiverInVMs(vm2, vm4);
+    createCacheInVMs(nyPort, vm3, vm5);
+    createReceiverInVMs(vm3, vm5);
+
+    vm2.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, false));
+    vm4.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, false));
+
+    vm3.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, false));
+    vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, false));
+
+    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+
+    vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+
+    stopSenderInVMsAsync("ny", vm2, vm4);
+
+    vm2.invoke(() -> WANTestBase.doPutsFrom(getTestMethodName() + "_PR", 0, 100));
+
+    // verify tmpDroppedEvents is 0 at site-ny
+    vm2.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+    vm4.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
+    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
+
+    vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 0));
+    vm5.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 0));
+
+
+    startSenderInVMsAsync("ny", vm2, vm4);
+
+    vm2.invoke(() -> WANTestBase.doPutsFrom(getTestMethodName() + "_PR", 100, 1000));
+
+    vm2.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+    vm4.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
+    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
+
+    vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 900));
+    vm5.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 900));
+
+    // verify the secondary's queues are drained at site-ny
+    vm2.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+    vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+  }
+
+  /**
+   * Test that a stopped primary gateway sender receiving events
+   * does not store them in tmpDroppedEvents but after started
+   * does not leave any event in the
+   * gateway sender's secondary queues.
+   * Site-LN: dsid=2: senderId="ny": vm2, vm4
+   * Site-NY: dsid=1: senderId="ln": vm3, vm6
+   * NY site's sender's manual-start=false
+   * LN site's sender's manual-start=false
+   *
+   * put some events from LN and stop one instance of the sender in NY simultaneously
+   * Start the stopped instance of the sender in NY.
+   * Make sure there are no events in tmpDroppedEvents and the queues are drained.
+   */
+  @Test
+  public void stoppedPrimarySenderShouldNotAddEventsToTmpDroppedEventsButStillDrainQueuesWhenStarted()
+      throws Exception {
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(2));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(1, lnPort));
+
+    createCacheInVMs(lnPort, vm2, vm4);
+    createReceiverInVMs(vm2, vm4);
+    createCacheInVMs(nyPort, vm3, vm5);
+    createReceiverInVMs(vm3, vm5);
+
+    vm2.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, false));
+    vm4.invoke(() -> WANTestBase.createSender("ny", 1, true, 100, 10, false, false, null, false));
+
+    vm3.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, false));
+    vm5.invoke(() -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, false));
+
+    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ny", 1, 100,
+        isOffHeap()));
+
+    vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+
+    stopSenderInVMsAsync("ny", vm2);
+
+    vm2.invoke(() -> WANTestBase.doPutsFrom(getTestMethodName() + "_PR", 0, 100));
+
+    // verify tmpDroppedEvents is 0 at site-ny
+    vm2.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+    vm4.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
+    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 100));
+
+    vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 50));
+    vm5.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 50));
+
+    startSenderInVMsAsync("ny", vm2);
+
+    vm2.invoke(() -> WANTestBase.doPutsFrom(getTestMethodName() + "_PR", 100, 1000));
+
+    vm2.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+    vm4.invoke(() -> WANTestBase.verifyTmpDroppedEventSize("ny", 0));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
+    vm4.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
+
+    vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 950));
+    vm5.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 950));
+
+    // verify the secondary's queues are drained at site-ny
+    vm2.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+    vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ny"));
+  }
 }


### PR DESCRIPTION
…ssible

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

This Draft PR tries to provide an alternative solution to the ones offered in RFC https://cwiki.apache.org/confluence/display/GEODE/Avoid+the+queuing+of+dropped+events+by+the+primary+gateway+sender+when+the+gateway+sender+is+stopped.

The high level idea consists of instead of trying not to store dropped events in tmpDroppedEvents to later send batch removal messages when the primary gateway sender is not started. Instead try to send the batch removal message when the event to be dropped is received. That way, when the sender is stopped for a long time and there are events coming, the memory of the AbstractGatewaySender will not grow with entries in the tmpDroppedEvents member.

In order to send the batch removal message directly, the eventProcessor for the AbstractGatewaySender must have been created. If it is not yet created because the sender was created with manual start set to true, while receiving events to be dropped, they will be stored in tmpDroppedEvents as there is no other choice. Nevertheless, in order to consume less memory, the event stored will be a simplified event containing only the necessary information to handle it.
