### PR TITLE
GEODE-8555: SimpleDiskRegionJunitTest fails on Windows

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
@@ -202,8 +202,8 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
     long id = oplog.getOplogId();
 
     StatisticsFactory factory = region.getCache().getDistributedSystem();
-    Oplog newOplog = new Oplog(id, dr.getOplogSet(),
-        new DirectoryHolder(factory, dirs[0], 1000000, 0));
+    Oplog newOplog =
+        new Oplog(id, dr.getOplogSet(), new DirectoryHolder(factory, dirs[0], 1000000, 0));
     dr.getDiskStore().getPersistentOplogs().setChild(newOplog);
     assertEquals(newOplog, dr.testHook_getChild());
     dr.setChild(oplog);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/SimpleDiskRegionJUnitTest.java
@@ -22,7 +22,6 @@ package org.apache.geode.internal.cache;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 
 import java.io.File;
 import java.util.Collections;
@@ -32,7 +31,6 @@ import java.util.Set;
 import org.junit.Test;
 
 import org.apache.geode.StatisticsFactory;
-import org.apache.geode.internal.lang.SystemUtils;
 import org.apache.geode.test.dunit.ThreadUtils;
 
 /**
@@ -56,9 +54,8 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
    */
   @Test
   public void testBasicClose() {
-    assumeFalse(SystemUtils.isWindows());
     {
-      deleteFiles();
+      forceDeleteFiles();
       try {
         region = DiskRegionHelperFactory.getAsyncOverFlowAndPersistRegion(cache, diskProps);
       } catch (Exception e) {
@@ -70,7 +67,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       checkIfContainsFileWithExt("lk");
     }
     {
-      deleteFiles();
+      forceDeleteFiles();
       try {
         region = DiskRegionHelperFactory.getAsyncOverFlowOnlyRegion(cache, diskProps);
       } catch (Exception e) {
@@ -82,7 +79,7 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
       checkIfContainsFileWithExt("lk");
     }
     {
-      deleteFiles();
+      forceDeleteFiles();
       try {
         region = DiskRegionHelperFactory.getAsyncPersistOnlyRegion(cache, diskProps);
       } catch (Exception e) {
@@ -205,8 +202,8 @@ public class SimpleDiskRegionJUnitTest extends DiskRegionTestingBase {
     long id = oplog.getOplogId();
 
     StatisticsFactory factory = region.getCache().getDistributedSystem();
-    Oplog newOplog =
-        new Oplog(id, dr.getOplogSet(), new DirectoryHolder(factory, dirs[0], 1000000, 0));
+    Oplog newOplog = new Oplog(id, dr.getOplogSet(),
+        new DirectoryHolder(factory, dirs[0], 1000000, 0));
     dr.getDiskStore().getPersistentOplogs().setChild(newOplog);
     assertEquals(newOplog, dr.testHook_getChild());
     dr.setChild(oplog);

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/DiskRegionTestingBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/DiskRegionTestingBase.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Properties;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +47,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.versions.VersionTag;
+import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * DiskRegionTestingBase: This class is extended to write more JUnit tests for Disk Regions.
@@ -198,6 +200,19 @@ public abstract class DiskRegionTestingBase {
   protected void deleteFiles() {
     closeDiskStores();
     tempDir.delete();
+  }
+
+  protected void forceDeleteFiles() {
+    closeDiskStores();
+    File file = tempDir.getRoot();
+    File[] files = file.listFiles();
+    for (File each : files) {
+      try {
+        FileUtils.forceDelete(each);
+      } catch (IOException e) {
+        LogService.getLogger().error("Caught", e);
+      }
+    }
   }
 
   protected void closeDiskStores() {

--- a/geode-junit/src/main/java/org/apache/geode/internal/cache/DiskRegionTestingBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/cache/DiskRegionTestingBase.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.rules.ErrorCollector;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 
@@ -47,7 +48,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.internal.cache.versions.VersionTag;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * DiskRegionTestingBase: This class is extended to write more JUnit tests for Disk Regions.
@@ -80,6 +80,9 @@ public abstract class DiskRegionTestingBase {
 
   @Rule
   public TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Rule
+  public ErrorCollector errorCollector = new ErrorCollector();
 
   @Before
   public final void setUp() throws Exception {
@@ -208,9 +211,11 @@ public abstract class DiskRegionTestingBase {
     File[] files = file.listFiles();
     for (File each : files) {
       try {
-        FileUtils.forceDelete(each);
+        if (!each.getName().contains(".gfs")) {
+          FileUtils.forceDelete(each);
+        }
       } catch (IOException e) {
-        LogService.getLogger().error("Caught", e);
+        errorCollector.addError(e);
       }
     }
   }


### PR DESCRIPTION
Co-authored-by: Ray Ingles <ringles@pivotal.io>

Updating Junit to 4.13, one test failed on Windows due to failure to delete some temporary test files.

https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/WindowsCoreIntegrationTestOpenJDK8/builds/455

```
org.apache.geode.internal.cache.SimpleDiskRegionJUnitTest > testBasicClose FAILED
    java.lang.AssertionError:  Exception in createOverflowOnly due to java.lang.IllegalStateException: The region "/testRegion" has been persisted to disk so it can not be recreated on the same disk store without persistence. Either destroy the persistent region, recreate it as overflow and persistent, or create the overflow only region on a different disk store.
        at org.junit.Assert.fail(Assert.java:89)
        at org.apache.geode.internal.cache.SimpleDiskRegionJUnitTest.testBasicClose(SimpleDiskRegionJUnitTest.java:75)
```