### PR TITLE
GEODE-8499: Redis subscriptions leak if they are not explicitly unsubscribed

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.pubsub;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.redis.mocks.MockSubscriber;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+public class SubscriptionsIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @ClassRule
+  public static ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  @Test
+  public void testForLeakySubscriptions() {
+
+    for (int i = 0; i < 100; i++) {
+      Jedis client = new Jedis("localhost", server.getPort());
+      client.ping();
+      MockSubscriber mockSubscriber = new MockSubscriber();
+      executor.submit(() -> client.subscribe(mockSubscriber, "same"));
+      mockSubscriber.awaitSubscribe("same");
+      client.close();
+    }
+
+    GeodeAwaitility.await()
+        .untilAsserted(() -> assertThat(server.getServer().getSubscriptionCount()).isEqualTo(0));
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
@@ -36,7 +36,7 @@ public class SubscriptionsIntegrationTest {
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
   @Test
-  public void testForLeakySubscriptions() {
+  public void testForLeakedSubscriptions() {
 
     for (int i = 0; i < 100; i++) {
       Jedis client = new Jedis("localhost", server.getPort());

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.pubsub;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -106,7 +108,9 @@ public class SubscriptionsIntegrationTest {
     List<Client> clients = new LinkedList<>();
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
     for (int i = 0; i < ITERATIONS; i++) {
-      Client client = new Client(mock(Channel.class));
+      Channel channel = mock(Channel.class);
+      when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
+      Client client = new Client(channel);
       clients.add(client);
       subscriptions
           .add(new ChannelSubscription(client, "channel".getBytes(), context, subscriptions));
@@ -127,7 +131,10 @@ public class SubscriptionsIntegrationTest {
     List<Client> clients = new LinkedList<>();
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
     for (int i = 0; i < ITERATIONS; i++) {
-      Client client = new Client(mock(Channel.class));
+      Channel channel = mock(Channel.class);
+      when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
+      Client client = new Client(channel);
+
       clients.add(client);
       subscriptions
           .add(new ChannelSubscription(client, "channel".getBytes(), context, subscriptions));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -74,8 +74,7 @@ public class GeodeRedisServer {
    * @param bindAddress The address to which the server will attempt to bind to; null
    *        causes it to bind to all local addresses.
    * @param port The port the server will bind to, will throw an IllegalArgumentException if
-   *        argument is less than 0. If the port is
-   *        {@value #RANDOM_PORT_INDICATOR} a random port is assigned.
+   *        argument is less than 0. If the port is 0 a random port is assigned.
    */
   public GeodeRedisServer(String bindAddress, int port, InternalCache cache) {
     if (ENABLE_REDIS_UNSUPPORTED_COMMANDS) {
@@ -97,6 +96,11 @@ public class GeodeRedisServer {
         this::allowUnsupportedCommands, this::shutdown, port, bindAddress, redisStats,
         cache.getInternalDistributedSystem().getDistributionManager().getExecutors()
             .getWaitingThreadPool());
+  }
+
+  @VisibleForTesting
+  public int getSubscriptionCount() {
+    return ((PubSubImpl) pubSub).getSubscriptionCount();
   }
 
   public void setAllowUnsupportedCommands(boolean allowUnsupportedCommands) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Client.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Client.java
@@ -19,6 +19,9 @@ package org.apache.geode.redis.internal.netty;
 import java.util.Objects;
 
 import io.netty.channel.Channel;
+import io.netty.util.concurrent.Future;
+import io.netty.util.concurrent.GenericFutureListener;
+
 
 public class Client {
   private Channel channel;
@@ -42,6 +45,11 @@ public class Client {
   @Override
   public int hashCode() {
     return Objects.hash(channel);
+  }
+
+  public void addShutdownListener(
+      GenericFutureListener<? extends Future<? super Void>> shutdownListener) {
+    channel.closeFuture().addListener(shutdownListener);
   }
 
   public boolean isDead() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscription.java
@@ -52,6 +52,8 @@ public abstract class AbstractSubscription implements Subscription {
     this.client = client;
     this.context = context;
     this.subscriptions = subscriptions;
+
+    client.addShutdownListener(future -> shutdown());
   }
 
   @Override

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -58,6 +58,10 @@ public class PubSubImpl implements PubSub {
     registerPublishFunction();
   }
 
+  public int getSubscriptionCount() {
+    return subscriptions.size();
+  }
+
   @Override
   public long publish(
       Region<ByteArrayWrapper, RedisData> dataRegion,

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
@@ -18,8 +18,10 @@ package org.apache.geode.redis.internal.pubsub;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import org.junit.Test;
 
 import org.apache.geode.redis.internal.executor.GlobPattern;
@@ -33,8 +35,10 @@ public class SubscriptionsJUnitTest {
     Subscriptions subscriptions = new Subscriptions();
 
     Channel channel = mock(Channel.class);
-    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
     Client client = new Client(channel);
+
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     subscriptions
         .add(new ChannelSubscription(client, "subscriptions".getBytes(), context, subscriptions));
@@ -48,8 +52,11 @@ public class SubscriptionsJUnitTest {
     Subscriptions subscriptions = new Subscriptions();
 
     Channel channel = mock(Channel.class);
-    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
     Client client = new Client(channel);
+
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+
     GlobPattern pattern = new GlobPattern("sub*s");
 
     subscriptions.add(new PatternSubscription(client, pattern, context, subscriptions));
@@ -62,8 +69,11 @@ public class SubscriptionsJUnitTest {
     Subscriptions subscriptions = new Subscriptions();
 
     Channel channel = mock(Channel.class);
-    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
     Client client = new Client(channel);
+
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+
     GlobPattern globPattern1 = new GlobPattern("sub*s");
     GlobPattern globPattern2 = new GlobPattern("subscriptions");
 
@@ -79,8 +89,10 @@ public class SubscriptionsJUnitTest {
     Subscriptions subscriptions = new Subscriptions();
 
     Channel channel = mock(Channel.class);
-    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
     Client client = new Client(channel);
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+
     GlobPattern globby = new GlobPattern("sub*s");
 
     subscriptions
@@ -105,10 +117,11 @@ public class SubscriptionsJUnitTest {
   public void findSubscribers() {
     Subscriptions subscriptions = new Subscriptions();
 
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
     Channel mockChannelOne = mock(Channel.class);
     Channel mockChannelTwo = mock(Channel.class);
-
-    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+    when(mockChannelOne.closeFuture()).thenReturn(mock(ChannelFuture.class));
+    when(mockChannelTwo.closeFuture()).thenReturn(mock(ChannelFuture.class));
     Client clientOne = new Client(mockChannelOne);
     Client clientTwo = new Client(mockChannelTwo);
 
@@ -126,11 +139,17 @@ public class SubscriptionsJUnitTest {
   @Test
   public void removeByClient() {
     Subscriptions subscriptions = new Subscriptions();
+
     Channel mockChannelOne = mock(Channel.class);
     Channel mockChannelTwo = mock(Channel.class);
-    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
+
+    when(mockChannelOne.closeFuture()).thenReturn(mock(ChannelFuture.class));
+    when(mockChannelTwo.closeFuture()).thenReturn(mock(ChannelFuture.class));
+
     Client clientOne = new Client(mockChannelOne);
     Client clientTwo = new Client(mockChannelTwo);
+
+    ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     ChannelSubscription subscriptionOne =
         new ChannelSubscription(clientOne, "subscriptions".getBytes(), context, subscriptions);
@@ -150,10 +169,11 @@ public class SubscriptionsJUnitTest {
   public void removeByClientAndPattern() {
 
     Subscriptions subscriptions = new Subscriptions();
-    Channel mockChannelOne = mock(Channel.class);
+    Channel channel = mock(Channel.class);
+    when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
+    Client client = new Client(channel);
 
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
-    Client client = new Client(mockChannelOne);
 
     ChannelSubscription channelSubscriberOne =
         new ChannelSubscription(client, "subscriptions".getBytes(), context, subscriptions);


### PR DESCRIPTION
Subscription structures leak if clients disconnect without unsubscribing. Normally subscriptions should be cleaned up when a PUBLISH is attempted but fails. We should try and detect clients disconnecting and remove the necessary subscription structures.

This code will properly shutdown a subscription when the connection is closed.

