### PR TITLE
GEODE-8506: BufferPool returns byte buffers that may be much larger t…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -1396,7 +1396,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   /**
    * The default value of the {@link ConfigurationProperties#SOCKET_BUFFER_SIZE} property
    */
-  int DEFAULT_SOCKET_BUFFER_SIZE = 32768;
+  static int DEFAULT_SOCKET_BUFFER_SIZE = 32768;
   /**
    * The minimum {@link ConfigurationProperties#SOCKET_BUFFER_SIZE}.
    * <p>

--- a/geode-core/src/test/java/org/apache/geode/internal/net/BufferPoolTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/BufferPoolTest.java
@@ -135,9 +135,6 @@ public class BufferPoolTest {
 
   @Test
   public void checkBufferSizeAfterAcquire() throws Exception {
-    // allocate a small buffer and a larger buffer. Check their sizes, etc and then
-    // release and reacquire them. They should be from separate buffer pools so there
-    // should still be a small buffer and a larger buffer.
     ByteBuffer buffer = bufferPool.acquireDirectReceiveBuffer(100);
 
     ByteBuffer newBuffer =
@@ -147,9 +144,9 @@ public class BufferPoolTest {
     assertThat(buffer.isDirect()).isTrue();
     assertThat(newBuffer.isDirect()).isTrue();
     assertThat(bufferPool.getPoolableBuffer(buffer).capacity())
-        .isGreaterThanOrEqualTo(4096);
+        .isGreaterThanOrEqualTo(BufferPool.SMALL_BUFFER_SIZE);
     assertThat(bufferPool.getPoolableBuffer(newBuffer).capacity())
-        .isGreaterThanOrEqualTo(32768);
+        .isGreaterThanOrEqualTo(BufferPool.MEDIUM_BUFFER_SIZE);
 
     assertThat(buffer.position()).isEqualTo(0);
     assertThat(buffer.limit()).isEqualTo(100);
@@ -168,9 +165,9 @@ public class BufferPoolTest {
     assertThat(buffer.isDirect()).isTrue();
     assertThat(newBuffer.isDirect()).isTrue();
     assertThat(bufferPool.getPoolableBuffer(buffer).capacity())
-        .isGreaterThanOrEqualTo(4096);
+        .isGreaterThanOrEqualTo(BufferPool.SMALL_BUFFER_SIZE);
     assertThat(bufferPool.getPoolableBuffer(newBuffer).capacity())
-        .isGreaterThanOrEqualTo(32768);
+        .isGreaterThanOrEqualTo(BufferPool.MEDIUM_BUFFER_SIZE);
 
     assertThat(buffer.position()).isEqualTo(0);
     assertThat(buffer.limit()).isEqualTo(1000);

--- a/geode-core/src/test/java/org/apache/geode/internal/net/BufferPoolTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/BufferPoolTest.java
@@ -121,8 +121,10 @@ public class BufferPoolTest {
 
     ByteBuffer newBuffer =
         bufferPool.acquireDirectReceiveBuffer(10000);
-    assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4096);
-    assertThat(newBuffer.capacity()).isGreaterThanOrEqualTo(32768);
+    assertThat(buffer.isDirect()).isTrue();
+    assertThat(newBuffer.isDirect()).isTrue();
+    assertThat(buffer.capacity()).isEqualTo(100);
+    assertThat(newBuffer.capacity()).isEqualTo(10000);
 
     // buffer should be ready to read the same amount of data
     assertThat(buffer.position()).isEqualTo(0);
@@ -133,27 +135,42 @@ public class BufferPoolTest {
 
   @Test
   public void checkBufferSizeAfterAcquire() throws Exception {
+    // allocate a small buffer and a larger buffer. Check their sizes, etc and then
+    // release and reacquire them. They should be from separate buffer pools so there
+    // should still be a small buffer and a larger buffer.
     ByteBuffer buffer = bufferPool.acquireDirectReceiveBuffer(100);
 
     ByteBuffer newBuffer =
         bufferPool.acquireDirectReceiveBuffer(10000);
-    assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4096);
-    assertThat(newBuffer.capacity()).isGreaterThanOrEqualTo(32768);
+    assertThat(buffer.capacity()).isEqualTo(100);
+    assertThat(newBuffer.capacity()).isEqualTo(10000);
+    assertThat(buffer.isDirect()).isTrue();
+    assertThat(newBuffer.isDirect()).isTrue();
+    assertThat(bufferPool.getPoolableBuffer(buffer).capacity())
+        .isGreaterThanOrEqualTo(4096);
+    assertThat(bufferPool.getPoolableBuffer(newBuffer).capacity())
+        .isGreaterThanOrEqualTo(32768);
 
     assertThat(buffer.position()).isEqualTo(0);
     assertThat(buffer.limit()).isEqualTo(100);
     assertThat(newBuffer.position()).isEqualTo(0);
     assertThat(newBuffer.limit()).isEqualTo(10000);
+
     bufferPool.releaseReceiveBuffer(buffer);
     bufferPool.releaseReceiveBuffer(newBuffer);
 
     buffer = bufferPool.acquireDirectReceiveBuffer(1000);
-
     newBuffer =
         bufferPool.acquireDirectReceiveBuffer(15000);
 
-    assertThat(buffer.capacity()).isGreaterThanOrEqualTo(4096);
-    assertThat(newBuffer.capacity()).isGreaterThanOrEqualTo(32768);
+    assertThat(buffer.capacity()).isEqualTo(1000);
+    assertThat(newBuffer.capacity()).isEqualTo(15000);
+    assertThat(buffer.isDirect()).isTrue();
+    assertThat(newBuffer.isDirect()).isTrue();
+    assertThat(bufferPool.getPoolableBuffer(buffer).capacity())
+        .isGreaterThanOrEqualTo(4096);
+    assertThat(bufferPool.getPoolableBuffer(newBuffer).capacity())
+        .isGreaterThanOrEqualTo(32768);
 
     assertThat(buffer.position()).isEqualTo(0);
     assertThat(buffer.limit()).isEqualTo(1000);

--- a/geode-core/src/test/java/org/apache/geode/internal/net/NioPlainEngineTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/NioPlainEngineTest.java
@@ -57,13 +57,12 @@ public class NioPlainEngineTest {
   @Test
   public void ensureWrappedCapacity() {
     ByteBuffer wrappedBuffer = bufferPool.acquireDirectReceiveBuffer(100);
-    verify(mockStats, times(1)).incReceiverBufferSize(any(Integer.class), any(Boolean.class));
     wrappedBuffer.put(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
     nioEngine.lastReadPosition = 10;
     int requestedCapacity = 210;
     ByteBuffer result = nioEngine.ensureWrappedCapacity(requestedCapacity, wrappedBuffer,
         BufferPool.BufferType.TRACKED_RECEIVER);
-    verify(mockStats, times(1)).incReceiverBufferSize(any(Integer.class), any(Boolean.class));
+    verify(mockStats, times(2)).incReceiverBufferSize(any(Integer.class), any(Boolean.class));
     assertThat(result.capacity()).isGreaterThanOrEqualTo(requestedCapacity);
     assertThat(result).isGreaterThanOrEqualTo(wrappedBuffer);
     // make sure that data was transferred to the new buffer

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/MsgStreamerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/MsgStreamerTest.java
@@ -88,7 +88,9 @@ public class MsgStreamerTest {
 
     when(connection1.getRemoteAddress()).thenReturn(member1);
     when(connection1.getRemoteVersion()).thenReturn(KnownVersion.CURRENT);
+    when(connection1.getSendBufferSize()).thenReturn(Connection.SMALL_BUFFER_SIZE);
     when(connection2.getRemoteAddress()).thenReturn(member2);
+    when(connection2.getSendBufferSize()).thenReturn(Connection.SMALL_BUFFER_SIZE);
     if (mixedDestinationVersions) {
       when(connection1.getRemoteVersion()).thenReturn(KnownVersion.GEODE_1_12_0);
     } else {


### PR DESCRIPTION
…han requested

Create a "slice" of the acquired buffer to return to the caller instead
of returning a buffer larger than what was requested.  On return we fish
out the parent buffer and put it back in the pool.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
