### PR TITLE
GEODE-8608: StateFlush could hang when the target member is shutdown

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ClusterDistributionManagerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ClusterDistributionManagerDUnitTest.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.net.InetAddress;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
@@ -66,12 +67,14 @@ import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.api.MemberDisconnectedException;
 import org.apache.geode.distributed.internal.membership.api.MembershipManagerHelper;
 import org.apache.geode.distributed.internal.membership.api.MembershipView;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
+import org.apache.geode.internal.cache.StateFlushOperation;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.SerializableRunnable;
@@ -238,6 +241,33 @@ public class ClusterDistributionManagerDUnitTest extends CacheTestCase {
     await().until(() -> listenerInvoked.get());
   }
 
+  @Test
+  public void shutdownMessageCausesTargetMemberToLeaveStateFlushReplyProcessor() {
+    vm1.invoke("join the cluster", () -> getSystem().getDistributedMember()); // lead member
+    system = getSystem(); // non-lead member
+    DistributedMember targetId = locatorvm.invoke(() -> {
+      return Locator.getLocator().getDistributedSystem().getDistributedMember();
+    });
+
+    StateFlushOperation.StateFlushReplyProcessor stateFlushReplyProcessor =
+        new StateFlushOperation.StateFlushReplyProcessor(getSystem().getDistributionManager(),
+            new HashSet(), targetId);
+    system.getDistributionManager().addMembershipListener(stateFlushReplyProcessor);
+    final InternalDistributedMember memberID = system.getDistributedMember();
+
+    locatorvm.invoke("send a shutdown message", () -> {
+      final DistributionManager distributionManager =
+          ((InternalDistributedSystem) Locator.getLocator().getDistributedSystem())
+              .getDistributionManager();
+      final ShutdownMessage shutdownMessage = new ShutdownMessage();
+      shutdownMessage.setRecipient(memberID);
+      shutdownMessage.setDistributionManagerId(distributionManager.getDistributionManagerId());
+      distributionManager.putOutgoing(shutdownMessage);
+    });
+
+    await().untilAsserted(
+        () -> assertThat(stateFlushReplyProcessor.getTargetMemberHasLeft()).isTrue());
+  }
 
   /**
    * Tests that a severe-level alert is generated if a member does not respond with an ack quickly

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.SystemFailure;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.distributed.DistributedMember;
@@ -750,7 +751,7 @@ public class StateFlushOperation {
     int originalCount;
 
     /** whether the target member has left the distributed system */
-    boolean targetMemberHasLeft;
+    volatile boolean targetMemberHasLeft;
 
     public StateFlushReplyProcessor(DistributionManager manager, Set initMembers,
         DistributedMember target) {
@@ -784,6 +785,11 @@ public class StateFlushOperation {
       if (!activeMembers.contains(this.targetMember)) {
         targetMemberHasLeft = true;
       }
+    }
+
+    @VisibleForTesting
+    public boolean getTargetMemberHasLeft() {
+      return targetMemberHasLeft;
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/StateFlushOperation.java
@@ -772,6 +772,9 @@ public class StateFlushOperation {
     @Override
     public void memberDeparted(DistributionManager distributionManager,
         final InternalDistributedMember id, final boolean crashed) {
+      if (id.equals(targetMember)) {
+        targetMemberHasLeft = true;
+      }
       super.memberDeparted(distributionManager, id, crashed);
     }
 


### PR DESCRIPTION
    Co-authored-by: Darrel Schneider <darrel@vmware.com>
    Co-authored-by: Anil <agingade@pivotal.io>
    Co-authored-by: Bill Burcham <bill.burcham@gmail.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
