### PR TITLE
GEODE-8606: Rename DistributedReference

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ReplicateRegionNetsearchDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ReplicateRegionNetsearchDistributedTest.java
@@ -36,7 +36,7 @@ import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.internal.cache.CachePerfStats;
 import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.rules.DistributedCloseableReference;
+import org.apache.geode.test.dunit.rules.DistributedReference;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 
@@ -60,11 +60,9 @@ public class ReplicateRegionNetsearchDistributedTest implements Serializable {
   @Rule
   public DistributedRule distributedRule = new DistributedRule();
   @Rule
-  public DistributedCloseableReference<ServerLauncher> serverLauncher =
-      new DistributedCloseableReference<>();
+  public DistributedReference<ServerLauncher> serverLauncher = new DistributedReference<>();
   @Rule
-  public DistributedCloseableReference<ClientCache> clientCache =
-      new DistributedCloseableReference<>();
+  public DistributedReference<ClientCache> clientCache = new DistributedReference<>();
   @Rule
   public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
@@ -75,9 +75,9 @@ import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.rules.DistributedBlackboard;
-import org.apache.geode.test.dunit.rules.DistributedCloseableReference;
 import org.apache.geode.test.dunit.rules.DistributedDiskDirRule;
 import org.apache.geode.test.dunit.rules.DistributedErrorCollector;
+import org.apache.geode.test.dunit.rules.DistributedReference;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.PartitioningTest;
@@ -105,7 +105,7 @@ public class FixedPartitioningDUnitTest implements Serializable {
   @Rule
   public DistributedRule distributedRule = new DistributedRule();
   @Rule
-  public DistributedCloseableReference<Cache> cache = new DistributedCloseableReference<>();
+  public DistributedReference<Cache> cache = new DistributedReference<>();
   @Rule
   public DistributedDiskDirRule diskDirRule = new DistributedDiskDirRule();
   @Rule

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/DistributedReferenceCacheExampleTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/DistributedReferenceCacheExampleTest.java
@@ -33,13 +33,13 @@ import org.junit.Test;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.rules.DistributedCloseableReference;
+import org.apache.geode.test.dunit.rules.DistributedReference;
 
 @SuppressWarnings("serial")
-public class DistributedCloseableReferenceCacheExampleTest implements Serializable {
+public class DistributedReferenceCacheExampleTest implements Serializable {
 
   @Rule
-  public DistributedCloseableReference<Cache> cache = new DistributedCloseableReference<>();
+  public DistributedReference<Cache> cache = new DistributedReference<>();
 
   @Before
   public void setUp() {

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/DistributedReferenceLocatorLauncherExampleTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/DistributedReferenceLocatorLauncherExampleTest.java
@@ -19,9 +19,10 @@ import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.test.dunit.VM.getController;
+import static org.apache.geode.test.dunit.VM.getHostName;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.apache.geode.test.dunit.VM.getVMId;
-import static org.apache.geode.test.dunit.rules.DistributedRule.getLocators;
+import static org.apache.geode.test.dunit.rules.DistributedRule.getLocatorPort;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.Serializable;
@@ -30,40 +31,51 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.apache.geode.distributed.ServerLauncher;
+import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.rules.DistributedCloseableReference;
+import org.apache.geode.test.dunit.rules.DistributedReference;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 
 @SuppressWarnings("serial")
-public class DistributedCloseableReferenceServerLauncherExampleTest implements Serializable {
+public class DistributedReferenceLocatorLauncherExampleTest implements Serializable {
 
   @Rule
-  public DistributedCloseableReference<ServerLauncher> serverLauncher =
-      new DistributedCloseableReference<>();
+  public DistributedReference<LocatorLauncher> locatorLauncher = new DistributedReference<>();
 
   @Rule
   public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
 
   @Before
   public void setUp() {
-    String locators = getLocators();
+    String hostName = getHostName();
+    int[] randomPorts = AvailablePortHelper.getRandomAvailableTCPPorts(5);
 
+    StringBuilder locators = new StringBuilder()
+        .append(hostName).append('[').append(getLocatorPort()).append(']').append(',')
+        .append(hostName).append('[').append(randomPorts[0]).append(']').append(',')
+        .append(hostName).append('[').append(randomPorts[1]).append(']').append(',')
+        .append(hostName).append('[').append(randomPorts[2]).append(']').append(',')
+        .append(hostName).append('[').append(randomPorts[3]).append(']').append(',')
+        .append(hostName).append('[').append(randomPorts[4]).append(']');
+
+    int index = 0;
     for (VM vm : asList(getVM(0), getVM(1), getVM(2), getVM(3), getController())) {
+      int whichPort = index++;
       vm.invoke(() -> {
-        String name = "server-" + getVMId();
-        ServerLauncher serverLauncher = new ServerLauncher.Builder()
+        String name = "locator-" + getVMId();
+        LocatorLauncher locatorLauncher = new LocatorLauncher.Builder()
             .setWorkingDirectory(temporaryFolder.newFolder(name).getAbsolutePath())
             .setMemberName(name)
-            .setDisableDefaultServer(true)
-            .set(LOCATORS, locators)
+            .setPort(randomPorts[whichPort])
+            .set(LOCATORS, locators.toString())
             .set(HTTP_SERVICE_PORT, "0")
             .set(JMX_MANAGER_PORT, "0")
             .build();
-        serverLauncher.start();
-        this.serverLauncher.set(serverLauncher);
+        locatorLauncher.start();
+        this.locatorLauncher.set(locatorLauncher);
       });
     }
   }
@@ -72,9 +84,9 @@ public class DistributedCloseableReferenceServerLauncherExampleTest implements S
   public void eachVmHasItsOwnLocatorLauncher() {
     for (VM vm : asList(getVM(0), getVM(1), getVM(2), getVM(3), getController())) {
       vm.invoke(() -> {
-        assertThat(serverLauncher.get()).isNotNull();
+        assertThat(locatorLauncher.get()).isNotNull();
 
-        InternalCache cache = (InternalCache) serverLauncher.get().getCache();
+        InternalCache cache = (InternalCache) locatorLauncher.get().getCache();
         InternalDistributedSystem system = cache.getInternalDistributedSystem();
         assertThat(system.getAllOtherMembers()).hasSize(5);
       });

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/DistributedReferenceSystemExampleTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/DistributedReferenceSystemExampleTest.java
@@ -32,14 +32,13 @@ import org.junit.Test;
 
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.rules.DistributedCloseableReference;
+import org.apache.geode.test.dunit.rules.DistributedReference;
 
 @SuppressWarnings("serial")
-public class DistributedCloseableReferenceSystemExampleTest implements Serializable {
+public class DistributedReferenceSystemExampleTest implements Serializable {
 
   @Rule
-  public DistributedCloseableReference<DistributedSystem> system =
-      new DistributedCloseableReference<>();
+  public DistributedReference<DistributedSystem> system = new DistributedReference<>();
 
   @Before
   public void setUp() {

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedReferenceTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedReferenceTest.java
@@ -36,11 +36,11 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.rules.DistributedCloseableReference;
+import org.apache.geode.test.dunit.rules.DistributedReference;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 
 @SuppressWarnings({"serial", "CodeBlock2Expr"})
-public class DistributedCloseableReferenceTest {
+public class DistributedReferenceTest {
 
   @Rule
   public DistributedRule distributedRule = new DistributedRule();
@@ -217,8 +217,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<AutoCloseable> autoCloseable = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<AutoCloseable> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<AutoCloseable> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -237,8 +236,8 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<AutoCloseable> autoCloseable = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<AutoCloseable> reference =
-        new DistributedCloseableReference<AutoCloseable>().autoClose(false);
+    public DistributedReference<AutoCloseable> reference = new DistributedReference<AutoCloseable>()
+        .autoClose(false);
 
     @Before
     public void setUp() {
@@ -257,8 +256,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<AutoCloseable> autoCloseable = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<AutoCloseable> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<AutoCloseable> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -282,8 +280,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<AutoCloseable> autoCloseable = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<AutoCloseable> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<AutoCloseable> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -311,8 +308,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<Closeable> closeable = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<Closeable> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<Closeable> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -331,8 +327,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<Closeable> closeable = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<Closeable> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<Closeable> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -356,8 +351,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<Closeable> closeable = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<Closeable> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<Closeable> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -385,8 +379,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithClose> withClose = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithClose> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithClose> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -405,8 +398,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithClose> withClose = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithClose> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithClose> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -430,8 +422,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithClose> withClose = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithClose> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithClose> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -459,8 +450,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithDisconnect> withDisconnect = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithDisconnect> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithDisconnect> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -479,8 +469,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithDisconnect> withDisconnect = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithDisconnect> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithDisconnect> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -504,8 +493,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithDisconnect> withDisconnect = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithDisconnect> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithDisconnect> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -533,8 +521,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithStop> withStop = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithStop> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithStop> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -553,8 +540,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithStop> withStop = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithStop> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithStop> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {
@@ -578,8 +564,7 @@ public class DistributedCloseableReferenceTest {
     private static final AtomicReference<WithStop> withStop = new AtomicReference<>();
 
     @Rule
-    public DistributedCloseableReference<WithStop> reference =
-        new DistributedCloseableReference<>();
+    public DistributedReference<WithStop> reference = new DistributedReference<>();
 
     @Before
     public void setUp() {

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedReference.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedReference.java
@@ -26,14 +26,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * DistributedCloseableReference is a JUnit Rule that provides automated tearDown for a static
+ * DistributedReference is a JUnit Rule that provides automated tearDown for a static
  * reference in every distributed test {@code VM}s including the main JUnit controller {@code VM}.
  * If the referenced value is an {@code AutoCloseable} or {@code Closeable} then it will be
  * auto-closed and set to null in every {@code VM} during tear down.
  *
  * <p>
  * If the referenced value is not an {@code AutoCloseable} or {@code Closeable}, the
- * {@code DistributedCloseableReference} will use reflection to invoke any method named
+ * {@code DistributedReference} will use reflection to invoke any method named
  * {@code close}, {@code disconnect}, or {@code stop} regardless of what interfaces are implemented
  * unless {@code autoClose} is set to false.
  *
@@ -47,7 +47,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <pre>
  * {@literal @}Rule
- * public DistributedCloseableReference&lt;ServerLauncher&gt; server = new DistributedCloseableReference&lt;&gt;();
+ * public DistributedReference&lt;ServerLauncher&gt; server = new DistributedReference&lt;&gt;();
  *
  * {@literal @}Before
  * public void setUp() throws IOException {
@@ -82,7 +82,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <pre>
  * {@literal @}Rule
- * public DistributedCloseableReference&lt;Cache&gt; cache = new DistributedCloseableReference&lt;&gt;();
+ * public DistributedReference&lt;Cache&gt; cache = new DistributedReference&lt;&gt;();
  *
  * {@literal @}Before
  * public void setUp() {
@@ -112,7 +112,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <pre>
  * {@literal @}Rule
- * public DistributedCloseableReference&lt;DistributedSystem&gt; system = new DistributedCloseableReference&lt;&gt;();
+ * public DistributedReference&lt;DistributedSystem&gt; system = new DistributedReference&lt;&gt;();
  *
  * {@literal @}Before
  * public void setUp() {
@@ -141,33 +141,33 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * <pre>
  * {@literal @}Rule
- * public DistributedCloseableReference&lt;ServerLauncher&gt; serverLauncher =
- *     new DistributedCloseableReference&lt;&gt;().autoClose(false);
+ * public DistributedReference&lt;ServerLauncher&gt; serverLauncher =
+ *     new DistributedReference&lt;&gt;().autoClose(false);
  * </pre>
  *
  * <p>
- * The {@code DistributedCloseableReference} value will still be set to null during tear down even
+ * The {@code DistributedReference} value will still be set to null during tear down even
  * if auto-closing is disabled.
  */
 @SuppressWarnings({"serial", "unused", "WeakerAccess"})
-public class DistributedCloseableReference<V> extends AbstractDistributedRule {
+public class DistributedReference<V> extends AbstractDistributedRule {
 
   private static final AtomicReference<Object> REFERENCE = new AtomicReference<>();
 
   private final AtomicBoolean autoClose = new AtomicBoolean(true);
 
-  public DistributedCloseableReference() {
+  public DistributedReference() {
     this(DEFAULT_VM_COUNT);
   }
 
-  public DistributedCloseableReference(int vmCount) {
+  public DistributedReference(int vmCount) {
     super(vmCount);
   }
 
   /**
    * Set false to disable autoClose during tearDown. Default is true.
    */
-  public DistributedCloseableReference<V> autoClose(boolean value) {
+  public DistributedReference<V> autoClose(boolean value) {
     autoClose.set(value);
     return this;
   }
@@ -186,7 +186,7 @@ public class DistributedCloseableReference<V> extends AbstractDistributedRule {
    *
    * @param newValue the new value
    */
-  public DistributedCloseableReference<V> set(V newValue) {
+  public DistributedReference<V> set(V newValue) {
     REFERENCE.set(newValue);
     return this;
   }


### PR DESCRIPTION
This prevents line-wrapping in tests using DistributedReference
improving readability.
