### PR TITLE
Redis StartUp tests use ephemeral port for Geode server

### DIFF
--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GeodeRedisServerStartUpAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/GeodeRedisServerStartUpAcceptanceTest.java
@@ -41,6 +41,7 @@ public class GeodeRedisServerStartUpAcceptanceTest {
 
     String startServerCommand = String.join(" ",
         "start server",
+        "--server-port", "0",
         "--name", "same-port-and-address-server",
         "--redis-bind-address", "localhost",
         "--redis-port", String.valueOf(port));
@@ -63,6 +64,7 @@ public class GeodeRedisServerStartUpAcceptanceTest {
 
     String startServerCommand = String.join(" ",
         "start server",
+        "--server-port", "0",
         "--name", "same-port-all-addresses-server",
         "--redis-port", String.valueOf(port));
     GfshExecution execution;
@@ -82,6 +84,7 @@ public class GeodeRedisServerStartUpAcceptanceTest {
 
     String startServerCommand = String.join(" ",
         "start server",
+        "--server-port", "0",
         "--name", "invalid-bind-server",
         "--redis-bind-address", "1.1.1.1");
     GfshExecution execution;


### PR DESCRIPTION
GeodeRedisServerStartUpAcceptanceTest tests were using GFSH to start up servers. This meant the Geode server would listen on the default port (40404), and if any other process had that port bound, startup would fail. The GFSH command has been updated to specify a random Geode server port.