### PR TITLE
GEODE-8393: Add sequence number to RedisString to support delta and APPEND

### DIFF
--- a/geode-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -11,14 +11,14 @@ fromData,8
 toData,8
 
 org/apache/geode/redis/internal/data/RedisHash,2
-fromData,14
 toData,14
+fromData,14
 
 org/apache/geode/redis/internal/data/RedisSet,2
-fromData,14
 toData,14
+fromData,14
 
 org/apache/geode/redis/internal/data/RedisString,2
-fromData,21
-toData,17
+fromData,29
+toData,25
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -191,7 +191,9 @@ public abstract class AbstractRedisData implements RedisData {
         applyDelta(new RemsDeltaInfo(readArrayList(in)));
         break;
       case APPEND:
-        applyDelta(new AppendDeltaInfo(DataSerializer.readByteArray(in)));
+        int sequence = DataSerializer.readPrimitiveInt(in);
+        byte[] byteArray = DataSerializer.readByteArray(in);
+        applyDelta(new AppendDeltaInfo(byteArray, sequence));
         break;
     }
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/delta/AppendDeltaInfo.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/delta/AppendDeltaInfo.java
@@ -23,17 +23,24 @@ import org.apache.geode.DataSerializer;
 
 public class AppendDeltaInfo implements DeltaInfo {
   private final byte[] appendBytes;
+  private final int sequence;
 
-  public AppendDeltaInfo(byte[] value) {
+  public AppendDeltaInfo(byte[] value, int sequence) {
     appendBytes = value;
+    this.sequence = sequence;
   }
 
   public byte[] getBytes() {
     return appendBytes;
   }
 
+  public int getSequence() {
+    return sequence;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     DataSerializer.writeEnum(DeltaType.APPEND, out);
+    DataSerializer.writePrimitiveInt(sequence, out);
     DataSerializer.writeByteArray(appendBytes, out);
   }
 }


### PR DESCRIPTION
- There seems to be an intermittent problem when Deltas arrive and a GII
  is in progress. This fix introduces a sequence number that is used for
  APPEND operations only. Since APPEND is NOT idempotent, duplicate
  deltas can be a problem and will cause data issues if applied when they
  should not be.

Co-Authored-By: Darrel Schneider <darrel@vmware.com>