### PR TITLE
GEODE-8469: fix windows test failure

### DIFF
--- a/dev-tools/dependencies/bump.sh
+++ b/dev-tools/dependencies/bump.sh
@@ -43,6 +43,7 @@ fi
 NAME="$1"
 SRCH="$2"
 REPL="$3"
+OLDV="$SRCH"
 SRCH=${SRCH//./\\.}
 git grep -n --color "$SRCH" | cat
 git grep -l "$SRCH" | while read f; do
@@ -50,7 +51,7 @@ git grep -l "$SRCH" | while read f; do
   rm -f $f.bak
 done
 git add -p
-git commit -m "Bump $NAME from $OLDV to $NEWV"
+git commit -m "Bump $NAME from $OLDV to $REPL"
 if [ $(git diff | wc -l) -gt 0 ] ; then
   git stash
   git stash drop

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ExpectedTimeoutRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ExpectedTimeoutRuleTest.java
@@ -82,9 +82,9 @@ public class ExpectedTimeoutRuleTest {
     assertThat(failures.size()).as("Failures: " + failures).isEqualTo(1);
 
     Failure failure = failures.get(0);
-    String expectedMessage = "\n"
+    String expectedMessage = System.lineSeparator()
         + "Expected: (an instance of java.util.concurrent.TimeoutException and exception with message a string containing \"this is a message for FailsWithExpectedTimeoutButWrongError\")"
-        + "\n" + "     "
+        + System.lineSeparator() + "     "
         + "but: an instance of java.util.concurrent.TimeoutException <java.lang.NullPointerException> is a java.lang.NullPointerException";
     assertThat(failure.getException()).isExactlyInstanceOf(AssertionError.class)
         .hasMessageContaining(expectedMessage);


### PR DESCRIPTION
newer dependency version uses platform-specific line separators, test did not