### PR TITLE
GEODE-8515: Redis PING should respond appropriately when called from within a SUBSCRIBE/PSUBSCRIBE

### DIFF
--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/TempTestSuite.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/TempTestSuite.java
@@ -1,0 +1,2 @@
+package org.apache.geode.redis;public class TempTestSuite {
+}

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/TempTestSuite.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/TempTestSuite.java
@@ -1,2 +1,0 @@
-package org.apache.geode.redis;public class TempTestSuite {
-}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
@@ -39,7 +39,7 @@ public class SubscriptionsIntegrationTest {
 
   @Test
   public void pingWhileSubscribed() {
-    Jedis client = new Jedis("localhost", server.getPort(), 1000000000);
+    Jedis client = new Jedis("localhost", server.getPort());
     MockSubscriber mockSubscriber = new MockSubscriber();
 
     executor.submit(() -> client.subscribe(mockSubscriber, "same"));

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubscriptionsIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
@@ -38,8 +37,6 @@ public class SubscriptionsIntegrationTest {
   @ClassRule
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
-  // @Test
-  // public void pingWith
   @Test
   public void pingWhileSubscribed() {
     Jedis client = new Jedis("localhost", server.getPort(), 1000000000);
@@ -70,22 +67,6 @@ public class SubscriptionsIntegrationTest {
     GeodeAwaitility.await()
         .untilAsserted(() -> assertThat(mockSubscriber.getReceivedPings().size()).isEqualTo(2));
     assertThat(mockSubscriber.getReceivedPings().get(0)).isEqualTo("potato");
-    mockSubscriber.unsubscribe();
-    client.close();
-  }
-
-  @Test
-  @Ignore("GEODE-8515")
-  public void pingWhileSubscribed() {
-    Jedis client = new Jedis("localhost", server.getPort());
-    MockSubscriber mockSubscriber = new MockSubscriber();
-
-    executor.submit(() -> client.subscribe(mockSubscriber, "same"));
-    mockSubscriber.awaitSubscribe("same");
-    mockSubscriber.ping();
-    GeodeAwaitility.await()
-        .untilAsserted(() -> assertThat(mockSubscriber.getReceivedPings().size()).isEqualTo(1));
-    assertThat(mockSubscriber.getReceivedPings().get(0)).isEqualTo("");
     mockSubscriber.unsubscribe();
     client.close();
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -30,19 +30,23 @@ public class PingExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-    byte[] result;
     RedisResponse redisResponse;
 
     if (context.getPubSub().findSubscribedChannels(context.getClient()).isEmpty()) {
-      result = PING_RESPONSE.getBytes();
+      byte[] result;
       if (commandElems.size() > 1) {
         result = commandElems.get(1);
+      } else {
+        result = PING_RESPONSE.getBytes();
       }
       redisResponse = RedisResponse.string(result);
     } else {
-      result = "".getBytes();
+      byte[] result;
+
       if (commandElems.size() > 1) {
         result = commandElems.get(1);
+      } else {
+        result = "".getBytes();
       }
       redisResponse =
           RedisResponse.array(Arrays.asList(PING_RESPONSE.toLowerCase().getBytes(), result));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -15,6 +15,7 @@
  */
 package org.apache.geode.redis.internal.executor.connection;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
@@ -31,9 +32,17 @@ public class PingExecutor extends AbstractExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
     byte[] result = PING_RESPONSE.getBytes();
+    byte[] subscribeResult = "".getBytes();
     if (commandElems.size() > 1) {
       result = commandElems.get(1);
+      subscribeResult = result;
     }
+
+    if (!context.getPubSub().findSubscribedChannels(context.getClient()).isEmpty()) {
+      return RedisResponse
+          .array(Arrays.asList(PING_RESPONSE.toLowerCase().getBytes(), subscribeResult));
+    }
+
     return RedisResponse.string(result);
   }
 }


### PR DESCRIPTION
From PING documentation (https://redis.io/commands/ping):

If the client is subscribed to a channel or a pattern, it will instead return a multi-bulk with a "pong" in the first position and an empty bulk in the second position, unless an argument is provided in which case it returns a copy of the argument.