### PR TITLE
GEODE-8486: record TransactionDataRebalancedException if tx put failed

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -148,7 +148,7 @@ public class TXState implements TXStateInterface {
   /** keeps track of results of txPutEntry */
   private Map<EventID, Boolean> seenResults = new HashMap<>();
   /** keeps track of TransactionDataRebalancedException during txPutEntry */
-  private Map<EventID, TransactionDataRebalancedException> failedExceptions = new HashMap<>();
+  private Map<EventID, TransactionDataRebalancedException> eventExceptions = new HashMap<>();
 
   @Immutable
   static final TXEntryState ENTRY_EXISTS = new TXEntryState();
@@ -211,14 +211,14 @@ public class TXState implements TXStateInterface {
   void recordEventException(EntryEventImpl event,
       TransactionDataRebalancedException exception) {
     if (event.getEventId() != null) {
-      this.failedExceptions.put(event.getEventId(), exception);
+      eventExceptions.put(event.getEventId(), exception);
     }
   }
 
   boolean getRecordedResultOrException(EntryEventImpl event) {
     boolean result = getRecordedResult(event);
-    if (!result && failedExceptions.containsKey(event.getEventId())) {
-      throw failedExceptions.get(event.getEventId());
+    if (!result && eventExceptions.containsKey(event.getEventId())) {
+      throw eventExceptions.get(event.getEventId());
     }
     return result;
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
@@ -32,7 +32,9 @@ import static org.mockito.Mockito.when;
 import javax.transaction.Status;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import org.apache.geode.cache.CommitConflictException;
 import org.apache.geode.cache.EntryNotFoundException;
@@ -40,16 +42,22 @@ import org.apache.geode.cache.FailedSynchronizationException;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.SynchronizationCommitConflictException;
 import org.apache.geode.cache.TransactionDataNodeHasDepartedException;
+import org.apache.geode.cache.TransactionDataRebalancedException;
 import org.apache.geode.cache.TransactionException;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 
 public class TXStateTest {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
   private TXStateProxyImpl txStateProxy;
   private CommitConflictException exception;
   private TransactionDataNodeHasDepartedException transactionDataNodeHasDepartedException;
   private SingleThreadJTAExecutor executor;
   private InternalCache cache;
   private InternalDistributedSystem internalDistributedSystem;
+  private final EntryEventImpl event = mock(EntryEventImpl.class);
+  private final EventID eventID = mock(EventID.class);
 
   @Before
   public void setup() {
@@ -62,6 +70,7 @@ public class TXStateTest {
 
     when(txStateProxy.getTxMgr()).thenReturn(mock(TXManagerImpl.class));
     when(cache.getInternalDistributedSystem()).thenReturn(internalDistributedSystem);
+    when(event.getEventId()).thenReturn(eventID);
   }
 
   @Test
@@ -298,4 +307,63 @@ public class TXStateTest {
     verify(regionState1).cleanup(region1);
   }
 
+  @Test
+  public void getRecordedResultsReturnsFalseIfRecordedFalse() {
+    TXState txState = spy(new TXState(txStateProxy, true, disabledClock()));
+    txState.recordEventAndResult(event, false);
+
+    assertThat(txState.getRecordedResult(event)).isFalse();
+  }
+
+  @Test
+  public void getRecordedResultsReturnsTrueIfRecordedTrue() {
+    TXState txState = spy(new TXState(txStateProxy, true, disabledClock()));
+    txState.recordEventAndResult(event, true);
+
+    assertThat(txState.getRecordedResult(event)).isTrue();
+  }
+
+  @Test
+  public void getRecordedResultOrExceptionThrowsIfRecordedException() {
+    expectedException.expect(TransactionDataRebalancedException.class);
+    TXState txState = spy(new TXState(txStateProxy, true, disabledClock()));
+    txState.recordEventAndResult(event, false);
+    txState.recordEventException(event, new TransactionDataRebalancedException(""));
+
+    txState.getRecordedResultOrException(event);
+  }
+
+  @Test
+  public void getRecordedResultOrExceptionReturnFalseIfRecordedFalse() {
+    TXState txState = spy(new TXState(txStateProxy, true, disabledClock()));
+    txState.recordEventAndResult(event, false);
+
+    assertThat(txState.getRecordedResultOrException(event)).isFalse();
+  }
+
+  @Test
+  public void getRecordedResultOrExceptionReturnTrueIfRecordedTrue() {
+    TXState txState = spy(new TXState(txStateProxy, true, disabledClock()));
+    txState.recordEventAndResult(event, true);
+
+    assertThat(txState.getRecordedResultOrException(event)).isTrue();
+  }
+
+  @Test
+  public void txPutEntryRecordExceptionIfFailedWithTransactionDataRebalancedException() {
+    expectedException.expect(TransactionDataRebalancedException.class);
+    TXState txState = spy(new TXState(txStateProxy, true, disabledClock()));
+    boolean ifNew = true;
+    boolean requireOldValue = false;
+    boolean checkResources = false;
+    TransactionDataRebalancedException exception = new TransactionDataRebalancedException("");
+    InternalRegion region = mock(InternalRegion.class);
+    when(event.getRegion()).thenReturn(region);
+    doThrow(exception).when(txState).txWriteEntry(region, event, ifNew, requireOldValue, null);
+
+    assertThat(txState.txPutEntry(event, ifNew, requireOldValue, checkResources, null)).isFalse();
+
+    verify(txState, never()).getRecordedResultOrException(event);
+    verify(txState).recordEventException(event, exception);
+  }
 }


### PR DESCRIPTION
  This is used to handle a retry of transactional put.

