### PR TITLE
GEODE-8572: Make LogExporter not read dirs

### DIFF
--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterFileIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/util/LogExporterFileIntegrationTest.java
@@ -24,7 +24,9 @@ import static org.mockito.Mockito.when;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
@@ -151,5 +153,13 @@ public class LogExporterFileIntegrationTest {
     assertThat(logExporter.findLogFiles(workingDir.toPath())).contains(gcLogFile.toPath());
     assertThat(logExporter.findLogFiles(workingDir.toPath()))
         .contains(gcRolledOverLogFile.toPath());
+  }
+
+  @Test
+  public void ignoresDirectoriesWhoseNamesMatchLogAndStatFilePredicates() throws IOException {
+    Files.createDirectories(workingDir.toPath().resolve("should-be-ignored.log"));
+    Files.createDirectories(workingDir.toPath().resolve("should-be-ignored.gfs"));
+
+    assertThat(logExporter.export()).isNull();
   }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/util/LogExporter.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/util/LogExporter.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
@@ -181,12 +180,13 @@ public class LogExporter {
   }
 
   private List<Path> findFiles(Path workingDir, Predicate<Path> fileSelector) throws IOException {
-    Stream<Path> selectedFiles/* = null */;
     if (!workingDir.toFile().isDirectory()) {
       return Collections.emptyList();
     }
-    selectedFiles = Files.list(workingDir).filter(fileSelector).filter(this.logFilter::acceptsFile);
-
-    return selectedFiles.collect(toList());
+    return Files.list(workingDir)
+        .filter(Files::isRegularFile)
+        .filter(fileSelector)
+        .filter(this.logFilter::acceptsFile)
+        .collect(toList());
   }
 }


### PR DESCRIPTION
Changed LogExporter to refrain from attempting to read directories, even
when a directory's path matches the exporter's file selector predicates.

Changed LogExporterIntegrationTest to configure the server to write
files in a unique subdirectory of the current working directory. Some
tests were configuring the server to use a temporary folder that could
be reused by other tests.