### PR TITLE
GEODE-8490: Docker containers are not properly cleaned up after native Redis acceptance tests

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/IgnoreOnWindowsRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/IgnoreOnWindowsRule.java
@@ -30,6 +30,6 @@ import org.junit.rules.RuleChain;
 public class IgnoreOnWindowsRule extends ExternalResource implements Serializable {
   @Override
   protected void before() throws Throwable {
-    Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
+    Assume.assumeFalse("Test ignored on Windows.", SystemUtils.IS_OS_WINDOWS);
   }
 }

--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
   commonTestImplementation(project(':geode-junit'))
   commonTestImplementation(project(':geode-dunit'))
+  commonTestImplementation('org.testcontainers:testcontainers')
   commonTestImplementation('redis.clients:jedis')
 
   integrationTestImplementation(project(':geode-dunit'))

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GlobPatternNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GlobPatternNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class GlobPatternNativeRedisAcceptanceTest extends GlobPatternIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/AuthNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/AuthNativeRedisAcceptanceTest.java
@@ -20,15 +20,13 @@ import org.junit.After;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.rules.TestRule;
 import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
 import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
-@Category({RedisTest.class})
 public class AuthNativeRedisAcceptanceTest extends AuthIntegrationTest {
 
   // Docker compose does not work on windows in CI. Ignore this test on windows
@@ -36,7 +34,13 @@ public class AuthNativeRedisAcceptanceTest extends AuthIntegrationTest {
   @ClassRule
   public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
 
-  private GenericContainer redisContainer;
+  // The ryuk container is responsible for cleanup at JVM exit. Since this class already closes the
+  // containers it starts, we do not need the ryuk container.
+  @ClassRule
+  public static EnvironmentVariables environmentVariables =
+      new EnvironmentVariables().set("TESTCONTAINERS_RYUK_DISABLED", "true");
+
+  private GenericContainer<?> redisContainer;
 
   @After
   public void tearDown() {

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/PingNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/PingNativeRedisAcceptanceTest.java
@@ -18,25 +18,17 @@ package org.apache.geode.redis.internal.executor.connection;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class PingNativeRedisAcceptanceTest extends PingIntegrationTest {
 
-  private static GenericContainer redisContainer;
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HashesNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HashesNativeRedisAcceptanceTest.java
@@ -19,29 +19,20 @@ import java.util.Random;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class HashesNativeRedisAcceptanceTest extends HashesIntegrationTest {
 
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
     rand = new Random();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/DelNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/DelNativeRedisAcceptanceTest.java
@@ -17,26 +17,18 @@ package org.apache.geode.redis.internal.executor.key;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class DelNativeRedisAcceptanceTest extends DelIntegrationTest {
 
-  private static GenericContainer redisContainer;
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
+    jedis2 = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExistsNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExistsNativeRedisAcceptanceTest.java
@@ -18,31 +18,20 @@ package org.apache.geode.redis.internal.executor.key;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class ExistsNativeRedisAcceptanceTest extends ExistsIntegrationTest {
 
-  private static GenericContainer redisContainer;
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
-    jedis3 = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
+    jedis2 = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
+    jedis3 = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExpireAtNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExpireAtNativeRedisAcceptanceTest.java
@@ -18,36 +18,22 @@ package org.apache.geode.redis.internal.executor.key;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class ExpireAtNativeRedisAcceptanceTest extends ExpireAtIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
-
-  private static GenericContainer redisContainer;
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 
   @AfterClass
   public static void classLevelTearDown() {
     jedis.close();
-    redisContainer.stop();
   }
 
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExpireNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/ExpireNativeRedisAcceptanceTest.java
@@ -18,29 +18,17 @@ package org.apache.geode.redis.internal.executor.key;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class ExpireNativeRedisAcceptanceTest extends ExpireIntegrationTest {
-
-  private static GenericContainer redisContainer;
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/KeysNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/KeysNativeRedisAcceptanceTest.java
@@ -17,27 +17,17 @@ package org.apache.geode.redis.internal.executor.key;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class KeysNativeRedisAcceptanceTest extends KeysIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/PTTLNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/PTTLNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.key;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class PTTLNativeRedisAcceptanceTest extends PTTLIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/PersistNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/PersistNativeRedisAcceptanceTest.java
@@ -18,28 +18,18 @@ package org.apache.geode.redis.internal.executor.key;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class PersistNativeRedisAcceptanceTest extends PersistIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
+    jedis2 = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/PexpireNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/PexpireNativeRedisAcceptanceTest.java
@@ -18,27 +18,17 @@ package org.apache.geode.redis.internal.executor.key;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class PexpireNativeRedisAcceptanceTest extends PexpireIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis("localhost", redis.getPort(), REDIS_CLIENT_TIMEOUT);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/RenameNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/RenameNativeRedisAcceptanceTest.java
@@ -20,27 +20,20 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class RenameNativeRedisAcceptanceTest extends RenameIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
     rand = new Random();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis3 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis3 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @Override

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/TTLNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/TTLNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.key;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class TTLNativeRedisAcceptanceTest extends TTLIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/TypeNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/key/TypeNativeRedisAcceptanceTest.java
@@ -16,23 +16,16 @@ package org.apache.geode.redis.internal.executor.key;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class TypeNativeRedisAcceptanceTest extends TypeIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -20,30 +20,18 @@ package org.apache.geode.redis.internal.executor.pubsub;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class PubSubNativeRedisAcceptanceTest extends PubSubIntegrationTest {
-
-  private static GenericContainer redisContainer;
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    subscriber = new Jedis("localhost", redisContainer.getFirstMappedPort(), JEDIS_TIMEOUT);
-    publisher = new Jedis("localhost", redisContainer.getFirstMappedPort(), JEDIS_TIMEOUT);
+    subscriber = new Jedis("localhost", redis.getPort(), JEDIS_TIMEOUT);
+    publisher = new Jedis("localhost", redis.getPort(), JEDIS_TIMEOUT);
   }
 
   @AfterClass
@@ -53,7 +41,7 @@ public class PubSubNativeRedisAcceptanceTest extends PubSubIntegrationTest {
   }
 
   public int getPort() {
-    return redisContainer.getFirstMappedPort();
+    return redis.getPort();
   }
 
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SDiffNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SDiffNativeRedisAcceptanceTest.java
@@ -18,28 +18,18 @@ package org.apache.geode.redis.internal.executor.set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SDiffNativeRedisAcceptanceTest extends SDiffIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SInterNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SInterNativeRedisAcceptanceTest.java
@@ -18,28 +18,18 @@ package org.apache.geode.redis.internal.executor.set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SInterNativeRedisAcceptanceTest extends SInterIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SIsMemberNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SIsMemberNativeRedisAcceptanceTest.java
@@ -17,26 +17,16 @@ package org.apache.geode.redis.internal.executor.set;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SIsMemberNativeRedisAcceptanceTest extends SIsMemberIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SMoveNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SMoveNativeRedisAcceptanceTest.java
@@ -18,28 +18,18 @@ package org.apache.geode.redis.internal.executor.set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SMoveNativeRedisAcceptanceTest extends SMoveIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SPopNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SPopNativeRedisAcceptanceTest.java
@@ -18,28 +18,19 @@ package org.apache.geode.redis.internal.executor.set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SPopNativeRedisAcceptanceTest extends SPopIntegrationTest {
 
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SRemNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SRemNativeRedisAcceptanceTest.java
@@ -18,28 +18,18 @@ package org.apache.geode.redis.internal.executor.set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SRemNativeRedisAcceptanceTest extends SRemIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SUnionNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SUnionNativeRedisAcceptanceTest.java
@@ -18,28 +18,19 @@ package org.apache.geode.redis.internal.executor.set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SUnionNativeRedisAcceptanceTest extends SUnionIntegrationTest {
 
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SetsNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SetsNativeRedisAcceptanceTest.java
@@ -18,28 +18,18 @@ package org.apache.geode.redis.internal.executor.set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.experimental.categories.Category;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.categories.RedisTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
-@Category({RedisTest.class})
 public class SetsNativeRedisAcceptanceTest extends SetsIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 
   @AfterClass

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/AppendNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/AppendNativeRedisAcceptanceTest.java
@@ -17,24 +17,17 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class AppendNativeRedisAcceptanceTest extends AppendIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/BitCountNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/BitCountNativeRedisAcceptanceTest.java
@@ -16,23 +16,17 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class BitCountNativeRedisAcceptanceTest extends BitCountIntegrationTest {
 
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/BitOpNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/BitOpNativeRedisAcceptanceTest.java
@@ -16,23 +16,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class BitOpNativeRedisAcceptanceTest extends BitOpIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/BitPosNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/BitPosNativeRedisAcceptanceTest.java
@@ -16,23 +16,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class BitPosNativeRedisAcceptanceTest extends BitPosIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/DecrByNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/DecrByNativeRedisAcceptanceTest.java
@@ -18,24 +18,17 @@ import java.util.Random;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class DecrByNativeRedisAcceptanceTest extends DecrByIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
     rand = new Random();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/DecrNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/DecrNativeRedisAcceptanceTest.java
@@ -17,24 +17,17 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class DecrNativeRedisAcceptanceTest extends DecrIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetBitNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetBitNativeRedisAcceptanceTest.java
@@ -16,23 +16,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class GetBitNativeRedisAcceptanceTest extends GetBitIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetNativeRedisAcceptanceTest.java
@@ -16,23 +16,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class GetNativeRedisAcceptanceTest extends GetIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetRangeNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetRangeNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class GetRangeNativeRedisAcceptanceTest extends GetRangeIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetSetNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/GetSetNativeRedisAcceptanceTest.java
@@ -17,24 +17,17 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class GetSetNativeRedisAcceptanceTest extends GetSetIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/IncrByFloatNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/IncrByFloatNativeRedisAcceptanceTest.java
@@ -18,24 +18,17 @@ import java.util.Random;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class IncrByFloatNativeRedisAcceptanceTest extends IncrByFloatIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
     rand = new Random();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/IncrByNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/IncrByNativeRedisAcceptanceTest.java
@@ -18,24 +18,17 @@ import java.util.Random;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class IncrByNativeRedisAcceptanceTest extends IncrByIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
     rand = new Random();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/IncrNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/IncrNativeRedisAcceptanceTest.java
@@ -17,24 +17,17 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class IncrNativeRedisAcceptanceTest extends IncrIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/MGetNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/MGetNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class MGetNativeRedisAcceptanceTest extends MGetIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/MSetNXNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/MSetNXNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class MSetNXNativeRedisAcceptanceTest extends MSetNXIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/MSetNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/MSetNativeRedisAcceptanceTest.java
@@ -17,24 +17,17 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class MSetNativeRedisAcceptanceTest extends MSetIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/PSetEXNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/PSetEXNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class PSetEXNativeRedisAcceptanceTest extends PSetEXIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetBitNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetBitNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class SetBitNativeRedisAcceptanceTest extends SetBitIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetExNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetExNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class SetExNativeRedisAcceptanceTest extends SetEXIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetNXNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetNXNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class SetNXNativeRedisAcceptanceTest extends SetNXIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetNativeRedisAcceptanceTest.java
@@ -17,24 +17,17 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class SetNativeRedisAcceptanceTest extends SetIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
-    jedis2 = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
+    jedis2 = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetRangeNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/SetRangeNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class SetRangeNativeRedisAcceptanceTest extends SetRangeIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/StrLenNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/string/StrLenNativeRedisAcceptanceTest.java
@@ -17,23 +17,16 @@ package org.apache.geode.redis.internal.executor.string;
 
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+import org.apache.geode.NativeRedisTestRule;
 
 public class StrLenNativeRedisAcceptanceTest extends StrLenIntegrationTest {
-
-  // Docker compose does not work on windows in CI. Ignore this test on windows
-  // Using a RuleChain to make sure we ignore the test before the rule comes into play
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setUp() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), 10000000);
+    jedis = new Jedis("localhost", redis.getPort(), 10000000);
   }
 }

--- a/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionAcceptanceTest.java
@@ -17,16 +17,14 @@ package session;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 
+import org.apache.geode.NativeRedisTestRule;
 import org.apache.geode.redis.session.RedisSessionDUnitTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 public class NativeRedisSessionAcceptanceTest extends RedisSessionDUnitTest {
 
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setup() {
@@ -38,9 +36,7 @@ public class NativeRedisSessionAcceptanceTest extends RedisSessionDUnitTest {
   }
 
   protected static void setupNativeRedis() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    ports.put(SERVER1, redisContainer.getFirstMappedPort());
+    ports.put(SERVER1, redis.getPort());
   }
 
   @Test

--- a/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionExpirationAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/session/NativeRedisSessionExpirationAcceptanceTest.java
@@ -17,16 +17,13 @@ package session;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
-import org.testcontainers.containers.GenericContainer;
 
+import org.apache.geode.NativeRedisTestRule;
 import org.apache.geode.redis.session.SessionExpirationDUnitTest;
-import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 public class NativeRedisSessionExpirationAcceptanceTest extends SessionExpirationDUnitTest {
-
   @ClassRule
-  public static TestRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
   @BeforeClass
   public static void setup() {
@@ -38,9 +35,7 @@ public class NativeRedisSessionExpirationAcceptanceTest extends SessionExpiratio
   }
 
   protected static void setupNativeRedis() {
-    GenericContainer redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
-    redisContainer.start();
-    ports.put(SERVER1, redisContainer.getFirstMappedPort());
+    ports.put(SERVER1, redis.getPort());
   }
 
 

--- a/geode-redis/src/commonTest/java/org/apache/geode/NativeRedisTestRule.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/NativeRedisTestRule.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode;
+
+import java.io.Serializable;
+
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.testcontainers.containers.GenericContainer;
+
+import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+
+public class NativeRedisTestRule extends ExternalResource implements Serializable {
+
+  private GenericContainer<?> redisContainer;
+  private final RuleChain delegate;
+
+  public NativeRedisTestRule() {
+    delegate = RuleChain
+        // Docker compose does not work on windows in CI. Ignore this test on windows
+        // Using a RuleChain to make sure we ignore the test before the rule comes into play
+        .outerRule(new IgnoreOnWindowsRule())
+        // The ryuk container is responsible for cleanup at JVM exit. Since this rule already closes
+        // the
+        // container it has started, we do not need the ryuk container.
+        .around(new EnvironmentVariables().set("TESTCONTAINERS_RYUK_DISABLED", "true"));
+  }
+
+  public int getPort() {
+    return redisContainer.getFirstMappedPort();
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    Statement containerStatement = new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        redisContainer = new GenericContainer<>("redis:5.0.6").withExposedPorts(6379);
+        redisContainer.start();
+        try {
+          base.evaluate(); // This will run the test.
+        } finally {
+          redisContainer.stop();
+        }
+      }
+    };
+
+    return delegate.apply(containerStatement, description);
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.After;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
@@ -33,9 +32,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.redis.internal.GeodeRedisServer;
-import org.apache.geode.test.junit.categories.RedisTest;
 
-@Category({RedisTest.class})
 public class AuthIntegrationTest {
 
   static final String PASSWORD = "pwd";


### PR DESCRIPTION
- Created a test rule (NativeRedisTestRule) to properly close and clean up all Docker containers created by the native Redis acceptance tests