### PR TITLE
Give each gradle worker a unique subdir name

### DIFF
--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/AbstractSessionsTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/AbstractSessionsTest.java
@@ -54,7 +54,8 @@ public abstract class AbstractSessionsTest {
 
   // Set up the servers we need
   protected static void setupServer(final DeltaSessionManager manager) throws Exception {
-    FileUtils.copyDirectory(Paths.get("..", "resources", "integrationTest", "tomcat").toFile(),
+    FileUtils.copyDirectory(
+        Paths.get("..", "..", "resources", "integrationTest", "tomcat").toFile(),
         new File("./tomcat"));
     port = SocketUtils.findAvailableTcpPort();
     server = new EmbeddedTomcat(port, "JVM-1");

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -30,9 +30,6 @@ compileTestJava {
 }
 
 test {
-  doFirst {
-    TestPropertiesWriter.writeTestProperties(buildDir, name)
-  }
   if (project.hasProperty('testMaxParallelForks')) {
     maxParallelForks = Integer.parseUnsignedInt(project.testMaxParallelForks)
   } else {
@@ -105,9 +102,6 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
            upgradeTest]) {
   forkEvery 1
 
-  doFirst {
-    TestPropertiesWriter.writeTestProperties(buildDir, name)
-  }
   outputs.upToDateWhen { false }
 }
 
@@ -175,14 +169,23 @@ configure([repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repe
 
 // apply common test configuration
 gradle.taskGraph.whenReady({ graph ->
+  // Give each worker a unique subdir name to use for its tests 
+  def uniqueWorkerSubdir = UUID.randomUUID().toString()
   tasks.withType(Test).each { test ->
     check.dependsOn test
     test.configure {
       onlyIf { !Boolean.getBoolean('skip.tests') }
 
-      def resultsDir = TestPropertiesWriter.testResultsDir(buildDir, test.name)
-      test.workingDir = resultsDir
+      // Run the task in the worker's unique subdir
+      def uniqueTaskSubdir = new File(test.name, uniqueWorkerSubdir).toString()
 
+      doFirst {
+        TestPropertiesWriter.writeTestProperties(buildDir, uniqueTaskSubdir)
+      }
+
+      def resultsDir = TestPropertiesWriter.testResultsDir(buildDir, uniqueTaskSubdir)
+      test.workingDir = resultsDir
+      
       reports.html.destination = file "$buildDir/reports/$name"
       testLogging {
         exceptionFormat = 'full'


### PR DESCRIPTION
Give each gradle worker a unique subdir name. Then run each test type in
the worker's unique subdir under the test type dir.

Authored-by: Dale Emery <demery@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
