### PR TITLE
GEODE-8498: make AbstractSubscription write to channel synchronously

### DIFF
--- a/geode-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -31,6 +31,7 @@ public class MockSubscriber extends JedisPubSub {
   private final CountDownLatch subscriptionLatch;
   private final CountDownLatch psubscriptionLatch;
   private final CountDownLatch unsubscriptionLatch;
+  private final CountDownLatch pUnsubscriptionLatch;
   private final List<String> receivedMessages = Collections.synchronizedList(new ArrayList<>());
   private final List<String> receivedPMessages = Collections.synchronizedList(new ArrayList<>());
   private final List<String> receivedPings = Collections.synchronizedList(new ArrayList<>());
@@ -47,14 +48,16 @@ public class MockSubscriber extends JedisPubSub {
   }
 
   public MockSubscriber(CountDownLatch subscriptionLatch) {
-    this(subscriptionLatch, new CountDownLatch(1), new CountDownLatch(1));
+    this(subscriptionLatch, new CountDownLatch(1), new CountDownLatch(1), new CountDownLatch(1));
   }
 
   public MockSubscriber(CountDownLatch subscriptionLatch, CountDownLatch unsubscriptionLatch,
-      CountDownLatch psubscriptionLatch) {
+      CountDownLatch psubscriptionLatch,
+      CountDownLatch pUnsubscriptionLatch) {
     this.subscriptionLatch = subscriptionLatch;
     this.psubscriptionLatch = psubscriptionLatch;
     this.unsubscriptionLatch = unsubscriptionLatch;
+    this.pUnsubscriptionLatch = pUnsubscriptionLatch;
   }
 
   @Override
@@ -176,6 +179,18 @@ public class MockSubscriber extends JedisPubSub {
   public void onPUnsubscribe(String pattern, int subscribedChannels) {
     switchThreadName(String.format("PUNSUBSCRIBE %s %d", pattern, subscribedChannels));
     punsubscribeInfos.add(new UnsubscribeInfo(pattern, subscribedChannels));
+    pUnsubscriptionLatch.countDown();
+  }
+
+  public void awaitPunsubscribe(String pChannel) {
+
+    try {
+      if (!pUnsubscriptionLatch.await(AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+        throw new RuntimeException("awaitPUnsubscribe timed out for pattern: " + pChannel);
+      }
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static class UnsubscribeInfo {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/LettucePubSubIntegrationTest.java
@@ -34,7 +34,6 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
@@ -152,7 +151,6 @@ public class LettucePubSubIntegrationTest {
   }
 
   @Test
-  @Ignore("GEODE-8498")
   public void subscribePsubscribeSameClient() throws InterruptedException {
     StatefulRedisPubSubConnection<String, String> subscriber = client.connectPubSub();
     StatefulRedisPubSubConnection<String, String> publisher = client.connectPubSub();
@@ -354,6 +352,7 @@ public class LettucePubSubIntegrationTest {
     }
 
     long publishCount = 0;
+
     for (Future<Long> r : results) {
       publishCount += r.get();
     }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
@@ -78,6 +78,11 @@ public class PubSubImplJUnitTest {
     }
 
     @Override
+    public ChannelPromise syncUninterruptibly() {
+      return this;
+    }
+
+    @Override
     public Throwable cause() {
       return new RuntimeException("aeotunhasoen");
     }


### PR DESCRIPTION
Adds punsubscriptionlatch countdown

WIP pipeline experiment without syncUninterupptibly

GEODE-8498 keep published messages to same client in order

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
