### PR TITLE
GEODE-8561: Ability to request Windows PR checks for an individual PR

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -22,7 +22,7 @@ groups:
 - name: main
   jobs:
   - {{ build_test.name }}
-{%- for test in tests if test.PLATFORM=="linux" %}
+{%- for test in tests %}
   {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
   - {{test.name}}Test{{java_test_version.name}}
   {%- endfor %}
@@ -35,6 +35,14 @@ resources:
     repository: {{repository.fork}}/geode
     disable_ci_skip: false
     skip_ssl_verification: false
+- name: geode-windows
+  type: pull-request
+  source:
+    access_token: ((github-apachegeode-ci-read-only-token))
+    repository: {{repository.fork}}/geode
+    disable_ci_skip: false
+    skip_ssl_verification: false
+    labels: [windows]
 - name: geode-status
   type: pull-request
   source:
@@ -250,7 +258,7 @@ jobs:
         get_params: {skip_download: true}
 
 
-{% for test in tests if test.PLATFORM=="linux"%}
+{% for test in tests %}
   {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
 - name: {{test.name}}Test{{java_test_version.name}}
   public: true
@@ -258,7 +266,11 @@ jobs:
   - do:
     - aggregate:
       - get: alpine-tools-image
+{%- if test.PLATFORM=="linux" %}
       - get: geode
+{%- else %}
+      - get: geode-windows
+{%- endif %}
         trigger: true
         version: every
         attempts: 2


### PR DESCRIPTION
In a [recent discussion on the dev list](https://lists.apache.org/x/thread.html/r4d0ad5898654525e59a5367e3ad101a14307118932a6d61fbf3d72cf@%3Cdev.geode.apache.org%3E), some felt it was unnecessary to add Windows PR checks to *every* PR.  However at least 8 times this year alone, this has led to changes being committed to develop that broke on Windows, stalling the pipeline.

This poses a problem, because even once you know your commit broke Windows, developers often have no way to test a fix.

A comment from Kirk asked if we could find a way to request extra (Windows) PR checks only for certain PRs, e.g. opt-in once you have found yourself in the position of having to fix a Windows failure.

This enables the PR pipeline to do just that.  Ordinary PRs will continue to behave exactly as before.  However, if you add the GitHub label "windows" to the PR (just below the reviewers list), additional PR checks for Windows will be run as well.  They will never be required checks so as always, you are free to merge before they have finished if you already got what you needed.