### PR TITLE
GEODE-8275: exclude cancelled jobs when looking for last completed job

### DIFF
--- a/ci/pipelines/mass-test-run/jinja.template.yml
+++ b/ci/pipelines/mass-test-run/jinja.template.yml
@@ -371,7 +371,7 @@ jobs:
             --team-name=((concourse-team)) \
             --username=((concourse-username)) \
             --password=((concourse-password))
-          latest_job=$(./fly -t cc builds --job="${BUILD_PIPELINE_NAME}/${job}" --json | jq -r 'max_by(.name | tonumber)')
+          latest_job=$(./fly -t cc builds --job="${BUILD_PIPELINE_NAME}/${job}" --json | jq -r '[.[] | select(.status!="aborted")] | max_by(.name | tonumber)')
           count=$(echo "${latest_job}" | jq -r .name)
           if [ $((${count}%{{metadata.mass_test_run_iterations}})) -ne 0 ]; then
             echo "Only generating report every [{{metadata.mass_test_run_iterations}}] jobs. Exiting."


### PR DESCRIPTION
this is helpful if someone accidentally plussed DistributedTestOpenJDK8 in the apache-develop-mass-test-run-pipeline, then tried to cancel it

you will still need to manually adjust the next run to 199x instead of 200x, but this change will at least allow the report to be generated, as otherwise it will not run if there is an extra job