### PR TITLE
GEODE-7696: Add comment to GMSHealthMonitor explaining when IllegalStateException may be thrown

### DIFF
--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -583,6 +583,8 @@ public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMoni
         // this is expected if it is a connection-timeout or other failure
         // to connect
       } catch (IllegalStateException e) {
+        // This is expected if ConnectTimeoutTask is scheduled on a timer that was already cancelled.
+        // Once a timer has been terminated, no more tasks may be scheduled on it.
         if (!isStopping) {
           logger.trace("Unexpected exception", e);
         }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -583,7 +583,8 @@ public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMoni
         // this is expected if it is a connection-timeout or other failure
         // to connect
       } catch (IllegalStateException e) {
-        // This is expected if ConnectTimeoutTask is scheduled on a timer that was already cancelled.
+        // This is expected if ConnectTimeoutTask is scheduled on a timer that was already
+        // cancelled.
         // Once a timer has been terminated, no more tasks may be scheduled on it.
         if (!isStopping) {
           logger.trace("Unexpected exception", e);


### PR DESCRIPTION
The catch block was just for logging what was considered an "unexpected exception" in the past.
This should more properly bubble up as it represents a state that is not internal to membership.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
