### PR TITLE
GEODE-8496: fix rest management test after dependency bump

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ListIndexManagementDUnitTest.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.cache.query.QueryService;
@@ -182,7 +181,7 @@ public class ListIndexManagementDUnitTest {
         .hasMessageContaining("Unable to construct the URI ");
   }
 
-  @Ignore("revisit in a separate PR")
+  @Test
   public void getIndex_fails_when_region_name_is_missing_from_filter() {
     indexConfig.setName("index1");
     assertThatThrownBy(() -> cms.get(indexConfig))


### PR DESCRIPTION
I've uncommented the test that started failing after 37 dependencies were bumped for GEODE-8496.  It appears as if the test was relying on a quirk of an underlying library to generate the unusual exception text it is expecting...seems as if we should really be enforcing this restriction in Geode code, if it's important...