### PR TITLE
GEODE-8498: Redis messages written to Netty channel sometimes delivered out of order

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
@@ -33,7 +33,6 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
@@ -137,7 +136,6 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  @Ignore("GEODE-8498")
   public void subscribePsubscribeSameClient() {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();


### PR DESCRIPTION
Error from .tcl tests:
```
[err]: Mix SUBSCRIBE and PSUBSCRIBE in tests/unit/pubsub.tcl
Expected 'pmessage foo.* foo.bar hello' to be equal to 'message foo.bar hello'

*** [err]: Mix SUBSCRIBE and PSUBSCRIBE in tests/unit/pubsub.tcl
Expected 'pmessage foo.* foo.bar hello' to be equal to 'message foo.bar hello'
```

When writing responses to a Netty channel, the messages may get written out of order in the `writeAndFlush` call. To verify this bug, we used a single thread to call `writeAndFlush` and added logging right before calling `writeAndFlush` and after `afterWrite` in the callback listener. We saw the messages get logged in the proper order before `writeAndFlush` was called, but the messages were logged out of order in the callback listener and arrived in the wrong order on the client.