### PR TITLE
GEODE-8579: Stop waiting locator-wait-time if all locators are available

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -194,6 +194,7 @@ dependencies {
   acceptanceTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
   integrationTestImplementation(project(':geode-core'))
+  integrationTestImplementation(project(':geode-membership'))
   integrationTestImplementation(project(':geode-gfsh'))
   integrationTestImplementation(project(':geode-log4j')) {
     exclude module: 'geode-core'

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/shell/StatusLocatorExitCodeAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/shell/StatusLocatorExitCodeAcceptanceTest.java
@@ -15,8 +15,6 @@
 package org.apache.geode.management.internal.cli.shell;
 
 import static java.util.Arrays.stream;
-import static org.apache.geode.internal.AvailablePort.SOCKET;
-import static org.apache.geode.internal.AvailablePort.getRandomAvailablePort;
 import static org.apache.geode.management.internal.cli.shell.DirectoryTree.printDirectoryTree;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,6 +27,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.ExitCode;
 import org.apache.geode.internal.process.PidFile;
 import org.apache.geode.test.junit.categories.GfshTest;
@@ -57,7 +56,7 @@ public class StatusLocatorExitCodeAcceptanceTest {
   @BeforeClass
   public static void startLocator() throws IOException {
     rootPath = gfshRule.getTemporaryFolder().getRoot().toPath();
-    locatorPort = getRandomAvailablePort(SOCKET);
+    locatorPort = AvailablePortHelper.getRandomAvailableTCPPort();
 
     GfshExecution execution = GfshScript.of(
         "start locator --name=" + LOCATOR_NAME + " --port=" + locatorPort)
@@ -122,7 +121,7 @@ public class StatusLocatorExitCodeAcceptanceTest {
 
   @Test
   public void statusCommandWithIncorrectPortShouldFail() {
-    int incorrectPort = getRandomAvailablePort(SOCKET);
+    int incorrectPort = AvailablePortHelper.getRandomAvailableTCPPort();
     String commandWithWrongPort = "status locator --port=" + incorrectPort;
 
     GfshScript.of(commandWithWrongPort)

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/shell/StatusServerExitCodeAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/shell/StatusServerExitCodeAcceptanceTest.java
@@ -15,8 +15,6 @@
 package org.apache.geode.management.internal.cli.shell;
 
 import static java.util.Arrays.stream;
-import static org.apache.geode.internal.AvailablePort.SOCKET;
-import static org.apache.geode.internal.AvailablePort.getRandomAvailablePort;
 import static org.apache.geode.management.internal.cli.shell.DirectoryTree.printDirectoryTree;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,6 +27,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.ExitCode;
 import org.apache.geode.internal.process.PidFile;
 import org.apache.geode.test.junit.categories.GfshTest;
@@ -58,7 +57,7 @@ public class StatusServerExitCodeAcceptanceTest {
   @BeforeClass
   public static void startCluster() throws IOException {
     rootPath = gfshRule.getTemporaryFolder().getRoot().toPath();
-    locatorPort = getRandomAvailablePort(SOCKET);
+    locatorPort = AvailablePortHelper.getRandomAvailableTCPPort();
 
     GfshExecution execution = GfshScript.of(
         "start locator --name=" + LOCATOR_NAME + " --port=" + locatorPort,

--- a/geode-core/src/integrationTest/java/org/apache/geode/codeAnalysis/RestrictUseOfInetAddressJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/codeAnalysis/RestrictUseOfInetAddressJUnitTest.java
@@ -195,7 +195,6 @@ public class RestrictUseOfInetAddressJUnitTest {
         "org/apache/geode/internal/AbstractConfig",
         // server-side communications
         "org/apache/geode/distributed/internal/direct/DirectChannel",
-        "org/apache/geode/internal/AvailablePort",
         "org/apache/geode/internal/cache/tier/sockets/AcceptorImpl",
         // old command-line tool replaced by gfsh
         "org/apache/geode/internal/DistributionLocator",

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
   testImplementation(project(':geode-common'))
   compileOnly(project(':geode-core'))
+  compileOnly(project(':geode-membership'))
   compileOnly(project(':geode-logging'))
   compileOnly(project(':geode-serialization'))
   compileOnly(project(':geode-unsafe'))

--- a/geode-junit/src/main/java/org/apache/geode/internal/AvailablePortHelper.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/AvailablePortHelper.java
@@ -15,7 +15,7 @@
 package org.apache.geode.internal;
 
 import static java.util.stream.Collectors.toList;
-import static org.apache.geode.distributed.internal.DistributionConfig.DEFAULT_MEMBERSHIP_PORT_RANGE;
+import static org.apache.geode.distributed.internal.membership.api.MembershipConfig.DEFAULT_MEMBERSHIP_PORT_RANGE;
 import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_LOWER_BOUND;
 import static org.apache.geode.internal.AvailablePort.AVAILABLE_PORTS_UPPER_BOUND;
 import static org.apache.geode.internal.AvailablePort.MULTICAST;

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -349,9 +349,9 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
               && state.possibleCoordinator.equals(this.localAddress)) {
             // if we haven't contacted a member of a cluster maybe this node should
             // become the coordinator.
-            if (state.joinedMembersContacted <= 0 && (now >= locatorGiveUpTime &&
+            if (state.joinedMembersContacted <= 0 && ((now >= locatorGiveUpTime &&
                 tries >= minimumRetriesBeforeBecomingCoordinator) ||
-                state.locatorsContacted >= locators.size()) {
+                state.locatorsContacted >= locators.size())) {
               synchronized (viewInstallationLock) {
                 becomeCoordinator();
               }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -349,9 +349,9 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
               && state.possibleCoordinator.equals(this.localAddress)) {
             // if we haven't contacted a member of a cluster maybe this node should
             // become the coordinator.
-            if (state.joinedMembersContacted <= 0 && (now >= locatorGiveUpTime) &&
-                (tries >= minimumRetriesBeforeBecomingCoordinator ||
-                    state.locatorsContacted >= locators.size())) {
+            if (state.joinedMembersContacted <= 0 && (now >= locatorGiveUpTime &&
+                tries >= minimumRetriesBeforeBecomingCoordinator) ||
+                state.locatorsContacted >= locators.size()) {
               synchronized (viewInstallationLock) {
                 becomeCoordinator();
               }

--- a/geode-membership/src/main/java/org/apache/geode/internal/AvailablePort.java
+++ b/geode-membership/src/main/java/org/apache/geode/internal/AvailablePort.java
@@ -32,7 +32,7 @@ import java.util.Enumeration;
 import java.util.Random;
 
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.distributed.internal.DistributionConfig;
+import org.apache.geode.distributed.internal.membership.api.MembershipConfig;
 import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.util.internal.GeodeGlossary;
 
@@ -118,7 +118,8 @@ public class AvailablePort {
         buffer[1] = (byte) 'i';
         buffer[2] = (byte) 'n';
         buffer[3] = (byte) 'g';
-        InetAddress mcid = addr == null ? DistributionConfig.DEFAULT_MCAST_ADDRESS : addr;
+        InetAddress mcid =
+            addr == null ? InetAddress.getByName(MembershipConfig.DEFAULT_MCAST_ADDRESS) : addr;
         SocketAddress mcaddr = new InetSocketAddress(mcid, port);
         socket.joinGroup(mcid);
         DatagramPacket packet = new DatagramPacket(buffer, 0, buffer.length, mcaddr);
@@ -349,7 +350,7 @@ public class AvailablePort {
       int port = getRandomWildcardBindPortNumber(useMembershipPortRange);
       if (isPortAvailable(port, protocol, addr)) {
         // don't return the products default multicast port
-        if (!(protocol == MULTICAST && port == DistributionConfig.DEFAULT_MCAST_PORT)) {
+        if (!(protocol == MULTICAST && port == MembershipConfig.DEFAULT_MCAST_PORT)) {
           return port;
         }
       }
@@ -430,8 +431,8 @@ public class AvailablePort {
       rangeBase = AVAILABLE_PORTS_LOWER_BOUND; // 20000/udp is securid
       rangeTop = AVAILABLE_PORTS_UPPER_BOUND; // 30000/tcp is spoolfax
     } else {
-      rangeBase = DistributionConfig.DEFAULT_MEMBERSHIP_PORT_RANGE[0];
-      rangeTop = DistributionConfig.DEFAULT_MEMBERSHIP_PORT_RANGE[1];
+      rangeBase = MembershipConfig.DEFAULT_MEMBERSHIP_PORT_RANGE[0];
+      rangeTop = MembershipConfig.DEFAULT_MEMBERSHIP_PORT_RANGE[1];
     }
 
     return rand.nextInt(rangeTop - rangeBase) + rangeBase;
@@ -506,10 +507,10 @@ public class AvailablePort {
     err.println(
         "This program either prints whether or not a port is available for a given protocol, or it prints out an available port for a given protocol.");
     err.println("");
-    ExitCode.FATAL.doSystemExit();
+    System.exit(1);
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws UnknownHostException {
     String protocolString = null;
     String addrString = null;
     String portString = null;
@@ -547,12 +548,7 @@ public class AvailablePort {
 
     InetAddress addr = null;
     if (addrString != null) {
-      try {
-        addr = InetAddress.getByName(addrString);
-      } catch (Exception e) {
-        e.printStackTrace();
-        ExitCode.FATAL.doSystemExit();
-      }
+      addr = InetAddress.getByName(addrString);
     }
 
     if (portString != null) {

--- a/geode-memcached/build.gradle
+++ b/geode-memcached/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   testImplementation('org.mockito:mockito-core')
   testImplementation(project(':geode-junit'))
 
+  integrationTestImplementation(project(':geode-membership'))
   integrationTestImplementation(project(':geode-core'))
   integrationTestImplementation('net.spy:spymemcached')
   integrationTestImplementation(project(':geode-junit'))

--- a/geode-pulse/geode-pulse-test/build.gradle
+++ b/geode-pulse/geode-pulse-test/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   }
 
   compile(project(':geode-core'))
+  compile(project(':geode-membership'))
   compile(project(':geode-http-service'))
   compile(project(':geode-junit')) {
     exclude module: 'geode-core'


### PR DESCRIPTION
If we can contact all other locators, we should stop waiting for
locator-wait-time to elapse.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
