### PR TITLE
GEODE-8533: Docs - compaction-threshold mechanism description are wrong

### DIFF
--- a/geode-docs/managing/disk_storage/compacting_disk_stores.html.md.erb
+++ b/geode-docs/managing/disk_storage/compacting_disk_stores.html.md.erb
@@ -24,7 +24,7 @@ When a cache operation is added to a disk store, any preexisting operation recor
 
 <%=vars.product_name%> compacts an old operation log by copying all non-garbage records into the current log and discarding the old files. As with logging, oplogs are rolled as needed during compaction to stay within the max oplog setting.
 
-You can configure the system to automatically compact any closed operation log when its garbage content reaches a certain percentage. You can also manually request compaction for online and offline disk stores. For the online disk store, the current operation log is not available for compaction, no matter how much garbage it contains.
+You can configure the system to automatically compact any closed operation log when its non-garbage content drops below a certain percentage. You can also manually request compaction for online and offline disk stores. For the online disk store, the current operation log is not available for compaction, no matter how much garbage it contains.
 
 ## <a id="compacting_disk_stores__section_98C6B6F48E4F4F0CB7749E426AF4D647" class="no-quick-link"></a>Log File Compaction for the Online Disk Store
 
@@ -36,7 +36,7 @@ Offline compaction runs essentially in the same way, but without the incoming ca
 
 Old log files become eligible for online compaction when their garbage content surpasses a configured percentage of the total file. A record is garbage when its operation is superseded by a more recent operation for the same object. During compaction, the non-garbage records are added to the current log along with new cache operations. Online compaction does not block current system operations.
 
--   **Automatic compaction**. When `auto-compact` is true, <%=vars.product_name%> automatically compacts each oplog when its garbage content surpasses the `compaction-threshold`. This takes cycles from your other operations, so you may want to disable this and only do manual compaction, to control the timing.
+-   **Automatic compaction**. When `auto-compact` is true, <%=vars.product_name%> automatically compacts each oplog when its non-garbage (live data) content drops below the `compaction-threshold`. This takes cycles from your other operations, so you may want to disable this and only do manual compaction, to control the timing.
 -   **Manual compaction**. To run manual compaction:
     -   Set the disk store attribute `allow-force-compaction` to true. This causes <%=vars.product_name%> to maintain extra data about the files so it can compact on demand. This is disabled by default to save space. You can run manual online compaction at any time while the system is running. Oplogs eligible for compaction based on the `compaction-threshold` are compacted into the current oplog.
     -   Run manual compaction as needed. <%=vars.product_name%> has two types of manual compaction:

--- a/geode-docs/managing/disk_storage/disk_store_configuration_params.html.md.erb
+++ b/geode-docs/managing/disk_storage/disk_store_configuration_params.html.md.erb
@@ -51,12 +51,15 @@ These `<disk-store>` attributes and subelements have corresponding `gfsh create 
 </tr>
 <tr>
 <td><code class="ph codeph">auto-compact</code></td>
-<td>Boolean indicating whether to automatically compact a file when it reaches the <code class="ph codeph">compaction-threshold</code>.</td>
+<td>Boolean indicating whether to automatically compact a file when it drops below the <code class="ph codeph">compaction-threshold</code>.</td>
 <td>true</td>
 </tr>
 <tr>
 <td><code class="ph codeph">compaction-threshold</code></td>
-<td>Percentage of garbage allowed in the file before it is eligible for compaction. Garbage is created by entry destroys, entry updates, and region destroys and creates. Surpassing this percentage does not make compaction occur—it makes the file eligible to be compacted when a compaction is done.</td>
+<td>Percentage (0..100) of live data (non-garbage content) remaining in the operation log, below which it is eligible for
+compaction. As garbage is created (by entry destroys, entry updates, and region destroys and
+creates) the percentage of remaining live data declines. Falling below this percentage does not make
+compaction occur&mdash;it makes the file eligible to be compacted when a compaction is done.</td>
 <td>50</td>
 </tr>
 <tr>

--- a/geode-docs/managing/disk_storage/using_disk_stores.html.md.erb
+++ b/geode-docs/managing/disk_storage/using_disk_stores.html.md.erb
@@ -35,13 +35,13 @@ Before you begin, you should understand <%=vars.product_name%> [Basic Configurat
 
 1.  Work with your system designers and developers to plan for anticipated disk storage requirements in your testing and production caching systems. Take into account space and functional requirements.
     -   For efficiency, separate data that is only overflowed in separate disk stores from data that is persisted or persisted and overflowed. Regions can be overflowed, persisted, or both. Server subscription queues are only overflowed.
-    -   When calculating your disk requirements, figure in your data modification patterns and your compaction strategy. <%=vars.product_name%> creates each oplog file at the max-oplog-size, which defaults to 1 GB. Obsolete operations are only removed from the oplogs during compaction, so you need enough space to store all operations that are done between compactions. For regions where you are doing a mix of updates and deletes, if you use automatic compaction, a good upper bound for the required disk space is
+    -   When calculating your disk requirements, figure in your data modification patterns and your compaction strategy. <%=vars.product_name%> creates each oplog file at the max-oplog-size, which defaults to 1 GB. Obsolete operations are removed from the oplogs only during compaction, so you need enough space to store all operations that are done between compactions. For regions where you are doing a mix of updates and deletes, if you use automatic compaction, a good upper bound for the required disk space is
 
         ``` pre
-        (1 / (1 - (compaction_threshold/100)) ) * data size
+        (1 / (compaction_threshold/100) ) * data size
         ```
 
-        where data size is the total size of all the data you store in the disk store. So, for the default compaction-threshold of 50, the disk space is roughly twice your data size. Note that the compaction thread could lag behind other operations, causing disk use to rise above the threshold temporarily. If you disable automatic compaction, the amount of disk required depends on how many obsolete operations accumulate between manual compactions.
+        where data size is the total size of all the data you store in the disk store. So, for the default compaction-threshold of 50, the disk space is roughly twice your data size. Note that the compaction thread could lag behind other operations, causing disk use to rise temporarily above the upper bound. If you disable automatic compaction, the amount of disk required depends on how many obsolete operations accumulate between manual compactions.
 
 2.  Work with your host system administrators to determine where to place your disk store directories, based on your anticipated disk storage requirements and the available disks on your host systems.
     -   Make sure the new storage does not interfere with other processes that use disk on your systems. If possible, store your files to disks that are not used by other processes, including virtual memory or swap space. If you have multiple disks available, for the best performance, place one directory on each disk.

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -300,7 +300,7 @@ If the specified directory does not exist, the command will create the directory
 </tr>
 <tr>
 <td><span class="keyword parmname">\-\-compaction-threshold</span></td>
-<td>Percentage of garbage allowed before the disk store is eligible for compaction.</td>
+<td>Percentage of non-garbage remaining, below which the disk store is eligible for compaction.</td>
 <td>50</td>
 </tr>
 <tr>


### PR DESCRIPTION
Questions for reviewers:
- Have the explanations satisfactorily stated that the compaction-threshold is a percentage of live data (non-garbage), as opposed to a percentage of garbage?
- Is it clear that the threshold is activated when the live data percentage drops below the threshold, as opposed to exceeding it?
- Is the modified formula for calculating required disk space correct?
Thanks!
