### PR TITLE
GEODE-8496: un-upgrade archunit to avoid OOM on JDK8

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -166,7 +166,7 @@
       <dependency>
         <groupId>com.tngtech.archunit</groupId>
         <artifactId>archunit-junit4</artifactId>
-        <version>0.14.1</version>
+        <version>0.12.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -105,7 +105,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'com.sun.istack', name: 'istack-commons-runtime', version: '3.0.11')
         api(group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2')
         api(group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.2')
-        api(group: 'com.tngtech.archunit', name:'archunit-junit4', version: '0.14.1')
+        api(group: 'com.tngtech.archunit', name:'archunit-junit4', version: '0.12.0')
         api(group: 'com.zaxxer', name: 'HikariCP', version: '3.4.5')
         api(group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4')
         api(group: 'commons-codec', name: 'commons-codec', version: '1.15')

--- a/dev-tools/dependencies/README.md
+++ b/dev-tools/dependencies/README.md
@@ -19,6 +19,7 @@ Step 2: filter out certain dependencies that we cannot change, such as:
 - protobuf
 - lucene
 - tomcat 6
+- archunit (13.0 and later get OOM on JDK8)
 
 Step 3: in some cases, maven suggests new majors, beta releases, or just wrong releases.
 Manually search for those dependencies on mavencentral to see if there is a better choice.

--- a/dev-tools/dependencies/bump.sh
+++ b/dev-tools/dependencies/bump.sh
@@ -24,7 +24,7 @@ fi
 
 if [ "$1" = "-l" ] ; then
   ./gradlew dependencyUpdates; find . | grep build/dependencyUpdates/report.txt | xargs cat \
-   | grep ' -> ' | egrep -v '(Gradle|antlr|protobuf|lucene|JUnitParams|docker-compose-rule|javax.servlet-api|gradle-tooling-api|springfox)' \
+   | grep ' -> ' | egrep -v '(Gradle|antlr|protobuf|lucene|JUnitParams|docker-compose-rule|javax.servlet-api|gradle-tooling-api|springfox|archunit)' \
    | sort -u | tr -d '][' | sed -e 's/ -> / /' -e 's#.*:#'"$0"' #'
   exit 0
 fi


### PR DESCRIPTION
#5537 passed in PR checked, which run only JDK11, but under JDK8 a bug in archunit is encountered which results in OOM:

https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/IntegrationTestOpenJDK8/builds/462

> java.lang.OutOfMemoryError: Java heap space
> 	at java.util.Formatter.parse(Formatter.java:2560)
> 	at java.util.Formatter.format(Formatter.java:2501)
> 	at java.util.Formatter.format(Formatter.java:2455)
> 	at java.lang.String.format(String.java:2940)
> 	at com.tngtech.archunit.core.domain.SourceCodeLocation.formatLocation(SourceCodeLocation.java:60)
> 	at com.tngtech.archunit.core.domain.SourceCodeLocation.<init>(SourceCodeLocation.java:78)
> 	at com.tngtech.archunit.core.domain.SourceCodeLocation.of(SourceCodeLocation.java:52)
> 	...

This archunit bug seems to have been introduced in 0.13.0, so downgrade to the version prior