### PR TITLE
GEODE-8584: Message transmission fails with IllegalStateException in socket i/o code

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -35,7 +35,7 @@ public class BufferPool {
   private final DMStats stats;
   private static final Logger logger = LogService.getLogger();
 
-  private static Method parentOfSliceMethod;
+  private Method parentOfSliceMethod;
 
   /**
    * Buffers may be acquired from the Buffers pool

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -331,7 +331,7 @@ public class BufferPool {
    * the non-sliced buffer for some reason, such as logging its hashcode.
    */
   @VisibleForTesting
-  public static ByteBuffer getPoolableBuffer(ByteBuffer buffer) {
+  public ByteBuffer getPoolableBuffer(ByteBuffer buffer) {
     if (!buffer.isDirect()) {
       return buffer;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -35,7 +35,7 @@ public class BufferPool {
   private final DMStats stats;
   private static final Logger logger = LogService.getLogger();
 
-  private Method parentOfSliceMethod;
+  private static Method parentOfSliceMethod;
 
   /**
    * Buffers may be acquired from the Buffers pool
@@ -326,10 +326,15 @@ public class BufferPool {
    * "slice" of the buffer having the requested capacity and hand that out instead.
    * When we put the buffer back in the pool we need to find the original, non-sliced,
    * buffer. This is held in DirectBuffer in its "attachment" field, which is a public
-   * method, though DirectBuffer is package-private.
+   * method, though DirectBuffer is package-private. This method is visible for use
+   * in debugging and testing. For debugging, invoke this method if you need to see
+   * the non-sliced buffer for some reason, such as logging its hashcode.
    */
   @VisibleForTesting
-  public ByteBuffer getPoolableBuffer(ByteBuffer buffer) {
+  public static ByteBuffer getPoolableBuffer(ByteBuffer buffer) {
+    if (!buffer.isDirect()) {
+      return buffer;
+    }
     ByteBuffer result = buffer;
     if (parentOfSliceMethod == null) {
       Class clazz = buffer.getClass();

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
@@ -21,7 +21,13 @@ import java.nio.channels.SocketChannel;
 /**
  * Prior to transmitting a buffer or processing a received buffer
  * a NioFilter should be called to wrap (transmit) or unwrap (received)
- * the buffer in case SSL is being used.
+ * the buffer in case SSL is being used.<br>
+ * Implementations of this class may not be thread-safe in regard to
+ * the buffers their methods return. These may be internal state that,
+ * if used concurrently by multiple threads could cause corruption.
+ * Appropriate external synchronization must be used in order to provide
+ * thread-safety. Do this by invoking getSynchObject() and synchronizing on
+ * the returned object while using the buffer.
  */
 public interface NioFilter {
 
@@ -88,9 +94,15 @@ public interface NioFilter {
   }
 
   /**
-   * returns the unwrapped byte buffer associated with the given wrapped buffer
+   * returns the unwrapped byte buffer associated with the given wrapped buffer.
    */
   ByteBuffer getUnwrappedBuffer(ByteBuffer wrappedBuffer);
 
-
+  /**
+   * returns an object to be used in synchronizing on the use of buffers returned by
+   * a NioFilter.
+   */
+  default Object getSynchObject() {
+    return this;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
@@ -75,6 +75,10 @@ public interface NioFilter {
     }
   }
 
+  default boolean isClosed() {
+    return false;
+  }
+
   /**
    * invoke this method when you are done using the NioFilter
    *

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -40,6 +40,7 @@ import javax.net.ssl.SSLSession;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.GemFireIOException;
+import org.apache.geode.annotations.internal.MakeImmutable;
 import org.apache.geode.internal.net.BufferPool.BufferType;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -52,6 +53,9 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
 public class NioSslEngine implements NioFilter {
   private static final Logger logger = LogService.getLogger();
 
+  // this variable requires the MakeImmutable annotation but the buffer is empty and
+  // not really modifiable
+  @MakeImmutable
   private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
   private final BufferPool bufferPool;

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -404,9 +404,9 @@ public class NioSslEngine implements NioFilter {
     } finally {
       logger.info("NioSSLEngine releasing two buffers myNetData={}({}), peerAppData={}({})",
           Integer.toHexString(System.identityHashCode(myNetData)),
-          (myNetData.isDirect()? "direct":"heap"),
+          (myNetData.isDirect() ? "direct" : "heap"),
           Integer.toHexString(System.identityHashCode(peerAppData)),
-          (myNetData.isDirect()? "direct":"heap"));
+          (myNetData.isDirect() ? "direct" : "heap"));
       ByteBuffer netData = myNetData;
       ByteBuffer appData = peerAppData;
       myNetData = null;

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -72,7 +72,7 @@ public class NioSslEngine implements NioFilter {
   /**
    * peerAppData holds the last unwrapped data from a peer
    */
-  volatile ByteBuffer peerAppData;
+  ByteBuffer peerAppData;
 
   NioSslEngine(SSLEngine engine, BufferPool bufferPool) {
     SSLSession session = engine.getSession();

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -402,11 +402,6 @@ public class NioSslEngine implements NioFilter {
     } catch (IOException e) {
       throw new GemFireIOException("exception closing SSL session", e);
     } finally {
-      logger.info("NioSSLEngine releasing two buffers myNetData={}({}), peerAppData={}({})",
-          Integer.toHexString(System.identityHashCode(myNetData)),
-          (myNetData.isDirect() ? "direct" : "heap"),
-          Integer.toHexString(System.identityHashCode(peerAppData)),
-          (myNetData.isDirect() ? "direct" : "heap"));
       ByteBuffer netData = myNetData;
       ByteBuffer appData = peerAppData;
       myNetData = null;

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -801,7 +801,7 @@ public class Connection implements Runnable {
 
   private void notifyHandshakeWaiter(boolean success) {
     if (getConduit().useSSL() && ioFilter != null) {
-      synchronized (ioFilter) {
+      synchronized (ioFilter.getSynchObject()) {
         if (!ioFilter.isClosed()) {
           // clear out any remaining handshake bytes
           ByteBuffer buffer = ioFilter.getUnwrappedBuffer(inputBuffer);
@@ -2440,115 +2440,117 @@ public class Connection implements Runnable {
         long queueTimeoutTarget = now + asyncQueueTimeout;
         channel.configureBlocking(false);
         try {
-          ByteBuffer wrappedBuffer = ioFilter.wrap(buffer);
-          int waitTime = 1;
-          do {
-            owner.getConduit().getCancelCriterion().checkCancelInProgress(null);
-            retries++;
-            int amtWritten;
-            if (FORCE_ASYNC_QUEUE) {
-              amtWritten = 0;
-            } else {
-              amtWritten = channel.write(wrappedBuffer);
-            }
-            if (amtWritten == 0) {
-              now = System.currentTimeMillis();
-              long timeoutTarget;
-              if (!forceAsync) {
-                if (now > distributionTimeoutTarget) {
-                  if (logger.isDebugEnabled()) {
-                    if (distributionTimeoutTarget == 0) {
-                      logger.debug(
-                          "Starting async pusher to handle async queue because distribution-timeout is 1 and the last socket write would have blocked.");
-                    } else {
-                      long blockedMs = now - distributionTimeoutTarget;
-                      blockedMs += asyncDistributionTimeout;
-                      logger.debug(
-                          "Blocked for {}ms which is longer than the max of {}ms so starting async pusher to handle async queue.",
-                          blockedMs, asyncDistributionTimeout);
+          synchronized (ioFilter.getSynchObject()) {
+            ByteBuffer wrappedBuffer = ioFilter.wrap(buffer);
+            int waitTime = 1;
+            do {
+              owner.getConduit().getCancelCriterion().checkCancelInProgress(null);
+              retries++;
+              int amtWritten;
+              if (FORCE_ASYNC_QUEUE) {
+                amtWritten = 0;
+              } else {
+                amtWritten = channel.write(wrappedBuffer);
+              }
+              if (amtWritten == 0) {
+                now = System.currentTimeMillis();
+                long timeoutTarget;
+                if (!forceAsync) {
+                  if (now > distributionTimeoutTarget) {
+                    if (logger.isDebugEnabled()) {
+                      if (distributionTimeoutTarget == 0) {
+                        logger.debug(
+                            "Starting async pusher to handle async queue because distribution-timeout is 1 and the last socket write would have blocked.");
+                      } else {
+                        long blockedMs = now - distributionTimeoutTarget;
+                        blockedMs += asyncDistributionTimeout;
+                        logger.debug(
+                            "Blocked for {}ms which is longer than the max of {}ms so starting async pusher to handle async queue.",
+                            blockedMs, asyncDistributionTimeout);
+                      }
+                    }
+                    stats.incAsyncDistributionTimeoutExceeded();
+                    if (totalAmtWritten > 0) {
+                      // we have written part of the msg to the socket buffer
+                      // and we are going to queue the remainder.
+                      // We set msg to null so that will not make
+                      // the partial msg a candidate for conflation.
+                      msg = null;
+                    }
+                    if (handleBlockedWrite(wrappedBuffer, msg)) {
+                      return;
                     }
                   }
-                  stats.incAsyncDistributionTimeoutExceeded();
-                  if (totalAmtWritten > 0) {
-                    // we have written part of the msg to the socket buffer
-                    // and we are going to queue the remainder.
-                    // We set msg to null so that will not make
-                    // the partial msg a candidate for conflation.
-                    msg = null;
+                  timeoutTarget = distributionTimeoutTarget;
+                } else {
+                  boolean disconnectNeeded = false;
+                  long curQueuedBytes = queuedBytes;
+                  if (curQueuedBytes > asyncMaxQueueSize) {
+                    logger.warn(
+                        "Queued bytes {} exceeds max of {}, asking slow receiver {} to disconnect.",
+                        curQueuedBytes, asyncMaxQueueSize, remoteAddr);
+                    stats.incAsyncQueueSizeExceeded(1);
+                    disconnectNeeded = true;
                   }
-                  if (handleBlockedWrite(wrappedBuffer, msg)) {
+                  if (now > queueTimeoutTarget) {
+                    // we have waited long enough the pusher has been idle too long!
+                    long blockedMs = now - queueTimeoutTarget;
+                    blockedMs += asyncQueueTimeout;
+                    logger.warn(
+                        "Blocked for {}ms which is longer than the max of {}ms, asking slow receiver {} to disconnect.",
+                        blockedMs,
+                        asyncQueueTimeout, remoteAddr);
+                    stats.incAsyncQueueTimeouts(1);
+                    disconnectNeeded = true;
+                  }
+                  if (disconnectNeeded) {
+                    disconnectSlowReceiver();
+                    synchronized (outgoingQueue) {
+                      asyncQueuingInProgress = false;
+                      outgoingQueue.notifyAll();
+                    }
                     return;
                   }
+                  timeoutTarget = queueTimeoutTarget;
                 }
-                timeoutTarget = distributionTimeoutTarget;
-              } else {
-                boolean disconnectNeeded = false;
-                long curQueuedBytes = queuedBytes;
-                if (curQueuedBytes > asyncMaxQueueSize) {
-                  logger.warn(
-                      "Queued bytes {} exceeds max of {}, asking slow receiver {} to disconnect.",
-                      curQueuedBytes, asyncMaxQueueSize, remoteAddr);
-                  stats.incAsyncQueueSizeExceeded(1);
-                  disconnectNeeded = true;
-                }
-                if (now > queueTimeoutTarget) {
-                  // we have waited long enough the pusher has been idle too long!
-                  long blockedMs = now - queueTimeoutTarget;
-                  blockedMs += asyncQueueTimeout;
-                  logger.warn(
-                      "Blocked for {}ms which is longer than the max of {}ms, asking slow receiver {} to disconnect.",
-                      blockedMs,
-                      asyncQueueTimeout, remoteAddr);
-                  stats.incAsyncQueueTimeouts(1);
-                  disconnectNeeded = true;
-                }
-                if (disconnectNeeded) {
-                  disconnectSlowReceiver();
-                  synchronized (outgoingQueue) {
-                    asyncQueuingInProgress = false;
-                    outgoingQueue.notifyAll();
+                {
+                  long msToWait = waitTime;
+                  long msRemaining = timeoutTarget - now;
+                  if (msRemaining > 0) {
+                    msRemaining /= 2;
                   }
-                  return;
-                }
-                timeoutTarget = queueTimeoutTarget;
-              }
-              {
-                long msToWait = waitTime;
-                long msRemaining = timeoutTarget - now;
-                if (msRemaining > 0) {
-                  msRemaining /= 2;
-                }
-                if (msRemaining < msToWait) {
-                  msToWait = msRemaining;
-                }
-                if (msToWait <= 0) {
-                  Thread.yield();
-                } else {
-                  boolean interrupted = Thread.interrupted();
-                  try {
-                    Thread.sleep(msToWait);
-                  } catch (InterruptedException ex) {
-                    interrupted = true;
-                    owner.getConduit().getCancelCriterion().checkCancelInProgress(ex);
-                  } finally {
-                    if (interrupted) {
-                      Thread.currentThread().interrupt();
+                  if (msRemaining < msToWait) {
+                    msToWait = msRemaining;
+                  }
+                  if (msToWait <= 0) {
+                    Thread.yield();
+                  } else {
+                    boolean interrupted = Thread.interrupted();
+                    try {
+                      Thread.sleep(msToWait);
+                    } catch (InterruptedException ex) {
+                      interrupted = true;
+                      owner.getConduit().getCancelCriterion().checkCancelInProgress(ex);
+                    } finally {
+                      if (interrupted) {
+                        Thread.currentThread().interrupt();
+                      }
                     }
                   }
                 }
+                if (waitTime < MAX_WAIT_TIME) {
+                  // double it since it is not yet the max
+                  waitTime <<= 1;
+                }
+              } // amtWritten == 0
+              else {
+                totalAmtWritten += amtWritten;
+                // reset queueTimeoutTarget since we made some progress
+                queueTimeoutTarget = System.currentTimeMillis() + asyncQueueTimeout;
+                waitTime = 1;
               }
-              if (waitTime < MAX_WAIT_TIME) {
-                // double it since it is not yet the max
-                waitTime <<= 1;
-              }
-            } // amtWritten == 0
-            else {
-              totalAmtWritten += amtWritten;
-              // reset queueTimeoutTarget since we made some progress
-              queueTimeoutTarget = System.currentTimeMillis() + asyncQueueTimeout;
-              waitTime = 1;
-            }
-          } while (wrappedBuffer.remaining() > 0);
+            } while (wrappedBuffer.remaining() > 0);
+          }
         } finally {
           channel.configureBlocking(true);
         }
@@ -2593,7 +2595,7 @@ public class Connection implements Runnable {
           // fall through
         }
         // synchronize on the ioFilter while using its network buffer
-        synchronized (ioFilter) {
+        synchronized (ioFilter.getSynchObject()) {
           ByteBuffer wrappedBuffer = ioFilter.wrap(buffer);
           while (wrappedBuffer.remaining() > 0) {
             int amtWritten = 0;
@@ -2731,68 +2733,70 @@ public class Connection implements Runnable {
   private void processInputBuffer() throws ConnectionException, IOException {
     inputBuffer.flip();
 
-    ByteBuffer peerDataBuffer = ioFilter.unwrap(inputBuffer);
-    peerDataBuffer.flip();
+    synchronized (ioFilter.getSynchObject()) {
+      ByteBuffer peerDataBuffer = ioFilter.unwrap(inputBuffer);
+      peerDataBuffer.flip();
 
-    boolean done = false;
+      boolean done = false;
 
-    while (!done && connected) {
-      owner.getConduit().getCancelCriterion().checkCancelInProgress(null);
-      int remaining = peerDataBuffer.remaining();
-      if (lengthSet || remaining >= MSG_HEADER_BYTES) {
-        if (!lengthSet) {
-          if (readMessageHeader(peerDataBuffer)) {
-            break;
+      while (!done && connected) {
+        owner.getConduit().getCancelCriterion().checkCancelInProgress(null);
+        int remaining = peerDataBuffer.remaining();
+        if (lengthSet || remaining >= MSG_HEADER_BYTES) {
+          if (!lengthSet) {
+            if (readMessageHeader(peerDataBuffer)) {
+              break;
+            }
           }
-        }
-        if (remaining >= messageLength + MSG_HEADER_BYTES) {
-          lengthSet = false;
-          peerDataBuffer.position(peerDataBuffer.position() + MSG_HEADER_BYTES);
-          // don't trust the message deserialization to leave the position in
-          // the correct spot. Some of the serialization uses buffered
-          // streams that can leave the position at the wrong spot
-          int startPos = peerDataBuffer.position();
-          int oldLimit = peerDataBuffer.limit();
-          peerDataBuffer.limit(startPos + messageLength);
+          if (remaining >= messageLength + MSG_HEADER_BYTES) {
+            lengthSet = false;
+            peerDataBuffer.position(peerDataBuffer.position() + MSG_HEADER_BYTES);
+            // don't trust the message deserialization to leave the position in
+            // the correct spot. Some of the serialization uses buffered
+            // streams that can leave the position at the wrong spot
+            int startPos = peerDataBuffer.position();
+            int oldLimit = peerDataBuffer.limit();
+            peerDataBuffer.limit(startPos + messageLength);
 
-          if (handshakeRead) {
-            try {
-              readMessage(peerDataBuffer);
-            } catch (SerializationException e) {
-              logger.info("input buffer startPos {} oldLimit {}", startPos, oldLimit);
-              throw e;
+            if (handshakeRead) {
+              try {
+                readMessage(peerDataBuffer);
+              } catch (SerializationException e) {
+                logger.info("input buffer startPos {} oldLimit {}", startPos, oldLimit);
+                throw e;
+              }
+            } else {
+              ByteBufferInputStream bbis = new ByteBufferInputStream(peerDataBuffer);
+              DataInputStream dis = new DataInputStream(bbis);
+              if (!isReceiver) {
+                // we read the handshake and then stop processing since we don't want
+                // to process the input buffer anymore in a handshake thread
+                readHandshakeForSender(dis, peerDataBuffer);
+                return;
+              }
+              if (readHandshakeForReceiver(dis)) {
+                ioFilter.doneReading(peerDataBuffer);
+                return;
+              }
             }
+            if (!connected) {
+              continue;
+            }
+            accessed();
+            peerDataBuffer.limit(oldLimit);
+            peerDataBuffer.position(startPos + messageLength);
           } else {
-            ByteBufferInputStream bbis = new ByteBufferInputStream(peerDataBuffer);
-            DataInputStream dis = new DataInputStream(bbis);
-            if (!isReceiver) {
-              // we read the handshake and then stop processing since we don't want
-              // to process the input buffer anymore in a handshake thread
-              readHandshakeForSender(dis, peerDataBuffer);
-              return;
-            }
-            if (readHandshakeForReceiver(dis)) {
+            done = true;
+            if (getConduit().useSSL()) {
               ioFilter.doneReading(peerDataBuffer);
-              return;
+            } else {
+              compactOrResizeBuffer(messageLength);
             }
           }
-          if (!connected) {
-            continue;
-          }
-          accessed();
-          peerDataBuffer.limit(oldLimit);
-          peerDataBuffer.position(startPos + messageLength);
         } else {
+          ioFilter.doneReading(peerDataBuffer);
           done = true;
-          if (getConduit().useSSL()) {
-            ioFilter.doneReading(peerDataBuffer);
-          } else {
-            compactOrResizeBuffer(messageLength);
-          }
         }
-      } else {
-        ioFilter.doneReading(peerDataBuffer);
-        done = true;
       }
     }
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
@@ -133,23 +133,6 @@ public class NioSslEngineTest {
     when(mockChannel.socket()).thenReturn(mockSocket);
     when(mockSocket.isClosed()).thenReturn(false);
 
-    // // initial read of handshake status followed by read of handshake status after task execution
-    // when(mockEngine.getHandshakeStatus()).thenReturn(NEED_UNWRAP, NEED_WRAP);
-    //
-    // // interleaved wraps/unwraps/task-execution
-    // when(mockEngine.unwrap(any(ByteBuffer.class), any(ByteBuffer.class))).thenReturn(
-    // new SSLEngineResult(OK, NEED_WRAP, 100, 100),
-    // new SSLEngineResult(BUFFER_OVERFLOW, NEED_UNWRAP, 0, 0),
-    // new SSLEngineResult(OK, NEED_TASK, 100, 0));
-    //
-    // when(mockEngine.getDelegatedTask()).thenReturn(() -> {
-    // }, (Runnable) null);
-    //
-    // when(mockEngine.wrap(any(ByteBuffer.class), any(ByteBuffer.class))).thenReturn(
-    // new SSLEngineResult(OK, NEED_UNWRAP, 100, 100),
-    // new SSLEngineResult(BUFFER_OVERFLOW, NEED_WRAP, 0, 0),
-    // new SSLEngineResult(CLOSED, FINISHED, 100, 0));
-    //
     assertThatThrownBy(() -> spyNioSslEngine.handshake(mockChannel, 10000,
         ByteBuffer.allocate(netBufferSize / 2))).isExactlyInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Provided buffer is too small");
@@ -212,6 +195,15 @@ public class NioSslEngineTest {
         new SSLEngineResult(CLOSED, FINISHED, 0, 100));
     nioSslEngine.close(mock(SocketChannel.class));
     nioSslEngine.checkClosed();
+  }
+
+  @Test
+  public void synchObjectIsSelf() {
+    // for thread-safety the synchronization object given to outside entities
+    // must be the the engine itself. This allows external manipulation or
+    // use of the engine's buffers to be protected in the same way as its synchronized
+    // methods
+    assertThat(nioSslEngine.getSynchObject()).isSameAs(nioSslEngine);
   }
 
   @Test


### PR DESCRIPTION
Add appropriate synchronization when using ioFilter's buffers.

Originally NioFilters were accessed only by a single thread at a time.  Eventually this changed, with Connection.asyncClose now invoking the close() method on the filter.  In the NioSslEngine this modifies the encrypted buffer, and that conflicted with the use of the buffer in Connection.writeFully().

Rather than just add additional synchronization to Connection.writeFully() I've examined all uses of NioSslEngine's buffers and have added synchronization around all of these uses.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
