### PR TITLE
GEODE-8493: Redis idle clients can cause server stuck thread warning

### DIFF
--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
@@ -388,7 +388,7 @@ public class PubSubDUnitTest {
 
   @Test
   public void testPubSubWithMoreSubscribersThanNettyWorkerThreads() throws Exception {
-    int CLIENT_COUNT = 1000;
+    int CLIENT_COUNT = 200;
     String CHANNEL_NAME = "best_channel_ever";
 
     List<Jedis> clients = new ArrayList<>();

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubDUnitTest.java
@@ -388,7 +388,7 @@ public class PubSubDUnitTest {
 
   @Test
   public void testPubSubWithMoreSubscribersThanNettyWorkerThreads() throws Exception {
-    int CLIENT_COUNT = 200;
+    int CLIENT_COUNT = 1000;
     String CHANNEL_NAME = "best_channel_ever";
 
     List<Jedis> clients = new ArrayList<>();


### PR DESCRIPTION
Changes type of executor service we used so that it does not log a stuck threads warning when Redis clients are idle