### PR TITLE
GEODE-8564: Updated CopyOnWriteHashSet's iterator implementation to support iterator.remove()

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/CopyOnWriteHashSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/CopyOnWriteHashSet.java
@@ -22,7 +22,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A Hash set where every modification makes an internal copy of a HashSet. Similar to
@@ -47,12 +49,36 @@ public class CopyOnWriteHashSet<T> implements Set<T>, Serializable {
   }
 
   /**
-   * Because I'm lazy, this iterator does not support modification of this set. If you need it, it
-   * shouldn't be too hard to implement.
+   * Create a custom {@link Iterator} implementation for the {@link CopyOnWriteHashSet}
    */
   @Override
   public Iterator<T> iterator() {
-    return Collections.unmodifiableSet(snapshot).iterator();
+    return new Iterator<T>() {
+
+      private Iterator<T> iterator = new LinkedList<>(snapshot).iterator();
+      private T currentElement;
+
+      @Override
+      public boolean hasNext() {
+        return iterator.hasNext();
+      }
+
+      @Override
+      public T next() {
+        currentElement = iterator.next();
+        return currentElement;
+      }
+
+      @Override
+      public void remove() {
+        snapshot.remove(currentElement);
+      }
+
+      @Override
+      public void forEachRemaining(Consumer<? super T> action) {
+        iterator.forEachRemaining(action);
+      }
+    };
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/CopyOnWriteHashSetJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/CopyOnWriteHashSetJUnitTest.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 
@@ -41,6 +42,25 @@ public class CopyOnWriteHashSetJUnitTest {
     set.add("b");
 
     assertEquals(copy, snap);
+  }
+
+  @Test
+  public void testIteratorRemove() {
+    CopyOnWriteHashSet<String> startingCollection = new CopyOnWriteHashSet<String>();
+    startingCollection.addAll(Arrays.asList("a", "b", "c", "d"));
+
+    Iterator<String> iterator = startingCollection.iterator();
+    while (iterator.hasNext()) {
+      String element = iterator.next();
+
+      if (element.equals("b")) {
+        iterator.remove();
+      }
+    }
+
+    assertEquals(3, startingCollection.size());
+
+    Assertions.assertThat(startingCollection).containsExactly("a", "c", "d");
   }
 
   @Test


### PR DESCRIPTION
Updated CopyOnWriteHashSet's iterator implementation to support iterator.remove().
Updated JCAManagedConnection to not use iterator.remove(). It will now
collect all items to remove and then use the CopyOnWriteHashSet removeAll
functionality to avoid unnecessary intermediary collection creations.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
