### PR TITLE
GEODE-8559: Compute interest routing info after transaction committed.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -2994,4 +2994,9 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       setRegion(getRegion().getPartitionedRegion());
     }
   }
+
+  @Override
+  public boolean isTransactional() {
+    return getTransactionId() != null;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
@@ -1165,10 +1165,7 @@ public class FilterProfile implements DataSerializableFixedID {
       return true;
     }
     FilterInfo localFilterInfo = getLocalFilterInfo(event);
-    if (localFilterInfo != null) {
-      return false;
-    }
-    return true;
+    return localFilterInfo == null;
   }
 
   FilterInfo getLocalFilterInfo(CacheEvent event) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.ANY_INIT;
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -1045,7 +1046,7 @@ public class FilterProfile implements DataSerializableFixedID {
 
   private final CacheProfile localProfile = new CacheProfile(this);
 
-  private final Profile[] localProfileArray = new Profile[] {localProfile};
+  final Profile[] localProfileArray = new Profile[] {localProfile};
 
   /** compute local routing information */
   public FilterInfo getLocalFilterRouting(CacheEvent event) {
@@ -1086,7 +1087,6 @@ public class FilterProfile implements DataSerializableFixedID {
     // bug #50809 - local routing for transactional ops must be done here
     // because the event isn't available later and we lose the old value for the entry
     boolean processLocalProfile = false;
-
     CqService cqService = getCqService(event.getRegion());
     if (cqService.isRunning()) {
       processLocalProfile =
@@ -1126,6 +1126,11 @@ public class FilterProfile implements DataSerializableFixedID {
    */
   public FilterRoutingInfo getFilterRoutingInfoPart2(FilterRoutingInfo part1Info,
       CacheEvent event) {
+    return getFilterRoutingInfoPart2(part1Info, event, false);
+  }
+
+  public FilterRoutingInfo getFilterRoutingInfoPart2(FilterRoutingInfo part1Info,
+      CacheEvent event, boolean computeInterestRoutingInfo) {
     FilterRoutingInfo result = part1Info;
     if (localProfile.hasCacheServer) {
       // bug #45520 - CQ events arriving out of order causes result set
@@ -1133,20 +1138,63 @@ public class FilterProfile implements DataSerializableFixedID {
       boolean isInConflict =
           event.getOperation().isEntry() && ((EntryEventImpl) event).isConcurrencyConflict();
       CqService cqService = getCqService(event.getRegion());
-      if (!isInConflict && cqService.isRunning()
-          && this.region != null /*
-                                  * && !( this.region.isUsedForPartitionedRegionBucket() || //
-                                  * partitioned region CQ this.region instanceof PartitionedRegion)
-                                  */) { // processing is done in part 1
+      if (!isInConflict && cqService.isRunning() && region != null) {
         if (result == null) {
           result = new FilterRoutingInfo();
         }
         if (logger.isDebugEnabled()) {
           logger.debug("getting local cq matches for {}", event);
         }
-        fillInCQRoutingInfo(event, true, NO_PROFILES, result);
+        setLocalCQRoutingInfo(event, result);
       }
+      result = setLocalInterestRoutingInfo(event, result, computeInterestRoutingInfo);
+    }
+    return result;
+  }
+
+  void setLocalCQRoutingInfo(CacheEvent event, FilterRoutingInfo result) {
+    if (isCQRoutingNeeded(event)) {
+      fillInCQRoutingInfo(event, true, NO_PROFILES, result);
+    } else {
+      result.setLocalFilterInfo(getLocalFilterInfo(event));
+    }
+  }
+
+  boolean isCQRoutingNeeded(CacheEvent event) {
+    if (!isTransactionalEvent(event)) {
+      return true;
+    }
+    FilterInfo localFilterInfo = getLocalFilterInfo(event);
+    if (localFilterInfo != null) {
+      return false;
+    }
+    return true;
+  }
+
+  FilterInfo getLocalFilterInfo(CacheEvent event) {
+    EntryEventImpl entryEvent = uncheckedCast(event);
+    return entryEvent.getLocalFilterInfo();
+  }
+
+  boolean isTransactionalEvent(CacheEvent event) {
+    if (event.getOperation().isEntry()) {
+      EntryEventImpl entryEvent = uncheckedCast(event);
+      return entryEvent.isTransactional();
+    }
+    return false;
+  }
+
+  FilterRoutingInfo setLocalInterestRoutingInfo(CacheEvent event, FilterRoutingInfo result,
+      boolean computeInterestRoutingInfo) {
+    if (!isTransactionalEvent(event)) {
       result = fillInInterestRoutingInfo(event, localProfileArray, result, Collections.emptySet());
+    } else {
+      // For transaction, compute interested clients after transaction is applied to cache.
+      FilterInfo filterInfo = ((EntryEventImpl) event).getLocalFilterInfo();
+      if (filterInfo == null || filterInfo.isChangeAppliedToCache() || computeInterestRoutingInfo) {
+        result =
+            fillInInterestRoutingInfo(event, localProfileArray, result, Collections.emptySet());
+      }
     }
     return result;
   }
@@ -1158,7 +1206,7 @@ public class FilterProfile implements DataSerializableFixedID {
    * @param peerProfiles the profiles getting this event
    * @param frInfo the routing table to update
    */
-  private void fillInCQRoutingInfo(CacheEvent event, boolean processLocalProfile,
+  void fillInCQRoutingInfo(CacheEvent event, boolean processLocalProfile,
       Profile[] peerProfiles, FilterRoutingInfo frInfo) {
     CqService cqService = getCqService(event.getRegion());
     if (cqService != null) {
@@ -1177,7 +1225,7 @@ public class FilterProfile implements DataSerializableFixedID {
     }
   }
 
-  private CqService getCqService(Region region) {
+  CqService getCqService(Region region) {
     return ((InternalCache) region.getRegionService()).getCqService();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterRoutingInfo.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterRoutingInfo.java
@@ -96,6 +96,10 @@ public class FilterRoutingInfo implements VersionedDataSerializable {
     this.hasLocalInterestBeenComputed = true;
   }
 
+  public void setLocalFilterInfo(FilterInfo filterInfo) {
+    localFilterInfo = filterInfo;
+  }
+
   /**
    * returns true if local interest has been computed
    */
@@ -332,6 +336,9 @@ public class FilterRoutingInfo implements VersionedDataSerializable {
     /** To identify where the filter is processed, locally or in remote node */
     public boolean filterProcessedLocally = false;
 
+    /** Used to determine when to computed interested clients for transactional events */
+    private transient boolean changeAppliedToCache = false;
+
     /** adds the content from another FilterInfo object. */
     public void addFilterInfo(FilterInfo other) {
       if (other.cqs != null) {
@@ -530,6 +537,14 @@ public class FilterRoutingInfo implements VersionedDataSerializable {
         }
       }
       return sb.toString();
+    }
+
+    public void setChangeAppliedToCache(boolean changeAppliedToCache) {
+      this.changeAppliedToCache = changeAppliedToCache;
+    }
+
+    public boolean isChangeAppliedToCache() {
+      return changeAppliedToCache;
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheEvent.java
@@ -83,4 +83,7 @@ public interface InternalCacheEvent extends CacheEvent {
    */
   VersionTag getVersionTag();
 
+  default boolean isTransactional() {
+    return false;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5804,7 +5804,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     FilterProfile filterProfile = getFilterProfile();
     FilterInfo routing = event.getLocalFilterInfo();
 
-    if (filterProfile != null && routing == null) {
+    if (filterProfile != null && isGenerateLocalFilterRoutingNeeded(event)) {
       boolean lockForCQ = false;
       Object regionEntryObject = null;
 
@@ -5840,6 +5840,17 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       }
       routing.clearCQRouting();
     }
+  }
+
+  boolean isGenerateLocalFilterRoutingNeeded(InternalCacheEvent event) {
+    FilterRoutingInfo.FilterInfo filterInfo = event.getLocalFilterInfo();
+    if (filterInfo == null) {
+      return true;
+    }
+    if (!event.isTransactional()) {
+      return false;
+    }
+    return filterInfo.isChangeAppliedToCache();
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -7928,7 +7928,7 @@ public class PartitionedRegion extends LocalRegion
 
   @Override
   void generateLocalFilterRouting(InternalCacheEvent event) {
-    if (event.getLocalFilterInfo() == null) {
+    if (isGenerateLocalFilterRoutingNeeded(event)) {
       super.generateLocalFilterRouting(event);
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
@@ -1963,6 +1963,11 @@ public class TXEntryState implements Releasable {
     }
 
     @Override
+    public boolean isTransactional() {
+      return true;
+    }
+
+    @Override
     public int compareTo(Object o) {
       TxEntryEventImpl other = (TxEntryEventImpl) o;
       return getSortValue() - other.getSortValue();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TxCallbackEventFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TxCallbackEventFactoryImpl.java
@@ -55,10 +55,10 @@ public class TxCallbackEventFactoryImpl implements TxCallbackEventFactory {
     @Retained
     EntryEventImpl retVal = EntryEventImpl.create(internalRegion, op, key, newValue,
         aCallbackArgument, txEntryState == null, originator);
+    // Need to make it a Transactional event so that routing info can be computed correctly.
+    retVal.setTransactionId(txId);
     boolean returnedRetVal = false;
     try {
-
-
       if (bridgeContext != null) {
         retVal.setContext(bridgeContext);
       }
@@ -135,7 +135,6 @@ public class TxCallbackEventFactoryImpl implements TxCallbackEventFactory {
           retVal.setLocalFilterInfo(fp.getLocalFilterRouting(retVal));
         }
       }
-      retVal.setTransactionId(txId);
       returnedRetVal = true;
       return retVal;
     } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientRegistrationEventQueueManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientRegistrationEventQueueManager.java
@@ -173,7 +173,7 @@ public class ClientRegistrationEventQueueManager {
 
         if (filterProfile != null) {
           FilterRoutingInfo filterRoutingInfo =
-              filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent);
+              filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent, true);
 
           if (filterRoutingInfo != null) {
             FilterRoutingInfo.FilterInfo filterInfo = filterRoutingInfo.getLocalFilterInfo();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/DistTxEntryEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/DistTxEntryEvent.java
@@ -72,6 +72,11 @@ public class DistTxEntryEvent extends EntryEventImpl {
   }
 
   @Override
+  public boolean isTransactional() {
+    return true;
+  }
+
+  @Override
   public void toData(DataOutput out,
       SerializationContext context) throws IOException {
     DataSerializer.writeObject(this.eventID, out);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventImplTest.java
@@ -61,12 +61,7 @@ public class EntryEventImplTest {
     doReturn(expectedRegionName).when(region).getFullPath();
     doReturn(keyInfo).when(region).getKeyInfo(any(), any(), any());
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
-
+    setupCache(region);
 
     // create entry event for the region
     EntryEventImpl e = createEntryEvent(region, value);
@@ -107,11 +102,7 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithByteArray() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     byte[] newValue = new byte[] {1, 2, 3};
     NewValueImporter nvImporter = mock(NewValueImporter.class);
@@ -126,11 +117,7 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithStringIgnoresNewValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     String newValue = "newValue";
     NewValueImporter nvImporter = mock(NewValueImporter.class);
@@ -148,11 +135,7 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithByteArrayCachedDeserializable() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     byte[] newValueBytes = new byte[] {1, 2, 3};
@@ -169,11 +152,7 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithStringCachedDeserializable() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     Object newValueObj = "newValueObj";
@@ -193,11 +172,7 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithStringCachedDeserializablePrefersNewValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     Object newValueObj = "newValueObj";
@@ -217,11 +192,7 @@ public class EntryEventImplTest {
   public void verifyExportNewValueWithStringCachedDeserializablePrefersCachedSerializedNewValue() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     CachedDeserializable newValue = mock(CachedDeserializable.class);
     Object newValueObj = "newValueObj";
@@ -339,11 +310,7 @@ public class EntryEventImplTest {
   public void verifyExportOldValueWithByteArray() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     byte[] oldValue = new byte[] {1, 2, 3};
     OldValueImporter ovImporter = mock(OldValueImporter.class);
@@ -359,11 +326,7 @@ public class EntryEventImplTest {
   public void verifyExportOldValueWithStringIgnoresOldValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     String oldValue = "oldValue";
     OldValueImporter ovImporter = mock(OldValueImporter.class);
@@ -382,11 +345,7 @@ public class EntryEventImplTest {
   public void verifyExportOldValuePrefersOldValueBytes() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     OldValueImporter ovImporter = mock(OldValueImporter.class);
     when(ovImporter.prefersOldSerialized()).thenReturn(true);
@@ -403,11 +362,7 @@ public class EntryEventImplTest {
   public void verifyExportOldValueWithCacheDeserializableByteArray() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     CachedDeserializable oldValue = mock(CachedDeserializable.class);
     byte[] oldValueBytes = new byte[] {1, 2, 3};
@@ -427,11 +382,7 @@ public class EntryEventImplTest {
     CachedDeserializable oldValue = mock(CachedDeserializable.class);
     Object oldValueObj = "oldValueObj";
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     when(oldValue.getValue()).thenReturn(oldValueObj);
     OldValueImporter ovImporter = mock(OldValueImporter.class);
@@ -449,11 +400,7 @@ public class EntryEventImplTest {
     CachedDeserializable oldValue = mock(CachedDeserializable.class);
     Object oldValueObj = "oldValueObj";
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     when(oldValue.getValue()).thenReturn(oldValueObj);
     OldValueImporter ovImporter = mock(OldValueImporter.class);
@@ -547,11 +494,7 @@ public class EntryEventImplTest {
   public void setOldValueUnforcedWithRemoveTokenChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -564,11 +507,7 @@ public class EntryEventImplTest {
   public void setOldValueForcedWithRemoveTokenChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -581,11 +520,7 @@ public class EntryEventImplTest {
   public void setOldValueUnforcedWithInvalidTokenNullsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -598,11 +533,7 @@ public class EntryEventImplTest {
   public void setOldValueForcedWithInvalidTokenNullsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -615,11 +546,7 @@ public class EntryEventImplTest {
   public void setOldValueUnforcedWithNullChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -632,11 +559,7 @@ public class EntryEventImplTest {
   public void setOldValueForcedWithNullChangesOldValueToNull() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -649,11 +572,7 @@ public class EntryEventImplTest {
   public void setOldValueForcedWithNotAvailableTokenSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -666,11 +585,7 @@ public class EntryEventImplTest {
   public void setOldValueUnforcedWithNotAvailableTokenSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -683,11 +598,7 @@ public class EntryEventImplTest {
   public void setOldUnforcedValueSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -700,11 +611,7 @@ public class EntryEventImplTest {
   public void setOldValueForcedSetsOldValue() {
     LocalRegion region = mock(LocalRegion.class);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     String UNINITIALIZED = "Uninitialized";
@@ -906,11 +813,7 @@ public class EntryEventImplTest {
     LocalRegion region = mock(LocalRegion.class);
     when(region.cacheTimeMillis()).thenReturn(timestamp);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     assertThat(e.getEventTime(0l)).isEqualTo(timestamp);
@@ -922,11 +825,7 @@ public class EntryEventImplTest {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
@@ -944,11 +843,7 @@ public class EntryEventImplTest {
     when(region.getConcurrencyChecksEnabled()).thenReturn(true);
     when(region.cacheTimeMillis()).thenReturn(timestamp);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
@@ -958,6 +853,14 @@ public class EntryEventImplTest {
     assertThat(tag.getVersionTimeStamp()).isEqualTo(timestampPlus2);
   }
 
+  private void setupCache(LocalRegion region) {
+    InternalCache cache = mock(InternalCache.class);
+    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
+    when(region.getCache()).thenReturn(cache);
+    when(cache.getDistributedSystem()).thenReturn(ids);
+    when(ids.getOffHeapStore()).thenReturn(null);
+  }
+
   @Test
   public void testGetEventTimeWithVersionTagConcurrencyChecksDisabledNoSuggestedTime() {
     long timestamp = System.currentTimeMillis();
@@ -965,11 +868,7 @@ public class EntryEventImplTest {
     when(region.getConcurrencyChecksEnabled()).thenReturn(false);
     when(region.cacheTimeMillis()).thenReturn(timestamp);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
@@ -984,17 +883,34 @@ public class EntryEventImplTest {
     LocalRegion region = mock(LocalRegion.class);
     when(region.getConcurrencyChecksEnabled()).thenReturn(false);
 
-    InternalCache cache = mock(InternalCache.class);
-    InternalDistributedSystem ids = mock(InternalDistributedSystem.class);
-    when(region.getCache()).thenReturn(cache);
-    when(cache.getDistributedSystem()).thenReturn(ids);
-    when(ids.getOffHeapStore()).thenReturn(null);
+    setupCache(region);
 
     EntryEventImpl e = createEntryEvent(region, null);
     VersionTag tag = VersionTag.create(mock(InternalDistributedMember.class));
     tag.setVersionTimeStamp(timestamp + 1000l);
     e.setVersionTag(tag);
     assertThat(e.getEventTime(timestamp)).isEqualTo(timestamp);
+  }
+
+  @Test
+  public void isTransactionalReturnsTrueIfTXIdIsSet() {
+    LocalRegion region = mock(LocalRegion.class);
+    setupCache(region);
+
+    EntryEventImpl event = createEntryEvent(region, null);
+    event.setTransactionId(mock(TXId.class));
+
+    assertThat(event.isTransactional()).isTrue();
+  }
+
+  @Test
+  public void isTransactionalReturnsFalseIfTXIdIsNotSet() {
+    LocalRegion region = mock(LocalRegion.class);
+    setupCache(region);
+
+    EntryEventImpl event = createEntryEvent(region, null);
+
+    assertThat(event.isTransactional()).isFalse();
   }
 
   private static class EntryEventImplWithOldValuesDisabled extends EntryEventImpl {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/FilterProfileTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/FilterProfileTest.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.CacheEvent;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.query.internal.cq.CqService;
+
+public class FilterProfileTest {
+  private LocalRegion region;
+  private FilterProfile filterProfile;
+  private final EntryEventImpl event = mock(EntryEventImpl.class);
+  private final CqService cqService = mock(CqService.class);
+  private final FilterRoutingInfo routingInfo = mock(FilterRoutingInfo.class);
+  private final FilterRoutingInfo.FilterInfo filterInfo = mock(FilterRoutingInfo.FilterInfo.class);
+
+  @Before
+  public void setUp() {
+    region = mock(LocalRegion.class);
+    GemFireCacheImpl mockCache = mock(GemFireCacheImpl.class);
+    when(mockCache.getCacheServers()).thenReturn(Collections.emptyList());
+    when(region.getGemFireCache()).thenReturn(mockCache);
+    filterProfile = spy(new FilterProfile(region));
+    when(cqService.isRunning()).thenReturn(true);
+    when(event.getOperation()).thenReturn(Operation.CREATE);
+    when(event.getRegion()).thenReturn(region);
+  }
+
+  @Test
+  public void getFilterRoutingInfoPart2DoesNotSetRoutingInfoIfNoCacheServer() {
+    filterProfile.getLocalProfile().hasCacheServer = false;
+    doReturn(cqService).when(filterProfile).getCqService(region);
+
+    assertThat(filterProfile.getFilterRoutingInfoPart2(routingInfo, event)).isEqualTo(routingInfo);
+
+    verify(filterProfile, never()).setLocalCQRoutingInfo(event, routingInfo);
+    verify(filterProfile, never()).setLocalInterestRoutingInfo(event, routingInfo, false);
+  }
+
+  @Test
+  public void getFilterRoutingInfoPart2SetsLocalCQAndInterestRoutingInfo() {
+    filterProfile.getLocalProfile().hasCacheServer = true;
+    doReturn(cqService).when(filterProfile).getCqService(region);
+
+    assertThat(filterProfile.getFilterRoutingInfoPart2(routingInfo, event)).isEqualTo(routingInfo);
+
+    verify(filterProfile).setLocalCQRoutingInfo(event, routingInfo);
+    verify(filterProfile).setLocalInterestRoutingInfo(event, routingInfo, false);
+  }
+
+  @Test
+  public void getFilterRoutingInfoPart2DoesNotSetLocalCQRoutingInfoIfNoRunningCQService() {
+    when(cqService.isRunning()).thenReturn(false);
+    filterProfile.getLocalProfile().hasCacheServer = true;
+    doReturn(cqService).when(filterProfile).getCqService(region);
+
+    assertThat(filterProfile.getFilterRoutingInfoPart2(routingInfo, event, true)).isEqualTo(
+        routingInfo);
+
+    verify(filterProfile, never()).setLocalCQRoutingInfo(event, routingInfo);
+    verify(filterProfile).setLocalInterestRoutingInfo(event, routingInfo, true);
+  }
+
+  @Test
+  public void getFilterRoutingInfoPart2DoesNotSetLocalCQRoutingInfoForEventInConflict() {
+    when(event.isConcurrencyConflict()).thenReturn(true);
+    filterProfile.getLocalProfile().hasCacheServer = true;
+    doReturn(cqService).when(filterProfile).getCqService(region);
+
+    assertThat(filterProfile.getFilterRoutingInfoPart2(routingInfo, event)).isEqualTo(routingInfo);
+
+    verify(filterProfile, never()).setLocalCQRoutingInfo(event, routingInfo);
+    verify(filterProfile).setLocalInterestRoutingInfo(event, routingInfo, false);
+  }
+
+  @Test
+  public void getFilterRoutingInfoPart2DoesNotSetLocalCQRoutingInfoIfRegionIsNull() {
+    filterProfile = spy(new FilterProfile());
+    filterProfile.getLocalProfile().hasCacheServer = true;
+    LocalRegion eventRegion = mock(LocalRegion.class);
+    when(event.getRegion()).thenReturn(eventRegion);
+    doReturn(cqService).when(filterProfile).getCqService(eventRegion);
+
+    assertThat(filterProfile.getFilterRoutingInfoPart2(routingInfo, event)).isEqualTo(routingInfo);
+
+    verify(filterProfile, never()).setLocalCQRoutingInfo(event, routingInfo);
+    verify(filterProfile).setLocalInterestRoutingInfo(event, routingInfo, false);
+  }
+
+  @Test
+  public void isTransactionalEventReturnsFalseIfNotEntryEvent() {
+    CacheEvent event = mock(CacheEvent.class);
+    when(event.getOperation()).thenReturn(Operation.REGION_CREATE);
+
+    assertThat(filterProfile.isTransactionalEvent(event)).isFalse();
+  }
+
+  @Test
+  public void isTransactionalEventReturnsTrueIfATransactionalEntryEvent() {
+    EntryEventImpl event = mock(EntryEventImpl.class);
+    when(event.getOperation()).thenReturn(Operation.UPDATE);
+    when(event.isTransactional()).thenReturn(true);
+
+    assertThat(filterProfile.isTransactionalEvent(event)).isTrue();
+  }
+
+  @Test
+  public void isTransactionalEventReturnsFalseIfNotATransactionalEntryEvent() {
+    EntryEventImpl event = mock(EntryEventImpl.class);
+    when(event.getOperation()).thenReturn(Operation.UPDATE);
+    when(event.isTransactional()).thenReturn(false);
+
+    assertThat(filterProfile.isTransactionalEvent(event)).isFalse();
+  }
+
+  @Test
+  public void isCQRoutingNeededReturnsTrueIfEventNotTransactional() {
+    doReturn(false).when(filterProfile).isTransactionalEvent(event);
+
+    assertThat(filterProfile.isCQRoutingNeeded(event)).isTrue();
+  }
+
+  @Test
+  public void isCQRoutingNeededReturnsTrueIfLocalFilterInfoIsNotSetInEvent() {
+    doReturn(true).when(filterProfile).isTransactionalEvent(event);
+    when(event.getLocalFilterInfo()).thenReturn(null);
+
+    assertThat(filterProfile.isCQRoutingNeeded(event)).isTrue();
+  }
+
+  @Test
+  public void isCQRoutingNeededReturnsFalseIfLocalFilterInfoIsSetInEvent() {
+    doReturn(true).when(filterProfile).isTransactionalEvent(event);
+    when(event.getLocalFilterInfo()).thenReturn(filterInfo);
+
+    assertThat(filterProfile.isCQRoutingNeeded(event)).isFalse();
+  }
+
+  @Test
+  public void setLocalCQRoutingInfoFillsInCQRoutingInfoIfCQRoutingNeeded() {
+    doReturn(true).when(filterProfile).isCQRoutingNeeded(event);
+    FilterRoutingInfo info = mock(FilterRoutingInfo.class);
+    doNothing().when(filterProfile).fillInCQRoutingInfo(event, true, FilterProfile.NO_PROFILES,
+        info);
+
+    filterProfile.setLocalCQRoutingInfo(event, info);
+
+    verify(filterProfile).fillInCQRoutingInfo(event, true, FilterProfile.NO_PROFILES, info);
+  }
+
+  @Test
+  public void setLocalCQRoutingInfoSetsLocalFilterInfoFromEventIfCQRoutingNotNeeded() {
+    doReturn(false).when(filterProfile).isCQRoutingNeeded(event);
+    when(event.getLocalFilterInfo()).thenReturn(filterInfo);
+
+
+    filterProfile.setLocalCQRoutingInfo(event, routingInfo);
+
+    verify(routingInfo).setLocalFilterInfo(filterInfo);
+  }
+
+  @Test
+  public void setLocalInterestRoutingInfoFillsInInterestRoutingInfoIfEventNotTransactional() {
+    doReturn(false).when(filterProfile).isTransactionalEvent(event);
+    doReturn(routingInfo).when(filterProfile).fillInInterestRoutingInfo(event,
+        filterProfile.localProfileArray, routingInfo, Collections.emptySet());
+
+    assertThat(filterProfile.setLocalInterestRoutingInfo(event, routingInfo, true))
+        .isEqualTo(routingInfo);
+
+    verify(filterProfile).fillInInterestRoutingInfo(event, filterProfile.localProfileArray,
+        routingInfo, Collections.emptySet());
+  }
+
+  @Test
+  public void setLocalInterestRoutingInfoFillsInInterestRoutingInfoIfNoFilterInfoInTransactionalEvent() {
+    doReturn(true).when(filterProfile).isTransactionalEvent(event);
+    doReturn(routingInfo).when(filterProfile).fillInInterestRoutingInfo(event,
+        filterProfile.localProfileArray, routingInfo, Collections.emptySet());
+
+    assertThat(filterProfile.setLocalInterestRoutingInfo(event, routingInfo, false))
+        .isEqualTo(routingInfo);
+
+    verify(filterProfile).fillInInterestRoutingInfo(event, filterProfile.localProfileArray,
+        routingInfo, Collections.emptySet());
+  }
+
+  @Test
+  public void setLocalInterestRoutingInfoFillsInInterestRoutingInfoIfChangeAppliedToCache() {
+    doReturn(true).when(filterProfile).isTransactionalEvent(event);
+    doReturn(routingInfo).when(filterProfile).fillInInterestRoutingInfo(event,
+        filterProfile.localProfileArray, routingInfo, Collections.emptySet());
+    when(event.getLocalFilterInfo()).thenReturn(filterInfo);
+    when(filterInfo.isChangeAppliedToCache()).thenReturn(true);
+
+    assertThat(filterProfile.setLocalInterestRoutingInfo(event, routingInfo, false))
+        .isEqualTo(routingInfo);
+
+    verify(filterProfile).fillInInterestRoutingInfo(event, filterProfile.localProfileArray,
+        routingInfo, Collections.emptySet());
+  }
+
+  @Test
+  public void setLocalInterestRoutingInfoDoesNotFillInInterestRoutingInfoIfNotAppliedToCacheYet() {
+    doReturn(true).when(filterProfile).isTransactionalEvent(event);
+    doReturn(routingInfo).when(filterProfile).fillInInterestRoutingInfo(event,
+        filterProfile.localProfileArray, routingInfo, Collections.emptySet());
+    when(event.getLocalFilterInfo()).thenReturn(filterInfo);
+    when(filterInfo.isChangeAppliedToCache()).thenReturn(false);
+
+    assertThat(filterProfile.setLocalInterestRoutingInfo(event, routingInfo, false))
+        .isEqualTo(routingInfo);
+
+    verify(filterProfile, never()).fillInInterestRoutingInfo(event, filterProfile.localProfileArray,
+        routingInfo, Collections.emptySet());
+  }
+
+  @Test
+  public void setLocalInterestRoutingInfoFillsInInterestRoutingInfoIfNeededToCompute() {
+    doReturn(true).when(filterProfile).isTransactionalEvent(event);
+    doReturn(routingInfo).when(filterProfile).fillInInterestRoutingInfo(event,
+        filterProfile.localProfileArray, routingInfo, Collections.emptySet());
+    when(event.getLocalFilterInfo()).thenReturn(filterInfo);
+    when(filterInfo.isChangeAppliedToCache()).thenReturn(false);
+
+    assertThat(filterProfile.setLocalInterestRoutingInfo(event, routingInfo, true))
+        .isEqualTo(routingInfo);
+
+    verify(filterProfile).fillInInterestRoutingInfo(event, filterProfile.localProfileArray,
+        routingInfo, Collections.emptySet());
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LocalRegionTest.java
@@ -222,4 +222,59 @@ public class LocalRegionTest {
     assertThat(result.get("key1")).isNull();
     assertThat(result.get("key2")).isEqualTo("value2");
   }
+
+  @Test
+  public void generateLocalFilterRoutingIsNeededIfFilterInfoNotSetInEvent() {
+    LocalRegion region =
+        spy(new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock()));
+    InternalCacheEvent event = mock(InternalCacheEvent.class);
+    when(event.getLocalFilterInfo()).thenReturn(null);
+
+    assertThat(region.isGenerateLocalFilterRoutingNeeded(event)).isTrue();
+  }
+
+  @Test
+  public void generateLocalFilterRoutingNotNeededIfNonTransactionalEventHasFilterInfo() {
+    LocalRegion region =
+        spy(new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock()));
+    InternalCacheEvent event = mock(InternalCacheEvent.class);
+    when(event.getLocalFilterInfo()).thenReturn(mock(FilterRoutingInfo.FilterInfo.class));
+    when(event.isTransactional()).thenReturn(false);
+
+    assertThat(region.isGenerateLocalFilterRoutingNeeded(event)).isFalse();
+  }
+
+  @Test
+  public void generateLocalFilterRoutingIsNeededIfChangeAppliedToCacheForTransactionalEvent() {
+    LocalRegion region =
+        spy(new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock()));
+    InternalCacheEvent event = mock(InternalCacheEvent.class);
+    FilterRoutingInfo.FilterInfo filterInfo = mock(FilterRoutingInfo.FilterInfo.class);
+    when(event.getLocalFilterInfo()).thenReturn(filterInfo);
+    when(event.isTransactional()).thenReturn(true);
+    when(filterInfo.isChangeAppliedToCache()).thenReturn(true);
+
+    assertThat(region.isGenerateLocalFilterRoutingNeeded(event)).isTrue();
+  }
+
+  @Test
+  public void generateLocalFilterRoutingIsNotNeededIfChangeNotAppliedToCacheYet() {
+    LocalRegion region =
+        spy(new LocalRegion("region", regionAttributes, null, cache, internalRegionArguments,
+            internalDataView, regionMapConstructor, serverRegionProxyConstructor, entryEventFactory,
+            poolFinder, regionPerfStatsFactory, disabledClock()));
+    InternalCacheEvent event = mock(InternalCacheEvent.class);
+    FilterRoutingInfo.FilterInfo filterInfo = mock(FilterRoutingInfo.FilterInfo.class);
+    when(event.getLocalFilterInfo()).thenReturn(filterInfo);
+    when(event.isTransactional()).thenReturn(true);
+    when(filterInfo.isChangeAppliedToCache()).thenReturn(false);
+
+    assertThat(region.isGenerateLocalFilterRoutingNeeded(event)).isFalse();
+  }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -21,7 +22,9 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -55,6 +58,26 @@ public class TXCommitMessageTest {
 
     verify(dm, timeout(60000)).putOutgoing(queryMessage);
     verify(processor, timeout(60000)).waitForRepliesUninterruptibly();
+  }
+
+  @Test
+  public void firePendingCallbacksSetsChangeAppliedToCacheInEventLocalFilterInfo() {
+    TXCommitMessage message = spy(new TXCommitMessage());
+    FilterRoutingInfo.FilterInfo filterInfo1 = mock(FilterRoutingInfo.FilterInfo.class);
+    FilterRoutingInfo.FilterInfo filterInfo2 = mock(FilterRoutingInfo.FilterInfo.class);
+    EntryEventImpl event1 = mock(EntryEventImpl.class, RETURNS_DEEP_STUBS);
+    EntryEventImpl event2 = mock(EntryEventImpl.class, RETURNS_DEEP_STUBS);
+    List<EntryEventImpl> callbacks = new ArrayList<>();
+    callbacks.add(event1);
+    callbacks.add(event2);
+    doReturn(event2).when(message).getLastTransactionEvent(callbacks);
+    when(event1.getLocalFilterInfo()).thenReturn(filterInfo1);
+    when(event2.getLocalFilterInfo()).thenReturn(filterInfo2);
+
+    message.firePendingCallbacks(callbacks);
+
+    verify(filterInfo1).setChangeAppliedToCache(true);
+    verify(filterInfo2).setChangeAppliedToCache(true);
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
@@ -29,6 +29,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.transaction.Status;
 
 import org.junit.Before;
@@ -365,5 +368,26 @@ public class TXStateTest {
 
     verify(txState, never()).getRecordedResultOrException(event);
     verify(txState).recordEventException(event, exception);
+  }
+
+  @Test
+  public void firePendingCallbacksSetsChangeAppliedToCacheInEventLocalFilterInfo() {
+    TXState txState = spy(new TXState(txStateProxy, true, disabledClock()));
+    FilterRoutingInfo.FilterInfo filterInfo1 = mock(FilterRoutingInfo.FilterInfo.class);
+    FilterRoutingInfo.FilterInfo filterInfo2 = mock(FilterRoutingInfo.FilterInfo.class);
+    EntryEventImpl event1 = mock(EntryEventImpl.class, RETURNS_DEEP_STUBS);
+    EntryEventImpl event2 = mock(EntryEventImpl.class, RETURNS_DEEP_STUBS);
+    List<EntryEventImpl> callbacks = new ArrayList<>();
+    callbacks.add(event1);
+    callbacks.add(event2);
+    doReturn(event2).when(txState).getLastTransactionEvent();
+    when(event1.getLocalFilterInfo()).thenReturn(filterInfo1);
+    when(event2.getLocalFilterInfo()).thenReturn(filterInfo2);
+    doReturn(callbacks).when(txState).getPendingCallbacks();
+
+    txState.firePendingCallbacks();
+
+    verify(filterInfo1).setChangeAppliedToCache(true);
+    verify(filterInfo2).setChangeAppliedToCache(true);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifierTest.java
@@ -262,7 +262,7 @@ public class CacheClientNotifierTest {
 
     FilterRoutingInfo filterRoutingInfo = mock(FilterRoutingInfo.class);
     when(filterRoutingInfo.getLocalFilterInfo()).thenReturn(filterInfo);
-    when(filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent))
+    when(filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent, true))
         .thenReturn(filterRoutingInfo);
     doReturn(clientUpdateMessage).when(cacheClientNotifierSpy)
         .constructClientMessage(internalCacheEvent);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientRegistrationEventQueueManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientRegistrationEventQueueManagerTest.java
@@ -63,7 +63,7 @@ public class ClientRegistrationEventQueueManagerTest {
 
     when(filterRoutingInfo.getLocalFilterInfo()).thenReturn(
         filterInfo);
-    when(filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent))
+    when(filterProfile.getFilterRoutingInfoPart2(null, internalCacheEvent, true))
         .thenReturn(filterRoutingInfo);
     when(localRegion.getFilterProfile()).thenReturn(filterProfile);
     when(internalCacheEvent.getRegion()).thenReturn(localRegion);

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/RemoteCQTransactionDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/RemoteCQTransactionDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -25,6 +26,7 @@ import static org.junit.Assert.fail;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -56,6 +58,7 @@ import org.apache.geode.cache.query.CqAttributes;
 import org.apache.geode.cache.query.CqAttributesFactory;
 import org.apache.geode.cache.query.CqEvent;
 import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.cache.util.CacheWriterAdapter;
@@ -66,7 +69,7 @@ import org.apache.geode.internal.cache.execute.data.CustId;
 import org.apache.geode.internal.cache.execute.data.Customer;
 import org.apache.geode.internal.cache.execute.data.Order;
 import org.apache.geode.internal.cache.execute.data.OrderId;
-import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableCallable;
@@ -76,13 +79,15 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 @Category({ClientSubscriptionTest.class})
 public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
+  private final VM accessor = VM.getVM(0);
+  private final VM dataStore = VM.getVM(1);
+  private final VM client = VM.getVM(2);
+  private final CustId expectedCustId = new CustId(6);
+  private final Customer expectedCustomer = new Customer("customer6", "address6");
 
-  protected final String CUSTOMER = "custRegion";
-  protected final String ORDER = "orderRegion";
-  protected final String D_REFERENCE = "distrReference";
-
-  final CustId expectedCustId = new CustId(6);
-  final Customer expectedCustomer = new Customer("customer6", "address6");
+  private static final String CUSTOMER = "custRegion";
+  private static final String ORDER = "orderRegion";
+  private static final String D_REFERENCE = "distrReference";
 
   private final SerializableCallable getNumberOfTXInProgress = new SerializableCallable() {
     @Override
@@ -156,7 +161,7 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  protected void initAccessorAndDataStore(VM accessor, VM datastore, final int redundantCopies) {
+  protected void initAccessorAndDataStore(VM accessor, VM dataStore, final int redundantCopies) {
     accessor.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
@@ -165,7 +170,7 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    datastore.invoke(new SerializableCallable() {
+    dataStore.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
         createRegion(false/* accessor */, redundantCopies, null);
@@ -175,9 +180,9 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
     });
   }
 
-  protected void initAccessorAndDataStore(VM accessor, VM datastore1, VM datastore2,
+  protected void initAccessorAndDataStore(VM accessor, VM dataStore1, VM dataStore2,
       final int redundantCopies) {
-    datastore2.invoke(new SerializableCallable() {
+    dataStore2.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
         createRegion(false/* accessor */, redundantCopies, null);
@@ -185,12 +190,12 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    initAccessorAndDataStore(accessor, datastore1, redundantCopies);
+    initAccessorAndDataStore(accessor, dataStore1, redundantCopies);
   }
 
-  private void initAccessorAndDataStoreWithInterestPolicy(VM accessor, VM datastore1, VM datastore2,
+  private void initAccessorAndDataStoreWithInterestPolicy(VM accessor, VM dataStore1, VM dataStore2,
       final int redundantCopies) {
-    datastore2.invoke(new SerializableCallable() {
+    dataStore2.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
         createRegion(false/* accessor */, redundantCopies, InterestPolicy.ALL);
@@ -198,7 +203,7 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    initAccessorAndDataStore(accessor, datastore1, redundantCopies);
+    initAccessorAndDataStore(accessor, dataStore1, redundantCopies);
   }
 
 
@@ -810,10 +815,12 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
     int invokeCount = 0;
     int invalidateCount = 0;
     int putCount = 0;
+    int destroyCount = 0;
     boolean putAllOp = false;
     boolean isOriginRemote = false;
     int creates;
     int updates;
+
 
     @Override
     public void afterCreate(EntryEvent event) {
@@ -846,6 +853,15 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       invoked = true;
       invokeCount++;
       invalidateCount++;
+      isOriginRemote = event.isOriginRemote();
+    }
+
+    @Override
+    public void afterDestroy(EntryEvent event) {
+      event.getRegion().getCache().getLogger().warning("ZZZ AFTER DESTROY:" + event.getKey());
+      invoked = true;
+      invokeCount++;
+      destroyCount++;
       isOriginRemote = event.isOriginRemote();
     }
 
@@ -891,16 +907,11 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
 
   @Test
   public void testTXWithCQCommitInDatastoreCQ() throws Exception {
-    Host host = Host.getHost(0);
-    VM accessor = host.getVM(0);
-    VM datastore = host.getVM(1);
-    VM client = host.getVM(2);
-
-    initAccessorAndDataStore(accessor, datastore, 0);
-    int port = startServer(datastore);
+    initAccessorAndDataStore(accessor, dataStore, 0);
+    int port = startServer(dataStore);
 
     createClientRegion(client, port, false, true, true);
-    datastore.invoke(new SerializableCallable() {
+    dataStore.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
@@ -917,35 +928,16 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    Thread.sleep(10000);
-    client.invoke(new SerializableCallable() {
-      @Override
-      public Object call() throws Exception {
-        Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
-        Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
-        Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        ClientListener cl = (ClientListener) custRegion.getAttributes().getCacheListeners()[0];
-
-        assertTrue(((ClientCQListener) custRegion.getCache().getQueryService().getCqs()[0]
-            .getCqAttributes().getCqListener()).invoked);
-        assertTrue(cl.invoked);
-        return null;
-      }
-    });
+    client.invoke(this::verifyCustomerRegion);
   }
 
   @Test
   public void testTXWithCQCommitInDatastoreConnectedToAccessorCQ() throws Exception {
-    Host host = Host.getHost(0);
-    VM accessor = host.getVM(0);
-    VM datastore = host.getVM(1);
-    VM client = host.getVM(2);
-
-    initAccessorAndDataStore(accessor, datastore, 0);
+    initAccessorAndDataStore(accessor, dataStore, 0);
     int port = startServer(accessor);
 
     createClientRegion(client, port, false, true, true);
-    datastore.invoke(new SerializableCallable() {
+    dataStore.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
@@ -960,34 +952,16 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    Thread.sleep(10000);
-    client.invoke(new SerializableCallable() {
-      @Override
-      public Object call() throws Exception {
-        Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
-        Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
-        Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        ClientListener cl = (ClientListener) custRegion.getAttributes().getCacheListeners()[0];
-        assertTrue(cl.invoked);
-        assertTrue(((ClientCQListener) custRegion.getCache().getQueryService().getCqs()[0]
-            .getCqAttributes().getCqListener()).invoked);
-        return null;
-      }
-    });
+    client.invoke(this::verifyCustomerRegion);
   }
 
   @Test
   public void testTXWithCQCommitInDatastoreConnectedToDatastoreCQ() throws Exception {
-    Host host = Host.getHost(0);
-    VM accessor = host.getVM(0);
-    VM datastore = host.getVM(1);
-    VM client = host.getVM(2);
-
-    initAccessorAndDataStore(accessor, datastore, 0);
-    int port = startServer(datastore);
+    initAccessorAndDataStore(accessor, dataStore, 0);
+    int port = startServer(dataStore);
 
     createClientRegion(client, port, false, true, true);
-    datastore.invoke(new SerializableCallable() {
+    dataStore.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
@@ -1002,31 +976,13 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    Thread.sleep(10000);
-    client.invoke(new SerializableCallable() {
-      @Override
-      public Object call() throws Exception {
-        Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
-        Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
-        Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        ClientListener cl = (ClientListener) custRegion.getAttributes().getCacheListeners()[0];
-        assertTrue(cl.invoked);
-        assertTrue(((ClientCQListener) custRegion.getCache().getQueryService().getCqs()[0]
-            .getCqAttributes().getCqListener()).invoked);
-        return null;
-      }
-    });
+    client.invoke(this::verifyCustomerRegion);
   }
 
   @Test
   public void testTXWithCQCommitInAccessorConnectedToDatastoreCQ() throws Exception {
-    Host host = Host.getHost(0);
-    VM accessor = host.getVM(0);
-    VM datastore = host.getVM(1);
-    VM client = host.getVM(2);
-
-    initAccessorAndDataStore(accessor, datastore, 0);
-    int port = startServer(datastore);
+    initAccessorAndDataStore(accessor, dataStore, 0);
+    int port = startServer(dataStore);
 
     createClientRegion(client, port, false, true, true);
     accessor.invoke(new SerializableCallable() {
@@ -1044,30 +1000,12 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    Thread.sleep(10000);
-    client.invoke(new SerializableCallable() {
-      @Override
-      public Object call() throws Exception {
-        Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
-        Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
-        Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        ClientListener cl = (ClientListener) custRegion.getAttributes().getCacheListeners()[0];
-        assertTrue(cl.invoked);
-        assertTrue(((ClientCQListener) custRegion.getCache().getQueryService().getCqs()[0]
-            .getCqAttributes().getCqListener()).invoked);
-        return null;
-      }
-    });
+    client.invoke(this::verifyCustomerRegion);
   }
 
   @Test
   public void testTXWithCQCommitInAccessorConnectedToAccessorCQ() throws Exception {
-    Host host = Host.getHost(0);
-    VM accessor = host.getVM(0);
-    VM datastore = host.getVM(1);
-    VM client = host.getVM(2);
-
-    initAccessorAndDataStore(accessor, datastore, 0);
+    initAccessorAndDataStore(accessor, dataStore, 0);
     int port = startServer(accessor);
 
     createClientRegion(client, port, false, true, true);
@@ -1086,34 +1024,16 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    Thread.sleep(10000);
-    client.invoke(new SerializableCallable() {
-      @Override
-      public Object call() throws Exception {
-        Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
-        Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
-        Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        ClientListener cl = (ClientListener) custRegion.getAttributes().getCacheListeners()[0];
-        assertTrue(cl.invoked);
-        assertTrue(((ClientCQListener) custRegion.getCache().getQueryService().getCqs()[0]
-            .getCqAttributes().getCqListener()).invoked);
-        return null;
-      }
-    });
+    client.invoke(this::verifyCustomerRegion);
   }
 
   @Test
   public void testCQCommitInDatastoreConnectedToAccessorCQ() throws Exception {
-    Host host = Host.getHost(0);
-    VM accessor = host.getVM(0);
-    VM datastore = host.getVM(1);
-    VM client = host.getVM(2);
-
-    initAccessorAndDataStore(accessor, datastore, 0);
+    initAccessorAndDataStore(accessor, dataStore, 0);
     int port = startServer(accessor);
 
     createClientRegion(client, port, false, true, true);
-    datastore.invoke(new SerializableCallable() {
+    dataStore.invoke(new SerializableCallable() {
       @Override
       public Object call() throws Exception {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
@@ -1128,20 +1048,124 @@ public class RemoteCQTransactionDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    Thread.sleep(10000);
-    client.invoke(new SerializableCallable() {
-      @Override
-      public Object call() throws Exception {
-        Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
-        Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
-        Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        ClientListener cl = (ClientListener) custRegion.getAttributes().getCacheListeners()[0];
-        assertTrue(cl.invoked);
-        assertTrue(((ClientCQListener) custRegion.getCache().getQueryService().getCqs()[0]
-            .getCqAttributes().getCqListener()).invoked);
-        return null;
-      }
-    });
+    client.invoke(this::verifyCustomerRegion);
   }
 
+  private void verifyCustomerRegion() {
+    verifyCustomerRegionListenerInvocation();
+    verifyCQListenerInvocation();
+  }
+
+  private void verifyCustomerRegionListenerInvocation() {
+    Region<CustId, Customer> customerRegion = getCache().getRegion(CUSTOMER);
+    ClientListener customerRegionListener =
+        (ClientListener) customerRegion.getAttributes().getCacheListeners()[0];
+    GeodeAwaitility.await()
+        .untilAsserted(() -> assertThat(customerRegionListener.invoked).isTrue());
+  }
+
+  @Test
+  public void testCQEntryDestroyCommitInDataStoreConnectedToAccessorCQ() {
+    doCQWithDelete(false, true);
+  }
+
+  @Test
+  public void testCQEntryDestroyCommitInAccessorConnectedToAccessorCQ() {
+    doCQWithDelete(false, false);
+  }
+
+  @Test
+  public void testCQEntryDestroyCommitInDataStoreConnectedToDataStoreCQ() {
+    doCQWithDelete(true, true);
+  }
+
+  @Test
+  public void testCQEntryDestroyCommitInAccessorConnectedToDataStoreCQ() {
+    doCQWithDelete(true, false);
+  }
+
+  private void doCQWithDelete(boolean startCacheServerOnDataStore,
+      boolean executeTransactionOnDataStore) {
+    initAccessorAndDataStore(accessor, dataStore, 0);
+    int port = startServer(startCacheServerOnDataStore);
+
+    createClientRegion(client, port, false, true, true);
+    client.invoke(this::registerCQForRefRegion);
+
+    executeDeleteTransaction(executeTransactionOnDataStore);
+    client.invoke(this::verify);
+  }
+
+  private int startServer(boolean onDataStore) {
+    if (onDataStore) {
+      return startServer(dataStore);
+    }
+    return startServer(accessor);
+  }
+
+  private void executeDeleteTransaction(boolean onDataStore) {
+    if (onDataStore) {
+      dataStore.invoke(this::doDeleteTransaction);
+    } else {
+      accessor.invoke(this::doDeleteTransaction);
+    }
+  }
+
+  private void registerCQForRefRegion() throws Exception {
+    CqAttributesFactory cqf = new CqAttributesFactory();
+    cqf.addCqListener(new ClientCQListener());
+    CqAttributes ca = cqf.create();
+    String refRegionPath = getCache().getRegion(D_REFERENCE).getFullPath();
+    getCache().getQueryService().newCq("SELECT * FROM " + refRegionPath, ca).execute();
+  }
+
+  private void doDeleteTransaction() {
+    Region<CustId, Customer> customerRegion = getCache().getRegion(CUSTOMER);
+    Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
+    Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
+    getCache().getCacheTransactionManager().begin();
+    doDelete(customerRegion, orderRegion, refRegion);
+    getCache().getCacheTransactionManager().commit();
+  }
+
+  private void doDelete(Region<CustId, Customer> customerRegion, Region<OrderId, Order> orderRegion,
+      Region<CustId, Customer> refRegion) {
+    CustId custId = new CustId(1);
+    OrderId orderId = new OrderId(1, custId);
+    customerRegion.destroy(custId);
+    orderRegion.destroy(orderId);
+    refRegion.destroy(custId);
+  }
+
+  private void verify() {
+    Region<CustId, Customer> customerRegion = getCache().getRegion(CUSTOMER);
+    Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
+    Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
+    verifyListenerInvocation(customerRegion, orderRegion, refRegion);
+    verifyCQListenerInvocation();
+  }
+
+  private void verifyListenerInvocation(Region<CustId, Customer> customerRegion,
+      Region<OrderId, Order> orderRegion,
+      Region<CustId, Customer> refRegion) {
+    ClientListener customerRegionListener =
+        (ClientListener) customerRegion.getAttributes().getCacheListeners()[0];
+    ClientListener orderRegionListener =
+        (ClientListener) orderRegion.getAttributes().getCacheListeners()[0];
+    ClientListener refRegionListener =
+        (ClientListener) refRegion.getAttributes().getCacheListeners()[0];
+    GeodeAwaitility.await()
+        .untilAsserted(() -> assertThat(customerRegionListener.invoked).isTrue());
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(orderRegionListener.invoked).isTrue());
+    GeodeAwaitility.await().untilAsserted(() -> assertThat(refRegionListener.invoked).isTrue());
+  }
+
+  private void verifyCQListenerInvocation() {
+    CqQuery[] queries = getCache().getQueryService().getCqs();
+    for (CqQuery query : queries) {
+      ClientCQListener listener = (ClientCQListener) query.getCqAttributes().getCqListener();
+      GeodeAwaitility.await().atMost(10, TimeUnit.SECONDS)
+          .untilAsserted(() -> assertThat(listener.invoked).isTrue());
+    }
+  }
 }


### PR DESCRIPTION
  * Compute interest routing info after transactional event has been
    applied to cache. This will make sure an interested client will
    either get the event through region snapshot taken or through
    HARegionQueue.
  * Add test coverage for CQ with transactional destroy event to make
    sure CQ routing is computed correctly.
  * Remove sleep in exiting test code.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
