### PR TITLE
GEODE-8544: Making VM class start versioned VM

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
@@ -123,7 +123,7 @@ public class VM implements Serializable {
    * @param whichVM A zero-based identifier of the VM
    */
   public static VM getVM(String version, int whichVM) {
-    return Host.getHost(0).getVM(whichVM);
+    return Host.getHost(0).getVM(version, whichVM);
   }
 
   /**


### PR DESCRIPTION
Fixing an issue where the VM class will not properly start a versioned server.