### PR TITLE
GEODE-8419: backported forward to support/1.12

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
@@ -168,7 +168,7 @@ public class SSLSocketHostNameVerificationIntegrationTest {
     this.clientSocket = clientChannel.socket();
 
     SSLEngine sslEngine =
-        this.socketCreator.createSSLEngine(this.localHost.getHostName(), 1234);
+        this.socketCreator.createSSLEngine(this.localHost.getHostName(), 1234, true);
 
     try {
       this.socketCreator.handshakeSSLSocketChannel(clientSocket.getChannel(),
@@ -200,7 +200,7 @@ public class SSLSocketHostNameVerificationIntegrationTest {
       try {
         socket = serverSocket.accept();
         SocketCreator sc = SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER);
-        final SSLEngine sslEngine = sc.createSSLEngine(this.localHost.getHostName(), 1234);
+        final SSLEngine sslEngine = sc.createSSLEngine(this.localHost.getHostName(), 1234, false);
         engine =
             sc.handshakeSSLSocketChannel(socket.getChannel(),
                 sslEngine,

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -217,7 +217,7 @@ public class SSLSocketIntegrationTest {
     clientSocket = clientChannel.socket();
     NioSslEngine engine =
         clusterSocketCreator.handshakeSSLSocketChannel(clientSocket.getChannel(),
-            clusterSocketCreator.createSSLEngine("localhost", 1234), 0, true,
+            clusterSocketCreator.createSSLEngine("localhost", 1234, true), 0, true,
             ByteBuffer.allocate(65535), new BufferPool(mock(DMStats.class)));
     clientChannel.configureBlocking(true);
 
@@ -264,7 +264,8 @@ public class SSLSocketIntegrationTest {
         socket = serverSocket.accept();
         SocketCreator sc = SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER);
         engine =
-            sc.handshakeSSLSocketChannel(socket.getChannel(), sc.createSSLEngine("localhost", 1234),
+            sc.handshakeSSLSocketChannel(socket.getChannel(), sc.createSSLEngine("localhost", 1234,
+                false),
                 timeoutMillis,
                 false,
                 ByteBuffer.allocate(65535),

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -1727,7 +1727,8 @@ public class Connection implements Runnable {
     if (getConduit().useSSL() && channel != null) {
       InetSocketAddress address = (InetSocketAddress) channel.getRemoteAddress();
       SSLEngine engine =
-          getConduit().getSocketCreator().createSSLEngine(address.getHostName(), address.getPort());
+          getConduit().getSocketCreator().createSSLEngine(address.getHostName(), address.getPort(),
+              clientSocket);
 
       int packetBufferSize = engine.getSession().getPacketBufferSize();
       if (inputBuffer == null || inputBuffer.capacity() < packetBufferSize) {

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorJUnitTest.java
@@ -15,20 +15,27 @@
 package org.apache.geode.internal.net;
 
 import static org.apache.geode.test.util.ResourceUtils.createTempFileFromResource;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.net.BindException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.internal.admin.SSLConfig;
 import org.apache.geode.test.junit.categories.MembershipTest;
@@ -96,6 +103,55 @@ public class SocketCreatorJUnitTest {
         serverSocket.close();
       }
     }
+  }
+
+  @Test
+  public void configureSSLEngine() {
+    SSLConfig config = new SSLConfig.Builder().setCiphers("someCipher").setEnabled(true)
+        .setProtocols("someProtocol").setRequireAuth(true).setKeystore("someKeystore.jks")
+        .setAlias("someAlias").setTruststore("someTruststore.jks")
+        .setEndpointIdentificationEnabled(true).build();
+
+    SSLContext context = mock(SSLContext.class);
+    SSLParameters parameters = mock(SSLParameters.class);
+
+    SocketCreator socketCreator = new SocketCreator(config, context);
+
+    SSLEngine engine = mock(SSLEngine.class);
+    when(engine.getSSLParameters()).thenReturn(parameters);
+
+    socketCreator.configureSSLEngine(engine, "somehost", 12345, true);
+
+    verify(engine).setUseClientMode(isA(Boolean.class));
+    verify(engine).setSSLParameters(parameters);
+    verify(engine, never()).setNeedClientAuth(isA(Boolean.class));
+
+    ArgumentCaptor<String[]> stringArrayCaptor = ArgumentCaptor.forClass(String[].class);
+    verify(engine).setEnabledProtocols(stringArrayCaptor.capture());
+    assertThat(stringArrayCaptor.getValue()).containsExactly("someProtocol");
+    verify(engine).setEnabledCipherSuites(stringArrayCaptor.capture());
+    assertThat(stringArrayCaptor.getValue()).containsExactly("someCipher");
+  }
+
+  @Test
+  public void configureSSLEngineUsingAny() {
+    SSLConfig config = new SSLConfig.Builder().setCiphers("any").setEnabled(true)
+        .setProtocols("any").setRequireAuth(true).setKeystore("someKeystore.jks")
+        .setAlias("someAlias").setTruststore("someTruststore.jks")
+        .setEndpointIdentificationEnabled(true).build();
+
+    SSLContext context = mock(SSLContext.class);
+    SSLParameters parameters = mock(SSLParameters.class);
+
+    SocketCreator socketCreator = new SocketCreator(config, context);
+
+    SSLEngine engine = mock(SSLEngine.class);
+    when(engine.getSSLParameters()).thenReturn(parameters);
+
+    socketCreator.configureSSLEngine(engine, "somehost", 12345, true);
+
+    verify(engine, never()).setEnabledCipherSuites(isA(String[].class));
+    verify(engine, never()).setEnabledProtocols(isA(String[].class));
   }
 
   private String getSingleKeyKeystore() {


### PR DESCRIPTION
**NOT READY FOR MERGE YET**

This is the fix for [GEODE-8419](https://issues.apache.org/jira/browse/GEODE-8419). I couldn't cherry-pick it directly from `develop` because `support/1.12` is missing some other changes that the GEODE-8419 fix on `develop` was dependent on. As a result I had to make the changes manually. Nevertheless I intend to manually add this comment to the squashed commit when I merge so as to satisfy the "commit check" CI checks:

(cherry picked from commit 537721ff815cf40eff85fde65db9b5e787471c89)

^ that's the SHA of the fix for GEODE-8419 on `develop`

See also:
* Original PR on `develop` https://github.com/apache/geode/pull/5465
* port to `support/1.13` branch https://github.com/apache/geode/pull/5594

- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?
