### PR TITLE
GEODE-8467: server fails to notify of a ForcedDisconnect and fails to tear down the cache

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -19,7 +19,9 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -92,6 +94,7 @@ public class GemFireCacheImplTest {
     typeRegistry = mock(TypeRegistry.class);
 
     DistributionConfig distributionConfig = mock(DistributionConfig.class);
+    when(distributionConfig.getUseSharedConfiguration()).thenReturn(false);
     DistributionManager distributionManager = mock(DistributionManager.class);
     ReplyProcessor21 replyProcessor21 = mock(ReplyProcessor21.class);
 
@@ -660,6 +663,15 @@ public class GemFireCacheImplTest {
     assertThat(nTrue.get()).isEqualTo(11);
     // 9 threads return false for locking
     assertThat(nFalse.get()).isEqualTo(9);
+  }
+
+  @Test
+  public void cacheXmlGenerationErrorDisablesAutoReconnect() {
+    gemFireCacheImpl.prepareForReconnect((printWriter) -> {
+      throw new RuntimeException("error generating cache XML");
+    });
+    verify(internalDistributedSystem.getConfig()).setDisableAutoReconnect(Boolean.TRUE);
+    verify(cacheConfig, never()).setCacheXMLDescription(isA(String.class));
   }
 
   @SuppressWarnings({"LambdaParameterHidesMemberVariable", "OverlyCoupledMethod", "unchecked"})

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -2023,13 +2023,14 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
         return;
       }
 
-      listener.saveConfig();
-
-      Thread reconnectThread = new LoggingThread("DisconnectThread", false, () -> {
-        lifecycleListener.forcedDisconnect();
-        uncleanShutdown(reason, shutdownCause);
-      });
-      reconnectThread.start();
+      try {
+        listener.saveConfig();
+      } finally {
+        new LoggingThread("DisconnectThread", false, () -> {
+          lifecycleListener.forcedDisconnect();
+          uncleanShutdown(reason, shutdownCause);
+        }).start();
+      }
     }
 
 


### PR DESCRIPTION
Catch exceptions that occur during XML generation and disable auto
reconnect.

Ensure that the DisconnectThread is launched by placing it in a
"finally" block.

@kamilla1201 @Bill

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
