### PR TITLE
GEODE-8587: Redis glob pattern does not match carriage return, line feed, and tab

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
@@ -85,6 +85,16 @@ public abstract class AbstractKeysIntegrationTest implements RedisPortSupplier {
   }
 
   @Test
+  public void givenSplat_withCarriageReturnLineFeedAndTab_returnsExpectedMatches() {
+    jedis.set(" foo bar ", "123");
+    jedis.set(" foo\r\nbar\r\n ", "456");
+    jedis.set(" \r\n\t\\x07\\x13 ", "789");
+
+    assertThat(jedis.keys("*")).containsExactlyInAnyOrder(" \r\n\t\\x07\\x13 ", " foo\r\nbar\r\n ",
+        " foo bar ");
+  }
+
+  @Test
   public void givenMalformedGlobPattern_returnsEmptySet() {
     assertThat(jedis.keys("[][]")).isEmpty();
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/GlobPattern.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/GlobPattern.java
@@ -137,7 +137,7 @@ public class GlobPattern {
       regex.append(']');
     }
 
-    return Pattern.compile(regex.toString());
+    return Pattern.compile(regex.toString(), Pattern.DOTALL | Pattern.MULTILINE);
   }
 
   @Override


### PR DESCRIPTION
Glob pattern should match carriage return, line feed, and tab
