### PR TITLE
GEODE-8516: Add Redis tests for multiple subscriptions for the same client

### DIFF
--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubNativeRedisAcceptanceTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.pubsub;
+
+
+import io.lettuce.core.RedisClient;
+import org.junit.Before;
+import org.junit.ClassRule;
+
+import org.apache.geode.NativeRedisTestRule;
+
+public class LettucePubSubNativeRedisAcceptanceTest extends LettucePubSubIntegrationTest {
+  @ClassRule
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
+
+  @Before
+  public void before() {
+    client = RedisClient.create("redis://localhost:" + redis.getPort());
+  }
+}

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsNativeRedisAcceptanceTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.pubsub;
+
+
+import org.junit.ClassRule;
+
+import org.apache.geode.NativeRedisTestRule;
+
+public class SubscriptionsNativeRedisAcceptanceTest extends SubscriptionsIntegrationTest {
+  @ClassRule
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
+}

--- a/geode-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -25,12 +25,16 @@ import java.util.concurrent.TimeUnit;
 import redis.clients.jedis.Client;
 import redis.clients.jedis.JedisPubSub;
 
+
 public class MockSubscriber extends JedisPubSub {
 
   private final CountDownLatch subscriptionLatch;
+  private final CountDownLatch psubscriptionLatch;
   private final CountDownLatch unsubscriptionLatch;
   private final List<String> receivedMessages = Collections.synchronizedList(new ArrayList<>());
   private final List<String> receivedPMessages = Collections.synchronizedList(new ArrayList<>());
+  private final List<String> receivedPings = Collections.synchronizedList(new ArrayList<>());
+  private final List<String> receivedEvents = Collections.synchronizedList(new ArrayList<>());
   public final List<UnsubscribeInfo> unsubscribeInfos =
       Collections.synchronizedList(new ArrayList<>());
   public final List<UnsubscribeInfo> punsubscribeInfos =
@@ -42,11 +46,13 @@ public class MockSubscriber extends JedisPubSub {
   }
 
   public MockSubscriber(CountDownLatch subscriptionLatch) {
-    this(subscriptionLatch, new CountDownLatch(1));
+    this(subscriptionLatch, new CountDownLatch(1), new CountDownLatch(1));
   }
 
-  public MockSubscriber(CountDownLatch subscriptionLatch, CountDownLatch unsubscriptionLatch) {
+  public MockSubscriber(CountDownLatch subscriptionLatch, CountDownLatch unsubscriptionLatch,
+      CountDownLatch psubscriptionLatch) {
     this.subscriptionLatch = subscriptionLatch;
+    this.psubscriptionLatch = psubscriptionLatch;
     this.unsubscriptionLatch = unsubscriptionLatch;
   }
 
@@ -75,16 +81,26 @@ public class MockSubscriber extends JedisPubSub {
     return new ArrayList<>(receivedPMessages);
   }
 
+  public List<String> getReceivedPings() {
+    return receivedPings;
+  }
+
+  public List<String> getReceivedEvents() {
+    return receivedEvents;
+  }
+
   @Override
   public void onMessage(String channel, String message) {
     switchThreadName(String.format("MESSAGE %s %s", channel, message));
     receivedMessages.add(message);
+    receivedEvents.add("message");
   }
 
   @Override
   public void onPMessage(String pattern, String channel, String message) {
     switchThreadName(String.format("PMESSAGE %s %s %s", pattern, channel, message));
     receivedPMessages.add(message);
+    receivedEvents.add("pmessage");
   }
 
   @Override
@@ -93,12 +109,34 @@ public class MockSubscriber extends JedisPubSub {
     subscriptionLatch.countDown();
   }
 
+  @Override
+  public void onPSubscribe(String pattern, int subscribedChannels) {
+    switchThreadName(String.format("PSUBSCRIBE %s", pattern));
+    psubscriptionLatch.countDown();
+  }
+
+  @Override
+  public void onPong(String pattern) {
+    switchThreadName(String.format("PONG %s", pattern));
+    receivedPings.add(pattern);
+  }
+
   private static final int AWAIT_TIMEOUT_MILLIS = 30000;
 
   public void awaitSubscribe(String channel) {
     try {
       if (!subscriptionLatch.await(AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
         throw new RuntimeException("awaitSubscribe timed out for channel: " + channel);
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void awaitPSubscribe(String pattern) {
+    try {
+      if (!psubscriptionLatch.await(AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+        throw new RuntimeException("awaitSubscribe timed out for channel: " + pattern);
       }
     } catch (InterruptedException e) {
       throw new RuntimeException(e);

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
@@ -33,6 +33,7 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
@@ -62,7 +63,7 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  public void testMultiSubscribeSameClient() {
+  public void multiSubscribeSameClient() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
     List<Map> messages = Collections.synchronizedList(new ArrayList<>());
@@ -99,7 +100,7 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  public void testMultiPsubscribeSameClient() {
+  public void multiPsubscribeSameClient() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
     List<Map> messages = Collections.synchronizedList(new ArrayList<>());
@@ -136,7 +137,8 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  public void testSubscribePsubscribeSameClient() {
+  @Ignore("GEODE-8498")
+  public void subscribePsubscribeSameClient() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
     List<String> messages = Collections.synchronizedList(new ArrayList<>());
@@ -166,7 +168,7 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  public void testMultiUnsubscribe() {
+  public void multiUnsubscribe() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     List<Map> counts = Collections.synchronizedList(new ArrayList<>());
     RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
@@ -196,7 +198,7 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  public void testMultiPunsubscribe() {
+  public void multiPunsubscribe() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     List<Map> counts = Collections.synchronizedList(new ArrayList<>());
     RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
@@ -227,7 +229,7 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  public void testUnsubscribePunsubscribe() {
+  public void unsubscribePunsubscribe() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     List<String> counts = Collections.synchronizedList(new ArrayList<>());
     RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
@@ -253,7 +255,7 @@ public class LettucePubSubIntegrationTest {
 
   // Lettuce does not currently allow PING while subscribed
   @Test
-  public void testSubscribePing() {
+  public void pingWhileSubscribed() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     subscriber.sync().subscribe(CHANNEL);
     assertThatThrownBy(() -> subscriber.sync().ping())
@@ -261,7 +263,7 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  public void testSubscribeQuit() {
+  public void quitWhileSubscribe() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
@@ -16,13 +16,19 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Future;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisFuture;
+import io.lettuce.core.pubsub.RedisPubSubAdapter;
+import io.lettuce.core.pubsub.RedisPubSubListener;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import org.junit.After;
 import org.junit.Before;
@@ -30,12 +36,14 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
 public class LettucePubSubIntegrationTest {
 
   private static final String CHANNEL = "best-channel";
-  private RedisClient client;
+  private static final String PATTERN = "best-*";
+  protected RedisClient client;
 
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();
@@ -53,6 +61,218 @@ public class LettucePubSubIntegrationTest {
     client.shutdown();
   }
 
+  @Test
+  public void testMultiSubscribeSameClient() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
+    List<Map> messages = Collections.synchronizedList(new ArrayList<>());
+
+    RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
+      @Override
+      public void message(String channel, String message) {
+        Map<String, String> channelMessageMap = new HashMap<>();
+        channelMessageMap.put(channel, message);
+        messages.add(channelMessageMap);
+      }
+    };
+
+    subscriber.addListener(listener);
+    subscriber.sync().subscribe(CHANNEL);
+    subscriber.sync().subscribe(CHANNEL);
+    subscriber.sync().subscribe("newChannel!");
+
+    long publishCount1 = publisher.sync().publish(CHANNEL, "message!");
+    long publishCount2 = publisher.sync().publish("newChannel!", "message from new channel");
+
+
+    Map<String, String> expectedMap1 = new HashMap<>();
+    expectedMap1.put(CHANNEL, "message!");
+    Map<String, String> expectedMap2 = new HashMap<>();
+    expectedMap2.put("newChannel!", "message from new channel");
+
+    assertThat(publishCount1).isEqualTo(1);
+    assertThat(publishCount2).isEqualTo(1);
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(messages).hasSize(2));
+    assertThat(messages).containsExactly(expectedMap1, expectedMap2);
+
+    subscriber.sync().unsubscribe();
+  }
+
+  @Test
+  public void testMultiPsubscribeSameClient() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
+    List<Map> messages = Collections.synchronizedList(new ArrayList<>());
+
+    RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
+      @Override
+      public void message(String pattern, String channel, String message) {
+        Map<String, String> patternMessageMap = new HashMap<>();
+        patternMessageMap.put(pattern, message);
+        messages.add(patternMessageMap);
+      }
+    };
+
+    subscriber.addListener(listener);
+    subscriber.sync().psubscribe(PATTERN);
+    subscriber.sync().psubscribe(PATTERN);
+    subscriber.sync().psubscribe("new-*");
+
+    long publishCount1 = publisher.sync().publish(CHANNEL, "message!");
+    long publishCount2 = publisher.sync().publish("new-channel!", "message from new channel");
+
+
+    Map<String, String> expectedMap1 = new HashMap<>();
+    expectedMap1.put(PATTERN, "message!");
+    Map<String, String> expectedMap2 = new HashMap<>();
+    expectedMap2.put("new-*", "message from new channel");
+
+    assertThat(publishCount1).isEqualTo(1);
+    assertThat(publishCount2).isEqualTo(1);
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(messages).hasSize(2));
+    assertThat(messages).containsExactly(expectedMap1, expectedMap2);
+
+    subscriber.sync().unsubscribe();
+  }
+
+  @Test
+  public void testSubscribePsubscribeSameClient() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
+    List<String> messages = Collections.synchronizedList(new ArrayList<>());
+
+    RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
+      @Override
+      public void message(String channel, String message) {
+        messages.add("message");
+      }
+
+      @Override
+      public void message(String pattern, String channel, String message) {
+        messages.add("pmessage");
+      }
+    };
+    subscriber.addListener(listener);
+    subscriber.sync().subscribe(CHANNEL);
+    subscriber.sync().psubscribe("best-*");
+    long publishCount = publisher.sync().publish(CHANNEL, "message!");
+
+
+    assertThat(publishCount).isEqualTo(2);
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(messages).hasSize(2));
+    assertThat(messages).containsExactly("message", "pmessage");
+
+    subscriber.sync().unsubscribe();
+  }
+
+  @Test
+  public void testMultiUnsubscribe() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    List<Map> counts = Collections.synchronizedList(new ArrayList<>());
+    RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
+      @Override
+      public void unsubscribed(String channel, long remainingSubscriptions) {
+        Map<String, Long> channelCount = new HashMap<>();
+        channelCount.put(channel, remainingSubscriptions);
+        counts.add(channelCount);
+      }
+    };
+    subscriber.addListener(listener);
+    subscriber.sync().subscribe(CHANNEL);
+    subscriber.sync().subscribe("new-channel!");
+    subscriber.sync().unsubscribe(CHANNEL);
+    subscriber.sync().unsubscribe(CHANNEL);
+    subscriber.sync().unsubscribe("new-channel!");
+
+    Map<String, Long> expectedMap1 = new HashMap<>();
+    expectedMap1.put(CHANNEL, 1L);
+    Map<String, Long> expectedMap2 = new HashMap<>();
+    expectedMap2.put(CHANNEL, 1L);
+    Map<String, Long> expectedMap3 = new HashMap<>();
+    expectedMap3.put("new-channel!", 0L);
+
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(counts).hasSize(3));
+    assertThat(counts).containsExactly(expectedMap1, expectedMap2, expectedMap3);
+  }
+
+  @Test
+  public void testMultiPunsubscribe() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    List<Map> counts = Collections.synchronizedList(new ArrayList<>());
+    RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
+      @Override
+      public void punsubscribed(String pattern, long remainingSubscriptions) {
+        Map<String, Long> patternCount = new HashMap<>();
+        patternCount.put(pattern, remainingSubscriptions);
+        counts.add(patternCount);
+      }
+    };
+
+    subscriber.addListener(listener);
+    subscriber.sync().psubscribe(PATTERN);
+    subscriber.sync().psubscribe("new-*");
+    subscriber.sync().punsubscribe(PATTERN);
+    subscriber.sync().punsubscribe(PATTERN);
+    subscriber.sync().punsubscribe("new-*");
+
+    Map<String, Long> expectedMap1 = new HashMap<>();
+    expectedMap1.put(PATTERN, 1L);
+    Map<String, Long> expectedMap2 = new HashMap<>();
+    expectedMap2.put(PATTERN, 1L);
+    Map<String, Long> expectedMap3 = new HashMap<>();
+    expectedMap3.put("new-*", 0L);
+
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(counts).hasSize(3));
+    assertThat(counts).containsExactly(expectedMap1, expectedMap2, expectedMap3);
+  }
+
+  @Test
+  public void testUnsubscribePunsubscribe() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    List<String> counts = Collections.synchronizedList(new ArrayList<>());
+    RedisPubSubListener<String, String> listener = new RedisPubSubAdapter<String, String>() {
+      @Override
+      public void unsubscribed(String channel, long numUnsubscribed) {
+        counts.add("unsubscribe");
+      }
+
+      @Override
+      public void punsubscribed(String pattern, long numPunsubscribed) {
+        counts.add("punsubscribe");
+      }
+    };
+    subscriber.addListener(listener);
+    subscriber.sync().subscribe(CHANNEL);
+    subscriber.sync().psubscribe("best-*");
+    subscriber.sync().unsubscribe(CHANNEL);
+    subscriber.sync().punsubscribe("best-*");
+
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(counts).hasSize(2));
+    assertThat(counts).containsExactly("unsubscribe", "punsubscribe");
+  }
+
+  // Lettuce does not currently allow PING while subscribed
+  @Test
+  public void testSubscribePing() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    subscriber.sync().subscribe(CHANNEL);
+    assertThatThrownBy(() -> subscriber.sync().ping())
+        .hasMessageContaining("Command PING not allowed while subscribed");
+  }
+
+  @Test
+  public void testSubscribeQuit() {
+    StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
+    StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
+
+    subscriber.sync().subscribe(CHANNEL);
+
+    String quitResponse = subscriber.sync().quit();
+    assertThat(quitResponse).isEqualTo("OK");
+
+    long publishCount = publisher.sync().publish(CHANNEL, "hello there");
+    assertThat(publishCount).isEqualTo(0L);
+  }
 
   @Test
   public void concurrentPublishersToMultipleSubscribers_doNotLosePublishMessages()

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
@@ -17,10 +17,13 @@ package org.apache.geode.redis.internal.executor.pubsub;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 import org.apache.geode.redis.mocks.MockSubscriber;
@@ -36,11 +39,55 @@ public class SubscriptionsIntegrationTest {
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
   @Test
-  public void testForLeakedSubscriptions() {
+  @Ignore("GEODE-8515")
+  public void testPingWhileSubscribed() {
+    Jedis client = new Jedis("localhost", server.getPort());
+    MockSubscriber mockSubscriber = new MockSubscriber();
 
+    executor.submit(() -> client.subscribe(mockSubscriber, "same"));
+    mockSubscriber.awaitSubscribe("same");
+    mockSubscriber.ping();
+    GeodeAwaitility.await()
+        .untilAsserted(() -> assertThat(mockSubscriber.getReceivedPings().size()).isEqualTo(1));
+    assertThat(mockSubscriber.getReceivedPings().get(0)).isEqualTo("");
+  }
+
+  @Test
+  public void testSubscribeWhileSubscribed() {
+    Jedis client = new Jedis("localhost", server.getPort());
+    MockSubscriber mockSubscriber = new MockSubscriber();
+
+    executor.submit(() -> client.subscribe(mockSubscriber, "same"));
+    mockSubscriber.awaitSubscribe("same");
+    mockSubscriber.psubscribe("sam*");
+    mockSubscriber.awaitPSubscribe("sam*");
+
+    Jedis publisher = new Jedis("localhost", server.getPort());
+    long publishCount = publisher.publish("same", "message");
+
+    assertThat(publishCount).isEqualTo(2L);
+    GeodeAwaitility.await()
+        .untilAsserted(() -> assertThat(mockSubscriber.getReceivedMessages()).hasSize(1));
+    GeodeAwaitility.await()
+        .untilAsserted(() -> assertThat(mockSubscriber.getReceivedPMessages()).hasSize(1));
+    assertThat(mockSubscriber.getReceivedEvents()).containsExactly("message", "pmessage");
+    mockSubscriber.unsubscribe();
+    client.close();
+  }
+
+  @Test
+  public void testUnsupportedCommandsWhileSubscribed() {
+    Jedis client = new Jedis("localhost", server.getPort());
+
+    client.sendCommand(Protocol.Command.SUBSCRIBE, "hello");
+    assertThatThrownBy(() -> client.set("not", "supported")).hasMessageContaining(
+        "ERR only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context");
+  }
+
+  @Test
+  public void testForLeakedSubscriptions() {
     for (int i = 0; i < 100; i++) {
       Jedis client = new Jedis("localhost", server.getPort());
-      client.ping();
       MockSubscriber mockSubscriber = new MockSubscriber();
       executor.submit(() -> client.subscribe(mockSubscriber, "same"));
       mockSubscriber.awaitSubscribe("same");

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -401,6 +401,20 @@ public enum RedisCommandType {
     return supportLevel == UNIMPLEMENTED;
   }
 
+  public boolean isAllowedWhileSubscribed() {
+    switch (this) {
+      case SUBSCRIBE:
+      case PSUBSCRIBE:
+      case UNSUBSCRIBE:
+      case PUNSUBSCRIBE:
+      case PING:
+      case QUIT:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext executionHandlerContext) {
     parameterRequirements.checkParameters(command, executionHandlerContext);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -283,6 +283,13 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
         return;
       }
 
+      if (!getPubSub().findSubscribedChannels(getClient()).isEmpty()) {
+        if (!command.getCommandType().isAllowedWhileSubscribed()) {
+          writeToChannel(RedisResponse
+              .error("only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context"));
+        }
+      }
+
       final long start = redisStats.startCommand(command.getCommandType());
       try {
         writeToChannel(command.execute(this));


### PR DESCRIPTION
The commands that are allowed in the context of a subscribed client are SUBSCRIBE, PSUBSCRIBE, UNSUBSCRIBE, PUNSUBSCRIBE, PING and QUIT.

Tests were added for these commands.  We also discovered that we were not throwing the proper error if we tried to do commands that were not supported while subscribed.  We corrected this issue.  The test for PING while subscribed was ignored because it is a different issue (https://issues.apache.org/jira/browse/GEODE-8515).