### PR TITLE
GEODE-8602: Wait for view to change in locator test

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
@@ -305,8 +305,8 @@ public class MembershipIntegrationTest {
     Membership<MemberIdentifier> membership1 = createMembership1.get(2, TimeUnit.MINUTES);
 
     // Make sure the members see each other in the view
-    assertThat(membership0.getView().getMembers()).hasSize(2);
-    assertThat(membership1.getView().getMembers()).hasSize(2);
+    await().untilAsserted(() -> assertThat(membership0.getView().getMembers()).hasSize(2));
+    await().untilAsserted(() -> assertThat(membership1.getView().getMembers()).hasSize(2));
   }
 
   private CompletableFuture<Membership<MemberIdentifier>> launchLocator(


### PR DESCRIPTION
Wait for the view to have size 2 instead of asserting it in
MembershipIntegrationTest.locatorsStopWaitingForLocatorWaitTimeIfAllLocatorsContacted,
because the view is updated asynchronously.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
